### PR TITLE
Initial Ansible support

### DIFF
--- a/google/string_utils.rb
+++ b/google/string_utils.rb
@@ -38,6 +38,11 @@ module Google
             .downcase
     end
 
+    # Add spaces before every capitalized word except first.
+    def self.uncombine(source)
+      source.gsub(/(?=[A-Z])/, ' ').strip
+    end
+
     def self.symbolize(key)
       key.to_sym unless key.nil?
     end

--- a/provider/ansible/common~compile.yaml
+++ b/provider/ansible/common~compile.yaml
@@ -1,0 +1,21 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These files contains code that needs to be compiled before being delivered to
+# the final module tree structure:
+'lib/ansible/module_utils/gcp_utils.py': 'provider/ansible/gcp_utils.py'
+'lib/ansible/utils/module_docs_fragments/gcp.py':
+  'provider/ansible/gcp_doc_frag.py'
+'test/integration/cloud-config-gcp.yml.template':
+  'provider/ansible/test_template.yaml'
+'test/runner/lib/cloud/gcp.py': 'provider/ansible/gcp_integration_runner.py'

--- a/provider/ansible/gcp_doc_frag.py
+++ b/provider/ansible/gcp_doc_frag.py
@@ -1,0 +1,45 @@
+# Copyright: (c) 2018, Google Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+class ModuleDocFragment(object):
+        # GCP doc fragment.
+        DOCUMENTATION = '''
+options:
+    state:
+        description:
+            - Whether the given zone should or should not be present.
+        required: true
+        choices: ["present", "absent"]
+        default: "present"
+    project:
+        description:
+            - The Google Cloud Platform project to use.
+        default: null
+    auth_kind:
+        description:
+            - The type of credential used.
+        required: true
+        choices: ["machineaccount", "serviceaccount", "application"]
+    service_account_file:
+        description:
+            - The path of a Service Account JSON file if serviceaccount is selected as type.
+    service_account_email:
+        description:
+            - An optional service account email address if machineaccount is selected
+              and the user does not wish to use the default email.
+    scopes:
+      description:
+          - Array of scopes to be used.
+      required: true
+notes:
+  - For authentication, you can set service_account_file using the
+    GCP_SERVICE_ACCOUNT_FILE env variable.
+  - For authentication, you can set service_account_email using the
+    GCP_SERVICE_ACCOUNT_EMAIL env variable.
+  - For authentication, you can set auth_kind using the GCP_AUTH_KIND env
+    variable.
+  - For authentication, you can set scopes using the GCP_SCOPES env variable.
+  - Environment variables values will only be used if the playbook values are
+    not set.
+'''

--- a/provider/ansible/gcp_integration_runner.py
+++ b/provider/ansible/gcp_integration_runner.py
@@ -1,0 +1,67 @@
+# Copyright: (c) 2018, Google Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""GCP plugin for integration tests."""
+from __future__ import absolute_import, print_function
+
+import os
+
+from lib.util import (
+    ApplicationError,
+    display,
+    is_shippable,
+)
+
+from lib.cloud import (
+    CloudProvider,
+    CloudEnvironment,
+)
+
+from lib.core_ci import (
+    AnsibleCoreCI, )
+
+
+class GcpCloudProvider(CloudProvider):
+    """GCP cloud provider plugin. Sets up cloud resources before delegation."""
+
+    def filter(self, targets, exclude):
+        """Filter out the cloud tests when the necessary config and resources are not available.
+        :type targets: tuple[TestTarget]
+        :type exclude: list[str]
+        """
+
+        if os.path.isfile(self.config_static_path):
+            return
+
+        super(GcpCloudProvider, self).filter(targets, exclude)
+
+    def setup(self):
+        """Setup the cloud resource before delegation and register a cleanup callback."""
+        super(GcpCloudProvider, self).setup()
+
+        if not self._use_static_config():
+            display.notice(
+                'static configuration could not be used. are you missing a template file?'
+            )
+
+
+class GcpCloudEnvironment(CloudEnvironment):
+    """GCP cloud environment plugin. Updates integration test environment after delegation."""
+
+    def configure_environment(self, env, cmd):
+        """
+        :type env: dict[str, str]
+        :type cmd: list[str]
+        """
+        cmd.append('-e')
+        cmd.append('@%s' % self.config_path)
+
+        cmd.append('-e')
+        cmd.append('resource_prefix=%s' % self.resource_prefix)
+
+    def on_failure(self, target, tries):
+        """
+        :type target: TestTarget
+        :type tries: int
+        """
+        if not tries and self.managed:
+            display.notice('%s failed' % target.name)

--- a/provider/ansible/gcp_utils.py
+++ b/provider/ansible/gcp_utils.py
@@ -1,0 +1,107 @@
+# Copyright (c), Google Inc, 2017
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+try:
+    import requests
+    HAS_REQUESTS = True
+except ImportError:
+    HAS_REQUESTS = False
+
+try:
+    import google.auth
+    import google.auth.compute_engine
+    from google.oauth2 import service_account
+    from google.auth.transport.requests import AuthorizedSession
+    HAS_GOOGLE_LIBRARIES = True
+except ImportError:
+    HAS_GOOGLE_LIBRARIES = False
+
+from ansible.module_utils.basic import AnsibleModule
+import os
+
+
+def navigate_hash(source, path, default=None):
+    key = path[0]
+    path = path[1:]
+    if key not in source:
+        return default
+    result = source[key]
+    if path:
+        return navigate_hash(result, path, default)
+    else:
+        return result
+
+
+class GcpAuthentication(object):
+    def __init__(self, module):
+        self.module = module
+        self._set_values
+        self._validate()
+
+    def session(self):
+        return AuthorizedSession(
+            self._credentials().with_scopes(self.module.params['scopes']))
+
+    def _set_values(self):
+        if not self.module.params['auth_kind']:
+            self.module.params['auth_kind'] = os.getenv('GCP_AUTH_KIND')
+
+        if not self.module.params['service_account_email']:
+            self.module.params['service_account_email'] = os.getenv('GCP_SERVICE_ACCOUNT_EMAIL')
+
+        if not self.module.params['service_account_file']:
+            self.module.params['service_account_file'] = os.getenv('GCP_SERVICE_ACCOUNT_FILE')
+
+        if not self.module.params['scopes']:
+            self.module.params['scopes'] = os.getenv('GCP_SCOPES')
+
+    def _validate(self):
+        if not HAS_REQUESTS:
+            self.module.fail_json(msg="Please install the requests library")
+
+        if not HAS_GOOGLE_LIBRARIES:
+            self.module.fail_json(msg="Please install the google-auth library")
+
+        if self.module.params['service_account_email'] is not None and self.module.params['auth_kind'] != 'machineaccount':
+            self.module.fail_json(
+                msg="Service Acccount Email only works with Machine Account-based authentication"
+            )
+
+        if self.module.params['service_account_file'] is not None and self.module.params['auth_kind'] != 'serviceaccount':
+            self.module.fail_json(
+                msg="Service Acccount File only works with Service Account-based authentication"
+            )
+
+    def _credentials(self):
+        cred_type = self.module.params['auth_kind']
+        if cred_type == 'application':
+            credentials, project_id = google.auth.default()
+            return credentials
+        elif cred_type == 'serviceaccount':
+            return service_account.Credentials.from_service_account_file(
+                self.module.params['service_account_file'])
+        elif cred_type == 'machineaccount':
+            return google.auth.compute_engine.Credentials(
+                self.module.params['service_account_email'])
+        else:
+   

--- a/provider/ansible/test_template.yaml
+++ b/provider/ansible/test_template.yaml
@@ -1,0 +1,17 @@
+# This is the configuration template for ansible-test GCP integration tests.
+#
+# You do not need this template if you are:
+#
+# 1) Running integration tests without using ansible-test.
+# 2) Using the automatically provisioned cloudstack-sim docker container in ansible-test.
+#
+# If you do not want to use the automatically provided GCP simulator,
+# fill in the @VAR placeholders below and save this file without the .template extension.
+# This will cause ansible-test to use the given configuration and not launch the simulator.
+#
+# It is recommended that you DO NOT use this template unless you cannot use the simulator.
+
+gcp_project: @PROJECT
+gcp_cred_file: @CRED_FILE
+gcp_cred_kind: @CRED_KIND
+gcp_cred_email: @CRED_EMAIL

--- a/templates/ansible/aliases
+++ b/templates/ansible/aliases
@@ -1,0 +1,1 @@
+cloud/gcp

--- a/templates/ansible/defaults_main.yaml
+++ b/templates/ansible/defaults_main.yaml
@@ -1,0 +1,3 @@
+---
+# defaults file
+resource_name: '{{resource_prefix}}'

--- a/templates/ansible/example.erb
+++ b/templates/ansible/example.erb
@@ -1,0 +1,42 @@
+---
+#----------------------------------------------------------
+<% resource_name = Google::StringUtils.uncombine(object.name).downcase -%>
+- name: create a <%= resource_name %>
+<%= lines(indent(example, 2)) -%>
+      state: present
+  register: result
+- name: assert changed is true
+  assert:
+    that:
+      - result.changed == true
+      - "result.kind == <%= quote_string(object.kind) -%>"
+# ----------------------------------------------------------------------------
+- name: create a <%= resource_name -%> that already exists
+<%= lines(indent(example, 2)) -%>
+      state: present
+  register: result
+- name: assert changed is false
+  assert:
+    that:
+      - result.changed == false
+      - "result.kind == <%= quote_string(object.kind) -%>"
+#----------------------------------------------------------
+- name: delete a <%= resource_name %>
+<%= lines(indent(example, 2)) -%>
+      state: absent
+  register: result
+- name: assert changed is true
+  assert:
+    that:
+      - result.changed == true
+      - result.has_key('kind') == False
+# ----------------------------------------------------------------------------
+- name: delete a <%= resource_name -%> that does not exist
+<%= lines(indent(example, 2)) -%>
+      state: absent
+  register: result
+- name: assert changed is false
+  assert:
+    that:
+      - result.changed == false
+      - result.has_key('kind') == False

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -22,7 +22,7 @@ ANSIBLE_METADATA = {'metadata_version': <%= metadata_version -%>,
 
 DOCUMENTATION='''
 ---
-module: <%= object.out_name %>
+module: <%= module_name(object) %>
 description: |
   <%= lines(object.description) -%>
 version_added: <%= lines(@config.manifest.version_added) -%>
@@ -45,6 +45,15 @@ options:
         required: <%= prop.required ? 'true' : 'false' %>
 <% end -%>
 '''
+
+<% if example -%>
+EXAMPLES='''
+<% res_readable_name = Google::StringUtils.uncombine(object.name) -%>
+- name: Create a <%= res_readable_name %>
+<%= lines(indent(example, 4)) -%>
+        state: 'present'
+'''
+<% end -%>
 
 RETURNS='''
 <% object.all_user_properties.select(&:output).each do |prop| -%>
@@ -138,3 +147,63 @@ def delete(module, link, kind):
     return return_if_object(module, auth.session().delete(link), kind)
 
 
+def resource_to_request(module):
+<%
+  properties_in_request = []
+  properties_in_request += object.parameters if object.parameters
+  properties_in_request += object.properties.reject(&:output)
+  properties_in_request = properties_in_request.compact
+-%>
+    request = {
+        u'kind': <%= quote_string(object.kind) -%>,
+<% properties_in_request.each do |prop| -%>
+<%=
+  lines(indent(
+    ["#{unicode_string(prop.field_name)}:",
+     "module.params[#{quote_string(prop.out_name)}],"].join(' '), 8))
+-%>
+<% end -%>
+    }
+    return { k: v for k,v in request.items() if v }
+
+
+def self_link(module)
+    return <%= self_link_url(object) -%>.format(**module.params)
+
+
+def collection(module)
+    return <%= collection_url(object) -%>.format(**module.params)
+
+
+def return_if_object(module, response, kind):
+    # If not found, return nothing.
+    if response.status_code == 404:
+        return None
+
+    # If no content, return nothing.
+    if response.status_code == 204:
+        return None
+
+    try:
+        response.raise_for_status
+        result = response.json()
+    except Exception as inst:
+        module.fail_json(msg="Invalid JSON response with error: %s" % inst)
+
+    if navigate_hash(result, ['error', 'errors']):
+        module.fail_json(msg=navigate_hash(result, ['error', 'errors']))
+    if result['kind'] != kind:
+        module.fail_json(msg="Incorrect result: {kind}".format(**result))
+
+    return result
+
+
+def is_different(module, response):
+    request = resource_to_request(module)
+
+    # Remove all output-only from response.
+    response = {k: v for k, v in response.items() if k in request}
+    return request != response
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
* Template for create, delete (update will throw error)
* Autogenerated docs with input, output, and examples
* Autogenerated integration tests using handwritten examples.
* Includes handwritten cloud test runner, utility file for auth, document fragment

This currently targets Python 3 and Python 2.7+.