### PR TITLE
Use the CI which lives in this repo instead of the old one.

### DIFF
--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -3,13 +3,14 @@ resource_types:
     - name: git-branch
       type: docker-image
       source:
-          repository: ((dockerhub-account.username))/concourse-git-resource
+          # Note: resource types cannot use credhub substitution - "nmckinley" is hardcoded here.
+          repository: nmckinley/concourse-git-resource
           tag: v0.1.7
 
     - name: github-pull-request
       type: docker-image
       source:
-          repository: ((dockerhub-account.username))/concourse-github-pr-resource
+          repository: nmckinley/concourse-github-pr-resource
           tag: v0.1.1
 
 resources:
@@ -32,13 +33,6 @@ resources:
       type: git-branch
       source:
           uri: git@github.com:((github-account.username))/terraform-provider-google.git
-          private_key: ((repo-key.private_key))
-
-    - name: ci
-      type: git
-      source:
-          uri: git@github.com:((github-account.username))/terraform-provider-google-ci.git
-          branch: master
           private_key: ((repo-key.private_key))
 
     - name: mm-approved-prs
@@ -75,25 +69,24 @@ jobs:
                 # trigger: true
                 params:
                     submodules: [build/terraform]
-              - get: ci
-            # consumes: ci, magic-modules (detached HEAD)
+            # consumes: magic-modules (detached HEAD)
             # produces: magic-modules-branched (new branch, with submodule)
           - task: branch-magic-modules
-            file: ci/magic-modules/branch.yml
-            # consumes: ci, magic-modules-branched
+            file: magic-modules/.ci/magic-modules/branch.yml
+            # consumes: magic-modules-branched
             # produces: terraform-generated
           - task: generate-terraform
-            file: ci/magic-modules/generate-terraform.yml
+            file: magic-modules-branched/.ci/magic-modules/generate-terraform.yml
             # Puts 'terraform-generated' into the robot's fork.
           - put: terraform-intermediate
             params:
                 repository: terraform-generated
                 branch_file: magic-modules-branched/branchname
                 only_if_diff: true
-            # consumes: ci, magic-modules-branched
+            # consumes: magic-modules-branched
             # produces: magic-modules-submodules
           - task: point-to-submodules
-            file: ci/magic-modules/point-to-submodules.yml
+            file: magic-modules-branched/.ci/magic-modules/point-to-submodules.yml
             params:
               # This needs to match the username for the 'terraform-intermediate' resource.
                 GH_USERNAME: ((github-account.username))
@@ -108,7 +101,6 @@ jobs:
     - name: terraform-test
       plan:
           - aggregate:
-              - get: ci
               - get: magic-modules
                 version: every
                 # trigger: true
@@ -116,11 +108,10 @@ jobs:
                     submodules: [build/terraform]
                 passed: [mm-generate]
           - task: test
-            file: ci/unit-tests/task.yml
+            file: magic-modules/.ci/unit-tests/task.yml
 
     - name: create-prs
       plan:
-          - get: ci
           - get: magic-modules
             version: every
             # trigger: true
@@ -132,7 +123,7 @@ jobs:
             passed: [mm-generate]
             version: every
           - task: create-pr
-            file: ci/magic-modules/create-pr.yml
+            file: magic-modules/.ci/magic-modules/create-pr.yml
             params:
                 GITHUB_TOKEN: ((github-account.password))
                 TERRAFORM_REPO: ((github-account.username))/terraform-provider-google
@@ -155,9 +146,8 @@ jobs:
     - name: merge-prs
       plan:
           - get: mm-approved-prs
-          - get: ci
           - task: merge-and-update
-            file: ci/magic-modules/merge.yml
+            file: mm-approved-prs/.ci/magic-modules/merge.yml
             params:
                 CREDS: ((repo-key.private_key))
           - put: magic-modules
@@ -175,21 +165,21 @@ jobs:
 
     - name: create-pr-image
       plan:
-          - get: ci
+          - get: magic-modules
           - put: nmckinley-pr
             params:
-              build: ci/containers/pull-request
+              build: magic-modules/.ci/containers/pull-request
 
     - name: test-terraform-pr
       plan:
           - aggregate:
-              - get: ci
+              - get: magic-modules
               - get: terraform
                 resource: terraform-pr
                 version: every
                 trigger: true
           - task: test
-            file: ci/unit-tests/test-terraform.yml
+            file: magic-modules/.ci/unit-tests/test-terraform.yml
             on_failure:
               put: terraform-pr
               params:

--- a/.ci/magic-modules/branch.yml
+++ b/.ci/magic-modules/branch.yml
@@ -1,5 +1,5 @@
 ---
-# This file takes two inputs: magic-modules in detached-HEAD state, and the CI repo.
+# This file takes one input: magic-modules in detached-HEAD state.
 # It spits out "magic-modules-branched", a magic-modules repo on a new branch (named
 # after the HEAD commit on the PR).
 platform: linux
@@ -12,10 +12,9 @@ image_resource:
 
 inputs:
     - name: magic-modules
-    - name: ci
 
 outputs:
     - name: magic-modules-branched
 
 run:
-    path: ci/magic-modules/branch-magic-modules.sh
+    path: magic-modules/.ci/magic-modules/branch-magic-modules.sh

--- a/.ci/magic-modules/create-pr.yml
+++ b/.ci/magic-modules/create-pr.yml
@@ -12,13 +12,12 @@ image_resource:
 
 inputs:
     - name: magic-modules
-    - name: ci
 
 outputs:
     - name: magic-modules-with-comment
 
 run:
-    path: ci/magic-modules/create-pr.sh
+    path: magic-modules/.ci/magic-modules/create-pr.sh
 
 params:
   GITHUB_TOKEN: ""

--- a/.ci/magic-modules/generate-terraform.yml
+++ b/.ci/magic-modules/generate-terraform.yml
@@ -12,10 +12,9 @@ image_resource:
 
 inputs:
     - name: magic-modules-branched
-    - name: ci
 
 outputs:
     - name: terraform-generated
 
 run:
-    path: ci/magic-modules/generate-terraform.sh
+    path: magic-modules-branched/.ci/magic-modules/generate-terraform.sh

--- a/.ci/magic-modules/merge.yml
+++ b/.ci/magic-modules/merge.yml
@@ -11,13 +11,12 @@ image_resource:
 
 inputs:
     - name: mm-approved-prs
-    - name: ci
 
 outputs:
     - name: mm-output
 
 run:
-    path: ci/magic-modules/merge-pr.sh
+    path: mm-approved-prs/.ci/magic-modules/merge-pr.sh
 
 params:
     CREDS: ""

--- a/.ci/magic-modules/point-to-submodules.yml
+++ b/.ci/magic-modules/point-to-submodules.yml
@@ -12,13 +12,12 @@ image_resource:
 
 inputs:
     - name: magic-modules-branched
-    - name: ci
 
 outputs:
     - name: magic-modules-submodules
 
 run:
-    path: ci/magic-modules/point-to-submodules.sh
+    path: magic-modules-branched/.ci/magic-modules/point-to-submodules.sh
 
 params:
   GH_USERNAME: ""

--- a/.ci/unit-tests/task.yml
+++ b/.ci/unit-tests/task.yml
@@ -1,13 +1,12 @@
 platform: linux
 inputs:
   - name: magic-modules
-  - name: ci
 image_resource:
   type: docker-image
   source:
     repository: golang
     tag: '1.9.3'
 run:
-  path: ci/unit-tests/run.sh
+  path: magic-modules/.ci/unit-tests/run.sh
   args:
     - magic-modules/build/terraform/

--- a/.ci/unit-tests/test-terraform.yml
+++ b/.ci/unit-tests/test-terraform.yml
@@ -1,13 +1,13 @@
 platform: linux
 inputs:
   - name: terraform
-  - name: ci
+  - name: magic-modules
 image_resource:
   type: docker-image
   source:
     repository: golang
     tag: '1.9.3'
 run:
-  path: ci/unit-tests/run.sh
+  path: magic-modules/.ci/unit-tests/run.sh
   args:
     - terraform/


### PR DESCRIPTION
**Your opinion needed!  This is only maybe the best way to do this!**

This PR changes the definition of the `ci` repo to be this repository, except tracking the `stable-ci` tag instead of `master`.  The reason I'm doing this, and not just using `master` (which is present in most of these tasks already), is because of development advantages of partially decoupling CI from the code under test.

There is a good argument to be made in the other direction, though!  The advantages of doing it this way are that there's stability - PRs which are based off old code will get the advantages of updates we made to the CI system, and once we push a change to `stable-ci`, we can be certain that it's evaluated for all following PRs.  The advantage of doing it the other way are atomicity - you can send one PR which tweaks generation for Ansible and change the CI to accommodate it in a single step, and they can be deployed and rolled back independently.

Please tell me what you think!  I'm asking for your opinions specifically because you have worked with Concourse before - Vincent on this repo before me, and Alex on Ansible just now.  :)