### PR TITLE
Split up containers into go-ruby and go-ruby-python.

### DIFF
--- a/.ci/containers/go-ruby-python/Dockerfile
+++ b/.ci/containers/go-ruby-python/Dockerfile
@@ -1,0 +1,6 @@
+FROM nmckinley/go-ruby:1.9-2.5
+
+# Install python & python libraries.
+RUN apt-get update
+RUN apt-get install -y python python-pip
+RUN pip install beautifulsoup4 mistune

--- a/.ci/containers/go-ruby/Dockerfile
+++ b/.ci/containers/go-ruby/Dockerfile
@@ -1,12 +1,14 @@
 from golang:1.9 as resource
 
+RUN go get golang.org/x/tools/cmd/goimports
+
+# Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts
 RUN echo "UserKnownHostsFile /known_hosts" >> /etc/ssh/ssh_config
+
+# Install Ruby from source.
 RUN apt-get update
 RUN apt-get install -y bzip2 libssl-dev libreadline-dev zlib1g-dev
-RUN apt-get install -y python python-pip
-RUN pip install beautifulsoup4 mistune
-
 ENV RUBY_VERSION 2.5.0
 ENV RUBYGEMS_VERSION 2.7.4
 ENV BUNDLER_VERSION 1.16.1
@@ -18,8 +20,6 @@ RUN ruby-build "$RUBY_VERSION" /usr/
 RUN gem update --system "$RUBYGEMS_VERSION"
 RUN gem install bundler --version "$BUNDLER_VERSION" --force
 
-# install things globally, for great justice
-# and don't create ".bundle" in all our apps
 ENV GEM_HOME /usr/local/bundle
 ENV BUNDLE_PATH="$GEM_HOME" \
 	BUNDLE_BIN="$GEM_HOME/bin" \

--- a/.ci/magic-modules/generate-terraform.yml
+++ b/.ci/magic-modules/generate-terraform.yml
@@ -7,8 +7,8 @@ platform: linux
 image_resource:
     type: docker-image
     source:
-        repository: nmckinley/go-ruby
-        tag: '1.9-2.5'
+        repository: nmckinley/go-ruby-python
+        tag: '1.9-2.5-2.7'
 
 inputs:
     - name: magic-modules-branched


### PR DESCRIPTION
Also adds goimports back in and a comment or two.