### PR TITLE
Add support for Map to Terraform

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -28,6 +28,9 @@ objects: !ruby/object:Api::Resource::HashArray
     skip: true
   Disk:
     # TODO: Add support for missing features needed by this resource
+    id: "{{name}}"
+    ignore:
+      - id
     skip: true
   DiskType:
     # TODO: Add support for missing features needed by this resource

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -55,7 +55,8 @@ module Provider
         Api::Type::Enum => 'schema.TypeString',
         Api::Type::ResourceRef => 'schema.TypeString',
         Api::Type::NestedObject => 'schema.TypeList',
-        Api::Type::Array => 'schema.TypeList'
+        Api::Type::Array => 'schema.TypeList',
+        Api::Type::NameValues => 'schema.TypeMap'
       }
     end
 

--- a/templates/terraform/expand_property_method.erb
+++ b/templates/terraform/expand_property_method.erb
@@ -12,7 +12,18 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 <% end -%>
-<% if tf_types.include?(property.class) -%>
+<% if property.is_a?(Api::Type::NameValues) -%>
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) map[string]string {
+  if v == nil {
+    return map[string]string{}
+  }
+  m := make(map[string]string)
+  for k, val := range v.(map[string]interface{}) {
+    m[k] = val.(string)
+  }
+  return m
+}
+<% elsif tf_types.include?(property.class) -%>
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) interface{} {
 <%
   if !effective_nested_properties(config, property).empty?

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -69,6 +69,12 @@
         <% end -%>
       },
   <% end -%>
+<% elsif property.is_a?(Api::Type::NameValues) -%>
+  Elem: &schema.Schema{Type: schema.TypeString},
+  <% if not (property.key_type == 'Api::Type::String' and property.value_type == 'Api::Type::String') -%>
+    // TODO(magic-modules): Handle this map specially - Terraform maps are String->String only,
+    // but this map is marked as being <%= property.key_type -%>-><%= property.value_type -%>.
+  <% end -%>
 <% end -%>
 <% if config['sensitive']&.include?(property.name) -%>
     Sensitive: true,


### PR DESCRIPTION
A map is called NameValues in MagicModules - this adds support for it
to Terraform.

-----------------------------------------------------------------
# [all]
No changes.
## [terraform]
Adds support for NameValues - should not make changes to any existing resource.
