### PR TITLE
Ensure that people get credit for their downstream PRs.

### DIFF
--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -22,6 +22,7 @@ go get
 popd
 
 pushd magic-modules-branched
+LAST_COMMIT_AUTHOR="$(git log --pretty="%an <%ae>" -n1 HEAD)"
 bundle install
 bundle exec compiler -p products/compute -e terraform -o "${GOPATH}/src/github.com/terraform-providers/terraform-provider-google/"
 
@@ -34,11 +35,13 @@ if [ -z "$TERRAFORM_COMMIT_MSG" ]; then
 fi
 
 pushd "build/terraform"
+# These config entries will set the "committer".
 git config --global user.email "magic-modules@google.com"
 git config --global user.name "Modular Magician"
 
 git add -A
-git commit -m "$TERRAFORM_COMMIT_MSG" || true  # don't crash if no changes
+# Set the "author" to the commit's real author.
+git commit -m "$TERRAFORM_COMMIT_MSG" --author="$LAST_COMMIT_AUTHOR" || true  # don't crash if no changes
 git checkout -B "$(cat ../../branchname)"
 popd
 


### PR DESCRIPTION
Get the last commit author and use that as the author of the downstream commit.  Retain modular magician as the "committer".  "Committer" is a feature useful for git repos where commits are made by email, but GitHub also tracks them separately - it's the thing that you see in GitHub logs where it says "<user>, with <user>, committed <thing>".

This is another self-testing PR.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
No changes
## [terraform]
Change author of downstream terraform commits.
## [puppet]
### [puppet-dns]
### [puppet-compute]
## [chef]
