### PR TITLE
Fix mm-approved-prs resource to watch and update the gcp repo

### DIFF
--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -19,6 +19,11 @@ resources:
       source:
           uri: git@github.com:((github-account.username))/magic-modules.git
           private_key: ((repo-key.private_key))
+    - name: magic-modules-gcp
+          type: git-branch
+          source:
+              uri: git@github.com:GoogleCloudPlatform/magic-modules.git
+              private_key: ((repo-key.private_key))
 
     - name: magic-modules-new-prs
       type: github-pull-request
@@ -37,7 +42,7 @@ resources:
     - name: mm-approved-prs
       type: github-pull-request
       source:
-          repo: ((github-account.username))/magic-modules
+          repo: GoogleCloudPlatform/magic-modules
           private_key: ((repo-key.private_key))
           access_token: ((github-account.password))
           only_mergeable: true
@@ -158,7 +163,7 @@ jobs:
             file: mm-approved-prs/.ci/magic-modules/merge.yml
             params:
                 CREDS: ((repo-key.private_key))
-          - put: magic-modules
+          - put: magic-modules-gcp
             params:
                 repository: mm-output
                 branch_file: mm-approved-prs/.git/branch


### PR DESCRIPTION
Change-Id: I20a434cf40d563680db9165115bd9ec7032ca6be

<!-- A summary of the changes in this commit goes here -->
CI change. No expected changes in the downstream repo.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-compute]
## [chef]
