### PR TITLE
Remove skip and instead allow overriding the exclude property

### DIFF
--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -24,6 +24,33 @@ manifest: !ruby/object:Provider::Ansible::Manifest
   version_added: '2.6'
   author: Google Inc. (@googlecloudplatform)
 # This is where custom code would be defined eventually.
+overrides: !ruby/object:Provider::ResourceOverrides
+  Firewall: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  Instance: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  InstanceGroupManager: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  InstanceTemplate: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  Snapshot: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  TargetHttpsProxy: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  TargetSslProxy: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  # Ansible tasks must alter infrastructure.
+  # This means that virtual objects are a poor fit.
+  DiskType: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  License: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  MachineType: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  Region: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  Zone: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
 # TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/47): Migrate objects to overrides
 objects: !ruby/object:Api::Resource::HashArray
   Disk:
@@ -51,32 +78,6 @@ objects: !ruby/object:Api::Resource::HashArray
     aliases:
       timeoutSec:
         - timeout_seconds
-  Firewall:
-    skip: true
-  Instance:
-    skip: true
-  InstanceGroupManager:
-    skip: true
-  InstanceTemplate:
-    skip: true
-  Snapshot:
-    skip: true
-  TargetHttpsProxy:
-    skip: true
-  TargetSslProxy:
-    skip: true
-  # Ansible tasks must alter infrastructure.
-  # This means that virtual objects are a poor fit.
-  DiskType:
-    skip: true
-  License:
-    skip: true
-  MachineType:
-    skip: true
-  Region:
-    skip: true
-  Zone:
-    skip: true
 examples: !ruby/object:Api::Resource::HashArray
 files: !ruby/object:Provider::Config::Files
   copy:

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -13,6 +13,22 @@
 
 --- !ruby/object:Provider::Terraform::Config
 overrides: !ruby/object:Provider::ResourceOverrides
+  Address: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  BackendService: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  Disk: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  DiskType: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  Firewall: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  ForwardingRule: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  GlobalAddress: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  GlobalForwardingRule: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
   HttpHealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
     description: |
       {{description}}
@@ -31,11 +47,52 @@ overrides: !ruby/object:Provider::ResourceOverrides
       should be preferred for all uses except
       [Network Load Balancers](https://cloud.google.com/compute/docs/load-balancing/network/)
       which still require the legacy version.
+  HealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  Image: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  Instance: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  InstanceGroup: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  InstanceGroupManager: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  InstanceTemplate: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  License: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  MachineType: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  Network: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  Region: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  Route: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  Snapshot: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  SslCertificate: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  Subnetwork: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  TargetHttpProxy: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  TargetHttpsProxy: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  TargetPool: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  TargetSslProxy: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  TargetTcpProxy: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  UrlMap: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  Zone: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  TargetPool: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
 # TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/47): Migrate objects to overrides
 objects: !ruby/object:Api::Resource::HashArray
-  Address:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
   BackendBucket:
     id: "{{name}}"
     ignore:
@@ -58,21 +115,10 @@ objects: !ruby/object:Api::Resource::HashArray
           location = "EU"
         }
         ```
-  BackendService:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
   Disk:
-    # TODO: Add support for missing features needed by this resource
     id: "{{name}}"
     ignore:
       - id
-    skip: true
-  DiskType:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
-  Firewall:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
   ForwardingRule:
     id: "{{name}}"
     ignore:
@@ -80,17 +126,12 @@ objects: !ruby/object:Api::Resource::HashArray
     diff_suppress_funcs:
       portRange: "portRangeDiffSuppress"
     # TODO: Add support for missing features needed by this resource
-    skip: true
   GlobalAddress:
     id: "{{name}}"
     ignore:
       - id
       - region # TODO: Remove this from api.yaml instead of ignoring
     # TODO: Add support for missing features needed by this resource
-    skip: true
-  GlobalForwardingRule:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
   HttpHealthCheck:
     id: "{{name}}"
     ignore:
@@ -135,9 +176,6 @@ objects: !ruby/object:Api::Resource::HashArray
           check_interval_sec = 1
         }
         ```
-  HealthCheck:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
   Image:
     id: "{{name}}"
     # TODO: Add support for aliasing. For instance, the sha1_checksum field
@@ -152,38 +190,9 @@ objects: !ruby/object:Api::Resource::HashArray
       - sourceType
       - licenses
     # TODO: Add support for missing features needed by this resource
-    skip: true
-  Instance:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
-  InstanceGroup:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
-  InstanceGroupManager:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
-  InstanceTemplate:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
-  License:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
-  MachineType:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
-  Network:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
-  Region:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
   Route:
     id: "{{name}}"
     # TODO: Add support for missing features needed by this resource
-    skip: true
-  Snapshot:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
   SslCertificate:
     id: "{{name}}"
     ignore:
@@ -192,44 +201,26 @@ objects: !ruby/object:Api::Resource::HashArray
       - certificate
       - privateKey
     # TODO: Add support for missing features needed by this resource
-    skip: true
   Subnetwork:
     id: "{{region}}/{{name}}"
     ignore:
       - id
     # TODO: Add support for missing features needed by this resource
-    skip: true
   TargetHttpProxy:
     id: "{{name}}"
     ignore:
       - id
     # TODO: Alias id to proxy_id
     # TODO: Add support for missing features needed by this resource
-    skip: true
   TargetHttpsProxy:
     id: "{{name}}"
     ignore:
       - id
     # TODO: Alias id to proxy_id
     # TODO: Add support for missing features needed by this resource
-    skip: true
   TargetPool:
     id: "{{name}}"
     # TODO: Add support for missing features needed by this resource
-    skip: true
-  TargetSslProxy:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
-  TargetTcpProxy:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
-  UrlMap:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
-  Zone:
-    # TODO: Add support for missing features needed by this resource
-    skip: true
-
 # This is for a list of example files.
 examples: !ruby/object:Api::Resource::HashArray
 

--- a/products/dns/ansible.yaml
+++ b/products/dns/ansible.yaml
@@ -24,14 +24,16 @@ manifest: !ruby/object:Provider::Ansible::Manifest
   version_added: '2.5'
   author: Google Inc. (@googlecloudplatform)
 # This is where custom code would be defined eventually.
+overrides: !ruby/object:Provider::ResourceOverrides
+  Project: !ruby/object:Provider::Ansible::ResourceOverride
+    # TODO(alexstephen): Re-evaluate merging Project into Ansible
+    exclude: true
+  Change: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+# TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/47): Migrate objects to overrides
 objects: !ruby/object:Api::Resource::HashArray
-  Change:
-    skip: true
   ManagedZone:
     editable: false
-  Project:
-    # TODO(alexstephen): Re-evaluate merging Project into Ansible
-    skip: true
   ResourceRecordSet:
     version_added: '2.6'
     imports:

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -18,6 +18,8 @@ require 'provider/ansible/example'
 require 'provider/ansible/documentation'
 require 'provider/ansible/module'
 require 'provider/ansible/request'
+require 'provider/ansible/resourceref'
+require 'provider/ansible/resource_override'
 require 'provider/ansible/selflink'
 
 module Provider

--- a/provider/ansible/resource_override.rb
+++ b/provider/ansible/resource_override.rb
@@ -15,6 +15,7 @@ require 'provider/resource_override'
 
 module Provider
   module Ansible
+    # Ansible-specific overrides to api.yaml.
     class ResourceOverride < Provider::ResourceOverride
       # TODO: Add Ansible specific properties here.
     end

--- a/provider/ansible/resource_override.rb
+++ b/provider/ansible/resource_override.rb
@@ -1,0 +1,22 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'provider/resource_override'
+
+module Provider
+  module Ansible
+    class ResourceOverride < Provider::ResourceOverride
+      # TODO: Add Ansible specific properties here.
+    end
+  end
+end

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -216,7 +216,6 @@ module Provider
 
     def generate_object(object, output_folder)
       data = build_object_data(object, output_folder)
-      return if data[:config]['skip']
 
       generate_resource data
       generate_resource_tests data

--- a/provider/resource_override.rb
+++ b/provider/resource_override.rb
@@ -17,16 +17,20 @@ module Provider
   # Override to an Api::Resource in api.yaml
   class ResourceOverride < Api::Object
     attr_reader :description
+    attr_reader :exclude
 
     def validate
       super
 
       check_optional_property :description, String
+      check_optional_property :exclude, :boolean
     end
 
     # Apply this override to the given instance of Api::Resource
     def apply(api_resource)
       extend_string api_resource, :description, @description
+
+      override_boolean api_resource, :exclude, @exclude
     end
 
     # Replace the `object_key` instance variable on `object` by the
@@ -39,6 +43,12 @@ module Provider
       new_val = override_val.gsub "{{#{object_key}}}", object_val
 
       object.instance_variable_set("@#{object_key}", new_val)
+    end
+
+    def override_boolean(object, object_key, override_val)
+      return if override_val.nil?
+
+      object.instance_variable_set("@#{object_key}", override_val)
     end
   end
 end

--- a/provider/terraform/resource_override.rb
+++ b/provider/terraform/resource_override.rb
@@ -16,6 +16,7 @@ require 'provider/resource_override'
 
 module Provider
   class Terraform < Provider::AbstractCore
+    # Terraform-specific overrides to api.yaml.
     class ResourceOverride < Provider::ResourceOverride
       # TODO: Add Terraform specific properties here.
     end


### PR DESCRIPTION
Relates to #47. This is part of the migration from `objects` to `overrides` in the provider yaml files.

- Allow overriding the api.yaml exclude property for a resource.
- This removes the need for having the `skip` property in the provider yaml files.

No changes expected in the downstream repos.

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-compute]
## [chef]
