### PR TITLE
Fix branching

### DIFF
--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -78,18 +78,8 @@ jobs:
             # produces: magic-modules-branched (new branch, with submodule)
           - task: branch-magic-modules
             file: magic-modules/.ci/magic-modules/branch.yml
-            # consumes: magic-modules-branched
-            # produces: magic-modules-branched (but with a different branch, if the other one is taken).
-          - try:
-              get: maybe-get-existing-magic-modules-branch
-              resource: magic-modules
-              params:
-                branch_file: magic-modules-branched/branchname
-              on_success:
-                task: use-sha-instead-of-pr-name
-                file: magic-modules/.ci/magic-modules/branch.yml
-                params:
-                  USE_SHA: true
+            params:
+              GH_TOKEN: ((github-account.password))
             # consumes: magic-modules-branched
             # produces: terraform-generated
           - task: generate-terraform

--- a/.ci/containers/python/Dockerfile
+++ b/.ci/containers/python/Dockerfile
@@ -1,0 +1,3 @@
+from python:2.7-stretch
+
+run pip install pygithub

--- a/.ci/magic-modules/branch-magic-modules.sh
+++ b/.ci/magic-modules/branch-magic-modules.sh
@@ -8,7 +8,10 @@ pushd "magic-modules"
 # logic in create-or-update-pr - because we decide whether to
 # create or to update by which one of these we're prefixed by.
 export GH_TOKEN
-if PR_ID=$(git config --get pullrequest.id) && [ -z "$USE_SHA" ] && [ -z "$(python ./.ci/magic-modules/get_downstream_prs.py "$PR_ID")" ]; then
+if PR_ID=$(git config --get pullrequest.id) &&
+  [ -z "$USE_SHA" ] &&
+  DEPS=$(python ./.ci/magic-modules/get_downstream_prs.py "$PR_ID") &&
+  [ -z "$DEPS" ]; then
   BRANCH="codegen-pr-$(git config --get pullrequest.id)"
 else
   BRANCH="codegen-sha-$(git rev-parse --short HEAD)"

--- a/.ci/magic-modules/branch-magic-modules.sh
+++ b/.ci/magic-modules/branch-magic-modules.sh
@@ -7,7 +7,8 @@ pushd "magic-modules"
 # them (or introduce other options) unless you also change the
 # logic in create-or-update-pr - because we decide whether to
 # create or to update by which one of these we're prefixed by.
-if git config --get pullrequest.id && [ -z "$USE_SHA" ]; then
+export GH_TOKEN
+if PR_ID=$(git config --get pullrequest.id) && [ -z "$USE_SHA" ] && [ -z "$(python ./.ci/magic-modules/get_downstream_prs.py "$PR_ID")" ]; then
   BRANCH="codegen-pr-$(git config --get pullrequest.id)"
 else
   BRANCH="codegen-sha-$(git rev-parse --short HEAD)"

--- a/.ci/magic-modules/branch.yml
+++ b/.ci/magic-modules/branch.yml
@@ -12,8 +12,8 @@ image_resource:
         # bash available, we can switch to that, but it's probably better to
         # minimize the number of containers used than to minimize the size of
         # the container in this particular (very short) task.
-        repository: nmckinley/go-ruby
-        tag: '1.9-2.5'
+        repository: nmckinley/python
+        tag: 'v0.0.1'
 
 inputs:
     - name: magic-modules

--- a/.ci/magic-modules/branch.yml
+++ b/.ci/magic-modules/branch.yml
@@ -23,6 +23,7 @@ outputs:
 
 params:
   USE_SHA: ""
+  GH_TOKEN: ""
 
 run:
     path: magic-modules/.ci/magic-modules/branch-magic-modules.sh

--- a/.ci/magic-modules/branch.yml
+++ b/.ci/magic-modules/branch.yml
@@ -7,11 +7,8 @@ platform: linux
 image_resource:
     type: docker-image
     source:
-        # Not necessary to have either go or ruby, but it's a container already
-        # in use in this pipeline - if we ever add a container that has git and
-        # bash available, we can switch to that, but it's probably better to
-        # minimize the number of containers used than to minimize the size of
-        # the container in this particular (very short) task.
+        # This task requires a container with 'git', 'python', and the pip
+        # package 'pygithub'.
         repository: nmckinley/python
         tag: 'v0.0.1'
 

--- a/.ci/magic-modules/get_downstream_prs.py
+++ b/.ci/magic-modules/get_downstream_prs.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+import functools
+import os
+import re
+import sys
+from github import Github
+
+if __name__ == '__main__':
+  g = Github(os.environ.get('GH_TOKEN'))
+  all_prs = functools.reduce(lambda x,y: x+re.findall(r'\ndepends: (https://github.com/.*)', y.body),
+      g.get_repo('GoogleCloudPlatform/magic-modules').get_pull(int(sys.argv[1])).get_issue_comments(), [])
+  for downstream_pr in all_prs:
+    print downstream_pr

--- a/.ci/magic-modules/get_downstream_prs.py
+++ b/.ci/magic-modules/get_downstream_prs.py
@@ -5,9 +5,18 @@ import re
 import sys
 from github import Github
 
+def append_github_dependencies_to_list(lst, comment_body):
+  list_of_urls = re.findall(r'^depends: (https://github.com/.*)', comment_body, re.MULTILINE)
+  return lst + list_of_urls
+
 if __name__ == '__main__':
   g = Github(os.environ.get('GH_TOKEN'))
-  all_prs = functools.reduce(lambda x,y: x+re.findall(r'\ndepends: (https://github.com/.*)', y.body),
-      g.get_repo('GoogleCloudPlatform/magic-modules').get_pull(int(sys.argv[1])).get_issue_comments(), [])
-  for downstream_pr in all_prs:
+  assert len(sys.argv) == 2
+  pr_number = int(sys.argv[1])
+  pull_request = g.get_repo('GoogleCloudPlatform/magic-modules').get_pull(pr_number)
+  comment_bodies = [c.body for c in pull_request.get_issue_comments()]
+  # "reduce" is "foldl" - apply this function to the result of the previous function and
+  # the next value in the iterable.
+  all_dependencies = functools.reduce(append_github_dependencies_to_list, comment_bodies, [])
+  for downstream_pr in all_dependencies:
     print downstream_pr


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->

The 'get' actually resolves the version _before_ the branch is chosen,
which means it can't know what the branch is, which means there's no
way for it work with the 'try / on_success' model.

Instead, I wrote some really simple python which gets existing
depends: ... comments.

I've tested it on PR #43 and it works.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
CI Changes only.
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-compute]
## [chef]
