### PR TITLE
Support overrides for resource properties and migrate Terraform.

### DIFF
--- a/api/resource.rb
+++ b/api/resource.rb
@@ -18,7 +18,7 @@ module Api
   # An object available in the product
   # rubocop:disable Metrics/ClassLength
   class Resource < Api::Object::Named
-    # The list of properties (attr_reader) that can be overriden in
+    # The list of properties (attr_reader) that can be overridden in
     # <provider>.yaml.
     module Properties
       attr_reader :description
@@ -45,7 +45,7 @@ module Api
 
     include Properties
 
-    # Properties can be overriden via Provider::PropertyOverride.
+    # Properties can be overridden via Provider::PropertyOverride.
     attr_reader :properties
     attr_reader :__product
 

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -30,7 +30,6 @@ module Api
       # default=name
       attr_reader :identity
       attr_reader :parameters
-      attr_reader :properties
       attr_reader :exclude
       attr_reader :virtual
       attr_reader :async
@@ -46,6 +45,8 @@ module Api
 
     include Properties
 
+    # Properties can be overriden via Provider::PropertyOverride.
+    attr_reader :properties
     attr_reader :__product
 
     # Allows overriding snowflake transport requests

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -45,7 +45,7 @@ module Api
 
     include Properties
 
-    # Properties can be overridden via Provider::PropertyOverride.
+    # Properties can be overridden via Provider::PropertyOverride
     attr_reader :properties
     attr_reader :__product
 

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -47,6 +47,7 @@ module Api
 
     # Properties can be overridden via Provider::PropertyOverride
     attr_reader :properties
+
     attr_reader :__product
 
     # Allows overriding snowflake transport requests

--- a/api/type.rb
+++ b/api/type.rb
@@ -17,13 +17,19 @@ require 'google/string_utils'
 module Api
   # Represents a property type
   class Type < Api::Object::Named
-    attr_reader :description
-    attr_reader :output # If set value will not be sent to server on sync
-    attr_reader :input # If set to true value is used only on creation
-    attr_reader :field
-    attr_reader :required
-    attr_reader :update_verb
-    attr_reader :update_url
+    # The list of properties (attr_reader) that can be overriden in
+    # <provider>.yaml.
+    module Fields
+      attr_reader :description
+      attr_reader :output # If set value will not be sent to server on sync
+      attr_reader :input # If set to true value is used only on creation
+      attr_reader :field
+      attr_reader :required
+      attr_reader :update_verb
+      attr_reader :update_url
+    end
+
+    include Fields
 
     attr_reader :__resource
     attr_reader :__parent # is nil for top-level properties

--- a/api/type.rb
+++ b/api/type.rb
@@ -20,6 +20,7 @@ module Api
     # The list of properties (attr_reader) that can be overridden in
     # <provider>.yaml.
     module Fields
+      attr_reader :name # duplicated here
       attr_reader :description
       attr_reader :output # If set value will not be sent to server on sync
       attr_reader :input # If set to true value is used only on creation

--- a/api/type.rb
+++ b/api/type.rb
@@ -17,7 +17,7 @@ require 'google/string_utils'
 module Api
   # Represents a property type
   class Type < Api::Object::Named
-    # The list of properties (attr_reader) that can be overriden in
+    # The list of properties (attr_reader) that can be overridden in
     # <provider>.yaml.
     module Fields
       attr_reader :description

--- a/api/type.rb
+++ b/api/type.rb
@@ -20,7 +20,7 @@ module Api
     # The list of properties (attr_reader) that can be overridden in
     # <provider>.yaml.
     module Fields
-      attr_reader :name # duplicated here
+      attr_reader :name # Duplicated here to enable overriding
       attr_reader :description
       attr_reader :output # If set value will not be sent to server on sync
       attr_reader :input # If set to true value is used only on creation

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -30,21 +30,26 @@ overrides: !ruby/object:Provider::ResourceOverrides
         location = "EU"
       }
       ```
+    id_format: "{{name}}"
   BackendService: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   Disk: !ruby/object:Provider::Terraform::ResourceOverride
+    id_format: "{{name}}"
     exclude: true
   DiskType: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   Firewall: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   ForwardingRule: !ruby/object:Provider::Terraform::ResourceOverride
+    id_format: "{{name}}"
     exclude: true
   GlobalAddress: !ruby/object:Provider::Terraform::ResourceOverride
+    id_format: "{{name}}"
     exclude: true
   GlobalForwardingRule: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   HttpHealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
+    id_format: "{{name}}"
     description: |
       {{description}}
 
@@ -64,6 +69,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
       }
       ```
   HttpsHealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
+    id_format: "{{name}}"
     description: |
       {{description}}
 
@@ -83,8 +89,10 @@ overrides: !ruby/object:Provider::ResourceOverrides
       }
       ```
   HealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
+    id_format: "{{name}}"
     exclude: true
   Image: !ruby/object:Provider::Terraform::ResourceOverride
+    id_format: "{{name}}"
     exclude: true
   Instance: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
@@ -103,17 +111,21 @@ overrides: !ruby/object:Provider::ResourceOverrides
   Region: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   Route: !ruby/object:Provider::Terraform::ResourceOverride
+    id_format: "{{name}}"
     exclude: true
   Snapshot: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   SslCertificate: !ruby/object:Provider::Terraform::ResourceOverride
+    id_format: "{{name}}"
     exclude: true
   Subnetwork: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{region}}/{{name}}"
     exclude: true
   TargetHttpProxy: !ruby/object:Provider::Terraform::ResourceOverride
+    id_format: "{{name}}"
     exclude: true
   TargetHttpsProxy: !ruby/object:Provider::Terraform::ResourceOverride
+    id_format: "{{name}}"
     exclude: true
   TargetPool: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
@@ -126,6 +138,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
   Zone: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   TargetPool: !ruby/object:Provider::Terraform::ResourceOverride
+    id_format: "{{name}}"
     exclude: true
 # TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/47): Migrate objects to overrides
 objects: !ruby/object:Api::Resource::HashArray

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -185,10 +185,14 @@ overrides: !ruby/object:Provider::ResourceOverrides
     exclude: true
   SslCertificate: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{name}}"
-    exclude: true
+    exclude: false
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
+      certificate: !ruby/object:Provider::Terraform::PropertyOverride
+        sensitive: true
+      privateKey: !ruby/object:Provider::Terraform::PropertyOverride
+        sensitive: true
   Subnetwork: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{region}}/{{name}}"
     exclude: true
@@ -222,11 +226,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
     exclude: true
 # TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/47): Migrate objects to overrides
 objects: !ruby/object:Api::Resource::HashArray
-  SslCertificate:
-    sensitive:
-      - certificate
-      - privateKey
-    # TODO: Add support for missing features needed by this resource
 # This is for a list of example files.
 examples: !ruby/object:Api::Resource::HashArray
 

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -32,6 +32,8 @@ overrides: !ruby/object:Provider::ResourceOverrides
       ```
     id_format: "{{name}}"
     properties:
+      id: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
       name: !ruby/object:Provider::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           regex: '^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$'
@@ -40,6 +42,9 @@ overrides: !ruby/object:Provider::ResourceOverrides
   Disk: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{name}}"
     exclude: true
+    properties:
+      id: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
   DiskType: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   Firewall: !ruby/object:Provider::Terraform::ResourceOverride
@@ -47,8 +52,16 @@ overrides: !ruby/object:Provider::ResourceOverrides
   ForwardingRule: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{name}}"
     exclude: true
+    properties:
+      id: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
   GlobalAddress: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{name}}"
+    properties:
+      id: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
+      region: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
     exclude: true
   GlobalForwardingRule: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
@@ -72,6 +85,9 @@ overrides: !ruby/object:Provider::ResourceOverrides
         check_interval_sec = 1
       }
       ```
+    properties:
+      id: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
   HttpsHealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{name}}"
     description: |
@@ -92,12 +108,34 @@ overrides: !ruby/object:Provider::ResourceOverrides
         check_interval_sec = 1
       }
       ```
+    properties:
+      id: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
   HealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{name}}"
     exclude: true
   Image: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{name}}"
     exclude: true
+    properties:
+      id: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
+      deprecated: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
+      guestOsFeatures: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
+      imageEncryptionKey: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
+      rawDisk.sha1Checksum: !ruby/object:Provider::Terraform::PropertyOverride
+        name: 'sha1'
+      sourceDiskEncryptionKey: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
+      sourceDiskId: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
+      sourceType: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
+      licenses: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
   Instance: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   InstanceGroup: !ruby/object:Provider::Terraform::ResourceOverride
@@ -122,15 +160,27 @@ overrides: !ruby/object:Provider::ResourceOverrides
   SslCertificate: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{name}}"
     exclude: true
+    properties:
+      id: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
   Subnetwork: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{region}}/{{name}}"
     exclude: true
+    properties:
+      id: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
   TargetHttpProxy: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{name}}"
     exclude: true
+    properties:
+      id: !ruby/object:Provider::Terraform::PropertyOverride
+        name: proxy_id
   TargetHttpsProxy: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{name}}"
     exclude: true
+    properties:
+      id: !ruby/object:Provider::Terraform::PropertyOverride
+        name: proxy_id
   TargetPool: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   TargetSslProxy: !ruby/object:Provider::Terraform::ResourceOverride
@@ -146,26 +196,11 @@ overrides: !ruby/object:Provider::ResourceOverrides
     exclude: true
 # TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/47): Migrate objects to overrides
 objects: !ruby/object:Api::Resource::HashArray
-  BackendBucket:
-    ignore:
-      - id
-  Disk:
-    ignore:
-      - id
   ForwardingRule:
-    ignore:
-      - id
     diff_suppress_funcs:
       portRange: "portRangeDiffSuppress"
     # TODO: Add support for missing features needed by this resource
-  GlobalAddress:
-    ignore:
-      - id
-      - region # TODO: Remove this from api.yaml instead of ignoring
-    # TODO: Add support for missing features needed by this resource
   HttpHealthCheck:
-    ignore:
-      - id
     default_values:
       checkIntervalSec: 5
       healthyThreshold: 2
@@ -174,8 +209,6 @@ objects: !ruby/object:Api::Resource::HashArray
       timeoutSec: 5
       unhealthyThreshold: 2
   HttpsHealthCheck:
-    ignore:
-      - id
     default_values:
       checkIntervalSec: 5
       healthyThreshold: 2
@@ -183,39 +216,10 @@ objects: !ruby/object:Api::Resource::HashArray
       requestPath: "/"
       timeoutSec: 5
       unhealthyThreshold: 2
-  Image:
-    # TODO: Add support for aliasing. For instance, the sha1_checksum field
-    # in raw_disk is currently named `sha1` in our Terraform provider.
-    ignore:
-      - id
-      - deprecated
-      - guestOsFeatures
-      - imageEncryptionKey
-      - sourceDiskEncryptionKey
-      - sourceDiskId
-      - sourceType
-      - licenses
-    # TODO: Add support for missing features needed by this resource
   SslCertificate:
-    ignore:
-      - id
     sensitive:
       - certificate
       - privateKey
-    # TODO: Add support for missing features needed by this resource
-  Subnetwork:
-    ignore:
-      - id
-    # TODO: Add support for missing features needed by this resource
-  TargetHttpProxy:
-    ignore:
-      - id
-    # TODO: Alias id to proxy_id
-    # TODO: Add support for missing features needed by this resource
-  TargetHttpsProxy:
-    ignore:
-      - id
-    # TODO: Alias id to proxy_id
     # TODO: Add support for missing features needed by this resource
 # This is for a list of example files.
 examples: !ruby/object:Api::Resource::HashArray

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -185,7 +185,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
     exclude: true
   SslCertificate: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{name}}"
-    exclude: false
+    exclude: true
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -30,7 +30,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
         location = "EU"
       }
       ```
-    id_format: "{{name}}"
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
@@ -40,7 +39,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
   BackendService: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   Disk: !ruby/object:Provider::Terraform::ResourceOverride
-    id_format: "{{name}}"
     exclude: true
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
@@ -50,7 +48,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
   Firewall: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   ForwardingRule: !ruby/object:Provider::Terraform::ResourceOverride
-    id_format: "{{name}}"
     exclude: true
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
@@ -58,7 +55,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
       portRange: !ruby/object:Provider::Terraform::PropertyOverride
         diff_suppress_func: 'portRangeDiffSuppress'
   GlobalAddress: !ruby/object:Provider::Terraform::ResourceOverride
-    id_format: "{{name}}"
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
@@ -68,7 +64,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
   GlobalForwardingRule: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   HttpHealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
-    id_format: "{{name}}"
     description: |
       {{description}}
 
@@ -103,7 +98,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
       unhealthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
         default_value: 2
   HttpsHealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
-    id_format: "{{name}}"
     description: |
       {{description}}
 
@@ -138,10 +132,8 @@ overrides: !ruby/object:Provider::ResourceOverrides
       unhealthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
         default_value: 2
   HealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
-    id_format: "{{name}}"
     exclude: true
   Image: !ruby/object:Provider::Terraform::ResourceOverride
-    id_format: "{{name}}"
     exclude: true
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
@@ -179,12 +171,10 @@ overrides: !ruby/object:Provider::ResourceOverrides
   Region: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   Route: !ruby/object:Provider::Terraform::ResourceOverride
-    id_format: "{{name}}"
     exclude: true
   Snapshot: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   SslCertificate: !ruby/object:Provider::Terraform::ResourceOverride
-    id_format: "{{name}}"
     exclude: true
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
@@ -200,13 +190,11 @@ overrides: !ruby/object:Provider::ResourceOverrides
       id: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
   TargetHttpProxy: !ruby/object:Provider::Terraform::ResourceOverride
-    id_format: "{{name}}"
     exclude: true
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
         name: proxy_id
   TargetHttpsProxy: !ruby/object:Provider::Terraform::ResourceOverride
-    id_format: "{{name}}"
     exclude: true
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
@@ -222,10 +210,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
   Zone: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   TargetPool: !ruby/object:Provider::Terraform::ResourceOverride
-    id_format: "{{name}}"
     exclude: true
-# TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/47): Migrate objects to overrides
-objects: !ruby/object:Api::Resource::HashArray
 # This is for a list of example files.
 examples: !ruby/object:Api::Resource::HashArray
 

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -51,7 +51,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
     exclude: true
   ForwardingRule: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{name}}"
-    exclude: false
+    exclude: true
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
@@ -90,6 +90,18 @@ overrides: !ruby/object:Provider::ResourceOverrides
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
+      checkIntervalSec: !ruby/object:Provider::Terraform::PropertyOverride
+        default_value: 5
+      healthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
+        default_value: 2
+      port: !ruby/object:Provider::Terraform::PropertyOverride
+        default_value: 80
+      requestPath: !ruby/object:Provider::Terraform::PropertyOverride
+        default_value: "/"
+      timeoutSec: !ruby/object:Provider::Terraform::PropertyOverride
+        default_value: 5
+      unhealthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
+        default_value: 2
   HttpsHealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{name}}"
     description: |
@@ -113,6 +125,18 @@ overrides: !ruby/object:Provider::ResourceOverrides
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
+      checkIntervalSec: !ruby/object:Provider::Terraform::PropertyOverride
+        default_value: 5
+      healthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
+        default_value: 2
+      port: !ruby/object:Provider::Terraform::PropertyOverride
+        default_value: 443
+      requestPath: !ruby/object:Provider::Terraform::PropertyOverride
+        default_value: "/"
+      timeoutSec: !ruby/object:Provider::Terraform::PropertyOverride
+        default_value: 5
+      unhealthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
+        default_value: 2
   HealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{name}}"
     exclude: true
@@ -198,22 +222,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
     exclude: true
 # TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/47): Migrate objects to overrides
 objects: !ruby/object:Api::Resource::HashArray
-  HttpHealthCheck:
-    default_values:
-      checkIntervalSec: 5
-      healthyThreshold: 2
-      port: 80
-      requestPath: "/"
-      timeoutSec: 5
-      unhealthyThreshold: 2
-  HttpsHealthCheck:
-    default_values:
-      checkIntervalSec: 5
-      healthyThreshold: 2
-      port: 443
-      requestPath: "/"
-      timeoutSec: 5
-      unhealthyThreshold: 2
   SslCertificate:
     sensitive:
       - certificate

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -31,6 +31,10 @@ overrides: !ruby/object:Provider::ResourceOverrides
       }
       ```
     id_format: "{{name}}"
+    properties:
+      name: !ruby/object:Provider::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          regex: '^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$'
   BackendService: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   Disk: !ruby/object:Provider::Terraform::ResourceOverride
@@ -145,9 +149,6 @@ objects: !ruby/object:Api::Resource::HashArray
   BackendBucket:
     ignore:
       - id
-    # TODO: look into moving validation into api.yaml
-    validation:
-      name: '^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$'
   Disk:
     ignore:
       - id

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -51,10 +51,12 @@ overrides: !ruby/object:Provider::ResourceOverrides
     exclude: true
   ForwardingRule: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{name}}"
-    exclude: true
+    exclude: false
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
+      portRange: !ruby/object:Provider::Terraform::PropertyOverride
+        diff_suppress_func: 'portRangeDiffSuppress'
   GlobalAddress: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{name}}"
     properties:
@@ -196,10 +198,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
     exclude: true
 # TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/47): Migrate objects to overrides
 objects: !ruby/object:Api::Resource::HashArray
-  ForwardingRule:
-    diff_suppress_funcs:
-      portRange: "portRangeDiffSuppress"
-    # TODO: Add support for missing features needed by this resource
   HttpHealthCheck:
     default_values:
       checkIntervalSec: 5

--- a/provider/property_override.rb
+++ b/provider/property_override.rb
@@ -12,60 +12,41 @@
 # limitations under the License.
 
 require 'api/object'
+require 'api/type'
 
 module Provider
-  # Override to an Api::Resource in api.yaml
-  class ResourceOverride < Api::Object
-    # TODO(rosbo): Find better naming to avoid confusion between properties of
-    # a resource such as its name and description vs the list of properties of
-    # that resource such as archiveSizeBytes, creationTimestamp and so on for
-    # the compute image resource.
-    include Api::Resource::Properties
+  # Override a resource property (Api::Type) in api.yaml
+  class PropertyOverride < Api::Object
+    include Api::Type::Fields
 
-    # Hash of properties where the key is the property path and the value is
-    # a Provider::PropertyOverride.
-    #
-    # The property path can take of these formats:
-    # - 'foo': Top-level property 'foo'
-    # - 'foo.bar': Property 'bar' nested under property 'foo'
-    attr_reader :properties
-
-    # Apply this override to the given instance of Api::Resource
-    def apply(api_resource)
-      ensure_resource_properties
-      update_overriden_properties(api_resource)
+    # Apply this override to property inheriting from Api::Type
+    def apply(api_property)
+      ensure_property_fields
+      update_overriden_fields api_property
 
       # TODO(nelsonjr): Enable revalidate the object to make sure we did not
       # break the object during the override process
       # | api_resource.validate # check if we did not break the object
     end
 
-    def validate
-      super
-
-      @properties ||= {}
-
-      check_property :properties, Hash
-    end
-
     private
 
-    # Updates the resource property to a new value
-    def update(resource, name, value)
-      resource.instance_variable_set("@#{name}".to_sym, value)
+    # Updates a property field to a new value
+    def update(property, field, value)
+      property.instance_variable_set("@#{field}".to_sym, value)
     end
 
-    # Attaches the overridden properties to Api::Resource and ensure they are
+    # Attaches the overridden fields to the property and ensure they are
     # present on the class.
-    def ensure_resource_properties
-      Api::Resource.send(:include, overriden) # override ...
+    def ensure_property_fields
+      Api::Type.send(:include, overriden) # override ...
       require_module overriden
       our_override_modules.each { |mod| require_module mod } # ... and verify
     end
 
     # Copies all overridable properties from ResourceOverride into
     # Api::Resource.
-    def update_overriden_properties(api_resource)
+    def update_overriden_fields(api_resource)
       our_override_modules.each do |mod|
         mod.instance_methods.each do |method|
           # If we have a variable for it, copy it.
@@ -80,15 +61,15 @@ module Provider
     # Returns all modules that contain overridable properties.
     def our_override_modules
       self.class.included_modules.select do |mod|
-        mod == Api::Resource::Properties \
-          || mod.name.split(':').last == 'OverrideProperties'
+        mod == Api::Type::Fields \
+          || mod.name.split(':').last == 'OverrideFields'
       end
     end
 
-    # Ensures that Api::Resource includes a module.
+    # Ensures that Api::Type includes a module.
     def require_module(clazz)
-      raise "Api::Resource did not include required #{clazz} module" \
-        unless Api::Resource.included_modules.include?(clazz)
+      raise "Api::Type did not include required #{clazz} module" \
+        unless Api::Type.included_modules.include?(clazz)
       raise "#{self.class} did not include required #{clazz} module" \
         unless self.class.included_modules.include?(clazz)
     end
@@ -96,12 +77,6 @@ module Provider
     # Returns the module that provides overriden properties for this provider.
     def overriden
       raise "overriden property should be implemented in #{self.class}"
-    end
-
-    def override_boolean(object, object_key, override_val)
-      return if override_val.nil?
-
-      object.instance_variable_set("@#{object_key}", override_val)
     end
   end
 end

--- a/provider/property_override.rb
+++ b/provider/property_override.rb
@@ -16,6 +16,7 @@ require 'api/type'
 
 module Provider
   # Override a resource property (Api::Type) in api.yaml
+  # TODO(rosbo): Shared common logic with ResourceOverride via a base class.
   class PropertyOverride < Api::Object
     include Api::Type::Fields
 

--- a/provider/resource_override.rb
+++ b/provider/resource_override.rb
@@ -16,10 +16,6 @@ require 'api/object'
 module Provider
   # Override to an Api::Resource in api.yaml
   class ResourceOverride < Api::Object
-    # TODO(rosbo): Find better naming to avoid confusion between properties of
-    # a resource such as its name and description vs the list of properties of
-    # that resource such as archiveSizeBytes, creationTimestamp and so on for
-    # the compute image resource.
     include Api::Resource::Properties
 
     # Hash of properties where the key is the property path and the value is

--- a/provider/resource_overrides.rb
+++ b/provider/resource_overrides.rb
@@ -102,7 +102,7 @@ module Provider
         api_property = find_property api_object, property_path.split('.')
         if api_property.nil?
           raise "The property to override must exists #{property_path} " \
-              "in resource #{name}"
+              "in resource #{api_object.name}"
         end
 
         property_override.apply api_property

--- a/provider/resource_overrides.rb
+++ b/provider/resource_overrides.rb
@@ -91,18 +91,21 @@ module Provider
         raise "The resource to override must exist #{name}" if api_object.nil?
         check_property_value 'overrides', override, Provider::ResourceOverride
         override.apply api_object
+        override_properties api_object, override
+      end
+    end
 
-        override.properties.each do |property_path, property_override|
-          check_property_value "properties['#{property_path}']",
-                               property_override, Provider::PropertyOverride
-          api_property = find_property api_object, property_path.split('.')
-          if api_property.nil?
-            raise "The property to override must exists #{property_path} " \
+    def override_properties(api_object, override)
+      override.properties.each do |property_path, property_override|
+        check_property_value "properties['#{property_path}']",
+                             property_override, Provider::PropertyOverride
+        api_property = find_property api_object, property_path.split('.')
+        if api_property.nil?
+          raise "The property to override must exists #{property_path} " \
               "in resource #{name}"
-          end
-
-          property_override.apply api_property
         end
+
+        property_override.apply api_property
       end
     end
 

--- a/provider/resource_overrides.rb
+++ b/provider/resource_overrides.rb
@@ -15,19 +15,18 @@ require 'api/object'
 require 'provider/resource_override'
 
 module Provider
-  # A hash of Provider::Override objects where the key is the api name for that
-  # object.
+  # A hash of Provider::ResourceOverride objects where the key is the api name
+  # for that object.
   #
   # Example usage in a provider.yaml file where you want to extend a resource
   # description:
   #
   # overrides: !ruby/object:Provider::ResourceOverrides
-  #   SomeResource:
-  #     !ruby/object:Provider::MyProvider::Override
-  #     description: |
-  #       {{ description}}
-  #
-  #       A tool-specific description complement
+  #   SomeResource: !ruby/object:Provider::MyProvider::ResourceOverride
+  #     description: '{{description}} A tool-specific description complement'
+  #     properties:
+  #       someProperty: !ruby/object:Provider::MyProvider::PropertyOverride
+  #         description: 'foobar' # replaces description
   #   ...
   class ResourceOverrides < Api::Object
     def consume_api(api)
@@ -91,6 +90,46 @@ module Provider
         raise "The resource to override must exist #{name}" if api_object.nil?
         check_property_value 'overrides', override, Provider::ResourceOverride
         override.apply api_object
+
+        override.properties.each do |property_path, property_override|
+          api_property = find_property api_object, property_path.split('.')
+          if api_property.nil?
+            raise "The property to override must exists #{property_path} " \
+              "in resource #{name}"
+          end
+
+          property_override.apply api_property
+        end
+      end
+    end
+
+    def find_property(api_entity, property_path)
+      property_name = property_path[0]
+      Google::LOGGER.info "find_property entity #{api_entity}"
+      Google::LOGGER.info "find_property property_name #{property_name}"
+      properties = get_properties api_entity
+      return nil if properties.nil?
+
+      Google::LOGGER.info "find_property properties #{properties}"
+
+      api_property = properties.find { |p| p.name == property_name }
+      return nil if api_property.nil?
+
+      property_path.shift
+      if property_path.empty?
+        api_property
+      else
+        find_property api_property, property_path
+      end
+    end
+
+    def get_properties(api_entity)
+      if api_entity.is_a?(Api::Resource) ||
+         api_entity.is_a?(Api::Type::NestedObject)
+        api_entity.properties
+      elsif api_entity.is_a?(Api::Type::Array) &&
+            api_entity.item_type.is_a?(Api::Type::NestedObject)
+        api_entity.item_type.properties
       end
     end
   end

--- a/provider/resource_overrides.rb
+++ b/provider/resource_overrides.rb
@@ -108,17 +108,11 @@ module Provider
 
     def find_property(api_entity, property_path)
       property_name = property_path[0]
-      Google::LOGGER.info "find_property entity #{api_entity}"
-      Google::LOGGER.info "find_property property_name #{property_name}"
       properties = get_properties api_entity
       return nil if properties.nil?
 
-      Google::LOGGER.info "find_property properties #{properties}"
-
       api_property = properties.find { |p| p.name == property_name }
       return nil if api_property.nil?
-
-      Google::LOGGER.info "find_property api_property #{api_property}"
 
       property_path.shift
       if property_path.empty?

--- a/provider/resource_overrides.rb
+++ b/provider/resource_overrides.rb
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 require 'api/object'
+require 'provider/property_override'
 require 'provider/resource_override'
 
 module Provider
@@ -92,6 +93,8 @@ module Provider
         override.apply api_object
 
         override.properties.each do |property_path, property_override|
+          check_property_value "properties['#{property_path}']",
+                               property_override, Provider::PropertyOverride
           api_property = find_property api_object, property_path.split('.')
           if api_property.nil?
             raise "The property to override must exists #{property_path} " \
@@ -114,6 +117,8 @@ module Provider
 
       api_property = properties.find { |p| p.name == property_name }
       return nil if api_property.nil?
+
+      Google::LOGGER.info "find_property api_property #{api_property}"
 
       property_path.shift
       if property_path.empty?

--- a/provider/resource_overrides.rb
+++ b/provider/resource_overrides.rb
@@ -28,6 +28,9 @@ module Provider
   #     properties:
   #       someProperty: !ruby/object:Provider::MyProvider::PropertyOverride
   #         description: 'foobar' # replaces description
+  #       anotherProperty.someNestedProperty:
+  #         !ruby/object:Provider::MyProvider::PropertyOverride
+  #         description: 'baz'
   #   ...
   class ResourceOverrides < Api::Object
     def consume_api(api)

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -99,21 +99,19 @@ module Provider
     end
 
     # Returns the resource properties without those ignored.
-    def effective_properties(config, properties)
-      properties.reject do |p|
-        config['ignore']&.include?(construct_property_key(p))
-      end
+    def effective_properties(properties)
+      properties.reject { |p| p.exclude }
     end
 
     # Returns the nested properties without those ignored. An empty list is
     # returned if the property is not a NestedObject or an Array of
     # NestedObjects.
-    def effective_nested_properties(config, property)
+    def effective_nested_properties(property)
       if property.is_a?(Api::Type::NestedObject)
-        effective_properties(config, property.properties)
+        effective_properties(property.properties)
       elsif property.is_a?(Api::Type::Array) &&
             property.item_type.is_a?(Api::Type::NestedObject)
-        effective_properties(config, property.item_type.properties)
+        effective_properties(property.item_type.properties)
       else
         []
       end

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -119,22 +119,6 @@ module Provider
 
     private
 
-    # Constructs the key uniquely identifying a property for a given resource.
-    #
-    # The key can take one of these formats:
-    # - 'foo': Top-level property 'foo'
-    # - 'foo.bar': Property 'bar' nested under property 'foo'
-    # - 'foo.*.bar': Property 'bar' of all nested objects in list 'foo'
-    def construct_property_key(property)
-      return property.name if property.parent.nil?
-
-      if property.parent.is_a?(Api::Type::Array)
-        construct_property_key(property.parent) + '.*'
-      else
-        construct_property_key(property.parent) + '.' + property.name
-      end
-    end
-
     # This function uses the resource.erb template to create one file
     # per resource. The resource.erb template forms the basis of a single
     # GCP Resource on Terraform.

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -14,6 +14,7 @@
 require 'provider/abstract_core'
 require 'provider/terraform/config'
 require 'provider/terraform/import'
+require 'provider/terraform/property_override'
 require 'provider/terraform/resource_override'
 require 'provider/terraform/sub_template'
 require 'google/golang_utils'

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -100,7 +100,7 @@ module Provider
 
     # Returns the resource properties without those ignored.
     def effective_properties(properties)
-      properties.reject { |p| p.exclude }
+      properties.reject(&:exclude)
     end
 
     # Returns the nested properties without those ignored. An empty list is

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -20,15 +20,11 @@ module Provider
     # Collection of fields allowed in the PropertyOverride section for
     # Terraform. All fields should be `attr_reader :<property>`
     module OverrideFields
-      attr_reader :exclude
-      # Adds a DiffSuppressFunc to the schema
-      attr_reader :diff_suppress_func
-      # TODO(rosbo): Consider sharing this functionality with the other tools.
-      attr_reader :default_value
-      # Adds `Sensitive: true` to the schema
-      attr_reader :sensitive
-      # Adds a ValidateFunc to the schema
-      attr_reader :validation
+      attr_reader :exclude # TODO(rosbo): Consider moving this to base
+      attr_reader :diff_suppress_func # Adds a DiffSuppressFunc to the schema
+      attr_reader :default_value # TODO(rosbo): Consider moving this to base
+      attr_reader :sensitive # Adds `Sensitive: true` to the schema
+      attr_reader :validation # Adds a ValidateFunc to the schema
     end
 
     # Support for schema ValidateFunc functionality.

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -21,6 +21,8 @@ module Provider
     # Terraform. All fields should be `attr_reader :<property>`
     module OverrideFields
       attr_reader :exclude
+      # Adds a DiffSuppressFunc to the schema field with the given name
+      attr_reader :diff_suppress_func
 
       attr_reader :validation
     end
@@ -49,6 +51,8 @@ module Provider
         @exclude ||= false # sets to false if nil
 
         check_property :exclude, :boolean
+
+        check_optional_property :diff_suppress_func, String
         check_optional_property :validation, Provider::Terraform::Validation
       end
 

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -21,15 +21,17 @@ module Provider
     # Terraform. All fields should be `attr_reader :<property>`
     module OverrideFields
       attr_reader :exclude
-      # Adds a DiffSuppressFunc to the schema field with the given name
+      # Adds a DiffSuppressFunc to the schema
       attr_reader :diff_suppress_func
-      # TODO: Consider sharing this functionality
+      # TODO(rosbo): Consider sharing this functionality with the other tools.
       attr_reader :default_value
-
+      # Adds `Sensitive: true` to the schema
+      attr_reader :sensitive
+      # Adds a ValidateFunc to the schema
       attr_reader :validation
     end
 
-    # Adds a ValidateFunc to the schema field.
+    # Support for schema ValidateFunc functionality.
     class Validation < Api::Object
       # Ensures the value matches this regex
       attr_reader :regex
@@ -50,9 +52,12 @@ module Provider
       def validate
         super
 
-        @exclude ||= false # sets to false if nil
+        # Ensures boolean values are set to false if nil
+        @exclude ||= false
+        @sensitive ||= false
 
         check_property :exclude, :boolean
+        check_property :sensitive, :boolean
 
         check_optional_property :diff_suppress_func, String
         check_optional_property :validation, Provider::Terraform::Validation

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -1,0 +1,54 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'provider/abstract_core'
+require 'provider/property_override'
+
+module Provider
+  class Terraform < Provider::AbstractCore
+    # Collection of fields allowed in the PropertyOverride section for
+    # Terraform. All fields should be `attr_reader :<property>`
+    module OverrideFields
+      # Terraform uses this regex of this field must match this regex.
+      attr_reader :validation_regex
+    end
+
+    # Terraform-specific overrides to api.yaml.
+    class PropertyOverride < Provider::PropertyOverride
+      include OverrideFields
+
+      def apply(property)
+        unless description.nil?
+          @description = format_string(:description, @description,
+                                       property.description)
+        end
+
+        super
+      end
+
+      def overriden
+        Provider::Terraform::OverrideFields
+      end
+
+      # Formats the string and potentially uses its old value as part of the new
+      # value. The marker should be in the form `{{name}}` where `name` is the
+      # field being formatted.
+      #
+      # Note: This function only supports the variable with the same name as the
+      # property being updated.
+      def format_string(name, mask, current_value)
+        mask.gsub "{{#{name.id2name}}}", current_value
+      end
+    end
+  end
+end

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -20,6 +20,8 @@ module Provider
     # Collection of fields allowed in the PropertyOverride section for
     # Terraform. All fields should be `attr_reader :<property>`
     module OverrideFields
+      attr_reader :exclude
+
       attr_reader :validation
     end
 
@@ -44,6 +46,9 @@ module Provider
       def validate
         super
 
+        @exclude ||= false # sets to false if nil
+
+        check_property :exclude, :boolean
         check_optional_property :validation, Provider::Terraform::Validation
       end
 

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -100,7 +100,8 @@ module Provider
         elsif api_property.is_a?(Api::Type::Integer)
           clazz = Integer
         else
-          raise "Update 'check_default_value_property' method to support default value for type #{api_property.class}"
+          raise "Update 'check_default_value_property' method to support " \
+                "default value for type #{api_property.class}"
         end
 
         check_optional_property :default_value, clazz

--- a/provider/terraform/sub_template.rb
+++ b/provider/terraform/sub_template.rb
@@ -17,42 +17,37 @@ module Provider
   class Terraform < Provider::AbstractCore
     # Functions to compile sub-templates.
     module SubTemplate
-      def build_schema_property(config, property, object)
+      def build_schema_property(property, object)
         compile_template'templates/terraform/schema_property.erb',
                         property: property,
-                        config: config,
                         object: object
       end
 
       # Transforms a Cloud API representation of a property into a Terraform
       # schema representation.
-      def build_flatten_method(config, prefix, property)
+      def build_flatten_method(prefix, property)
         compile_template 'templates/terraform/flatten_property_method.erb',
                          prefix: prefix,
-                         property: property,
-                         config: config
+                         property: property
       end
 
       # Transforms a Terraform schema representation of a property into a
       # representation used by the Cloud API.
-      def build_expand_method(config, prefix, property)
+      def build_expand_method(prefix, property)
         compile_template 'templates/terraform/expand_property_method.erb',
                          prefix: prefix,
-                         property: property,
-                         config: config
+                         property: property
       end
 
-      def build_property_documentation(config, property)
+      def build_property_documentation(property)
         compile_template 'templates/terraform/property_documentation.erb',
-                         property: property,
-                         config: config
+                         property: property
       end
 
-      def build_nested_property_documentation(config, property)
+      def build_nested_property_documentation(property)
         compile_template(
           'templates/terraform/nested_property_documentation.erb',
-          property: property,
-          config: config
+          property: property
         )
       end
 

--- a/spec/data/good-file.yaml
+++ b/spec/data/good-file.yaml
@@ -68,3 +68,18 @@ objects:
           - :value1
           - 'value2'
           - 3
+      - !ruby/object:Api::Type::NestedObject
+         name: 'nested-property'
+         description: 'a nested object property'
+         properties:
+           - !ruby/object:Api::Type::String
+             name: 'property1'
+             description: 'a nested property'
+      - !ruby/object:Api::Type::Array
+        name: 'array-property'
+        description: 'an array of nested object property'
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+             name: 'property1'
+             description: 'a nested property'

--- a/spec/data/good-resource-overrides.yaml
+++ b/spec/data/good-resource-overrides.yaml
@@ -1,0 +1,10 @@
+!ruby/object:Provider::ResourceOverrides
+AnotherResource: !ruby/object:Provider::Terraform::ResourceOverride
+  description: '{{description}} bar'
+  properties:
+    property1: !ruby/object:Provider::Terraform::PropertyOverride
+      description: 'foo'
+    nested-property.property1: !ruby/object:Provider::Terraform::PropertyOverride
+      description: 'bar'
+    array-property.property1: !ruby/object:Provider::Terraform::PropertyOverride
+      description: 'baz'

--- a/spec/provider_resource_overrides_spec.rb
+++ b/spec/provider_resource_overrides_spec.rb
@@ -1,0 +1,145 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+class File
+  class << self
+    alias real_open open
+    alias real_read read
+  end
+end
+
+describe Provider::ResourceOverrides do
+  context 'good file product' do
+    let(:product) { Api::Compiler.new('spec/data/good-file.yaml').run }
+
+    before do
+      allow_open 'spec/data/good-file.yaml'
+      allow_open 'spec/data/good-resource-overrides.yaml'
+
+      product.validate
+    end
+
+    context 'with resource with overrides' do
+      let(:overrides) do
+        Provider::ResourceOverride.parse(
+          IO.read('spec/data/good-resource-overrides.yaml')
+        )
+      end
+
+      before do
+        overrides.consume_api(product)
+        overrides.validate
+      end
+
+      subject(:resource) do
+        product.objects.find { |o| o.name == 'AnotherResource' }
+      end
+
+      it 'overrides resource description' do
+        expect(resource.description).to eq 'blah blah bar'
+      end
+
+      it 'overrides property description' do
+        property = resource.properties.find { |p| p.name == 'property1' }
+        expect(property.description).to eq 'foo'
+      end
+
+      it 'overrides nested property description' do
+        property = resource.properties.find { |p| p.name == 'nested-property' }
+        nested_property = property.properties.find do |p|
+          p.name == 'property1'
+        end
+        expect(nested_property.description).to eq 'bar'
+      end
+
+      it 'overrides array of nested property description' do
+        property = resource.properties.find { |p| p.name == 'array-property' }
+        nested_property = property.item_type.properties.find do |p|
+          p.name == 'property1'
+        end
+        expect(nested_property.description).to eq 'baz'
+      end
+    end
+
+    context 'with resource with invalid property path' do
+      context 'referring to missing top-level property' do
+        subject { -> { create_overrides(product, 'missing-property') } }
+
+        it { is_expected.to raise_error StandardError, /missing-property/ }
+      end
+
+      context 'referring to missing nested property' do
+        subject do
+          -> { create_overrides(product, 'nested-property.missing-property') }
+        end
+
+        it do
+          is_expected.to raise_error(
+            StandardError,
+            /nested-property.missing-property/
+          )
+        end
+      end
+
+      context 'referring to missing array nested property' do
+        subject do
+          -> { create_overrides(product, 'array-property.missing-property') }
+        end
+
+        it do
+          is_expected.to raise_error(
+            StandardError,
+            /array-property.missing-property/
+          )
+        end
+      end
+
+      context 'referring to a nested property in non-nested type' do
+        subject do
+          -> { create_overrides(product, 'property1.missing-property') }
+        end
+
+        it do
+          is_expected.to raise_error(
+            StandardError,
+            /property1.missing-property/
+          )
+        end
+      end
+    end
+  end
+
+  def create_overrides(product, property_path)
+    overrides = Google::YamlValidator.parse(
+      %(
+      !ruby/object:Provider::ResourceOverrides
+      AnotherResource: !ruby/object:Provider::Terraform::ResourceOverride
+        properties:
+          #{property_path}: !ruby/object:Provider::Terraform::PropertyOverride
+            description: foobar
+      )
+    )
+
+    overrides.consume_api(product)
+    overrides.validate
+
+    overrides
+  end
+
+  def allow_open(file_name)
+    IO.expects(:read).with(file_name).returns(File.real_read(file_name))
+      .at_least(0)
+  end
+end

--- a/templates/terraform/expand_property_method.erb
+++ b/templates/terraform/expand_property_method.erb
@@ -45,7 +45,7 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) int
   return req
 }
   <% nested_properties.each do |prop| -%>
-    <%= lines(build_expand_method(config, prefix + titlelize_property(property), prop), 1) -%>
+    <%= lines(build_expand_method(prefix + titlelize_property(property), prop), 1) -%>
   <% end -%>
 <% else -%>
   return v

--- a/templates/terraform/expand_property_method.erb
+++ b/templates/terraform/expand_property_method.erb
@@ -26,8 +26,8 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) map
 <% elsif tf_types.include?(property.class) -%>
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) interface{} {
 <%
-  if !effective_nested_properties(config, property).empty?
-    nested_properties = effective_nested_properties(config, property)
+  if !effective_nested_properties(property).empty?
+    nested_properties = effective_nested_properties(property)
 -%>
   l := v.([]interface{})
   req := make([]interface{}, 0, len(l))

--- a/templates/terraform/flatten_property_method.erb
+++ b/templates/terraform/flatten_property_method.erb
@@ -17,7 +17,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) in
 <% if property.is_a?(Api::Type::NestedObject) -%>
   original := v.(map[string]interface{})
   transformed := make(map[string]interface{})
-  <% effective_properties(config, property.properties).each do |prop| -%>
+  <% effective_properties(property.properties).each do |prop| -%>
     transformed["<%= Google::StringUtils.underscore(prop.name) -%>"] =
     flatten<%= prefix -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(original["<%= prop.name -%>"])
   <% end -%>
@@ -28,7 +28,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) in
   for _, raw := range l {
     original := raw.(map[string]interface{})
     transformed = append(transformed, map[string]interface{}{
-    <% effective_properties(config, property.item_type.properties).each do |prop| -%>
+    <% effective_properties(property.item_type.properties).each do |prop| -%>
       "<%= Google::StringUtils.underscore(prop.name) -%>": flatten<%= prefix -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(original["<%= prop.name -%>"]),
     <% end -%>
     })
@@ -38,8 +38,8 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) in
   return v
 <% end # property.is_a?(Api::Type::NestedObject) -%>
 }
-<% if !effective_nested_properties(config, property).empty? -%>
-  <% effective_nested_properties(config, property).each do |prop| -%>
+<% if !effective_nested_properties(property).empty? -%>
+  <% effective_nested_properties(property).each do |prop| -%>
     <%= lines(build_flatten_method(config, prefix + titlelize_property(property), prop), 1) -%>
   <% end -%>
 <% end -%>

--- a/templates/terraform/flatten_property_method.erb
+++ b/templates/terraform/flatten_property_method.erb
@@ -40,7 +40,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) in
 }
 <% if !effective_nested_properties(property).empty? -%>
   <% effective_nested_properties(property).each do |prop| -%>
-    <%= lines(build_flatten_method(config, prefix + titlelize_property(property), prop), 1) -%>
+    <%= lines(build_flatten_method(prefix + titlelize_property(property), prop), 1) -%>
   <% end -%>
 <% end -%>
 <% else -%>

--- a/templates/terraform/nested_property_documentation.erb
+++ b/templates/terraform/nested_property_documentation.erb
@@ -4,9 +4,9 @@
 -%>
 The `<%= Google::StringUtils.underscore(property.name) -%>` block <%= if property.output then "contains" else "supports" end -%>:
 <% nested_properties.each do |prop| -%>
-<%= build_property_documentation(config, prop) -%>
+<%= build_property_documentation(prop) -%>
 <% end -%>
 <% nested_properties.each do |prop| -%>
-  <%= build_nested_property_documentation(config, prop) -%>
+  <%= build_nested_property_documentation(prop) -%>
 <% end -%>
 <% end -%>

--- a/templates/terraform/nested_property_documentation.erb
+++ b/templates/terraform/nested_property_documentation.erb
@@ -1,5 +1,5 @@
 <%
-  nested_properties = effective_nested_properties(config, property)
+  nested_properties = effective_nested_properties(property)
   if !nested_properties.empty?
 -%>
 The `<%= Google::StringUtils.underscore(property.name) -%>` block <%= if property.output then "contains" else "supports" end -%>:

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -18,7 +18,7 @@ package google
 
 <%
   resource_name = product_ns + object.name
-  properties = effective_properties(config, object.all_user_properties)
+  properties = effective_properties(object.all_user_properties)
   settable_properties = properties.reject(&:output)
   api_name_lower = String.new(product_ns)
   api_name_lower[0] = api_name_lower[0].downcase

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -47,7 +47,7 @@ func resource<%= resource_name -%>() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 <% order_properties(properties).each do |prop| -%>
-	<%= lines(build_schema_property(config, prop, object)) -%>
+	<%= lines(build_schema_property(prop, object)) -%>
 <% end -%>
 <% if object.base_url.include?("{{project}}") -%>
 			"project": &schema.Schema{
@@ -279,9 +279,9 @@ func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{
 }
 
 <% properties.each do |prop| -%>
-<%= lines(build_flatten_method(config, resource_name, prop), 1) -%>
+<%= lines(build_flatten_method(resource_name, prop), 1) -%>
 <% end -%>
 
 <% settable_properties.each do |prop| -%>
-<%= lines(build_expand_method(config, resource_name, prop), 1) -%>
+<%= lines(build_expand_method(resource_name, prop), 1) -%>
 <% end -%>

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -56,17 +56,17 @@ To get more information about <%= object.name -%>, see:
 The following arguments are supported:
 
 <% properties.select(&:required).each do |prop| -%>
-<%= lines(build_property_documentation(config, prop)) -%>
+<%= lines(build_property_documentation(prop)) -%>
 <% end -%>
 
 <% properties.select(&:required).each do |prop| -%>
-<%= lines(build_nested_property_documentation(config, prop)) -%>
+<%= lines(build_nested_property_documentation(prop)) -%>
 <% end -%>
 
 - - -
 
 <% properties.reject(&:required).reject(&:output).each do |prop| -%>
-<%= lines(build_property_documentation(config, prop)) -%>
+<%= lines(build_property_documentation(prop)) -%>
 <% end -%>
 <% if object.base_url.include?("{{project}}") -%>
 * `project` (Optional) The ID of the project in which the resource belongs.
@@ -74,7 +74,7 @@ The following arguments are supported:
 <% end -%>
 
 <% properties.reject(&:required).reject(&:output).each do |prop| -%>
-<%= lines(build_nested_property_documentation(config, prop)) -%>
+<%= lines(build_nested_property_documentation(prop)) -%>
 <% end -%>
 
 ## Attributes Reference
@@ -82,14 +82,14 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are exported:
 
 <% properties.select(&:output).each do |prop| -%>
-<%= lines(build_property_documentation(config, prop)) -%>
+<%= lines(build_property_documentation(prop)) -%>
 <% end -%>
 <% if (object.exports || []).any? { |e| e.is_a?(Api::Type::SelfLink)} -%>
 * `self_link` - The URI of the created resource.
 <% end -%>
 
 <% properties.select(&:output).each do |prop| -%>
-<%= lines(build_nested_property_documentation(config, prop)) -%>
+<%= lines(build_nested_property_documentation(prop)) -%>
 <% end -%>
 
 ## Timeouts

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -16,7 +16,7 @@
 <%
   api_name_lower = product_ns.downcase
   resource_name = Google::StringUtils.underscore(object.name)
-  properties = effective_properties(config, object.all_user_properties)
+  properties = effective_properties(object.all_user_properties)
 -%>
 
 ---

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -74,7 +74,7 @@
     // but this map is marked as being <%= property.key_type -%>-><%= property.value_type -%>.
   <% end -%>
 <% end -%>
-<% if config['sensitive']&.include?(property.name) -%>
+<% if property.sensitive -%>
     Sensitive: true,
 <% end -%>
 <% unless property.default_value.nil? -%>

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -13,7 +13,6 @@
   # limitations under the License.
 <% end -%>
 <% if tf_types.include?(property.class) -%>
-<% property_key = construct_property_key(property) -%>
 "<%= Google::StringUtils.underscore(property.name) -%>": {
   Type: <%= tf_types[property.class] %>,
 <% if property.required -%>
@@ -39,7 +38,7 @@
   Elem: &schema.Resource{
     Schema: map[string]*schema.Schema{
       <% order_properties(effective_properties(property.properties)).each do |prop| -%>
-        <%= lines(build_schema_property(config, prop, object)) -%>
+        <%= lines(build_schema_property(prop, object)) -%>
       <% end -%>
     },
   },
@@ -48,7 +47,7 @@
       Elem: &schema.Resource{
         Schema: map[string]*schema.Schema{
           <% order_properties(effective_properties(property.item_type.properties)).each do |prop| -%>
-            <%= lines(build_schema_property(config, prop, object)) -%>
+            <%= lines(build_schema_property(prop, object)) -%>
           <% end -%>
         },
       },

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -77,9 +77,8 @@
 <% if config['sensitive']&.include?(property.name) -%>
     Sensitive: true,
 <% end -%>
-<% default_values = config['default_values'] -%>
-<% if default_values&.include?(property_key) -%>
-    Default: <%= go_literal(default_values[property_key]) -%>,
+<% unless property.default_value.nil? -%>
+    Default: <%= go_literal(property.default_value) -%>,
 <% end -%>
 },
 <% else -%>

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -26,9 +26,8 @@
 <% if force_new?(property, object) -%>
   ForceNew: true,
 <% end -%>
-<% validate_fns = config['validation'] -%>
-<% if validate_fns&.key?(property_key) -%>
-  ValidateFunc: validateRegexp(`<%= validate_fns[property_key] -%>`),
+<% unless property.validation.nil? || property.validation.regex.nil? -%>
+  ValidateFunc: validateRegexp(`<%= property.validation.regex -%>`),
 <% end -%>
 <% diff_suppress_fns = config['diff_suppress_funcs'] -%>
 <% if diff_suppress_fns&.key?(property_key) -%>

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -29,9 +29,8 @@
 <% unless property.validation.nil? || property.validation.regex.nil? -%>
   ValidateFunc: validateRegexp(`<%= property.validation.regex -%>`),
 <% end -%>
-<% diff_suppress_fns = config['diff_suppress_funcs'] -%>
-<% if diff_suppress_fns&.key?(property_key) -%>
-  DiffSuppressFunc: <%= diff_suppress_fns[property_key] %>,
+<% if !property.diff_suppress_func.nil? -%>
+  DiffSuppressFunc: <%= property.diff_suppress_func %>,
 <% elsif property.is_a?(Api::Type::ResourceRef) -%>
   DiffSuppressFunc: compareSelfLinkOrResourceName,
 <% end -%>

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -39,7 +39,7 @@
   MaxItems: 1,
   Elem: &schema.Resource{
     Schema: map[string]*schema.Schema{
-      <% order_properties(effective_properties(config, property.properties)).each do |prop| -%>
+      <% order_properties(effective_properties(property.properties)).each do |prop| -%>
         <%= lines(build_schema_property(config, prop, object)) -%>
       <% end -%>
     },
@@ -48,7 +48,7 @@
   <% if property.item_type.is_a?(Api::Type::NestedObject) -%>
       Elem: &schema.Resource{
         Schema: map[string]*schema.Schema{
-          <% order_properties(effective_properties(config, property.item_type.properties)).each do |prop| -%>
+          <% order_properties(effective_properties(property.item_type.properties)).each do |prop| -%>
             <%= lines(build_schema_property(config, prop, object)) -%>
           <% end -%>
         },


### PR DESCRIPTION
Completes #47 for Terraform.

Allows overriding top-level and nested properties.

I considered support property overrides at the end type level (Boolean, Integer, String, NestedObject and so on), however, this would have created a lot of complexities and this simpler model is flexible enough for all Terraform use cases. Let me know if you think it won't work for the other tools.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-compute]
## [chef]
