### PR TITLE
Enables automatic copy of overridden properties.

### DIFF
--- a/api/resource.rb
+++ b/api/resource.rb
@@ -18,27 +18,33 @@ module Api
   # An object available in the product
   # rubocop:disable Metrics/ClassLength
   class Resource < Api::Object::Named
-    attr_reader :description
-    attr_reader :kind
-    attr_reader :base_url
-    attr_reader :self_link
-    attr_reader :self_link_query
-    # identity: an array with items that uniquely identify the resource.
-    # default=name
-    attr_reader :identity
-    attr_reader :parameters
-    attr_reader :properties
-    attr_reader :exclude
-    attr_reader :virtual
-    attr_reader :async
-    attr_reader :readonly
-    attr_reader :exports
-    attr_reader :label_override
-    attr_reader :transport
-    attr_reader :references
-    attr_reader :create_verb
-    attr_reader :update_verb
-    attr_reader :input # If true, the resource is not updatable as a whole unit
+    # The list of properties (attr_reader) that can be overriden in
+    # <provider>.yaml.
+    module Properties
+      attr_reader :description
+      attr_reader :kind
+      attr_reader :base_url
+      attr_reader :self_link
+      attr_reader :self_link_query
+      # identity: an array with items that uniquely identify the resource.
+      # default=name
+      attr_reader :identity
+      attr_reader :parameters
+      attr_reader :properties
+      attr_reader :exclude
+      attr_reader :virtual
+      attr_reader :async
+      attr_reader :readonly
+      attr_reader :exports
+      attr_reader :label_override
+      attr_reader :transport
+      attr_reader :references
+      attr_reader :create_verb
+      attr_reader :update_verb
+      attr_reader :input # If true, resource is not updatable as a whole unit
+    end
+
+    include Properties
 
     attr_reader :__product
 

--- a/provider/terraform/resource_override.rb
+++ b/provider/terraform/resource_override.rb
@@ -16,9 +16,40 @@ require 'provider/resource_override'
 
 module Provider
   class Terraform < Provider::AbstractCore
-    # Terraform-specific overrides to api.yaml.
+    # Collection of properties allowed in the ResourceOverride section for
+    # Terraform. All properties should be `attr_reader :<property>`
+    module OverrideProperties
+    end
+
+    # A class to control overridden properties on terraform.yaml in lieu of
+    # values from api.yaml.
     class ResourceOverride < Provider::ResourceOverride
-      # TODO: Add Terraform specific properties here.
+      include OverrideProperties
+
+      def apply(resource)
+        unless description.nil?
+          @description = format_string(:description, @description,
+                                       resource.description)
+        end
+
+        super
+      end
+
+      private
+
+      def overriden
+        Provider::Terraform::OverrideProperties
+      end
+
+      # Formats the string and potentially uses its old value as part of the new
+      # value. The marker should be in the form `{{name}}` where `name` is the
+      # field being formatted.
+      #
+      # Note: This function only supports the variable with the same name as the
+      # property being updated.
+      def format_string(name, mask, current_value)
+        mask.gsub "{{#{name.id2name}}}", current_value
+      end
     end
   end
 end


### PR DESCRIPTION
Improves upon the resource override strategy;

1) enables all properties available in Api::Resource to be referenced from Provider::Transport
2) automatically copies all properties overriden in provider.yaml
3) keeps the ability to perform custom actions during apply process

This PR is in Terraform only (no side effects) and a following PR for Puppet will come later (where we'll move from objects: to overrides: in puppet.yaml)