### PR TITLE
Port compute/puppet to new strong-typed overrides.

### DIFF
--- a/api/resource.rb
+++ b/api/resource.rb
@@ -182,7 +182,6 @@ module Api
       [@__product.prefix, Google::StringUtils.underscore(@name)].join('_')
     end
 
-    # rubocop:disable Lint/DuplicateMethods
     def identity
       props = all_user_properties
       if @identity.nil?
@@ -191,7 +190,6 @@ module Api
         props.select { |p| @identity.include?(p.name) }
       end
     end
-    # rubocop:enable Lint/DuplicateMethods
 
     # 'identity' is already taken by Ruby.
     def __identity

--- a/products/compute/puppet.yaml
+++ b/products/compute/puppet.yaml
@@ -33,73 +33,75 @@ manifest: !ruby/object:Provider::Puppet::Manifest
 <%= indent(include('provider/puppet/common~operating_systems.yaml'), 4) %>
 # TODO(nelsonjr): Match all special behavior Puppet <=> Chef.
 # TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/47): Migrate objects to overrides
-objects: !ruby/object:Api::Resource::HashArray
-  BackendService:
-    # TODO(alexstephen): Document the access_api_results field.
-    access_api_results: true
-    resource_to_request_patch: |
-      unless @fetched.nil?
-        # Convert to pure JSON
-        request = JSON.parse(request.to_json)
-        request['fingerprint'] = @fetched['fingerprint']
-      end
-  Disk:
+overrides: !ruby/object:Provider::ResourceOverrides
+  BackendService: !ruby/object:Provider::Puppet::ResourceOverride
+    handlers: !ruby/object:Provider::Puppet::Handlers
+      resource_to_request_patch: |
+        unless @fetched.nil?
+          # Convert to pure JSON
+          request = JSON.parse(request.to_json)
+          request['fingerprint'] = @fetched['fingerprint']
+        end
+  Disk: !ruby/object:Provider::Puppet::ResourceOverride
     # TODO(nelsonjr): Implement specific actions, such as resize and setLabels.
-    flush: raise 'Disk cannot be edited'
-  DiskType:
+    handlers: !ruby/object:Provider::Puppet::Handlers
+      flush: raise 'Disk cannot be edited'
+  DiskType: !ruby/object:Provider::Puppet::ResourceOverride
     # TODO(nelsonjr): Make sure that attempts to create a disk fails
-    flush: |
-      raise [
-        'DiskType requirements specified in the manifest do not match',
-        "values provided by Google Cloud Platform: #{dirty_display_formatted}"
-      ].join(' ')
+    handlers: !ruby/object:Provider::Puppet::Handlers
+      flush: |
+        raise [
+          'DiskType requirements specified in the manifest do not match',
+          "values provided by Google Cloud Platform: #{dirty_display_formatted}"
+        ].join(' ')
     provider_helpers:
-      include:
-        - 'products/compute/helpers/provider_disk_type.rb'
-  Instance:
+      - 'products/compute/helpers/provider_disk_type.rb'
+  Instance: !ruby/object:Provider::Puppet::ResourceOverride
     provider_helpers:
-      include:
-        - 'products/compute/helpers/provider_instance.rb'
-        - 'products/compute/helpers/instance_metadata.rb'
-  InstanceGroup:
+      - 'products/compute/helpers/provider_instance.rb'
+      - 'products/compute/helpers/instance_metadata.rb'
+  InstanceGroup: !ruby/object:Provider::Puppet::ResourceOverride
     # TODO(nelsonjr): Implement specific actions, such as addInstance and
     # setNamedPorts.
-    flush: raise 'InstanceGroup cannot be edited.'
-  InstanceTemplate:
+    handlers: !ruby/object:Provider::Puppet::Handlers
+      flush: raise 'InstanceGroup cannot be edited.'
+  InstanceTemplate: !ruby/object:Provider::Puppet::ResourceOverride
     provider_helpers:
-      include:
-        - 'products/compute/helpers/provider_instance_template.rb'
-        - 'products/compute/helpers/instance_metadata.rb'
-  Network:
-    flush: |
-      unless @dirty.keys == [:auto_create_subnetworks]
-        raise ['Network specification mismatch and cannot be edited.',
-               'The only allowed change is from Auto to Custom type.'].join(' ')
-      end
-      handle_auto_to_custom_change
+      - 'products/compute/helpers/provider_instance_template.rb'
+      - 'products/compute/helpers/instance_metadata.rb'
+  Network: !ruby/object:Provider::Puppet::ResourceOverride
+    handlers: !ruby/object:Provider::Puppet::Handlers
+      flush: |
+        unless @dirty.keys == [:auto_create_subnetworks]
+          raise [
+            'Network specification mismatch and cannot be edited.',
+            'The only allowed change is from Auto to Custom type.'
+          ].join(' ')
+        end
+        handle_auto_to_custom_change
     provider_helpers:
-      include:
-        - 'products/compute/helpers/provider_network.rb'
-  Snapshot:
+      - 'products/compute/helpers/provider_network.rb'
+  Snapshot: !ruby/object:Provider::Puppet::ResourceOverride
+    handlers: !ruby/object:Provider::Puppet::Handlers
+      create: |
+        disk = Google::Compute::Api::Disk.new(resource[:source].resource,
+                                              resource[:zone].resource,
+                                              resource[:project],
+                                              fetch_auth(resource))
+        # TODO(nelsonjr): Wait for operation to complete
+        disk.snapshot(
+          resource[:name],
+          Google::HashUtils.symbolize_keys(JSON.parse(resource_to_request))
+        )
     requires:
       - google/compute/api/gcompute_disk
-    create: |
-      disk = Google::Compute::Api::Disk.new(resource[:source].resource,
-                                            resource[:zone].resource,
-                                            resource[:project],
-                                            fetch_auth(resource))
-      # TODO(nelsonjr): Wait for operation to complete
-      disk.snapshot(
-        resource[:name],
-        Google::HashUtils.symbolize_keys(JSON.parse(resource_to_request))
-      )
-  TargetPool:
+  TargetPool: !ruby/object:Provider::Puppet::ResourceOverride
     provider_helpers:
-      include:
-        - 'products/compute/helpers/provider_target_pool.rb'
-  Region:
+      - 'products/compute/helpers/provider_target_pool.rb'
+  Region: !ruby/object:Provider::Puppet::ResourceOverride
     # TODO(nelsonjr): Make sure that attempts to create a region fails
-    flush: raise 'Region cannot be edited' if @dirty
+    handlers: !ruby/object:Provider::Puppet::Handlers
+      flush: raise 'Region cannot be edited' if @dirty
 functions:
   - !ruby/object:Provider::Config::Function
     name: 'gcompute_address_ip'

--- a/provider/puppet.rb
+++ b/provider/puppet.rb
@@ -18,6 +18,7 @@ require 'provider/config'
 require 'provider/core'
 require 'provider/puppet/codegen'
 require 'provider/puppet/manifest'
+require 'provider/puppet/resource_override'
 require 'provider/puppet/test_manifest'
 require 'provider/test_matrix'
 
@@ -468,14 +469,14 @@ module Provider
     end
 
     # Emits all the Puppet client functions available for use by end users.
-    def generate_client_function(output_folder, fn)
+    def generate_client_function(output_folder, func)
       target_folder = File.join(output_folder, 'lib', 'puppet', 'functions')
       {
-        fn: fn,
+        fn: func,
         target_folder: target_folder,
         template: 'templates/puppet/function.erb',
         output_folder: output_folder,
-        out_file: File.join(target_folder, "#{fn.name}.rb")
+        out_file: File.join(target_folder, "#{func.name}.rb")
       }
     end
 

--- a/provider/puppet/resource_override.rb
+++ b/provider/puppet/resource_override.rb
@@ -1,0 +1,66 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'provider/core'
+require 'provider/resource_override'
+
+module Provider
+  class Puppet < Provider::Core
+    # Puppet specific properties to be added to Api::Resource
+    module OverrideProperties
+      attr_reader :handlers
+      attr_reader :provider_helpers
+      attr_reader :requires
+    end
+
+    # Custom Puppet code to handle type convergence operations
+    class Handlers < Api::Object
+      attr_reader :create
+      attr_reader :delete
+      attr_reader :flush
+      attr_reader :resource_to_request_patch
+
+      def validate
+        super
+
+        check_optional_property :create, String
+        check_optional_property :delete, String
+        check_optional_property :flush, String
+        check_optional_property :resource_to_request_patch, String
+      end
+    end
+
+    # Product specific overriden properties for Puppet
+    class ResourceOverride < Provider::ResourceOverride
+      include OverrideProperties
+
+      def validate
+        @provider_helpers ||= []
+
+        super
+
+        check_optional_property :access_api_results, :boolean
+        check_optional_property :handlers, Provider::Puppet::Handlers
+
+        check_property_list :provider_helpers, String
+        check_property_list :requires, String
+      end
+
+      private
+
+      def overriden
+        Provider::Puppet::OverrideProperties
+      end
+    end
+  end
+end

--- a/templates/provider_helpers.erb
+++ b/templates/provider_helpers.erb
@@ -1,6 +1,3 @@
 <%=
-  lines(Google::HashUtils.navigate(config,
-                                   %w[provider_helpers include], []).map do |f|
-          lines(compile(f))
-        end.join("\n"))
+  lines(object&.provider_helpers&.map { |f| lines(compile(f)) }&.join("\n"))
 -%>

--- a/templates/puppet/provider.erb
+++ b/templates/puppet/provider.erb
@@ -38,10 +38,7 @@
                                 upd_method.downcase)
   end
 
-  custom_requires = Google::HashUtils.navigate(config, %w[requires])
-  unless custom_requires.nil?
-    requires << custom_requires
-  end
+  requires << object&.requires unless object&.requires.nil?
 -%>
 <%= lines(emit_requires(requires)) -%>
 
@@ -234,21 +231,20 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   def create
     debug('create')
     @created = true
-<% custom_create = get_code_multiline config, 'create' -%>
-<% if custom_create.nil? -%>
+<% if object&.handlers&.create.nil? -%>
 <%
-  if object.create_verb.nil? || object.create_verb == :POST
-    body_new = 'collection(@resource)'
-    request_new = "Google::#{product_ns}::Network::Post.new"
-  elsif object.create_verb == :PUT
-    body_new = 'self_link(@resource)'
-    request_new = "Google::#{product_ns}::Network::Put.new"
-  end
+     if object.create_verb.nil? || object.create_verb == :POST
+       body_new = 'collection(@resource)'
+       request_new = "Google::#{product_ns}::Network::Post.new"
+     elsif object.create_verb == :PUT
+       body_new = 'self_link(@resource)'
+       request_new = "Google::#{product_ns}::Network::Put.new"
+     end
 
-  request_patch = get_code_multiline config, 'resource_create_patch'
-  custom_resource = true?(Google::HashUtils.navigate(
-    config, %w[provider_helpers custom_create_resource]
-  ))
+     request_patch = get_code_multiline config, 'resource_create_patch'
+     custom_resource = true?(Google::HashUtils.navigate(
+       config, %w[provider_helpers custom_create_resource]
+     ))
 -%>
 <%=
   lines(indent_list(["create_req = #{request_new}(#{body_new}"].concat(
@@ -266,9 +262,9 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 <% else -%>
     <%= fetch_assign -%>wait_for_operation create_req.send, @resource
 <% end -%>
-<% else -%>
-<%= lines(indent(custom_create, 4)) -%>
-<% end -%>
+<% else # object&.handlers&.create.nil? -%>
+<%= lines(indent(object&.handlers&.create, 4)) -%>
+<% end # object&.handlers&.create.nil? -%>
     @property_hash[:ensure] = :present
   end
 
@@ -303,9 +299,8 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 <% # TODO(nelsonjr): Remove @dirty or SQL does not do idempotent updates. -%>
     # return on !@dirty is for aiding testing (puppet already guarantees that)
     return if @created || @deleted || !@dirty
-<% custom_flush = get_code_multiline config, 'flush' -%>
 <%
-   if custom_flush.nil?
+   if object&.handlers&.flush.nil?
      put_new = if upd_method.nil?
                  "Google::#{product_ns}::Network::Put.new"
                else
@@ -330,9 +325,9 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   <% obj_kind = object.kind? ? ", '#{object.kind}'" : '' -%>
   <%= fetch_assign -%>return_if_object update_req.send<%= obj_kind %>
 <%   end # object.async -%>
-<% else # custom_flush.nil? -%>
-<%= lines(indent(custom_flush, 4)) -%>
-<% end # custom_flush.nil? -%>
+<% else # object&.handlers&.flush.nil? -%>
+<%= lines(indent(object&.handlers&.flush, 4)) -%>
+<% end # object&.handlers&.flush&.nil? -%>
   end
 
   def dirty(field, from, to)
@@ -441,13 +436,11 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
     r2r_code << ''
   end
 
-  resource_to_request_patch = get_code_multiline config,
-                                                 'resource_to_request_patch'
-  unless resource_to_request_patch.nil?
+  unless object&.handlers&.resource_to_request_patch.nil?
     r2r_code << '' unless has_boolean
-    r2r_code << resource_to_request_patch
+    r2r_code << object&.handlers&.resource_to_request_patch
     r2r_code << ''
-  end # resource_to_request_patch.nil?
+  end # object&.handlers&.resource_to_request_patch.nil?
 
   if object.encoder?
     r2r_code << '# Format request to conform with API endpoint'


### PR DESCRIPTION
Moves compute/puppet.yaml from objects: to overrides: and update provider.erb template.