### PR TITLE
Port dns/puppet to new strong-typed overrides.

### DIFF
--- a/api/resource.rb
+++ b/api/resource.rb
@@ -303,7 +303,7 @@ module Api
     #   object: An Api::Resource object
     def save_api_results?(config)
       exported_properties.any? { |p| p.is_a? Api::Type::FetchedExternal } \
-        || Google::HashUtils.navigate(config, %w[access_api_results])
+        || access_api_results
     end
 
     private

--- a/google/yaml_validator.rb
+++ b/google/yaml_validator.rb
@@ -89,6 +89,11 @@ module Google
       prop_value.validate if prop_value.is_a?(Api::Object)
     end
 
+    def default_value_property(property, def_value)
+      value = instance_variable_get("@#{property}")
+      instance_variable_set("@#{property}", def_value) if value.nil?
+    end
+
     def check_extraneous_properties
       instance_variables.each do |variable|
         var_name = variable.id2name[1..-1]

--- a/products/dns/puppet.yaml
+++ b/products/dns/puppet.yaml
@@ -28,46 +28,43 @@ manifest: !ruby/object:Provider::Puppet::Manifest
       versions: '>= 0.2.0 < 0.3.0'
   operating_systems:
 <%= indent(include('provider/puppet/common~operating_systems.yaml'), 4) %>
-objects: !ruby/object:Api::Resource::HashArray
-  ManagedZone:
-    flush: raise 'DNS Managed Zone cannot be edited' if @dirty
-  ResourceRecordSet:
-    # template.provider: enables to specify another source for code production
-    # | template:
-    # |   provider: 'products/dns/templates/resource_record_set.erb'
-    # TODO(alexstephen): Document the access_api_results field.
+overrides: !ruby/object:Provider::ResourceOverrides
+  ManagedZone: !ruby/object:Provider::Puppet::ResourceOverride
+    handlers: !ruby/object:Provider::Puppet::Handlers
+      flush: raise 'DNS Managed Zone cannot be edited' if @dirty
+  ResourceRecordSet: !ruby/object:Provider::Puppet::ResourceOverride
     access_api_results: true
-    create: |
-      change = create_change nil, updated_record, @resource
-      change_id = change['id'].to_i
-      debug("created for transaction '#{change_id}' to complete")
-      wait_for_change_to_complete change_id, @resource \
-        if change['status'] == 'pending'
-    delete: |
-      change = create_change @fetched, nil, @resource
-      change_id = change['id'].to_i
-      debug("created for transaction '#{change_id}' to complete")
-      wait_for_change_to_complete change_id, @resource \
-        if change['status'] == 'pending'
-    flush: |
-      change = create_change @fetched, updated_record, @resource
-      change_id = change['id'].to_i
-      debug("created for transaction '#{change_id}' to complete")
-      wait_for_change_to_complete change_id, @resource \
-        if change['status'] == 'pending'
-    request_to_query: |
-      # DNS service already did server-side filtering of resource.
-      lambda { |resource| true }
+    handlers: !ruby/object:Provider::Puppet::Handlers
+      create: |
+        change = create_change nil, updated_record, @resource
+        change_id = change['id'].to_i
+        debug("created for transaction '#{change_id}' to complete")
+        wait_for_change_to_complete change_id, @resource \
+          if change['status'] == 'pending'
+      delete: |
+        change = create_change @fetched, nil, @resource
+        change_id = change['id'].to_i
+        debug("created for transaction '#{change_id}' to complete")
+        wait_for_change_to_complete change_id, @resource \
+          if change['status'] == 'pending'
+      flush: |
+        change = create_change @fetched, updated_record, @resource
+        change_id = change['id'].to_i
+        debug("created for transaction '#{change_id}' to complete")
+        wait_for_change_to_complete change_id, @resource \
+          if change['status'] == 'pending'
+      request_to_query: |
+        # DNS service already did server-side filtering of resource.
+        lambda { |resource| true }
     provider_helpers:
-      visible:
-        unwrap_resource: false
-        resource_to_request: false
-        return_if_object: false
-      include:
-        - 'products/dns/helpers/puppet_provider_resource_set.rb.erb'
-        - 'products/dns/helpers/provider_resource_set.rb.erb'
-  Project:
-    flush: raise 'DNS Project cannot be edited' if @dirty
+      - 'products/dns/helpers/puppet_provider_resource_set.rb.erb'
+      - 'products/dns/helpers/provider_resource_set.rb.erb'
+    resource_to_request: false
+    return_if_object: false
+    unwrap_resource: false
+  Project: !ruby/object:Provider::Puppet::ResourceOverride
+    handlers: !ruby/object:Provider::Puppet::Handlers
+      flush: raise 'DNS Project cannot be edited' if @dirty
 tests: !ruby/object:Api::Resource::HashArray
 <%= indent(include('products/dns/test.yaml'), 2) %>
 examples: !ruby/object:Api::Resource::HashArray

--- a/provider/puppet/resource_override.rb
+++ b/provider/puppet/resource_override.rb
@@ -18,9 +18,15 @@ module Provider
   class Puppet < Provider::Core
     # Puppet specific properties to be added to Api::Resource
     module OverrideProperties
+      attr_reader :access_api_results
       attr_reader :handlers
       attr_reader :provider_helpers
       attr_reader :requires
+      attr_reader :resource_to_request
+      attr_reader :return_if_object
+      attr_reader :unwrap_resource
+      attr_reader :custom_create_resource
+      attr_reader :custom_update_resource
     end
 
     # Custom Puppet code to handle type convergence operations
@@ -28,6 +34,7 @@ module Provider
       attr_reader :create
       attr_reader :delete
       attr_reader :flush
+      attr_reader :request_to_query
       attr_reader :resource_to_request_patch
 
       def validate
@@ -36,6 +43,7 @@ module Provider
         check_optional_property :create, String
         check_optional_property :delete, String
         check_optional_property :flush, String
+        check_optional_property :request_to_query, String
         check_optional_property :resource_to_request_patch, String
       end
     end
@@ -45,12 +53,24 @@ module Provider
       include OverrideProperties
 
       def validate
-        @provider_helpers ||= []
+        default_value_property :access_api_results, false
+        default_value_property :custom_create_resource, false
+        default_value_property :custom_update_resource, false
+        default_value_property :provider_helpers, []
+        default_value_property :resource_to_request, true
+        default_value_property :return_if_object, true
+        default_value_property :unwrap_resource, true
 
         super
 
-        check_optional_property :access_api_results, :boolean
+        check_property :access_api_results, :boolean
+        check_property :custom_create_resource, :boolean
+        check_property :custom_update_resource, :boolean
         check_optional_property :handlers, Provider::Puppet::Handlers
+        check_optional_property :requires, Array
+        check_property :resource_to_request, :boolean
+        check_property :return_if_object, :boolean
+        check_property :unwrap_resource, :boolean
 
         check_property_list :provider_helpers, String
         check_property_list :requires, String

--- a/templates/puppet/provider.erb
+++ b/templates/puppet/provider.erb
@@ -186,8 +186,8 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
       ['result = new({ title: name,',
        'ensure: :present }.merge(fetch_to_hash(fetch)))'].join(' ')
     end,
-    ('result.instance_variable_set(:@fetched, fetch)' if \
-       object.save_api_results?(config)),
+    ('result.instance_variable_set(:@fetched, fetch)' \
+       if object.save_api_results?(config)),
     'result'
   ].compact
   f2h_code = [
@@ -242,9 +242,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
      end
 
      request_patch = get_code_multiline config, 'resource_create_patch'
-     custom_resource = true?(Google::HashUtils.navigate(
-       config, %w[provider_helpers custom_create_resource]
-     ))
+     custom_resource = true?(object.custom_create_resource)
 -%>
 <%=
   lines(indent_list(["create_req = #{request_new}(#{body_new}"].concat(
@@ -271,8 +269,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   def destroy
     debug('destroy')
     @deleted = true
-<% custom_delete = get_code_multiline config, 'delete' -%>
-<% if custom_delete.nil? -%>
+<% if object&.handlers&.delete.nil? -%>
 <%   dele_new = "Google::#{product_ns}::Network::Delete.new" -%>
 <%=
   lines(indent_list(["delete_req = #{dele_new}(self_link(@resource)"].concat(
@@ -282,14 +279,14 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   ), 4))
 -%>
 <% kind_param = object.kind? ? ", '#{object.kind}'" : '' -%>
-<% unless object.async -%>
+<%   unless object.async -%>
     return_if_object delete_req.send<%= kind_param %>
-<% else -%>
+<%   else -%>
     wait_for_operation delete_req.send, @resource
-<% end -%>
-<% else -%>
-<%= lines(indent(custom_delete, 4)) -%>
-<% end -%>
+<%   end -%>
+<% else # object&.handlers&.delete.nil? -%>
+<%= lines(indent(object&.handlers&.delete, 4)) -%>
+<% end # object&.handlers&.delete.nil? -%>
     @property_hash[:ensure] = :absent
   end
 
@@ -306,9 +303,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
                else
                  "Google::#{product_ns}::Network::#{upd_method.capitalize}.new"
                end
-    custom_resource = true?(Google::HashUtils.navigate(
-      config, %w[provider_helpers custom_update_resource]
-    ))
+    custom_resource = true?(object.custom_update_resource)
 -%>
 <%=
   lines(indent_list(["update_req = #{put_new}(self_link(@resource)"].concat(
@@ -399,9 +394,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   lines(indent(emit_method('self.resource_to_hash', %w[resource], r2h_code,
                            file_relative), 2), 1)
 -%>
-<% unless false?(Google::HashUtils.navigate(config,
-                                            %w[provider_helpers visible
-                                               resource_to_request])) -%>
+<% unless false?(object.resource_to_request) -%>
 <%
   prop_code = []
   prop_code << "kind: '#{object.kind}'" if object.kind?
@@ -455,9 +448,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
                              file_relative), 2), 1) -%>
 <% end # visible:resource_to_request -%>
 <%
-  unless false?(Google::HashUtils.navigate(config,
-                                           %w[provider_helpers visible
-                                              unwrap_resource]))
+  unless false?(object.unwrap_resource)
     unless object.self_link_query.nil?
 -%>
 <%

--- a/templates/transport.erb
+++ b/templates/transport.erb
@@ -53,9 +53,7 @@ def self.fetch_wrapped_resource(resource, kind, wrap_kind, wrap_path)
   result
 end
 
-<%   unless false?(Google::HashUtils.navigate(config,
-                                              %w[provider_helpers visible
-                                                 unwrap_resource])) -%>
+<%   unless false?(object.unwrap_resource) -%>
 def unwrap_resource(result, resource)
   self.class.unwrap_resource(result, resource)
 end


### PR DESCRIPTION
This change should be no-op and generates no changes in the DNS submodule.