### PR TITLE
Port sql/puppet to new strong-typed overrides.

### DIFF
--- a/products/sql/puppet.yaml
+++ b/products/sql/puppet.yaml
@@ -29,87 +29,90 @@ manifest: !ruby/object:Provider::Puppet::Manifest
       versions: '>= 0.2.0 < 0.3.0'
   operating_systems:
 <%= indent(include('provider/puppet/common~operating_systems.yaml'), 4) %>
-objects: !ruby/object:Api::Resource::HashArray
-  Database:
-    # TODO(nelsonjr): Once bugs in the body are resolved remove this override.
-    return_if_object: |
-      # rubocop:disable Metrics/CyclomaticComplexity
-      def self.return_if_object(response, kind)
-        raise "Bad response: #{response}" \
-          unless response.is_a?(Net::HTTPResponse)
-        return if response.is_a?(Net::HTTPNotFound)
-        return if response.is_a?(Net::HTTPNoContent)
-        # TODO(nelsonjr): Remove return of Net::HTTPForbidden from
-        # return_if_object once Cloud SQL bug http://b/62635365 is resolved.
-        # Currently the API returns 403 for objects that do not exist, even when
-        # the user has access to the project. This is being changed to return
-        # 404 as it is supposed to be.  Once 404 is the correct response the
-        # temporary workaround should be removed.
-        return if response.is_a?(Net::HTTPForbidden)
-        result = JSON.parse(response.body)
-        raise_if_errors result, %w[error errors], 'message'
-        raise "Bad response: #{response}" unless response.is_a?(Net::HTTPOK)
-        # TODO(nelsonjr): Revert this check back to standard once Cloud SQL
-        # bug http://b/62841551 is resolved.
-        # Currently the sql#operation#targetLink for create returns a
-        # sql#database while for a delete it returns a sql#instance.
-        # | raise "Incorrect result: #{result['kind']} (expecting #{kind})" \
-        # |   unless result['kind'] == kind
-        raise "Incorrect result: #{result['kind']} (expecting #{kind})" \
-          unless [kind, 'sql#instance'].include?(result['kind'])
-        result
-      end
-      # rubocop:enable Metrics/CyclomaticComplexity
+overrides: !ruby/object:Provider::ResourceOverrides
+  Database: !ruby/object:Provider::Puppet::ResourceOverride
+    handlers: !ruby/object:Provider::Puppet::Handlers
+      # TODO(nelsonjr): Once bugs in the body are resolved remove this override.
+      return_if_object: |
+        # rubocop:disable Metrics/CyclomaticComplexity
+        def self.return_if_object(response, kind)
+          raise "Bad response: #{response}" \
+            unless response.is_a?(Net::HTTPResponse)
+          return if response.is_a?(Net::HTTPNotFound)
+          return if response.is_a?(Net::HTTPNoContent)
+          # TODO(nelsonjr): Remove return of Net::HTTPForbidden from
+          # return_if_object once Cloud SQL bug http://b/62635365 is resolved.
+          # Currently the API returns 403 for objects that do not exist, even
+          # when the user has access to the project. This is being changed to
+          # return 404 as it is supposed to be.  Once 404 is the correct
+          # response the temporary workaround should be removed.
+          return if response.is_a?(Net::HTTPForbidden)
+          result = JSON.parse(response.body)
+          raise_if_errors result, %w[error errors], 'message'
+          raise "Bad response: #{response}" unless response.is_a?(Net::HTTPOK)
+          # TODO(nelsonjr): Revert this check back to standard once Cloud SQL
+          # bug http://b/62841551 is resolved.
+          # Currently the sql#operation#targetLink for create returns a
+          # sql#database while for a delete it returns a sql#instance.
+          # | raise "Incorrect result: #{result['kind']} (expecting #{kind})" \
+          # |   unless result['kind'] == kind
+          raise "Incorrect result: #{result['kind']} (expecting #{kind})" \
+            unless [kind, 'sql#instance'].include?(result['kind'])
+          result
+        end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
-      def return_if_object(response, kind)
-        self.class.return_if_object(response, kind)
-      end
-  Flag:
-    flush: |
-      raise('Cloud SQL flag does not match expectations.')
-  Instance:
+        def return_if_object(response, kind)
+          self.class.return_if_object(response, kind)
+        end
+  Flag: !ruby/object:Provider::Puppet::ResourceOverride
+    handlers: !ruby/object:Provider::Puppet::Handlers
+      flush: |
+        raise('Cloud SQL flag does not match expectations.')
+  Instance: !ruby/object:Provider::Puppet::ResourceOverride
     # TODO(alexstephen): Document the access_api_results field.
     access_api_results: true
-    # TODO(nelsonjr): Once bugs in the body are resolved remove this override.
-    return_if_object: |
-      # rubocop:disable Metrics/CyclomaticComplexity
-      def self.return_if_object(response, kind)
-        raise "Bad response: #{response}" \
-          unless response.is_a?(Net::HTTPResponse)
-        return if response.is_a?(Net::HTTPNotFound)
-        return if response.is_a?(Net::HTTPNoContent)
-        # TODO(nelsonjr): Remove return of Net::HTTPForbidden from
-        # return_if_object once Cloud SQL Bug http://b/62635365 is resolved.
-        # Currently the API returns 403 for objects that do not exist, even when
-        # the user has access to the project. This is being changed to return
-        # 404 as it is supposed to be.  Once 404 is the correct response the
-        # temporary workaround should be removed.
-        return if response.is_a?(Net::HTTPForbidden)
-        result = JSON.parse(response.body)
-        raise_if_errors result, %w[error errors], 'message'
-        raise "Bad response: #{response}" unless response.is_a?(Net::HTTPOK)
-        raise "Incorrect result: #{result['kind']} (expecting #{kind})" \
-          unless result['kind'] == kind
-        result
-      end
-      # rubocop:enable Metrics/CyclomaticComplexity
+    handlers: !ruby/object:Provider::Puppet::Handlers
+      # TODO(nelsonjr): Once bugs in the body are resolved remove this override.
+      return_if_object: |
+        # rubocop:disable Metrics/CyclomaticComplexity
+        def self.return_if_object(response, kind)
+          raise "Bad response: #{response}" \
+            unless response.is_a?(Net::HTTPResponse)
+          return if response.is_a?(Net::HTTPNotFound)
+          return if response.is_a?(Net::HTTPNoContent)
+          # TODO(nelsonjr): Remove return of Net::HTTPForbidden from
+          # return_if_object once Cloud SQL Bug http://b/62635365 is resolved.
+          # Currently the API returns 403 for objects that do not exist, even
+          # when the user has access to the project. This is being changed to
+          # return 404 as it is supposed to be.  Once 404 is the correct
+          # response the temporary workaround should be removed.
+          return if response.is_a?(Net::HTTPForbidden)
+          result = JSON.parse(response.body)
+          raise_if_errors result, %w[error errors], 'message'
+          raise "Bad response: #{response}" unless response.is_a?(Net::HTTPOK)
+          raise "Incorrect result: #{result['kind']} (expecting #{kind})" \
+            unless result['kind'] == kind
+          result
+        end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
-      def return_if_object(response, kind)
-        self.class.return_if_object(response, kind)
-      end
-    resource_to_request_patch: |
-      unless @fetched.nil?
-        # Convert to pure JSON
-        request = JSON.parse(request.to_json)
-        request['settings']['settingsVersion'] =
-          @fetched['settings']['settingsVersion']
-      end
-  SslCert:
-    flush: |
-      raise('Cloud SQL SSL certificate mismatch.')
-  Tier:
-    flush: |
-      raise('Cloud SQL tier does not match expectations.')
+        def return_if_object(response, kind)
+          self.class.return_if_object(response, kind)
+        end
+      resource_to_request_patch: |
+        unless @fetched.nil?
+          # Convert to pure JSON
+          request = JSON.parse(request.to_json)
+          request['settings']['settingsVersion'] =
+            @fetched['settings']['settingsVersion']
+        end
+  SslCert: !ruby/object:Provider::Puppet::ResourceOverride
+    handlers: !ruby/object:Provider::Puppet::Handlers
+      flush: raise('Cloud SQL SSL certificate mismatch.')
+  Tier: !ruby/object:Provider::Puppet::ResourceOverride
+    handlers: !ruby/object:Provider::Puppet::Handlers
+      flush: raise('Cloud SQL tier does not match expectations.')
 functions:
   - !ruby/object:Provider::Config::Function
     name: 'gsql_instance_ip'

--- a/provider/puppet/resource_override.rb
+++ b/provider/puppet/resource_override.rb
@@ -37,6 +37,7 @@ module Provider
       attr_reader :flush
       attr_reader :request_to_query
       attr_reader :resource_to_request_patch
+      attr_reader :return_if_object
 
       def validate
         super
@@ -46,6 +47,7 @@ module Provider
         check_optional_property :flush, String
         check_optional_property :request_to_query, String
         check_optional_property :resource_to_request_patch, String
+        check_optional_property :return_if_object, String
       end
     end
 

--- a/templates/puppet/provider.erb
+++ b/templates/puppet/provider.erb
@@ -494,12 +494,11 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 <% else # custom_self_link.nil? -%>
 <%= lines(indent(emit_link('self_link', custom_self_link, true), 2), 1) -%>
 <% end # custom_self_link.nil? -%>
-<% custom_return_if_object = get_code_multiline config, 'return_if_object' -%>
-<% if custom_return_if_object.nil? -%>
+<% if object&.handlers&.return_if_object.nil? -%>
 <%= lines(indent(compile('templates/return_if_object.erb'), 2)) %>
-<% else # custom_return_if_object.nil? -%>
-<%= lines(indent(custom_return_if_object, 2), 1) -%>
-<% end # custom_return_if_object.nil? -%>
+<% else # object&.handlers&.return_if_object.nil? -%>
+<%= lines(indent(object&.handlers&.return_if_object, 2), 1) -%>
+<% end # object&.handlers&.return_if_object.nil? -%>
 <%= lines(indent(compile('templates/expand_variables.erb'), 2)) %>
 <%=
   if object.async


### PR DESCRIPTION
This change produces no functional side effects on SQL submodule.

It changes a comment formatting though to make it 80-columns friendly sql/puppet.yaml file.