### PR TITLE
Port resourcemanager/puppet to new strong-typed overrides.

### DIFF
--- a/api/resource.rb
+++ b/api/resource.rb
@@ -305,7 +305,7 @@ module Api
     #   object: An Api::Resource object
     def save_api_results?(config)
       exported_properties.any? { |p| p.is_a? Api::Type::FetchedExternal } \
-        || access_api_results
+        || Google::HashUtils.navigate(config, %w[access_api_results])
     end
 
     private

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -305,7 +305,7 @@ module Api
     #   object: An Api::Resource object
     def save_api_results?(config)
       exported_properties.any? { |p| p.is_a? Api::Type::FetchedExternal } \
-        || Google::HashUtils.navigate(config, %w[access_api_results])
+        || access_api_results
     end
 
     private

--- a/products/resourcemanager/puppet.yaml
+++ b/products/resourcemanager/puppet.yaml
@@ -30,32 +30,33 @@ manifest: !ruby/object:Provider::Puppet::Manifest
       versions: '>= 0.2.0 < 0.3.0'
   operating_systems:
 <%= indent(include('provider/puppet/common~operating_systems.yaml'), 4) %>
-objects: !ruby/object:Api::Resource::HashArray
-  Project:
-    return_if_object: |
-      # rubocop:disable Metrics/CyclomaticComplexity
-      def self.return_if_object(response)
-        raise "Bad response: #{response}" \
-          unless response.is_a?(Net::HTTPResponse)
-        return if response.is_a?(Net::HTTPNotFound)
-        return if response.is_a?(Net::HTTPNoContent)
-        # TODO(nelsonjr): Remove return of Net::HTTPForbidden from
-        # return_if_object once Cloud SQL bug http://b/62635365 is resolved.
-        # Currently the API returns 403 for objects that do not exist, even when
-        # the user has access to the project. This is being changed to return
-        # 404 as it is supposed to be.  Once 404 is the correct response the
-        # temporary workaround should be removed.
-        return if response.is_a?(Net::HTTPForbidden)
-        result = JSON.parse(response.body)
-        raise_if_errors result, %w[error errors], 'message'
-        raise "Bad response: #{response}" unless response.is_a?(Net::HTTPOK)
-        result
-      end
-      # rubocop:enable Metrics/CyclomaticComplexity
+overrides: !ruby/object:Provider::ResourceOverrides
+  Project: !ruby/object:Provider::Puppet::ResourceOverride
+    handlers: !ruby/object:Provider::Puppet::Handlers
+      return_if_object: |
+        # rubocop:disable Metrics/CyclomaticComplexity
+        def self.return_if_object(response)
+          raise "Bad response: #{response}" \
+            unless response.is_a?(Net::HTTPResponse)
+          return if response.is_a?(Net::HTTPNotFound)
+          return if response.is_a?(Net::HTTPNoContent)
+          # TODO(nelsonjr): Remove return of Net::HTTPForbidden from
+          # return_if_object once Cloud SQL bug http://b/62635365 is resolved.
+          # Currently the API returns 403 for objects that do not exist, even
+          # when the user has access to the project. This is being changed to
+          # return 404 as it is supposed to be.  Once 404 is the correct
+          # response the temporary workaround should be removed.
+          return if response.is_a?(Net::HTTPForbidden)
+          result = JSON.parse(response.body)
+          raise_if_errors result, %w[error errors], 'message'
+          raise "Bad response: #{response}" unless response.is_a?(Net::HTTPOK)
+          result
+        end
+        # rubocop:enable Metrics/CyclomaticComplexity
 
-      def return_if_object(response)
-        self.class.return_if_object(response)
-      end
+        def return_if_object(response)
+          self.class.return_if_object(response)
+        end
 examples: !ruby/object:Api::Resource::HashArray
   Project:
     - project.pp

--- a/provider/puppet/resource_override.rb
+++ b/provider/puppet/resource_override.rb
@@ -18,40 +18,25 @@ module Provider
   class Puppet < Provider::Core
     # Puppet specific properties to be added to Api::Resource
     module OverrideProperties
-      attr_reader :access_api_results
-      attr_reader :custom_create_resource
-      attr_reader :custom_update_resource
       attr_reader :handlers
-      attr_reader :manual
       attr_reader :provider_helpers
       attr_reader :requires
-      attr_reader :resource_to_request
-      attr_reader :return_if_object
-      attr_reader :unwrap_resource
     end
 
     # Custom Puppet code to handle type convergence operations
     class Handlers < Api::Object
-      attr_reader :collection  # A custom collection function to use
       attr_reader :create
       attr_reader :delete
       attr_reader :flush
-      attr_reader :request_to_query
       attr_reader :resource_to_request_patch
-      attr_reader :return_if_object
-      attr_reader :self_link  # A custom self_link function to use
 
       def validate
         super
 
-        check_optional_property :collection, String
         check_optional_property :create, String
         check_optional_property :delete, String
         check_optional_property :flush, String
-        check_optional_property :request_to_query, String
         check_optional_property :resource_to_request_patch, String
-        check_optional_property :return_if_object, String
-        check_optional_property :self_link, String
       end
     end
 
@@ -60,26 +45,12 @@ module Provider
       include OverrideProperties
 
       def validate
-        default_value_property :access_api_results, false
-        default_value_property :custom_create_resource, false
-        default_value_property :custom_update_resource, false
-        default_value_property :manual, false
-        default_value_property :provider_helpers, []
-        default_value_property :resource_to_request, true
-        default_value_property :return_if_object, true
-        default_value_property :unwrap_resource, true
+        @provider_helpers ||= []
 
         super
 
-        check_property :access_api_results, :boolean
-        check_property :custom_create_resource, :boolean
-        check_property :custom_update_resource, :boolean
+        check_optional_property :access_api_results, :boolean
         check_optional_property :handlers, Provider::Puppet::Handlers
-        check_property :manual, :boolean
-        check_optional_property :requires, Array
-        check_property :resource_to_request, :boolean
-        check_property :return_if_object, :boolean
-        check_property :unwrap_resource, :boolean
 
         check_property_list :provider_helpers, String
         check_property_list :requires, String

--- a/provider/puppet/resource_override.rb
+++ b/provider/puppet/resource_override.rb
@@ -18,9 +18,15 @@ module Provider
   class Puppet < Provider::Core
     # Puppet specific properties to be added to Api::Resource
     module OverrideProperties
+      attr_reader :access_api_results
       attr_reader :handlers
       attr_reader :provider_helpers
       attr_reader :requires
+      attr_reader :resource_to_request
+      attr_reader :return_if_object
+      attr_reader :unwrap_resource
+      attr_reader :custom_create_resource
+      attr_reader :custom_update_resource
     end
 
     # Custom Puppet code to handle type convergence operations
@@ -28,6 +34,7 @@ module Provider
       attr_reader :create
       attr_reader :delete
       attr_reader :flush
+      attr_reader :request_to_query
       attr_reader :resource_to_request_patch
 
       def validate
@@ -36,6 +43,7 @@ module Provider
         check_optional_property :create, String
         check_optional_property :delete, String
         check_optional_property :flush, String
+        check_optional_property :request_to_query, String
         check_optional_property :resource_to_request_patch, String
       end
     end
@@ -45,12 +53,24 @@ module Provider
       include OverrideProperties
 
       def validate
-        @provider_helpers ||= []
+        default_value_property :access_api_results, false
+        default_value_property :custom_create_resource, false
+        default_value_property :custom_update_resource, false
+        default_value_property :provider_helpers, []
+        default_value_property :resource_to_request, true
+        default_value_property :return_if_object, true
+        default_value_property :unwrap_resource, true
 
         super
 
-        check_optional_property :access_api_results, :boolean
+        check_property :access_api_results, :boolean
+        check_property :custom_create_resource, :boolean
+        check_property :custom_update_resource, :boolean
         check_optional_property :handlers, Provider::Puppet::Handlers
+        check_optional_property :requires, Array
+        check_property :resource_to_request, :boolean
+        check_property :return_if_object, :boolean
+        check_property :unwrap_resource, :boolean
 
         check_property_list :provider_helpers, String
         check_property_list :requires, String

--- a/provider/puppet/resource_override.rb
+++ b/provider/puppet/resource_override.rb
@@ -37,6 +37,7 @@ module Provider
       attr_reader :flush
       attr_reader :request_to_query
       attr_reader :resource_to_request_patch
+      attr_reader :return_if_object
 
       def validate
         super
@@ -46,6 +47,7 @@ module Provider
         check_optional_property :flush, String
         check_optional_property :request_to_query, String
         check_optional_property :resource_to_request_patch, String
+        check_optional_property :return_if_object, String
       end
     end
 

--- a/provider/puppet/resource_override.rb
+++ b/provider/puppet/resource_override.rb
@@ -20,6 +20,7 @@ module Provider
     module OverrideProperties
       attr_reader :access_api_results
       attr_reader :handlers
+      attr_reader :manual
       attr_reader :provider_helpers
       attr_reader :requires
       attr_reader :resource_to_request
@@ -56,6 +57,7 @@ module Provider
         default_value_property :access_api_results, false
         default_value_property :custom_create_resource, false
         default_value_property :custom_update_resource, false
+        default_value_property :manual, false
         default_value_property :provider_helpers, []
         default_value_property :resource_to_request, true
         default_value_property :return_if_object, true
@@ -67,6 +69,7 @@ module Provider
         check_property :custom_create_resource, :boolean
         check_property :custom_update_resource, :boolean
         check_optional_property :handlers, Provider::Puppet::Handlers
+        check_property :manual, :boolean
         check_optional_property :requires, Array
         check_property :resource_to_request, :boolean
         check_property :return_if_object, :boolean

--- a/provider/puppet/resource_override.rb
+++ b/provider/puppet/resource_override.rb
@@ -19,6 +19,8 @@ module Provider
     # Puppet specific properties to be added to Api::Resource
     module OverrideProperties
       attr_reader :access_api_results
+      attr_reader :custom_create_resource
+      attr_reader :custom_update_resource
       attr_reader :handlers
       attr_reader :manual
       attr_reader :provider_helpers
@@ -26,28 +28,30 @@ module Provider
       attr_reader :resource_to_request
       attr_reader :return_if_object
       attr_reader :unwrap_resource
-      attr_reader :custom_create_resource
-      attr_reader :custom_update_resource
     end
 
     # Custom Puppet code to handle type convergence operations
     class Handlers < Api::Object
+      attr_reader :collection  # A custom collection function to use
       attr_reader :create
       attr_reader :delete
       attr_reader :flush
       attr_reader :request_to_query
       attr_reader :resource_to_request_patch
       attr_reader :return_if_object
+      attr_reader :self_link  # A custom self_link function to use
 
       def validate
         super
 
+        check_optional_property :collection, String
         check_optional_property :create, String
         check_optional_property :delete, String
         check_optional_property :flush, String
         check_optional_property :request_to_query, String
         check_optional_property :resource_to_request_patch, String
         check_optional_property :return_if_object, String
+        check_optional_property :self_link, String
       end
     end
 

--- a/templates/puppet/provider.erb
+++ b/templates/puppet/provider.erb
@@ -186,8 +186,8 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
       ['result = new({ title: name,',
        'ensure: :present }.merge(fetch_to_hash(fetch)))'].join(' ')
     end,
-    ('result.instance_variable_set(:@fetched, fetch)' \
-       if object.save_api_results?(config)),
+    ('result.instance_variable_set(:@fetched, fetch)' if \
+       object.save_api_results?(config)),
     'result'
   ].compact
   f2h_code = [

--- a/templates/puppet/provider.erb
+++ b/templates/puppet/provider.erb
@@ -38,7 +38,7 @@
                                 object.update_verb.to_s.downcase)
   end
 
-  requires << object&.requires unless object&.requires.nil?
+  requires << object.requires unless object.requires.nil?
 -%>
 <%= lines(emit_requires(requires)) -%>
 
@@ -231,7 +231,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   def create
     debug('create')
     @created = true
-<% if object&.handlers&.create.nil? -%>
+<% if object&.handlers.create.nil? -%>
 <%
      if object.create_verb.nil? || object.create_verb == :POST
        body_new = 'collection(@resource)'
@@ -260,16 +260,16 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 <% else -%>
     <%= fetch_assign -%>wait_for_operation create_req.send, @resource
 <% end -%>
-<% else # object&.handlers&.create.nil? -%>
-<%= lines(indent(object&.handlers&.create, 4)) -%>
-<% end # object&.handlers&.create.nil? -%>
+<% else # object&.handlers.create.nil? -%>
+<%= lines(indent(object.handlers.create, 4)) -%>
+<% end # object&.handlers.create.nil? -%>
     @property_hash[:ensure] = :present
   end
 
   def destroy
     debug('destroy')
     @deleted = true
-<% if object&.handlers&.delete.nil? -%>
+<% if object&.handlers.delete.nil? -%>
 <%   dele_new = "Google::#{product_ns}::Network::Delete.new" -%>
 <%=
   lines(indent_list(["delete_req = #{dele_new}(self_link(@resource)"].concat(
@@ -284,9 +284,9 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 <%   else -%>
     wait_for_operation delete_req.send, @resource
 <%   end -%>
-<% else # object&.handlers&.delete.nil? -%>
-<%= lines(indent(object&.handlers&.delete, 4)) -%>
-<% end # object&.handlers&.delete.nil? -%>
+<% else # object&.handlers.delete.nil? -%>
+<%= lines(indent(object.handlers.delete, 4)) -%>
+<% end # object&.handlers.delete.nil? -%>
     @property_hash[:ensure] = :absent
   end
 
@@ -297,8 +297,8 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
     # return on !@dirty is for aiding testing (puppet already guarantees that)
     return if @created || @deleted || !@dirty
 <%
-   if object&.handlers&.flush.nil?
-     put_new = if upd_method.nil?
+   if object&.handlers.flush.nil?
+     put_new = if object.update_verb.nil?
                  "Google::#{product_ns}::Network::Put.new"
                else
                  [
@@ -324,9 +324,9 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   <% obj_kind = object.kind? ? ", '#{object.kind}'" : '' -%>
   <%= fetch_assign -%>return_if_object update_req.send<%= obj_kind %>
 <%   end # object.async -%>
-<% else # object&.handlers&.flush.nil? -%>
-<%= lines(indent(object&.handlers&.flush, 4)) -%>
-<% end # object&.handlers&.flush&.nil? -%>
+<% else # object&.handlers.flush.nil? -%>
+<%= lines(indent(object.handlers.flush, 4)) -%>
+<% end # object&.handlers.flush.nil? -%>
   end
 
   def dirty(field, from, to)
@@ -435,7 +435,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 
   unless object&.handlers&.resource_to_request_patch.nil?
     r2r_code << '' unless has_boolean
-    r2r_code << object&.handlers&.resource_to_request_patch
+    r2r_code << object.handlers.resource_to_request_patch
     r2r_code << ''
   end # object&.handlers&.resource_to_request_patch.nil?
 
@@ -496,13 +496,20 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 <% if object&.handlers.self_link.nil? -%>
 <%   if object.self_link.nil? -%>
 <%= lines(indent(emit_link('self_link', self_link_url(object), true), 2), 1) -%>
-<% else # custom_self_link.nil? -%>
-<%= lines(indent(emit_link('self_link', custom_self_link, true), 2), 1) -%>
-<% end # custom_self_link.nil? -%>
+<%   else # object.self_link.nil? -%>
+<%= lines(indent(emit_link('self_link', object.self_link, true), 2), 1) -%>
+<%   end # object.self_link.nil? -%>
+<% else # object&.handlers.self_link.nil? -%>
+<%=
+  lines_before(
+    lines(indent(emit_link('self_link', object.handlers.self_link, true), 2), 1)
+  )
+-%>
+<% end # object&.handlers.self_link.nil? -%>
 <% if object&.handlers&.return_if_object.nil? -%>
 <%= lines(indent(compile('templates/return_if_object.erb'), 2)) %>
 <% else # object&.handlers&.return_if_object.nil? -%>
-<%= lines(indent(object&.handlers&.return_if_object, 2), 1) -%>
+<%= lines(indent(object.handlers.return_if_object, 2), 1) -%>
 <% end # object&.handlers&.return_if_object.nil? -%>
 <%= lines(indent(compile('templates/expand_variables.erb'), 2)) %>
 <%=

--- a/templates/puppet/provider.erb
+++ b/templates/puppet/provider.erb
@@ -496,20 +496,13 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 <% if object&.handlers.self_link.nil? -%>
 <%   if object.self_link.nil? -%>
 <%= lines(indent(emit_link('self_link', self_link_url(object), true), 2), 1) -%>
-<%   else # object.self_link.nil? -%>
-<%= lines(indent(emit_link('self_link', object.self_link, true), 2), 1) -%>
-<%   end # object.self_link.nil? -%>
-<% else # object&.handlers.self_link.nil? -%>
-<%=
-  lines_before(
-    lines(indent(emit_link('self_link', object.handlers.self_link, true), 2), 1)
-  )
--%>
-<% end # object&.handlers.self_link.nil? -%>
+<% else # custom_self_link.nil? -%>
+<%= lines(indent(emit_link('self_link', custom_self_link, true), 2), 1) -%>
+<% end # custom_self_link.nil? -%>
 <% if object&.handlers&.return_if_object.nil? -%>
 <%= lines(indent(compile('templates/return_if_object.erb'), 2)) %>
 <% else # object&.handlers&.return_if_object.nil? -%>
-<%= lines(indent(object.handlers.return_if_object, 2), 1) -%>
+<%= lines(indent(object&.handlers&.return_if_object, 2), 1) -%>
 <% end # object&.handlers&.return_if_object.nil? -%>
 <%= lines(indent(compile('templates/expand_variables.erb'), 2)) %>
 <%=

--- a/templates/puppet/provider.erb
+++ b/templates/puppet/provider.erb
@@ -38,7 +38,7 @@
                                 object.update_verb.to_s.downcase)
   end
 
-  requires << object.requires unless object.requires.nil?
+  requires << object&.requires unless object&.requires.nil?
 -%>
 <%= lines(emit_requires(requires)) -%>
 
@@ -231,7 +231,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   def create
     debug('create')
     @created = true
-<% if object&.handlers.create.nil? -%>
+<% if object&.handlers&.create.nil? -%>
 <%
      if object.create_verb.nil? || object.create_verb == :POST
        body_new = 'collection(@resource)'
@@ -242,7 +242,9 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
      end
 
      request_patch = get_code_multiline config, 'resource_create_patch'
-     custom_resource = true?(object.custom_create_resource)
+     custom_resource = true?(Google::HashUtils.navigate(
+       config, %w[provider_helpers custom_create_resource]
+     ))
 -%>
 <%=
   lines(indent_list(["create_req = #{request_new}(#{body_new}"].concat(
@@ -260,9 +262,9 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 <% else -%>
     <%= fetch_assign -%>wait_for_operation create_req.send, @resource
 <% end -%>
-<% else # object&.handlers.create.nil? -%>
-<%= lines(indent(object.handlers.create, 4)) -%>
-<% end # object&.handlers.create.nil? -%>
+<% else # object&.handlers&.create.nil? -%>
+<%= lines(indent(object&.handlers&.create, 4)) -%>
+<% end # object&.handlers&.create.nil? -%>
     @property_hash[:ensure] = :present
   end
 
@@ -297,8 +299,8 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
     # return on !@dirty is for aiding testing (puppet already guarantees that)
     return if @created || @deleted || !@dirty
 <%
-   if object&.handlers.flush.nil?
-     put_new = if object.update_verb.nil?
+   if object&.handlers&.flush.nil?
+     put_new = if upd_method.nil?
                  "Google::#{product_ns}::Network::Put.new"
                else
                  [
@@ -324,9 +326,9 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   <% obj_kind = object.kind? ? ", '#{object.kind}'" : '' -%>
   <%= fetch_assign -%>return_if_object update_req.send<%= obj_kind %>
 <%   end # object.async -%>
-<% else # object&.handlers.flush.nil? -%>
-<%= lines(indent(object.handlers.flush, 4)) -%>
-<% end # object&.handlers.flush.nil? -%>
+<% else # object&.handlers&.flush.nil? -%>
+<%= lines(indent(object&.handlers&.flush, 4)) -%>
+<% end # object&.handlers&.flush&.nil? -%>
   end
 
   def dirty(field, from, to)
@@ -435,7 +437,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 
   unless object&.handlers&.resource_to_request_patch.nil?
     r2r_code << '' unless has_boolean
-    r2r_code << object.handlers.resource_to_request_patch
+    r2r_code << object&.handlers&.resource_to_request_patch
     r2r_code << ''
   end # object&.handlers&.resource_to_request_patch.nil?
 

--- a/templates/puppet/provider.erb
+++ b/templates/puppet/provider.erb
@@ -231,7 +231,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   def create
     debug('create')
     @created = true
-<% if object&.handlers.create.nil? -%>
+<% if object&.handlers&.create.nil? -%>
 <%
      if object.create_verb.nil? || object.create_verb == :POST
        body_new = 'collection(@resource)'
@@ -269,7 +269,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   def destroy
     debug('destroy')
     @deleted = true
-<% if object&.handlers.delete.nil? -%>
+<% if object&.handlers&.delete.nil? -%>
 <%   dele_new = "Google::#{product_ns}::Network::Delete.new" -%>
 <%=
   lines(indent_list(["delete_req = #{dele_new}(self_link(@resource)"].concat(

--- a/templates/puppet/provider.erb
+++ b/templates/puppet/provider.erb
@@ -494,11 +494,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 -%>
 <% end # object.collection.nil? -%>
 <% if object&.handlers.self_link.nil? -%>
-<%   if object.self_link.nil? -%>
 <%= lines(indent(emit_link('self_link', self_link_url(object), true), 2), 1) -%>
-<%   else # object.self_link.nil? -%>
-<%= lines(indent(emit_link('self_link', object.self_link, true), 2), 1) -%>
-<%   end # object.self_link.nil? -%>
 <% else # object&.handlers.self_link.nil? -%>
 <%=
   lines_before(

--- a/templates/puppet/provider.erb
+++ b/templates/puppet/provider.erb
@@ -186,8 +186,8 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
       ['result = new({ title: name,',
        'ensure: :present }.merge(fetch_to_hash(fetch)))'].join(' ')
     end,
-    ('result.instance_variable_set(:@fetched, fetch)' if \
-       object.save_api_results?(config)),
+    ('result.instance_variable_set(:@fetched, fetch)' \
+       if object.save_api_results?(config)),
     'result'
   ].compact
   f2h_code = [
@@ -242,9 +242,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
      end
 
      request_patch = get_code_multiline config, 'resource_create_patch'
-     custom_resource = true?(Google::HashUtils.navigate(
-       config, %w[provider_helpers custom_create_resource]
-     ))
+     custom_resource = true?(object.custom_create_resource)
 -%>
 <%=
   lines(indent_list(["create_req = #{request_new}(#{body_new}"].concat(
@@ -271,7 +269,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   def destroy
     debug('destroy')
     @deleted = true
-<% if object&.handlers.delete.nil? -%>
+<% if object&.handlers&.delete.nil? -%>
 <%   dele_new = "Google::#{product_ns}::Network::Delete.new" -%>
 <%=
   lines(indent_list(["delete_req = #{dele_new}(self_link(@resource)"].concat(
@@ -286,9 +284,9 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 <%   else -%>
     wait_for_operation delete_req.send, @resource
 <%   end -%>
-<% else # object&.handlers.delete.nil? -%>
-<%= lines(indent(object.handlers.delete, 4)) -%>
-<% end # object&.handlers.delete.nil? -%>
+<% else # object&.handlers&.delete.nil? -%>
+<%= lines(indent(object&.handlers&.delete, 4)) -%>
+<% end # object&.handlers&.delete.nil? -%>
     @property_hash[:ensure] = :absent
   end
 

--- a/templates/puppet/provider.erb
+++ b/templates/puppet/provider.erb
@@ -260,9 +260,9 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 <% else -%>
     <%= fetch_assign -%>wait_for_operation create_req.send, @resource
 <% end -%>
-<% else # object&.handlers.create.nil? -%>
+<% else # object&.handlers&.create.nil? -%>
 <%= lines(indent(object.handlers.create, 4)) -%>
-<% end # object&.handlers.create.nil? -%>
+<% end # object&.handlers&.create.nil? -%>
     @property_hash[:ensure] = :present
   end
 
@@ -284,9 +284,9 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 <%   else -%>
     wait_for_operation delete_req.send, @resource
 <%   end -%>
-<% else # object&.handlers.delete.nil? -%>
+<% else # object&.handlers&.delete.nil? -%>
 <%= lines(indent(object.handlers.delete, 4)) -%>
-<% end # object&.handlers.delete.nil? -%>
+<% end # object&.handlers&.delete.nil? -%>
     @property_hash[:ensure] = :absent
   end
 
@@ -297,7 +297,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
     # return on !@dirty is for aiding testing (puppet already guarantees that)
     return if @created || @deleted || !@dirty
 <%
-   if object&.handlers.flush.nil?
+   if object&.handlers&.flush.nil?
      put_new = if object.update_verb.nil?
                  "Google::#{product_ns}::Network::Put.new"
                else
@@ -324,9 +324,9 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   <% obj_kind = object.kind? ? ", '#{object.kind}'" : '' -%>
   <%= fetch_assign -%>return_if_object update_req.send<%= obj_kind %>
 <%   end # object.async -%>
-<% else # object&.handlers.flush.nil? -%>
+<% else # object&.handlers&.flush.nil? -%>
 <%= lines(indent(object.handlers.flush, 4)) -%>
-<% end # object&.handlers.flush.nil? -%>
+<% end # object&.handlers&.flush&.nil? -%>
   end
 
   def dirty(field, from, to)
@@ -486,22 +486,22 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
     super(message)
   end
 
-<% if object&.handlers.collection.nil? -%>
+<% if object&.handlers&.collection.nil? -%>
 <%= lines(indent(emit_link('collection', collection_url(object), true), 2)) %>
-<% else # object.collection.nil? -%>
+<% else # object&.handlers&.collection.nil? -%>
 <%=
   lines(indent(emit_link('collection', object.handlers.collection, true), 2))
 -%>
-<% end # object.collection.nil? -%>
-<% if object&.handlers.self_link.nil? -%>
+<% end # object&.handlers&.collection.nil? -%>
+<% if object&.handlers&.self_link.nil? -%>
 <%= lines(indent(emit_link('self_link', self_link_url(object), true), 2), 1) -%>
-<% else # object&.handlers.self_link.nil? -%>
+<% else # object&.handlers&.self_link.nil? -%>
 <%=
   lines_before(
     lines(indent(emit_link('self_link', object.handlers.self_link, true), 2), 1)
   )
 -%>
-<% end # object&.handlers.self_link.nil? -%>
+<% end # object&.handlers&.self_link.nil? -%>
 <% if object&.handlers&.return_if_object.nil? -%>
 <%= lines(indent(compile('templates/return_if_object.erb'), 2)) %>
 <% else # object&.handlers&.return_if_object.nil? -%>


### PR DESCRIPTION
No functional changes to Resource Manager submodule.

Only change is comment reformatted to fit puppet.yaml to 80-chars limit.