### PR TITLE
One step closter to autogenerating SSL Proxies in Terraform

### DIFF
--- a/api/object.rb
+++ b/api/object.rb
@@ -32,7 +32,7 @@ module Api
       attr_reader :api_name
 
       def validate
-        @api_name = name
+        @api_name ||= name
 
         super
         check_property :name, String

--- a/api/object.rb
+++ b/api/object.rb
@@ -27,7 +27,13 @@ module Api
 
       include Properties
 
+      # original value of :name before the provider override happens
+      # same as :name if not overridden in provider
+      attr_reader :api_name
+
       def validate
+        @api_name = name
+
         super
         check_property :name, String
       end

--- a/api/object.rb
+++ b/api/object.rb
@@ -29,6 +29,8 @@ module Api
 
       # original value of :name before the provider override happens
       # same as :name if not overridden in provider
+      # TODO(rosbo): Add a pre-validate method and ensure this value is never
+      # set by the user.
       attr_reader :api_name
 
       def validate

--- a/api/type.rb
+++ b/api/type.rb
@@ -169,6 +169,7 @@ module Api
     # Represents an array, and stores its items' type
     class Array < Composite
       attr_reader :item_type
+      attr_reader :max_size
 
       STRING_ARRAY_TYPE = [Api::Type::Array, Api::Type::String].freeze
       NESTED_ARRAY_TYPE = [Api::Type::Array, Api::Type::NestedObject].freeze
@@ -186,6 +187,8 @@ module Api
           || type?(@item_type)
           raise "Invalid type #{@item_type}"
         end
+
+        check_optional_property :max_size, ::Integer
       end
 
       def item_type_class

--- a/api/type.rb
+++ b/api/type.rb
@@ -21,7 +21,7 @@ module Api
     # <provider>.yaml.
     module Fields
       include Api::Object::Named::Properties
-      
+
       attr_reader :description
       attr_reader :output # If set value will not be sent to server on sync
       attr_reader :input # If set to true value is used only on creation

--- a/api/type.rb
+++ b/api/type.rb
@@ -20,7 +20,8 @@ module Api
     # The list of properties (attr_reader) that can be overridden in
     # <provider>.yaml.
     module Fields
-      attr_reader :name # Duplicated here to enable overriding
+      include Api::Object::Named::Properties
+      
       attr_reader :description
       attr_reader :output # If set value will not be sent to server on sync
       attr_reader :input # If set to true value is used only on creation

--- a/google/golang_utils.rb
+++ b/google/golang_utils.rb
@@ -29,6 +29,8 @@ module Google
         "\"#{value}\""
       elsif value.is_a?(Numeric)
         value.to_s
+      elsif value.is_a?(Symbol)
+        "\"#{value}\""
       else
         raise "Unsupported go literal #{value}"
       end

--- a/google/golang_utils.rb
+++ b/google/golang_utils.rb
@@ -25,12 +25,10 @@ module Google
     # quotes in the string like "\"foo\"" which is not a pattern we want to
     # see in our yaml config files.
     def go_literal(value)
-      if value.is_a?(String)
+      if value.is_a?(String) || value.is_a?(Symbol)
         "\"#{value}\""
       elsif value.is_a?(Numeric)
         value.to_s
-      elsif value.is_a?(Symbol)
-        "\"#{value}\""
       else
         raise "Unsupported go literal #{value}"
       end

--- a/google/string_utils.rb
+++ b/google/string_utils.rb
@@ -48,5 +48,13 @@ module Google
       key.to_sym unless key.nil?
     end
     # rubocop:enable Style/SafeNavigation
+
+    # Returns all the characters up until the period (.) or returns text
+    # unchanged if there is no period.
+    def self.first_sentence(text)
+      period_pos = text.index '.'
+      return text if period_pos.nil?
+      return text[0, period_pos]
+    end
   end
 end

--- a/google/string_utils.rb
+++ b/google/string_utils.rb
@@ -52,9 +52,9 @@ module Google
     # Returns all the characters up until the period (.) or returns text
     # unchanged if there is no period.
     def self.first_sentence(text)
-      period_pos = text.index /[\.\?!]/
+      period_pos = text.index(/[\.\?!]/)
       return text if period_pos.nil?
-      return text[0, period_pos+1]
+      text[0, period_pos + 1]
     end
   end
 end

--- a/google/string_utils.rb
+++ b/google/string_utils.rb
@@ -52,9 +52,9 @@ module Google
     # Returns all the characters up until the period (.) or returns text
     # unchanged if there is no period.
     def self.first_sentence(text)
-      period_pos = text.index '.'
+      period_pos = text.index /[\.\?!]/
       return text if period_pos.nil?
-      return text[0, period_pos]
+      return text[0, period_pos+1]
     end
   end
 end

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2795,10 +2795,18 @@ objects:
     name: 'TargetSslProxy'
     kind: 'compute#targetSslProxy'
     base_url: projects/{{project}}/global/targetSslProxies
+    input: true
+    exports:
+      - !ruby/object:Api::Type::SelfLink
+        name: 'selfLink'
     description: |
       Represents a TargetSslProxy resource, which is used by one or more
       global forwarding rule to route incoming SSL requests to a backend
       service.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Setting Up SSL proxy for Google Cloud Load Balancing': 'https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/'
+      api: 'https://cloud.google.com/compute/docs/reference/latest/targetSslProxies'
 <%= indent(compile_file({}, 'templates/global_async.yaml.erb'), 4) %>
     properties:
       - !ruby/object:Api::Type::Time
@@ -2808,6 +2816,7 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'description'
         description: 'An optional description of this resource.'
+        input: true
       - !ruby/object:Api::Type::Integer
         name: 'id'
         description: 'The unique identifier for the resource.'
@@ -2822,6 +2831,8 @@ objects:
           first character must be a lowercase letter, and all following
           characters must be a dash, lowercase letter, or digit, except the last
           character, which cannot be a dash.
+        input: true
+        required: true
       - !ruby/object:Api::Type::Enum
         name: 'proxyHeader'
         description: |
@@ -2830,18 +2841,27 @@ objects:
         values:
           - :NONE
           - :PROXY_V1
+        update_verb: :POST
+        update_url: 'projects/{{project}}/global/targetSslProxies/{{name}}/setProxyHeader'
       - !ruby/object:Api::Type::ResourceRef
         name: 'service'
         resource: 'BackendService'
         imports: 'selfLink'
         description: |
           A reference to the BackendService resource.
+        required: true
+        update_verb: :POST
+        update_url: 'projects/{{project}}/global/targetSslProxies/{{name}}/setBackendService'
       - !ruby/object:Api::Type::Array
         name: 'sslCertificates'
+        max_size: 1
         description: |
           A list of SslCertificate resources that are used to authenticate
           connections between users and the load balancer. Currently, exactly
           one SSL certificate must be specified.
+        required: true
+        update_verb: :POST
+        update_url: 'projects/{{project}}/global/targetSslProxies/{{name}}/setSslCertificates'
         item_type: !ruby/object:Api::Type::ResourceRef
           name: 'sslCertificate'
           resource: 'SslCertificate'

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -205,6 +205,8 @@ overrides: !ruby/object:Provider::ResourceOverrides
   TargetPool: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   TargetSslProxy: !ruby/object:Provider::Terraform::ResourceOverride
+    # TODO(rosbo): Support sslCertificates given as name or self_link
+    exclude: true
     examples: |
       ```hcl
       resource "google_compute_target_ssl_proxy" "default" {

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -196,16 +196,51 @@ overrides: !ruby/object:Provider::ResourceOverrides
     exclude: true
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
-        name: proxy_id
+        name: proxyId
   TargetHttpsProxy: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
-        name: proxy_id
+        name: proxyId
   TargetPool: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   TargetSslProxy: !ruby/object:Provider::Terraform::ResourceOverride
-    exclude: true
+    examples: |
+      ```hcl
+      resource "google_compute_target_ssl_proxy" "default" {
+        name = "test"
+        backend_service = "${google_compute_backend_service.default.self_link}"
+        ssl_certificates = ["${google_compute_ssl_certificate.default.self_link}"]
+      }
+
+      resource "google_compute_ssl_certificate" "default" {
+        name = "default-cert"
+        private_key = "${file("path/to/test.key")}"
+        certificate = "${file("path/to/test.crt")}"
+      }
+
+      resource "google_compute_backend_service" "default" {
+        name = "default-backend"
+        protocol    = "SSL"
+        health_checks = ["${google_compute_health_check.default.self_link}"]
+      }
+
+      resource "google_compute_health_check" "default" {
+        name = "default-health-check"
+        check_interval_sec = 1
+        timeout_sec = 1
+        tcp_health_check {
+          port = "443"
+        }
+      }
+      ```
+    properties:
+      id: !ruby/object:Provider::Terraform::PropertyOverride
+        name: proxyId
+      proxyHeader: !ruby/object:Provider::Terraform::PropertyOverride
+        default_value: :NONE
+      service: !ruby/object:Provider::Terraform::PropertyOverride
+        name: backendService
   TargetTcpProxy: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   TargetVpnGateway: !ruby/object:Provider::Terraform::ResourceOverride

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -95,6 +95,8 @@ module Provider
           clazz = String
         elsif api_property.is_a?(Api::Type::Integer)
           clazz = Integer
+        elsif api_property.is_a?(Api::Type::Enum)
+          clazz = Symbol
         else
           raise "Update 'check_default_value_property' method to support " \
                 "default value for type #{api_property.class}"

--- a/spec/google_golang_spec.rb
+++ b/spec/google_golang_spec.rb
@@ -37,6 +37,11 @@ describe Google::GolangUtils do
       it { is_expected.to eq '0.987' }
     end
 
+    describe 'symbol' do
+      subject { golang.go_literal(:NONE) }
+      it { is_expected.to eq '"NONE"' }
+    end
+
     describe 'unknown type' do
       subject { -> { golang.go_literal(Class.new) } }
       it { is_expected.to raise_error(/Unsupported/) }

--- a/spec/string_utils_spec.rb
+++ b/spec/string_utils_spec.rb
@@ -29,21 +29,21 @@ describe Google::StringUtils do
       subject do
         described_class.first_sentence('Lorem ipsum. Dolor sit amet. Elit')
       end
-      it { is_expected.to eq 'Lorem ipsum.'}
+      it { is_expected.to eq 'Lorem ipsum.' }
     end
 
     context 'sentence end with question mark' do
       subject do
         described_class.first_sentence('Lorem ipsum? Dolor sit amet. Elit')
       end
-      it { is_expected.to eq 'Lorem ipsum?'}
+      it { is_expected.to eq 'Lorem ipsum?' }
     end
 
     context 'sentence end with exclamation mark' do
       subject do
         described_class.first_sentence('Lorem ipsum! Dolor sit amet. Elit')
       end
-      it { is_expected.to eq 'Lorem ipsum!'}
+      it { is_expected.to eq 'Lorem ipsum!' }
     end
 
     context 'no period returns full string' do

--- a/spec/string_utils_spec.rb
+++ b/spec/string_utils_spec.rb
@@ -19,8 +19,22 @@ describe Google::StringUtils do
     it { is_expected.to eq 'someStringWithUnderscores' }
   end
 
-  describe '#underscore' do
+  context '#underscore' do
     subject { described_class.underscore('aStringInCamelCase') }
     it { is_expected.to eq 'a_string_in_camel_case' }
+  end
+
+  context '#first_sentence' do
+    context 'sentence end with period' do
+      subject do
+        described_class.first_sentence('Lorem ipsum. Dolor sit amet. Elit')
+      end
+      it { is_expected.to eq 'Lorem ipsum'}
+    end
+
+    context 'no period returns full string' do
+      subject { described_class.first_sentence('Lorem ipsum dolor') }
+      it { is_expected.to eq 'Lorem ipsum dolor' }
+    end
   end
 end

--- a/spec/string_utils_spec.rb
+++ b/spec/string_utils_spec.rb
@@ -29,7 +29,21 @@ describe Google::StringUtils do
       subject do
         described_class.first_sentence('Lorem ipsum. Dolor sit amet. Elit')
       end
-      it { is_expected.to eq 'Lorem ipsum'}
+      it { is_expected.to eq 'Lorem ipsum.'}
+    end
+
+    context 'sentence end with question mark' do
+      subject do
+        described_class.first_sentence('Lorem ipsum? Dolor sit amet. Elit')
+      end
+      it { is_expected.to eq 'Lorem ipsum?'}
+    end
+
+    context 'sentence end with exclamation mark' do
+      subject do
+        described_class.first_sentence('Lorem ipsum! Dolor sit amet. Elit')
+      end
+      it { is_expected.to eq 'Lorem ipsum!'}
     end
 
     context 'no period returns full string' do

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -77,7 +77,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 
 	obj := map[string]interface{}{
 <% settable_properties.each do |prop| -%>
-  "<%= prop.name -%>": expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>")),
+  "<%= prop.api_name -%>": expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>")),
 <% end -%>
 	}
 
@@ -137,7 +137,7 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
 	}
 
 <% properties.each do |prop| -%>
-  d.Set("<%= Google::StringUtils.underscore(prop.name) -%>", flatten<%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.name -%>"]))
+  d.Set("<%= Google::StringUtils.underscore(prop.name) -%>", flatten<%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.api_name -%>"]))
 <% end -%>
 	d.Set("self_link", res["selfLink"])
 <% if object.base_url.include?("{{project}}") -%>
@@ -159,7 +159,7 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 	<% unless object.input -%>
 	obj := map[string]interface{}{
 		<% settable_properties.each do |prop| -%>
-		"<%= prop.name -%>": expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>")),
+		"<%= prop.api_name -%>": expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>")),
 		<% end -%>
 	}
 
@@ -192,12 +192,12 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 	var obj map[string]interface{}
 	var url string
 	var res map[string]interface{}
-	var op <%= api_name_lower -%>.Operation
+	op := &<%= api_name_lower -%>.Operation{}
 
 	<% settable_properties.reject { |p| p.update_url.nil? }.each do |prop| -%>
 	if d.HasChange("<%= Google::StringUtils.underscore(prop.name) -%>") {
 		obj = map[string]interface{}{
-			"<%= prop.name -%>": expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>")),
+			"<%= prop.api_name -%>": expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>")),
 		}
 		url, err = replaceVars(d, config, "<%= update_url(object, prop.update_url) -%>")
 		if err != nil {
@@ -208,7 +208,7 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 			return fmt.Errorf("Error updating <%= object.name -%> %q: %s", d.Id(), err)
 		}
 
-		err = Convert(res, &op)
+		err = Convert(res, op)
 		if err != nil {
 			return err
 		}

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -24,7 +24,7 @@ layout: "google"
 page_title: "Google: google_<%= api_name_lower -%>_<%= resource_name -%>"
 sidebar_current: "docs-google-<%= api_name_lower -%>-<%= resource_name.gsub("_", "-") -%>"
 description: |-
-  <%= object.description.lines.first -%>
+  <%= Google::StringUtils.first_sentence(object.description) -%>
 ---
 
 # google\_<%= api_name_lower -%>\_<%= resource_name.gsub("_", "\\_") %>

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -47,6 +47,9 @@
     },
   },
 <% elsif property.is_a?(Api::Type::Array) -%>
+	<% unless property.max_size.nil? -%>
+			MaxItems: <%= property.max_size %>,
+	<% end -%>
   <% if property.item_type.is_a?(Api::Type::NestedObject) -%>
       Elem: &schema.Resource{
         Schema: map[string]*schema.Schema{


### PR DESCRIPTION
- Short description in tf documentation includes the first sentence instead of the first line
- Array type can specify a max size
- Keep track of the original resource/property name
- Support printing Enum symbols in golang
- Fix bugs in tf update method for non standard update method
- There is only one feature missing (accept name or self_link for ResourceRef field) to be able to autogenerate this resource and I will do it in a separate CL because it will affect existing resources.

Change-Id: I94756d7ec3f9f5b8f17853637122013f944f27ab

<!-- A summary of the changes in this commit goes here -->


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-compute]
## [chef]
