### PR TITLE
Port storage/puppet to new strong-typed overrides.

### DIFF
--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -27,8 +27,13 @@ module Provider
     # Settings for the Ansible provider
     class Config < Provider::Config
       attr_reader :manifest
+
       def provider
         Provider::Ansible::Core
+      end
+
+      def resource_override
+        Provider::Ansible::ResourceOverride
       end
 
       def validate

--- a/provider/ansible/resource_override.rb
+++ b/provider/ansible/resource_override.rb
@@ -17,11 +17,20 @@ module Provider
   module Ansible
     # Ansible specific properties to be added to Api::Resource
     module OverrideProperties
+      attr_reader :access_api_results
     end
 
     # Product specific overriden properties for Ansible
     class ResourceOverride < Provider::ResourceOverride
       include OverrideProperties
+
+      def validate
+        super
+
+        default_value_property :access_api_results, false
+
+        check_property :access_api_results, :boolean
+      end
 
       private
 

--- a/provider/config.rb
+++ b/provider/config.rb
@@ -193,6 +193,7 @@ module Provider
       # class features
       source = config.compile(cfg_file)
       config = Google::YamlValidator.parse(source)
+      config.default_overrides
       config.spread_api config, api, [], '' unless api.nil?
       config.validate
       config
@@ -204,10 +205,13 @@ module Provider
 
     def validate
       super
+
+      default_overrides
+
       check_property :examples, Api::Resource::HashArray unless @examples.nil?
       check_property :files, Provider::Config::Files unless @files.nil?
       check_property :objects, Api::Resource::HashArray unless @objects.nil?
-      check_optional_property :overrides, Provider::ResourceOverrides
+      check_property :overrides, Provider::ResourceOverrides
       check_property :test_data, Provider::Config::TestData \
         unless @test_data.nil?
       check_property :tests, Api::Resource::HashArray unless @tests.nil?
@@ -230,6 +234,11 @@ module Provider
         var_value.consume_api api if var_value.respond_to?(:consume_api)
         spread_api(var_value, api, visited, indent)
       end
+    end
+
+    def default_overrides
+      @overrides ||= Provider::ResourceOverrides.new
+      @overrides.consume_config self
     end
   end
 end

--- a/provider/puppet.rb
+++ b/provider/puppet.rb
@@ -41,8 +41,13 @@ module Provider
         Provider::Puppet
       end
 
+      def resource_override
+        Provider::Puppet::ResourceOverride
+      end
+
       def validate
         super
+
         check_optional_property :manifest, Provider::Puppet::Manifest
         check_property_list :functions, Provider::Config::Function
         check_property_list :bolt_tasks, Provider::Puppet::BoltTask

--- a/provider/resource_overrides.rb
+++ b/provider/resource_overrides.rb
@@ -37,10 +37,16 @@ module Provider
       @__api = api
     end
 
+    def consume_config(config)
+      @__config = config
+    end
+
     def validate
       return unless @__objects.nil? # allows idempotency of calling validate
+      return if @__api.nil?
+      populate_nonoverridden_objects
       convert_findings_to_hash
-      override_objects unless @__api.nil?
+      override_objects
       super
     end
 
@@ -135,6 +141,14 @@ module Provider
       elsif api_entity.is_a?(Api::Type::Array) &&
             api_entity.item_type.is_a?(Api::Type::NestedObject)
         api_entity.item_type.properties
+      end
+    end
+
+    def populate_nonoverridden_objects
+      @__api.objects.each do |object|
+        var_name = "@#{object.name}".to_sym
+        instance_variable_set(var_name, @__config.resource_override.new) \
+          unless instance_variables.include?(var_name)
       end
     end
   end

--- a/provider/terraform/config.rb
+++ b/provider/terraform/config.rb
@@ -21,6 +21,10 @@ module Provider
       def provider
         Provider::Terraform
       end
+
+      def resource_override
+        Provider::Terraform::ResourceOverride
+      end
     end
   end
 end


### PR DESCRIPTION
Enables puppet.yaml without any overrides: section, or partial listing of overridden objects.