### PR TITLE
Add newline after resource short description in documentation

### DIFF
--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -24,7 +24,7 @@ layout: "google"
 page_title: "Google: google_<%= api_name_lower -%>_<%= resource_name -%>"
 sidebar_current: "docs-google-<%= api_name_lower -%>-<%= resource_name.gsub("_", "-") -%>"
 description: |-
-  <%= Google::StringUtils.first_sentence(object.description) -%>
+  <%= Google::StringUtils.first_sentence(object.description) %>
 ---
 
 # google\_<%= api_name_lower -%>\_<%= resource_name.gsub("_", "\\_") %>


### PR DESCRIPTION
Also includes the change in the downstream repository to include the first sentence instead of the first line for resource description. See issue #83 

<!-- A summary of the changes in this commit goes here -->


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Add newline after resource short description in documentation
## [puppet]
### [puppet-dns]
### [puppet-compute]
## [chef]
