### PR TITLE
ResourceRef fields in Terraform accept name or partial/full self_link

### DIFF
--- a/provider/terraform/sub_template.rb
+++ b/provider/terraform/sub_template.rb
@@ -39,6 +39,12 @@ module Provider
                          property: property
       end
 
+      def build_expand_resource_ref(var_name, property)
+        compile_template 'templates/terraform/expand_resource_ref.erb',
+                         var_name: var_name,
+                         property: property
+      end
+
       def build_property_documentation(property)
         compile_template 'templates/terraform/property_documentation.erb',
                          property: property

--- a/templates/terraform/expand_property_method.erb
+++ b/templates/terraform/expand_property_method.erb
@@ -13,18 +13,18 @@
   # limitations under the License.
 <% end -%>
 <% if property.is_a?(Api::Type::NameValues) -%>
-func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) map[string]string {
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) (map[string]string, error) {
   if v == nil {
-    return map[string]string{}
+    return map[string]string{}, nil
   }
   m := make(map[string]string)
   for k, val := range v.(map[string]interface{}) {
     m[k] = val.(string)
   }
-  return m
+  return m, nil
 }
 <% elsif tf_types.include?(property.class) -%>
-func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) interface{} {
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) (interface{}, error) {
 <%
   if !effective_nested_properties(property).empty?
     nested_properties = effective_nested_properties(property)
@@ -42,15 +42,33 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) int
 
     req = append(req, transformed)
   }
-  return req
-}
+  return req, nil
   <% nested_properties.each do |prop| -%>
     <%= lines(build_expand_method(prefix + titlelize_property(property), prop), 1) -%>
   <% end -%>
+<% elsif property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::ResourceRef) -%>
+  l := v.([]interface{})
+  req := make([]interface{}, 0, len(l))
+  for _, raw := range l {
+    f, err := <%= build_expand_resource_ref('raw.(string)', property.item_type) %>
+    if err != nil {
+      return nil, fmt.Errorf("Invalid value for <%= Google::StringUtils.underscore(property.name) -%>: %s", err)
+    }
+    req = append(req, f.RelativeLink())
+  }
+  return req, nil
 <% else -%>
-  return v
-}
+  <% if property.is_a?(Api::Type::ResourceRef) -%>
+  f, err := <%= build_expand_resource_ref('v.(string)', property) %>
+  if err != nil {
+    return nil, fmt.Errorf("Invalid value for <%= Google::StringUtils.underscore(property.name) -%>: %s", err)
+  }
+  return f.RelativeLink(), nil
+  <% else -%>
+  return v, nil
+  <% end -%>
 <% end -%>
+}
 <% else -%>
   // TODO: Property '<%= property.name -%>' of type <%= property.class -%> is not supported
 <% end # tf_types.include?(property.class) -%>

--- a/templates/terraform/expand_resource_ref.erb
+++ b/templates/terraform/expand_resource_ref.erb
@@ -1,0 +1,10 @@
+<%
+	resource_type = property.resource_ref.base_url.split('/').last
+-%>
+<% if property.resource_ref.base_url.include?('{{region}}') -%>
+parseRegionalFieldValue("<%= resource_type -%>", <%= var_name -%>, "project", "region", "zone", d, config, true)
+<% elsif property.resource_ref.base_url.include?('{{zone}}') -%>
+parseZonalFieldValue("<%= resource_type -%>", <%= var_name -%>, "project", "zone", d, config, true)
+<% else -%>
+parseGlobalFieldValue("<%= resource_type -%>", <%= var_name -%>, "project", d, config, true)
+<% end -%>

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -75,9 +75,16 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 		return err
 	}
 
+<% settable_properties.each do |prop| -%>
+	<%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>"), d, config)
+	if err != nil {
+		return err
+	}
+<% end -%>
+
 	obj := map[string]interface{}{
 <% settable_properties.each do |prop| -%>
-  "<%= prop.api_name -%>": expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>")),
+  "<%= prop.api_name -%>": <%= prop.api_name -%>Prop,
 <% end -%>
 	}
 
@@ -157,9 +164,17 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 	}
 
 	<% unless object.input -%>
+
+	<% settable_properties.each do |prop| -%>
+	<%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>"), d, config)
+	if err != nil {
+		return err
+	}
+	<% end -%>
+
 	obj := map[string]interface{}{
 		<% settable_properties.each do |prop| -%>
-		"<%= prop.api_name -%>": expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>")),
+			"<%= prop.api_name -%>": <%= prop.api_name -%>Prop,
 		<% end -%>
 	}
 
@@ -189,15 +204,23 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 		return err
 	}
 	<% else # unless object.input -%>
-	var obj map[string]interface{}
 	var url string
 	var res map[string]interface{}
 	op := &<%= api_name_lower -%>.Operation{}
 
 	<% settable_properties.reject { |p| p.update_url.nil? }.each do |prop| -%>
 	if d.HasChange("<%= Google::StringUtils.underscore(prop.name) -%>") {
-		obj = map[string]interface{}{
-			"<%= prop.api_name -%>": expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>")),
+		<% settable_properties.each do |prop| -%>
+			<%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>"), d, config)
+			if err != nil {
+				return err
+			}
+		<% end -%>
+
+		obj := map[string]interface{}{
+		<% settable_properties.each do |prop| -%>
+			"<%= prop.api_name -%>": <%= prop.api_name -%>Prop,
+		<% end -%>
 		}
 		url, err = replaceVars(d, config, "<%= update_url(object, prop.update_url) -%>")
 		if err != nil {


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Expand methods can now throw an error since parsing resourceref may fail if no project, zone or region is set.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
ResourceRef fields accept name-only or partial/full self_link
## [puppet]
### [puppet-dns]
### [puppet-compute]
## [chef]
