### PR TITLE
Sync all relevant generated submodules to master HEAD before generating

### DIFF
--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -117,6 +117,7 @@ jobs:
             file: magic-modules/.ci/magic-modules/branch.yml
             params:
               GH_TOKEN: ((github-account.password))
+              CREDS: ((repo-key.private_key))
           - aggregate:
             - do:
                 # consumes: magic-modules-branched

--- a/.ci/containers/python/Dockerfile
+++ b/.ci/containers/python/Dockerfile
@@ -1,3 +1,6 @@
 from python:2.7-stretch
 
 run pip install pygithub
+# Set up Github SSH cloning.
+RUN ssh-keyscan github.com >> /known_hosts
+RUN echo "UserKnownHostsFile /known_hosts" >> /etc/ssh/ssh_config

--- a/.ci/magic-modules/branch-magic-modules.sh
+++ b/.ci/magic-modules/branch-magic-modules.sh
@@ -21,4 +21,13 @@ git checkout -B "$BRANCH"
 # this output is no longer available.
 echo "$BRANCH" > ./branchname
 
+set +x
+# Don't show the credential in the output.
+echo "$CREDS" > ~/github_private_key
+set -x
+chmod 400 ~/github_private_key
+
+# Update to head on master on all submodules, so we avoid spurious diffs.
+ssh-agent bash -c "ssh-add ~/github_private_key; git submodule update --remote --init build/terraform build/puppet/sql build/puppet/compute"
+
 cp -r ./ ../magic-modules-branched/

--- a/.ci/magic-modules/branch.yml
+++ b/.ci/magic-modules/branch.yml
@@ -10,7 +10,7 @@ image_resource:
         # This task requires a container with 'git', 'python', and the pip
         # package 'pygithub'.
         repository: nmckinley/python
-        tag: 'v0.0.1'
+        tag: 'v0.0.2'
 
 inputs:
     - name: magic-modules

--- a/.ci/magic-modules/branch.yml
+++ b/.ci/magic-modules/branch.yml
@@ -21,6 +21,7 @@ outputs:
 params:
   USE_SHA: ""
   GH_TOKEN: ""
+  CREDS: ""
 
 run:
     path: magic-modules/.ci/magic-modules/branch-magic-modules.sh

--- a/.ci/magic-modules/generate-puppet.sh
+++ b/.ci/magic-modules/generate-puppet.sh
@@ -10,8 +10,6 @@ set -e
 IFS="," read -ra PRODUCT_ARRAY <<< "$PRODUCTS"
 for PRD in "${PRODUCT_ARRAY[@]}"; do
   pushd magic-modules-branched
-    git submodule update --init "build/puppet/$PRD"
-
     LAST_COMMIT_AUTHOR="$(git log --pretty="%an <%ae>" -n1 HEAD)"
     find build/puppet/"${PRD}"/ -type f -not -name '.git*' -print0 | xargs -0 rm -rf --
     bundle install

--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -13,7 +13,6 @@ export GOPATH="${PWD}/go"
 mkdir -p "${GOPATH}/src/github.com/terraform-providers"
 
 pushd magic-modules-branched
-git submodule update --init build/terraform
 ln -s "${PWD}/build/terraform/" "${GOPATH}/src/github.com/terraform-providers/terraform-provider-google"
 popd
 


### PR DESCRIPTION
This will prevent virtually all spurious diffs caused by downstream changes that don't get
propagated back up to magic-modules.  It comes at the extremely minor cost of not being
able to intentionally keep a submodule behind master HEAD via The Magician (doing so,
if for whatever reason it is necessary, will require some extra manual work).

-----------------------------------------------------------------
# [all]
CI changes only - ignore
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
