### PR TITLE
User validation in the version bump.

### DIFF
--- a/.ci/ci.yml
+++ b/.ci/ci.yml
@@ -11,7 +11,7 @@ resource_types:
       type: docker-image
       source:
           repository: nmckinley/concourse-github-pr-resource
-          tag: v0.1.4
+          tag: v0.1.5
 
     - name: gcs-resource
       type: docker-image
@@ -37,7 +37,7 @@ resources:
           repo: GoogleCloudPlatform/magic-modules
           private_key: ((repo-key.private_key))
           access_token: ((github-account.password))
-          authorship_restriction: false
+          authorship_restriction: true
 
     - name: terraform-intermediate
       type: git-branch


### PR DESCRIPTION
Github classifies us all as "contributors" rather than "members", "collaborators", or "owners" - I'm not sure why, exactly.  I bumped up the permissibility of `authorship_restriction`, built a new container into v0.1.5, and added it back in here.

-----------------------------------------------------------------
# [all]
CI changes only
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-compute]
## [chef]
