### PR TITLE
Merge more submodules.

### DIFF
--- a/.ci/magic-modules/merge-pr.sh
+++ b/.ci/magic-modules/merge-pr.sh
@@ -24,12 +24,16 @@ git config pullrequest.id "$ID"
 git checkout "$BRANCH"
 git config --global user.email "magic-modules@google.com"
 git config --global user.name "Modular Magician"
+git config -f .gitmodules submodule.build/puppet/sql.branch master
+git config -f .gitmodules submodule.build/puppet/sql.url "git@github.com:GoogleCloudPlatform/puppet-google-sql.git"
+git config -f .gitmodules submodule.build/puppet/compute.branch master
+git config -f .gitmodules submodule.build/puppet/compute.url "git@github.com:GoogleCloudPlatform/puppet-google-compute.git"
 git config -f .gitmodules submodule.build/terraform.branch master
 git config -f .gitmodules submodule.build/terraform.url "git@github.com:terraform-providers/terraform-provider-google.git"
-ssh-agent bash -c "ssh-add ~/github_private_key; git submodule update --remote --init build/terraform"
+ssh-agent bash -c "ssh-add ~/github_private_key; git submodule update --remote --init build/terraform build/puppet/compute build/puppet/sql"
 
-git add build/terraform
+git add build/terraform build/puppet/compute build/puppet/sql
 git add .gitmodules
 
-git commit -m "Update terraform -> HEAD on $(date)"
+git commit -m "Update tracked submodules -> HEAD on $(date)"
 echo "Merged PR #$ID." > ./commit_message


### PR DESCRIPTION
This change is a stopgap - right now the `merge-prs` task doesn't successfully update all the submodules for all the PRs it creates, which is wrong!  To avoid having to create a bunch more "updating submodules" commits and PRs, this is a stopgap until my next PR (which makes adding new repos 100x easier and tracks all affected submodules in one place).

Not pretty, just expedient.  :)

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
CI changes only.
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
