### PR TITLE
Autogenerate provider-compute-gen.go file

### DIFF
--- a/.ci/magic-modules/create-pr.sh
+++ b/.ci/magic-modules/create-pr.sh
@@ -83,7 +83,7 @@ else
   # PR, rather than create a new one.
   git branch -f "$ORIGINAL_PR_BRANCH"
 
-  if [ -z "$TERRAFORM_REPO_USER" ]; then
+  if [ -n "$TERRAFORM_REPO_USER" ]; then
     pushd build/terraform
     git branch -f "$ORIGINAL_PR_BRANCH"
     popd

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -401,7 +401,7 @@ files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.
   # This is usually to add licensing info, autogeneration notices, etc.
   compile:
-    # 'compiled_file': 'templates/terraform/compiled_file'
+    'google/provider_{{product_name}}_gen.go': 'templates/terraform/provider_gen.erb'
 
 # This is for custom testing code. All of our tests follow a specific pattern
 # that sometimes needs to be deviated from. We're working towards a world where

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -179,6 +179,8 @@ module Provider
         Google::LOGGER.info "Compiling #{source} => #{target}"
         target_file = File.join(output_folder, target)
                           .gsub('{{product_name}}', @api.prefix[1..-1])
+
+        manifest = @config.respond_to?(:manifest) ? @config.manifest : {}
         generate_file(
           data.clone.merge(
             name: target,
@@ -186,7 +188,7 @@ module Provider
             object: {},
             config: {},
             scopes: @api.scopes,
-            manifest: @config.manifest,
+            manifest: manifest,
             tests: '',
             template: source,
             generated_files: @generated,
@@ -198,6 +200,10 @@ module Provider
             product_ns: Google::StringUtils.camelize(@api.prefix[1..-1], :upper)
           )
         )
+
+        if File.extname(target_file) == '.go'
+          %x(goimports -w #{target_file})
+        end
       end
     end
     # rubocop:enable Metrics/MethodLength

--- a/templates/terraform/provider_gen.erb
+++ b/templates/terraform/provider_gen.erb
@@ -1,0 +1,26 @@
+<% if false # the license inside this if block pertains to this file -%>
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+<% end -%>
+<%= lines(autogen_notice :go) -%>
+
+package google
+
+import "github.com/hashicorp/terraform/helper/schema"
+
+var Generated<%= product_ns -%>ResourcesMap = map[string]*schema.Resource{
+<% product.objects.reject { |r| r.exclude }.each do |object| -%>
+<% resource_name = product_ns + object.name -%>
+	"google_<%= Google::StringUtils.underscore(resource_name) -%>": resource<%= resource_name -%>(),
+<% end -%>
+}


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->

This change allows to introduce new resources to Terraform in one MM commit (allows to also run the terraform acceptance tests against that PR). 

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Autogenerate provider-compute-gen.go file
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
