### PR TITLE
Another -n / -z mistake.

### DIFF
--- a/.ci/magic-modules/create-pr.sh
+++ b/.ci/magic-modules/create-pr.sh
@@ -83,7 +83,7 @@ else
   # PR, rather than create a new one.
   git branch -f "$ORIGINAL_PR_BRANCH"
 
-  if [ -z "$TERRAFORM_REPO_USER" ]; then
+  if [ -n "$TERRAFORM_REPO_USER" ]; then
     pushd build/terraform
     git branch -f "$ORIGINAL_PR_BRANCH"
     popd


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
:man_facepalming: :man_facepalming: :man_facepalming: 

I think this is the last version of this mistake.  I hope.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
No changes.
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
