### PR TITLE
Update github resource version to add ability to detect ready PRs.

### DIFF
--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -33,7 +33,7 @@ resource_types:
       type: docker-image
       source:
           repository: nmckinley/concourse-github-pr-resource
-          tag: v0.1.5
+          tag: v0.1.7
 
     - name: gcs-resource
       type: docker-image
@@ -91,6 +91,8 @@ resources:
           access_token: ((github-account.password))
           only_mergeable: true
           require_review_approval: true
+          check_dependent_prs: true
+          label: downstream-generated
 
     - name: nmckinley-pr
       type: docker-image
@@ -335,6 +337,7 @@ jobs:
             params:
                 path: mm-output
                 status: success
+                label: downstream-generated
                 merge:
                     method: squash
                     commit_msg: mm-output/commit_message


### PR DESCRIPTION
This is an upgrade to a new version of the PR resource I built.  This one contains the ability to check whether the "depends: ..." comments represent merged PRs.  It also adds the label 'downstream-generated' to PRs when their downstreams are generated, and makes the auto-merge resource only look at those PRs which have had their downstreams generated already.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
No changes expected.
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
