### PR TITLE
Support default value from API in Terraform

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -86,17 +86,23 @@ overrides: !ruby/object:Provider::ResourceOverrides
       id: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
       checkIntervalSec: !ruby/object:Provider::Terraform::PropertyOverride
-        default_value: 5
+        default: !ruby/object:Provider::Terraform::Default
+          value: 5
       healthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
-        default_value: 2
+        default: !ruby/object:Provider::Terraform::Default
+          value: 2
       port: !ruby/object:Provider::Terraform::PropertyOverride
-        default_value: 80
+        default: !ruby/object:Provider::Terraform::Default
+          value: 80
       requestPath: !ruby/object:Provider::Terraform::PropertyOverride
-        default_value: "/"
+        default: !ruby/object:Provider::Terraform::Default
+          value: "/"
       timeoutSec: !ruby/object:Provider::Terraform::PropertyOverride
-        default_value: 5
+        default: !ruby/object:Provider::Terraform::Default
+          value: 5
       unhealthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
-        default_value: 2
+        default: !ruby/object:Provider::Terraform::Default
+          value: 2
   HttpsHealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
     description: |
       {{description}}
@@ -120,17 +126,23 @@ overrides: !ruby/object:Provider::ResourceOverrides
       id: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
       checkIntervalSec: !ruby/object:Provider::Terraform::PropertyOverride
-        default_value: 5
+        default: !ruby/object:Provider::Terraform::Default
+          value: 5
       healthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
-        default_value: 2
+        default: !ruby/object:Provider::Terraform::Default
+          value: 2
       port: !ruby/object:Provider::Terraform::PropertyOverride
-        default_value: 443
+        default: !ruby/object:Provider::Terraform::Default
+          value: 443
       requestPath: !ruby/object:Provider::Terraform::PropertyOverride
-        default_value: "/"
+        default: !ruby/object:Provider::Terraform::Default
+          value: "/"
       timeoutSec: !ruby/object:Provider::Terraform::PropertyOverride
-        default_value: 5
+        default: !ruby/object:Provider::Terraform::Default
+          value: 5
       unhealthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
-        default_value: 2
+        default: !ruby/object:Provider::Terraform::Default
+          value: 2
   HealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   Image: !ruby/object:Provider::Terraform::ResourceOverride
@@ -283,7 +295,8 @@ overrides: !ruby/object:Provider::ResourceOverrides
       id: !ruby/object:Provider::Terraform::PropertyOverride
         name: proxyId
       proxyHeader: !ruby/object:Provider::Terraform::PropertyOverride
-        default_value: :NONE
+        default: !ruby/object:Provider::Terraform::Default
+          value: :NONE
       service: !ruby/object:Provider::Terraform::PropertyOverride
         name: backendService
   TargetTcpProxy: !ruby/object:Provider::Terraform::ResourceOverride

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -58,7 +58,7 @@ module Provider
         # Ensure boolean values are set to false if nil
         @from_api ||= false
 
-        check_optional_property :from_api, :boolean
+        check_property :from_api, :boolean
 
         raise "'value' and 'from_api' cannot be both set for 'default'"  \
           if from_api && !value.nil?

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -41,9 +41,10 @@ module Provider
       end
     end
 
-    # Default value for the property if any. These properties are mutually
-    # exclusive.
+    # Default value for the property if any.
     class Default < Api::Object
+      # the attributes below are mutually exclusive.
+
       # if specified, then this will be set as the default value in the schema
       attr_reader :value
       # if true, then we get the default value from the Google API if no value

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -15,7 +15,10 @@
 <% if tf_types.include?(property.class) -%>
 "<%= Google::StringUtils.underscore(property.name) -%>": {
   Type: <%= tf_types[property.class] %>,
-<% if property.required -%>
+<%	if property.default.from_api -%>
+	Computed: true,
+	Optional: true,
+<% elsif property.required -%>
   Required: true,
 <% elsif property.output -%>
   Computed: true,
@@ -83,8 +86,8 @@
 <% if property.sensitive -%>
     Sensitive: true,
 <% end -%>
-<% unless property.default_value.nil? -%>
-    Default: <%= go_literal(property.default_value) -%>,
+<% unless property.default.value.nil? -%>
+    Default: <%= go_literal(property.default.value) -%>,
 <% end -%>
 },
 <% else -%>


### PR DESCRIPTION
a.k.a Default & Optional properties.

This will allow me to release the vpn_gateway and target_pool resource in a subsequent PR. 

No expected changes into downstream repositories.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
