### PR TITLE
Always parse a string fixed64 string to a int64 even on 32 bits platform

### DIFF
--- a/templates/terraform/flatten_property_method.erb
+++ b/templates/terraform/flatten_property_method.erb
@@ -37,7 +37,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) in
 <% elsif property.is_a?(Api::Type::Integer) -%>
 	// Handles the string fixed64 format
 	if strVal, ok := v.(string); ok {
-		if intVal, err := strconv.Atoi(strVal); err == nil {
+		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
 			return intVal
 		} // let terraform core handle it if we can't convert the string to an int.
 	}


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->

strconv.Atoi returns the result of ParseInt(s, 10, 0). The last parameter is the `bitSize`. When `bitSize` is 0, it uses the default platform number of bits(32 for 32bits architecture) and crashes when parsing.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Always parse a string int64 with 64bits even on 32bits platform
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
