### PR TITLE
Disable autogeneration for vpn gateway in terraform

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -394,7 +394,8 @@ overrides: !ruby/object:Provider::ResourceOverrides
           value: :NONE
   TargetVpnGateway: !ruby/object:Provider::Terraform::ResourceOverride
     name: 'VpnGateway'
-    exclude: false
+    # TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/156): Re-enable code generation for this resource
+    exclude: true
     examples: |
       ```hcl
       resource "google_compute_network" "network1" {


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->

Once @ndmckinley's work to support custom in magic-modules is in, we can go back to autogenerating this resource

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Disable autogeneration for google_compute_vpn_gateway
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
