### PR TITLE
replace product base_url with versions object

### DIFF
--- a/api/product.rb
+++ b/api/product.rb
@@ -18,22 +18,59 @@ require 'compile/core'
 module Api
   # Repesents a product to be managed
   class Product < Api::Object::Named
-    attr_reader :base_url
     attr_reader :objects
     attr_reader :prefix
     attr_reader :scopes
+    attr_reader :versions
 
     include Compile::Core
 
     def validate
       super
       set_variables @objects, :__product
-      check_property :base_url, String
       check_property :objects, Array
       check_property_list :objects, Api::Resource
       check_property :prefix, String
       check_property :scopes, ::Array
       check_property_list :scopes, String
+
+      check_versions
+    end
+
+    # Represents a version of the API for this product
+    class Version < Api::Object
+      attr_reader :base_url
+      attr_reader :default
+      attr_reader :name
+
+      def validate
+        super
+        check_property :base_url, String
+        check_property :name, String
+        check_optional_property :default, [TrueClass, FalseClass]
+      end
+    end
+
+    def default_version
+      @versions.each do |v|
+        return v if v.default
+      end
+    end
+
+    private
+
+    def check_versions
+      check_property :versions, Array
+      check_property_list :versions, Api::Product::Version
+
+      # Confirm that at exactly one version is the default
+      defaults = 0
+      @versions.each do |v|
+        defaults += 1 if v.default
+      end
+
+      raise "Product '#{@name}' must specify exactly one default API version" \
+        if defaults != 1
     end
   end
 end

--- a/api/product.rb
+++ b/api/product.rb
@@ -45,9 +45,11 @@ module Api
 
       def validate
         super
+        @default ||= false
+
         check_property :base_url, String
         check_property :name, String
-        check_optional_property :default, [TrueClass, FalseClass]
+        check_property :default, :boolean
       end
     end
 
@@ -55,6 +57,8 @@ module Api
       @versions.each do |v|
         return v if v.default
       end
+
+      return @versions.last if @versions.length == 1
     end
 
     private
@@ -63,14 +67,17 @@ module Api
       check_property :versions, Array
       check_property_list :versions, Api::Product::Version
 
-      # Confirm that at exactly one version is the default
+      # Confirm that at most one version is the default
       defaults = 0
       @versions.each do |v|
         defaults += 1 if v.default
       end
 
-      raise "Product '#{@name}' must specify exactly one default API version" \
-        if defaults != 1
+      raise "Product '#{@name}' must specify at most one default API version" \
+        if defaults > 1
+
+      raise "Product '#{@name}' must specify a default API version" \
+        if defaults == 0 && @versions.length > 1
     end
   end
 end

--- a/api/product.rb
+++ b/api/product.rb
@@ -77,7 +77,7 @@ module Api
         if defaults > 1
 
       raise "Product '#{@name}' must specify a default API version" \
-        if defaults == 0 && @versions.length > 1
+        if defaults.zero? && @versions.length > 1
     end
   end
 end

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -271,7 +271,7 @@ module Api
     # Returns all of the properties that are a part of the self_link or
     # collection URLs
     def uri_properties
-      [@base_url, @__product.base_url].map do |url|
+      [@base_url, @__product.default_version.base_url].map do |url|
         parts = url.scan(/\{\{(.*?)\}\}/).flatten
         parts << 'name'
         parts.delete('project')

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 75.96
+    "covered_percent": 65.56
   }
 }

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 65.56
+    "covered_percent": 80.11
   }
 }

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -16,7 +16,14 @@
 --- !ruby/object:Api::Product
 name: Google Compute Engine
 prefix: gcompute
-base_url: https://www.googleapis.com/compute/v1/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://www.googleapis.com/compute/v1/
+    default: true
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://www.googleapis.com/compute/beta/
 scopes:
   - https://www.googleapis.com/auth/compute
 objects:

--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -14,7 +14,11 @@
 --- !ruby/object:Api::Product
 name: Google Container Engine
 prefix: gcontainer
-base_url: https://container.googleapis.com/v1/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://container.googleapis.com/v1/
+    default: true
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 objects:

--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -18,7 +18,6 @@ versions:
   - !ruby/object:Api::Product::Version
     name: v1
     base_url: https://container.googleapis.com/v1/
-    default: true
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 objects:

--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: Google Cloud DNS
 prefix: gdns
-base_url: https://www.googleapis.com/dns/v1/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://www.googleapis.com/dns/v1/
 scopes:
   - https://www.googleapis.com/auth/ndev.clouddns.readwrite
 objects:

--- a/products/iam/api.yaml
+++ b/products/iam/api.yaml
@@ -16,7 +16,10 @@
 --- !ruby/object:Api::Product
 name: Google Cloud IAM
 prefix: giam
-base_url: https://iam.googleapis.com/v1/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://iam.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/iam
 objects:

--- a/products/pubsub/api.yaml
+++ b/products/pubsub/api.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: Google Cloud Pub/Sub
 prefix: gpubsub
-base_url: https://pubsub.googleapis.com/v1/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://pubsub.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/pubsub
 objects:

--- a/products/resourcemanager/api.yaml
+++ b/products/resourcemanager/api.yaml
@@ -18,7 +18,6 @@ versions:
   - !ruby/object:Api::Product::Version
     name: v1
     base_url: https://cloudresourcemanager.googleapis.com/v1/
-    default: true
 scopes:
   # All access is needed to create projects.
   - https://www.googleapis.com/auth/cloud-platform

--- a/products/resourcemanager/api.yaml
+++ b/products/resourcemanager/api.yaml
@@ -14,7 +14,11 @@
 --- !ruby/object:Api::Product
 name: Google Cloud Resource Manager
 prefix: gresourcemanager
-base_url: https://cloudresourcemanager.googleapis.com/v1/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://cloudresourcemanager.googleapis.com/v1/
+    default: true
 scopes:
   # All access is needed to create projects.
   - https://www.googleapis.com/auth/cloud-platform

--- a/products/spanner/api.yaml
+++ b/products/spanner/api.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: Google Spanner
 prefix: gspanner
-base_url: https://spanner.googleapis.com/v1/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://spanner.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/spanner.admin
 objects:

--- a/products/sql/api.yaml
+++ b/products/sql/api.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: Google Cloud SQL
 prefix: gsql
-base_url: https://www.googleapis.com/sql/v1beta4/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://www.googleapis.com/sql/v1beta4/
 scopes:
   - https://www.googleapis.com/auth/sqlservice.admin
 objects:

--- a/products/storage/api.yaml
+++ b/products/storage/api.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: Google Cloud Storage
 prefix: gstorage
-base_url: https://www.googleapis.com/storage/v1/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://www.googleapis.com/storage/v1/
 scopes:
   - https://www.googleapis.com/auth/devstorage.full_control
 objects:

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -98,14 +98,14 @@ module Provider
 
       def collection_url(resource)
         base_url = resource.base_url.split("\n").map(&:strip).compact
-        full_url = [resource.__product.base_url, base_url].flatten.join
+        full_url = [resource.__product.default_version.base_url, base_url].flatten.join
         # Double {} replaced with single {} to support Python string
         # interpolation
         "\"#{full_url.gsub('{{', '{').gsub('}}', '}')}\""
       end
 
       def async_operation_url(resource)
-        base_url = resource.__product.base_url
+        base_url = resource.__product.default_version.base_url
         url = [base_url, resource.async.operation.base_url].join
         "\"#{url.gsub('{{', '{').gsub('}}', '}')}\""
       end

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -98,7 +98,8 @@ module Provider
 
       def collection_url(resource)
         base_url = resource.base_url.split("\n").map(&:strip).compact
-        full_url = [resource.__product.default_version.base_url, base_url].flatten.join
+        full_url = [resource.__product.default_version.base_url,
+                    base_url].flatten.join
         # Double {} replaced with single {} to support Python string
         # interpolation
         "\"#{full_url.gsub('{{', '{').gsub('}}', '}')}\""

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -360,7 +360,7 @@ module Provider
     end
 
     def self_link_raw_url(resource)
-      base_url = resource.__product.base_url.split("\n").map(&:strip).compact
+      base_url = resource.__product.default_version.base_url.split("\n").map(&:strip).compact
       if resource.self_link.nil?
         [base_url, [resource.base_url, '{{name}}'].join('/')]
       else

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -350,13 +350,13 @@ module Provider
     end
 
     def async_operation_url(resource)
-      build_url(resource.__product.base_url, resource.async.operation.base_url,
+      build_url(resource.__product.default_version.base_url, resource.async.operation.base_url,
                 true)
     end
 
     def collection_url(resource)
       base_url = resource.base_url.split("\n").map(&:strip).compact
-      build_url(resource.__product.base_url, base_url)
+      build_url(resource.__product.default_version.base_url, base_url)
     end
 
     def self_link_raw_url(resource)

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -350,7 +350,8 @@ module Provider
     end
 
     def async_operation_url(resource)
-      build_url(resource.__product.default_version.base_url, resource.async.operation.base_url,
+      build_url(resource.__product.default_version.base_url,
+                resource.async.operation.base_url,
                 true)
     end
 
@@ -360,7 +361,8 @@ module Provider
     end
 
     def self_link_raw_url(resource)
-      base_url = resource.__product.default_version.base_url.split("\n").map(&:strip).compact
+      base_url = resource.__product.default_version.base_url
+                         .split("\n").map(&:strip).compact
       if resource.self_link.nil?
         [base_url, [resource.base_url, '{{name}}'].join('/')]
       else

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -71,12 +71,12 @@ module Provider
 
     def collection_url(resource)
       base_url = resource.base_url.split("\n").map(&:strip).compact
-      [resource.__product.base_url, base_url].flatten.join
+      [resource.__product.default_version.base_url, base_url].flatten.join
     end
 
     def update_url(resource, url_part)
       return self_link_url(resource) if url_part.nil?
-      [resource.__product.base_url, url_part].flatten.join
+      [resource.__product.default_version.base_url, url_part].flatten.join
     end
 
     # Transforms a format string with field markers to a regex string with

--- a/spec/data/good-export-file.yaml
+++ b/spec/data/good-export-file.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: My Product
 prefix: myproduct
-base_url: http://myproduct.google.com/api
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: http://myproduct.google.com/api
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/good-file.yaml
+++ b/spec/data/good-file.yaml
@@ -18,7 +18,6 @@ versions:
   - !ruby/object:Api::Product::Version
     name: v1
     base_url: http://myproduct.google.com/api/
-    default: true
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/good-file.yaml
+++ b/spec/data/good-file.yaml
@@ -14,7 +14,11 @@
 --- !ruby/object:Api::Product
 name: My Product
 prefix: myproduct
-base_url: http://myproduct.google.com/api/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: http://myproduct.google.com/api/
+    default: true
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/good-longuri.yaml
+++ b/spec/data/good-longuri.yaml
@@ -14,7 +14,11 @@
 --- !ruby/object:Api::Product
 name: My Product
 prefix: myproduct
-base_url: http://myproduct.google.com/myapi/v123
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v123
+    base_url: http://myproduct.google.com/api/v123
+    default: true
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/good-longuri.yaml
+++ b/spec/data/good-longuri.yaml
@@ -17,8 +17,7 @@ prefix: myproduct
 versions:
   - !ruby/object:Api::Product::Version
     name: v123
-    base_url: http://myproduct.google.com/api/v123
-    default: true
+    base_url: http://myproduct.google.com/myapi/v123
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/good-multi-file.yaml
+++ b/spec/data/good-multi-file.yaml
@@ -14,7 +14,11 @@
 --- !ruby/object:Api::Product
 name: My Product
 prefix: multiproduct
-base_url: http://myproduct.google.com/api
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: http://myproduct.google.com/api
+    default: true
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/good-multi-file.yaml
+++ b/spec/data/good-multi-file.yaml
@@ -18,7 +18,6 @@ versions:
   - !ruby/object:Api::Product::Version
     name: v1
     base_url: http://myproduct.google.com/api
-    default: true
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/good-multi2-file.yaml
+++ b/spec/data/good-multi2-file.yaml
@@ -14,7 +14,11 @@
 --- !ruby/object:Api::Product
 name: My Product
 prefix: multiproduct
-base_url: http://myproduct.google.com/api
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: http://myproduct.google.com/api
+    default: true
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/good-multi2-file.yaml
+++ b/spec/data/good-multi2-file.yaml
@@ -18,7 +18,6 @@ versions:
   - !ruby/object:Api::Product::Version
     name: v1
     base_url: http://myproduct.google.com/api
-    default: true
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/good-single-file.yaml
+++ b/spec/data/good-single-file.yaml
@@ -18,7 +18,6 @@ versions:
   - !ruby/object:Api::Product::Version
     name: v1
     base_url: http://myproduct.google.com/api
-    default: true
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/good-single-file.yaml
+++ b/spec/data/good-single-file.yaml
@@ -14,7 +14,11 @@
 --- !ruby/object:Api::Product
 name: My Product
 prefix: myproduct
-base_url: http://myproduct.google.com/api
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: http://myproduct.google.com/api
+    default: true
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/good-single-readonly-file.yaml
+++ b/spec/data/good-single-readonly-file.yaml
@@ -18,7 +18,6 @@ versions:
   - !ruby/object:Api::Product::Version
     name: v1
     base_url: http://myproduct.google.com/api
-    default: true
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/good-single-readonly-file.yaml
+++ b/spec/data/good-single-readonly-file.yaml
@@ -14,7 +14,11 @@
 --- !ruby/object:Api::Product
 name: My Product
 prefix: myproduct
-base_url: http://myproduct.google.com/api
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: http://myproduct.google.com/api
+    default: true
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/resourceref-missingimports.yaml
+++ b/spec/data/resourceref-missingimports.yaml
@@ -14,7 +14,9 @@
 --- !ruby/object:Api::Product
 name: My Product
 prefix: myproduct
-base_url: http://myproduct.google.com/api
+versions:
+  - name: v1
+    base_url: http://myproduct.google.com/api
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/resourceref-missingresource.yaml
+++ b/spec/data/resourceref-missingresource.yaml
@@ -14,7 +14,9 @@
 --- !ruby/object:Api::Product
 name: My Product
 prefix: myproduct
-base_url: http://myproduct.google.com/api
+versions:
+  - name: v1
+    base_url: http://myproduct.google.com/api
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/product_spec.rb
+++ b/spec/product_spec.rb
@@ -96,7 +96,7 @@ describe Api::Product do
 
     it do
       is_expected.to raise_error(StandardError,
-                                 /must specify exactly one default/)
+                                 /must specify at most one default/)
     end
   end
 
@@ -129,7 +129,7 @@ describe Api::Product do
 
     it do
       is_expected.to raise_error(StandardError,
-                                 /must specify exactly one default/)
+                                 /must specify a default/)
     end
   end
 


### PR DESCRIPTION
First step towards #155. Adds the ability to set multiple versions, but doesn't do anything with that yet- for now, it just uses the default version for everything, so there should be no changes to downstream repos.


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
