### PR TITLE
Add a swissknife container to manually test out changes with puppet

### DIFF
--- a/tools/swissknife/CHANGELOG.md
+++ b/tools/swissknife/CHANGELOG.md
@@ -1,0 +1,4 @@
+0.1
+---
+
+* Initial image with Puppet only support

--- a/tools/swissknife/Dockerfile
+++ b/tools/swissknife/Dockerfile
@@ -1,0 +1,26 @@
+FROM ruby:2.5
+
+ENV PUPPET_AGENT_VERSION="5.5.0"
+
+# Install puppet agent
+RUN apt-get update && \
+	wget https://apt.puppetlabs.com/puppet5-release-stretch.deb && \
+	dpkg -i puppet5-release-stretch.deb && \
+	rm puppet5-release-stretch.deb && \
+	apt-get update && \
+    apt-get install --no-install-recommends -y puppet-agent="$PUPPET_AGENT_VERSION"-1stretch && \
+    apt-get clean
+
+# Install gem required by gauth
+RUN gem install googleauth google-api-client
+
+# Setup symlink for puppet modules
+COPY docker-entrypoint.sh /usr/local/bin
+
+ENV PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
+ENV FACTER_cred_path=/etc/creds.json
+
+WORKDIR ~
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/tools/swissknife/README.md
+++ b/tools/swissknife/README.md
@@ -1,0 +1,91 @@
+# Magic Modules Swiss Knife (SK)
+
+A docker container with all the Magic Modules providers installed. 
+
+## Requirements
+
+* docker
+
+## Providers
+
+* Puppet
+* Ansible *(Not yet supported)* 
+* Chef *(Not yet supported)*
+* Terraform *(Not yet supported)*
+
+## Usage
+
+### Step 1: Create credentials
+
+1. In the Google Cloud console, go to IAM & admin > Service accounts
+1. Create a new service account and download the json credential file.
+1. Grant the required permissions to the service account.
+
+### Step 2: Launch the container
+
+In a terminal on your development machine, run:
+
+```sh
+# Specify the path to your credential file and magic-modules checkout.
+export SK_CRED=~/path/to/your/cred/file
+export SK_MM_PATH=~/path/to/magic-modules
+
+# Generate the Magic Module for all providers
+cd $SK_MM_PATH
+bundle exec rake compile 
+
+# Run the Swiss Knife container and start a bash session
+docker run -i -t -v $SK_MM_PATH:/opt/magic-modules -v $SK_CRED:/etc/creds.json gcr.io/magic-modules/swiss-knife
+```
+
+### Step 3: Test your changes
+
+#### Puppet
+
+Inside the Swiss Knife container, run:
+
+```sh
+puppet apply /opt/magic-modules/build/puppet/compute/examples/delete_target_https_proxy.pp
+puppet apply /opt/magic-modules/build/puppet/compute/examples/target_https_proxy.pp
+```
+
+#### Chef
+
+Not yet supported
+
+#### Terraform
+
+Not yet supported
+
+#### Ansible
+
+Not yet supported
+
+### Step 4: Rinse, repeat
+
+Your `magic-modules` directory on your development machine is shared with the
+Swiss Knife docker container.
+
+This means you can simply make changes and call `bundle exec rake compile` and
+the Swiss Knife will pick up the latest change.
+
+## Developing the Swiss Knife
+
+If you wish to add or improve support for any providers, 
+
+### Building a new image
+
+```sh
+cd `/path/to/magic-modules/tools/swissknife
+docker build -t swiss-knife .
+```
+
+### Publishing a new image
+
+This requires extra permissions to write to the storage bucket.
+
+```sh
+# Replace <VERSION> with the version you want. e.g.: 0.1
+docker tag swiss-knife gcr.io/magic-modules/swiss-knife:<VERSION>
+gcloud docker -- push gcr.io/magic-modules/swiss-knife:<VERSION>
+```

--- a/tools/swissknife/docker-entrypoint.sh
+++ b/tools/swissknife/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+set -x
+
+# Setup symlinks for puppet modules
+declare -r module_path="/opt/puppetlabs/puppet/modules"
+declare -r root_dir="/opt/magic-modules"
+
+echo "Root dir: ${root_dir}"
+
+for mod in ${root_dir}/build/puppet/*; do
+	mod_name=$(basename "${mod}")
+	ln -s "$(realpath "${mod}")" "${module_path}/g${mod_name}"
+done
+
+exec "$@"


### PR DESCRIPTION
This is a tool I presented yesterday at our meeting.

In a follow-up PR, I will be adding support for Terraform.

<!-- A summary of the changes in this commit goes here -->


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
