### PR TITLE
Changes to the Disk resource to better match the API.

### DIFF
--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -24,6 +24,7 @@ pushd magic-modules-branched
 LAST_COMMIT_AUTHOR="$(git log --pretty="%an <%ae>" -n1 HEAD)"
 bundle install
 bundle exec compiler -p products/compute -e terraform -o "${GOPATH}/src/github.com/terraform-providers/terraform-provider-google/"
+bundle exec compiler -p products/resourcemanager -e terraform -o "${GOPATH}/src/github.com/terraform-providers/terraform-provider-google/"
 
 # This command can crash - if that happens, the script should not fail.
 set +e

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: ruby # ruby version defined in .ruby-version will be used
 
+before_install:
+# some ruby versions come with a broken version of rubygems, update to
+# consistent version
+- gem update --system 2.7.6
+- gem install bundler -v '>= 1.16.1'
+
 script:
 - bundle exec rake test:rubocop
 - bundle exec rake test:spec

--- a/api/product.rb
+++ b/api/product.rb
@@ -18,22 +18,66 @@ require 'compile/core'
 module Api
   # Repesents a product to be managed
   class Product < Api::Object::Named
-    attr_reader :base_url
     attr_reader :objects
     attr_reader :prefix
     attr_reader :scopes
+    attr_reader :versions
 
     include Compile::Core
 
     def validate
       super
       set_variables @objects, :__product
-      check_property :base_url, String
       check_property :objects, Array
       check_property_list :objects, Api::Resource
       check_property :prefix, String
       check_property :scopes, ::Array
       check_property_list :scopes, String
+
+      check_versions
+    end
+
+    # Represents a version of the API for this product
+    class Version < Api::Object
+      attr_reader :base_url
+      attr_reader :default
+      attr_reader :name
+
+      def validate
+        super
+        @default ||= false
+
+        check_property :base_url, String
+        check_property :name, String
+        check_property :default, :boolean
+      end
+    end
+
+    def default_version
+      @versions.each do |v|
+        return v if v.default
+      end
+
+      return @versions.last if @versions.length == 1
+    end
+
+    private
+
+    def check_versions
+      check_property :versions, Array
+      check_property_list :versions, Api::Product::Version
+
+      # Confirm that at most one version is the default
+      defaults = 0
+      @versions.each do |v|
+        defaults += 1 if v.default
+      end
+
+      raise "Product '#{@name}' must specify at most one default API version" \
+        if defaults > 1
+
+      raise "Product '#{@name}' must specify a default API version" \
+        if defaults.zero? && @versions.length > 1
     end
   end
 end

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -249,8 +249,14 @@ module Api
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
 
+    # Returns all properties and parameters including the ones that are
+    # excluded. This is used for PropertyOverride validation
+    def all_properties
+      ((properties || []) + (parameters || []))
+    end
+
     def all_user_properties
-      ((properties || []) + (parameters || [])).reject(&:exclude)
+      all_properties.reject(&:exclude)
     end
 
     def required_properties

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -250,7 +250,7 @@ module Api
     # rubocop:enable Metrics/MethodLength
 
     def all_user_properties
-      (properties || []) + (parameters || [])
+      ((properties || []) + (parameters || [])).reject(&:exclude)
     end
 
     def required_properties

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -271,7 +271,7 @@ module Api
     # Returns all of the properties that are a part of the self_link or
     # collection URLs
     def uri_properties
-      [@base_url, @__product.base_url].map do |url|
+      [@base_url, @__product.default_version.base_url].map do |url|
         parts = url.scan(/\{\{(.*?)\}\}/).flatten
         parts << 'name'
         parts.delete('project')

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -47,10 +47,10 @@ module Api
     include Properties
 
     # Parameters can be overridden via Provider::PropertyOverride
-    attr_reader :parameters
+    # A custom getter is used for :parameters instead of `attr_reader`
 
     # Properties can be overridden via Provider::PropertyOverride
-    attr_reader :properties
+    # A custom getter is used for :properties instead of `attr_reader`
 
     attr_reader :__product
 
@@ -249,14 +249,22 @@ module Api
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
 
+    def properties
+      (@properties || []).reject(&:exclude)
+    end
+
+    def parameters
+      (@parameters || []).reject(&:exclude)
+    end
+
     # Returns all properties and parameters including the ones that are
     # excluded. This is used for PropertyOverride validation
     def all_properties
-      ((properties || []) + (parameters || []))
+      ((@properties || []) + (@parameters || []))
     end
 
     def all_user_properties
-      all_properties.reject(&:exclude)
+      properties + parameters
     end
 
     def required_properties

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -27,9 +27,15 @@ module Api
       attr_reader :kind
       attr_reader :base_url
       attr_reader :self_link
+      # This is useful in case you need to change the query made for
+      # GET/DELETE requests only.  In particular, this is often used
+      # to add query parameters.
       attr_reader :self_link_query
-      # identity: an array with items that uniquely identify the resource.
-      # default=name
+      # This is an array with items that uniquely identify the resource.
+      # This is useful in case an API returns a list result and we need
+      # to fetch the particular resource we're interested in from that
+      # list.  Otherwise, it's safe to leave empty.
+      # If empty, we assume that `name` is the identifier.
       attr_reader :identity
       attr_reader :exclude
       attr_reader :virtual

--- a/api/type.rb
+++ b/api/type.rb
@@ -23,6 +23,8 @@ module Api
       include Api::Object::Named::Properties
 
       attr_reader :description
+      attr_reader :exclude
+
       attr_reader :output # If set value will not be sent to server on sync
       attr_reader :input # If set to true value is used only on creation
       attr_reader :field
@@ -40,7 +42,11 @@ module Api
 
     def validate
       super
+      @exclude ||= false
+
       check_property :description, ::String
+      check_property :exclude, :boolean
+
       check_optional_property :output, :boolean
       check_optional_property :field, ::String
       check_optional_property :required, :boolean
@@ -339,7 +345,7 @@ module Api
 
     # An structured object composed of other objects.
     class NestedObject < Composite
-      attr_reader :properties
+      # A custom getter is used for :properties instead of `attr_reader`
 
       def validate
         @description = 'A nested object resource' if @description.nil?
@@ -371,6 +377,10 @@ module Api
 
       def requires
         [property_file].concat(properties.map(&:requires))
+      end
+
+      def properties
+        @properties.reject(&:exclude)
       end
     end
 

--- a/api/type.rb
+++ b/api/type.rb
@@ -396,6 +396,7 @@ module Api
       attr_reader :value_type
 
       def validate
+        super
         check_property :key_type, ::String
         check_property :value_type, ::String
         raise "Invalid type #{@key_type}" unless type?(@key_type)

--- a/api/type.rb
+++ b/api/type.rb
@@ -286,7 +286,7 @@ module Api
         @name = @resource if @name.nil?
         @description = "A reference to #{@resource} resource"
 
-        return if @__resource.nil? || @__resource.exclude
+        return if @__resource.nil? || @__resource.exclude || @exclude
 
         check_property :resource, ::String
         check_property :imports, ::String

--- a/api/type.rb
+++ b/api/type.rb
@@ -284,7 +284,8 @@ module Api
       def validate
         super
         @name = @resource if @name.nil?
-        @description = "A reference to #{@resource} resource"
+        @description = "A reference to #{@resource} resource" \
+          if @description.nil?
 
         return if @__resource.nil? || @__resource.exclude || @exclude
 

--- a/api/type.rb
+++ b/api/type.rb
@@ -16,12 +16,14 @@ require 'google/string_utils'
 
 module Api
   # Represents a property type
+  # rubocop:disable Metrics/ClassLength
   class Type < Api::Object::Named
     # The list of properties (attr_reader) that can be overridden in
     # <provider>.yaml.
     module Fields
       include Api::Object::Named::Properties
 
+      attr_reader :default_value
       attr_reader :description
       attr_reader :exclude
 
@@ -57,6 +59,26 @@ module Api
       check_optional_property_oneof_default \
         :update_verb, %i[POST PUT PATCH NONE], @__resource&.update_verb, Symbol
       check_optional_property :update_url, ::String
+
+      check_default_value_property
+    end
+
+    def check_default_value_property
+      return if @default_value.nil?
+
+      case self
+      when Api::Type::String
+        clazz = ::String
+      when Api::Type::Integer
+        clazz = ::Integer
+      when Api::Type::Enum
+        clazz = ::Symbol
+      else
+        raise "Update 'check_default_value_property' method to support " \
+              "default value for type #{self.class}"
+      end
+
+      check_optional_property :default_value, clazz
     end
 
     def type
@@ -422,4 +444,5 @@ module Api
       ]
     end
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/api/type.rb
+++ b/api/type.rb
@@ -379,6 +379,12 @@ module Api
         [property_file].concat(properties.map(&:requires))
       end
 
+      # Returns all properties including the ones that are excluded
+      # This is used for PropertyOverride validation
+      def all_properties
+        @properties
+      end
+
       def properties
         @properties.reject(&:exclude)
       end

--- a/compiler.rb
+++ b/compiler.rb
@@ -81,7 +81,6 @@ api.validate
 pp api if ENV['COMPILER_DEBUG']
 
 config = Provider::Config.parse(File.join(catalog, provider), api)
-config.validate
 pp config if ENV['COMPILER_DEBUG']
 
 provider = config.provider.new(config, api)

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 75.96
+    "covered_percent": 80.11
   }
 }

--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -32,6 +32,72 @@ overrides: !ruby/object:Provider::ResourceOverrides
           - timeout_seconds
   Disk: !ruby/object:Provider::Ansible::ResourceOverride
     editable: false
+  ForwardingRule: !ruby/object:Provider::Ansible::ResourceOverride
+    properties:
+      IPAddress:  !ruby/object:Provider::Ansible::PropertyOverride
+        description: |
+          The IP address that this forwarding rule is serving on behalf of.
+
+          Addresses are restricted based on the forwarding rule's load balancing
+          scheme (EXTERNAL or INTERNAL) and scope (global or regional).
+
+          When the load balancing scheme is EXTERNAL, for global forwarding
+          rules, the address must be a global IP, and for regional forwarding
+          rules, the address must live in the same region as the forwarding
+          rule. If this field is empty, an ephemeral IPv4 address from the same
+          scope (global or regional) will be assigned. A regional forwarding
+          rule supports IPv4 only. A global forwarding rule supports either IPv4
+          or IPv6.
+
+          When the load balancing scheme is INTERNAL, this can only be an RFC
+          1918 IP address belonging to the network/subnet configured for the
+          forwarding rule. By default, if this field is empty, an ephemeral
+          internal IP address will be automatically allocated from the IP range
+          of the subnet or network configured for this forwarding rule.
+
+          An address can be specified either by a literal IP address or a URL
+          reference to an existing Address resource. The following examples are
+          all valid:
+
+          * 100.1.2.3
+          * https://www.googleapis.com/compute/v1/projects/project/regions/region/addresses/address
+          * projects/project/regions/region/addresses/address
+          * regions/region/addresses/address
+          * global/addresses/address
+          * address
+  GlobalForwardingRule: !ruby/object:Provider::Ansible::ResourceOverride
+    properties:
+      IPAddress:  !ruby/object:Provider::Ansible::PropertyOverride
+        description: |
+          The IP address that this forwarding rule is serving on behalf of.
+
+          Addresses are restricted based on the forwarding rule's load balancing
+          scheme (EXTERNAL or INTERNAL) and scope (global or regional).
+
+          When the load balancing scheme is EXTERNAL, for global forwarding
+          rules, the address must be a global IP, and for regional forwarding
+          rules, the address must live in the same region as the forwarding
+          rule. If this field is empty, an ephemeral IPv4 address from the same
+          scope (global or regional) will be assigned. A regional forwarding
+          rule supports IPv4 only. A global forwarding rule supports either IPv4
+          or IPv6.
+
+          When the load balancing scheme is INTERNAL, this can only be an RFC
+          1918 IP address belonging to the network/subnet configured for the
+          forwarding rule. By default, if this field is empty, an ephemeral
+          internal IP address will be automatically allocated from the IP range
+          of the subnet or network configured for this forwarding rule.
+
+          An address can be specified either by a literal IP address or a URL
+          reference to an existing Address resource. The following examples are
+          all valid:
+
+          * 100.1.2.3
+          * https://www.googleapis.com/compute/v1/projects/project/regions/region/addresses/address
+          * projects/project/regions/region/addresses/address
+          * regions/region/addresses/address
+          * global/addresses/address
+          * address
   HealthCheck: !ruby/object:Provider::Ansible::ResourceOverride
     properties:
       timeoutSec: !ruby/object:Provider::Ansible::PropertyOverride
@@ -60,6 +126,18 @@ overrides: !ruby/object:Provider::ResourceOverrides
     provider_helpers:
       - 'products/compute/helpers/provider_instance.py'
       - 'products/compute/helpers/instance_metadata.py'
+  Route: !ruby/object:Provider::Ansible::ResourceOverride
+    properties:
+      nextHopGateway: !ruby/object:Provider::Ansible::PropertyOverride
+        description: |
+          URL to a gateway that should handle matching packets.
+
+          Currently, you can only specify the internet gateway, using a full or
+          partial valid URL:
+
+          * https://www.googleapis.com/compute/v1/projects/project/global/gateways/default-internet-gateway
+          * projects/project/global/gateways/default-internet-gateway
+          * global/gateways/default-internet-gateway
   TargetPool: !ruby/object:Provider::Ansible::ResourceOverride
     provider_helpers:
       - 'products/compute/helpers/provider_target_pool.py'

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2304,8 +2304,7 @@ objects:
           Currently, you can only specify the internet gateway, using a full or
           partial valid URL:
 
-          * https://www.googleapis.com/compute/v1/projects/project/
-              global/gateways/default-internet-gateway
+          * https://www.googleapis.com/compute/v1/projects/project/global/gateways/default-internet-gateway
           * projects/project/global/gateways/default-internet-gateway
           * global/gateways/default-internet-gateway
         input: true

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2505,6 +2505,104 @@ objects:
         description: 'The private key in PEM format.'
         input: true
   - !ruby/object:Api::Resource
+    name: 'SslPolicy'
+    # TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/173): Enable
+    exclude: true
+    kind: 'compute#sslPolicy'
+    base_url: projects/{project}/global/sslPolicies
+    exports:
+      - !ruby/object:Api::Type::SelfLink
+        name: 'selfLink'
+    description: |
+      Represents a SSL policy. SSL policies give you the ability to control the
+      features of SSL that your SSL proxy or HTTPS load balancer negotiates.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+          guides:
+            'Using SSL Policies': 'https://cloud.google.com/compute/docs/load-balancing/ssl-policies'
+          api: 'https://cloud.google.com/compute/docs/reference/rest/v1/sslPolicies'
+<%= indent(compile_file({}, 'templates/global_async.yaml.erb'), 4) %>
+    properties:
+      - !ruby/object:Api::Type::Time
+        name: 'creationTimestamp'
+        description: 'Creation timestamp in RFC3339 text format.'
+        output: true
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: 'An optional description of this resource.'
+      - !ruby/object:Api::Type::Integer
+        name: 'id'
+        description: 'The unique identifier for the resource.'
+        output: true
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Name of the resource. Provided by the client when the resource is
+          created. The name must be 1-63 characters long, and comply with
+          RFC1035. Specifically, the name must be 1-63 characters long and match
+          the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+          first character must be a lowercase letter, and all following
+          characters must be a dash, lowercase letter, or digit, except the last
+          character, which cannot be a dash.
+        required: true
+        # TODO: profile, minTlsVersion, enabledFeatures, customFeatures, fingerprint, warnings, kind
+      - !ruby/object:Api::Type::Enum
+        name: 'profile'
+        description: |
+          Profile specifies the set of SSL features that can be used by the
+          load balancer when negotiating SSL with clients. This can be one of
+          COMPATIBLE, MODERN, RESTRICTED, or CUSTOM. If using CUSTOM, the set
+          of SSL features to enable must be specified in the customFeatures
+          field.
+        values:
+          - :COMPATIBLE
+          - :MODERN
+          - :RESTRICTED
+          - :CUSTOM
+      - !ruby/object:Api::Type::Enum
+        name: 'minTlsVersion'
+        description: |
+          The minimum version of SSL protocol that can be used by the clients
+          to establish a connection with the load balancer. This can be one of
+          TLS_1_0, TLS_1_1, TLS_1_2.
+        values:
+          - :TLS_1_0
+          - :TLS_1_1
+          - :TLS_1_2
+      - !ruby/object:Api::Type::Array
+        name: 'enabledFeatures'
+        description: 'The list of features enabled in the SSL policy.'
+        output: true
+        item_type: Api::Type::String
+      - !ruby/object:Api::Type::Array
+        name: 'customFeatures'
+        description: |
+          A list of features enabled when the selected profile is CUSTOM. The
+          method returns the set of features that can be specified in this
+          list. This field must be empty if the profile is not CUSTOM.
+        item_type: Api::Type::String
+      - !ruby/object:Api::Type::String
+        name: 'fingerprint'
+        description: |
+          Fingerprint of this resource. A hash of the contents stored in this
+          object. This field is used in optimistic locking.
+        output: true
+      - !ruby/object:Api::Type::Array
+        name: 'warnings'
+        description: |
+          If potential misconfigurations are detected for this SSL policy, this
+          field will be populated with warning messages.
+        output: true
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'code'
+              description: 'A warning code, if applicable.'
+              output: true
+            - !ruby/object:Api::Type::String
+              name: 'message'
+              description: 'A human-readable description of the warning code.'
+              output: true
+  - !ruby/object:Api::Resource
     name: 'Subnetwork'
     kind: 'compute#subnetwork'
     base_url: projects/{{project}}/regions/{{region}}/subnetworks
@@ -2723,6 +2821,19 @@ objects:
         required: true
         update_verb: :POST
         update_url: 'projects/{{project}}/targetHttpsProxies/{{name}}/setUrlMap'
+      - !ruby/object:Api::Type::ResourceRef
+        name: 'sslPolicy'
+        # TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/173): Enable
+        exclude: true
+        resource: 'SslPolicy'
+        imports: 'selfLink'
+        description: |
+          A reference to the SslPolicy resource that will be associated with
+          the TargetHttpsProxy resource. If not set, the TargetHttpsProxy
+          resource will not have any SSL policy configured.
+        update_verb: :POST
+        update_url:
+          'projects/{{project}}/global/targetHttpsProxies/{{name}}/setSslPolicy'
   - !ruby/object:Api::Resource
     name: 'TargetPool'
     kind: 'compute#targetPool'

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2845,6 +2845,11 @@ objects:
     exports:
       - !ruby/object:Api::Type::SelfLink
         name: 'selfLink'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+          'https://cloud.google.com/compute/docs/load-balancing/network/target-pools'
+      api: 'https://cloud.google.com/compute/docs/reference/rest/v1/targetPools'
     transport: !ruby/object:Api::Resource::Transport
       encoder: encode_request
       decoder: decode_request
@@ -2861,6 +2866,7 @@ objects:
         name: 'backupPool'
         resource: 'TargetPool'
         imports: 'selfLink'
+        input: true
         description: |
           This field is applicable only when the containing target pool is
           serving a forwarding rule as the primary pool, and its failoverRatio
@@ -2936,6 +2942,7 @@ objects:
           first character must be a lowercase letter, and all following
           characters must be a dash, lowercase letter, or digit, except the last
           character, which cannot be a dash.
+        input: true
         required: true
       - !ruby/object:Api::Type::Enum
         name: 'sessionAffinity'
@@ -2949,6 +2956,7 @@ objects:
           - CLIENT_IP_PROTO: Connections from the same client IP with the same
             IP protocol will go to the same instance in the pool while that
             instance remains healthy.
+        input: true
         values:
           - :NONE
           - :CLIENT_IP

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2304,7 +2304,8 @@ objects:
           Currently, you can only specify the internet gateway, using a full or
           partial valid URL:
 
-          * https://www.googleapis.com/compute/v1/projects/project/global/gateways/default-internet-gateway
+          * https://www.googleapis.com/compute/v1/projects/project/
+                global/gateways/default-internet-gateway
           * projects/project/global/gateways/default-internet-gateway
           * global/gateways/default-internet-gateway
         input: true

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -1025,6 +1025,7 @@ objects:
         description: |
           How often (in seconds) to send a health check. The default value is 5
           seconds.
+        default_value: 5
       - !ruby/object:Api::Type::Time
         name: 'creationTimestamp'
         description: 'Creation timestamp in RFC3339 text format.'
@@ -1179,6 +1180,7 @@ objects:
         description: |
           How often (in seconds) to send a health check. The default value is 5
           seconds.
+        default_value: 5
       - !ruby/object:Api::Type::Time
         name: 'creationTimestamp'
         description: 'Creation timestamp in RFC3339 text format.'
@@ -1215,11 +1217,13 @@ objects:
           How long (in seconds) to wait before claiming failure.
           The default value is 5 seconds.  It is invalid for timeoutSec to have
           greater value than checkIntervalSec.
+        default_value: 5
       - !ruby/object:Api::Type::Integer
         name: 'unhealthyThreshold'
         description: |
           A so-far healthy instance will be marked unhealthy after this many
           consecutive failures. The default value is 2.
+        default_value: 2
       - !ruby/object:Api::Type::Enum
         name: 'type'
         description: |

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2509,7 +2509,8 @@ objects:
     # TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/173): Enable
     exclude: true
     kind: 'compute#sslPolicy'
-    base_url: projects/{project}/global/sslPolicies
+    base_url: projects/{{project}}/global/sslPolicies
+    update_verb: :PATCH
     exports:
       - !ruby/object:Api::Type::SelfLink
         name: 'selfLink'
@@ -2529,6 +2530,7 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'description'
         description: 'An optional description of this resource.'
+        input: true
       - !ruby/object:Api::Type::Integer
         name: 'id'
         description: 'The unique identifier for the resource.'
@@ -2543,6 +2545,7 @@ objects:
           first character must be a lowercase letter, and all following
           characters must be a dash, lowercase letter, or digit, except the last
           character, which cannot be a dash.
+        input: true
         required: true
         # TODO: profile, minTlsVersion, enabledFeatures, customFeatures, fingerprint, warnings, kind
       - !ruby/object:Api::Type::Enum
@@ -2550,9 +2553,9 @@ objects:
         description: |
           Profile specifies the set of SSL features that can be used by the
           load balancer when negotiating SSL with clients. This can be one of
-          COMPATIBLE, MODERN, RESTRICTED, or CUSTOM. If using CUSTOM, the set
-          of SSL features to enable must be specified in the customFeatures
-          field.
+          `COMPATIBLE`, `MODERN`, `RESTRICTED`, or `CUSTOM`. If using `CUSTOM`,
+          the set of SSL features to enable must be specified in the
+          `customFeatures` field.
         values:
           - :COMPATIBLE
           - :MODERN
@@ -2563,7 +2566,7 @@ objects:
         description: |
           The minimum version of SSL protocol that can be used by the clients
           to establish a connection with the load balancer. This can be one of
-          TLS_1_0, TLS_1_1, TLS_1_2.
+          `TLS_1_0`, `TLS_1_1`, `TLS_1_2`.
         values:
           - :TLS_1_0
           - :TLS_1_1

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -16,7 +16,14 @@
 --- !ruby/object:Api::Product
 name: Google Compute Engine
 prefix: gcompute
-base_url: https://www.googleapis.com/compute/v1/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://www.googleapis.com/compute/v1/
+    default: true
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://www.googleapis.com/compute/beta/
 scopes:
   - https://www.googleapis.com/auth/compute
 objects:

--- a/products/compute/forwarding_rule_properties.yaml
+++ b/products/compute/forwarding_rule_properties.yaml
@@ -54,8 +54,7 @@
     all valid:
 
     * 100.1.2.3
-    * https://www.googleapis.com/compute/v1/projects/project
-        /regions/region/addresses/address
+    * https://www.googleapis.com/compute/v1/projects/project/regions/region/addresses/address
     * projects/project/regions/region/addresses/address
     * regions/region/addresses/address
     * global/addresses/address

--- a/products/compute/forwarding_rule_properties.yaml
+++ b/products/compute/forwarding_rule_properties.yaml
@@ -54,7 +54,8 @@
     all valid:
 
     * 100.1.2.3
-    * https://www.googleapis.com/compute/v1/projects/project/regions/region/addresses/address
+    * https://www.googleapis.com/compute/v1/projects/project/regions/
+         region/addresses/address
     * projects/project/regions/region/addresses/address
     * regions/region/addresses/address
     * global/addresses/address

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -91,23 +91,17 @@ overrides: !ruby/object:Provider::ResourceOverrides
       id: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
       checkIntervalSec: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 5
+        default_value: 5
       healthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 2
+        default_value: 2
       port: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 80
+        default_value: 80
       requestPath: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: "/"
+        default_value: "/"
       timeoutSec: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 5
+        default_value: 5
       unhealthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 2
+        default_value: 2
   HttpsHealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
     description: |
       {{description}}
@@ -131,23 +125,17 @@ overrides: !ruby/object:Provider::ResourceOverrides
       id: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
       checkIntervalSec: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 5
+        default_value: 5
       healthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 2
+        default_value: 2
       port: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 443
+        default_value: 443
       requestPath: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: "/"
+        default_value: "/"
       timeoutSec: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 5
+        default_value: 5
       unhealthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 2
+        default_value: 2
   HealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   Image: !ruby/object:Provider::Terraform::ResourceOverride
@@ -248,8 +236,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
       enabledFeatures: !ruby/object:Provider::Terraform::PropertyOverride
         is_set: true
       profile: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: :COMPATIBLE
+        default_value: :COMPATIBLE
         description: |
           {{description}}
           See the [official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies#profilefeaturesupport)
@@ -257,8 +244,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
           `CUSTOM` is used, the `custom_features` attribute **must be set**.
           Default is `COMPATIBLE`.
       minTlsVersion: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: :TLS_1_0
+        default_value: :TLS_1_0
         description : '{{description}} Default is `TLS_1_0`.'
       warnings: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
@@ -411,8 +397,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
       region: !ruby/object:Provider::Terraform::PropertyOverride
         required: false # the provider-default value will be used if not specified
       sessionAffinity: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: :NONE
+        default_value: :NONE
       # TODO: Custom code needed for updating `instances` and `healthCheck`.
       #       Update methods are (add|remove)Instance, (add/remove)HealthCheck
   TargetSslProxy: !ruby/object:Provider::Terraform::ResourceOverride
@@ -449,8 +434,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
       id: !ruby/object:Provider::Terraform::PropertyOverride
         name: proxyId
       proxyHeader: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: :NONE
+        default_value: :NONE
       service: !ruby/object:Provider::Terraform::PropertyOverride
         name: backendService
   TargetTcpProxy: !ruby/object:Provider::Terraform::ResourceOverride
@@ -486,8 +470,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
       service: !ruby/object:Provider::Terraform::PropertyOverride
         name: backendService
       proxyHeader: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: :NONE
+        default_value: :NONE
   TargetVpnGateway: !ruby/object:Provider::Terraform::ResourceOverride
     name: 'VpnGateway'
     exclude: false
@@ -564,8 +547,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
         exclude: true
       region: !ruby/object:Provider::Terraform::PropertyOverride
         required: false # the provider-default value will be used if not specified
-        default: !ruby/object:Provider::Terraform::Default
-          from_api: true
+        default_from_api: true
         custom_flatten: 'templates/terraform/custom_flatten/region_name_only.erb'
       forwardingRules: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -396,8 +396,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
           value: :NONE
   TargetVpnGateway: !ruby/object:Provider::Terraform::ResourceOverride
     name: 'VpnGateway'
-    # TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/156): Re-enable code generation for this resource
-    exclude: true
+    exclude: false
     examples: |
       ```hcl
       resource "google_compute_network" "network1" {
@@ -473,7 +472,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
         required: false # the provider-default value will be used if not specified
         default: !ruby/object:Provider::Terraform::Default
           from_api: true
-        state_func: 'NameFromSelfLinkStateFunc'
+        custom_flatten: 'templates/terraform/custom_flatten/region_name_only.erb'
       forwardingRules: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
       tunnels: !ruby/object:Provider::Terraform::PropertyOverride

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -317,6 +317,8 @@ overrides: !ruby/object:Provider::ResourceOverrides
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
         name: proxyId
+      sslPolicy: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: false
   TargetPool: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   TargetSslProxy: !ruby/object:Provider::Terraform::ResourceOverride

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -200,6 +200,68 @@ overrides: !ruby/object:Provider::ResourceOverrides
         sensitive: true
       privateKey: !ruby/object:Provider::Terraform::PropertyOverride
         sensitive: true
+  SslPolicy: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: false
+    examples: |
+      ```hcl
+      resource "google_compute_ssl_policy" "prod-ssl-policy" {
+        name    = "production-ssl-policy"
+        profile = "MODERN"
+      }
+
+      resource "google_compute_ssl_policy" "nonprod-ssl-policy" {
+        name            = "nonprod-ssl-policy"
+        profile         = "MODERN"
+        min_tls_version = "TLS_1_2"
+      }
+
+      resource "google_compute_ssl_policy" "custom-ssl-policy" {
+        name            = "custom-ssl-policy"
+        min_tls_version = "TLS_1_2"
+        profile         = "CUSTOM"
+        custom_features = ["TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"]
+      }
+      ```
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      constants:  'templates/terraform/constants/ssl_policy.erb'
+      resource_definition: 'templates/terraform/resource_definition/ssl_policy.erb'
+      update_encoder: 'templates/terraform/update_encoder/ssl_policy.erb'
+    properties:
+      id: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
+      customFeatures: !ruby/object:Provider::Terraform::PropertyOverride
+        is_set: true
+        # TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/187) replace references automatically
+        # Overriding the whole description because original has references to
+        # other fields which are in camelCase in api.yaml.
+        description: |
+          Profile specifies the set of SSL features that can be used by the
+          load balancer when negotiating SSL with clients. This can be one of
+          `COMPATIBLE`, `MODERN`, `RESTRICTED`, or `CUSTOM`. If using `CUSTOM`,
+          the set of SSL features to enable must be specified in the
+          `customFeatures` field.
+
+          See the [official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies#profilefeaturesupport)
+          for which ciphers are available to use. **Note**: this argument
+          *must* be present when using the `CUSTOM` profile. This argument
+          *must not* be present when using any other profile.
+      enabledFeatures: !ruby/object:Provider::Terraform::PropertyOverride
+        is_set: true
+      profile: !ruby/object:Provider::Terraform::PropertyOverride
+        default: !ruby/object:Provider::Terraform::Default
+          value: :COMPATIBLE
+        description: |
+          {{description}}
+          See the [official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies#profilefeaturesupport)
+          for information on what cipher suites each profile provides. If
+          `CUSTOM` is used, the `custom_features` attribute **must be set**.
+          Default is `COMPATIBLE`.
+      minTlsVersion: !ruby/object:Provider::Terraform::PropertyOverride
+        default: !ruby/object:Provider::Terraform::Default
+          value: :TLS_1_0
+        description : '{{description}} Default is `TLS_1_0`.'
+      warnings: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
   Subnetwork: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{region}}/{{name}}"
     exclude: true

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -383,6 +383,38 @@ overrides: !ruby/object:Provider::ResourceOverrides
         exclude: false
   TargetPool: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
+    examples: |
+      ```hcl
+      resource "google_compute_target_pool" "default" {
+        name = "instance-pool"
+
+        instances = [
+          "us-central1-a/myinstance1",
+          "us-central1-b/myinstance2",
+        ]
+
+        health_checks = [
+          "${google_compute_http_health_check.default.name}",
+        ]
+      }
+
+      resource "google_compute_http_health_check" "default" {
+        name               = "default"
+        request_path       = "/"
+        check_interval_sec = 1
+        timeout_sec        = 1
+      }
+      ```
+    properties:
+      id: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: true
+      region: !ruby/object:Provider::Terraform::PropertyOverride
+        required: false # the provider-default value will be used if not specified
+      sessionAffinity: !ruby/object:Provider::Terraform::PropertyOverride
+        default: !ruby/object:Provider::Terraform::Default
+          value: :NONE
+      # TODO: Custom code needed for updating `instances` and `healthCheck`.
+      #       Update methods are (add|remove)Instance, (add/remove)HealthCheck
   TargetSslProxy: !ruby/object:Provider::Terraform::ResourceOverride
     examples: |
       ```hcl
@@ -542,8 +574,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
   UrlMap: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   Zone: !ruby/object:Provider::Terraform::ResourceOverride
-    exclude: true
-  TargetPool: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
 # This is for a list of example files.
 examples: !ruby/object:Api::Resource::HashArray

--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: Google Container Engine
 prefix: gcontainer
-base_url: https://container.googleapis.com/v1/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://container.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 objects:

--- a/products/container/chef.yaml
+++ b/products/container/chef.yaml
@@ -33,6 +33,8 @@ overrides: !ruby/object:Provider::ResourceOverrides
   NodePool: !ruby/object:Provider::Chef::ResourceOverride
     provider_helpers:
       - 'products/container/helpers/provider_node_pool.rb'
+  KubeConfig: !ruby/object:Provider::Chef::ResourceOverride
+    manual: true
 examples: !ruby/object:Api::Resource::HashArray
   Cluster:
     - delete_cluster.rb
@@ -40,6 +42,8 @@ examples: !ruby/object:Api::Resource::HashArray
   NodePool:
     - delete_node_pool.rb
     - node_pool.rb
+  KubeConfig:
+    - kube_config.rb
 files: !ruby/object:Provider::Config::Files
   copy:
 <%= indent(include('provider/chef/common~copy.yaml'), 4) %>

--- a/products/container/examples/chef/kube_config.rb
+++ b/products/container/examples/chef/kube_config.rb
@@ -16,6 +16,39 @@
 <%= compile 'templates/license.erb' -%>
 
 <%= lines(autogen_notice :chef) -%>
+
+<%= compile 'templates/chef/example~auth.rb.erb' -%>
+
+raise "Missing parameter 'cluster_id'. Please read docs at #{__FILE__}" \
+  unless ENV.key?('cluster_id')
+
+<% res_name = 'mycluster-#{ENV[\'cluster_id\']}' -%>
+gcontainer_cluster <%= quote_string(res_name) -%> do
+  action :create
+  initial_node_count 2
+  master_auth(
+    username: 'cluster_admin',
+    password: 'my-secret-password'
+  )
+  node_config(
+    machine_type: 'n1-standard-4', # we want 4-cores for our cluster
+    disk_size_gb: 500              # ... and a lot of disk space
+  )
+  zone 'us-central1-a'
+  project 'google.com:graphite-playground'
+  credential 'mycred'
+end
+
+directory '/home/alexstephen/.kube' do
+  action :create
+end
 <% end # name == README.md -%>
 
-# TODO(rambleraptor): Add kube_config example here.
+gcontainer_kubeconfig '/home/alexstephen/.kube/config' do
+  action :create
+  context "gke-mycluster-#{ENV['cluster_id']}"
+  cluster "mycluster-#{ENV['cluster_id']}"
+  zone 'us-central1-a'
+  project 'google.com:graphite-playground'
+  credential 'mycred'
+end

--- a/products/container/files/provider~chef~kube_config.rb
+++ b/products/container/files/provider~chef~kube_config.rb
@@ -1,0 +1,123 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Add our google/ lib
+$LOAD_PATH.unshift ::File.expand_path('../libraries', ::File.dirname(__FILE__))
+
+require 'chef/resource'
+require 'google/container/network/get'
+require 'google/container/property/boolean'
+require 'google/container/property/cluster_name'
+require 'google/container/property/string'
+require 'google/hash_utils'
+require 'yaml'
+
+module Google
+  module GCONTAINER
+    class KubeConfig < Chef::Resource
+      resource_name :gcontainer_kubeconfig
+
+      property :cluster,
+               [String, ::Google::Container::Data::ClusterNameRef],
+               coerce: ::Google::Container::Property::ClusterNameRef.coerce,
+               desired_state: true
+      property :zone,
+               ::String,
+               coerce: ::Google::Container::Property::String.coerce,
+               desired_state: true
+      property :context,
+               ::String,
+               coerce: ::Google::Container::Property::String.coerce,
+               desired_state: true
+      property :credential, String, desired_state: false, required: true
+      property :project, String, desired_state: false, required: true
+
+      action :create do
+        IO.write(@new_resource.name, kube_config(@new_resource).to_yaml)
+      end
+
+      action :delete do
+        File.delete(@new_resource.name) if File.exist(@new_resource.name)
+      end
+
+      private
+
+      action_class do
+        def fetch_auth(resource)
+          resource.resources("gauth_credential[#{resource.credential}]")
+        end
+
+        def fetch_cluster(resource)
+          id = resource.cluster.resource
+          Chef.run_context.resource_collection.each do |entry|
+            return entry if entry.name == id
+          end
+          raise ArgumentError, "gcontainer_cluster[#{id}] not found"
+        end
+
+        # rubocop:disable Metrics/MethodLength
+        def kube_config(resource)
+          cluster = fetch_cluster(resource)
+          endpoint = URI.parse("https://#{cluster.exports[:endpoint]}")
+          auth = fetch_auth(resource).authorization.authorize(endpoint).last
+          context = resource.context || cluster.name
+          {
+            'apiVersion' => 'v1',
+            'clusters' => [
+              {
+                'name' => context,
+                'cluster' => {
+                  'certificate-authority-data' =>
+                    cluster.exports[:master_auth]['clusterCaCertificate'],
+                  'server' => endpoint.to_s
+                }
+              }
+            ],
+            'contexts' => [
+              {
+                'name' => context,
+                'context' => {
+                  'cluster' => context,
+                  'user' => context
+                }
+              }
+            ],
+            'current-context' => context,
+            'kind' => 'Config',
+            'preferences' => {},
+            'users' => [
+              {
+                'name' => context,
+                'user' => {
+                  'auth-provider' => {
+                    'config' => {
+                      'access-token' => auth.token,
+                      'cmd-args' => 'config config-helper --format=json',
+                      'cmd-path' => '/usr/lib64/google-cloud-sdk/bin/gcloud',
+                      'expiry-key' => '{.credential.token_expiry}',
+                      'token-key' => '{.credential.access_token}'
+                    },
+                    'name' => 'gcp'
+                  },
+                  'username' => cluster.exports[:master_auth]['username'],
+                  'password' => cluster.exports[:master_auth]['password']
+                }
+              }
+            ]
+          }
+          # rubocop:enable Metrics/MethodLength
+        end
+      end
+    end
+  end
+end

--- a/products/container/node_config.yaml
+++ b/products/container/node_config.yaml
@@ -106,8 +106,7 @@
     The limit for this value is dependant upon the maximum number of
     disks available on a machine per zone. See:
 
-    https://cloud.google.com/compute/docs/disks/
-      local-ssd#local_ssd_limits
+    https://cloud.google.com/compute/docs/disks/local-ssd#local_ssd_limits
 
     for more information.
 - !ruby/object:Api::Type::Array

--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: Google Cloud DNS
 prefix: gdns
-base_url: https://www.googleapis.com/dns/v1/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://www.googleapis.com/dns/v1/
 scopes:
   - https://www.googleapis.com/auth/ndev.clouddns.readwrite
 objects:

--- a/products/iam/api.yaml
+++ b/products/iam/api.yaml
@@ -16,7 +16,10 @@
 --- !ruby/object:Api::Product
 name: Google Cloud IAM
 prefix: giam
-base_url: https://iam.googleapis.com/v1/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://iam.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/iam
 objects:

--- a/products/pubsub/api.yaml
+++ b/products/pubsub/api.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: Google Cloud Pub/Sub
 prefix: gpubsub
-base_url: https://pubsub.googleapis.com/v1/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://pubsub.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/pubsub
 objects:

--- a/products/resourcemanager/api.yaml
+++ b/products/resourcemanager/api.yaml
@@ -93,3 +93,66 @@ objects:
             name: 'id'
             description: Id of the organization
 
+  - !ruby/object:Api::Resource
+    name: 'Lien'
+    base_url: liens
+    exclude: true
+    # This resource has some issues - it returns a list when you query for it.
+    # You can't use the same URL for GET and DELETE.  This here is the URL that
+    # we use for GET, and the DELETE is in custom code.  If this happens a lot,
+    # we might build a more general solution, but this is the only resource I know
+    # of where that happens.
+    self_link: liens?parent={{parent}}
+    self_link_query: !ruby/object:Api::Resource::ResponseList
+      # This isn't a real 'kind' - this API has some inconsistencies and doesn't return one.
+      kind: 'resourceManager#liensList'
+      items: 'liens'
+    identity:
+      - name
+    description: A Lien represents an encumbrance on the actions that can be performed on a resource.
+    input: true
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: parent
+        input: true
+        required: true
+        description: |
+          A reference to the resource this Lien is attached to.
+          The server will validate the parent against those for which Liens are supported.
+          Since a variety of objects can have Liens against them, you must provide the type
+          prefix (e.g. "projects/my-project-name").
+      - !ruby/object:Api::Type::Array
+        name: 'restrictions'
+        description: |
+          The types of operations which should be blocked as a result of this Lien.
+          Each value should correspond to an IAM permission. The server will validate
+          the permissions against those for which Liens are supported.  An empty
+          list is meaningless and will be rejected.
+          e.g. ['resourcemanager.projects.delete']
+        item_type: 'Api::Type::String'
+        input: true
+        required: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: name
+        description: A system-generated unique identifier for this Lien.
+        output: true
+      - !ruby/object:Api::Type::String
+        name: reason 
+        description: |
+          Concise user-visible strings indicating why an action cannot be performed
+          on a resource. Maximum length of 200 characters.
+        input: true
+        required: true
+      - !ruby/object:Api::Type::String
+        name: origin
+        description: |
+          A stable, user-visible/meaningful string identifying the origin
+          of the Lien, intended to be inspected programmatically. Maximum length of
+          200 characters.
+        input: true
+        required: true
+      - !ruby/object:Api::Type::Time
+        name: 'createTime'
+        description: 'Time of creation'
+        output: true

--- a/products/resourcemanager/api.yaml
+++ b/products/resourcemanager/api.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: Google Cloud Resource Manager
 prefix: gresourcemanager
-base_url: https://cloudresourcemanager.googleapis.com/v1/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://cloudresourcemanager.googleapis.com/v1/
 scopes:
   # All access is needed to create projects.
   - https://www.googleapis.com/auth/cloud-platform

--- a/products/resourcemanager/terraform.yaml
+++ b/products/resourcemanager/terraform.yaml
@@ -1,0 +1,58 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Terraform::Config
+overrides: !ruby/object:Provider::ResourceOverrides
+  Project: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: true
+  Lien: !ruby/object:Provider::Terraform::ResourceOverride
+    exclude: false
+    import_format: ["{{parent}}/{{name}}"]
+    examples: |
+      ```hcl
+      resource "random_id" "r" {
+        byte_length = 8
+      }
+
+      resource "google_project" "project" {
+        project_id = "project-${random_id.r.hex}"
+        name = "A very important project!"
+      }
+
+      resource "google_resourcemanager_lien" "lien" {
+        parent = "projects/${google_project.project.number}"
+        restrictions = ["resourcemanager.projects.delete"]
+        origin = "machine-readable-explanation"
+        reason = "This project is very important to me!"
+      }
+      ```
+    properties:
+      name: !ruby/object:Provider::Terraform::PropertyOverride
+        custom_flatten: templates/terraform/custom_flatten/region_name_only.erb
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      post_create: templates/terraform/post_create/lien.erb
+      post_import: templates/terraform/post_import/lien_import.erb
+      pre_delete: templates/terraform/pre_delete/modify_delete_url.erb
+      decoder: templates/terraform/decoders/avoid_meaningless_project_update.erb
+# This is for copying files over
+files: !ruby/object:Provider::Config::Files
+  # All of these files will be copied verbatim.
+  copy:
+    'google/transport.go': 'templates/terraform/transport.go'
+    'google/transport_test.go': 'templates/terraform/transport_test.go'
+    'google/import.go': 'templates/terraform/import.go'
+    'google/import_test.go': 'templates/terraform/import_test.go'
+  # These files have templating (ERB) code that will be run.
+  # This is usually to add licensing info, autogeneration notices, etc.
+  compile:
+    'google/provider_{{product_name}}_gen.go': 'templates/terraform/provider_gen.erb'

--- a/products/spanner/api.yaml
+++ b/products/spanner/api.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: Google Spanner
 prefix: gspanner
-base_url: https://spanner.googleapis.com/v1/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://spanner.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/spanner.admin
 objects:

--- a/products/sql/api.yaml
+++ b/products/sql/api.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: Google Cloud SQL
 prefix: gsql
-base_url: https://www.googleapis.com/sql/v1beta4/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://www.googleapis.com/sql/v1beta4/
 scopes:
   - https://www.googleapis.com/auth/sqlservice.admin
 objects:

--- a/products/storage/api.yaml
+++ b/products/storage/api.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: Google Cloud Storage
 prefix: gstorage
-base_url: https://www.googleapis.com/storage/v1/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://www.googleapis.com/storage/v1/
 scopes:
   - https://www.googleapis.com/auth/devstorage.full_control
 objects:

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -98,14 +98,15 @@ module Provider
 
       def collection_url(resource)
         base_url = resource.base_url.split("\n").map(&:strip).compact
-        full_url = [resource.__product.base_url, base_url].flatten.join
+        full_url = [resource.__product.default_version.base_url,
+                    base_url].flatten.join
         # Double {} replaced with single {} to support Python string
         # interpolation
         "\"#{full_url.gsub('{{', '{').gsub('}}', '}')}\""
       end
 
       def async_operation_url(resource)
-        base_url = resource.__product.base_url
+        base_url = resource.__product.default_version.base_url
         url = [base_url, resource.async.operation.base_url].join
         "\"#{url.gsub('{{', '{').gsub('}}', '}')}\""
       end

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -141,11 +141,15 @@ module Provider
       end
 
       # Builds out the minimal YAML block for DOCUMENTATION
+      # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/MethodLength
       def minimal_doc_block(prop, _object, spaces)
+        required = prop.required && !prop.default_value ? 'true' : 'false'
         [
           minimal_yaml(prop, spaces),
           indent([
-            "required: #{prop.required ? 'true' : 'false'}",
+            "required: #{required}",
+            ("default: #{prop.default_value}" if prop.default_value),
             ('type: bool' if prop.is_a? Api::Type::Boolean),
             ("aliases: [#{prop.aliases.join(', ')}]" if prop.aliases),
             (if prop.is_a? Api::Type::Enum
@@ -157,7 +161,8 @@ module Provider
           ].compact, 4)
         ]
       end
-      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/MethodLength
 
       # Builds out the minimal YAML block for RETURNS
       def minimal_return_block(prop, spaces)

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -58,6 +58,7 @@ module Provider
       # rubocop:disable Metrics/AbcSize
       def bullet_line(paragraph, spaces, _multiline = true, add_period = true)
         paragraph += '.' unless paragraph.end_with?('.') || !add_period
+        paragraph = format_url(paragraph)
         paragraph = paragraph.tr("\n", ' ').strip
 
         # Paragraph placed inside array to get bullet point.
@@ -109,6 +110,16 @@ module Provider
       end
 
       private
+
+      # Find URLs and surround with U()
+      def format_url(paragraph)
+        paragraph.gsub(%r{
+          https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]
+          [a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+
+          [a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))
+          [a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9]\.[^\s]{2,}
+        }x, 'U(\\0)')
+      end
 
       # Returns formatted nested documentation for a set of properties.
       def nested_return(properties, spaces)

--- a/provider/ansible/module.rb
+++ b/provider/ansible/module.rb
@@ -47,9 +47,11 @@ module Provider
       end
 
       # Returns an array of all base options for a given property.
+      # rubocop:disable Metrics/CyclomaticComplexity
       def prop_options(prop, _object, spaces)
         [
-          ('required=True' if prop.required),
+          ('required=True' if prop.required && !prop.default_value),
+          ("default=#{prop.default_value}" if prop.default_value),
           "type=#{quote_string(python_type(prop))}",
           (choices_enum(prop, spaces) if prop.is_a? Api::Type::Enum),
           ("elements=#{quote_string(python_type(prop.item_type))}" \
@@ -58,8 +60,7 @@ module Provider
             if prop.aliases)
         ].compact
       end
-      # rubocop:enable Metrics/AbcSize
-      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       # Returns a formatted string represented the choices of an enum
       # rubocop:disable Metrics/AbcSize

--- a/provider/chef.rb
+++ b/provider/chef.rb
@@ -292,9 +292,19 @@ module Provider
       FileUtils.mkpath target_folder
       name = Google::StringUtils.underscore(data[:object].name)
       generate_resource_file data.clone.merge(
-        default_template: 'templates/chef/resource.erb',
+        default_template: provider_template_source(data),
         out_file: File.join(target_folder, "#{name}.rb")
       )
+    end
+
+    def provider_template_source(data)
+      if data[:object].manual
+        object_name = Google::StringUtils.underscore(data[:object].name)
+        File.join('products', data[:product_name], 'files',
+                  "provider~chef~#{object_name}.rb")
+      else
+        'templates/chef/resource.erb'
+      end
     end
 
     def generate_resource_tests(data)

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -350,17 +350,19 @@ module Provider
     end
 
     def async_operation_url(resource)
-      build_url(resource.__product.base_url, resource.async.operation.base_url,
+      build_url(resource.__product.default_version.base_url,
+                resource.async.operation.base_url,
                 true)
     end
 
     def collection_url(resource)
       base_url = resource.base_url.split("\n").map(&:strip).compact
-      build_url(resource.__product.base_url, base_url)
+      build_url(resource.__product.default_version.base_url, base_url)
     end
 
     def self_link_raw_url(resource)
-      base_url = resource.__product.base_url.split("\n").map(&:strip).compact
+      base_url = resource.__product.default_version.base_url
+                         .split("\n").map(&:strip).compact
       if resource.self_link.nil?
         [base_url, [resource.base_url, '{{name}}'].join('/')]
       else

--- a/provider/resource_overrides.rb
+++ b/provider/resource_overrides.rb
@@ -137,12 +137,12 @@ module Provider
 
     def get_properties(api_entity)
       if api_entity.is_a?(Api::Resource)
-        api_entity.all_user_properties
+        api_entity.all_properties
       elsif api_entity.is_a?(Api::Type::NestedObject)
-        api_entity.properties
+        api_entity.all_properties
       elsif api_entity.is_a?(Api::Type::Array) &&
             api_entity.item_type.is_a?(Api::Type::NestedObject)
-        api_entity.item_type.properties
+        api_entity.item_type.all_properties
       end
     end
 

--- a/provider/resource_overrides.rb
+++ b/provider/resource_overrides.rb
@@ -112,8 +112,8 @@ module Provider
                              property_override, Provider::PropertyOverride
         api_property = find_property api_object, property_path.split('.')
         if api_property.nil?
-          raise "The property to override must exists #{property_path} " \
-                "in resource #{api_object.name}"
+          raise "The property to override '#{property_path}' must exist in " \
+                "resource #{api_object.name}"
         end
         property_override.apply api_property
       end
@@ -158,6 +158,19 @@ module Provider
       api_entity.all_user_properties.each do |prop|
         override.properties[prop.name] = @__config.property_override.new \
           unless override.properties.include?(prop.name)
+        populate_nonoverriden_nested_properties prop.name, prop, override
+      end
+    end
+
+    def populate_nonoverriden_nested_properties(prefix, property, override)
+      nested_properties = get_properties(property)
+      return if nested_properties.nil?
+
+      nested_properties.each do |nested_prop|
+        key = "#{prefix}.#{nested_prop.name}"
+        override.properties[key] = @__config.property_override.new \
+          unless override.properties.include?(key)
+        populate_nonoverriden_nested_properties key, nested_prop, override
       end
     end
   end

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -98,20 +98,14 @@ module Provider
       p
     end
 
-    # Returns the resource properties without those ignored.
-    def effective_properties(properties)
-      properties.reject(&:exclude)
-    end
-
-    # Returns the nested properties without those ignored. An empty list is
-    # returned if the property is not a NestedObject or an Array of
-    # NestedObjects.
-    def effective_nested_properties(property)
+    # Returns the nested properties. An empty list is returned if the property
+    # is not a NestedObject or an Array of NestedObjects.
+    def nested_properties(property)
       if property.is_a?(Api::Type::NestedObject)
-        effective_properties(property.properties)
+        property.properties
       elsif property.is_a?(Api::Type::Array) &&
             property.item_type.is_a?(Api::Type::NestedObject)
-        effective_properties(property.item_type.properties)
+        property.item_type.properties
       else
         []
       end

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -14,6 +14,7 @@
 require 'provider/abstract_core'
 require 'provider/terraform/config'
 require 'provider/terraform/import'
+require 'provider/terraform/custom_code'
 require 'provider/terraform/property_override'
 require 'provider/terraform/resource_override'
 require 'provider/terraform/sub_template'

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -71,12 +71,12 @@ module Provider
 
     def collection_url(resource)
       base_url = resource.base_url.split("\n").map(&:strip).compact
-      [resource.__product.base_url, base_url].flatten.join
+      [resource.__product.default_version.base_url, base_url].flatten.join
     end
 
     def update_url(resource, url_part)
       return self_link_url(resource) if url_part.nil?
-      [resource.__product.base_url, url_part].flatten.join
+      [resource.__product.default_version.base_url, url_part].flatten.join
     end
 
     # Transforms a format string with field markers to a regex string with

--- a/provider/terraform/custom_code.rb
+++ b/provider/terraform/custom_code.rb
@@ -1,0 +1,120 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'api/object'
+require 'provider/abstract_core'
+require 'provider/property_override'
+
+module Provider
+  class Terraform < Provider::AbstractCore
+    # Inserts custom code into terraform resources.
+    class CustomCode < Api::Object
+      # Collection of fields allowed in the CustomCode section for
+      # Terraform.
+
+      # All custom code attributes are string-typed.  The string should
+      # be the name of a template file which will be compiled in the
+      # specified / described place.
+      #
+      # ======================
+      # schema.Resource stuff
+      # ======================
+      # Extra Schema Entries go below all other schema entries in the
+      # resource's Resource.Schema map.  They should be formatted as
+      # entries in the map, e.g. `"foo": &schema.Schema{ ... },`.
+      attr_reader :extra_schema_entry
+      # Resource definition code is inserted below everything else
+      # in the resource's Resource {...} definition.  This may be useful
+      # for things like a MigrateState / SchemaVersion pair.
+      # This is likely to be used rarely and may be removed if all its
+      # use cases are covered in other ways.
+      attr_reader :resource_definition
+      # ====================
+      # Encoders & Decoders
+      # ====================
+      # The encoders are functions which take the `obj` map after it
+      # has been assembled in either "Create" or "Update" and mutate it
+      # before it is sent to the server.  There are lots of reasons you
+      # might want to use these - any differences between local schema
+      # and remote schema will be placed here.
+      # Because the call signature of this function cannot be changed,
+      # the template will place the function header and closing } for
+      # you, and your custom code template should *not* include them.
+      attr_reader :encoder
+      # The update encoder is the encoder used in Update - if one is
+      # not provided, the regular encoder is used.  If neither is
+      # provided, of course, neither is used.  Similarly, the custom
+      # code should *not* include the function header or closing }.
+      # Update encoders are only used if object.input is false,
+      # because when object.input is true, only individual fields
+      # can be updated - in that case, use a custom expander.
+      attr_reader :update_encoder
+      # The decoder is the opposite of the encoder - it's called
+      # after the Read succeeds, rather than before Create / Update
+      # are called.  Like with encoders, the decoder should not
+      # include the function header or closing }.
+      attr_reader :decoder
+
+      # =====================
+      # Simple customizations
+      # =====================
+      # Constants go above everything else in the file, and include
+      # things like methods that will be referred to by name elsewhere
+      # (e.g. "fooBarDiffSuppress") and regexes that are necessarily
+      # exported (e.g. "fooBarValidationRegex").
+      attr_reader :constants
+      # This code is run after the Create call succeeds.  It's placed
+      # in the Create function directly without modification.
+      attr_reader :post_create
+      # This code is run before the Update call happens.  It's placed
+      # in the Update function, just after the encoder call, before
+      # the Update call.  Just like the encoder, it is only used if
+      # object.input is false.
+      attr_reader :pre_update
+      # This code is run after the Update call happens.  It's placed
+      # in the Update function, just after the call succeeds.
+      # Just like the encoder, it is only used if object.input is
+      # false.
+      attr_reader :post_update
+      # This code is run just before the Delete call happens.  It's
+      # useful to prepare an object for deletion, e.g. by detaching
+      # a disk before deleting it.
+      attr_reader :pre_delete
+      # This code replaces the entire import method.  Since the import
+      # method's function header can't be changed, the template
+      # inserts that for you - do not include it in your custom code.
+      attr_reader :custom_import
+      # This code is run just after the import method succeeds - it
+      # is useful for parsing attributes that are necessary for
+      # the Read() method to succeed.
+      attr_reader :post_import
+
+      def validate
+        super
+
+        check_optional_property :extra_schema_entry, String
+        check_optional_property :resource_definition, String
+        check_optional_property :encoder, String
+        check_optional_property :update_encoder, String
+        check_optional_property :decoder, String
+        check_optional_property :constants, String
+        check_optional_property :post_create, String
+        check_optional_property :pre_update, String
+        check_optional_property :post_update, String
+        check_optional_property :pre_delete, String
+        check_optional_property :custom_import, String
+        check_optional_property :post_import, String
+      end
+    end
+  end
+end

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -25,6 +25,38 @@ module Provider
       attr_reader :default
       attr_reader :sensitive # Adds `Sensitive: true` to the schema
       attr_reader :validation # Adds a ValidateFunc to the schema
+
+      # ===========
+      # Custom code
+      # ===========
+      # All custom code attributes are string-typed.  The string should
+      # be the name of a template file which will be compiled in the
+      # specified / described place.
+      #
+      # Property Updates are used when a resource is updateable but
+      # resource.input is true.  In this case, only individual
+      # properties can be updated.  The value of this attribute should
+      # be the path to a template which will be compiled. This code is placed
+      # *inline* in the obj := { ... } definition - it is not a custom
+      # function, it is a custom statement.  Note that this cannot
+      # be used for nested properties, as they are not present in the
+      # obj := {...} statement.  This statement template receives `property`
+      # and `prefix` to aid in code reuse.
+      attr_reader :update_statement
+      # A custom flattener replaces the default flattener for an attribute.
+      # It is called as part of Read.  It can return an object of any
+      # type, and may sometimes need to return an object with non-interface{}
+      # type so that the d.Set() call will succeed, so the function
+      # header *is* a part of the custom code template.  To help with
+      # creating the function header, `property` and `prefix` are available,
+      # just as they are in the standard flattener template.
+      attr_reader :custom_flatten
+      # A custom expander replaces the default expander for an attribute.
+      # It is called as part of Create, and as part of Update if
+      # object.input is false.  It can return an object of any type,
+      # so the function header *is* part of the custom code template.
+      # As with flatten, `property` and `prefix` are available.
+      attr_reader :custom_expand
     end
 
     # Support for schema ValidateFunc functionality.
@@ -62,6 +94,10 @@ module Provider
 
         raise "'value' and 'from_api' cannot be both set for 'default'"  \
           if from_api && !value.nil?
+
+        check_optional_property :update_statement, String
+        check_optional_property :custom_flatten, String
+        check_optional_property :custom_expand, String
       end
 
       def apply(api_property)

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -26,6 +26,12 @@ module Provider
       attr_reader :sensitive # Adds `Sensitive: true` to the schema
       attr_reader :validation # Adds a ValidateFunc to the schema
 
+      attr_reader :is_set # Uses a Set instead of an Array
+      # Optional function to determine the unique ID of an item in the set
+      # If not specified, schema.HashString (when elements are string) or
+      # schema.HashSchema are used.
+      attr_reader :set_hash_func
+
       # ===========
       # Custom code
       # ===========
@@ -133,21 +139,32 @@ module Provider
 
         # Ensures boolean values are set to false if nil
         @sensitive ||= false
+        @is_set ||= false
 
         @default ||= Provider::Terraform::Default.new
 
         check_property :sensitive, :boolean
+        check_property :is_set, :boolean
         check_property :default, Provider::Terraform::Default
 
         check_optional_property :diff_suppress_func, String
         check_optional_property :state_func, String
         check_optional_property :validation, Provider::Terraform::Validation
+        check_optional_property :set_hash_func, String
       end
 
       def apply(api_property)
         unless description.nil?
           @description = format_string(:description, @description,
                                        api_property.description)
+        end
+
+        unless api_property.is_a?(Api::Type::Array)
+          if @is_set
+            raise 'Set can only be specified for Api::Type::Array. ' \
+                  "Type is #{api_property.class} for property "\
+                  "'#{api_property.name}'"
+          end
         end
 
         @default.apply(api_property)

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -20,7 +20,6 @@ module Provider
     # Collection of fields allowed in the PropertyOverride section for
     # Terraform. All fields should be `attr_reader :<property>`
     module OverrideFields
-      attr_reader :exclude # TODO(rosbo): Consider moving this to base
       attr_reader :diff_suppress_func # Adds a DiffSuppressFunc to the schema
       attr_reader :state_func # Adds a StateFunc to the schema
       attr_reader :default
@@ -97,12 +96,10 @@ module Provider
         super
 
         # Ensures boolean values are set to false if nil
-        @exclude ||= false
         @sensitive ||= false
 
         @default ||= Provider::Terraform::Default.new
 
-        check_property :exclude, :boolean
         check_property :sensitive, :boolean
         check_property :default, Provider::Terraform::Default
 

--- a/provider/terraform/resource_override.rb
+++ b/provider/terraform/resource_override.rb
@@ -13,6 +13,7 @@
 
 require 'provider/abstract_core'
 require 'provider/resource_override'
+require 'provider/terraform/custom_code'
 
 module Provider
   class Terraform < Provider::AbstractCore
@@ -22,6 +23,7 @@ module Provider
       # The Terraform resource id format used when calling #setId(...).
       # For instance, `{{name}}` means the id will be the resource name.
       attr_reader :id_format
+      attr_reader :custom_code
 
       attr_reader :examples
     end
@@ -35,10 +37,12 @@ module Provider
         super
 
         @id_format ||= '{{name}}'
+        @custom_code ||= Provider::Terraform::CustomCode.new
 
         check_property :id_format, String
 
         check_optional_property :examples, String
+        check_optional_property :custom_code, Provider::Terraform::CustomCode
       end
 
       def apply(resource)

--- a/provider/terraform/resource_override.rb
+++ b/provider/terraform/resource_override.rb
@@ -23,6 +23,7 @@ module Provider
       # The Terraform resource id format used when calling #setId(...).
       # For instance, `{{name}}` means the id will be the resource name.
       attr_reader :id_format
+      attr_reader :import_format
       attr_reader :custom_code
 
       attr_reader :examples
@@ -37,12 +38,14 @@ module Provider
         super
 
         @id_format ||= '{{name}}'
+        @import_format ||= []
         @custom_code ||= Provider::Terraform::CustomCode.new
 
         check_property :id_format, String
 
         check_optional_property :examples, String
         check_optional_property :custom_code, Provider::Terraform::CustomCode
+        check_property :import_format, Array
       end
 
       def apply(resource)

--- a/spec/data/good-export-file.yaml
+++ b/spec/data/good-export-file.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: My Product
 prefix: myproduct
-base_url: http://myproduct.google.com/api
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: http://myproduct.google.com/api
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/good-file.yaml
+++ b/spec/data/good-file.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: My Product
 prefix: myproduct
-base_url: http://myproduct.google.com/api/
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: http://myproduct.google.com/api/
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/good-longuri.yaml
+++ b/spec/data/good-longuri.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: My Product
 prefix: myproduct
-base_url: http://myproduct.google.com/myapi/v123
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v123
+    base_url: http://myproduct.google.com/myapi/v123
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/good-multi-file.yaml
+++ b/spec/data/good-multi-file.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: My Product
 prefix: multiproduct
-base_url: http://myproduct.google.com/api
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: http://myproduct.google.com/api
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/good-multi2-file.yaml
+++ b/spec/data/good-multi2-file.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: My Product
 prefix: multiproduct
-base_url: http://myproduct.google.com/api
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: http://myproduct.google.com/api
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/good-single-file.yaml
+++ b/spec/data/good-single-file.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: My Product
 prefix: myproduct
-base_url: http://myproduct.google.com/api
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: http://myproduct.google.com/api
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/good-single-readonly-file.yaml
+++ b/spec/data/good-single-readonly-file.yaml
@@ -14,7 +14,10 @@
 --- !ruby/object:Api::Product
 name: My Product
 prefix: myproduct
-base_url: http://myproduct.google.com/api
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: http://myproduct.google.com/api
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/resourceref-missingimports.yaml
+++ b/spec/data/resourceref-missingimports.yaml
@@ -14,7 +14,9 @@
 --- !ruby/object:Api::Product
 name: My Product
 prefix: myproduct
-base_url: http://myproduct.google.com/api
+versions:
+  - name: v1
+    base_url: http://myproduct.google.com/api
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/data/resourceref-missingresource.yaml
+++ b/spec/data/resourceref-missingresource.yaml
@@ -14,7 +14,9 @@
 --- !ruby/object:Api::Product
 name: My Product
 prefix: myproduct
-base_url: http://myproduct.google.com/api
+versions:
+  - name: v1
+    base_url: http://myproduct.google.com/api
 scopes:
   - http://scope-to-my-api/
 objects:

--- a/spec/product_spec.rb
+++ b/spec/product_spec.rb
@@ -23,7 +23,10 @@ describe Api::Product do
     subject do
       lambda do
         product('name: "foo"',
-                'base_url: "http://foo/var/"',
+                'versions:',
+                '  - !ruby/object:Api::Product::Version',
+                '    name: v1',
+                '    base_url: "http://foo/var/"',
                 'objects:',
                 '  - !ruby/object:Api::Resource',
                 '    kind: foo#resource',
@@ -39,10 +42,12 @@ describe Api::Product do
     it { is_expected.to raise_error(StandardError, /Missing 'prefix'/) }
   end
 
-  context 'requires base_url' do
+  context 'requires versions' do
     subject do
       lambda do
         product('name: "foo"',
+                'scopes:',
+                '  - link/to/scope',
                 'prefix: "bar"',
                 'objects:',
                 '  - !ruby/object:Api::Resource',
@@ -52,11 +57,80 @@ describe Api::Product do
                 '    name: "res1"',
                 '    properties:',
                 '      - !ruby/object:Api::Type',
-                '        name: var').validate
+                '        name: var',
+                '        description: desc').validate
       end
     end
 
-    it { is_expected.to raise_error(StandardError, /Missing 'base_url'/) }
+    it { is_expected.to raise_error(StandardError, /Missing 'versions'/) }
+  end
+
+  context 'requires at most one default version' do
+    subject do
+      lambda do
+        product('name: "foo"',
+                'scopes:',
+                '  - link/to/scope',
+                'prefix: "bar"',
+                'versions:',
+                '  - !ruby/object:Api::Product::Version',
+                '    name: v1',
+                '    base_url: "http://foo/var/v1"',
+                '    default: true',
+                '  - !ruby/object:Api::Product::Version',
+                '    name: beta',
+                '    base_url: "http://foo/var/beta"',
+                '    default: true',
+                'objects:',
+                '  - !ruby/object:Api::Resource',
+                '    kind: foo#resource',
+                '    base_url: myres/',
+                '    description: foo',
+                '    name: "res1"',
+                '    properties:',
+                '      - !ruby/object:Api::Type',
+                '        name: var',
+                '        description: desc').validate
+      end
+    end
+
+    it do
+      is_expected.to raise_error(StandardError,
+                                 /must specify at most one default/)
+    end
+  end
+
+  context 'requires at least one default version' do
+    subject do
+      lambda do
+        product('name: "foo"',
+                'scopes:',
+                '  - link/to/scope',
+                'prefix: "bar"',
+                'versions:',
+                '  - !ruby/object:Api::Product::Version',
+                '    name: v1',
+                '    base_url: "http://foo/var/v1"',
+                '  - !ruby/object:Api::Product::Version',
+                '    name: beta',
+                '    base_url: "http://foo/var/beta"',
+                'objects:',
+                '  - !ruby/object:Api::Resource',
+                '    kind: foo#resource',
+                '    base_url: myres/',
+                '    description: foo',
+                '    name: "res1"',
+                '    properties:',
+                '      - !ruby/object:Api::Type',
+                '        name: var',
+                '        description: desc').validate
+      end
+    end
+
+    it do
+      is_expected.to raise_error(StandardError,
+                                 /must specify a default/)
+    end
   end
 
   context 'requires objects' do
@@ -64,7 +138,10 @@ describe Api::Product do
       lambda do
         product('name: "foo"',
                 'prefix: "bar"',
-                'base_url: "baz"').validate
+                'versions:',
+                '  - !ruby/object:Api::Product::Version',
+                '    name: v1',
+                '    base_url: "baz"').validate
       end
     end
     it { is_expected.to raise_error(StandardError, /Missing 'objects'/) }
@@ -75,7 +152,10 @@ describe Api::Product do
       lambda do
         product('name: "foo"',
                 'prefix: "bar"',
-                'base_url: "baz"',
+                'versions:',
+                '  - !ruby/object:Api::Product::Version',
+                '    name: v1',
+                '    base_url: "baz"',
                 'objects:',
                 '  - bah. bad object!').validate
       end

--- a/templates/terraform/constants/ssl_policy.erb
+++ b/templates/terraform/constants/ssl_policy.erb
@@ -1,0 +1,34 @@
+<% if false # the license inside this if block pertains to this file  -%>
+	# Copyright 2017 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+<% end -%>
+func sslPolicyCustomizeDiff(diff *schema.ResourceDiff, v interface{}) error {
+	profile := diff.Get("profile")
+	customFeaturesCount := diff.Get("custom_features.#")
+
+	// Validate that policy configs aren't incompatible during all phases
+	// CUSTOM profile demands non-zero custom_features, and other profiles (i.e., not CUSTOM) demand zero custom_features
+	if diff.HasChange("profile") || diff.HasChange("custom_features") {
+		if profile.(string) == "CUSTOM" {
+			if customFeaturesCount.(int) == 0 {
+				return fmt.Errorf("Error in SSL Policy %s: the profile is set to %s but no custom_features are set.", diff.Get("name"), profile.(string))
+      }
+		} else {
+			if customFeaturesCount != 0 {
+				return fmt.Errorf("Error in SSL Policy %s: the profile is set to %s but using custom_features requires the profile to be CUSTOM.", diff.Get("name"), profile.(string))
+			}
+		}
+		return nil
+	}
+	return nil
+}

--- a/templates/terraform/custom_flatten/region_name_only.erb
+++ b/templates/terraform/custom_flatten/region_name_only.erb
@@ -1,0 +1,17 @@
+<% if false # the license inside this if block pertains to this file -%>
+	# Copyright 2017 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+<% end -%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) interface{} {
+	return NameFromSelfLinkStateFunc(v)
+}

--- a/templates/terraform/decoders/avoid_meaningless_project_update.erb
+++ b/templates/terraform/decoders/avoid_meaningless_project_update.erb
@@ -1,0 +1,54 @@
+  // The problem we're trying to solve here is that this property is a Project,
+  // and there are a lot of ways to specify a Project, including the ID vs
+  // Number, which is something that we can't address in a diffsuppress.
+  // Since we can't enforce a particular method of entering the project,
+  // we're just going to have to use whatever the user entered, whether
+  // it's project/projectName, project/12345, projectName, or 12345.
+  // The normal behavior of this method would be 'return res' - and that's
+  // what we'll fall back to if any of our conditions aren't met.  Those
+  // conditions are:
+  // 1) if the new or old values contain '/', the prefix of that is 'projects'.
+  // 2) if either is non-numeric, a project with that ID exists.
+  // 3) the project IDs represented by both the new and old values are the same.
+  config := meta.(*Config)
+  new := res["parent"].(string)
+  old := d.Get("parent").(string)
+  if strings.HasPrefix(new, "projects/") {
+    new = strings.Split(new, "/")[1]
+  }
+  if strings.HasPrefix(old, "projects/") {
+    old = strings.Split(old, "/")[1]
+  }
+  log.Printf("[DEBUG] Trying to figure out whether to use %s or %s", old, new)
+  // If there's still a '/' in there, the value must not be a project ID.
+  if strings.Contains(old, "/") || strings.Contains(new, "/") {
+    return res, nil
+  }
+  // If 'old' isn't entirely numeric, let's assume it's a project ID.
+  // If it's a project ID
+  var oldProjId int64
+  var newProjId int64
+  if oldVal, err := strconv.ParseInt(old, 10, 64); err == nil {
+    log.Printf("[DEBUG] The old value was a real number: %d", oldVal)
+    oldProjId = oldVal
+  } else {
+    pOld, err := config.clientResourceManager.Projects.Get(old).Do()
+    if err != nil {
+      return res, nil
+    }
+    oldProjId = pOld.ProjectNumber
+  }
+  if newVal, err := strconv.ParseInt(new, 10, 64); err == nil {
+    log.Printf("[DEBUG] The new value was a real number: %d", newVal)
+    newProjId = newVal
+  } else {
+    pNew, err := config.clientResourceManager.Projects.Get(new).Do()
+    if err != nil {
+      return res, nil
+    }
+    newProjId = pNew.ProjectNumber
+  }
+  if newProjId == oldProjId {
+    res["parent"] = d.Get("parent")
+  }
+  return res, nil

--- a/templates/terraform/expand_property_method.erb
+++ b/templates/terraform/expand_property_method.erb
@@ -36,13 +36,19 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
     transformed := make(map[string]interface{})
 
     <% nested_properties.each do |prop| -%>
-      transformed["<%= prop.name -%>"] =
-      expand<%= prefix -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(original["<%= Google::StringUtils.underscore(prop.name) -%>"])
+      transformed<%= titlelize_property(prop) -%>, err := expand<%= prefix -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(original["<%= Google::StringUtils.underscore(prop.name) -%>"], d, config)
+      if err != nil {
+        return nil, err
+      }
+      transformed["<%= prop.name -%>"] = transformed<%= titlelize_property(prop) -%>
+
     <% end -%>
 
     req = append(req, transformed)
   }
   return req, nil
+}
+
   <% nested_properties.each do |prop| -%>
     <%= lines(build_expand_method(prefix + titlelize_property(property), prop), 1) -%>
   <% end -%>
@@ -57,6 +63,7 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
     req = append(req, f.RelativeLink())
   }
   return req, nil
+}
 <% else -%>
   <% if property.is_a?(Api::Type::ResourceRef) -%>
   f, err := <%= build_expand_resource_ref('v.(string)', property) %>
@@ -64,11 +71,13 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
     return nil, fmt.Errorf("Invalid value for <%= Google::StringUtils.underscore(property.name) -%>: %s", err)
   }
   return f.RelativeLink(), nil
+}
   <% else -%>
   return v, nil
+}
   <% end -%>
 <% end -%>
-}
 <% else -%>
   // TODO: Property '<%= property.name -%>' of type <%= property.class -%> is not supported
+}
 <% end # tf_types.include?(property.class) -%>

--- a/templates/terraform/expand_property_method.erb
+++ b/templates/terraform/expand_property_method.erb
@@ -30,6 +30,9 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
 }
 <% elsif tf_types.include?(property.class) -%>
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) (interface{}, error) {
+<% if property.is_set -%>
+  v = v.(*schema.Set).List()
+<% end -%>
 <%
   if !nested_properties(property).empty?
     nested_properties = nested_properties(property)

--- a/templates/terraform/expand_property_method.erb
+++ b/templates/terraform/expand_property_method.erb
@@ -26,8 +26,8 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
 <% elsif tf_types.include?(property.class) -%>
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) (interface{}, error) {
 <%
-  if !effective_nested_properties(property).empty?
-    nested_properties = effective_nested_properties(property)
+  if !nested_properties(property).empty?
+    nested_properties = nested_properties(property)
 -%>
   l := v.([]interface{})
   req := make([]interface{}, 0, len(l))

--- a/templates/terraform/expand_property_method.erb
+++ b/templates/terraform/expand_property_method.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <% if property.custom_expand -%>
 <%= lines(compile_template(property.custom_expand,
-                           prefix: resource_name,
+                           prefix: prefix,
                            property: property)) -%>
 <% else -%>
 <% if property.is_a?(Api::Type::NameValues) -%>

--- a/templates/terraform/expand_property_method.erb
+++ b/templates/terraform/expand_property_method.erb
@@ -12,6 +12,11 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 <% end -%>
+<% if property.custom_expand -%>
+<%= lines(compile_template(property.custom_expand,
+                           prefix: resource_name,
+                           property: property)) -%>
+<% else -%>
 <% if property.is_a?(Api::Type::NameValues) -%>
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) (map[string]string, error) {
   if v == nil {
@@ -81,3 +86,4 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
   // TODO: Property '<%= property.name -%>' of type <%= property.class -%> is not supported
 }
 <% end # tf_types.include?(property.class) -%>
+<% end # custom_code check -%>

--- a/templates/terraform/flatten_property_method.erb
+++ b/templates/terraform/flatten_property_method.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <% if property.custom_flatten -%>
 <%= lines(compile_template(property.custom_flatten,
-                           prefix: resource_name,
+                           prefix: prefix,
                            property: property)) -%>
 <% else -%>
 <% if tf_types.include?(property.class) -%>

--- a/templates/terraform/flatten_property_method.erb
+++ b/templates/terraform/flatten_property_method.erb
@@ -20,7 +20,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) in
   }
   original := v.(map[string]interface{})
   transformed := make(map[string]interface{})
-  <% effective_properties(property.properties).each do |prop| -%>
+  <% property.properties.each do |prop| -%>
     transformed["<%= Google::StringUtils.underscore(prop.name) -%>"] =
     flatten<%= prefix -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(original["<%= prop.name -%>"])
   <% end -%>
@@ -31,7 +31,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) in
   for _, raw := range l {
     original := raw.(map[string]interface{})
     transformed = append(transformed, map[string]interface{}{
-    <% effective_properties(property.item_type.properties).each do |prop| -%>
+    <% property.item_type.properties.each do |prop| -%>
       "<%= Google::StringUtils.underscore(prop.name) -%>": flatten<%= prefix -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(original["<%= prop.name -%>"]),
     <% end -%>
     })
@@ -49,8 +49,8 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) in
   return v
 <% end # property.is_a?(Api::Type::NestedObject) -%>
 }
-<% if !effective_nested_properties(property).empty? -%>
-  <% effective_nested_properties(property).each do |prop| -%>
+<% if !nested_properties(property).empty? -%>
+  <% nested_properties(property).each do |prop| -%>
     <%= lines(build_flatten_method(prefix + titlelize_property(property), prop), 1) -%>
   <% end -%>
 <% end -%>

--- a/templates/terraform/flatten_property_method.erb
+++ b/templates/terraform/flatten_property_method.erb
@@ -15,6 +15,9 @@
 <% if tf_types.include?(property.class) -%>
 func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) interface{} {
 <% if property.is_a?(Api::Type::NestedObject) -%>
+  if v == nil {
+    return nil
+  }
   original := v.(map[string]interface{})
   transformed := make(map[string]interface{})
   <% effective_properties(property.properties).each do |prop| -%>

--- a/templates/terraform/flatten_property_method.erb
+++ b/templates/terraform/flatten_property_method.erb
@@ -12,6 +12,11 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 <% end -%>
+<% if property.custom_flatten -%>
+<%= lines(compile_template(property.custom_flatten,
+                           prefix: resource_name,
+                           property: property)) -%>
+<% else -%>
 <% if tf_types.include?(property.class) -%>
 func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) interface{} {
 <% if property.is_a?(Api::Type::NestedObject) -%>
@@ -57,3 +62,4 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) in
 <% else -%>
   // TODO: Property '<%= property.name -%>' of type <%= property.class -%> is not supported
 <% end # tf_types.include?(property.class) -%>
+<% end # custom code check -%>

--- a/templates/terraform/nested_property_documentation.erb
+++ b/templates/terraform/nested_property_documentation.erb
@@ -1,5 +1,5 @@
 <%
-  nested_properties = effective_nested_properties(property)
+  nested_properties = nested_properties(property)
   if !nested_properties.empty?
 -%>
 The `<%= Google::StringUtils.underscore(property.name) -%>` block <%= if property.output then "contains" else "supports" end -%>:

--- a/templates/terraform/post_create/lien.erb
+++ b/templates/terraform/post_create/lien.erb
@@ -1,0 +1,9 @@
+// This resource is unusual - instead of returning an Operation from
+// Create, it returns the created object itself.  We don't parse
+// any of the values there, preferring to centralize that logic in
+// Read().  In this resource, Read is also unusual - it requires
+// us to know the server-side generated name of the object we're
+// trying to fetch, and the only way to know that is to capture
+// it here.  The following two lines do that.
+d.SetId(flattenResourceManagerLienName(res["name"]).(string))
+d.Set("name", flattenResourceManagerLienName(res["name"]))

--- a/templates/terraform/post_import/lien_import.erb
+++ b/templates/terraform/post_import/lien_import.erb
@@ -1,0 +1,5 @@
+parent, err := replaceVars(d, config, "projects/{{parent}}")
+if err != nil {
+		return nil, err
+}
+d.Set("parent", parent)

--- a/templates/terraform/pre_delete/modify_delete_url.erb
+++ b/templates/terraform/pre_delete/modify_delete_url.erb
@@ -1,0 +1,4 @@
+url, err = replaceVars(d, config, "<%= object.__product.default_version.base_url -%><%=object.base_url-%>/{{name}}")
+if err != nil {
+	return err
+}

--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -4,7 +4,7 @@
 <% elsif !property.output -%>
   (Optional)
 <% end -%>
-  <%= property.description.strip -%>
+<%= indent(property.description.strip, 2) -%>
 <% if property.is_a?(Api::Type::NestedObject) || (property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::NestedObject)) -%>
   Structure is documented below.
 <% end -%>

--- a/templates/terraform/provider_gen.erb
+++ b/templates/terraform/provider_gen.erb
@@ -18,6 +18,11 @@ package google
 
 import "github.com/hashicorp/terraform/helper/schema"
 
+
+<% if product_ns == 'Resourcemanager'
+		product_ns = 'ResourceManager'
+end -%>
+
 var Generated<%= product_ns -%>ResourcesMap = map[string]*schema.Resource{
 <% product.objects.reject { |r| r.exclude }.each do |object| -%>
 <% resource_name = product_ns + object.name -%>

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -19,11 +19,20 @@ package google
 <%= lines(compile(object.custom_code.constants)) if object.custom_code.constants %>
 
 <%
-  resource_name = product_ns + object.name
-  properties = object.all_user_properties
-  settable_properties = properties.reject(&:output)
-  api_name_lower = String.new(product_ns)
-  api_name_lower[0] = api_name_lower[0].downcase
+	# ResourceManager APIs need to be imported from api/cloudresourcemanager, need to
+	# be namespaced as ResourceManager, and need to be upstream as gresourcemanager,
+  # which leads to a product_ns of 'Resourcemanager'.
+  # TODO: fix this hack.
+	if product_ns == 'Resourcemanager'
+		product_ns = 'ResourceManager'
+	end
+	resource_name = product_ns + object.name
+	properties = object.all_user_properties
+	settable_properties = properties.reject(&:output)
+	api_name_lower = String.new(product_ns)
+	api_name_lower[0] = api_name_lower[0].downcase
+	has_project = object.base_url.include?("{{project}}")
+	has_self_link = (object.exports || []).any? { |e| e.is_a?(Api::Type::SelfLink)}
 -%>
 
 func resource<%= resource_name -%>() *schema.Resource {
@@ -39,6 +48,7 @@ func resource<%= resource_name -%>() *schema.Resource {
 			State: resource<%= resource_name -%>Import,
 		},
 
+		<% unless object.async.nil? -%>
 		Timeouts: &schema.ResourceTimeout {
 			Create: schema.DefaultTimeout(<%= object.async.operation.timeouts.insert_sec -%> * time.Second),
 			<% if updatable?(object, properties) -%>
@@ -46,6 +56,7 @@ func resource<%= resource_name -%>() *schema.Resource {
 			<% end -%>
 			Delete: schema.DefaultTimeout(<%= object.async.operation.timeouts.delete_sec -%> * time.Second),
 		},
+		<% end -%>
 <%= lines(compile(object.custom_code.resource_definition)) if object.custom_code.resource_definition -%>
 
 		Schema: map[string]*schema.Schema{
@@ -53,7 +64,7 @@ func resource<%= resource_name -%>() *schema.Resource {
 	<%= lines(build_schema_property(prop, object)) -%>
 <% end -%>
 <%= lines(compile(object.custom_code.extra_schema_entry)) if object.custom_code.extra_schema_entry -%>
-<% if object.base_url.include?("{{project}}") -%>
+<% if has_project -%>
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -61,7 +72,7 @@ func resource<%= resource_name -%>() *schema.Resource {
 				ForceNew: true,
 			},
 <% end -%>
-<% if (object.exports || []).any? { |e| e.is_a?(Api::Type::SelfLink)} -%>
+<% if has_self_link -%>
 			"self_link": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -74,10 +85,12 @@ func resource<%= resource_name -%>() *schema.Resource {
 func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+  <% if has_project -%>
 	project, err := getProject(d, config)
 	if err != nil {
 		return err
-	}
+  }
+  <% end -%>
 
 <% settable_properties.each do |prop| -%>
 	<%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>"), d, config)
@@ -116,6 +129,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 	}
 	d.SetId(id)
 
+	<% unless object.async.nil? -%>
 	op := &<%= api_name_lower -%>.Operation{}
 	err = Convert(res, op)
 	if err != nil {
@@ -123,7 +137,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 	}
 
 	waitErr := <%= api_name_lower -%>OperationWaitTime(
-		config.client<%= product_ns -%>, op, project, "Creating <%= object.name -%>",
+	config.client<%= product_ns -%>, op,<% if has_project -%> project, <% end -%> "Creating <%= object.name -%>",
 		int(d.Timeout(schema.TimeoutCreate).Minutes()))
 
 	if waitErr != nil {
@@ -131,6 +145,9 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 		d.SetId("")
 		return fmt.Errorf("Error waiting to create <%= object.name -%>: %s", waitErr)
 	}
+	<% end -%>
+
+	log.Printf("[DEBUG] Finished creating <%= object.name -%> %q: %#v", d.Id(), res)
 
 <%= lines(compile(object.custom_code.post_create)) if object.custom_code.post_create -%>
 
@@ -140,10 +157,12 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+  <% if has_project -%>
 	project, err := getProject(d, config)
 	if err != nil {
 		return err
-	}
+  }
+  <% end -%>
 
 	url, err := replaceVars(d, config, "<%= self_link_url(object) -%>")
 	if err != nil {
@@ -154,21 +173,37 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("<%= resource_name -%> %q", d.Id()))
 	}
+
+<% unless object.self_link_query.nil? -%>
+	<%# This part of the template extracts the one resource we're interested in
+			from the list that gets returned.  self_link_query is a field which
+			describes a list result from a read. -%>
+    <%= compile_template('templates/terraform/self_link_query.erb',
+												 object: object,
+												 settable_properties: settable_properties,
+												 resource_name: resource_name) -%>
+<% end -%>
+
 <% if object.custom_code.decoder -%>
-  res, err = <%= resource_name -%>Decoder(d, meta, res)
+  res, err = resource<%= resource_name -%>Decoder(d, meta, res)
   if err != nil {
     return err
   }
 <% end -%>
+
+
+
 <% properties.each do |prop| -%>
   if err := d.Set("<%= Google::StringUtils.underscore(prop.name) -%>", flatten<%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.api_name -%>"])); err != nil {
 		return fmt.Errorf("Error reading <%= object.name -%>: %s", err)
 	}
 <% end -%>
+	<% if has_self_link -%>
 	if err := d.Set("self_link", res["selfLink"]); err != nil {
 		return fmt.Errorf("Error reading <%= object.name -%>: %s", err)
 	}
-<% if object.base_url.include?("{{project}}") -%>
+	<% end -%>
+<% if has_project -%>
 	if err := d.Set("project", project); err != nil {
 		return fmt.Errorf("Error reading <%= object.name -%>: %s", err)
 	}
@@ -181,10 +216,12 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
 func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+  <% if has_project -%>
 	project, err := getProject(d, config)
 	if err != nil {
 		return err
 	}
+  <% end -%>
 
 	<% if object.input -%>
 	var obj map[string]interface{}
@@ -227,18 +264,21 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 			return fmt.Errorf("Error updating <%= object.name -%> %q: %s", d.Id(), err)
 		}
 
+		<% unless object.async.nil? -%>
 		err = Convert(res, op)
 		if err != nil {
 			return err
 		}
 
 		err = <%= api_name_lower -%>OperationWaitTime(
-			config.client<%= product_ns -%>, op, project, "Updating <%= object.name -%>",
+			config.client<%= product_ns -%>, op, <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
 			int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 
 		if err != nil {
 			return err
 		}
+
+		<% end -%>
 
 		<% props.each do |prop|	-%>
 		d.SetPartial("<%= Google::StringUtils.underscore(prop.name) -%>")
@@ -280,6 +320,7 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 	return fmt.Errorf("Error updating <%= object.name -%> %q: %s", d.Id(), err)
 	}
 
+	<% unless object.async.nil? -%>
 	op := &<%= api_name_lower -%>.Operation{}
 	err = Convert(res, op)
 	if err != nil {
@@ -287,12 +328,13 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 	}
 
 	err = <%= api_name_lower -%>OperationWaitTime(
-	config.client<%= product_ns -%>, op, project, "Updating <%= object.name -%>",
+	config.client<%= product_ns -%>, op, <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
 	int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 
 	if err != nil {
 	return err
 	}
+	<% end -%>
 	<% end -%>
 
 <%= lines(compile(object.custom_code.post_update)) if object.custom_code.post_update -%>
@@ -303,10 +345,12 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+  <% if has_project -%>
 	project, err := getProject(d, config)
 	if err != nil {
 		return err
-	}
+  }
+  <% end -%>
 
 	url, err := replaceVars(d, config, "<%= self_link_url(object) -%>")
 	if err != nil {
@@ -320,6 +364,7 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error deleting <%= object.name -%> %q: %s", d.Id(), err)
 	}
 
+	<% unless object.async.nil? -%>
 	op := &<%= api_name_lower -%>.Operation{}
 	err = Convert(res, op)
 	if err != nil {
@@ -327,13 +372,15 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
 	}
 
 	err = <%= api_name_lower -%>OperationWaitTime(
-		config.client<%= product_ns -%>, op, project, "Deleting <%= object.name -%>",
+		config.client<%= product_ns -%>, op, <% if has_project -%> project, <% end -%> "Deleting <%= object.name -%>",
 		int(d.Timeout(schema.TimeoutDelete).Minutes()))
 
 	if err != nil {
 		return err
 	}
+	<% end -%>
 
+	log.Printf("[DEBUG] Finished deleting <%= object.name -%> %q: %#v", d.Id(), res)
 	return nil
 }
 

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -18,7 +18,7 @@ package google
 
 <%
   resource_name = product_ns + object.name
-  properties = effective_properties(object.all_user_properties)
+  properties = object.all_user_properties
   settable_properties = properties.reject(&:output)
   api_name_lower = String.new(product_ns)
   api_name_lower[0] = api_name_lower[0].downcase

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -16,6 +16,8 @@
 
 package google
 
+<%= lines(compile(object.custom_code.constants)) if object.custom_code.constants %>
+
 <%
   resource_name = product_ns + object.name
   properties = object.all_user_properties
@@ -44,11 +46,13 @@ func resource<%= resource_name -%>() *schema.Resource {
 			<% end -%>
 			Delete: schema.DefaultTimeout(<%= object.async.operation.timeouts.delete_sec -%> * time.Second),
 		},
+<%= lines(compile(object.custom_code.resource_definition)) if object.custom_code.resource_definition -%>
 
 		Schema: map[string]*schema.Schema{
 <% order_properties(properties).each do |prop| -%>
 	<%= lines(build_schema_property(prop, object)) -%>
 <% end -%>
+<%= lines(compile(object.custom_code.extra_schema_entry)) if object.custom_code.extra_schema_entry -%>
 <% if object.base_url.include?("{{project}}") -%>
 			"project": {
 				Type:     schema.TypeString,
@@ -87,6 +91,12 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
   "<%= prop.api_name -%>": <%= prop.api_name -%>Prop,
 <% end -%>
 	}
+  <% if object.custom_code.encoder -%>
+  obj, err = resource<%= resource_name -%>Encoder(d, meta, obj)
+  if err != nil {
+    return err
+  }
+  <% end -%>
 
 	url, err := replaceVars(d, config, "<%= collection_url(object) -%>")
 	if err != nil {
@@ -122,6 +132,8 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error waiting to create <%= object.name -%>: %s", waitErr)
 	}
 
+<%= lines(compile(object.custom_code.post_create)) if object.custom_code.post_create -%>
+
 	return resource<%= resource_name -%>Read(d, meta)
 }
 
@@ -142,8 +154,14 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("<%= resource_name -%> %q", d.Id()))
 	}
+<% if object.custom_code.decoder -%>
+  res, err = <%= resource_name -%>Decoder(d, meta, res)
+  if err != nil {
+    return err
+  }
+<% end -%>
 <% properties.each do |prop| -%>
-	if err := d.Set("<%= Google::StringUtils.underscore(prop.name) -%>", flatten<%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.api_name -%>"])); err != nil {
+  if err := d.Set("<%= Google::StringUtils.underscore(prop.name) -%>", flatten<%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.api_name -%>"])); err != nil {
 		return fmt.Errorf("Error reading <%= object.name -%>: %s", err)
 	}
 <% end -%>
@@ -186,7 +204,13 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 
 		obj := map[string]interface{}{
 		<% props.each do |prop| -%>
+      <% if prop.update_statement -%>
+        <%= prop.api_name -%>": <%= compile_template(prop.update_statement,
+                                                     prefix: resource_name,
+                                                     property: prop) -%>
+      <% else -%>
 			"<%= prop.api_name -%>": <%= prop.api_name -%>Prop,
+      <% end -%>
 		<% end -%>
 		}
 		url, err = replaceVars(d, config, "<%= update_url(object, key[:update_url]) -%>")
@@ -232,12 +256,19 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 	<% end -%>
 	}
 
+	<%# We need to decide what encoder to use here - if there's an update encoder, use that! -%>
+	<% if object.custom_code.update_encoder -%>
+	obj, err = resource<%= resource_name -%>UpdateEncoder(d, meta, obj)
+	<% elsif object.custom_code.encoder -%>
+	obj, err = resource<%= resource_name -%>Encoder(d, meta, obj)
+	<% end -%>
 	url, err := replaceVars(d, config, "<%= self_link_url(object) -%>")
 	if err != nil {
 	return err
 	}
 
 	log.Printf("[DEBUG] Updating <%= object.name -%> %q: %#v", d.Id(), obj)
+<%= lines(compile(object.custom_code.pre_update)) if object.custom_code.pre_update -%>
 	res, err := sendRequest(config, "<%= object.update_verb -%>", url, obj)
 
 	if err != nil {
@@ -259,6 +290,7 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 	}
 	<% end -%>
 
+<%= lines(compile(object.custom_code.post_update)) if object.custom_code.post_update -%>
 	return resource<%= resource_name -%>Read(d, meta)
 }
 <% end -%>
@@ -276,6 +308,7 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
 		return err
 	}
 
+<%= lines(compile(object.custom_code.pre_delete)) if object.custom_code.pre_delete -%>
 	log.Printf("[DEBUG] Deleting <%= object.name -%> %q", d.Id())
 	res, err := Delete(config, url)
 	if err != nil {
@@ -300,8 +333,11 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
 }
 
 func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+<% if object.custom_code.custom_import -%>
+  <%= lines(compile(object.custom_code.custom_import)) -%>
+<% else -%>
 	config := meta.(*Config)
-	parseImportId([]string{<%= '"' + import_id_formats(object).map{|s| format2regex s}.join('","') + '"' -%>}, d, config)
+	parseImportId([]string{"<%= import_id_formats(object).map{|s| format2regex s}.join('","') -%>"}, d, config)
 
 	// Replace import id for the resource id
 	id, err := replaceVars(d, config, "<%= object.id_format -%>")
@@ -309,8 +345,10 @@ func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{
 		return nil, fmt.Errorf("Error constructing id: %s", err)
 	}
 	d.SetId(id)
+  <%= lines(compile(object.custom_code.post_import)) if object.custom_code.post_import -%>
 
 	return []*schema.ResourceData{d}, nil
+<% end -%>
 }
 
 <% properties.each do |prop| -%>
@@ -319,4 +357,22 @@ func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{
 
 <% settable_properties.each do |prop| -%>
 <%= lines(build_expand_method(resource_name, prop), 1) -%>
+<% end -%>
+
+<% if object.custom_code.encoder -%>
+func resource<%= resource_name -%>Encoder(d *schema.ResourceData, meta interface{}, obj map[string]interface{}) (map[string]interface{}, error) {
+  <%= lines(compile(object.custom_code.encoder)) -%>
+}
+<% end -%>
+
+<% if object.custom_code.update_encoder-%>
+func resource<%= resource_name -%>UpdateEncoder(d *schema.ResourceData, meta interface{}, obj map[string]interface{}) (map[string]interface{}, error) {
+  <%= lines(compile(object.custom_code.update_encoder)) -%>
+}
+<% end -%>
+
+<% if object.custom_code.decoder -%>
+func resource<%= resource_name -%>Decoder(d *schema.ResourceData, meta interface{}, res map[string]interface{}) (map[string]interface{}, error) {
+  <%= lines(compile(object.custom_code.decoder)) -%>
+}
 <% end -%>

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -88,7 +88,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 
 	obj := map[string]interface{}{
 <% settable_properties.each do |prop| -%>
-  "<%= prop.api_name -%>": <%= prop.api_name -%>Prop,
+	"<%= prop.api_name -%>": <%= prop.api_name -%>Prop,
 <% end -%>
 	}
   <% if object.custom_code.encoder -%>
@@ -187,22 +187,27 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 	}
 
 	<% if object.input -%>
+	var obj map[string]interface{}
 	var url string
 	var res map[string]interface{}
 	op := &<%= api_name_lower -%>.Operation{}
 
 	d.Partial(true)
 
-	<% properties_by_custom_update(settable_properties).each do |key, props| -%>
+	<% properties_by_custom_update(properties).each do |key, props| -%>
 	if <%= props.map { |prop| "d.HasChange(\"#{Google::StringUtils.underscore(prop.name)}\")" }.join ' || ' -%> {
 		<% props.each do |prop| -%>
-			<%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>"), d, config)
+			<% if settable_properties.include? prop -%>
+				<%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>"), d, config)
 			if err != nil {
 				return err
 			}
+			<% else -%>
+			<%= prop.api_name -%>Prop := d.Get("<%= Google::StringUtils.underscore(prop.name) -%>")
+			<% end -%>
 		<% end -%>
 
-		obj := map[string]interface{}{
+		obj = map[string]interface{}{
 		<% props.each do |prop| -%>
       <% if prop.update_statement -%>
         <%= prop.api_name -%>": <%= compile_template(prop.update_statement,

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -15,7 +15,7 @@
 <%
   api_name_lower = product_ns.downcase
   resource_name = Google::StringUtils.underscore(object.name)
-  properties = effective_properties(object.all_user_properties)
+  properties = object.all_user_properties
 -%>
 ---
 <%= lines(autogen_notice :yaml) -%>

--- a/templates/terraform/resource_definition/ssl_policy.erb
+++ b/templates/terraform/resource_definition/ssl_policy.erb
@@ -1,0 +1,15 @@
+<% if false # the license inside this if block pertains to this file -%>
+	# Copyright 2017 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+<% end -%>
+CustomizeDiff: sslPolicyCustomizeDiff,

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -15,7 +15,8 @@
 <% if tf_types.include?(property.class) -%>
 "<%= Google::StringUtils.underscore(property.name) -%>": {
   Type: <%= tf_types[property.class] %>,
-<%	if property.default.from_api -%>
+<%# TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/167) Remove safe-access -%>
+<%	if property.default&.from_api -%>
 	Computed: true,
 	Optional: true,
 <% elsif property.required -%>
@@ -96,7 +97,8 @@
 <% if property.sensitive -%>
     Sensitive: true,
 <% end -%>
-<% unless property.default.value.nil? -%>
+<%# TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/167) Remove safe-access -%>
+<% unless property.default&.value.nil? -%>
     Default: <%= go_literal(property.default.value) -%>,
 <% end -%>
 },

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -15,8 +15,7 @@
 <% if tf_types.include?(property.class) -%>
 "<%= Google::StringUtils.underscore(property.name) -%>": {
   Type: <%= tf_types[property.class] %>,
-<%# TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/167) Remove safe-access -%>
-<%	if property.default&.from_api -%>
+<%	if property.default.from_api -%>
 	Computed: true,
 	Optional: true,
 <% elsif property.required -%>
@@ -97,8 +96,7 @@
 <% if property.sensitive -%>
     Sensitive: true,
 <% end -%>
-<%# TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/167) Remove safe-access -%>
-<% unless property.default&.value.nil? -%>
+<% unless property.default.value.nil? -%>
     Default: <%= go_literal(property.default.value) -%>,
 <% end -%>
 },

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -19,7 +19,7 @@
   <% else -%>
   Type: <%= tf_types[property.class] %>,
   <% end -%>
-<%	if property.default.from_api -%>
+<%	if property.default_from_api -%>
 	Computed: true,
 	Optional: true,
 <% elsif property.required -%>
@@ -109,8 +109,8 @@
 <% if property.sensitive -%>
     Sensitive: true,
 <% end -%>
-<% unless property.default.value.nil? -%>
-    Default: <%= go_literal(property.default.value) -%>,
+<% unless property.default_value.nil? -%>
+    Default: <%= go_literal(property.default_value) -%>,
 <% end -%>
 },
 <% else -%>

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -55,7 +55,7 @@
   MaxItems: 1,
   Elem: &schema.Resource{
     Schema: map[string]*schema.Schema{
-      <% order_properties(effective_properties(property.properties)).each do |prop| -%>
+      <% order_properties(property.properties).each do |prop| -%>
         <%= lines(build_schema_property(prop, object)) -%>
       <% end -%>
     },
@@ -67,7 +67,7 @@
   <% if property.item_type.is_a?(Api::Type::NestedObject) -%>
       Elem: &schema.Resource{
         Schema: map[string]*schema.Schema{
-          <% order_properties(effective_properties(property.item_type.properties)).each do |prop| -%>
+          <% order_properties(property.item_type.properties).each do |prop| -%>
             <%= lines(build_schema_property(prop, object)) -%>
           <% end -%>
         },

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -14,7 +14,11 @@
 <% end -%>
 <% if tf_types.include?(property.class) -%>
 "<%= Google::StringUtils.underscore(property.name) -%>": {
+  <% if property.is_set -%>
+  Type: schema.TypeSet,
+  <% else -%>
   Type: <%= tf_types[property.class] %>,
+  <% end -%>
 <%	if property.default.from_api -%>
 	Computed: true,
 	Optional: true,
@@ -86,6 +90,15 @@
         <% end -%>
       },
   <% end -%>
+  <% if property.is_set -%>
+    <% if !property.set_hash_func.nil? -%>
+    Set: <%= property.set_hash_func -%>,
+    <% elsif property.item_type.is_a?(String) -%>
+    Set: schema.HashString,
+    <% else -%>
+    // Default schema.HashSchema is used.
+  <% end -%>
+	<% end -%>
 <% elsif property.is_a?(Api::Type::NameValues) -%>
   Elem: &schema.Schema{Type: schema.TypeString},
   <% if not (property.key_type == 'Api::Type::String' and property.value_type == 'Api::Type::String') -%>

--- a/templates/terraform/self_link_query.erb
+++ b/templates/terraform/self_link_query.erb
@@ -1,0 +1,37 @@
+	// Extract the object we're interested in from the list response.
+	itemsList_ := res["<%= object.self_link_query.items -%>"]
+	var itemsList []interface{}
+	if itemsList_ != nil {
+		itemsList = itemsList_.([]interface{})
+	}
+	listObj := make([]map[string]interface{}, len(itemsList))
+	for i, item := range itemsList {
+		listObj[i] = item.(map[string]interface{})
+	}
+	res = nil
+	for _, item := range listObj {
+	<% object.identity.each do |prop| -%>
+		<% if settable_properties.include?(prop) -%>
+		this<%= titlelize_property(prop) -%>, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>"), d, config)
+		if err != nil {
+			return err
+		}
+		<% else -%>
+			this<%= titlelize_property(prop) -%> := d.Get("<%= Google::StringUtils.underscore(prop.name) -%>")
+		<% end -%>
+		that<%= titlelize_property(prop) -%> := flatten<%= resource_name -%><%= titlelize_property(prop) -%>(item["<%= prop.api_name -%>"])
+		log.Printf("[DEBUG] Checking equality of %#v, %#v", that<%= titlelize_property(prop) -%>, this<%= titlelize_property(prop) -%>)
+		if !reflect.DeepEqual(that<%= titlelize_property(prop) -%>, this<%= titlelize_property(prop) -%>) {
+			continue
+		}
+	<% end -%>
+		res = item
+		break
+	}
+	if res == nil {
+		// Object isn't there any more - remove it from the state.
+		log.Printf("[DEBUG] Removing <%= resource_name -%> because it couldn't be matched.")
+		d.SetId("")
+		return nil
+	}
+

--- a/templates/terraform/tests/resource_compute_target_https_proxy_test.go
+++ b/templates/terraform/tests/resource_compute_target_https_proxy_test.go
@@ -156,6 +156,7 @@ resource "google_compute_target_https_proxy" "foobar" {
 	name = "httpsproxy-test-%s"
 	url_map = "${google_compute_url_map.foobar.self_link}"
 	ssl_certificates = ["${google_compute_ssl_certificate.foobar1.self_link}"]
+	ssl_policy = "${google_compute_ssl_policy.foobar.self_link}"
 }
 
 resource "google_compute_backend_service" "foobar" {
@@ -192,6 +193,13 @@ resource "google_compute_url_map" "foobar" {
 	}
 }
 
+resource "google_compute_ssl_policy" "foobar" {
+	name            = "sslproxy-test-%s"
+	description     = "my-description"
+	min_tls_version = "TLS_1_2"
+	profile         = "MODERN"
+}
+
 resource "google_compute_ssl_certificate" "foobar1" {
 	name = "httpsproxy-test-cert1-%s"
 	description = "very descriptive"
@@ -205,7 +213,7 @@ resource "google_compute_ssl_certificate" "foobar2" {
 	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
 	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
 }
-`, id, id, id, id, id, id)
+`, id, id, id, id, id, id, id)
 }
 
 func testAccComputeTargetHttpsProxy_basic2(id string) string {
@@ -254,6 +262,13 @@ resource "google_compute_url_map" "foobar" {
 	}
 }
 
+resource "google_compute_ssl_policy" "foobar" {
+	name            = "sslproxy-test-%s"
+	description     = "my-description"
+	min_tls_version = "TLS_1_2"
+	profile         = "MODERN"
+}
+
 resource "google_compute_ssl_certificate" "foobar1" {
 	name = "httpsproxy-test-cert1-%s"
 	description = "very descriptive"
@@ -267,5 +282,5 @@ resource "google_compute_ssl_certificate" "foobar2" {
 	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
 	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
 }
-`, id, id, id, id, id, id)
+`, id, id, id, id, id, id, id)
 }

--- a/templates/terraform/transport.go
+++ b/templates/terraform/transport.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"reflect"
 	"regexp"
 	"strings"
@@ -75,23 +76,23 @@ func isEmptyValue(v reflect.Value) bool {
 	return false
 }
 
-func Post(config *Config, url string, body map[string]interface{}) (map[string]interface{}, error) {
-	return sendRequest(config, "POST", url, body)
+func Post(config *Config, rawurl string, body map[string]interface{}) (map[string]interface{}, error) {
+	return sendRequest(config, "POST", rawurl, body)
 }
 
-func Get(config *Config, url string) (map[string]interface{}, error) {
-	return sendRequest(config, "GET", url, nil)
+func Get(config *Config, rawurl string) (map[string]interface{}, error) {
+	return sendRequest(config, "GET", rawurl, nil)
 }
 
-func Put(config *Config, url string, body map[string]interface{}) (map[string]interface{}, error) {
-	return sendRequest(config, "PUT", url, body)
+func Put(config *Config, rawurl string, body map[string]interface{}) (map[string]interface{}, error) {
+	return sendRequest(config, "PUT", rawurl, body)
 }
 
-func Delete(config *Config, url string) (map[string]interface{}, error) {
-	return sendRequest(config, "DELETE", url, nil)
+func Delete(config *Config, rawurl string) (map[string]interface{}, error) {
+	return sendRequest(config, "DELETE", rawurl, nil)
 }
 
-func sendRequest(config *Config, method, url string, body map[string]interface{}) (map[string]interface{}, error) {
+func sendRequest(config *Config, method, rawurl string, body map[string]interface{}) (map[string]interface{}, error) {
 	reqHeaders := make(http.Header)
 	reqHeaders.Set("User-Agent", config.userAgent)
 	reqHeaders.Set("Content-Type", "application/json")
@@ -105,7 +106,15 @@ func sendRequest(config *Config, method, url string, body map[string]interface{}
 		}
 	}
 
-	req, err := http.NewRequest(method, url+"?alt=json", &buf)
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return nil, err
+	}
+	q := u.Query()
+	q.Set("alt", "json")
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequest(method, u.String(), &buf)
 	if err != nil {
 		return nil, err
 	}

--- a/templates/terraform/update_encoder/ssl_policy.erb
+++ b/templates/terraform/update_encoder/ssl_policy.erb
@@ -1,0 +1,24 @@
+<% if false # the license inside this if block pertains to this file -%>
+	# Copyright 2017 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+<% end -%>
+// TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/184): Handle fingerprint consistently
+obj["fingerprint"] = d.Get("fingerprint")
+
+// TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/183): Can we generalize this
+// Send a null fields if customFeatures is empty.
+if v, ok := obj["customFeatures"]; ok && len(v.([]interface{})) == 0 {
+	obj["customFeatures"] = nil
+}
+
+return obj, nil

--- a/tools/swissknife/CHANGELOG.md
+++ b/tools/swissknife/CHANGELOG.md
@@ -1,0 +1,4 @@
+0.1
+---
+
+* Initial image with Puppet only support

--- a/tools/swissknife/Dockerfile
+++ b/tools/swissknife/Dockerfile
@@ -1,0 +1,26 @@
+FROM ruby:2.5
+
+ENV PUPPET_AGENT_VERSION="5.5.0"
+
+# Install puppet agent
+RUN apt-get update && \
+	wget https://apt.puppetlabs.com/puppet5-release-stretch.deb && \
+	dpkg -i puppet5-release-stretch.deb && \
+	rm puppet5-release-stretch.deb && \
+	apt-get update && \
+    apt-get install --no-install-recommends -y puppet-agent="$PUPPET_AGENT_VERSION"-1stretch && \
+    apt-get clean
+
+# Install gem required by gauth
+RUN gem install googleauth google-api-client
+
+# Setup symlink for puppet modules
+COPY docker-entrypoint.sh /usr/local/bin
+
+ENV PATH=/opt/puppetlabs/server/bin:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
+ENV FACTER_cred_path=/etc/creds.json
+
+WORKDIR ~
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/tools/swissknife/README.md
+++ b/tools/swissknife/README.md
@@ -1,0 +1,91 @@
+# Magic Modules Swiss Knife (SK)
+
+A docker container with all the Magic Modules providers installed. 
+
+## Requirements
+
+* docker
+
+## Providers
+
+* Puppet
+* Ansible *(Not yet supported)* 
+* Chef *(Not yet supported)*
+* Terraform *(Not yet supported)*
+
+## Usage
+
+### Step 1: Create credentials
+
+1. In the Google Cloud console, go to IAM & admin > Service accounts
+1. Create a new service account and download the json credential file.
+1. Grant the required permissions to the service account.
+
+### Step 2: Launch the container
+
+In a terminal on your development machine, run:
+
+```sh
+# Specify the path to your credential file and magic-modules checkout.
+export SK_CRED=~/path/to/your/cred/file
+export SK_MM_PATH=~/path/to/magic-modules
+
+# Generate the Magic Module for all providers
+cd $SK_MM_PATH
+bundle exec rake compile 
+
+# Run the Swiss Knife container and start a bash session
+docker run -i -t -v $SK_MM_PATH:/opt/magic-modules -v $SK_CRED:/etc/creds.json gcr.io/magic-modules/swiss-knife
+```
+
+### Step 3: Test your changes
+
+#### Puppet
+
+Inside the Swiss Knife container, run:
+
+```sh
+puppet apply /opt/magic-modules/build/puppet/compute/examples/delete_target_https_proxy.pp
+puppet apply /opt/magic-modules/build/puppet/compute/examples/target_https_proxy.pp
+```
+
+#### Chef
+
+Not yet supported
+
+#### Terraform
+
+Not yet supported
+
+#### Ansible
+
+Not yet supported
+
+### Step 4: Rinse, repeat
+
+Your `magic-modules` directory on your development machine is shared with the
+Swiss Knife docker container.
+
+This means you can simply make changes and call `bundle exec rake compile` and
+the Swiss Knife will pick up the latest change.
+
+## Developing the Swiss Knife
+
+If you wish to add or improve support for any providers, 
+
+### Building a new image
+
+```sh
+cd `/path/to/magic-modules/tools/swissknife
+docker build -t swiss-knife .
+```
+
+### Publishing a new image
+
+This requires extra permissions to write to the storage bucket.
+
+```sh
+# Replace <VERSION> with the version you want. e.g.: 0.1
+docker tag swiss-knife gcr.io/magic-modules/swiss-knife:<VERSION>
+gcloud docker -- push gcr.io/magic-modules/swiss-knife:<VERSION>
+```

--- a/tools/swissknife/docker-entrypoint.sh
+++ b/tools/swissknife/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+set -x
+
+# Setup symlinks for puppet modules
+declare -r module_path="/opt/puppetlabs/puppet/modules"
+declare -r root_dir="/opt/magic-modules"
+
+echo "Root dir: ${root_dir}"
+
+for mod in ${root_dir}/build/puppet/*; do
+	mod_name=$(basename "${mod}")
+	ln -s "$(realpath "${mod}")" "${module_path}/g${mod_name}"
+done
+
+exec "$@"


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
* The Disk resource has `labels`, which need to be updated using `labelFingerprint` at the `setLabels` endpoint.
* The `sizeGb` attribute is updateable using the `resize` endpoint.
* The whole Disk resource is not updateable - so it's `input: true`.
* `type` is provided when creating the resource, so it is `output: false`.

This is in preparation for enabling this resource in Terraform.  It should create a PR for puppet automatically, and the changes will be rolled into chef the next time chef is caught-up with `master` after merge.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Updates to Disk resource to better match the API.
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
