### PR TITLE
Bugfixes to make nested properties work correctly.

### DIFF
--- a/templates/terraform/expand_property_method.erb
+++ b/templates/terraform/expand_property_method.erb
@@ -36,13 +36,19 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
     transformed := make(map[string]interface{})
 
     <% nested_properties.each do |prop| -%>
-      transformed["<%= prop.name -%>"] =
-      expand<%= prefix -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(original["<%= Google::StringUtils.underscore(prop.name) -%>"])
+      transformed<%= titlelize_property(prop) -%>, err := expand<%= prefix -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(original["<%= Google::StringUtils.underscore(prop.name) -%>"], d, config)
+      if err != nil {
+        return nil, err
+      }
+      transformed["<%= prop.name -%>"] = transformed<%= titlelize_property(prop) -%>
+
     <% end -%>
 
     req = append(req, transformed)
   }
   return req, nil
+}
+
   <% nested_properties.each do |prop| -%>
     <%= lines(build_expand_method(prefix + titlelize_property(property), prop), 1) -%>
   <% end -%>
@@ -57,6 +63,7 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
     req = append(req, f.RelativeLink())
   }
   return req, nil
+}
 <% else -%>
   <% if property.is_a?(Api::Type::ResourceRef) -%>
   f, err := <%= build_expand_resource_ref('v.(string)', property) %>
@@ -64,11 +71,13 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
     return nil, fmt.Errorf("Invalid value for <%= Google::StringUtils.underscore(property.name) -%>: %s", err)
   }
   return f.RelativeLink(), nil
+}
   <% else -%>
   return v, nil
+}
   <% end -%>
 <% end -%>
-}
 <% else -%>
   // TODO: Property '<%= property.name -%>' of type <%= property.class -%> is not supported
+}
 <% end # tf_types.include?(property.class) -%>

--- a/templates/terraform/flatten_property_method.erb
+++ b/templates/terraform/flatten_property_method.erb
@@ -15,6 +15,9 @@
 <% if tf_types.include?(property.class) -%>
 func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) interface{} {
 <% if property.is_a?(Api::Type::NestedObject) -%>
+  if v == nil {
+    return nil
+  }
   original := v.(map[string]interface{})
   transformed := make(map[string]interface{})
   <% effective_properties(property.properties).each do |prop| -%>

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -15,7 +15,7 @@
 <% if tf_types.include?(property.class) -%>
 "<%= Google::StringUtils.underscore(property.name) -%>": {
   Type: <%= tf_types[property.class] %>,
-<%	if property.default.from_api -%>
+<%	if property.default&.from_api -%>
 	Computed: true,
 	Optional: true,
 <% elsif property.required -%>
@@ -96,7 +96,7 @@
 <% if property.sensitive -%>
     Sensitive: true,
 <% end -%>
-<% unless property.default.value.nil? -%>
+<% unless property.default&.value.nil? -%>
     Default: <%= go_literal(property.default.value) -%>,
 <% end -%>
 },

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -15,6 +15,7 @@
 <% if tf_types.include?(property.class) -%>
 "<%= Google::StringUtils.underscore(property.name) -%>": {
   Type: <%= tf_types[property.class] %>,
+<%# TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/167) Remove safe-access -%>
 <%	if property.default&.from_api -%>
 	Computed: true,
 	Optional: true,
@@ -96,6 +97,7 @@
 <% if property.sensitive -%>
     Sensitive: true,
 <% end -%>
+<%# TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/167) Remove safe-access -%>
 <% unless property.default&.value.nil? -%>
     Default: <%= go_literal(property.default.value) -%>,
 <% end -%>


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
As it stands, nested properties generate their expanders inside the main body of the nesting expander.  Since the generated expanders are themselves meant to be top-level functions (e.g. they have names), this does not work.  We need to change `expand_property_method.erb` to generate those methods outside the main body of the nesting expander (which unfortunately means a proliferation of `}`s that were previously manageable centrally.  :disappointed: 

Also, nil nested properties were causing panics so `flatten_property_method.erb` needs to be modified to support that.

@rosbo: the third change made you squint a bit when I proposed it, but I didn't understand why.  :)  Can you help me out?  I think the error might have been caused by a missing `super` in `validate` that I had to add in https://github.com/GoogleCloudPlatform/magic-modules/pull/163/files#diff-9ea7653c94b1bfed36d020d121ae71fdR383 ... but I'm not sure!

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
