### PR TITLE
Allow overriding excluded property

### DIFF
--- a/api/resource.rb
+++ b/api/resource.rb
@@ -249,8 +249,14 @@ module Api
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
 
+    # Returns all properties and parameters including the ones that are
+    # excluded. This is used for PropertyOverride validation
+    def all_properties
+      ((properties || []) + (parameters || []))
+    end
+
     def all_user_properties
-      ((properties || []) + (parameters || [])).reject(&:exclude)
+      all_properties.reject(&:exclude)
     end
 
     def required_properties

--- a/api/type.rb
+++ b/api/type.rb
@@ -379,6 +379,12 @@ module Api
         [property_file].concat(properties.map(&:requires))
       end
 
+      # Returns all properties including the ones that are excluded
+      # This is used for PropertyOverride validation
+      def all_properties
+        @properties
+      end
+
       def properties
         @properties.reject(&:exclude)
       end

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2076,6 +2076,7 @@ objects:
         required: true
   - !ruby/object:Api::Resource
     name: 'Network'
+    exclude: true
     kind: 'compute#network'
     base_url: projects/{{project}}/global/networks
     exports:

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2076,7 +2076,6 @@ objects:
         required: true
   - !ruby/object:Api::Resource
     name: 'Network'
-    exclude: true
     kind: 'compute#network'
     base_url: projects/{{project}}/global/networks
     exports:

--- a/provider/resource_overrides.rb
+++ b/provider/resource_overrides.rb
@@ -137,12 +137,12 @@ module Provider
 
     def get_properties(api_entity)
       if api_entity.is_a?(Api::Resource)
-        api_entity.all_user_properties
+        api_entity.all_properties
       elsif api_entity.is_a?(Api::Type::NestedObject)
-        api_entity.properties
+        api_entity.all_properties
       elsif api_entity.is_a?(Api::Type::Array) &&
             api_entity.item_type.is_a?(Api::Type::NestedObject)
-        api_entity.item_type.properties
+        api_entity.item_type.all_properties
       end
     end
 


### PR DESCRIPTION
If a property was excluded in `api.yaml`, we couldn't override it in `my-provider.yaml` because the validation would fail since in the eyes of ResourceOverrides, this property did not exist.

Allowing this is important to be able to set `exclude: true` in api.yaml to exclude for all providers and then in, for example, `terraform.yaml` we can add `exclude: false` to enable it only in Terrafom.

<!-- A summary of the changes in this commit goes here -->


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
