### PR TITLE
Remove redundant call to validate

### DIFF
--- a/compiler.rb
+++ b/compiler.rb
@@ -81,7 +81,6 @@ api.validate
 pp api if ENV['COMPILER_DEBUG']
 
 config = Provider::Config.parse(File.join(catalog, provider), api)
-config.validate
 pp config if ENV['COMPILER_DEBUG']
 
 provider = config.provider.new(config, api)


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->

`Provider::Config.parse(...)` already calls `config.validate`

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
