### PR TITLE
Also populate nonoverriden nested fields

### DIFF
--- a/provider/resource_overrides.rb
+++ b/provider/resource_overrides.rb
@@ -112,8 +112,8 @@ module Provider
                              property_override, Provider::PropertyOverride
         api_property = find_property api_object, property_path.split('.')
         if api_property.nil?
-          raise "The property to override must exists #{property_path} " \
-                "in resource #{api_object.name}"
+          raise "The property to override '#{property_path}' must exists in " \
+                "resource #{api_object.name}"
         end
         property_override.apply api_property
       end
@@ -158,6 +158,19 @@ module Provider
       api_entity.all_user_properties.each do |prop|
         override.properties[prop.name] = @__config.property_override.new \
           unless override.properties.include?(prop.name)
+        populate_nonoverriden_nested_properties prop.name, prop, override
+      end
+    end
+
+    def populate_nonoverriden_nested_properties(prefix, property, override)
+      nested_properties = get_properties(property)
+      return if nested_properties.nil?
+
+      nested_properties.each do |nested_prop|
+        key = "#{prefix}.#{nested_prop.name}"
+        override.properties[key] = @__config.property_override.new \
+          unless override.properties.include?(key)
+        populate_nonoverriden_nested_properties key, nested_prop, override
       end
     end
   end

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -15,8 +15,7 @@
 <% if tf_types.include?(property.class) -%>
 "<%= Google::StringUtils.underscore(property.name) -%>": {
   Type: <%= tf_types[property.class] %>,
-<%# TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/167) Remove safe-access -%>
-<%	if property.default&.from_api -%>
+<%	if property.default.from_api -%>
 	Computed: true,
 	Optional: true,
 <% elsif property.required -%>
@@ -97,8 +96,7 @@
 <% if property.sensitive -%>
     Sensitive: true,
 <% end -%>
-<%# TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/167) Remove safe-access -%>
-<% unless property.default&.value.nil? -%>
+<% unless property.default.value.nil? -%>
     Default: <%= go_literal(property.default.value) -%>,
 <% end -%>
 },


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->

Fixes #167.

Populating nonoverridden properties ensures that the validate method is called (and the default values are set) for all properties and that the provider specific properties are added. This simplify the logic in the templates because you can assume the fields have "sane" default values (as long as the validate method sets sane default values).

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
