### PR TITLE
Skip ResourceRef check if the property is excluded

### DIFF
--- a/api/type.rb
+++ b/api/type.rb
@@ -286,7 +286,7 @@ module Api
         @name = @resource if @name.nil?
         @description = "A reference to #{@resource} resource"
 
-        return if @__resource.nil? || @__resource.exclude
+        return if @__resource.nil? || @__resource.exclude || @exclude
 
         check_property :resource, ::String
         check_property :imports, ::String


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->

If a ResourceRef property is excluded, we should not check if it points to an existing resource.

This allows adding a new resource and ResourceRef pointing to that new resource for only one of the provider.

My use case is I am adding `SslPolicy` and a `sslPolicy` ResourceRef field to `TargetHttpsProxy`. I want to exclude both of them from all the providers except Terraform (I will create an issue so each provider owner can add them whenever they are ready to). However, the ResourceRef fails in that case because the SslPolicy doesn't exist (excluded). We want to allow that.

The checks are still in place for Terraform because the `sslPolicy` is not excluded for Terraform. The check doesn't fail because the `SslPolicy` resource is not excluded neither for Terraform

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
