### PR TITLE
Make sure excluded properties are properly handled in puppet

### DIFF
--- a/api/resource.rb
+++ b/api/resource.rb
@@ -47,10 +47,10 @@ module Api
     include Properties
 
     # Parameters can be overridden via Provider::PropertyOverride
-    attr_reader :parameters
+    # A custom getter is used for :parameters instead of `attr_reader`
 
     # Properties can be overridden via Provider::PropertyOverride
-    attr_reader :properties
+    # A custom getter is used for :properties instead of `attr_reader`
 
     attr_reader :__product
 
@@ -249,14 +249,22 @@ module Api
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
 
+    def properties
+      (@properties || []).reject(&:exclude)
+    end
+
+    def parameters
+      (@parameters || []).reject(&:exclude)
+    end
+
     # Returns all properties and parameters including the ones that are
     # excluded. This is used for PropertyOverride validation
     def all_properties
-      ((properties || []) + (parameters || []))
+      ((@properties || []) + (@parameters || []))
     end
 
     def all_user_properties
-      all_properties.reject(&:exclude)
+      properties + parameters
     end
 
     def required_properties


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->

Puppet calls `resource#properties` and `resource#parameters` directly.

Terraform calls resource#all_user_properties which filters out excluded properties.

This change updates the getter for properties and parameters in resource to filter out the excluded properties.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
