### PR TITLE
Fix indentation in terraform property documentation

### DIFF
--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -4,7 +4,7 @@
 <% elsif !property.output -%>
   (Optional)
 <% end -%>
-  <%= property.description.strip -%>
+<%= indent(property.description.strip, 2) -%>
 <% if property.is_a?(Api::Type::NestedObject) || (property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::NestedObject)) -%>
   Structure is documented below.
 <% end -%>


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->

This is essential if there is a blank line in the description body. With a blank line, it exits the list indentation in markdown unless you are still indented properly.

```
Renders ok
* foo
bar

---

Does not renders ok
* foo

bar

----

With this fix, it renders ok:

* foo
  
   bar


```

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Fix indentation in property documentation
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
