### PR TITLE
Use the new default value feature in api.yaml in terraform

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -91,23 +91,17 @@ overrides: !ruby/object:Provider::ResourceOverrides
       id: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
       checkIntervalSec: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 5
+        default_value: 5
       healthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 2
+        default_value: 2
       port: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 80
+        default_value: 80
       requestPath: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: "/"
+        default_value: "/"
       timeoutSec: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 5
+        default_value: 5
       unhealthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 2
+        default_value: 2
   HttpsHealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
     description: |
       {{description}}
@@ -131,23 +125,17 @@ overrides: !ruby/object:Provider::ResourceOverrides
       id: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
       checkIntervalSec: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 5
+        default_value: 5
       healthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 2
+        default_value: 2
       port: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 443
+        default_value: 443
       requestPath: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: "/"
+        default_value: "/"
       timeoutSec: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 5
+        default_value: 5
       unhealthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: 2
+        default_value: 2
   HealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   Image: !ruby/object:Provider::Terraform::ResourceOverride
@@ -248,8 +236,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
       enabledFeatures: !ruby/object:Provider::Terraform::PropertyOverride
         is_set: true
       profile: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: :COMPATIBLE
+        default_value: :COMPATIBLE
         description: |
           {{description}}
           See the [official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies#profilefeaturesupport)
@@ -257,8 +244,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
           `CUSTOM` is used, the `custom_features` attribute **must be set**.
           Default is `COMPATIBLE`.
       minTlsVersion: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: :TLS_1_0
+        default_value: :TLS_1_0
         description : '{{description}} Default is `TLS_1_0`.'
       warnings: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
@@ -411,8 +397,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
       region: !ruby/object:Provider::Terraform::PropertyOverride
         required: false # the provider-default value will be used if not specified
       sessionAffinity: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: :NONE
+        default_value: :NONE
       # TODO: Custom code needed for updating `instances` and `healthCheck`.
       #       Update methods are (add|remove)Instance, (add/remove)HealthCheck
   TargetSslProxy: !ruby/object:Provider::Terraform::ResourceOverride
@@ -449,8 +434,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
       id: !ruby/object:Provider::Terraform::PropertyOverride
         name: proxyId
       proxyHeader: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: :NONE
+        default_value: :NONE
       service: !ruby/object:Provider::Terraform::PropertyOverride
         name: backendService
   TargetTcpProxy: !ruby/object:Provider::Terraform::ResourceOverride
@@ -486,8 +470,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
       service: !ruby/object:Provider::Terraform::PropertyOverride
         name: backendService
       proxyHeader: !ruby/object:Provider::Terraform::PropertyOverride
-        default: !ruby/object:Provider::Terraform::Default
-          value: :NONE
+        default_value: :NONE
   TargetVpnGateway: !ruby/object:Provider::Terraform::ResourceOverride
     name: 'VpnGateway'
     exclude: false
@@ -564,8 +547,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
         exclude: true
       region: !ruby/object:Provider::Terraform::PropertyOverride
         required: false # the provider-default value will be used if not specified
-        default: !ruby/object:Provider::Terraform::Default
-          from_api: true
+        default_from_api: true
         custom_flatten: 'templates/terraform/custom_flatten/region_name_only.erb'
       forwardingRules: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -22,7 +22,6 @@ module Provider
     module OverrideFields
       attr_reader :diff_suppress_func # Adds a DiffSuppressFunc to the schema
       attr_reader :state_func # Adds a StateFunc to the schema
-      attr_reader :default
       attr_reader :sensitive # Adds `Sensitive: true` to the schema
       attr_reader :validation # Adds a ValidateFunc to the schema
 
@@ -31,6 +30,11 @@ module Provider
       # If not specified, schema.HashString (when elements are string) or
       # schema.HashSchema are used.
       attr_reader :set_hash_func
+
+      # if true, then we get the default value from the Google API if no value
+      # is set in the terraform configuration for this field.
+      # It translates to setting the field to Computed & Optional in the schema.
+      attr_reader :default_from_api
 
       # ===========
       # Custom code
@@ -79,57 +83,6 @@ module Provider
       end
     end
 
-    # Default value for the property if any.
-    class Default < Api::Object
-      # the attributes below are mutually exclusive.
-
-      # if specified, then this will be set as the default value in the schema
-      attr_reader :value
-      # if true, then we get the default value from the Google API if no value
-      # is set in the terraform configuration for this field.
-      # It translates to setting the field to Computed & Optional in the schema.
-      attr_reader :from_api
-
-      def validate
-        super
-
-        # Ensure boolean values are set to false if nil
-        @from_api ||= false
-
-        check_property :from_api, :boolean
-
-        raise "'value' and 'from_api' cannot be both set for 'default'"  \
-          if from_api && !value.nil?
-
-        check_optional_property :update_statement, String
-        check_optional_property :custom_flatten, String
-        check_optional_property :custom_expand, String
-      end
-
-      def apply(api_property)
-        # This can't be done in validate because we don't have access to the
-        # api.yaml property yet.
-        check_default_value_property api_property
-      end
-
-      def check_default_value_property(api_property)
-        return if @default_value.nil?
-
-        if api_property.is_a?(Api::Type::String)
-          clazz = String
-        elsif api_property.is_a?(Api::Type::Integer)
-          clazz = Integer
-        elsif api_property.is_a?(Api::Type::Enum)
-          clazz = Symbol
-        else
-          raise "Update 'check_default_value_property' method to support " \
-                "default value for type #{api_property.class}"
-        end
-
-        check_optional_property :value, clazz
-      end
-    end
-
     # Terraform-specific overrides to api.yaml.
     class PropertyOverride < Provider::PropertyOverride
       include OverrideFields
@@ -140,17 +93,23 @@ module Provider
         # Ensures boolean values are set to false if nil
         @sensitive ||= false
         @is_set ||= false
-
-        @default ||= Provider::Terraform::Default.new
+        @default_from_api ||= false
 
         check_property :sensitive, :boolean
         check_property :is_set, :boolean
-        check_property :default, Provider::Terraform::Default
+        check_property :default_from_api, :boolean
 
         check_optional_property :diff_suppress_func, String
         check_optional_property :state_func, String
         check_optional_property :validation, Provider::Terraform::Validation
         check_optional_property :set_hash_func, String
+
+        check_optional_property :update_statement, String
+        check_optional_property :custom_flatten, String
+        check_optional_property :custom_expand, String
+
+        raise "'default_value' and 'default_from_api' cannot be both set for 'default'"  \
+          if default_from_api && !default_value.nil?
       end
 
       def apply(api_property)
@@ -166,8 +125,6 @@ module Provider
                   "'#{api_property.name}'"
           end
         end
-
-        @default.apply(api_property)
 
         super
       end

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -87,6 +87,7 @@ module Provider
     class PropertyOverride < Provider::PropertyOverride
       include OverrideFields
 
+      # rubocop:disable Metrics/MethodLength
       def validate
         super
 
@@ -108,9 +109,10 @@ module Provider
         check_optional_property :custom_flatten, String
         check_optional_property :custom_expand, String
 
-        raise "'default_value' and 'default_from_api' cannot be both set for 'default'"  \
+        raise "'default_value' and 'default_from_api' cannot be both set"  \
           if default_from_api && !default_value.nil?
       end
+      # rubocop:enable Metrics/MethodLength
 
       def apply(api_property)
         unless description.nil?

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -19,7 +19,7 @@
   <% else -%>
   Type: <%= tf_types[property.class] %>,
   <% end -%>
-<%	if property.default.from_api -%>
+<%	if property.default_from_api -%>
 	Computed: true,
 	Optional: true,
 <% elsif property.required -%>
@@ -109,8 +109,8 @@
 <% if property.sensitive -%>
     Sensitive: true,
 <% end -%>
-<% unless property.default.value.nil? -%>
-    Default: <%= go_literal(property.default.value) -%>,
+<% unless property.default_value.nil? -%>
+    Default: <%= go_literal(property.default_value) -%>,
 <% end -%>
 },
 <% else -%>


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->

Terraform had its own concept of default value. @rambleraptor added this feature to api.yaml yesterday #148. This PR updates Terraform to use the api.yaml default_value feature. As always, you can override it in a provider.

For now, I blindly updated our terraform.yaml file to simply use the override feature. We may, in a separate PR, move some of these values up to api.yaml 

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
