### PR TITLE
Remove Terraform-specific hack.

### DIFF
--- a/products/resourcemanager/terraform.yaml
+++ b/products/resourcemanager/terraform.yaml
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Provider::Terraform::Config
+name: ResourceManager
 overrides: !ruby/object:Provider::ResourceOverrides
   Project: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true

--- a/provider/config.rb
+++ b/provider/config.rb
@@ -36,7 +36,7 @@ module Provider
     # product.prefix, which is in the format 'g<nameofproduct>', e.g.
     # gcompute or gresourcemanager.  This is munged in many places.
     # Some examples:
-    #   - prefix[1:-1] ('compute' / 'resourcemanager') for the 
+    #   - prefix[1:-1] ('compute' / 'resourcemanager') for the
     #     directory to fetch chef / puppet examples.
     #   - camelCase(prefix[1:-1]) for resource namespaces.
     #   - TitleCase(prefix[1:-1]) for resource names in terraform.

--- a/provider/config.rb
+++ b/provider/config.rb
@@ -32,6 +32,19 @@ module Provider
     attr_reader :style
     attr_reader :changelog
     attr_reader :functions
+    # Product names are complicated in MagicModules.  They are given by
+    # product.prefix, which is in the format 'g<nameofproduct>', e.g.
+    # gcompute or gresourcemanager.  This is munged in many places.
+    # Some examples:
+    #   - prefix[1:-1] ('compute' / 'resourcemanager') for the 
+    #     directory to fetch chef / puppet examples.
+    #   - camelCase(prefix[1:-1]) for resource namespaces.
+    #   - TitleCase(prefix[1:-1]) for resource names in terraform.
+    #   - prefix[1:-1] again, for working with libraries directly.
+    # This override does not change any of those inner workings, but
+    # instead is passed directly to the template as `product_ns` if
+    # set.  Otherwise, the normal logic applies.
+    attr_reader :name
 
     # A custom client side function provided by the module.
     class Function < Api::Object::Named

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -298,8 +298,12 @@ module Provider
     end
 
     def generate_resource_file(data)
-      product_ns = @config.name.nil? ? Google::StringUtils.camelize(
-        data[:object].__product.prefix[1..-1], :upper) : @config.name
+      product_ns = if @config.name.nil?
+                     Google::StringUtils.camelize(data[:object].__product
+                       .prefix[1..-1], :upper)
+                   else
+                     @config.name
+                   end
       generate_file(data.clone.merge(
         # Override with provider specific template for this object, if needed
         template: Google::HashUtils.navigate(data[:config], ['template',

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -298,14 +298,14 @@ module Provider
     end
 
     def generate_resource_file(data)
+      product_ns = @config.name.nil? ? Google::StringUtils.camelize(
+        data[:object].__product.prefix[1..-1], :upper) : @config.name
       generate_file(data.clone.merge(
         # Override with provider specific template for this object, if needed
         template: Google::HashUtils.navigate(data[:config], ['template',
                                                              data[:type]],
                                              data[:default_template]),
-        product_ns:
-          Google::StringUtils.camelize(data[:object].__product.prefix[1..-1],
-                                       :upper)
+        product_ns: product_ns
       ))
     end
 

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -19,13 +19,6 @@ package google
 <%= lines(compile(object.custom_code.constants)) if object.custom_code.constants %>
 
 <%
-	# ResourceManager APIs need to be imported from api/cloudresourcemanager, need to
-	# be namespaced as ResourceManager, and need to be upstream as gresourcemanager,
-  # which leads to a product_ns of 'Resourcemanager'.
-  # TODO: fix this hack.
-	if product_ns == 'Resourcemanager'
-		product_ns = 'ResourceManager'
-	end
 	resource_name = product_ns + object.name
 	properties = object.all_user_properties
 	settable_properties = properties.reject(&:output)


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Removes a terraform-specific hack to add a slightly-less-hacky provider-agnostic way of solving the same problem.

More specifically, adds `name` as a field in the generic Provider::Config, and uses that instead of the normal `product_ns` if present.  I tested it with Chef and with Terraform, works fine with both.

I tried to explain how limited this solution is in a comment - I don't think it's very clear right now and would appreciate wording suggestions.

I tested this with chef and terraform - there are no changes to the terraform repo as a result of this change, and Chef seemed to work fine with no name override.

This fixes #195.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
No changes expected.
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
