### PR TITLE
Apply patches

### DIFF
--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -167,13 +167,18 @@ jobs:
 
     - name: mm-generate
       plan:
-          - aggregate:
-              - get: magic-modules
-                resource: magic-modules-new-prs
-                version: every
-                trigger: true
-                params:
-                    fetch_merge: true
+          - get: magic-modules
+            resource: magic-modules-new-prs
+            version: every
+            trigger: true
+            params:
+                fetch_merge: true
+            # consumes: magic-modules (because that's where the code is)
+            # products: patches
+          - task: get-merged-patches
+            file: magic-modules/.ci/magic-modules/get-merged-patches.yml
+            params:
+              GH_TOKEN: ((github-account.password))
             # consumes: magic-modules (detached HEAD)
             # produces: magic-modules-branched (new branch, with submodule)
           - task: branch-magic-modules

--- a/.ci/magic-modules/download_patches.py
+++ b/.ci/magic-modules/download_patches.py
@@ -18,6 +18,6 @@ if __name__ == '__main__':
       pr = repo.get_pull(int(pull[1]))
       print 'Checking %s to see if it should be downloaded.' % (pr,)
       if pr.is_merged():
-        download_location = os.path.join(pull[0], pull[1] + '.patch')
+        download_location = os.path.join(patches, pull[0], pull[1] + '.patch')
         os.makedirs(os.path.dirname(download_location))
         urllib.urlretrieve(pr.patch_url, download_location)

--- a/.ci/magic-modules/download_patches.py
+++ b/.ci/magic-modules/download_patches.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+import get_downstream_prs
+import itertools
+import re
+import operator
+import os
+
+from github import Github
+
+if __name__ == '__main__':
+  g = Github(os.environ.get('GH_TOKEN'))
+  open_pulls = g.get_repo('GoogleCloudPlatform/magic-modules').get_pulls(state='open')
+  depends = [item for sublist in [get_downstream_prs.get_github_dependencies(g, open_pull.number) for open_pull in open_pulls] for item in sublist]
+  parsed_dependencies = [re.match(r'https://github.com/([\w-]+/[\w-]+)/pull/(\d+)', d).groups() for d in depends]
+  for r, pulls in itertools.groupby(parsed_dependencies, key=operator.itemgetter(0)):
+    repo = g.get_repo(r)
+    for pull in pulls:
+      pr = repo.get_pull(int(pull[1]))
+      print 'Checking %s to see if it should be downloaded.' % (pr,)
+      if pr.is_merged():
+        download_location = os.path.join(pull[0], pull[1] + '.patch')
+        os.makedirs(os.path.dirname(download_location))
+        urllib.urlretrieve(pr.patch_url, download_location)

--- a/.ci/magic-modules/download_patches.py
+++ b/.ci/magic-modules/download_patches.py
@@ -4,6 +4,7 @@ import itertools
 import re
 import operator
 import os
+import urllib
 
 from github import Github
 
@@ -18,6 +19,7 @@ if __name__ == '__main__':
       pr = repo.get_pull(int(pull[1]))
       print 'Checking %s to see if it should be downloaded.' % (pr,)
       if pr.is_merged():
-        download_location = os.path.join(patches, pull[0], pull[1] + '.patch')
-        os.makedirs(os.path.dirname(download_location))
+        download_location = os.path.join('./patches', pull[0], pull[1] + '.patch')
+        if not os.path.exists(os.path.dirname(download_location)):
+          os.makedirs(os.path.dirname(download_location))
         urllib.urlretrieve(pr.patch_url, download_location)

--- a/.ci/magic-modules/generate-ansible.sh
+++ b/.ci/magic-modules/generate-ansible.sh
@@ -33,7 +33,7 @@ git add -A
 git commit -m "$ANSIBLE_COMMIT_MSG" --author="$LAST_COMMIT_AUTHOR" || true  # don't crash if no changes
 git checkout -B "$(cat ../../branchname)"
 
-apply_patches patches/terraform-providers/terraform-provider-google "$ANSIBLE_COMMIT_MSG" "$LAST_COMMIT_AUTHOR"
+apply_patches patches/terraform-providers/terraform-provider-google "$ANSIBLE_COMMIT_MSG" "$LAST_COMMIT_AUTHOR" "devel"
 popd
 popd
 

--- a/.ci/magic-modules/generate-ansible.sh
+++ b/.ci/magic-modules/generate-ansible.sh
@@ -5,6 +5,7 @@
 
 set -x
 set -e
+source "$(dirname "$0")/helpers.sh"
 
 pushd magic-modules-branched
 LAST_COMMIT_AUTHOR="$(git log --pretty="%an <%ae>" -n1 HEAD)"
@@ -32,7 +33,7 @@ git add -A
 git commit -m "$ANSIBLE_COMMIT_MSG" --author="$LAST_COMMIT_AUTHOR" || true  # don't crash if no changes
 git checkout -B "$(cat ../../branchname)"
 
-apply_patches patches/terraform-providers/terraform-provider-google "$TERRAFORM_COMMIT_MSG" "$LAST_COMMIT_AUTHOR"
+apply_patches patches/terraform-providers/terraform-provider-google "$ANSIBLE_COMMIT_MSG" "$LAST_COMMIT_AUTHOR"
 popd
 popd
 

--- a/.ci/magic-modules/generate-ansible.sh
+++ b/.ci/magic-modules/generate-ansible.sh
@@ -31,8 +31,9 @@ git add -A
 # Set the "author" to the commit's real author.
 git commit -m "$ANSIBLE_COMMIT_MSG" --author="$LAST_COMMIT_AUTHOR" || true  # don't crash if no changes
 git checkout -B "$(cat ../../branchname)"
-popd
 
+apply_patches patches/terraform-providers/terraform-provider-google "$TERRAFORM_COMMIT_MSG" "$LAST_COMMIT_AUTHOR"
+popd
 popd
 
 git clone magic-modules-branched/build/ansible ./ansible-generated

--- a/.ci/magic-modules/generate-ansible.sh
+++ b/.ci/magic-modules/generate-ansible.sh
@@ -6,7 +6,7 @@
 set -x
 set -e
 source "$(dirname "$0")/helpers.sh"
-
+PATCH_DIR="$(pwd)/patches"
 pushd magic-modules-branched
 LAST_COMMIT_AUTHOR="$(git log --pretty="%an <%ae>" -n1 HEAD)"
 bundle install
@@ -33,7 +33,7 @@ git add -A
 git commit -m "$ANSIBLE_COMMIT_MSG" --author="$LAST_COMMIT_AUTHOR" || true  # don't crash if no changes
 git checkout -B "$(cat ../../branchname)"
 
-apply_patches patches/terraform-providers/terraform-provider-google "$ANSIBLE_COMMIT_MSG" "$LAST_COMMIT_AUTHOR" "devel"
+apply_patches "$PATCH_DIR/modular-magician/ansible" "$ANSIBLE_COMMIT_MSG" "$LAST_COMMIT_AUTHOR" "devel"
 popd
 popd
 

--- a/.ci/magic-modules/generate-ansible.yml
+++ b/.ci/magic-modules/generate-ansible.yml
@@ -1,5 +1,5 @@
 ---
-# This file takes two inputs: magic-modules-branched in detached-HEAD state, and the CI repo.
+# This file takes two inputs: magic-modules-branched in detached-HEAD state, and the patches.
 # It spits out "ansible-generated", a ansible repo on a new branch (named after the
 # HEAD commit on the PR), with the new generated code in it.
 platform: linux
@@ -12,6 +12,7 @@ image_resource:
 
 inputs:
     - name: magic-modules-branched
+    - name: patches
 
 outputs:
     - name: ansible-generated

--- a/.ci/magic-modules/generate-puppet-chef.sh
+++ b/.ci/magic-modules/generate-puppet-chef.sh
@@ -36,7 +36,7 @@ for PRD in "${PRODUCT_ARRAY[@]}"; do
       # Set the "author" to the commit's real author.
       git commit -m "$COMMIT_MSG" --author="$LAST_COMMIT_AUTHOR" || true  # don't crash if no changes
       git checkout -B "$(cat ../../../branchname)"
-      apply_patches "patches/GoogleCloudPlatform/$PROVIDER-google-$PRD" "$COMMIT_MSG" "$LAST_COMMIT_AUTHOR"
+      apply_patches "patches/GoogleCloudPlatform/$PROVIDER-google-$PRD" "$COMMIT_MSG" "$LAST_COMMIT_AUTHOR" "master"
     popd
   popd
   git clone "magic-modules-branched/build/$PROVIDER/$PRD" "$PROVIDER-generated/$PRD"

--- a/.ci/magic-modules/generate-puppet-chef.sh
+++ b/.ci/magic-modules/generate-puppet-chef.sh
@@ -7,6 +7,7 @@
 set -x
 set -e
 source "$(dirname "$0")/helpers.sh"
+PATCH_DIR="$(pwd)/patches"
 
 IFS="," read -ra PRODUCT_ARRAY <<< "$PRODUCTS"
 for PRD in "${PRODUCT_ARRAY[@]}"; do
@@ -36,7 +37,7 @@ for PRD in "${PRODUCT_ARRAY[@]}"; do
       # Set the "author" to the commit's real author.
       git commit -m "$COMMIT_MSG" --author="$LAST_COMMIT_AUTHOR" || true  # don't crash if no changes
       git checkout -B "$(cat ../../../branchname)"
-      apply_patches "patches/GoogleCloudPlatform/$PROVIDER-google-$PRD" "$COMMIT_MSG" "$LAST_COMMIT_AUTHOR" "master"
+      apply_patches "$PATCH_DIR/GoogleCloudPlatform/$PROVIDER-google-$PRD" "$COMMIT_MSG" "$LAST_COMMIT_AUTHOR" "master"
     popd
   popd
   git clone "magic-modules-branched/build/$PROVIDER/$PRD" "$PROVIDER-generated/$PRD"

--- a/.ci/magic-modules/generate-puppet-chef.sh
+++ b/.ci/magic-modules/generate-puppet-chef.sh
@@ -6,6 +6,7 @@
 
 set -x
 set -e
+source "$(dirname "$0")/helpers.sh"
 
 IFS="," read -ra PRODUCT_ARRAY <<< "$PRODUCTS"
 for PRD in "${PRODUCT_ARRAY[@]}"; do
@@ -35,6 +36,7 @@ for PRD in "${PRODUCT_ARRAY[@]}"; do
       # Set the "author" to the commit's real author.
       git commit -m "$COMMIT_MSG" --author="$LAST_COMMIT_AUTHOR" || true  # don't crash if no changes
       git checkout -B "$(cat ../../../branchname)"
+      apply_patches "patch/GoogleCloudPlatform/puppet-google-$PRD" "$PUPPET_COMMIT_MSG" "$LAST_COMMIT_AUTHOR"
     popd
   popd
   git clone "magic-modules-branched/build/$PROVIDER/$PRD" "$PROVIDER-generated/$PRD"

--- a/.ci/magic-modules/generate-puppet-chef.sh
+++ b/.ci/magic-modules/generate-puppet-chef.sh
@@ -36,7 +36,7 @@ for PRD in "${PRODUCT_ARRAY[@]}"; do
       # Set the "author" to the commit's real author.
       git commit -m "$COMMIT_MSG" --author="$LAST_COMMIT_AUTHOR" || true  # don't crash if no changes
       git checkout -B "$(cat ../../../branchname)"
-      apply_patches "patch/GoogleCloudPlatform/puppet-google-$PRD" "$PUPPET_COMMIT_MSG" "$LAST_COMMIT_AUTHOR"
+      apply_patches "patches/GoogleCloudPlatform/$PROVIDER-google-$PRD" "$PUPPET_COMMIT_MSG" "$LAST_COMMIT_AUTHOR"
     popd
   popd
   git clone "magic-modules-branched/build/$PROVIDER/$PRD" "$PROVIDER-generated/$PRD"

--- a/.ci/magic-modules/generate-puppet-chef.sh
+++ b/.ci/magic-modules/generate-puppet-chef.sh
@@ -36,7 +36,7 @@ for PRD in "${PRODUCT_ARRAY[@]}"; do
       # Set the "author" to the commit's real author.
       git commit -m "$COMMIT_MSG" --author="$LAST_COMMIT_AUTHOR" || true  # don't crash if no changes
       git checkout -B "$(cat ../../../branchname)"
-      apply_patches "patches/GoogleCloudPlatform/$PROVIDER-google-$PRD" "$PUPPET_COMMIT_MSG" "$LAST_COMMIT_AUTHOR"
+      apply_patches "patches/GoogleCloudPlatform/$PROVIDER-google-$PRD" "$COMMIT_MSG" "$LAST_COMMIT_AUTHOR"
     popd
   popd
   git clone "magic-modules-branched/build/$PROVIDER/$PRD" "$PROVIDER-generated/$PRD"

--- a/.ci/magic-modules/generate-puppet.yml
+++ b/.ci/magic-modules/generate-puppet.yml
@@ -1,5 +1,5 @@
 ---
-# This file takes two inputs: magic-modules-branched in detached-HEAD state, and the CI repo.
+# This file takes two inputs: magic-modules-branched in detached-HEAD state, and the patches.
 # It spits out "puppet-generated", a directory containing puppet repos on a new branch
 # (named after the HEAD commit on the PR), with the new generated code in it.
 platform: linux
@@ -12,6 +12,7 @@ image_resource:
 
 inputs:
     - name: magic-modules-branched
+    - name: patches
 
 outputs:
     - name: puppet-generated

--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -6,6 +6,7 @@
 set -x
 set -e
 source "$(dirname "$0")/helpers.sh"
+PATCH_DIR="$(pwd)/patches"
 
 # Create $GOPATH structure - in order to successfully run Terraform codegen, we need to run
 # it with a correctly-set-up $GOPATH.  It calls out to `goimports`, which means that
@@ -49,7 +50,7 @@ git add -A
 git commit -m "$TERRAFORM_COMMIT_MSG" --author="$LAST_COMMIT_AUTHOR" || true  # don't crash if no changes
 git checkout -B "$(cat ../../branchname)"
 
-apply_patches patches/terraform-providers/terraform-provider-google "$TERRAFORM_COMMIT_MSG" "$LAST_COMMIT_AUTHOR" "master"
+apply_patches "$PATCH_DIR/terraform-providers/terraform-provider-google" "$TERRAFORM_COMMIT_MSG" "$LAST_COMMIT_AUTHOR" "master"
 
 popd
 popd

--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -49,7 +49,7 @@ git add -A
 git commit -m "$TERRAFORM_COMMIT_MSG" --author="$LAST_COMMIT_AUTHOR" || true  # don't crash if no changes
 git checkout -B "$(cat ../../branchname)"
 
-apply_patches patches/terraform-providers/terraform-provider-google "$TERRAFORM_COMMIT_MSG" "$LAST_COMMIT_AUTHOR"
+apply_patches patches/terraform-providers/terraform-provider-google "$TERRAFORM_COMMIT_MSG" "$LAST_COMMIT_AUTHOR" "master"
 
 popd
 popd

--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -5,6 +5,7 @@
 
 set -x
 set -e
+source "$(dirname "$0")/helpers.sh"
 
 # Create $GOPATH structure - in order to successfully run Terraform codegen, we need to run
 # it with a correctly-set-up $GOPATH.  It calls out to `goimports`, which means that
@@ -47,8 +48,10 @@ git add -A
 # Set the "author" to the commit's real author.
 git commit -m "$TERRAFORM_COMMIT_MSG" --author="$LAST_COMMIT_AUTHOR" || true  # don't crash if no changes
 git checkout -B "$(cat ../../branchname)"
-popd
 
+apply_patches patch/terraform-providers/terraform-provider-google "$TERRAFORM_COMMIT_MSG" "$LAST_COMMIT_AUTHOR"
+
+popd
 popd
 
 git clone magic-modules-branched/build/terraform ./terraform-generated

--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -49,7 +49,7 @@ git add -A
 git commit -m "$TERRAFORM_COMMIT_MSG" --author="$LAST_COMMIT_AUTHOR" || true  # don't crash if no changes
 git checkout -B "$(cat ../../branchname)"
 
-apply_patches patch/terraform-providers/terraform-provider-google "$TERRAFORM_COMMIT_MSG" "$LAST_COMMIT_AUTHOR"
+apply_patches patches/terraform-providers/terraform-provider-google "$TERRAFORM_COMMIT_MSG" "$LAST_COMMIT_AUTHOR"
 
 popd
 popd

--- a/.ci/magic-modules/generate-terraform.yml
+++ b/.ci/magic-modules/generate-terraform.yml
@@ -1,5 +1,5 @@
 ---
-# This file takes two inputs: magic-modules-branched in detached-HEAD state, and the CI repo.
+# This file takes two inputs: magic-modules-branched in detached-HEAD state, and the list of patches.
 # It spits out "terraform-generated", a terraform repo on a new branch (named after the
 # HEAD commit on the PR), with the new generated code in it.
 platform: linux
@@ -12,6 +12,7 @@ image_resource:
 
 inputs:
     - name: magic-modules-branched
+    - name: patches
 
 outputs:
     - name: terraform-generated

--- a/.ci/magic-modules/get-merged-patches.yml
+++ b/.ci/magic-modules/get-merged-patches.yml
@@ -1,0 +1,28 @@
+---
+# This file takes in only magic-modules, to get the code that
+# it runs.  It does need the github API token.
+# It produces "patches", a set of directories that contain
+# `git format-patch` style patches for any PR which was generated
+# by MagicModules, and which has already been merged, despite
+# the upstream MagicModules PR not yet being merged.
+platform: linux
+
+image_resource:
+    type: docker-image
+    source:
+        # This task requires a container with python and the pip
+        # package 'pygithub'.
+        repository: nmckinley/python
+        tag: 'v0.0.2'
+
+inputs:
+    - name: magic-modules
+
+outputs:
+    - name: patches
+
+params:
+  GH_TOKEN: ""
+
+run:
+    path: magic-modules/.ci/magic-modules/download_patches.py

--- a/.ci/magic-modules/get_downstream_prs.py
+++ b/.ci/magic-modules/get_downstream_prs.py
@@ -9,14 +9,15 @@ def append_github_dependencies_to_list(lst, comment_body):
   list_of_urls = re.findall(r'^depends: (https://github.com/.*)', comment_body, re.MULTILINE)
   return lst + list_of_urls
 
-if __name__ == '__main__':
-  g = Github(os.environ.get('GH_TOKEN'))
-  assert len(sys.argv) == 2
-  pr_number = int(sys.argv[1])
+def get_github_dependencies(g, pr_number):
   pull_request = g.get_repo('GoogleCloudPlatform/magic-modules').get_pull(pr_number)
   comment_bodies = [c.body for c in pull_request.get_issue_comments()]
   # "reduce" is "foldl" - apply this function to the result of the previous function and
   # the next value in the iterable.
-  all_dependencies = functools.reduce(append_github_dependencies_to_list, comment_bodies, [])
-  for downstream_pr in all_dependencies:
+  return functools.reduce(append_github_dependencies_to_list, comment_bodies, [])
+
+if __name__ == '__main__':
+  g = Github(os.environ.get('GH_TOKEN'))
+  assert len(sys.argv) == 2
+  for downstream_pr in get_github_dependencies(g, int(sys.argv[1])):
     print downstream_pr

--- a/.ci/magic-modules/helpers.sh
+++ b/.ci/magic-modules/helpers.sh
@@ -14,7 +14,7 @@ function apply_patches {
   # This looks a little silly, but here's what we're doing.
   # We get rid of all the commits since we diverged from 'master',
   # We keep all the changes (--soft).
-  git reset --soft "$(git merge-base HEAD master)"
+  git reset --soft "$(git merge-base HEAD "$4")"
   # Then we commit again.
   git commit -m "$2" --author="$3" || true  # don't crash if no changes
 }

--- a/.ci/magic-modules/helpers.sh
+++ b/.ci/magic-modules/helpers.sh
@@ -1,0 +1,20 @@
+# Arguments to 'apply_patches' are:
+# - name of patch directory
+# - commit message
+# - author
+function apply_patches {
+  # Apply necessary downstream patches.
+  shopt -s nullglob
+  for patch in "$1"/*; do
+    # This is going to apply the patch as at least 1 commit, possibly more.
+    git am --signoff "$patch"
+  done
+  shopt -u nullglob
+  # Now, collapse the patch commits into one.
+  # This looks a little silly, but here's what we're doing.
+  # We get rid of all the commits since we diverged from 'master',
+  # We keep all the changes (--soft).
+  git reset --soft "$(git merge-base HEAD master)"
+  # Then we commit again.
+  git commit -m "$2" --author="$3" || true  # don't crash if no changes
+}


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
This solves a weird problem that I think might start coming up more often.

* You create a MM PR (call it `MMPR1`), and it creates two PRs downstream, in Terraform and Puppet, call them `TFPR1` and `PPR1`.
* `TFPR1` is merged, but `PPR1` is not.
* Consequently, `MMPR1` _cannot_ be merged.
* You create `MMPR2`, which affects Terraform, and creates `TFPR2`.
* `MMPR2` does not include the commit of `MMPR1`, which is not merged.
* `TFPR2` reverts the changes of `TFPR1`, because the code used to generate it is not present in the version of MagicModules that `MMPR2` is based on.
* Worse, `MMPR3`, which makes no changes to the downstream code, will open `TFPR3`, reverting `TFPR1`.

This solves the problem in a way that I kind of like, but I want your opinion on - we fetch any PR which is merged downstream, as a diff which should be applied after our changes.  If that PR's patch applies cleanly, that's great.  If it doesn't, then we're in a state where we actually can't generate a correct PR, and generation _should_ fail (as it does, in this change) rather than produce a PR which will apply incorrectly.

NB: This has the maybe somewhat forward-looking benefit that it is agnostic to the source of the patches.  If someone decided they just _had_ to make a modification to a Terraform resource, but didn't want to bother with the MagicModules work to make that change, this could be modified to fetch that PR as well.  Might be handy to have.

Another note - The order of operations here is
* Generate normally & commit
* Apply patches
* Reset git state to before the first commit
* Commit again

This is because applying patches fails if your working tree isn't clean.  We need the patches to apply after the generation, because otherwise generation will blow those changes away again.  We want the whole thing (generation + patches) as a single commit because splitting it up won't provide any useful information.

What do you think?

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
CI change only
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
