### PR TITLE
Idea: Adding linting to ERB templates

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,74 @@
+---
+linters:
+  # Ensures that all <% tags have a closing tag.
+  SelfClosingTag:
+    enabled: true
+  # Ensures that all ending tags use the -%> notion.
+  RightTrim:
+    enabled: true
+    enforced_style: '-'
+  # Trailing whitespace in ERB templates
+  TrailingWhitespace:
+    enabled: true
+  # Ensure that
+  # ```
+  # <%
+  #  code
+  # -%>
+  # ```
+  # notion is followed
+  # Note: This will not check for proper code indentation.
+  ClosingErbTagIndent:
+    enabled: true
+  # Ensure there's a newline at the end of the file.
+  FinalNewline:
+    enabled: true
+  # Run Rubocop on code in tags
+  Rubocop:
+    enabled: true
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+      # erb-lint guidelines recommended turning these cops off.
+      # They don't apply to ERB tags.
+      Layout/InitialIndentation:
+        Enabled: false
+      Layout/TrailingBlankLines:
+        Enabled: false
+      Layout/TrailingWhitespace:
+        Enabled: false
+      Naming/FileName:
+        Enabled: false
+      Style/FrozenStringLiteralComment:
+        Enabled: false
+      Metrics/LineLength:
+        Enabled: false
+      Lint/UselessAssignment:
+        Enabled: false
+      Rails/OutputSafety:
+        Enabled: false
+  # ---------------------------------------
+  # Turning off unnecessary default linters
+  # ---------------------------------------
+  # Terraform uses tabs.
+  SpaceIndentation:
+    enabled: false
+  # Our formatting for nesting if/else statements involves having multiple
+  # spaces after <% tags, which this cop does not like.
+  SpaceAroundErbTag:
+    enabled: false
+  # We have double newlines all over the place because we're writing code,
+  # not HTML
+  ExtraNewline:
+    enabled: false
+  # We don't write any Javascript
+  AllowedScriptType:
+    enabled: false
+  NoJavascriptTagHelper:
+    enabled: false
+  # These cops seems to confuse lines in our template with Ruby code.
+  # Best to ignore.
+  ParserErrors:
+    enabled: false
+  SpaceInHtmlTag:
+    enabled: false

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -29,6 +29,19 @@ linters:
     rubocop_config:
       inherit_from:
         - .rubocop.yml
+      # We don't want `rubocop:disable` statements in erb templates.
+      Metrics/AbcSize:
+        Max: 100
+      Metrics/BlockLength:
+        Max: 100
+      Metrics/MethodLength:
+        Max: 100
+      # We use comments in `end` lines to help navigate templates.
+      Style/CommentedKeyword:
+        Enabled: false
+      # Rubocop confuses some generated code with poorly interpolated strings
+      Lint/InterpolationCheck:
+        Enabled: false
       # erb-lint guidelines recommended turning these cops off.
       # They don't apply to ERB tags.
       Layout/InitialIndentation:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -51,6 +51,7 @@ linters:
   # Turning off unnecessary default linters
   # ---------------------------------------
   # Terraform uses tabs.
+  # TODO: #218: Identify if Terraform should use tabs in the future.
   SpaceIndentation:
     enabled: false
   # Our formatting for nesting if/else statements involves having multiple

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -42,6 +42,10 @@ linters:
       # Rubocop confuses some generated code with poorly interpolated strings
       Lint/InterpolationCheck:
         Enabled: false
+      # Length of static objects makes it easier to determine
+      # why some constants are calculated
+      Performance/FixedSize:
+        Enabled: false
       # erb-lint guidelines recommended turning these cops off.
       # They don't apply to ERB tags.
       Layout/InitialIndentation:

--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,10 @@ gem 'binding_of_caller'
 gem 'rake'
 
 group :test do
+  gem 'erb_lint'
   gem 'mocha'
   gem 'parallel_tests'
   gem 'rspec'
   gem 'rubocop'
   gem 'simplecov'
-  gem 'erb_lint'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ group :test do
   gem 'rspec'
   gem 'rubocop'
   gem 'simplecov'
+  gem 'erb_lint'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,68 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    actionview (5.2.0)
+      activesupport (= 5.2.0)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    activesupport (5.2.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     ast (2.4.0)
+    better_html (1.0.10)
+      actionview (>= 4.0)
+      activesupport (>= 4.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      html_tokenizer (~> 0.0.6)
+      parser (>= 2.4)
+      smart_properties
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
+    builder (3.2.3)
+    colorize (0.8.1)
+    concurrent-ruby (1.0.5)
+    crass (1.0.4)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
     docile (1.1.5)
+    erb_lint (0.0.24)
+      activesupport
+      better_html (~> 1.0.7)
+      colorize
+      html_tokenizer
+      rubocop (~> 0.51)
+      smart_properties
+    erubi (1.7.1)
+    html_tokenizer (0.0.6)
+    i18n (1.0.1)
+      concurrent-ruby (~> 1.0)
     json (2.1.0)
+    loofah (2.2.2)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
     metaclass (0.0.4)
+    mini_portile2 (2.3.0)
+    minitest (5.11.3)
     mocha (1.3.0)
       metaclass (~> 0.0.1)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
     parallel (1.12.1)
     parallel_tests (2.21.3)
       parallel
     parser (2.4.0.2)
       ast (~> 2.3)
     powerpack (0.1.1)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     rainbow (3.0.0)
     rake (12.3.0)
     rspec (3.7.0)
@@ -45,6 +91,10 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    smart_properties (1.13.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     unicode-display_width (1.3.0)
 
 PLATFORMS
@@ -52,6 +102,7 @@ PLATFORMS
 
 DEPENDENCIES
   binding_of_caller
+  erb_lint
   mocha
   parallel_tests
   rake
@@ -60,4 +111,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/README.md
+++ b/README.md
@@ -164,6 +164,12 @@ Use `rspec` to test Magic Module changes:
 
     bundle exec rspec
 
+## Linting Magic Modules templates
+
+Use `erb-lint` to check Magic Modules templates:
+
+    bundle exec erblint **/*.erb
+
 
 ## Testing the generated code
 

--- a/products/_bundle/templates/ansible/lookup.erb
+++ b/products/_bundle/templates/ansible/lookup.erb
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2017 Google
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-<%= lines(autogen_notice :python) -%>
+<%= lines(autogen_notice(:python)) -%>
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
@@ -139,11 +139,11 @@ class Gcp<%= object.name -%>(object):
 <%
     default = get_code_multiline config, 'default'
     if default.nil?
-      if object.exports[0].is_a? String
-        default = object.exports[0]
-      else
-        default = Google::StringUtils.underscore(object.exports[0].name)
-      end
+      default = if object.exports[0].is_a? String
+                  object.exports[0]
+                else
+                  Google::StringUtils.underscore(object.exports[0].name)
+                end
     end
 -%>
         if 'return' in self.module.params:

--- a/products/_bundle/templates/chef/README.md.erb
+++ b/products/_bundle/templates/chef/README.md.erb
@@ -49,7 +49,7 @@ The `google/cloud` cookbook installs the following cookbooks automatically:
   lines(indent(
           product_details.map { |p| p[:name] }
                          .map { |p| "- [#{p}](##{p.downcase.tr(' ', '-')})" }, 2
-       ))
+  ))
 -%>
   - [Google Authentication](#google-authentication)
 

--- a/products/compute/helpers/api_gcompute_disk.erb
+++ b/products/compute/helpers/api_gcompute_disk.erb
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/compute/network/post'
 

--- a/products/compute/helpers/api_gcompute_instance.erb
+++ b/products/compute/helpers/api_gcompute_instance.erb
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/compute/network/post'
 

--- a/products/container/helpers/api_gcontainer_node_pool.erb
+++ b/products/container/helpers/api_gcontainer_node_pool.erb
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/container/network/post'
 

--- a/products/pubsub/helpers/api_gpubsub_topic.erb
+++ b/products/pubsub/helpers/api_gpubsub_topic.erb
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/pubsub/network/post'
 

--- a/products/spanner/helpers/instance_helpers.rb.erb
+++ b/products/spanner/helpers/instance_helpers.rb.erb
@@ -18,7 +18,7 @@ def resource_to_update
     "projects/#{resource[:project]}/instanceConfigs/#{resource[:config]}"
   {
     'instance' => instance,
-<% fields = object.properties.select { |p| !p.output }.map(&:name) -%>
+<% fields = object.properties.reject(&:output).map(&:name) -%>
     'fieldMask' => %w[<%= fields.join(' ') -%>].join(',')
   }.to_json
 end

--- a/products/sql/helpers/api_gsql_instance.erb
+++ b/products/sql/helpers/api_gsql_instance.erb
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/sql/network/post'
 

--- a/products/sql/helpers/api_gsql_user.erb
+++ b/products/sql/helpers/api_gsql_user.erb
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/sql/network/post'
 

--- a/products/storage/helpers/api_gstorage_object.erb
+++ b/products/storage/helpers/api_gstorage_object.erb
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/storage/network/post'
 

--- a/templates/ansible/async.erb
+++ b/templates/ansible/async.erb
@@ -28,29 +28,29 @@ def wait_for_operation(module, response):
 <%=
   obj_kind = quote_string(object.kind)
   lines(format(
-    [
-      [
-        "return fetch_wrapped_resource(module, #{obj_kind},",
-        ("'#{object.self_link_query.kind}'," if object.self_link_query.kind?),
-        "'#{object.self_link_query.items}')"
-      ].join(' '),
-      [
-        [
-         "return fetch_wrapped_resource(resource, #{obj_kind},",
-         ("'#{object.self_link_query.kind}'," if object.self_link_query.kind?)
-        ].join(' '),
-        indent([
-          "'#{object.self_link_query.items}')"
-        ], 23) # 23 = align with ( previous line
-      ],
-      [
-        "return fetch_wrapped_resource(resource, #{obj_kind},",
-        indent([
-          "'#{object.self_link_query.kind}',",
-          "'#{object.self_link_query.items}')"
-        ], 23) # 31 = align with ( previous line
-      ]
-    ], 4
+          [
+            [
+              "return fetch_wrapped_resource(module, #{obj_kind},",
+              ("'#{object.self_link_query.kind}'," if object.self_link_query.kind?),
+              "'#{object.self_link_query.items}')"
+            ].join(' '),
+            [
+              [
+                "return fetch_wrapped_resource(resource, #{obj_kind},",
+                ("'#{object.self_link_query.kind}'," if object.self_link_query.kind?)
+              ].join(' '),
+              indent([
+                       "'#{object.self_link_query.items}')"
+                     ], 23) # 23 = align with ( previous line
+            ],
+            [
+              "return fetch_wrapped_resource(resource, #{obj_kind},",
+              indent([
+                       "'#{object.self_link_query.kind}',",
+                       "'#{object.self_link_query.items}')"
+                     ], 23) # 31 = align with ( previous line
+            ]
+          ], 4
   ))
 -%>
 <% end # object.self_link_query.nil? -%>
@@ -67,7 +67,7 @@ def wait_for_completion(status, op_result, module):
     op_uri = async_op_url(module, {'op_id': op_id})
     while status != '<%= object.async.status.complete -%>':
         raise_if_errors(op_result, <%= err_path -%>, '<%= err_msg -%>')
-        time.sleep(<%= sprintf('%.1f', object.async.operation.wait_ms / 1000.0) %>)
+        time.sleep(<%= format('%.1f', object.async.operation.wait_ms / 1000.0) %>)
         if status not in [<%= allowed_states.join(', ') -%>]:
             module.fail_json(msg="Invalid result %s" % status)
 <% if object.kind? -%>

--- a/templates/ansible/example.erb
+++ b/templates/ansible/example.erb
@@ -1,5 +1,5 @@
 ---
-<%= lines(autogen_notice :yaml) -%>
+<%= lines(autogen_notice(:yaml)) -%>
 # Pre-test setup
 <% unless example.dependencies.nil? -%>
 <% example.dependencies.each do |depend| -%>

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -3,7 +3,7 @@
 #
 # Copyright (C) 2017 Google
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-<%= lines(autogen_notice :python) -%>
+<%= lines(autogen_notice(:python)) -%>
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
@@ -109,8 +109,7 @@ def main():
 <% if object.self_link_query.nil? -%>
 <%
   method = method_call('fetch_resource', ['module', 'self_link(module)',
-                                          ('kind' if object.kind?),
-                                         ])
+                                          ('kind' if object.kind?)])
 -%>
     fetch = <%= method %>
 <% else # object.self_link_query.nil? -%>
@@ -129,20 +128,20 @@ def main():
             if is_different(module, fetch):
 <%
   method = method_call('update', [
-                                   'module', 'self_link(module)',
-                                   ('kind' if object.kind?),
-                                   ('fetch' if object.save_api_results?)
-                                 ])
+                         'module', 'self_link(module)',
+                         ('kind' if object.kind?),
+                         ('fetch' if object.save_api_results?)
+                       ])
 -%>
 <%= lines(indent("fetch = #{method}", 16)) -%>
                 changed = True
         else:
 <%
   method = method_call('delete', [
-                                   'module', 'self_link(module)',
-                                   ('kind' if object.kind?),
-                                   ('fetch' if object.save_api_results?)
-                                 ])
+                         'module', 'self_link(module)',
+                         ('kind' if object.kind?),
+                         ('fetch' if object.save_api_results?)
+                       ])
 -%>
 <%= lines(indent(method, 12)) -%>
             fetch = {}
@@ -174,8 +173,7 @@ def main():
 <% prod_name = object.__product.prefix[1..-1] -%>
 <% unless object.virtual -%>
 <%# TODO: kind param not always needed.
-  # https://github.com/GoogleCloudPlatform/magic-modules/issues/45
--%>
+  # https://github.com/GoogleCloudPlatform/magic-modules/issues/45 -%>
 <%= method_decl('create', ['module', 'link', ('kind' if object.kind?)]) %>
 <% if object.create.nil? -%>
     auth = GcpSession(module, <%= quote_string(prod_name) -%>)
@@ -194,8 +192,7 @@ def main():
     ['module',
      method_call("auth#{create_verb}",
                  ['link', 'resource_to_request(module)']),
-     ('kind' if !object.async && object.kind?)
-   ]
+     ('kind' if !object.async && object.kind?)]
   )
 -%>
     return <%= method %>
@@ -216,11 +213,11 @@ def main():
   method = method_call(
     object.async ? 'wait_for_operation' : 'return_if_object',
     [
-     'module',
-     method_call("auth.#{update_verb}",
-                 ['link', 'resource_to_request(module)']),
-     ('kind' if !object.async && object.kind?)
-   ]
+      'module',
+      method_call("auth.#{update_verb}",
+                  ['link', 'resource_to_request(module)']),
+      ('kind' if !object.async && object.kind?)
+    ]
   )
 -%>
     return <%= method %>
@@ -242,9 +239,8 @@ def main():
   method = method_call(
     object.async ? 'wait_for_operation' : 'return_if_object',
     ['module',
-     method_call("auth.delete", ['link']),
-     ('kind' if !object.async && object.kind?)
-   ]
+     method_call('auth.delete', ['link']),
+     ('kind' if !object.async && object.kind?)]
   )
 -%>
     return <%= method %>

--- a/templates/async.erb
+++ b/templates/async.erb
@@ -29,33 +29,33 @@ def wait_for_operation(response, resource)
 <% if object.self_link_query.nil? -%>
 <%=
   lines(format(
-    [
-      [
-        'fetch_resource(',
-        indent([
-          'resource,',
-          'URI.parse(::Google::HashUtils.navigate(wait_for_completion(status,',
-          indent(['op_result,',
-                  'resource),'], 59), # 59 = align with last ( previous line
-          # 39 = align with ( previous line
-          indent("#{res_path}))#{',' if object.kind?}", 39),
-          ("'#{object.kind}'" if object.kind?)
-        ].compact, 2),
-        ')'
-      ],
-      [
-        'wait_done = wait_for_completion(status, op_result, resource)',
-        'fetch_resource(',
-        indent([
-          'resource,',
-          'URI.parse(::Google::HashUtils.navigate(wait_done,',
-          # 39 = align with ( previous line
-          indent("#{res_path}))#{',' if object.kind?}", 39),
-          ("'#{object.kind}'" if object.kind?)
-        ].compact, 2),
-        ')'
-      ]
-    ], 2, inside_indent
+          [
+            [
+              'fetch_resource(',
+              indent([
+                'resource,',
+                'URI.parse(::Google::HashUtils.navigate(wait_for_completion(status,',
+                indent(['op_result,',
+                        'resource),'], 59), # 59 = align with last ( previous line
+                # 39 = align with ( previous line
+                indent("#{res_path}))#{',' if object.kind?}", 39),
+                ("'#{object.kind}'" if object.kind?)
+              ].compact, 2),
+              ')'
+            ],
+            [
+              'wait_done = wait_for_completion(status, op_result, resource)',
+              'fetch_resource(',
+              indent([
+                'resource,',
+                'URI.parse(::Google::HashUtils.navigate(wait_done,',
+                # 39 = align with ( previous line
+                indent("#{res_path}))#{',' if object.kind?}", 39),
+                ("'#{object.kind}'" if object.kind?)
+              ].compact, 2),
+              ')'
+            ]
+          ], 2, inside_indent
   ))
 -%>
 <% else # object.self_link_query.nil? -%>
@@ -63,29 +63,29 @@ def wait_for_operation(response, resource)
 <% obj_kind = object.kind? ? "'#{object.kind}'," : '' -%>
 <%=
   lines(format(
-    [
-      [
-        "fetch_wrapped_resource(resource, #{obj_kind}",
-        ("'#{object.self_link_query.kind}'," if object.self_link_query.kind?),
-        "'#{object.self_link_query.items}')"
-      ].join(' '),
-      [
-        [
-         "fetch_wrapped_resource(resource, #{obj_kind}",
-         ("'#{object.self_link_query.kind}'," if object.self_link_query.kind?)
-        ].join(' '),
-        indent([
-          "'#{object.self_link_query.items}')"
-        ], 23) # 23 = align with ( previous line
-      ],
-      [
-        "fetch_wrapped_resource(resource, #{obj_kind}",
-        indent([
-          "'#{object.self_link_query.kind}',",
-          "'#{object.self_link_query.items}')"
-        ], 23) # 31 = align with ( previous line
-      ]
-    ], 2, inside_indent
+          [
+            [
+              "fetch_wrapped_resource(resource, #{obj_kind}",
+              ("'#{object.self_link_query.kind}'," if object.self_link_query.kind?),
+              "'#{object.self_link_query.items}')"
+            ].join(' '),
+            [
+              [
+                "fetch_wrapped_resource(resource, #{obj_kind}",
+                ("'#{object.self_link_query.kind}'," if object.self_link_query.kind?)
+              ].join(' '),
+              indent([
+                       "'#{object.self_link_query.items}')"
+                     ], 23) # 23 = align with ( previous line
+            ],
+            [
+              "fetch_wrapped_resource(resource, #{obj_kind}",
+              indent([
+                       "'#{object.self_link_query.kind}',",
+                       "'#{object.self_link_query.items}')"
+                     ], 23) # 31 = align with ( previous line
+            ]
+          ], 2, inside_indent
   ))
 -%>
 <% end # object.self_link_query.nil? -%>
@@ -100,7 +100,7 @@ def wait_for_completion(status, op_result, resource)
 <%   err_path = Google::HashUtils.path2navigate(object.async.error.path) -%>
 <%   err_msg = object.async.error.message -%>
     raise_if_errors op_result, <%= err_path -%>, '<%= err_msg -%>'
-    sleep <%= sprintf('%.1f', object.async.operation.wait_ms / 1000.0) %>
+    sleep <%= format('%.1f', object.async.operation.wait_ms / 1000.0) %>
 <%   allowed_states = object.async.status.allowed -%>
     raise "Invalid result '#{status}' on <%= object.out_name -%>." \
       unless %w[<%= allowed_states.join(' ') -%>].include?(status)

--- a/templates/bundle.rb.erb
+++ b/templates/bundle.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'open3'
 

--- a/templates/chef/Berksfile.erb
+++ b/templates/chef/Berksfile.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :chef) -%>
+<%= lines(autogen_notice(:chef)) -%>
 
 source 'https://supermarket.chef.io'
 

--- a/templates/chef/Gemfile.erb
+++ b/templates/chef/Gemfile.erb
@@ -14,14 +14,14 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :gemfile) -%>
+<%= lines(autogen_notice(:gemfile)) -%>
 
 source 'https://rubygems.org'
 
 group :test do
 <%
-  # TODO(alexstephen + Chef): Investigate how to remove the two google gems
-  # from all cookbooks except google-gauth
+# TODO(alexstephen + Chef): Investigate how to remove the two google gems
+# from all cookbooks except google-gauth
 -%>
   gem 'chef'
   gem 'chefspec', '~> 6.2.0'

--- a/templates/chef/README.md.erb
+++ b/templates/chef/README.md.erb
@@ -54,7 +54,7 @@ For complete details of the authentication cookbook, visit the
 
 ## Resources
 
-<% objects = product.objects.select { |o| !o.exclude } -%>
+<% objects = product.objects.reject(&:exclude) -%>
 <% objects.each do |object| -%>
 * [`<%= object.out_name -%>`](#<%= object.out_name -%>) -
 <%= lines(indent(wrap_field(object.description, 6), 2)) -%>
@@ -92,8 +92,8 @@ If the resource already exists Chef will attempt to delete it.", 0)) -%>
 
 #### Properties
 
-<% # TODO(nelsonjr): Add suffixes "(read only)" "(output only") etc
-   # on all providers -%>
+<%# TODO(nelsonjr): Add suffixes "(read only)" "(output only") etc
+# on all providers -%>
 <%   object.all_user_properties.each do |property| -%>
 * `<%= property.out_name -%>` -
 <%
@@ -110,8 +110,7 @@ If the resource already exists Chef will attempt to delete it.", 0)) -%>
 <%= build_nested_object(property.item_type, "#{property.out_name}[]").join -%>
 <% elsif property.is_a? Api::Type::Array and \
   property.item_type.is_a? Api::Type::Array
-   raise "Array of arrays. Not supported."
--%>
+   raise "Array of arrays. Not supported." -%>
 <% end # property.is_a? Api::Type::NestedObject -%>
 <%   end # object.all_user_properties.-%>
 #### Label

--- a/templates/chef/chefignore.erb
+++ b/templates/chef/chefignore.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :chef) -%>
+<%= lines(autogen_notice(:chef)) -%>
 
 # Put files/directories that should be ignored in this file when uploading
 # to a chef-server or supermarket.

--- a/templates/chef/credential.erb
+++ b/templates/chef/credential.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'chef/resource'
 

--- a/templates/chef/foodcritic_spec.rb.erb
+++ b/templates/chef/foodcritic_spec.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'spec_helper'
 

--- a/templates/chef/function.erb
+++ b/templates/chef/function.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 <% unless fn.search_paths.nil? -%>
 <%=
@@ -38,7 +38,7 @@
 module Google
   # Module that holds all client-side functions
   module Functions
-<% args = fn.arguments.map { |a| a.name }.join(', ') -%>
+<% args = fn.arguments.map(&:name).join(', ') -%>
     def self.<%= fn.name -%>(<%= args -%>)
 <%= lines(indent(fn.code, 6)) -%>
     end
@@ -46,6 +46,6 @@ module Google
     def <%= fn.name -%>(<%= args -%>)
       ::Google::Functions.<%= fn.name -%>(<%= args -%>)
     end
-<%= lines(lines_before(indent(fn.helpers,4))) unless fn.helpers.nil? -%>
+<%= lines(lines_before(indent(fn.helpers, 4))) unless fn.helpers.nil? -%>
   end
 end

--- a/templates/chef/google-gauth~metadata.rb.erb
+++ b/templates/chef/google-gauth~metadata.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 name 'google-gauth'
 maintainer 'The Authors'

--- a/templates/chef/init_library_path.rb.erb
+++ b/templates/chef/init_library_path.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 # Add libraries/ to library search path
 $LOAD_PATH.unshift ::File.expand_path(::File.dirname(__FILE__))

--- a/templates/chef/metadata.rb.erb
+++ b/templates/chef/metadata.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 name 'google-<%= product.prefix -%>'
 maintainer 'Google'

--- a/templates/chef/property/array.rb.erb
+++ b/templates/chef/property/array.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 module Google
   module <%= product_ns %>

--- a/templates/chef/property/array_typed.rb.erb
+++ b/templates/chef/property/array_typed.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/<%= prop_ns_dir -%>/property/array'
 

--- a/templates/chef/property/boolean.rb.erb
+++ b/templates/chef/property/boolean.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 module Google
   module <%= product_ns %>

--- a/templates/chef/property/double.rb.erb
+++ b/templates/chef/property/double.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 module Google
   module <%= product_ns %>

--- a/templates/chef/property/enum.rb.erb
+++ b/templates/chef/property/enum.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 module Google
   module <%= product_ns %>

--- a/templates/chef/property/integer.rb.erb
+++ b/templates/chef/property/integer.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 module Google
   module <%= product_ns %>

--- a/templates/chef/property/namevalues.rb.erb
+++ b/templates/chef/property/namevalues.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 module Google
   module <%= product_ns %>

--- a/templates/chef/property/nested_object.rb.erb
+++ b/templates/chef/property/nested_object.rb.erb
@@ -31,10 +31,10 @@
           [
             "@#{prop.out_name} =",
             indent([
-              "#{parser}(",
-              indent("args[:#{source}]", 2),
-              ')'
-            ], 2)
+                     "#{parser}(",
+                     indent("args[:#{source}]", 2),
+                     ')'
+                   ], 2)
           ]
         ], 0, 10
       )
@@ -54,10 +54,10 @@
           [
             "@#{prop.out_name} =",
             indent([
-              "#{parser}(",
-              indent("args['#{source}']", 2),
-              ')'
-            ], 2)
+                     "#{parser}(",
+                     indent("args['#{source}']", 2),
+                     ')'
+                   ], 2)
           ]
         ], 0, 10
       )
@@ -66,7 +66,7 @@
 -%>
 <%= compile('templates/license.erb') -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 <% if emit_array -%>
 require 'google/<%= prop_ns_dir -%>/property/array'
@@ -75,18 +75,19 @@ module Google
   module <%= product_ns %>
     module Data
 <%= lines(indent(
-      emit_rubocop(binding, :class,
-                   ['Google', product_ns, 'Data', class_name].join('::'),
-                   :disabled),
-      6)) -%>
+            emit_rubocop(binding, :class,
+                         ['Google', product_ns, 'Data', class_name].join('::'),
+                         :disabled),
+            6
+    )) -%>
 <%=
   lines(format([
-    ["# A class to manage data for #{field} for #{obj_name}."],
-    [
-      "# A class to manage data for #{field} for",
-      "# #{obj_name}."
-    ]
-  ], 6))
+                 ["# A class to manage data for #{field} for #{obj_name}."],
+                 [
+                   "# A class to manage data for #{field} for",
+                   "# #{obj_name}."
+                 ]
+               ], 6))
 -%>
       class <%= class_name %>
         include Comparable
@@ -108,14 +109,14 @@ module Google
           [
             "#{prop.out_name}: ['[',",
             indent([
-              "#{prop.out_name}.map(&:to_json).join(', '),",
-              "']'].join(' ')"
-            ], prop.out_name.length + 3), # 3 = ": ["
+                     "#{prop.out_name}.map(&:to_json).join(', '),",
+                     "']'].join(' ')"
+                   ], prop.out_name.length + 3), # 3 = ": ["
           ]
         elsif prop.item_type.is_a?(::String)
           "#{prop.out_name}: #{prop.out_name}.to_s"
         else
-          raise "Unknown array type"
+          raise 'Unknown array type'
         end
       else
         "#{prop.out_name}: #{prop.out_name}.to_s"
@@ -172,11 +173,10 @@ module Google
                                       .join(', '),
                                     ['{',
                                      indent_list([
-                                       "self: #{prop.out_name}",
-                                       "other: other.#{prop.out_name}"
-                                     ], 2),
-                                     '}'
-                                    ]
+                                                   "self: #{prop.out_name}",
+                                                   "other: other.#{prop.out_name}"
+                                                 ], 2),
+                                     '}']
                                   ], 0, 12
                                 )
                               end, 2)
@@ -219,15 +219,15 @@ module Google
     module Property
 <%=
   lines(format([
-    ["# A class to manage input to #{field} for #{obj_name}."],
-    [
-      "# A class to manage input to #{field} for",
-      "# #{obj_name}."
-    ]
-  ], 6))
+                 ["# A class to manage input to #{field} for #{obj_name}."],
+                 [
+                   "# A class to manage input to #{field} for",
+                   "# #{obj_name}."
+                 ]
+               ], 6))
 -%>
       class <%= class_name %>
-<%= emit_coerce(product_ns, "#{class_name}", 8) -%>
+<%= emit_coerce(product_ns, class_name.to_s, 8) -%>
         # Used for parsing Chef catalog
         def self.catalog_parse(value)
           return if value.nil?

--- a/templates/chef/property/resourceref.rb.erb
+++ b/templates/chef/property/resourceref.rb.erb
@@ -19,7 +19,7 @@ require 'google/<%= prop_ns_dir -%>/property/array'
 <%#           imports - name of property being fetched -%>
 <%= compile('templates/license.erb') -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 module Google
   module <%= product_ns %>

--- a/templates/chef/property/string.rb.erb
+++ b/templates/chef/property/string.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 module Google
   module <%= product_ns %>

--- a/templates/chef/property/time.rb.erb
+++ b/templates/chef/property/time.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'time'
 
@@ -25,8 +25,8 @@ module Google
       class Time < ::Time
 <%# TODO(alexstephen): Add a .to_resource method to replace .to_s -%>
 <%
-  # Overriden .to_s ensures that value coercison does not need to be placed
-  # within the providers. Providers do not have to worry about the time formats
+# Overriden .to_s ensures that value coercison does not need to be placed
+# within the providers. Providers do not have to worry about the time formats
 -%>
         def to_s
           # All GCP APIs expect timestamps in the ISO-8601 / RFC3339 format

--- a/templates/chef/resource.erb
+++ b/templates/chef/resource.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 # Add our google/ lib
 $LOAD_PATH.unshift ::File.expand_path('../libraries', ::File.dirname(__FILE__))
@@ -40,10 +40,11 @@ module Google
   module <%= @api.prefix.upcase %>
     # A provider to manage <%= @api.name -%> resources.
 <%= lines(indent(
-      emit_rubocop(binding, :class,
-                   ['Google', @api.prefix.upcase, object.name].join('::'),
-                   :disabled),
-      4)) -%>
+            emit_rubocop(binding, :class,
+                         ['Google', @api.prefix.upcase, object.name].join('::'),
+                         :disabled),
+            4
+    )) -%>
     class <%= object.name -%> < Chef::Resource
       resource_name :<%= object.out_name %>
 
@@ -59,12 +60,12 @@ module Google
 <% if prop_decl(prop) == "Array" -%>
 <%=
   lines(format([
-    ["# #{property_out_name(prop)} is Array of #{prop.property_type}"],
-    [
-     "# #{property_out_name(prop)} is Array of",
-     "# #{prop.property_type}"
-    ]
-  ], 6))
+                 ["# #{property_out_name(prop)} is Array of #{prop.property_type}"],
+                 [
+                   "# #{property_out_name(prop)} is Array of",
+                   "# #{prop.property_type}"
+                 ]
+               ], 6))
 -%>
 <% end -%>
 <%=
@@ -77,8 +78,8 @@ module Google
                  ],
                  # Prop name on first line, all others on second line
                  [
-                   "#{prop_name}",
-                   ["#{indent(prop_decl(prop), 9)}",
+                   prop_name.to_s,
+                   [indent(prop_decl(prop), 9).to_s,
                     "coerce: ::#{prop.property_type}.coerce",
                     prop_attrs].flatten.join(', ')
                  ],
@@ -97,7 +98,7 @@ module Google
                    "#{prop_name},",
                    "#{indent(prop_decl(prop), 9)},",
                    indent("coerce: ::#{prop.property_type}.coerce,", 9),
-                   "#{indent(prop_attrs.join(', '), 9)}"
+                   indent(prop_attrs.join(', '), 9).to_s
                  ],
                  # Prop name on first line, prop types on second line
                  # Coercion two-liner on third + fourth lines
@@ -105,10 +106,10 @@ module Google
                  [
                    "#{prop_name},",
                    "#{indent(prop_decl(prop), 9)},",
-                   indent("coerce: \\", 9),
+                   indent('coerce: \\', 9),
                    indent("::#{prop.property_type}.coerce,", 11),
-                   "#{indent(prop_attrs.join(', '), 9)}"
-                 ],
+                   indent(prop_attrs.join(', '), 9).to_s
+                 ]
                ], 6))
 -%>
 <% end -%>
@@ -138,12 +139,12 @@ module Google
         if fetch.nil?
 <%=
   lines(format([
-    ["converge_by \"Creating #{object.out_name}[\#{new_resource.name}]\" do"],
-    [
-      "converge_by ['Creating #{object.out_name}',",
-      indent('"[#{new_resource.name}]"].join do', 13)
-    ]
-  ], 10, 0))
+                 ["converge_by \"Creating #{object.out_name}[\#{new_resource.name}]\" do"],
+                 [
+                   "converge_by ['Creating #{object.out_name}',",
+                   indent('"[#{new_resource.name}]"].join do', 13)
+                 ]
+               ], 10, 0))
 -%>
             # TODO(nelsonjr): Show a list of variables to create
             # TODO(nelsonjr): Determine how to print green like update converge
@@ -206,23 +207,23 @@ module Google
           [
             "@current_resource.#{name} =",
             indent([
-              "#{type}.api_parse(",
-              indent("::Google::HashUtils.navigate(fetch, %w[#{fetch_tree}])",
-                     2),
-              ')'
-            ], 2)
+                     "#{type}.api_parse(",
+                     indent("::Google::HashUtils.navigate(fetch, %w[#{fetch_tree}])",
+                            2),
+                     ')'
+                   ], 2)
           ],
           [
             "@current_resource.#{name} =",
             indent([
-              "#{type}.api_parse(",
-              indent([
-                '::Google::HashUtils.navigate(',
-                indent("fetch, %w[#{fetch_tree}]", 2),
-                ')'
-              ], 2),
-              ')'
-            ], 2)
+                     "#{type}.api_parse(",
+                     indent([
+                              '::Google::HashUtils.navigate(',
+                              indent("fetch, %w[#{fetch_tree}]", 2),
+                              ')'
+                            ], 2),
+                     ')'
+                   ], 2)
           ]
         ], 0, 12
       )
@@ -230,8 +231,8 @@ module Google
       assignment = format(
         [
           [
-           "@current_resource.#{name} =",
-           "#{type}.api_parse(fetch['#{field_name}'])"
+            "@current_resource.#{name} =",
+            "#{type}.api_parse(fetch['#{field_name}'])"
           ].join(' '),
           [
             "@current_resource.#{name} =",
@@ -240,10 +241,10 @@ module Google
           [
             "@current_resource.#{name} =",
             indent([
-              "#{type}.api_parse(",
-              indent("fetch['#{field_name}']", 2),
-              ')'
-            ], 2)
+                     "#{type}.api_parse(",
+                     indent("fetch['#{field_name}']", 2),
+                     ')'
+                   ], 2)
           ]
         ], 0, 12
       )
@@ -281,12 +282,12 @@ module Google
         unless fetch.nil?
 <%=
   lines(format([
-    ["converge_by \"Deleting #{object.out_name}[\#{new_resource.name}]\" do"],
-    [
-      "converge_by ['Deleting #{object.out_name}',",
-      indent('"[#{new_resource.name}]"].join do', 13)
-    ]
-  ], 10, 0))
+                 ["converge_by \"Deleting #{object.out_name}[\#{new_resource.name}]\" do"],
+                 [
+                   "converge_by ['Deleting #{object.out_name}',",
+                   indent('"[#{new_resource.name}]"].join do', 13)
+                 ]
+               ], 10, 0))
 -%>
 <% if object&.handlers&.delete.nil? -%>
             delete_req = ::Google::<%= product_ns -%>::Network::Delete.new(
@@ -331,29 +332,28 @@ module Google
 <%
   prop_code = []
   prop_code << "kind: '#{object.kind}'" if object.kind?
-  prop_code.concat(object.properties.reject { |p| p.output }
+  prop_code.concat(object.properties.reject(&:output)
                                     .map do |prop|
-    override_name = property_out_name(prop)
-    override_name = label_name(object) if override_name == 'name'
-    format([
-      ["#{prop.field_name}: new_resource.#{override_name}"],
-      ["#{prop.field_name}:",
-       indent("new_resource.#{override_name}", 2)],
-    ], 0, 12)
-  end)
+                     override_name = property_out_name(prop)
+                     override_name = label_name(object) if override_name == 'name'
+                     format([
+                              ["#{prop.field_name}: new_resource.#{override_name}"],
+                              ["#{prop.field_name}:",
+                               indent("new_resource.#{override_name}", 2)]
+                            ], 0, 12)
+                   end)
 
   prop_code.concat((object.parameters || [])
-           .select { |p| p.input }
+           .select(&:input)
            .map do |prop|
              override_name = property_out_name(prop)
              override_name = label_name(object) if override_name == 'name'
              format([
-               ["#{prop.field_name}: new_resource.#{override_name}"],
-               ["#{prop.field_name}:",
-                indent("new_resource.#{override_name}", 2)],
-             ], 0, 12)
-           end
-  )
+                      ["#{prop.field_name}: new_resource.#{override_name}"],
+                      ["#{prop.field_name}:",
+                       indent("new_resource.#{override_name}", 2)]
+                    ], 0, 12)
+           end)
 
   r2r_code = []
   r2r_code << 'request = {'
@@ -371,7 +371,7 @@ module Google
   end
 
   r2r_code << 'request.to_json'
-  -%>
+-%>
 <%=
   lines(indent(emit_method('resource_to_request', [], r2r_code, file_relative),
                8), 1)
@@ -406,15 +406,16 @@ module Google
             compute_changes.each { |log| puts "    - #{log.strip}\n" }
 <% if object&.handlers&.update.nil? -%>
 <%   put_new = "::Google::#{product_ns}::Network::Put.new" -%>
-<%= lines(indent("update_req =", 12)) -%>
+<%= lines(indent('update_req =', 12)) -%>
 <%=
   lines(indent_list([
-    "#{put_new}(self_link(@new_resource)"].concat(
+    "#{put_new}(self_link(@new_resource)"
+  ].concat(
     indent([
-      'fetch_auth(@new_resource)',
-      "'application/json'",
-      'resource_to_request)'
-    ], put_new.length + 1).split("\n")
+             'fetch_auth(@new_resource)',
+             "'application/json'",
+             'resource_to_request)'
+           ], put_new.length + 1).split("\n")
   ), 14))
 -%>
 <%   if object.async -%>
@@ -438,10 +439,10 @@ module Google
 <%
   all_properties = object.all_user_properties
   has_project_property = \
-     !object.all_user_properties.select { |o| o.name == 'project' }.empty?
+    !object.all_user_properties.select { |o| o.name == 'project' }.empty?
   project_arg = has_project_property ? [] : ['project: resource.project']
   has_name = !object.all_user_properties.select { |o| o.name == 'name' }.empty?
-  name_prop = "name: resource.name"
+  name_prop = 'name: resource.name'
   name_prop = "name: resource.#{label_name(object)}" if has_name
   r2h_code = [
     '{',
@@ -452,12 +453,12 @@ module Google
       ].compact
     ).concat(all_properties.reject { |p| p.name == 'name' }.map do |prop|
       format([
-        ["#{prop.out_name}: resource.#{property_out_name(prop)}"],
-        [
-          "#{prop.out_name}:",
-          indent("resource.#{property_out_name(prop)}", 2)
-        ]
-      ], 0, 12)
+               ["#{prop.out_name}: resource.#{property_out_name(prop)}"],
+               [
+                 "#{prop.out_name}:",
+                 indent("resource.#{property_out_name(prop)}", 2)
+               ]
+             ], 0, 12)
     end), 2),
     '}.reject { |_, v| v.nil? }'
   ]
@@ -566,7 +567,7 @@ module Google
 <% else # object&.handlers&.collection.nil? -%>
 <%=
   lines(indent(emit_link('collection', object.handlers.collection, true), 8))
- %>
+%>
 <% end # object&.handlers&.collection.nil? -%>
 <% if object&.handlers&.self_link.nil? -%>
 <%= lines(indent(emit_link('self_link', self_link_url(object), true), 8), 1) -%>
@@ -591,9 +592,10 @@ module Google
       end
     end
 <%= lines(indent(
-      emit_rubocop(binding, :class,
-                   ['Google', @api.prefix.upcase, object.name].join('::'),
-                   :enabled),
-      4)) -%>
+            emit_rubocop(binding, :class,
+                         ['Google', @api.prefix.upcase, object.name].join('::'),
+                         :enabled),
+            4
+    )) -%>
   end
 end

--- a/templates/chef/resource_spec.erb
+++ b/templates/chef/resource_spec.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :chef) -%>
+<%= lines(autogen_notice(:chef)) -%>
 
 require 'spec_helper'
 
@@ -40,104 +40,102 @@ require 'spec_helper'
 # TODO(alexstephen): Add tests for manage
 # TODO(alexstephen): Add tests for modify
 <%
-if object.virtual
-  test_matrix = Provider::TestMatrix.new(template, object, self,
-    exists: {
-      changes: [ # read-only object mistmatch
-        [:no_name, :fail],
-        [:has_name, :fail]
-      ],
-      no_change: [
-        [:no_name, :pass],
-        [:has_name, :pass]
-      ],
-    },
-    missing: [
-      [:no_name, :fail],
-      [:has_name, :fail]
-    ]
-  )
-else
-  test_matrix = Provider::TestMatrix.new(template, object, self,
-    present: {
-      exists: {
-        changes: { # converge
-          no_name: [:pass, :fail],
-          has_name: [:pass, :fail]
-        },
-        no_change: { # no action
-          no_name: [:pass, :fail],
-          has_name: [:pass, :fail]
-        }
-      },
-      missing: { # create
-        # changes == ignore
-        no_name: [:pass, :fail],
-        has_name: [:pass, :fail]
-      }
-    },
-    absent: {
-      exists: { # delete
-        # changes == ignore
-        no_name: [:pass, :fail],
-        has_name: [:pass, :fail]
-      },
-      missing: { # no action
-        # changes == ignore
-        no_name: [:pass, :fail],
-        has_name: [:pass, :fail]
-      }
-    }
-  )
-end
+test_matrix = if object.virtual
+                Provider::TestMatrix.new(template, object, self,
+                                         exists: {
+                                           changes: [ # read-only object mistmatch
+                                             %i[no_name fail],
+                                             %i[has_name fail]
+                                           ],
+                                           no_change: [
+                                             %i[no_name pass],
+                                             %i[has_name pass]
+                                           ]
+                                         },
+                                         missing: [
+                                           %i[no_name fail],
+                                           %i[has_name fail]
+                                         ])
+              else
+                Provider::TestMatrix.new(template, object, self,
+                                         present: {
+                                           exists: {
+                                             changes: { # converge
+                                               no_name: %i[pass fail],
+                                               has_name: %i[pass fail]
+                                             },
+                                             no_change: { # no action
+                                               no_name: %i[pass fail],
+                                               has_name: %i[pass fail]
+                                             }
+                                           },
+                                           missing: { # create
+                                             # changes == ignore
+                                             no_name: %i[pass fail],
+                                             has_name: %i[pass fail]
+                                           }
+                                         },
+                                         absent: {
+                                           exists: { # delete
+                                             # changes == ignore
+                                             no_name: %i[pass fail],
+                                             has_name: %i[pass fail]
+                                           },
+                                           missing: { # no action
+                                             # changes == ignore
+                                             no_name: %i[pass fail],
+                                             has_name: %i[pass fail]
+                                           }
+                                         })
+              end
 
 prop_data = Provider::TestData::Expectations.new(self, @data_gen)
 catalogger = Provider::ChefTestCatalogFormatter.new self
 -%>
 context '<%= object.out_name -%>' do
 <% if object.virtual -%>
-<% # Object does NOT provides 'ensure' parameter -%>
+<%# Object does NOT provides 'ensure' parameter -%>
 <%= test_matrix.push(:ignore, :exists) -%>
 <%= test_matrix.push(:ignore, :exists, :no_change) -%>
-<%= test_matrix.push(:ignore, :exists, :no_change, [:no_name, :pass]) -%>
+<%= test_matrix.push(:ignore, :exists, :no_change, %i[no_name pass]) -%>
         # TODO(alexstephen): Implement new test format.
-<%= test_matrix.pop(:ignore, :exists, :no_change, [:no_name, :pass]) -%>
+<%= test_matrix.pop(:ignore, :exists, :no_change, %i[no_name pass]) -%>
 
-<%= test_matrix.push(:ignore, :exists, :no_change, [:has_name, :pass]) -%>
+<%= test_matrix.push(:ignore, :exists, :no_change, %i[has_name pass]) -%>
         # TODO(alexstephen): Implement new test format.
-<%= test_matrix.pop(:ignore, :exists, :no_change, [:has_name, :pass]) -%>
+<%= test_matrix.pop(:ignore, :exists, :no_change, %i[has_name pass]) -%>
 <%= test_matrix.pop(:ignore, :exists, :no_change) -%>
 
 <%= test_matrix.push(:ignore, :exists, :changes) -%>
-<%= test_matrix.push(:ignore, :exists, :changes, [:no_name, :fail]) -%>
+<%= test_matrix.push(:ignore, :exists, :changes, %i[no_name fail]) -%>
         # TODO(alexstephen): Implement new test format.
         subject { -> { raise '[placeholder] This should fail.' } }
         it { is_expected.to raise_error(RuntimeError, /placeholder/) }
-<%= test_matrix.pop(:ignore, :exists, :changes, [:no_name, :fail]) -%>
+<%= test_matrix.pop(:ignore, :exists, :changes, %i[no_name fail]) -%>
 
-<%= test_matrix.push(:ignore, :exists, :changes, [:has_name, :fail]) -%>
+<%= test_matrix.push(:ignore, :exists, :changes, %i[has_name fail]) -%>
         # TODO(alexstephen): Implement new test format.
         subject { -> { raise '[placeholder] This should fail.' } }
         it { is_expected.to raise_error(RuntimeError, /placeholder/) }
-<%= test_matrix.pop(:ignore, :exists, :changes, [:has_name, :fail]) -%>
+<%= test_matrix.pop(:ignore, :exists, :changes, %i[has_name fail]) -%>
 <%= test_matrix.pop(:ignore, :exists, :changes) -%>
 <%= test_matrix.pop(:ignore, :exists) -%>
 
 <%= test_matrix.push(:ignore, :missing) -%>
-<%= test_matrix.push(:ignore, :missing, :ignore, [:no_name, :fail]) -%>
+<%= test_matrix.push(:ignore, :missing, :ignore, %i[no_name fail]) -%>
       # TODO(alexstephen): Implement new test format.
       subject { -> { raise '[placeholder] This should fail.' } }
       it { is_expected.to raise_error(RuntimeError, /placeholder/) }
-<%= test_matrix.pop(:ignore, :missing, :ignore, [:no_name, :fail]) -%>
+<%= test_matrix.pop(:ignore, :missing, :ignore, %i[no_name fail]) -%>
 
-<%= test_matrix.push(:ignore, :missing, :ignore, [:has_name, :fail]) -%>
+<%= test_matrix.push(:ignore, :missing, :ignore, %i[has_name fail]) -%>
       # TODO(alexstephen): Implement new test format.
       subject { -> { raise '[placeholder] This should fail.' } }
       it { is_expected.to raise_error(RuntimeError, /placeholder/) }
-<%= test_matrix.pop(:ignore, :missing, :ignore, [:has_name, :fail]) -%>
+<%= test_matrix.pop(:ignore, :missing, :ignore, %i[has_name fail]) -%>
 <%= test_matrix.pop(:ignore, :missing) -%>
 <% else -%>
-<% # Object that provides 'ensure' parameter -%>
+<%# Object that provides 'ensure' parameter -%>
 <%= test_matrix.push(:present) -%>
 <%= test_matrix.push(:present, :exists) -%>
 <%= test_matrix.push(:present, :exists, :no_change) -%>
@@ -370,9 +368,9 @@ context '<%= object.out_name -%>' do
     end
 <%=
   lines(indent(format([
-    ["recipe_path = \"google-#{object.__product.prefix.downcase}",
-     "::\#{recipe_name}\""].join
-  ]), 4))
+                        ["recipe_path = \"google-#{object.__product.prefix.downcase}",
+                         "::\#{recipe_name}\""].join
+                      ]), 4))
 -%>
     begin
       yield recipe_path

--- a/templates/chef/spec_helper.rb.erb
+++ b/templates/chef/spec_helper.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 #----------------------------------------------------------
 # Setup timezone.

--- a/templates/chef/tests/absent~delete.erb
+++ b/templates/chef/tests/absent~delete.erb
@@ -22,7 +22,7 @@
                                                 path: config_path + %w[before],
                                                 exists: true,
                                                 has_name: has_name
-                                               }, collector)
+                                              }, collector)
 
   resource_block = resources.flatten(1).uniq.map { |r| lines(r) }.join("\n")
 -%>
@@ -80,9 +80,9 @@ subject do
 -%>
 <%=
   format([
-    [find_lines[0] + " #{find_lines[1]}"],
-    [find_lines[0], indent(find_lines[1], 24)]
-  ], 2, (test_matrix.level + 1) * 2)
+           [find_lines[0] + " #{find_lines[1]}"],
+           [find_lines[0], indent(find_lines[1], 24)]
+         ], 2, (test_matrix.level + 1) * 2)
 %>
 end
 

--- a/templates/chef/tests/absent~no_action.erb
+++ b/templates/chef/tests/absent~no_action.erb
@@ -78,8 +78,8 @@ subject do
 -%>
 <%=
   format([
-    [find_lines[0] + " #{find_lines[1]}"],
-    [find_lines[0], indent(find_lines[1], 24)]
-  ], 2, (test_matrix.level + 1) * 2)
+           [find_lines[0] + " #{find_lines[1]}"],
+           [find_lines[0], indent(find_lines[1], 24)]
+         ], 2, (test_matrix.level + 1) * 2)
 %>
 end

--- a/templates/chef/tests/present~create.erb
+++ b/templates/chef/tests/present~create.erb
@@ -39,7 +39,7 @@
   references_self_type = false
   collector.each do |obj|
     references_self_type = true if obj.parent && \
-      obj.parent.__resource == obj.object
+                                   obj.parent.__resource == obj.object
   end
   resource_block = resources.flatten(1).uniq.map { |r| lines(r) }.join("\n")
 -%>
@@ -95,14 +95,14 @@ subject do
 -%>
 <%=
   format([
-    [find_lines[0] + " #{find_lines[1]}"],
-    [find_lines[0], indent(find_lines[1], 24)]
-  ], 2, (test_matrix.level + 1) * 2)
+           [find_lines[0] + " #{find_lines[1]}"],
+           [find_lines[0], indent(find_lines[1], 24)]
+         ], 2, (test_matrix.level + 1) * 2)
 %>
 end
 
-<% # TODO(alexstephen): Temporarily disblae tests where object has reference
-   # to its own type -%>
+<%# TODO(alexstephen): Temporarily disblae tests where object has reference
+# to its own type -%>
 <% if references_self_type -%>
 it 'should run test correctly', broken: true do
   pending('Implement tests where object references its own type')
@@ -113,8 +113,8 @@ it 'should run test correctly' do
                              'title0')
 end
 <%
-object.all_user_properties.select { |p| !p.output }
-                          .each do |p|
+object.all_user_properties.reject(&:output)
+      .each do |p|
 -%>
 <%
   value = @data_gen.value(p.class, p, 0)
@@ -123,9 +123,9 @@ object.all_user_properties.select { |p| !p.output }
 -%>
 <%=
   lines(indent(@property.property(p, 0, @data_gen.comparator(p),
-                                   value,
-                                   (test_matrix.level + 1) * 2,
-                                   name_override), 0))
+                                  value,
+                                  (test_matrix.level + 1) * 2,
+                                  name_override), 0))
 %>
 <% end # all_user_props.each -%>
 <% end # references_self_type -%>

--- a/templates/chef/tests/present~no_changes.erb
+++ b/templates/chef/tests/present~no_changes.erb
@@ -9,7 +9,7 @@
   cust_before = get_code_multiline(tests, config_path)
 
   def expt(id, has_name, object, space_used, prop_data)
-    line = "expect_network_get_success"
+    line = 'expect_network_get_success'
     prop_data.create_expectation(line, has_name, object, space_used, [], id)
   end
 
@@ -50,7 +50,7 @@
   references_self_type = false
   collector.each do |obj|
     references_self_type = true if obj.parent && \
-      obj.parent.__resource == obj.object
+                                   obj.parent.__resource == obj.object
   end
 
   resource_block = resources.flatten(1).uniq.map { |r| lines(r) }.join("\n")
@@ -122,17 +122,17 @@ context '<%= object.out_name -%>[title<%= index -%>]' do
 -%>
 <%=
   lines(format([
-          [find_lines.join(' ')],
-          [
-           find_lines[0],
-           indent(find_lines[1], 23)
-          ]
-        ], 4, (test_matrix.level + 2) * 2))
+                 [find_lines.join(' ')],
+                 [
+                   find_lines[0],
+                   indent(find_lines[1], 23)
+                 ]
+               ], 4, (test_matrix.level + 2) * 2))
 -%>
   end
 <%
-object.all_user_properties.select { |p| !p.output }
-                          .each do |p|
+object.all_user_properties.reject(&:output)
+      .each do |p|
 -%>
 <%
   value = @data_gen.value(p.class, p, index)
@@ -142,9 +142,9 @@ object.all_user_properties.select { |p| !p.output }
 
 <%=
   lines(indent(@property.property(p, index, @data_gen.comparator(p),
-                                   value,
-                                   (test_matrix.level + 2) * 2,
-                                   name_override), 2))
+                                  value,
+                                  (test_matrix.level + 2) * 2,
+                                  name_override), 2))
 -%>
 <% end # all_user_props.each -%>
 <% end # references_self_type -%>

--- a/templates/example/resource.erb
+++ b/templates/example/resource.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 Resource Name: <%= object.name %>
 Resource Properties:

--- a/templates/fake_auth.erb
+++ b/templates/fake_auth.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile('templates/license.erb') -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 module Google
   # A dummy authorization handler that responds to the same authorize interface

--- a/templates/network/base.rb.erb
+++ b/templates/network/base.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'net/http'
 require 'net/https'

--- a/templates/network/delete.rb.erb
+++ b/templates/network/delete.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/<%= product_ns_dir -%>/<%= Compile::Libraries::NETWORK -%>/base'
 

--- a/templates/network/delete_spec.rb.erb
+++ b/templates/network/delete_spec.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'spec_helper'
 
@@ -32,12 +32,12 @@ describe Google::<%= product_ns -%>::Network::Delete do
   context 'verify proper request' do
 <%=
   lines(format([
-                ["before(:each) { #{blocker}.allow_delete(uri) }"],
-                [
-                  'before(:each) do',
-                  indent("#{blocker}.allow_delete(uri)", 2),
-                  'end'
-                ]
+                 ["before(:each) { #{blocker}.allow_delete(uri) }"],
+                 [
+                   'before(:each) do',
+                   indent("#{blocker}.allow_delete(uri)", 2),
+                   'end'
+                 ]
                ], 4), 1)
 -%>
     subject { described_class.new(uri, credential).send }

--- a/templates/network/get.rb.erb
+++ b/templates/network/get.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/<%= product_ns_dir -%>/<%= Compile::Libraries::NETWORK -%>/base'
 

--- a/templates/network/get_spec.rb.erb
+++ b/templates/network/get_spec.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'spec_helper'
 require 'uri'

--- a/templates/network/network_blocker.rb.erb
+++ b/templates/network/network_blocker.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'net/http'
 require 'singleton'

--- a/templates/network/network_blocker_spec.rb.erb
+++ b/templates/network/network_blocker_spec.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'spec_helper'
 

--- a/templates/network/patch.rb.erb
+++ b/templates/network/patch.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/<%= product_ns_dir -%>/<%= Compile::Libraries::NETWORK -%>/base'
 

--- a/templates/network/patch_spec.rb.erb
+++ b/templates/network/patch_spec.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'spec_helper'
 require 'uri'

--- a/templates/network/post.rb.erb
+++ b/templates/network/post.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/<%= product_ns_dir -%>/<%= Compile::Libraries::NETWORK -%>/base'
 

--- a/templates/network/post_spec.rb.erb
+++ b/templates/network/post_spec.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'spec_helper'
 require 'uri'

--- a/templates/network/put.rb.erb
+++ b/templates/network/put.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/<%= product_ns_dir -%>/<%= Compile::Libraries::NETWORK -%>/base'
 

--- a/templates/network/put_spec.rb.erb
+++ b/templates/network/put_spec.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'spec_helper'
 require 'uri'

--- a/templates/network_spec.yaml.erb
+++ b/templates/network_spec.yaml.erb
@@ -14,6 +14,6 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :yaml) -%>
+<%= lines(autogen_notice(:yaml)) -%>
 
 <%= test_data.to_yaml -%>

--- a/templates/puppet/README.md.erb
+++ b/templates/puppet/README.md.erb
@@ -41,8 +41,8 @@
 
       if nested_prop.is_a? Api::Type::NestedObject
         object_lines.concat(build_nested_object(nested_prop, next_path))
-      elsif nested_prop.is_a? Api::Type::Array and
-        nested_prop.item_type.is_a? Api::Type::NestedObject
+      elsif nested_prop.is_a?(Api::Type::Array) &&
+            nested_prop.item_type.is_a?(Api::Type::NestedObject)
         object_lines.concat(build_nested_object(nested_prop.item_type,
                                                 "#{next_path}[]"))
       end
@@ -112,7 +112,7 @@ required gems.
 
 ### Examples
 
-<% objects = product.objects.select { |o| !o.exclude } -%>
+<% objects = product.objects.reject(&:exclude) -%>
 <% objects.each do |object| -%>
 #### `<%= object.out_name -%>`
 
@@ -182,8 +182,7 @@ change by asserting it in the manifest.
 <%= build_nested_object(property.item_type, "#{property.out_name}[]").join -%>
 <% elsif property.is_a? Api::Type::Array and \
   property.item_type.is_a? Api::Type::Array
-   raise "Array of arrays. Not supported."
--%>
+   raise "Array of arrays. Not supported." -%>
 <% end # property.is_a? Api::Type::NestedObject -%>
 <%   end # object.all_user_properties.each -%>
 
@@ -201,8 +200,7 @@ change by asserting it in the manifest.
 <%= build_nested_object(property.item_type, "#{property.out_name}[]").join -%>
 <% elsif property.is_a? Api::Type::Array and \
   property.item_type.is_a? Api::Type::Array
-   raise "Array of arrays. Not supported."
--%>
+   raise "Array of arrays. Not supported." -%>
 <% end # property.is_a? Api::Type::NestedObject -%>
 <%     end # output_only.each -%>
 <%   end # output_only.empty? -%>

--- a/templates/puppet/bolt~task.json.erb
+++ b/templates/puppet/bolt~task.json.erb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 <% end -%>
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 {
   "description": "<%= task.description_display -%>",
   "supports_noop": false,
@@ -23,9 +23,9 @@
                       [
                         "\"#{arg.name}\": {",
                         indent([
-                          "\"description\": \"#{arg.description_display}\",",
-                          "\"type\": \"#{arg.type_metadata(self)}\""
-                        ], 2),
+                                 "\"description\": \"#{arg.description_display}\",",
+                                 "\"type\": \"#{arg.type_metadata(self)}\""
+                               ], 2),
                         '}'
                       ].join("\n")
                     end, 4))

--- a/templates/puppet/bolt~task.pp.erb
+++ b/templates/puppet/bolt~task.pp.erb
@@ -14,7 +14,7 @@
 <% end -%>
 #!/bin/bash
 <%= compile 'templates/license.erb' -%>
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 declare -r puppet='/opt/puppetlabs/bin/puppet'
 declare -r ruby='/opt/puppetlabs/puppet/bin/ruby'
@@ -83,7 +83,8 @@ $puppet apply ${puppet_args} 1>${run_log} 2>&1 <<EOF
             "\\$#{f_name} = #{@api.prefix}_task_validate_param(",
             indent(
               ['\\$params', quote_string(arg.name),
-               quote_string(arg.default.code.to_s.strip)].join(', '), 2),
+               quote_string(arg.default.code.to_s.strip)].join(', '), 2
+            ),
             ')'
           ].compact
         ]
@@ -103,9 +104,9 @@ $puppet apply ${puppet_args} 1>${run_log} 2>&1 <<EOF
                unless arg.comment.nil?),
             "\\$#{f_name} = #{@api.prefix}_task_validate_param(",
             indent([
-                     "\\$params", quote_string(arg.name),
-                     quote_string(Provider::Puppet::BOLT_UNDEF_MAGIC)
-                   ].join(', '), 2),
+              '\\$params', quote_string(arg.name),
+              quote_string(Provider::Puppet::BOLT_UNDEF_MAGIC)
+            ].join(', '), 2),
             ')'
           ].compact
         ]

--- a/templates/puppet/bolt~task.rb.erb
+++ b/templates/puppet/bolt~task.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 #!/opt/puppetlabs/puppet/bin/ruby
 <%= compile 'templates/license.erb' -%>
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 <%=
   lines(wrap_field(task.description_display, 0).split("\n")

--- a/templates/puppet/bolt~task_load_params.rb.erb
+++ b/templates/puppet/bolt~task_load_params.rb.erb
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'puppet'
 require 'puppet/error'

--- a/templates/puppet/bolt~task_validate_param.rb.erb
+++ b/templates/puppet/bolt~task_validate_param.rb.erb
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'puppet'
 require 'json'

--- a/templates/puppet/function.erb
+++ b/templates/puppet/function.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :puppet) -%>
+<%= lines(autogen_notice(:puppet)) -%>
 
 <%=
   lines(fn.requires.sort.map { |r| "require '#{r}'" }, 1) \
@@ -34,8 +34,8 @@ Puppet::Functions.create_function(:<%= fn.name -%>) do
 <% end # fn.arguments.each -%>
   end
 
-  def <%= fn.name -%>(<%= fn.arguments.map { |a| a.name }.join(', ') -%>)
+  def <%= fn.name -%>(<%= fn.arguments.map(&:name).join(', ') -%>)
 <%= lines(indent(fn.code, 4)) -%>
   end
-<%= lines(lines_before(indent(fn.helpers,2))) unless fn.helpers.nil? -%>
+<%= lines(lines_before(indent(fn.helpers, 2))) unless fn.helpers.nil? -%>
 end

--- a/templates/puppet/property/array.rb.erb
+++ b/templates/puppet/property/array.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/<%= prop_ns_dir -%>/property/base'
 
@@ -26,11 +26,11 @@ module Google
       class Array < Google::<%= product_ns -%>::Property::Base
 <%=
   lines(format([
-                ["# Sets #{full_name} to match all elements, not any."],
-                [
-                  "# Sets #{full_name} to match all elements, not",
-                  '# any.'
-                ]
+                 ["# Sets #{full_name} to match all elements, not any."],
+                 [
+                   "# Sets #{full_name} to match all elements, not",
+                   '# any.'
+                 ]
                ], 8))
 -%>
         def self.match_all_array

--- a/templates/puppet/property/array_typed.rb.erb
+++ b/templates/puppet/property/array_typed.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile('templates/license.erb') -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/<%= prop_ns_dir -%>/property/array'
 

--- a/templates/puppet/property/base.rb.erb
+++ b/templates/puppet/property/base.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'puppet/property'
 

--- a/templates/puppet/property/boolean.rb.erb
+++ b/templates/puppet/property/boolean.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/<%= prop_ns_dir -%>/property/base'
 

--- a/templates/puppet/property/double.rb.erb
+++ b/templates/puppet/property/double.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/<%= prop_ns_dir -%>/property/base'
 

--- a/templates/puppet/property/enum.rb.erb
+++ b/templates/puppet/property/enum.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/<%= prop_ns_dir -%>/property/base'
 

--- a/templates/puppet/property/integer.rb.erb
+++ b/templates/puppet/property/integer.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/<%= prop_ns_dir -%>/property/base'
 

--- a/templates/puppet/property/namevalues.rb.erb
+++ b/templates/puppet/property/namevalues.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/<%= prop_ns_dir -%>/property/base'
 

--- a/templates/puppet/property/nested_object.rb.erb
+++ b/templates/puppet/property/nested_object.rb.erb
@@ -30,10 +30,10 @@
         [
           "@#{prop.out_name} =",
           indent([
-            "#{parser}(",
-            indent("args['#{source}']", 2),
-            ')'
-          ], 2)
+                   "#{parser}(",
+                   indent("args['#{source}']", 2),
+                   ')'
+                 ], 2)
         ]
       ], 0, 10
     )
@@ -41,7 +41,7 @@
 -%>
 <%= compile('templates/license.erb') -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 <%
   requires = []
@@ -54,18 +54,19 @@ module Google
   module <%= product_ns %>
     module Data
 <%= lines(indent(
-      emit_rubocop(binding, :class,
-                   ['Google', product_ns, 'Data', class_name].join('::'),
-                   :disabled),
-      6)) -%>
+            emit_rubocop(binding, :class,
+                         ['Google', product_ns, 'Data', class_name].join('::'),
+                         :disabled),
+            6
+    )) -%>
 <%=
   lines(format([
-    ["# A class to manage data for #{field} for #{obj_name}."],
-    [
-      "# A class to manage data for #{field} for",
-      "# #{obj_name}."
-    ]
-  ], 6))
+                 ["# A class to manage data for #{field} for #{obj_name}."],
+                 [
+                   "# A class to manage data for #{field} for",
+                   "# #{obj_name}."
+                 ]
+               ], 6))
 -%>
       class <%= class_name %>
         include Comparable
@@ -87,14 +88,14 @@ module Google
           [
             "#{prop.out_name}: ['[',",
             indent([
-              "#{prop.out_name}.map(&:to_json).join(', '),",
-              "']'].join(' ')"
-            ], prop.out_name.length + 3), # 3 = ": ["
+                     "#{prop.out_name}.map(&:to_json).join(', '),",
+                     "']'].join(' ')"
+                   ], prop.out_name.length + 3), # 3 = ": ["
           ]
         elsif prop.item_type.is_a?(::String)
           "#{prop.out_name}: #{prop.out_name}"
         else
-          raise "Unknown array type"
+          raise 'Unknown array type'
         end
       else
         "#{prop.out_name}: #{prop.out_name}"
@@ -148,11 +149,10 @@ module Google
                                       .join(', '),
                                     ['{',
                                      indent_list([
-                                       "self: #{prop.out_name}",
-                                       "other: other.#{prop.out_name}"
-                                     ], 2),
-                                     '}'
-                                    ]
+                                                   "self: #{prop.out_name}",
+                                                   "other: other.#{prop.out_name}"
+                                                 ], 2),
+                                     '}']
                                   ], 0, 12
                                 )
                               end, 2)
@@ -192,12 +192,12 @@ module Google
     module Property
 <%=
   lines(format([
-    ["# A class to manage input to #{field} for #{obj_name}."],
-    [
-      "# A class to manage input to #{field} for",
-      "# #{obj_name}."
-    ]
-  ], 6))
+                 ["# A class to manage input to #{field} for #{obj_name}."],
+                 [
+                   "# A class to manage input to #{field} for",
+                   "# #{obj_name}."
+                 ]
+               ], 6))
 -%>
       class <%= class_name %> < Google::<%= product_ns %>::Property::Base
         # Used for parsing Puppet catalog

--- a/templates/puppet/property/resourceref.rb.erb
+++ b/templates/puppet/property/resourceref.rb.erb
@@ -16,7 +16,7 @@
 <%#           imports - name of property being fetched -%>
 <%= compile('templates/license.erb') -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 <%
   requires = []
@@ -82,13 +82,14 @@ module Google
 <% out_name = property.resource_ref.out_name -%>
 <%=
   lines(format(
-    [
-      ["Google::ObjectStore.instance[:#{out_name}].each do |entry|"],
-      [
-        "Google::ObjectStore.instance[:#{out_name}]",
-        '                   .each do |entry|'
-      ],
-    ], 10))
+          [
+            ["Google::ObjectStore.instance[:#{out_name}].each do |entry|"],
+            [
+              "Google::ObjectStore.instance[:#{out_name}]",
+              '                   .each do |entry|'
+            ]
+          ], 10
+  ))
 -%>
             return entry.exports[:<%= imports -%>] if entry.title == @title
           end

--- a/templates/puppet/property/string.rb.erb
+++ b/templates/puppet/property/string.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/<%= prop_ns_dir -%>/property/base'
 

--- a/templates/puppet/property/time.rb.erb
+++ b/templates/puppet/property/time.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'google/<%= prop_ns_dir -%>/property/base'
 
@@ -25,8 +25,8 @@ module Google
       class Time < ::Time
 <%# TODO(alexstephen): Add a .to_resource method to replace .to_s -%>
 <%
-  # Overriden .to_s ensures that value coercison does not need to be placed
-  # within the providers. Providers do not have to worry about the time formats
+# Overriden .to_s ensures that value coercison does not need to be placed
+# within the providers. Providers do not have to worry about the time formats
 -%>
         def to_s
           # All GCP APIs expect timestamps in the ISO-8601 / RFC3339 format

--- a/templates/puppet/provider.erb
+++ b/templates/puppet/provider.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 <%
   inside_indent = 2
@@ -25,9 +25,7 @@
   requires << 'google/hash_utils'
   requires << emit_google_lib(binding, Compile::Libraries::NETWORK, 'get')
   requires << 'puppet'
-  unless object.exports.nil?
-    requires << 'google/object_store'
-  end
+  requires << 'google/object_store' unless object.exports.nil?
   unless object.readonly
     requires << emit_google_lib(binding, Compile::Libraries::NETWORK, 'delete')
     requires << emit_google_lib(binding, Compile::Libraries::NETWORK, 'post')
@@ -69,46 +67,49 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 <%   if object.self_link_query.nil? -%>
 <%=
   lines(format(
-    [
-      ('fetch = fetch_resource(resource, self_link(resource))' \
-       unless object.kind?),
-      ['fetch = fetch_resource(resource, self_link(resource),',
-       "'#{object.kind}')"].join(' '),
-      [
-        'fetch = fetch_resource(resource, self_link(resource),',
-        indent("'#{object.kind}')", 23) # 23 = align previous until (
-      ]
-    ].compact, 6
+          [
+            ('fetch = fetch_resource(resource, self_link(resource))' \
+             unless object.kind?),
+            ['fetch = fetch_resource(resource, self_link(resource),',
+             "'#{object.kind}')"].join(' '),
+            [
+              'fetch = fetch_resource(resource, self_link(resource),',
+              indent("'#{object.kind}')", 23) # 23 = align previous until (
+            ]
+          ].compact, 6
   ))
 -%>
 <%   else # object.self_link_query.nil? -%>
 <%
-  self_link_kind = !object.self_link_query.kind.nil? ? \
-  "'#{object.self_link_query.kind}'," : ''
+  self_link_kind = if !object.self_link_query.kind.nil?
+                     "'#{object.self_link_query.kind}',"
+                   else
+                     ''
+                   end
 
   obj_kind = object.kind? ? "'#{object.kind}'," : ''
 -%>
 <%=
   lines(format(
-    [
-      ["fetch = fetch_wrapped_resource(resource, #{obj_kind}",
-       "#{self_link_kind}",
-       "'#{object.self_link_query.items}')"].join(' '),
-      [
-        ["fetch = fetch_wrapped_resource(resource, #{obj_kind}",
-         "#{self_link_kind}"].join(' '),
-        indent([
-          "'#{object.self_link_query.items}')"
-        ], 31) # 31 = align with ( previous line
-      ],
-      [
-        "fetch = fetch_wrapped_resource(resource, #{obj_kind}",
-        indent([
-          "#{self_link_kind}",
-          "'#{object.self_link_query.items}')"
-        ], 31) # 31 = align with ( previous line
-      ]
-    ], 6
+          [
+            ["fetch = fetch_wrapped_resource(resource, #{obj_kind}",
+             self_link_kind.to_s,
+             "'#{object.self_link_query.items}')"].join(' '),
+            [
+              ["fetch = fetch_wrapped_resource(resource, #{obj_kind}",
+               self_link_kind.to_s].join(' '),
+              indent([
+                       "'#{object.self_link_query.items}')"
+                     ], 31) # 31 = align with ( previous line
+            ],
+            [
+              "fetch = fetch_wrapped_resource(resource, #{obj_kind}",
+              indent([
+                       self_link_kind.to_s,
+                       "'#{object.self_link_query.items}')"
+                     ], 31) # 31 = align with ( previous line
+            ]
+          ], 6
   ))
 -%>
 <%   end # object.self_link_query.nil? -%>
@@ -135,37 +136,37 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
       if api_name.include?('.')
         fetch_tree = api_name.split('.').join(' ')
         format([
-          [
-            "#{name}: #{type}.api_munge(",
-            indent("Google::HashUtils.navigate(fetch, %w[#{fetch_tree}])", 2),
-            ')'
-          ],
-          [
-            "#{name}: \\",
-            "#{type}.api_munge(",
-            indent("Google::HashUtils.navigate(fetch, %w[#{fetch_tree}])", 2),
-            ')'
-          ]
-        ], 0, 7)
+                 [
+                   "#{name}: #{type}.api_munge(",
+                   indent("Google::HashUtils.navigate(fetch, %w[#{fetch_tree}])", 2),
+                   ')'
+                 ],
+                 [
+                   "#{name}: \\",
+                   "#{type}.api_munge(",
+                   indent("Google::HashUtils.navigate(fetch, %w[#{fetch_tree}])", 2),
+                   ')'
+                 ]
+               ], 0, 7)
       else
         format([
-          ["#{name}: #{type}.api_munge(fetch['#{prop.field_name}'])"],
-          [
-            "#{name}:",
-            indent("#{type}.api_munge(fetch['#{prop.field_name}'])", 2)
-          ],
-          [
-            "#{name}: #{type}.api_munge(",
-            indent("fetch['#{prop.field_name}']", 2),
-            ')',
-          ],
-          [
-            "#{name}:",
-            indent(["#{type}.api_munge(",
-                    indent("fetch['#{prop.field_name}']", 2),
-                    ')'], 2)
-          ]
-        ], 0, 7) # 6 spaces = indent, 1 space = trailing comma (it's a list)
+                 ["#{name}: #{type}.api_munge(fetch['#{prop.field_name}'])"],
+                 [
+                   "#{name}:",
+                   indent("#{type}.api_munge(fetch['#{prop.field_name}'])", 2)
+                 ],
+                 [
+                   "#{name}: #{type}.api_munge(",
+                   indent("fetch['#{prop.field_name}']", 2),
+                   ')'
+                 ],
+                 [
+                   "#{name}:",
+                   indent(["#{type}.api_munge(",
+                           indent("fetch['#{prop.field_name}']", 2),
+                           ')'], 2)
+                 ]
+               ], 0, 7) # 6 spaces = indent, 1 space = trailing comma (it's a list)
       end
     end
   assigns.concat(input_only.map do |prop|
@@ -192,7 +193,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   f2h_code = [
     '{',
     indent_list(assigns, 2),
-    '}.reject { |_, v| v.nil? }',
+    '}.reject { |_, v| v.nil? }'
   ]
 -%>
 <% custom_present = get_code_multiline config, 'present' -%>
@@ -218,14 +219,14 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   end
 
 <%
-  # TODO(nelsonjr): Investigate if we can have a timeout to wait for operations
-  # that we did not start to complete. For example if you start a firewall
-  # change via Developer Console and attempt to apply the manifest you get:
-  #
-  # Error: /Stage[main]/Main/Gcompute_firewall[test-firewall-allow-ssh]: Could
-  # not evaluate: Operation failed: The resource
-  # 'projects/google.com:graphite-playground/global/firewalls/....'
-  # is not ready
+# TODO(nelsonjr): Investigate if we can have a timeout to wait for operations
+# that we did not start to complete. For example if you start a firewall
+# change via Developer Console and attempt to apply the manifest you get:
+#
+# Error: /Stage[main]/Main/Gcompute_firewall[test-firewall-allow-ssh]: Could
+# not evaluate: Operation failed: The resource
+# 'projects/google.com:graphite-playground/global/firewalls/....'
+# is not ready
 -%>
   def create
     debug('create')
@@ -245,11 +246,11 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 -%>
 <%=
   lines(indent_list(["create_req = #{request_new}(#{body_new}"].concat(
-    indent([
-      'fetch_auth(@resource)',
-      "'application/json'",
-      "#{custom_resource ? 'resource_to_create' : 'resource_to_request'})"
-    ], request_new.length + 14).split("\n") # 14 = 'create_req = ' + '('
+                      indent([
+                               'fetch_auth(@resource)',
+                               "'application/json'",
+                               "#{custom_resource ? 'resource_to_create' : 'resource_to_request'})"
+                             ], request_new.length + 14).split("\n") # 14 = 'create_req = ' + '('
   ), 4))
 -%>
 <% fetch_assign = object.save_api_results? ? '@fetched = ' : '' -%>
@@ -272,9 +273,9 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 <%   dele_new = "Google::#{product_ns}::Network::Delete.new" -%>
 <%=
   lines(indent_list(["delete_req = #{dele_new}(self_link(@resource)"].concat(
-    indent([
-      'fetch_auth(@resource))'
-    ], dele_new.length + 14).split("\n") # 14 = 'delete_req = ' + '('
+                      indent([
+                               'fetch_auth(@resource))'
+                             ], dele_new.length + 14).split("\n") # 14 = 'delete_req = ' + '('
   ), 4))
 -%>
 <% kind_param = object.kind? ? ", '#{object.kind}'" : '' -%>
@@ -292,7 +293,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 <% end -%>
   def flush
     debug('flush')
-<% # TODO(nelsonjr): Remove @dirty or SQL does not do idempotent updates. -%>
+<%# TODO(nelsonjr): Remove @dirty or SQL does not do idempotent updates. -%>
     # return on !@dirty is for aiding testing (puppet already guarantees that)
     return if @created || @deleted || !@dirty
 <%
@@ -310,11 +311,11 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 -%>
 <%=
   lines(indent_list(["update_req = #{put_new}(self_link(@resource)"].concat(
-    indent([
-      'fetch_auth(@resource)',
-      "'application/json'",
-      "#{custom_resource ? 'resource_to_update' : 'resource_to_request'})"
-    ], put_new.length + 14).split("\n") # 14 = 'update_req = ' + '('
+                      indent([
+                               'fetch_auth(@resource)',
+                               "'application/json'",
+                               "#{custom_resource ? 'resource_to_update' : 'resource_to_request'})"
+                             ], put_new.length + 14).split("\n") # 14 = 'update_req = ' + '('
   ), 4))
 -%>
 <%   if object.async -%>
@@ -355,7 +356,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   private
 <%
   all_props = object.all_user_properties
-  has_boolean = !all_props.select{ |o| o.is_a?(Api::Type::Boolean) }.empty?
+  has_boolean = !all_props.select { |o| o.is_a?(Api::Type::Boolean) }.empty?
 -%>
 <% if has_boolean -%>
 
@@ -373,22 +374,22 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 <%
   all_properties = object.all_user_properties
   has_project_property = \
-     !object.all_user_properties.select { |o| o.name == 'project' }.empty?
+    !object.all_user_properties.select { |o| o.name == 'project' }.empty?
   project_arg = has_project_property ? [] : ['project: resource[:project]']
   r2h_code = [
     '{',
     indent_list(project_arg.concat([
-      'name: resource[:name]',
-      ("kind: '#{object.kind}'" if object.kind?)
-    ]).concat(all_properties.select { |p| p.name != 'name' }.map do |prop|
-      format([
-        ["#{prop.out_name}: resource[:#{prop.out_name}]"],
-        [
-          "#{prop.out_name}:",
-          indent("resource[:#{prop.out_name}]", 2)
-        ]
-      ], 0, 4)
-    end).compact, 2),
+                                     'name: resource[:name]',
+                                     ("kind: '#{object.kind}'" if object.kind?)
+                                   ]).concat(all_properties.reject { |p| p.name == 'name' }.map do |prop|
+                                               format([
+                                                        ["#{prop.out_name}: resource[:#{prop.out_name}]"],
+                                                        [
+                                                          "#{prop.out_name}:",
+                                                          indent("resource[:#{prop.out_name}]", 2)
+                                                        ]
+                                                      ], 0, 4)
+                                             end).compact, 2),
     '}.reject { |_, v| v.nil? }'
   ]
 -%>
@@ -402,14 +403,14 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   prop_code = []
   prop_code << "kind: '#{object.kind}'" if object.kind?
   prop_code.concat(
-    object.properties.select { |p| !p.output }
+    object.properties.reject(&:output)
                      .map do |prop|
                        "#{prop.field_name}: @resource[:#{prop.out_name}]"
                      end
   )
   prop_code.concat(
     (object.parameters || [])
-      .select { |p| p.input }
+      .select(&:input)
       .map do |prop|
         "#{prop.field_name}: @resource[:#{prop.out_name}]"
       end

--- a/templates/puppet/provider_spec.erb
+++ b/templates/puppet/provider_spec.erb
@@ -14,74 +14,75 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :puppet) -%>
+<%= lines(autogen_notice(:puppet)) -%>
 
 require 'spec_helper'
 
 <%
-if object.virtual
-  test_matrix = Provider::TestMatrix.new(template, object, self,
-    exists: {
-      changes: [ # read-only object mistmatch
-        [:no_name, :fail],
-        [:has_name, :fail]
-      ],
-      no_change: [
-        [:no_name, :pass],
-        [:has_name, :pass]
-      ],
-    },
-    missing: [
-      [:no_name, :fail],
-      [:has_name, :fail]
-    ]
-  )
-else
-  test_matrix = Provider::TestMatrix.new(template, object, self,
-    present: {
-      exists: {
-        changes: { # flush
-          no_name: [:pass, :fail],
-          has_name: [:pass, :fail]
-        },
-        no_change: { # no action
-          no_name: [:pass, :fail],
-          has_name: [:pass, :fail]
-        }
-      },
-      missing: { # create
-        # changes == ignore
-        no_name: [:pass, :fail],
-        has_name: [:pass, :fail]
-      }
-    },
-    absent: {
-      exists: { # delete
-        # changes == ignore
-        no_name: [:pass, :fail],
-        has_name: [:pass, :fail]
-      },
-      missing: { # no action
-        # changes == ignore
-        no_name: [:pass, :fail],
-        has_name: [:pass, :fail]
-      }
-    }
-  )
-end
+test_matrix = if object.virtual
+                Provider::TestMatrix.new(template, object, self,
+                                         exists: {
+                                           changes: [ # read-only object mistmatch
+                                             %i[no_name fail],
+                                             %i[has_name fail]
+                                           ],
+                                           no_change: [
+                                             %i[no_name pass],
+                                             %i[has_name pass]
+                                           ]
+                                         },
+                                         missing: [
+                                           %i[no_name fail],
+                                           %i[has_name fail]
+                                         ])
+
+              else
+                Provider::TestMatrix.new(template, object, self,
+                                         present: {
+                                           exists: {
+                                             changes: { # flush
+                                               no_name: %i[pass fail],
+                                               has_name: %i[pass fail]
+                                             },
+                                             no_change: { # no action
+                                               no_name: %i[pass fail],
+                                               has_name: %i[pass fail]
+                                             }
+                                           },
+                                           missing: { # create
+                                             # changes == ignore
+                                             no_name: %i[pass fail],
+                                             has_name: %i[pass fail]
+                                           }
+                                         },
+                                         absent: {
+                                           exists: { # delete
+                                             # changes == ignore
+                                             no_name: %i[pass fail],
+                                             has_name: %i[pass fail]
+                                           },
+                                           missing: { # no action
+                                             # changes == ignore
+                                             no_name: %i[pass fail],
+                                             has_name: %i[pass fail]
+                                           }
+                                         })
+
+              end
 
 prop_data = Provider::TestData::Expectations.new(self, @data_gen)
 manifester = Provider::PuppetTestManifestFormatter.new self
 -%>
 <%=
   lines(format(
-    [
-      ["describe Puppet::Type.type(:#{object.out_name}).provider(:google) do"],
-      [
-        "describe Puppet::Type.type(:#{object.out_name})",
-        indent('.provider(:google) do', 21)
-      ]
-    ]))
+          [
+            ["describe Puppet::Type.type(:#{object.out_name}).provider(:google) do"],
+            [
+              "describe Puppet::Type.type(:#{object.out_name})",
+              indent('.provider(:google) do', 21)
+            ]
+          ]
+  ))
 -%>
   before(:all) do
     cred = Google::FakeAuthorization.new
@@ -95,48 +96,48 @@ manifester = Provider::PuppetTestManifestFormatter.new self
   end
 
 <% if object.virtual -%>
-<% # Object does NOT provides 'ensure' parameter -%>
+<%# Object does NOT provides 'ensure' parameter -%>
 <%= test_matrix.push(:ignore, :exists) -%>
 <%= test_matrix.push(:ignore, :exists, :no_change) -%>
-<%= test_matrix.push(:ignore, :exists, :no_change, [:no_name, :pass]) -%>
+<%= test_matrix.push(:ignore, :exists, :no_change, %i[no_name pass]) -%>
         # TODO(nelsonjr): Implement new test format.
-<%= test_matrix.pop(:ignore, :exists, :no_change, [:no_name, :pass]) -%>
+<%= test_matrix.pop(:ignore, :exists, :no_change, %i[no_name pass]) -%>
 
-<%= test_matrix.push(:ignore, :exists, :no_change, [:has_name, :pass]) -%>
+<%= test_matrix.push(:ignore, :exists, :no_change, %i[has_name pass]) -%>
         # TODO(nelsonjr): Implement new test format.
-<%= test_matrix.pop(:ignore, :exists, :no_change, [:has_name, :pass]) -%>
+<%= test_matrix.pop(:ignore, :exists, :no_change, %i[has_name pass]) -%>
 <%= test_matrix.pop(:ignore, :exists, :no_change) -%>
 
 <%= test_matrix.push(:ignore, :exists, :changes) -%>
-<%= test_matrix.push(:ignore, :exists, :changes, [:no_name, :fail]) -%>
+<%= test_matrix.push(:ignore, :exists, :changes, %i[no_name fail]) -%>
         # TODO(nelsonjr): Implement new test format.
         subject { -> { raise '[placeholder] This should fail.' } }
         it { is_expected.to raise_error(RuntimeError, /placeholder/) }
-<%= test_matrix.pop(:ignore, :exists, :changes, [:no_name, :fail]) -%>
+<%= test_matrix.pop(:ignore, :exists, :changes, %i[no_name fail]) -%>
 
-<%= test_matrix.push(:ignore, :exists, :changes, [:has_name, :fail]) -%>
+<%= test_matrix.push(:ignore, :exists, :changes, %i[has_name fail]) -%>
         # TODO(nelsonjr): Implement new test format.
         subject { -> { raise '[placeholder] This should fail.' } }
         it { is_expected.to raise_error(RuntimeError, /placeholder/) }
-<%= test_matrix.pop(:ignore, :exists, :changes, [:has_name, :fail]) -%>
+<%= test_matrix.pop(:ignore, :exists, :changes, %i[has_name fail]) -%>
 <%= test_matrix.pop(:ignore, :exists, :changes) -%>
 <%= test_matrix.pop(:ignore, :exists) -%>
 
 <%= test_matrix.push(:ignore, :missing) -%>
-<%= test_matrix.push(:ignore, :missing, :ignore, [:no_name, :fail]) -%>
+<%= test_matrix.push(:ignore, :missing, :ignore, %i[no_name fail]) -%>
       # TODO(nelsonjr): Implement new test format.
       subject { -> { raise '[placeholder] This should fail.' } }
       it { is_expected.to raise_error(RuntimeError, /placeholder/) }
-<%= test_matrix.pop(:ignore, :missing, :ignore, [:no_name, :fail]) -%>
+<%= test_matrix.pop(:ignore, :missing, :ignore, %i[no_name fail]) -%>
 
-<%= test_matrix.push(:ignore, :missing, :ignore, [:has_name, :fail]) -%>
+<%= test_matrix.push(:ignore, :missing, :ignore, %i[has_name fail]) -%>
       # TODO(nelsonjr): Implement new test format.
       subject { -> { raise '[placeholder] This should fail.' } }
       it { is_expected.to raise_error(RuntimeError, /placeholder/) }
-<%= test_matrix.pop(:ignore, :missing, :ignore, [:has_name, :fail]) -%>
+<%= test_matrix.pop(:ignore, :missing, :ignore, %i[has_name fail]) -%>
 <%= test_matrix.pop(:ignore, :missing) -%>
 <% else -%>
-<% # Object that provides 'ensure' parameter -%>
+<%# Object that provides 'ensure' parameter -%>
 <%= test_matrix.push(:present) -%>
 <%= test_matrix.push(:present, :exists) -%>
 <%= test_matrix.push(:present, :exists, :no_change) -%>
@@ -371,8 +372,8 @@ manifester = Provider::PuppetTestManifestFormatter.new self
         {
 <%
     export_values = object.exported_properties.map do |p|
-                      "#{p.out_name}: '#{@data_gen.value(p.class, p, 0)}'"
-                    end
+      "#{p.out_name}: '#{@data_gen.value(p.class, p, 0)}'"
+    end
 -%>
 <%= indent_list(export_values, 10) %>
         }

--- a/templates/puppet/puppetlint_spec.rb.erb
+++ b/templates/puppet/puppetlint_spec.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 require 'spec_helper'
 

--- a/templates/puppet/spec_helper.rb.erb
+++ b/templates/puppet/spec_helper.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 #----------------------------------------------------------
 # Setup timezone.

--- a/templates/puppet/test~absent~delete.erb
+++ b/templates/puppet/test~absent~delete.erb
@@ -25,7 +25,7 @@
   # TestObjects instance.
 
   collector = Dependencies::DependencyGraph.new(@data_gen)
-  collector.add(object, 0, (name ? :name : :title), {ensure: 'absent'})
+  collector.add(object, 0, (name ? :name : :title), ensure: 'absent')
 
   # Generate the Puppet manifest using the graph of objects above.
   # This manifest will be ordered by dependencies.
@@ -42,7 +42,7 @@
                                                 path: config_path + %w[before],
                                                 exists: true,
                                                 has_name: name
-                                               }, collector)
+                                              }, collector)
 
   resource_block = resources.flatten(1).uniq.map { |r| lines(r) }.join("\n")
   res_name = "#{object.out_name.capitalize}[title0]"

--- a/templates/puppet/test~absent~no_action.erb
+++ b/templates/puppet/test~absent~no_action.erb
@@ -24,8 +24,7 @@
   # This graph, including the current object, will be stored in a
   # TestObjects instance.
   collector = Dependencies::DependencyGraph.new(@data_gen)
-  collector.add(object, 0, (name ? :name : :title), {ensure: 'absent'})
-
+  collector.add(object, 0, (name ? :name : :title), ensure: 'absent')
 
   # Generate the Puppet manifest using the graph of objects above.
   # This manifest will be ordered by dependencies.
@@ -41,7 +40,6 @@
                                                 exists: false,
                                                 has_name: name
                                               }, collector)
-
 
   resource_block = resources.flatten(1).uniq.map { |r| lines(r) }.join("\n")
   res_name = "#{object.out_name.capitalize}[title0]"

--- a/templates/puppet/test~present~create.erb
+++ b/templates/puppet/test~present~create.erb
@@ -30,7 +30,6 @@
                                               name ? :name : :title,
                                               ensure: 'present')
 
-
   # Creates the expect_network_* statements required for this test.
   # This includes the expect statements for all referenced resources.
   expect_data = @create_data.create_expect_data(config_path + %w[result],
@@ -51,7 +50,7 @@
   references_self_type = false
   collector.each do |obj|
     references_self_type = true if obj.parent && \
-      obj.parent.__resource == obj.object
+                                   obj.parent.__resource == obj.object
   end
 
   resource_block = resources.flatten(1).uniq.map { |r| lines(r) }.join("\n")
@@ -69,21 +68,21 @@
 <%=
   res_name = "#{object.out_name.capitalize}[title0]"
   lines(format([
-    [").catalog.resource('#{res_name}').provider.ensure"],
-    [
-      ").catalog.resource('#{res_name}').provider",
-      indent('.ensure', 2)
-    ],
-    [
-      ").catalog.resource('#{res_name}')",
-      indent('.provider.ensure', 2)
-    ],
-  ], inside_indent))
+                 [").catalog.resource('#{res_name}').provider.ensure"],
+                 [
+                   ").catalog.resource('#{res_name}').provider",
+                   indent('.ensure', 2)
+                 ],
+                 [
+                   ").catalog.resource('#{res_name}')",
+                   indent('.provider.ensure', 2)
+                 ]
+               ], inside_indent))
 -%>
           end
 
-<% # TODO(nelsonjr): Temporarily disable the tests where an object has a
-   # reference to its own type -%>
+<%# TODO(nelsonjr): Temporarily disable the tests where an object has a
+# reference to its own type -%>
 <% if references_self_type -%>
           it 'was expected to be present', broken: true do
             pending('Implement tests where object references its own type.')

--- a/templates/puppet/test~present~no_changes.erb
+++ b/templates/puppet/test~present~no_changes.erb
@@ -34,7 +34,6 @@
                                               name ? :name : :title,
                                               ensure: 'present')
 
-
   # Creates the expect_network_* statements required for this test.
   # This includes the expect statements for all referenced resources.
   expectations = [
@@ -58,7 +57,7 @@
   references_self_type = false
   collector.each do |obj|
     references_self_type = true if obj.parent && \
-      obj.parent.__resource == obj.object
+                                   obj.parent.__resource == obj.object
   end
 -%>
 <% if !cust_before.nil? -%>
@@ -88,12 +87,12 @@
               subject do
 <%=
   lines(format([
-          ["catalog.resource('#{res_name}').provider"],
-          [
-            "catalog.resource('#{res_name}')",
-            "       .provider"
-          ]
-        ], 16))
+                 ["catalog.resource('#{res_name}').provider"],
+                 [
+                   "catalog.resource('#{res_name}')",
+                   '       .provider'
+                 ]
+               ], 16))
 -%>
               end
 
@@ -114,7 +113,7 @@
 <%=    lines(indent(@property.property(prop, index,
                                        @data_gen.comparator(prop),
                                        @data_gen.value(prop.class, prop, index),
-                                        inside_indent),
+                                       inside_indent),
                     inside_indent)) -%>
 <%   end # if !name-%>
 <% end # if references_self_type -%>

--- a/templates/puppet/type.erb
+++ b/templates/puppet/type.erb
@@ -14,14 +14,12 @@
 <% end -%>
 <%= compile('templates/license.erb') -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 <%
   requires = generate_requires(object.all_user_properties)
   requires << 'puppet'
-  unless object.exports.nil?
-    requires << 'google/object_store'
-  end
+  requires << 'google/object_store' unless object.exports.nil?
 -%>
 <%= lines(emit_requires(requires)) -%>
 
@@ -47,14 +45,14 @@ Puppet::Type.newtype(:<%= object.out_name -%>) do
 <% if param.required -%>
 <%=
   lines(format(
-    [
-      ["raise \"\#{ref} required property '#{param.out_name}' is missing\"",
-       'if reference.nil?'].join(' '),
-      [
-        "raise \"\#{ref} required property '#{param.out_name}' is missing\" \\",
-        indent('if reference.nil?', 2)
-      ]
-    ], 4
+          [
+            ["raise \"\#{ref} required property '#{param.out_name}' is missing\"",
+             'if reference.nil?'].join(' '),
+            [
+              "raise \"\#{ref} required property '#{param.out_name}' is missing\" \\",
+              indent('if reference.nil?', 2)
+            ]
+          ], 4
   ))
 -%>
     reference.autorequires
@@ -110,17 +108,20 @@ Puppet::Type.newtype(:<%= object.out_name -%>) do
   format([
     ["newparam(:#{p.out_name}", namevar,
      "parent: #{p.property_type}) do"].compact.join(', '),
-    (indent_list([
-       "newparam(:#{p.out_name}, #{namevar}",
-       # + 12 = newparam(: + ,
-       indent("parent: #{p.property_type}) do", p.out_name.length + 12)
-     ], 0) unless namevar.nil?),
+    (unless namevar.nil?
+       indent_list([
+                     "newparam(:#{p.out_name}, #{namevar}",
+                     # + 12 = newparam(: + ,
+                     indent("parent: #{p.property_type}) do", p.out_name.length + 12)
+                   ], 0)
+     end),
     indent_list([
       "newparam(:#{p.out_name}",
       (indent(namevar, 9) unless namevar.nil?),
       indent("parent: #{p.property_type}) do", 9)
-    ].compact, 0),
-  ].compact, 2) %>
+    ].compact, 0)
+  ].compact, 2)
+%>
 <%= format_description(p, 4, 'desc') %>
 <%= property_body(p) -%>
 <% unless p.validation.nil? -%>
@@ -132,20 +133,19 @@ Puppet::Type.newtype(:<%= object.out_name -%>) do
 <% end -%>
 <% end -%>
 <% object.properties.each do |p|
-      Google::LOGGER.info "Generating #{object.name}.#{p.name}: #{p.type}"
--%>
+      Google::LOGGER.info "Generating #{object.name}.#{p.name}: #{p.type}" -%>
 
 <%=
-  new_property_len = 'newproperty('.length
+  new_property_len = 'newperty('.length
   format([
-    ["newproperty(:#{p.out_name}, parent: #{p.property_type}) do"],
-    [
-      "newproperty(:#{p.out_name},",
-      indent("parent: #{p.property_type}) do", new_property_len)
-    ],
-  ], 2)
+           ["newproperty(:#{p.out_name}, parent: #{p.property_type}) do"],
+           [
+             "newproperty(:#{p.out_name},",
+             indent("parent: #{p.property_type}) do", new_property_len)
+           ]
+         ], 2)
 %>
-<%= format_description(p, 4, 'desc', p.output ? "(output only)" : "") %>
+<%= format_description(p, 4, 'desc', p.output ? '(output only)' : '') %>
 <%= property_body(p) -%>
   end
 <% end -%>

--- a/templates/resourceref_mocks.erb
+++ b/templates/resourceref_mocks.erb
@@ -70,7 +70,7 @@ end
   self_link_ref = emit_link("self_link_#{ref_underscore_name}",
                             self_link_url(prop_ref),
                             false)
-  self_link_ref = self_link_ref.gsub("expand_variables",
+  self_link_ref = self_link_ref.gsub('expand_variables',
                                      "expand_variables_#{ref_underscore_name}")
 -%>
 <%= lines(self_link_ref, 1) -%>

--- a/templates/terraform/constants/disk.erb
+++ b/templates/terraform/constants/disk.erb
@@ -202,7 +202,7 @@ func diskEncryptionKeyDiffSuppress(k, old, new string, d *schema.ResourceData) b
       return d.Get("disk_encryption_key_raw").(string) != ""
     } else if new == "1" && old == "0" {
       // This will be handled by diffing the 'raw_key' attribute.
-      return true 
+      return true
     }
   } else if strings.HasSuffix(k, "raw_key") {
     disk_key := d.Get("disk_encryption_key_raw").(string)

--- a/templates/terraform/custom_expand/encryption_key_expand.erb
+++ b/templates/terraform/custom_expand/encryption_key_expand.erb
@@ -8,7 +8,7 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
 		req = append(req, outMap)
   <% if property.name == "diskEncryptionKey" -%>
 	} else {
-		// Check alternative setting? 
+		// Check alternative setting?
 		if altV, ok := d.GetOk("disk_encryption_key_raw"); ok && altV != "" {
 			outMap := make(map[string]interface{})
 			outMap["rawKey"] = altV

--- a/templates/terraform/expand_resource_ref.erb
+++ b/templates/terraform/expand_resource_ref.erb
@@ -1,5 +1,5 @@
 <%
-	resource_type = property.resource_ref.base_url.split('/').last
+  resource_type = property.resource_ref.base_url.split('/').last
 -%>
 <% if property.resource_ref.base_url.include?('{{region}}') -%>
 parseRegionalFieldValue("<%= resource_type -%>", <%= var_name -%>, "project", "region", "zone", d, config, true)

--- a/templates/terraform/nested_property_documentation.erb
+++ b/templates/terraform/nested_property_documentation.erb
@@ -2,7 +2,7 @@
   nested_properties = nested_properties(property)
   if !nested_properties.empty?
 -%>
-The `<%= Google::StringUtils.underscore(property.name) -%>` block <%= if property.output then "contains" else "supports" end -%>:
+The `<%= Google::StringUtils.underscore(property.name) -%>` block <%= property.output ? 'contains' : 'supports' -%>:
 <% nested_properties.each do |prop| -%>
 <%= lines(build_property_documentation(prop)) -%>
 <% end -%>

--- a/templates/terraform/post_import/disk.erb
+++ b/templates/terraform/post_import/disk.erb
@@ -18,7 +18,7 @@ if zone, err := getZone(d, config); err != nil || zone == "" {
   getDisk := func(zone string) (interface{}, error) {
     return config.clientCompute.Disks.Get(project, zone, d.Id()).Do()
   }
-  resource, err := getZonalResourceFromRegion(getDisk, region, config.clientCompute, project) 
+  resource, err := getZonalResourceFromRegion(getDisk, region, config.clientCompute, project)
   if err != nil {
     return nil, err
   }

--- a/templates/terraform/provider_gen.erb
+++ b/templates/terraform/provider_gen.erb
@@ -12,19 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 <% end -%>
-<%= lines(autogen_notice :go) -%>
+<%= lines(autogen_notice(:go)) -%>
 
 package google
 
 import "github.com/hashicorp/terraform/helper/schema"
 
 
-<% if product_ns == 'Resourcemanager'
-		product_ns = 'ResourceManager'
-end -%>
+<% product_ns = 'ResourceManager' if product_ns == 'Resourcemanager' -%>
 
 var Generated<%= product_ns -%>ResourcesMap = map[string]*schema.Resource{
-<% product.objects.reject { |r| r.exclude }.each do |object| -%>
+<% product.objects.reject(&:exclude).each do |object| -%>
 <% resource_name = product_ns + object.name -%>
 	"google_<%= Google::StringUtils.underscore(resource_name) -%>": resource<%= resource_name -%>(),
 <% end -%>

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 <% end -%>
-<%= lines(autogen_notice :go) -%>
+<%= lines(autogen_notice(:go)) -%>
 
 package google
 
 <%= lines(compile(object.custom_code.constants)) if object.custom_code.constants -%>
 
 <%
-	resource_name = product_ns + object.name
-	properties = object.all_user_properties
-	settable_properties = properties.reject(&:output)
-	api_name_lower = String.new(product_ns)
-	api_name_lower[0] = api_name_lower[0].downcase
-	has_project = object.base_url.include?("{{project}}")
-	has_self_link = (object.exports || []).any? { |e| e.is_a?(Api::Type::SelfLink)}
+  resource_name = product_ns + object.name
+  properties = object.all_user_properties
+  settable_properties = properties.reject(&:output)
+  api_name_lower = String.new(product_ns)
+  api_name_lower[0] = api_name_lower[0].downcase
+  has_project = object.base_url.include?('{{project}}')
+  has_self_link = (object.exports || []).any? { |e| e.is_a?(Api::Type::SelfLink) }
 -%>
 
 func resource<%= resource_name -%>() *schema.Resource {
@@ -172,9 +172,9 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
 			from the list that gets returned.  self_link_query is a field which
 			describes a list result from a read. -%>
     <%= compile_template('templates/terraform/self_link_query.erb',
-												 object: object,
-												 settable_properties: settable_properties,
-												 resource_name: resource_name) -%>
+                         object: object,
+                         settable_properties: settable_properties,
+                         resource_name: resource_name) -%>
 <% end -%>
 
 <% if object.custom_code.decoder -%>
@@ -241,8 +241,8 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 		<% props.each do |prop| -%>
       <% if prop.update_statement -%>
         "<%= prop.api_name -%>": <%= compile_template(prop.update_statement,
-                                                     prefix: resource_name,
-                                                     property: prop) -%>
+                                                      prefix: resource_name,
+                                                      property: prop) -%>
       <% else -%>
 			"<%= prop.api_name -%>": <%= prop.api_name -%>Prop,
       <% end -%>
@@ -382,7 +382,7 @@ func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{
   <%= lines(compile(object.custom_code.custom_import)) -%>
 <% else -%>
 	config := meta.(*Config)
-	parseImportId([]string{"<%= import_id_formats(object).map{|s| format2regex s}.join('","') -%>"}, d, config)
+	parseImportId([]string{"<%= import_id_formats(object).map { |s| format2regex s }.join('","') -%>"}, d, config)
 
 	// Replace import id for the resource id
 	id, err := replaceVars(d, config, "<%= object.id_format -%>")

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -18,15 +18,15 @@
   properties = object.all_user_properties
 -%>
 ---
-<%= lines(autogen_notice :yaml) -%>
+<%= lines(autogen_notice(:yaml)) -%>
 layout: "google"
 page_title: "Google: google_<%= api_name_lower -%>_<%= resource_name -%>"
-sidebar_current: "docs-google-<%= api_name_lower -%>-<%= resource_name.gsub("_", "-") -%>"
+sidebar_current: "docs-google-<%= api_name_lower -%>-<%= resource_name.tr('_', '-') -%>"
 description: |-
 <%= indent(Google::StringUtils.first_sentence(object.description), 2) %>
 ---
 
-# google\_<%= api_name_lower -%>\_<%= resource_name.gsub("_", "\\_") %>
+# google\_<%= api_name_lower -%>\_<%= resource_name.gsub('_', '\\_') %>
 
 <%= lines(object.description) -%>
 

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -41,8 +41,8 @@
 <% end # property.validation.nil?  -%>
 <% if property.is_a?(Api::Type::Enum) && property.validation.nil? -%>
 <%
-	enum_values = property.values
-	enum_values.push "" unless property.required
+  enum_values = property.values
+  enum_values.push '' unless property.required
 -%>
 	ValidateFunc: validation.StringInSlice([]string{"<%= enum_values.join '","' -%>"}, false),
 <% end -%>

--- a/templates/terraform/self_link_query.erb
+++ b/templates/terraform/self_link_query.erb
@@ -34,4 +34,3 @@
 		d.SetId("")
 		return nil
 	}
-

--- a/templates/test_constants.rb.erb
+++ b/templates/test_constants.rb.erb
@@ -14,7 +14,7 @@
 <% end -%>
 <%= compile 'templates/license.erb' -%>
 
-<%= lines(autogen_notice :ruby) -%>
+<%= lines(autogen_notice(:ruby)) -%>
 
 <%
 def data_to_constant(name, data)
@@ -38,14 +38,14 @@ end
     source = info[:source]
     if source.size == 1
       [
-        "# Constants for: #{source.first.map { |s| s.to_s }.join('.')}",
+        "# Constants for: #{source.first.map(&:to_s).join('.')}",
         data_to_constant(name, info[:data])
       ]
     else # source.size == 1
       [
         '# Constants for the following objects:',
         source.map do |ss|
-          t = ss.map { |s| s.to_s }.join('.')
+          t = ss.map(&:to_s).join('.')
           "\# - #{t}"
         end,
         data_to_constant(name, info[:data])
@@ -56,11 +56,11 @@ end
 module GoogleTests
 <%= lines(indent(emit_rubocop(binding, :module,
                               %w[GoogleTests Constants].join('::'), :disabled),
-          2)) -%>
+                 2)) -%>
   module Constants
 <%= lines(indent(var_map.map { |v| lines(v) }.join("\n"), 4)) -%>
   end
 <%= lines(indent(emit_rubocop(binding, :module,
                               %w[GoogleTests Constants].join('::'), :enabled),
-          2)) -%>
+                 2)) -%>
 end

--- a/templates/transport.erb
+++ b/templates/transport.erb
@@ -32,13 +32,13 @@ end
 def fetch_wrapped_resource(resource, kind, wrap_kind, wrap_path)
 <%=
   lines(format(
-    [
-      'self.class.fetch_wrapped_resource(resource, kind, wrap_kind, wrap_path)',
-      [
-        'self.class.fetch_wrapped_resource(resource, kind, wrap_kind,',
-        indent('wrap_path)', 34) # 34 = align with ( previous line
-      ]
-    ], 2, inside_indent
+          [
+            'self.class.fetch_wrapped_resource(resource, kind, wrap_kind, wrap_path)',
+            [
+              'self.class.fetch_wrapped_resource(resource, kind, wrap_kind,',
+              indent('wrap_path)', 34) # 34 = align with ( previous line
+            ]
+          ], 2, inside_indent
   ))
 -%>
 end


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
This change does not affect Magic Modules output.

I found a gem called [erb-lint](https://github.com/Shopify/erb-lint) that does some great linting on ERB templates.

I added the gem to the Gemfile and then turned off some of its linting rules. I added explanations for which ones I turned on and off. There's a lot of current errors that erb-lint is throwing.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Adding linting to ERB templates
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
