### PR TITLE
Ansible CI changes - ansible should run all products

### DIFF
--- a/.ci/magic-modules/generate-ansible.sh
+++ b/.ci/magic-modules/generate-ansible.sh
@@ -9,7 +9,10 @@ set -e
 pushd magic-modules-branched
 LAST_COMMIT_AUTHOR="$(git log --pretty="%an <%ae>" -n1 HEAD)"
 bundle install
-bundle exec compiler -p products/compute -e ansible -o "build/ansible/"
+for i in $(find products/ -name 'ansible.yaml' -printf '%h\n');
+do
+  bundle exec compiler -p $i -e ansible -o "build/ansible/"
+done
 
 # This command can crash - if that happens, the script should not fail.
 set +e


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Ansible should run all products, not just compute.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Ansible CI changes - ansible should run all products
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
## [ansible]
Bringing Ansible to HEAD
