### PR TITLE
Run rspec in parallel for MM tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'rake'
 
 group :test do
   gem 'mocha'
+  gem 'parallel_tests'
   gem 'rspec'
   gem 'rubocop'
   gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,8 @@ GEM
     mocha (1.3.0)
       metaclass (~> 0.0.1)
     parallel (1.12.1)
+    parallel_tests (2.21.3)
+      parallel
     parser (2.4.0.2)
       ast (~> 2.3)
     powerpack (0.1.1)
@@ -51,6 +53,7 @@ PLATFORMS
 DEPENDENCIES
   binding_of_caller
   mocha
+  parallel_tests
   rake
   rspec
   rubocop

--- a/spec/data/terraform-config.yaml
+++ b/spec/data/terraform-config.yaml
@@ -12,9 +12,4 @@
 # limitations under the License.
 
 --- !ruby/object:Provider::Terraform::Config
-objects: !ruby/object:Api::Resource::HashArray
-  BackendBucket:
-    id: "{{name}}"
-    ignore: ["id"]
-    validation:
-      name: "^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$"
+overrides: !ruby/object:Provider::ResourceOverrides

--- a/spec/provider_terraform_import_spec.rb
+++ b/spec/provider_terraform_import_spec.rb
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 require 'spec_helper'
+require 'provider/terraform'
 
 class File
   class << self
@@ -22,14 +23,17 @@ end
 
 describe Provider::Terraform do
   context 'static' do
-    let(:config) { Provider::Config.parse('spec/data/terraform-config.yaml') }
     let(:product) { Api::Compiler.new('spec/data/good-file.yaml').run }
+    let(:config) do
+      Provider::Config.parse('spec/data/terraform-config.yaml', product)
+    end
     let(:provider) { Provider::Terraform.new(config, product) }
 
     before do
       allow_open 'spec/data/good-file.yaml'
       allow_open 'spec/data/terraform-config.yaml'
       product.validate
+      config.validate
     end
 
     describe '#import_id_formats' do

--- a/spec/provider_terraform_spec.rb
+++ b/spec/provider_terraform_spec.rb
@@ -22,14 +22,17 @@ end
 
 describe Provider::Terraform do
   context 'good file product' do
-    let(:config) { Provider::Config.parse('spec/data/terraform-config.yaml') }
     let(:product) { Api::Compiler.new('spec/data/good-file.yaml').run }
+    let(:config) do
+      Provider::Config.parse('spec/data/terraform-config.yaml', product)
+    end
     let(:provider) { Provider::Terraform.new(config, product) }
 
     before do
       allow_open 'spec/data/good-file.yaml'
       allow_open 'spec/data/terraform-config.yaml'
       product.validate
+      config.validate
     end
 
     describe '#format2regex' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,4 +62,4 @@ end
 
 require 'pp'
 
-Google::LOGGER.info 'Runing tests'
+Google::LOGGER.info 'Running tests'

--- a/tasks/rspec.rb
+++ b/tasks/rspec.rb
@@ -11,8 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'rspec/core/rake_task'
+require 'parallel_tests'
 
 namespace 'test' do
-  RSpec::Core::RakeTask.new(:spec)
+  desc 'Run RSpec code example'
+  task :spec do |_, _|
+    abort unless system('parallel_rspec spec/')
+  end
 end


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->

Checks the box for the MM tests in #72. I will add support for puppet and chef test in a follow-up PR.

The previous `spec:test` target wasn't running some of the tests and they were failing. I fixed them.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
## [ansible]
