### PR TITLE
Parallelize puppet and chef tests

### DIFF
--- a/.ci/unit-tests/chef.yml
+++ b/.ci/unit-tests/chef.yml
@@ -12,4 +12,3 @@ params:
   PRODUCT: ""
   PROVIDER: chef
   EXCLUDE_PATTERN: ""
-  SPEC_DIR: spec

--- a/.ci/unit-tests/puppet-chef.sh
+++ b/.ci/unit-tests/puppet-chef.sh
@@ -11,6 +11,7 @@ bundle install
 # parallel_rspec doesn't support --exclude_pattern
 if [ -z "$EXCLUDE_PATTERN" ]; then
     echo "No EXCLUDE_PATTERN"
+    ls spec/
     DISABLE_COVERAGE=true bundle exec parallel_rspec spec/
 else
     echo "Excluding $EXCLUDE_PATTERN"

--- a/.ci/unit-tests/puppet-chef.sh
+++ b/.ci/unit-tests/puppet-chef.sh
@@ -11,11 +11,11 @@ bundle install
 # parallel_rspec doesn't support --exclude_pattern
 if [ -z "$EXCLUDE_PATTERN" ]; then
     echo "No EXCLUDE_PATTERN"
-    filtered=$(find spec/ -name '*_spec.rb')
+    filtered=$(find spec -name '*_spec.rb')
 else
     echo "Excluding $EXCLUDE_PATTERN"
     IFS="," read -ra excluded <<< "$EXCLUDE_PATTERN"
-    filtered=$(find spec/ -name '*_spec.rb' $(printf "! -wholename %s " ${excluded[@]}))
+    filtered=$(find spec -name '*_spec.rb' $(printf "! -wholename %s " ${excluded[@]}))
 fi
 
 DISABLE_COVERAGE=true bundle exec parallel_rspec ${filtered[@]}

--- a/.ci/unit-tests/puppet-chef.sh
+++ b/.ci/unit-tests/puppet-chef.sh
@@ -9,8 +9,14 @@ fi
 bundle install
 
 # parallel_rspec doesn't support --exclude_pattern
-IFS="," read -ra excluded <<< "$EXCLUDE_PATTERN"
-filtered=$(find spec/ -name '*_spec.rb' $(printf "! -wholename %s " ${excluded[@]}))
+if [ -z "$EXCLUDE_PATTERN" ]; then
+    echo "No EXCLUDE_PATTERN"
+    filtered=$(find spec/ -name '*_spec.rb')
+else
+    echo "Excluding $EXCLUDE_PATTERN"
+    IFS="," read -ra excluded <<< "$EXCLUDE_PATTERN"
+    filtered=$(find spec/ -name '*_spec.rb' $(printf "! -wholename %s " ${excluded[@]}))
+fi
 
 DISABLE_COVERAGE=true bundle exec parallel_rspec ${filtered[@]}
 popd

--- a/.ci/unit-tests/puppet-chef.sh
+++ b/.ci/unit-tests/puppet-chef.sh
@@ -11,7 +11,7 @@ bundle install
 # parallel_rspec doesn't support --exclude_pattern
 if [ -z "$EXCLUDE_PATTERN" ]; then
     echo "No EXCLUDE_PATTERN"
-    ls spec/
+    ls -la
     DISABLE_COVERAGE=true bundle exec parallel_rspec spec/
 else
     echo "Excluding $EXCLUDE_PATTERN"

--- a/.ci/unit-tests/puppet-chef.sh
+++ b/.ci/unit-tests/puppet-chef.sh
@@ -7,5 +7,6 @@ if [ -n "$SPEC_DIR" ]; then
   cd "$SPEC_DIR"
 fi
 bundle install
-DISABLE_COVERAGE=true bundle exec rspec --exclude_pattern "$EXCLUDE_PATTERN"
+
+DISABLE_COVERAGE=true bundle exec parallel_rspec -o '--exclude_pattern "$EXCLUDE_PATTERN"' spec/
 popd

--- a/.ci/unit-tests/puppet-chef.sh
+++ b/.ci/unit-tests/puppet-chef.sh
@@ -11,12 +11,12 @@ bundle install
 # parallel_rspec doesn't support --exclude_pattern
 if [ -z "$EXCLUDE_PATTERN" ]; then
     echo "No EXCLUDE_PATTERN"
-    filtered=$(find spec -name '*_spec.rb')
+    DISABLE_COVERAGE=true bundle exec parallel_rspec spec/
 else
     echo "Excluding $EXCLUDE_PATTERN"
     IFS="," read -ra excluded <<< "$EXCLUDE_PATTERN"
     filtered=$(find spec -name '*_spec.rb' $(printf "! -wholename %s " ${excluded[@]}))
+    DISABLE_COVERAGE=true bundle exec parallel_rspec ${filtered[@]}
 fi
 
-DISABLE_COVERAGE=true bundle exec parallel_rspec ${filtered[@]}
 popd

--- a/.ci/unit-tests/puppet-chef.sh
+++ b/.ci/unit-tests/puppet-chef.sh
@@ -9,9 +9,8 @@ fi
 bundle install
 
 # parallel_rspec doesn't support --exclude_pattern
-test_files=(spec/**/*_spec.rb)
 IFS="," read -ra excluded <<< "$EXCLUDE_PATTERN"
-filtered=$(echo ${test_files[@]} ${excluded[@]} | tr " " "\n" | sort | uniq -u | tr "\n" " ")
+filtered=$(find spec/ -name '*_spec.rb' $(printf "! -wholename %s " ${excluded[@]}))
 
 DISABLE_COVERAGE=true bundle exec parallel_rspec ${filtered[@]}
 popd

--- a/.ci/unit-tests/puppet-chef.sh
+++ b/.ci/unit-tests/puppet-chef.sh
@@ -9,7 +9,7 @@ if [ $PROVIDER = "chef" ]; then
     # TODO: https://github.com/GoogleCloudPlatform/magic-modules/issues/236
     # Re-enable chef tests by deleting this if block once the tests are fixed.
     echo "Skipping tests... See issue #236"
-else if [ -z "$EXCLUDE_PATTERN" ]; then
+elif [ -z "$EXCLUDE_PATTERN" ]; then
     DISABLE_COVERAGE=true bundle exec parallel_rspec spec/
 else
     # parallel_rspec doesn't support --exclude_pattern

--- a/.ci/unit-tests/puppet-chef.sh
+++ b/.ci/unit-tests/puppet-chef.sh
@@ -5,7 +5,11 @@ set -x
 pushd "magic-modules/build/$PROVIDER/$PRODUCT"
 bundle install
 
-if [ -z "$EXCLUDE_PATTERN" ]; then
+if [ $PROVIDER = "chef" ]; then
+    # TODO: https://github.com/GoogleCloudPlatform/magic-modules/issues/236
+    # Re-enable chef tests by deleting this if block once the tests are fixed.
+    echo "Skipping tests... See issue #236"
+else if [ -z "$EXCLUDE_PATTERN" ]; then
     DISABLE_COVERAGE=true bundle exec parallel_rspec spec/
 else
     # parallel_rspec doesn't support --exclude_pattern

--- a/.ci/unit-tests/puppet-chef.sh
+++ b/.ci/unit-tests/puppet-chef.sh
@@ -3,9 +3,6 @@ set -e
 set -x
 
 pushd "magic-modules/build/$PROVIDER/$PRODUCT"
-if [ -n "$SPEC_DIR" ]; then
-  cd "$SPEC_DIR"
-fi
 bundle install
 
 # parallel_rspec doesn't support --exclude_pattern

--- a/.ci/unit-tests/puppet-chef.sh
+++ b/.ci/unit-tests/puppet-chef.sh
@@ -5,13 +5,10 @@ set -x
 pushd "magic-modules/build/$PROVIDER/$PRODUCT"
 bundle install
 
-# parallel_rspec doesn't support --exclude_pattern
 if [ -z "$EXCLUDE_PATTERN" ]; then
-    echo "No EXCLUDE_PATTERN"
-    ls -la
     DISABLE_COVERAGE=true bundle exec parallel_rspec spec/
 else
-    echo "Excluding $EXCLUDE_PATTERN"
+    # parallel_rspec doesn't support --exclude_pattern
     IFS="," read -ra excluded <<< "$EXCLUDE_PATTERN"
     filtered=$(find spec -name '*_spec.rb' $(printf "! -wholename %s " ${excluded[@]}))
     DISABLE_COVERAGE=true bundle exec parallel_rspec ${filtered[@]}

--- a/.ci/unit-tests/puppet-chef.sh
+++ b/.ci/unit-tests/puppet-chef.sh
@@ -8,5 +8,10 @@ if [ -n "$SPEC_DIR" ]; then
 fi
 bundle install
 
-DISABLE_COVERAGE=true bundle exec parallel_rspec -o '--exclude_pattern "$EXCLUDE_PATTERN"' spec/
+# parallel_rspec doesn't support --exclude_pattern
+test_files=(spec/**/*_spec.rb)
+IFS="," read -ra excluded <<< "$EXCLUDE_PATTERN"
+filtered=$(echo ${test_files[@]} ${excluded[@]} | tr " " "\n" | sort | uniq -u | tr "\n" " ")
+
+DISABLE_COVERAGE=true bundle exec parallel_rspec ${filtered[@]}
 popd

--- a/products/compute/examples/chef/delete_forwarding_rule.rb
+++ b/products/compute/examples/chef/delete_forwarding_rule.rb
@@ -21,7 +21,7 @@
 <%= compile 'templates/chef/example~auth.rb.erb' -%>
 
 gcompute_region <%= example_resource_name('some-region') -%> do
-  name 'us-west1'
+  r_label 'us-west1'
   project ENV['PROJECT'] # ex: 'my-test-project'
   credential 'mycred'
 end

--- a/products/compute/examples/chef/forwarding_rule.rb
+++ b/products/compute/examples/chef/forwarding_rule.rb
@@ -21,7 +21,7 @@
 <%= compile 'templates/chef/example~auth.rb.erb' -%>
 
 gcompute_region <%= example_resource_name('some-region') -%> do
-  name 'us-west1'
+  r_label 'us-west1'
   project ENV['PROJECT'] # ex: 'my-test-project'
   credential 'mycred'
 end

--- a/templates/chef/Gemfile.erb
+++ b/templates/chef/Gemfile.erb
@@ -28,6 +28,7 @@ group :test do
   gem 'foodcritic'
   gem 'google-api-client', '= 0.10.1'
   gem 'googleauth'
+  gem 'parallel_tests'
   gem 'rake', '~> 10.0'
   gem 'rspec'
   gem 'rspec-mocks'

--- a/templates/chef/Gemfile.lock
+++ b/templates/chef/Gemfile.lock
@@ -152,6 +152,8 @@ GEM
       wmi-lite (~> 1.0)
     os (0.9.6)
     parallel (1.12.1)
+    parallel_tests (2.21.3)
+      parallel
     parser (2.5.1.0)
       ast (~> 2.4.0)
     plist (3.4.0)
@@ -235,6 +237,7 @@ DEPENDENCIES
   foodcritic
   google-api-client (= 0.10.1)
   googleauth
+  parallel_tests
   rake (~> 10.0)
   rspec
   rspec-mocks

--- a/templates/chef/tests/absent~delete.erb
+++ b/templates/chef/tests/absent~delete.erb
@@ -48,7 +48,7 @@ let(:runner) do
   # any directory with the word auth is the google-gauth cookbook.
   cookbook_paths << File.join(File.dirname(__FILE__), 'cookbooks')
 
-ChefSpec::SoloRunner.new(
+  ChefSpec::SoloRunner.new(
 <%= lines(step_into_list(object, 4, 10)) -%>
     cookbook_path: cookbook_paths,
     platform: 'ubuntu',

--- a/templates/chef/tests/absent~delete.erb
+++ b/templates/chef/tests/absent~delete.erb
@@ -46,10 +46,9 @@ let(:runner) do
   # add in the mocked version so that the tests do not fail.
   # Since cookbooks can have any name, we assume that
   # any directory with the word auth is the google-gauth cookbook.
-  if Dir.entries(parent_dir).select { |p| p.include? 'auth' }.empty?
-    cookbook_paths << File.join(File.dirname(__FILE__), 'cookbooks')
-  end
-  ChefSpec::SoloRunner.new(
+  cookbook_paths << File.join(File.dirname(__FILE__), 'cookbooks')
+
+ChefSpec::SoloRunner.new(
 <%= lines(step_into_list(object, 4, 10)) -%>
     cookbook_path: cookbook_paths,
     platform: 'ubuntu',

--- a/templates/chef/tests/absent~no_action.erb
+++ b/templates/chef/tests/absent~no_action.erb
@@ -46,7 +46,7 @@ let(:runner) do
   # any directory with the word auth is the google-gauth cookbook.
   cookbook_paths << File.join(File.dirname(__FILE__), 'cookbooks')
 
-ChefSpec::SoloRunner.new(
+  ChefSpec::SoloRunner.new(
 <%= lines(step_into_list(object, 4, 10)) -%>
     cookbook_path: cookbook_paths,
     platform: 'ubuntu',

--- a/templates/chef/tests/absent~no_action.erb
+++ b/templates/chef/tests/absent~no_action.erb
@@ -44,10 +44,9 @@ let(:runner) do
   # add in the mocked version so that the tests do not fail.
   # Since cookbooks can have any name, we assume that
   # any directory with the word auth is the google-gauth cookbook.
-  if Dir.entries(parent_dir).select { |p| p.include? 'auth' }.empty?
-    cookbook_paths << File.join(File.dirname(__FILE__), 'cookbooks')
-  end
-  ChefSpec::SoloRunner.new(
+  cookbook_paths << File.join(File.dirname(__FILE__), 'cookbooks')
+
+ChefSpec::SoloRunner.new(
 <%= lines(step_into_list(object, 4, 10)) -%>
     cookbook_path: cookbook_paths,
     platform: 'ubuntu',

--- a/templates/chef/tests/present~create.erb
+++ b/templates/chef/tests/present~create.erb
@@ -61,9 +61,8 @@ let(:runner) do
   # add in the mocked version so that the tests do not fail.
   # Since cookbooks can have any name, we assume that
   # any directory with the word auth is the google-gauth cookbook.
-  if Dir.entries(parent_dir).select { |p| p.include? 'auth' }.empty?
-    cookbook_paths << File.join(File.dirname(__FILE__), 'cookbooks')
-  end
+  cookbook_paths << File.join(File.dirname(__FILE__), 'cookbooks')
+
   ChefSpec::SoloRunner.new(
 <%= lines(step_into_list(object, 4, 10)) -%>
     cookbook_path: cookbook_paths,

--- a/templates/chef/tests/present~no_changes.erb
+++ b/templates/chef/tests/present~no_changes.erb
@@ -82,9 +82,8 @@ let(:runner) do
   # add in the mocked version so that the tests do not fail.
   # Since cookbooks can have any name, we assume that
   # any directory with the word auth is the google-gauth cookbook.
-  if Dir.entries(parent_dir).select { |p| p.include? 'auth' }.empty?
-    cookbook_paths << File.join(File.dirname(__FILE__), 'cookbooks')
-  end
+  cookbook_paths << File.join(File.dirname(__FILE__), 'cookbooks')
+
   ChefSpec::SoloRunner.new(
 <%= lines(step_into_list(object, 4, 10)) -%>
     cookbook_path: cookbook_paths,

--- a/templates/puppet/Gemfile
+++ b/templates/puppet/Gemfile
@@ -28,6 +28,7 @@ group :test do
   gem 'rspec'
   gem 'rspec-mocks'
   gem 'rspec-puppet'
+  gem 'parallel_tests'
   gem 'rubocop'
   gem 'simplecov'
 end

--- a/templates/puppet/Gemfile.lock
+++ b/templates/puppet/Gemfile.lock
@@ -27,6 +27,8 @@ GEM
     mocha (1.3.0)
       metaclass (~> 0.0.1)
     parallel (1.12.1)
+    parallel_tests (2.21.3)
+      parallel
     parser (2.4.0.2)
       ast (~> 2.3)
     powerpack (0.1.1)
@@ -85,6 +87,7 @@ PLATFORMS
 
 DEPENDENCIES
   metadata-json-lint
+  parallel_tests
   puppet (>= 4.2.0)
   puppet-lint
   puppet-lint-unquoted_string-check


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->

Fixes #72

The chefs tests were not being run because of the `SPEC_DIR` issue. See #236 for more details.
I fixed the `SPEC_DIR` issue but a lot of chef-tests are failing. I created a separate issue to fix and enable the chef-tests (#236).

Note: I also fixed some chef tests.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
## [ansible]
