### PR TITLE
25 lines to a method, not 15.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,7 +29,7 @@ Metrics/ModuleLength:
     - 'compile/core.rb'
 
 Metrics/MethodLength:
-  Max: 15
+  Max: 25
 
 Security/Eval:
   Exclude:

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -345,7 +345,6 @@ module Api
     #                     avoid self-referencing objects.
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/PerceivedComplexity
     def resourcerefs_for_properties(props, original_obj)
       rrefs = []

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -179,7 +179,6 @@ module Provider
         end.any?
       end
 
-      # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/AbcSize
       def resourceref_hash_for_links(link, object)
         props_in_link = link.scan(/{([a-z_]*)}/).flatten

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -142,7 +142,6 @@ module Provider
 
       # Builds out the minimal YAML block for DOCUMENTATION
       # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/MethodLength
       def minimal_doc_block(prop, _object, spaces)
         required = prop.required && !prop.default_value ? 'true' : 'false'
         [

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -177,7 +177,6 @@ module Provider
 
       private
 
-      # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/CyclomaticComplexity
       def build_task(state, hash, object, noop = false)
         verb = verbs[state.to_sym]

--- a/provider/ansible/module.rb
+++ b/provider/ansible/module.rb
@@ -64,7 +64,6 @@ module Provider
 
       # Returns a formatted string represented the choices of an enum
       # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/MethodLength
       def choices_enum(prop, spaces)
         name = Google::StringUtils.underscore(prop.out_name)
         type = "type=#{quote_string(python_type(prop))}"

--- a/provider/ansible/request.rb
+++ b/provider/ansible/request.rb
@@ -87,7 +87,6 @@ module Provider
         ].join(' ')
       end
 
-      # rubocop:disable Metrics/MethodLength
       def response_output(prop, hash_name, module_name)
         # If input true, treat like request, but use module names.
         return request_output(prop, "#{module_name}.params", module_name) \

--- a/provider/ansible/resource_override.rb
+++ b/provider/ansible/resource_override.rb
@@ -32,8 +32,6 @@ module Provider
     # Product specific overriden properties for Ansible
     class ResourceOverride < Provider::ResourceOverride
       include OverrideProperties
-
-      # rubocop:disable Metrics/MethodLength
       def validate
         super
 

--- a/provider/ansible/selflink.rb
+++ b/provider/ansible/selflink.rb
@@ -46,7 +46,6 @@ module Provider
         end
       end
 
-      # rubocop:disable Metrics/MethodLength
       def selflink_function(resource)
         url = self_link_url(resource).gsub('{project}', '.*')
                                      .gsub('{name}', '[a-z1-9\-]*')

--- a/provider/chef.rb
+++ b/provider/chef.rb
@@ -72,7 +72,6 @@ module Provider
     end
 
     # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
     def prop_decl(prop)
@@ -125,7 +124,6 @@ module Provider
     # Returns a list of all resource types being tested
     # ChefSpec requires this list to include all ResourceRefs
     # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
     def step_into_list(object, indent, start_indent)
       steps = [object.out_name].concat(object.all_resourcerefs
                                              .map(&:resource_ref)
@@ -162,7 +160,6 @@ module Provider
       )
     end
 
-    # rubocop:disable Metrics/MethodLength
     def emit_coerce(product_ns, class_name, spaces_used = 0)
       type = "::Google::#{product_ns}::Property::#{class_name}"
       lines(format([
@@ -355,7 +352,6 @@ module Provider
     #                '/' (ex. first_level/second_level) or an array denoted
     #                by [] (ex. array_of_nested_props[])
     # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
     def build_nested_object(prop, current_path)
       object_lines = []
       prop.properties.each do |nested_prop|

--- a/provider/chef/test_catalog.rb
+++ b/provider/chef/test_catalog.rb
@@ -120,7 +120,6 @@ module Provider
     end
 
     # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
     def handlers
       {
         Api::Type::Boolean => ->(v) { v ? 'true' : 'false' },

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -229,7 +229,6 @@ module Provider
       generate_network_datas data, object
     end
 
-    # rubocop:disable Metrics/MethodLength
     # Generates all 6 network data files for a object.
     # This includes all combinations of seeds [0-2] and title == / != name
     # Each data file is a YAML file with all properties possible on an object.

--- a/provider/puppet.rb
+++ b/provider/puppet.rb
@@ -519,7 +519,6 @@ module Provider
       )
     end
 
-    # rubocop:disable Metrics/MethodLength
     def generate_bolt_tasks_code(task, output_folder)
       style = task.style
       template = File.join('templates', 'puppet', case style

--- a/provider/puppet/test_manifest.rb
+++ b/provider/puppet/test_manifest.rb
@@ -104,7 +104,6 @@ module Provider
     end
 
     # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
     def handlers
       {
         Api::Type::Boolean => ->(v) { v ? 'true' : 'false' },

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -86,8 +86,6 @@ module Provider
     # Terraform-specific overrides to api.yaml.
     class PropertyOverride < Provider::PropertyOverride
       include OverrideFields
-
-      # rubocop:disable Metrics/MethodLength
       def validate
         super
 

--- a/provider/test_data/create_data.rb
+++ b/provider/test_data/create_data.rb
@@ -22,7 +22,6 @@ module Provider
       end
 
       # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/MethodLength
       #
       # Returns a hash representing the data expected in a POST call to GCP
       # Used for unit tests
@@ -63,7 +62,6 @@ module Provider
       private
 
       # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/PerceivedComplexity
       def expect_hash(prop, name_prop, has_name, seed = 0)
@@ -95,7 +93,6 @@ module Provider
       # rubocop:enable Metrics/AbcSize
 
       # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/MethodLength
       def expect_array_hash(prop, seed = 0)
         if prop.item_type.class <= Api::Type::NestedObject
           [

--- a/provider/test_data/expectations.rb
+++ b/provider/test_data/expectations.rb
@@ -170,7 +170,6 @@ module Provider
       # rubocop:enable Metrics/PerceivedComplexity
 
       # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/ParameterLists
       # Given an expectation (i.e. "expect_network_get_success"),
       # returns that expectation with all necessary parameters.

--- a/provider/test_data/formatter.rb
+++ b/provider/test_data/formatter.rb
@@ -61,7 +61,6 @@ module Provider
 
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/PerceivedComplexity
       # prop_name_method is a method that returns the proper name of the object
       # rref_value: If true, return the value being exported by the ref'd block
@@ -88,12 +87,11 @@ module Provider
           raise "Unknown property type: #{prop.class}"
         end
       end
+
       # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/CyclomaticComplexity
       # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/PerceivedComplexity
-
-      # rubocop:disable Metrics/MethodLength
       # prop_name_method should be a valid method on a Api::Type::*
       # Typically, this will be "out_name" or "field_name"
       def emit_manifest_array(type, prop, seed, ctx, prop_name_method)
@@ -148,7 +146,6 @@ module Provider
 
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/PerceivedComplexity
       def select_properties(props, kind, extra)
         name_props = props.select { |p| p.name == 'name' }

--- a/provider/test_data/generator.rb
+++ b/provider/test_data/generator.rb
@@ -68,7 +68,6 @@ module Provider
 
       private
 
-      # rubocop:disable Metrics/MethodLength
       def values
         {
           Api::Type::Boolean => method(:boolean_value),

--- a/provider/test_data/property.rb
+++ b/provider/test_data/property.rb
@@ -27,7 +27,6 @@ module Provider
       #   it { is_expected.to have_attributes({prop.name}: #{expected value}) }
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/MethodLength
       # rubocop:disable Metrics/ParameterLists
       # rubocop:disable Metrics/PerceivedComplexity
       def property(prop, index, comparator, value, start_indent = 0,

--- a/provider/test_data/spec_formatter.rb
+++ b/provider/test_data/spec_formatter.rb
@@ -49,7 +49,6 @@ module Provider
         @provider = provider
       end
 
-      # rubocop:disable Metrics/MethodLength
       def generate(object, _, kind, seed, extra)
         props = object.all_user_properties
         name = Google::StringUtils.underscore(object.name)
@@ -121,7 +120,6 @@ module Provider
       end
 
       # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/MethodLength
       def handlers
         {
           Api::Type::Boolean => ->(v) { v },

--- a/spec/network_blocker.rb
+++ b/spec/network_blocker.rb
@@ -112,8 +112,6 @@ module Net
                 send_request start trace unlock].include?(m)
         next
       end
-
-      # rubocop:disable Metrics/MethodLength
       define_method(m) do |*args|
         request_allowed = true
 

--- a/spec/provider_chef_spec.rb
+++ b/spec/provider_chef_spec.rb
@@ -172,7 +172,6 @@ describe Provider::Chef do
   end
 
   # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/MethodLength
   def output_expectations_libraries(data)
     dw = dummy_writer
     output_file \

--- a/spec/provider_puppet_spec.rb
+++ b/spec/provider_puppet_spec.rb
@@ -568,7 +568,6 @@ describe Provider::Puppet do
   end
 
   # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/MethodLength
   def output_expectations_resource_ref(data)
     rref_name = "#{data[:kind]}_#{data[:resourceref][:name]}"
     rref_file = [data[:resourceref][:name].tr('_', ''),


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
We discussed this a few weeks ago - this just ups the limit for a ruby method to something a bit more sensible.  No changes to downstream code.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-dns]
### [puppet-sql]
### [puppet-compute]
## [chef]
## [ansible]
