### PR TITLE
Fix encryption key issue.

### DIFF
--- a/templates/terraform/constants/disk.erb
+++ b/templates/terraform/constants/disk.erb
@@ -206,10 +206,10 @@ func diskEncryptionKeyDiffSuppress(k, old, new string, d *schema.ResourceData) b
     }
   } else if strings.HasSuffix(k, "raw_key") {
     disk_key := d.Get("disk_encryption_key_raw").(string)
-    return disk_key == old
+    return disk_key == old && old != "" && new == ""
   } else if k == "disk_encryption_key_raw" {
     disk_key := d.Get("disk_encryption_key.0.raw_key").(string)
-    return disk_key == old
+    return disk_key == old && old != "" && new == ""
   }
   return false
 }

--- a/templates/terraform/custom_expand/encryption_key_expand.erb
+++ b/templates/terraform/custom_expand/encryption_key_expand.erb
@@ -9,7 +9,7 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
   <% if property.name == "diskEncryptionKey" -%>
 	} else {
 		// Check alternative setting? 
-		if altV, ok := d.GetOk("disk_encryption_key_raw"); ok {
+		if altV, ok := d.GetOk("disk_encryption_key_raw"); ok && altV != "" {
 			outMap := make(map[string]interface{})
 			outMap["rawKey"] = altV
 			req = append(req, outMap)


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
This fixes Terraform's `TestAccComputeInstance_diskEncryption`, `TestAccComputeInstance_attachedDiskUpdate`, and `TestAccComputeSnapshot_encryption`.  The issue was, we were treating `disk_encryption_key_raw:  "" -> "somerealvalue"` as if there was no diff, and consequently the value was empty while creating a disk.  The tests in `Disk` were too permissive - they just checked for a mismatch between object state and prod, not that object state had an encryption key.  I have adjusted that as well and will push that change to the generated PR.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Correct issue with Disk encryption.