### PR TITLE
Ansible: SQL Users

### DIFF
--- a/products/sql/ansible.yaml
+++ b/products/sql/ansible.yaml
@@ -76,14 +76,38 @@ overrides: !ruby/object:Provider::ResourceOverrides
           module.fail_json(msg="Incorrect result: {kind}".format(**result))
 
       return result
+  User: !ruby/object:Provider::Ansible::ResourceOverride
+    unwrap_resource: true
+    return_if_object: |
+      # If not found, return nothing.
+      if response.status_code == 404:
+          return None
+
+      # If no content, return nothing.
+      if response.status_code == 204:
+          return None
+
+      # SQL only: return on 403 if not exist
+      if response.status_code == 403:
+          return None
+
+      try:
+          result = response.json()
+      except getattr(json.decoder, 'JSONDecodeError', ValueError) as inst:
+          module.fail_json(msg="Invalid JSON response with error: %s" % inst)
+
+      if navigate_hash(result, ['error', 'errors']):
+          module.fail_json(msg=navigate_hash(result, ['error', 'errors']))
+      if result['kind'] not in [kind, 'sql#instance']:
+          module.fail_json(msg="Incorrect result: {kind}".format(**result))
+
+      return result
   # Objects not implmented yet.
   Tier: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: true
   SslCert: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: true
   Flag: !ruby/object:Provider::Ansible::ResourceOverride
-    exclude: true
-  User: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: true
 files: !ruby/object:Provider::Config::Files
   copy:

--- a/products/sql/ansible.yaml
+++ b/products/sql/ansible.yaml
@@ -28,80 +28,14 @@ overrides: !ruby/object:Provider::ResourceOverrides
   Instance: !ruby/object:Provider::Ansible::ResourceOverride
     access_api_results: true
     return_if_object: |
-      # If not found, return nothing.
-      if response.status_code == 404:
-          return None
-
-      # If no content, return nothing.
-      if response.status_code == 204:
-          return None
-
-      # SQL only: return on 403 if not exist
-      if response.status_code == 403:
-          return None
-
-      try:
-          result = response.json()
-      except getattr(json.decoder, 'JSONDecodeError', ValueError) as inst:
-          module.fail_json(msg="Invalid JSON response with error: %s" % inst)
-
-      if navigate_hash(result, ['error', 'errors']):
-          module.fail_json(msg=navigate_hash(result, ['error', 'errors']))
-      if result['kind'] != kind:
-          module.fail_json(msg="Incorrect result: {kind}".format(**result))
-
-      return result
+<%= lines(indent(compile('products/sql/helpers/ansible/return_if_object.py'), 6)) -%>
   Database: !ruby/object:Provider::Ansible::ResourceOverride
     return_if_object: |
-      # If not found, return nothing.
-      if response.status_code == 404:
-          return None
-
-      # If no content, return nothing.
-      if response.status_code == 204:
-          return None
-
-      # SQL only: return on 403 if not exist
-      if response.status_code == 403:
-          return None
-
-      try:
-          result = response.json()
-      except getattr(json.decoder, 'JSONDecodeError', ValueError) as inst:
-          module.fail_json(msg="Invalid JSON response with error: %s" % inst)
-
-      if navigate_hash(result, ['error', 'errors']):
-          module.fail_json(msg=navigate_hash(result, ['error', 'errors']))
-      if result['kind'] not in [kind, 'sql#instance']:
-          module.fail_json(msg="Incorrect result: {kind}".format(**result))
-
-      return result
+<%= lines(indent(compile('products/sql/helpers/ansible/return_if_object.py'), 6)) -%>
   User: !ruby/object:Provider::Ansible::ResourceOverride
     unwrap_resource: true
     return_if_object: |
-      # If not found, return nothing.
-      if response.status_code == 404:
-          return None
-
-      # If no content, return nothing.
-      if response.status_code == 204:
-          return None
-
-      # SQL only: return on 403 if not exist
-      if response.status_code == 403:
-          return None
-
-      try:
-          result = response.json()
-      except getattr(json.decoder, 'JSONDecodeError', ValueError) as inst:
-          module.fail_json(msg="Invalid JSON response with error: %s" % inst)
-
-      if navigate_hash(result, ['error', 'errors']):
-          module.fail_json(msg=navigate_hash(result, ['error', 'errors']))
-      if result['kind'] not in [kind, 'sql#instance']:
-          module.fail_json(msg="Incorrect result: {kind}".format(**result))
-
-      return result
+<%= lines(indent(compile('products/sql/helpers/ansible/return_if_object.py'), 6)) -%>
   # Objects not implmented yet.
   Tier: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: true

--- a/products/sql/examples/ansible/user.yaml
+++ b/products/sql/examples/ansible/user.yaml
@@ -30,7 +30,8 @@ dependencies:
 task: !ruby/object:Provider::Ansible::Task
   name: gcp_sql_user
   code: |
-    name: <%= ctx[:name] %>
+    # Can't use Ansible random name because it's too long
+    name: 'test-user'
     host: '10.1.2.3'
     password: 'secret-password'
     instance: "{{ instance }}"

--- a/products/sql/examples/ansible/user.yaml
+++ b/products/sql/examples/ansible/user.yaml
@@ -1,0 +1,39 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- !ruby/object:Provider::Ansible::Example
+dependencies:
+  - !ruby/object:Provider::Ansible::Task
+    name: gcp_sql_instance
+    code: |
+      name: <%= dependency_name('instance', 'user') %>
+      settings:
+        ip_configuration:
+          authorized_networks:
+            - name: 'google dns server'
+              value: '8.8.8.8/32'
+        tier: db-n1-standard-1
+      region: us-central1
+      project: <%= ctx[:project] %>
+      auth_kind: <%= ctx[:auth_kind] %>
+      service_account_file: <%= ctx[:service_account_file] %>
+    register: instance
+task: !ruby/object:Provider::Ansible::Task
+  name: gcp_sql_user
+  code: |
+    name: <%= ctx[:name] %>
+    host: '10.1.2.3'
+    password: 'secret-password'
+    instance: "{{ instance }}"
+    project: <%= ctx[:project] %>
+    auth_kind: <%= ctx[:auth_kind] %>
+    service_account_file: <%= ctx[:service_account_file] %>

--- a/products/sql/helpers/ansible/return_if_object.py
+++ b/products/sql/helpers/ansible/return_if_object.py
@@ -1,0 +1,23 @@
+# If not found, return nothing.
+if response.status_code == 404:
+    return None
+
+# If no content, return nothing.
+if response.status_code == 204:
+    return None
+
+# SQL only: return on 403 if not exist
+if response.status_code == 403:
+    return None
+
+try:
+    result = response.json()
+except getattr(json.decoder, 'JSONDecodeError', ValueError) as inst:
+    module.fail_json(msg="Invalid JSON response with error: %s" % inst)
+
+if navigate_hash(result, ['error', 'errors']):
+    module.fail_json(msg=navigate_hash(result, ['error', 'errors']))
+if result['kind'] != kind:
+    module.fail_json(msg="Incorrect result: {kind}".format(**result))
+
+return result

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -171,10 +171,10 @@ module Provider
       # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/AbcSize
 
-      def emit_method(name, args, code, file_name, opts = {})
+      def emit_method(name, args, code, _file_name, _opts = {})
         [
           method_decl(name, args),
-          indent(code, 4),
+          indent(code, 4)
         ].compact.join("\n")
       end
 

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -171,6 +171,13 @@ module Provider
       # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/AbcSize
 
+      def emit_method(name, args, code, file_name, opts = {})
+        [
+          method_decl(name, args),
+          indent(code, 4),
+        ].compact.join("\n")
+      end
+
       def rrefs_in_link(link, object)
         props_in_link = link.scan(/{([a-z_]*)}/).flatten
         (object.parameters || []).select do |p|

--- a/provider/ansible/resource_override.rb
+++ b/provider/ansible/resource_override.rb
@@ -26,6 +26,7 @@ module Provider
       attr_reader :imports
       attr_reader :provider_helpers
       attr_reader :return_if_object
+      attr_reader :unwrap_resource
       attr_reader :update
       attr_reader :version_added
     end
@@ -41,6 +42,7 @@ module Provider
         default_value_property :editable, true
         default_value_property :imports, []
         default_value_property :provider_helpers, []
+        default_value_property :unwrap_resource, false
 
         check_property :access_api_results, :boolean
         check_optional_property :collection, ::String
@@ -52,6 +54,7 @@ module Provider
         check_property :provider_helpers, ::Array
         check_optional_property :return_if_object, ::String
         check_optional_property :update, ::String
+        check_optional_property :unwrap_resource, :boolean
         check_optional_property :version_added, ::String
       end
       # rubocop:enable Metrics/MethodLength

--- a/templates/ansible/async.erb
+++ b/templates/ansible/async.erb
@@ -24,19 +24,19 @@ def wait_for_operation(module, response):
     return fetch_resource(module, navigate_hash(wait_done, <%= res_path -%>))
 <%   end # object.kind? -%>
 <% else # object.self_link_query.nil? -%>
-    wait_for_completion(status, op_result, resource)
+    wait_for_completion(status, op_result, module)
 <%=
   obj_kind = quote_string(object.kind)
   lines(format(
     [
       [
-        "return fetch_wrapped_resource(resource, #{obj_kind}",
+        "return fetch_wrapped_resource(module, #{obj_kind},",
         ("'#{object.self_link_query.kind}'," if object.self_link_query.kind?),
         "'#{object.self_link_query.items}')"
       ].join(' '),
       [
         [
-         "return fetch_wrapped_resource(resource, #{obj_kind}",
+         "return fetch_wrapped_resource(resource, #{obj_kind},",
          ("'#{object.self_link_query.kind}'," if object.self_link_query.kind?)
         ].join(' '),
         indent([
@@ -44,7 +44,7 @@ def wait_for_operation(module, response):
         ], 23) # 23 = align with ( previous line
       ],
       [
-        "return fetch_wrapped_resource(resource, #{obj_kind}",
+        "return fetch_wrapped_resource(resource, #{obj_kind},",
         indent([
           "'#{object.self_link_query.kind}',",
           "'#{object.self_link_query.items}')"

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -274,7 +274,34 @@ def resource_to_request(module):
             return_vals[k] = v
 
     return return_vals
+<% unless false?(object.unwrap_resource) -%>
+<%
+  urf_code = [
+    'return {',
+    indent_list(
+      Hash[object.identity.map { |i| [i, "module.params[#{quote_string(i.out_name)}]"] }]
+        .map { |k, v| "#{quote_string(k.out_name)}: #{v}" }, 4
+    ),
+    '}'
+  ]
+-%>
+<%= lines_before(lines(emit_method('unwrap_resource_filter', %w[module],
+                             urf_code, file_relative), 1), 1) -%>
 
+def unwrap_resource(result, module):
+    query_predicate = unwrap_resource_filter(resource)
+    matched_items = []
+    for item in result:
+        if all(item[k] == query_predicate[k] for query_predicate.keys()):
+            matched_items.append(item)
+    if len(matched_items) > 1:
+        module.fail_json(msg="More than 1 result found: %s" % matched_items)
+
+    if matched_items:
+        return matched_items[0]
+    else:
+        return None
+<% end -%>
 
 <%= lines(compile('templates/ansible/transport.erb'), 2) -%>
 <%= lines(emit_link('self_link', self_link_url(object), object)) -%>

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -303,13 +303,10 @@ def unwrap_resource(result, module):
         return None
 <% end -%>
 
+
 <%= lines(compile('templates/ansible/transport.erb'), 2) -%>
-<%= lines(emit_link('self_link', self_link_url(object), object)) -%>
-
-
-<%= lines(emit_link('collection', collection_url(object), object)) -%>
-
-
+<%= lines(emit_link('self_link', self_link_url(object), object), 2) -%>
+<%= lines(emit_link('collection', collection_url(object), object), 2) -%>
 <%=
   lines(method_decl('return_if_object', ['module', 'response',
                                          ('kind' if object.kind?)]))

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -285,8 +285,10 @@ def resource_to_request(module):
     '}'
   ]
 -%>
-<%= lines_before(lines(emit_method('unwrap_resource_filter', %w[module],
-                             urf_code, file_relative), 1), 1) -%>
+<%=
+  lines_before(lines(emit_method('unwrap_resource_filter', %w[module],
+                                 urf_code, file_relative), 1), 1)
+-%>
 
 def unwrap_resource(result, module):
     query_predicate = unwrap_resource_filter(module)

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -327,7 +327,6 @@ def unwrap_resource(result, module):
         result = response.json()
     except getattr(json.decoder, 'JSONDecodeError', ValueError) as inst:
         module.fail_json(msg="Invalid JSON response with error: %s" % inst)
-<% end # if object.return_if_object -%>
 
 <% if object.decoder? -%>
     result = <%= object.transport.decoder -%>(result, module)
@@ -341,6 +340,7 @@ def unwrap_resource(result, module):
 <% end # object.kind? -%>
 
     return result
+<% end # if object.return_if_object -%>
 
 
 def is_different(module, response):

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -289,10 +289,10 @@ def resource_to_request(module):
                              urf_code, file_relative), 1), 1) -%>
 
 def unwrap_resource(result, module):
-    query_predicate = unwrap_resource_filter(resource)
+    query_predicate = unwrap_resource_filter(module)
     matched_items = []
     for item in result:
-        if all(item[k] == query_predicate[k] for query_predicate.keys()):
+        if all(item[k] == query_predicate[k] for k in query_predicate.keys()):
             matched_items.append(item)
     if len(matched_items) > 1:
         module.fail_json(msg="More than 1 result found: %s" % matched_items)


### PR DESCRIPTION
User support for SQL on Ansible

- This also has some cleanup + refactors. Mostly in relation to fetch_wrapped_resource, which is a SQL user thing.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Ansible: SQL Users + fetch_wrapped_resource support
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
Ansible: SQL Users
