### PR TITLE
Validation to ensure URL parameters are listed as parameters

### DIFF
--- a/api/resource.rb
+++ b/api/resource.rb
@@ -251,6 +251,8 @@ module Api
       check_property_list :properties, Api::Type
 
       check_identity unless @identity.nil?
+
+      check_url
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
@@ -291,12 +293,12 @@ module Api
     # Returns all of the properties that are a part of the self_link or
     # collection URLs
     def uri_properties
-      [@base_url, @__product.default_version.base_url].map do |url|
+      [@base_url, @__product.default_version.base_url].compact.map do |url|
         parts = url.scan(/\{\{(.*?)\}\}/).flatten
         parts << 'name'
         parts.delete('project')
         parts.map { |pt| all_user_properties.select { |p| p.name == pt }[0] }
-      end.flatten
+      end.flatten.compact
     end
 
     def check_identity
@@ -306,6 +308,17 @@ module Api
       @identity.each do |i|
         raise "Missing property/parameter for identity #{i}" \
           if all_user_properties.select { |p| p.name == i }.empty?
+      end
+    end
+
+    def check_url
+      ignored_props = ['project', 'name']
+      props = uri_properties.select { |x| !ignored_props.include? x.name }
+      unless props.map { |x| parameters.include? x }.all?
+        forgotten = props.select { |x| !parameters.include? x }
+                                  .map { |x| x.name }
+        res = all_user_properties[0].__resource.name
+        raise "#{forgotten} not listed as parameters, but in URL in #{res}"
       end
     end
 

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -1991,6 +1991,13 @@ objects:
       Represents a MachineType resource. Machine types determine the virtualized
       hardware specifications of your virtual machine instances, such as the
       amount of memory or number of virtual CPUs.
+    parameters:
+      - !ruby/object:Api::Type::ResourceRef
+        name: 'zone'
+        resource: 'Zone'
+        imports: 'name'
+        description: 'The zone the machine type is defined.'
+        required: true
     properties:
       - !ruby/object:Api::Type::Time
         name: 'creationTimestamp'
@@ -2082,12 +2089,6 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'name'
         description: 'Name of the resource.'
-      - !ruby/object:Api::Type::ResourceRef
-        name: 'zone'
-        resource: 'Zone'
-        imports: 'name'
-        description: 'The zone the machine type is defined.'
-        required: true
   - !ruby/object:Api::Resource
     name: 'Network'
     kind: 'compute#network'
@@ -2658,6 +2659,16 @@ objects:
                         delete_sec: 6 * 60}},
                       'templates/regional_async.yaml.erb'), 4)
 %>
+    parameters:
+      - !ruby/object:Api::Type::ResourceRef
+        name: 'region'
+        resource: 'Region'
+        imports: 'name'
+        description: |
+          URL of the region where the regional address resides.
+          This field is not applicable to global addresses.
+        required: true
+        input: true
     properties:
       - !ruby/object:Api::Type::Time
         name: 'creationTimestamp'
@@ -2713,15 +2724,6 @@ objects:
         description: |
           Whether the VMs in this subnet can access Google services without
           assigned external IP addresses.
-      - !ruby/object:Api::Type::ResourceRef
-        name: 'region'
-        resource: 'Region'
-        imports: 'name'
-        description: |
-          URL of the region where the regional address resides.
-          This field is not applicable to global addresses.
-        required: true
-        input: true
   - !ruby/object:Api::Resource
     name: 'TargetHttpProxy'
     kind: 'compute#targetHttpProxy'


### PR DESCRIPTION
If a parameter is listed in a URL, it should be a parameter, not a property.

Idea for validation goes to @ndmckinley 
<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Validation to ensure URL parameters are listed as parameters
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
