### PR TITLE
Adding bundle support on Rakefile

### DIFF
--- a/tasks/common.rb
+++ b/tasks/common.rb
@@ -28,7 +28,7 @@ def modules_for_provider(provider)
   products = File.join(File.dirname(__FILE__), '..', 'products')
   files = Dir.glob("#{products}/**/#{provider}.yaml")
   files.map do |file|
-    match = file.match(%r{^.*products\/([a-z]*)\/.*yaml.*})
+    match = file.match(%r{^.*products\/([_a-z]*)\/.*yaml.*})
     match&.captures&.at(0)
   end.compact
 end


### PR DESCRIPTION
Rakefile doesn't handle _bundle providers, which can cause unintended build breakages.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Adding bundle support on Rakefile
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
