### PR TITLE
Ansible facts modules

### DIFF
--- a/.ci/magic-modules/merge-pr.sh
+++ b/.ci/magic-modules/merge-pr.sh
@@ -44,9 +44,9 @@ echo "Merged PR #$ID." > ./commit_message
 
 set +e
 if [ "$REPO" != "GoogleCloudPlatform/magic-modules" ]; then
-  git remote add push-target "git@github.com:$REPO"
+  git remote add non-gcp-push-target "git@github.com:$REPO"
   # We know we have a commit, so all the machinery of the git resources is
   # unnecessary.  We can just try to push directly, without forcing.
-  ssh-agent bash -c "ssh-add ~/github_private_key; git push push-target $BRANCH"
+  ssh-agent bash -c "ssh-add ~/github_private_key; git push non-gcp-push-target $BRANCH"
 fi
 set -e

--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -24,6 +24,82 @@ manifest: !ruby/object:Provider::Ansible::Manifest
   version_added: '2.6'
   author: Google Inc. (@googlecloudplatform)
 # This is where custom code would be defined eventually.
+datasources: !ruby/object:Provider::ResourceOverrides
+  Instance: !ruby/object:Provider::Ansible::ResourceOverride
+    version_added: '2.7'
+  Address: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  Autoscaler: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  BackendBucket: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  BackendService: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  Disk: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  Firewall: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  ForwardingRule: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  GlobalAddress: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  GlobalForwardingRule: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  HealthCheck: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  HttpHealthCheck: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  HttpsHealthCheck: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  Image: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  InstanceGroup: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  InstanceGroupManager: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  InstanceTemplate: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  Network: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  RegionAutoscaler: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  Route: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  Router: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  Snapshot: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  SslCertificate: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  SslPolicy: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  Subnetwork: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  TargetPool: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  TargetHttpProxy: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  TargetHttpsProxy: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  TargetSslProxy: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  TargetTcpProxy: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  TargetVpnGateway: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  UrlMap: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  # Readonly resources.
+  DiskType: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  License: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  MachineType: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  Region: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  Zone: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
 overrides: !ruby/object:Provider::ResourceOverrides
   BackendService: !ruby/object:Provider::Ansible::ResourceOverride
     properties:

--- a/products/compute/examples/ansible/instance.yaml
+++ b/products/compute/examples/ansible/instance.yaml
@@ -62,12 +62,13 @@ task: !ruby/object:Provider::Ansible::Task
     project: <%= ctx[:project] %>
     auth_kind: <%= ctx[:auth_kind] %>
     service_account_file: <%= ctx[:service_account_file] %>
-verifier: !ruby/object:Provider::Ansible::Verifier
-  command: |
-    gcloud compute instances describe
-      --project="{{ gcp_project }}"
-      --zone="us-central1-a"
-      "{{ resource_name }}"
-  failure: !ruby/object:Provider::Ansible::ComputeFailureCondition
-    region: zones/us-central1-a
-    type: instances
+verifier: !ruby/object:Provider::Ansible::FactsVerifier
+  parameters:
+    zone: 'us-central1-a'
+facts: !ruby/object:Provider::Ansible::Task
+  name: gcp_compute_instance_facts
+  code: |
+    zone: 'us-central1-a'
+    project: <%= ctx[:project] %>
+    auth_kind: <%= ctx[:auth_kind] %>
+    service_account_file: <%= ctx[:service_account_file] %>

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -249,6 +249,10 @@ module Provider
         field.scan(/\S.{0,#{avail_columns}}\S(?=\s|$)|\S+/)
       end
 
+      def list_kind(object)
+        "#{object.kind}List"
+      end
+
       private
 
       def get_example(cfg_file)
@@ -299,6 +303,17 @@ module Provider
           default_template: 'templates/ansible/example.erb',
           out_file: File.join(target_folder,
                               "test/integration/targets/#{name}/tasks/main.yml")
+        )
+      end
+
+      def compile_datasource(data)
+        target_folder = data[:output_folder]
+        FileUtils.mkpath target_folder
+        name = "#{module_name(data[:object])}_facts"
+        generate_resource_file data.clone.merge(
+          default_template: 'templates/ansible/facts.erb',
+          out_file: File.join(target_folder,
+                              "lib/ansible/modules/cloud/google/#{name}.py")
         )
       end
 

--- a/provider/ansible/resource_override.rb
+++ b/provider/ansible/resource_override.rb
@@ -24,6 +24,7 @@ module Provider
       attr_reader :create
       attr_reader :delete
       attr_reader :editable
+      attr_reader :filter_url
       attr_reader :hidden
       attr_reader :imports
       attr_reader :provider_helpers
@@ -45,6 +46,7 @@ module Provider
         default_value_property :custom_update_resource, false
         default_value_property :exclude, false
         default_value_property :editable, true
+        default_value_property :filter_url, ''
         default_value_property :imports, []
         default_value_property :provider_helpers, []
         default_value_property :unwrap_resource, false
@@ -56,6 +58,7 @@ module Provider
         check_optional_property :create, ::String
         check_optional_property :delete, ::String
         check_property :editable, :boolean
+        check_property :filter_url, ::String
         check_optional_property :hidden, ::Array
         check_property :imports, ::Array
         check_property :provider_helpers, ::Array

--- a/provider/config.rb
+++ b/provider/config.rb
@@ -23,6 +23,8 @@ module Provider
     extend Compile::Core
 
     attr_reader :overrides
+    # Overrides for datasources
+    attr_reader :datasources
     attr_reader :objects
     attr_reader :examples
     attr_reader :properties # TODO(nelsonjr): Remove this once bug 193 is fixed.

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -78,6 +78,9 @@ module Provider
       # or compiled.
       compile_files(output_folder) \
         unless @config.files.nil? || @config.files.compile.nil?
+
+      generate_datasources(output_folder, types, version) \
+        unless @config.datasources.nil?
       apply_file_acls(output_folder) \
         unless @config.files.nil? || @config.files.permissions.nil?
       verify_test_matrixes
@@ -235,6 +238,42 @@ module Provider
       generate_resource_tests data
       generate_properties data, object.all_user_properties
       generate_network_datas data, object
+    end
+
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
+    def generate_datasources(output_folder, types, version)
+      # We need to apply overrides for datasources
+      @config.datasources.validate
+
+      @api.set_properties_based_on_version(version)
+      @api.objects.each do |object|
+        if !types.empty? && !types.include?(object.name)
+          Google::LOGGER.info(
+            "Excluding #{object.name} datasource per user request"
+          )
+        elsif types.empty? && object.exclude
+          Google::LOGGER.info(
+            "Excluding #{object.name} datasource per API catalog"
+          )
+        elsif types.empty? && object.exclude_if_not_in_version(version)
+          Google::LOGGER.info(
+            "Excluding #{object.name} datasource per API version"
+          )
+        else
+          generate_datasource object, output_folder, version
+        end
+      end
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/AbcSize
+
+    def generate_datasource(object, output_folder, version)
+      data = build_object_data(object, output_folder, version)
+
+      compile_datasource data
     end
 
     # Generates all 6 network data files for a object.

--- a/tasks/common.rb
+++ b/tasks/common.rb
@@ -13,6 +13,7 @@
 
 PROVIDER_FOLDERS = {
   ansible: 'build/ansible',
+  ansible_facts: 'build/ansible',
   puppet: 'build/puppet/%s',
   chef: 'build/chef/%s',
   terraform: 'build/terraform'

--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -1,0 +1,157 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017 Google
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+<%= lines(autogen_notice :python) -%>
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+################################################################################
+# Documentation
+################################################################################
+
+<%
+  metadata_version = quote_string(@config.manifest.get('metadata_version',
+                                                       config))
+  supported_by = quote_string(@config.manifest.get('supported_by', config))
+-%>
+ANSIBLE_METADATA = {'metadata_version': <%= metadata_version -%>,
+                    'status': <%= @config.manifest.get('status', config) -%>,
+                    'supported_by': <%= supported_by -%>}
+
+DOCUMENTATION = '''
+---
+module: <%= module_name(object) %>_facts
+description:
+  - Gather facts for GCP <%= object.name %>
+short_description: Gather facts for GCP <%= object.name  %>
+version_added: <%= lines(@config.manifest.get('version_added', config)) -%>
+author: <%= lines(@config.manifest.get('author', config)) -%>
+requirements:
+<% @config.manifest.get('requirements', config).each do |line| -%>
+<%= lines(indent(bullet_line(line, 4, false, false), 4)) -%>
+<% end -%>
+options:
+    filters:
+       description:
+           A list of filter value pairs. Available filters are listed here
+           U(<%= object.filter_url -%>).
+           Each additional filter in the list will act be added as an AND condition
+           (filter1 and filter2)
+<% object.parameters.each do |prop| -%>
+<%= lines(indent(doc_property_yaml(prop, object, 4), 4)) -%>
+<% end -%>
+extends_documentation_fragment: gcp
+'''
+
+<% if example and example.facts -%>
+EXAMPLES = '''
+<%= lines(example.facts.build_example('facts', object)) -%>
+'''
+<% end -%>
+
+RETURN = '''
+<% object.all_user_properties.each do |prop| -%>
+<%= lines(indent(return_property_yaml(prop, 4), 4)) -%>
+<% end -%>
+'''
+
+################################################################################
+# Imports
+################################################################################
+from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest
+import json
+
+################################################################################
+# Main
+################################################################################
+
+
+def main():
+<%
+  mod_props = object.parameters.map do |prop|
+    python_dict_for_property(prop, object)
+  end
+-%>
+    module = GcpModule(
+        argument_spec=dict(
+            filters=dict(type='list', elements='str'),
+<%= lines(indent_list(mod_props, 12)) -%>
+        )
+    )
+
+    if 'scopes' not in module.params:
+        module.params['scopes'] = <%= python_literal(object.__product.scopes) %>
+
+    items = fetch_list(module, collection(module), query_options(module.params['filters']))
+    if items.get('items'):
+        items = items.get('items')
+    else:
+        items = []
+    return_value = {
+        'items': items
+    }
+    module.exit_json(**return_value)
+
+
+<%= lines(emit_link('collection', collection_url(object), object)) -%>
+
+
+def fetch_list(module, link, query):
+<% prod_name = object.__product.prefix[1..-1] -%>
+    auth = GcpSession(module, <%= quote_string(prod_name) -%>)
+    response = auth.get(link, params={'filter': query})
+    return return_if_object(module, response)
+
+
+def query_options(filters):
+    '''
+        :param config_data: contents of the inventory config file
+        :return A fully built query string
+    '''
+    if not filters:
+        return ''
+
+    if len(filters) == 1:
+        return filters[0]
+    else:
+        queries = []
+        for f in filters:
+            # For multiple queries, all queries should have ()
+            if f[0] != '(' and f[-1] != ')':
+                queries.append("(%s)" % ''.join(f))
+            else:
+                queries.append(f)
+
+        return ' '.join(queries)
+
+
+<%=
+  lines(method_decl('return_if_object', ['module', 'response']))
+-%>
+    # If not found, return nothing.
+    if response.status_code == 404:
+        return None
+
+    # If no content, return nothing.
+    if response.status_code == 204:
+        return None
+
+    try:
+        module.raise_for_status(response)
+        result = response.json()
+    except getattr(json.decoder, 'JSONDecodeError', ValueError) as inst:
+        module.fail_json(msg="Invalid JSON response with error: %s" % inst)
+
+    if navigate_hash(result, ['error', 'errors']):
+        module.fail_json(msg=navigate_hash(result, ['error', 'errors']))
+<% if object.kind? -%>
+    if result['kind'] != <%= quote_string(list_kind(object)) %>:
+        module.fail_json(msg="Incorrect result: {kind}".format(**result))
+<% end # object.kind? -%>
+
+    return result
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This may end up being a long-running PR.

This PR is meant to get support for Ansible facts modules started. So far, the gcp_compute_instance_facts module works.

There is missing documentation and I doubt linters will work on this.

Let me know your thoughts on the best way to slowly merge this in.
<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
