### PR TITLE
Removing hardcoded project names on Puppet examples

### DIFF
--- a/docs/providers/puppet.md
+++ b/docs/providers/puppet.md
@@ -65,7 +65,8 @@ to install all of the dependent gems for the GCP modules.
 ```
   # Project name is hardcoded. You probably aren't using our default project.
   sed -i 's/google.com:graphite-playground/your-project/g' path/to/example
-  FACTER_cred_path=<path to service account> puppet apply <path to example>
+  FACTER_cred_path=<path to service account> FACTER_project=<project name>
+    puppet apply <path to example>
 ```
 All environment variables have to be passed in with the `FACTER_` prefix.
 You may have to change project names on examples.

--- a/products/compute/examples/puppet/address.pp
+++ b/products/compute/examples/puppet/address.pp
@@ -22,13 +22,13 @@
 <% end # name == README.md -%>
 gcompute_region { <%= example_resource_name('some-region') -%>:
   name       => 'us-west1',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_address { <%= example_resource_name('test1') -%>:
   ensure     => present,
   region     => <%= example_resource_name('some-region') -%>,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/backend_bucket.pp
+++ b/products/compute/examples/puppet/backend_bucket.pp
@@ -34,6 +34,6 @@ gcompute_backend_bucket { <%= example_resource_name('be-bucket-connection') -%>:
   bucket_name => <%= example_resource_name('backend-bucket-test') -%>,
   description => 'A BackendBucket to connect LNB w/ Storage Bucket',
   enable_cdn  => true,
-  project     => 'google.com:graphite-playground',
+  project     => $project, # e.g. 'my-test-project'
   credential  => 'mycred',
 }

--- a/products/compute/examples/puppet/backend_service.pp
+++ b/products/compute/examples/puppet/backend_service.pp
@@ -27,14 +27,14 @@
 #   - Health check
 <% else # name == README.md -%>
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_instance_group { <%= example_resource_name('my-puppet-masters') -%>:
   ensure     => present,
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -48,6 +48,6 @@ gcompute_backend_service { <%= example_resource_name('my-app-backend') -%>:
   health_checks => [
     gcompute_health_check_ref('another-hc', 'google.com:graphite-playground'),
   ],
-  project       => 'google.com:graphite-playground',
+  project       => $project, # e.g. 'my-test-project'
   credential    => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_address.pp
+++ b/products/compute/examples/puppet/delete_address.pp
@@ -22,13 +22,13 @@
 <% end # name == README.md -%>
 gcompute_region { <%= example_resource_name('some-region') -%>:
   name       => 'us-west1',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_address { <%= example_resource_name('test1') -%>:
   ensure     => absent,
   region     => <%= example_resource_name('some-region') -%>,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_backend_bucket.pp
+++ b/products/compute/examples/puppet/delete_backend_bucket.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_backend_bucket { <%= example_resource_name('be-bucket-connection') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_backend_service.pp
+++ b/products/compute/examples/puppet/delete_backend_service.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_backend_service { <%= example_resource_name('my-app-backend') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_disk.pp
+++ b/products/compute/examples/puppet/delete_disk.pp
@@ -20,7 +20,7 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -28,6 +28,6 @@ gcompute_zone { 'us-central1-a':
 gcompute_disk { <%= example_resource_name('data-disk-1') -%>:
   ensure     => absent,
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_firewall.pp
+++ b/products/compute/examples/puppet/delete_firewall.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_firewall { <%= example_resource_name('test-fw-allow-ssh') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_forwarding_rule.pp
+++ b/products/compute/examples/puppet/delete_forwarding_rule.pp
@@ -21,7 +21,7 @@
 
 gcompute_region { <%= example_resource_name('some-region') -%>:
   name       => 'us-west1',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -29,6 +29,6 @@ gcompute_region { <%= example_resource_name('some-region') -%>:
 gcompute_forwarding_rule { <%= example_resource_name('test1') -%>:
   ensure     => absent,
   region     => <%= example_resource_name('some-region') -%>,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_global_address.pp
+++ b/products/compute/examples/puppet/delete_global_address.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_global_address { <%= example_resource_name('my-app-lb-address') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_global_forwarding_rule.pp
+++ b/products/compute/examples/puppet/delete_global_forwarding_rule.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_global_forwarding_rule { <%= example_resource_name('test1') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_health_check.pp
+++ b/products/compute/examples/puppet/delete_health_check.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_health_check { <%= example_resource_name('my-app-tcp-hc') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_http_health_check.pp
+++ b/products/compute/examples/puppet/delete_http_health_check.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_http_health_check { <%= example_resource_name('my-app-http-hc') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_https_health_check.pp
+++ b/products/compute/examples/puppet/delete_https_health_check.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_https_health_check { <%= example_resource_name('my-app-https-hc') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_image.pp
+++ b/products/compute/examples/puppet/delete_image.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_image { <%= example_resource_name('test-image') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred'
 }

--- a/products/compute/examples/puppet/delete_instance.pp
+++ b/products/compute/examples/puppet/delete_instance.pp
@@ -20,7 +20,7 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -28,6 +28,6 @@ gcompute_zone { 'us-central1-a':
 gcompute_instance { <%= example_resource_name('instance-test') -%>:
   ensure     => absent,
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_instance_group.pp
+++ b/products/compute/examples/puppet/delete_instance_group.pp
@@ -20,7 +20,7 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -28,6 +28,6 @@ gcompute_zone { 'us-central1-a':
 gcompute_instance_group { <%= example_resource_name('my-puppet-masters') -%>:
   ensure     => absent,
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_instance_group_manager.pp
+++ b/products/compute/examples/puppet/delete_instance_group_manager.pp
@@ -20,7 +20,7 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gcompute_zone { 'us-west1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -28,6 +28,6 @@ gcompute_zone { 'us-west1-a':
 gcompute_instance_group_manager { <%= example_resource_name('test1') -%>:
   ensure     => absent,
   zone       => 'us-west1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_instance_template.pp
+++ b/products/compute/examples/puppet/delete_instance_template.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_instance_template { <%= example_resource_name('instance-template') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_network.pp
+++ b/products/compute/examples/puppet/delete_network.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_network { <%= example_resource_name('mynetwork-${network_id}') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_route.pp
+++ b/products/compute/examples/puppet/delete_route.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_route { <%= example_resource_name('corp-route') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_snapshot.pp
+++ b/products/compute/examples/puppet/delete_snapshot.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_snapshot { <%= example_resource_name('data-disk-snapshot-1') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_ssl_certificate.pp
+++ b/products/compute/examples/puppet/delete_ssl_certificate.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_ssl_certificate { <%= example_resource_name('sample-certificate') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_subnetwork.pp
+++ b/products/compute/examples/puppet/delete_subnetwork.pp
@@ -21,7 +21,7 @@
 
 gcompute_region { <%= example_resource_name('some-region') -%>:
   name       => 'us-west1',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -32,6 +32,6 @@ gcompute_region { <%= example_resource_name('some-region') -%>:
 gcompute_subnetwork { <%= example_resource_name('servers') -%>:
   ensure     => absent,
   region     => <%= example_resource_name('some-region') -%>,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_target_http_proxy.pp
+++ b/products/compute/examples/puppet/delete_target_http_proxy.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_target_http_proxy { <%= example_resource_name('my-http-proxy') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_target_https_proxy.pp
+++ b/products/compute/examples/puppet/delete_target_https_proxy.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_target_https_proxy { <%= example_resource_name('my-https-proxy') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_target_pool.pp
+++ b/products/compute/examples/puppet/delete_target_pool.pp
@@ -22,13 +22,13 @@
 <% end # name == README.md -%>
 gcompute_region { <%= example_resource_name('some-region') -%>:
   name       => 'us-west1',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_target_pool { <%= example_resource_name('test1') -%>:
   ensure     => absent,
   region     => <%= example_resource_name('some-region') -%>,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_target_ssl_proxy.pp
+++ b/products/compute/examples/puppet/delete_target_ssl_proxy.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_target_ssl_proxy { <%= example_resource_name('my-ssl-proxy') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_target_tcp_proxy.pp
+++ b/products/compute/examples/puppet/delete_target_tcp_proxy.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_target_tcp_proxy { <%= example_resource_name('my-tcp-proxy') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/delete_url_map.pp
+++ b/products/compute/examples/puppet/delete_url_map.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_url_map { <%= example_resource_name('my-url-map') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/disk.pp
+++ b/products/compute/examples/puppet/disk.pp
@@ -20,7 +20,7 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -32,6 +32,6 @@ gcompute_disk { <%= example_resource_name('data-disk-1') -%>:
     raw_key => 'SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=',
   },
   zone                => 'us-central1-a',
-  project             => 'google.com:graphite-playground',
+  project             => $project, # e.g. 'my-test-project'
   credential          => 'mycred',
 }

--- a/products/compute/examples/puppet/disk_type.pp
+++ b/products/compute/examples/puppet/disk_type.pp
@@ -20,7 +20,7 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -29,6 +29,6 @@ gcompute_disk_type { 'pd-standard':
   default_disk_size_gb => 500,
   deprecated_deleted   => undef, # undef = not deprecated
   zone                 => 'us-central1-a',
-  project              => 'google.com:graphite-playground',
+  project              => $project, # e.g. 'my-test-project'
   credential           => 'mycred',
 }

--- a/products/compute/examples/puppet/firewall.pp
+++ b/products/compute/examples/puppet/firewall.pp
@@ -37,6 +37,6 @@ gcompute_firewall { <%= example_resource_name('test-fw-allow-ssh') -%>:
   source_tags => [
     'test-ssh-clients',
   ],
-  project     => 'google.com:graphite-playground',
+  project     => $project, # e.g. 'my-test-project'
   credential  => 'mycred',
 }

--- a/products/compute/examples/puppet/firewall~change1.pp
+++ b/products/compute/examples/puppet/firewall~change1.pp
@@ -36,6 +36,6 @@ gcompute_firewall { 'test-firewall-allow-ssh':
       ],
     },
   ],
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/forwarding_rule.pp
+++ b/products/compute/examples/puppet/forwarding_rule.pp
@@ -21,21 +21,21 @@
 
 gcompute_region { <%= example_resource_name('some-region') -%>:
   name       => 'us-west1',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_address { <%= example_resource_name('some-address') -%>:
   ensure     => present,
   region     => <%= example_resource_name('some-region') -%>,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_target_pool { <%= example_resource_name('target-pool') -%>:
   ensure     => present,
   region     => <%= example_resource_name('some-region') -%>,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -50,6 +50,6 @@ gcompute_forwarding_rule { <%= example_resource_name('test1') -%>:
   port_range  => '80',
   target      => <%= example_resource_name('target-pool') -%>,
   region      => <%= example_resource_name('some-region') -%>,
-  project     => 'google.com:graphite-playground',
+  project     => $project, # e.g. 'my-test-project'
   credential  => 'mycred',
 }

--- a/products/compute/examples/puppet/global_address.pp
+++ b/products/compute/examples/puppet/global_address.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gcompute_global_address { <%= example_resource_name('my-app-lb-address') -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/global_forwarding_rule.pp
+++ b/products/compute/examples/puppet/global_forwarding_rule.pp
@@ -21,19 +21,19 @@
 
 gcompute_global_address { <%= example_resource_name('my-app-lb-address') -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_instance_group { <%= example_resource_name('my-puppet-masters') -%>:
   ensure     => present,
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -46,21 +46,21 @@ gcompute_backend_service { <%= example_resource_name('my-app-backend') -%>:
   health_checks => [
     gcompute_health_check_ref('another-hc', 'google.com:graphite-playground'),
   ],
-  project       => 'google.com:graphite-playground',
+  project       => $project, # e.g. 'my-test-project'
   credential    => 'mycred',
 }
 
 gcompute_url_map { <%= example_resource_name('my-url-map') -%>:
   ensure          => present,
   default_service => <%= example_resource_name('my-app-backend') -%>,
-  project         => 'google.com:graphite-playground',
+  project         => $project, # e.g. 'my-test-project'
   credential      => 'mycred',
 }
 
 gcompute_target_http_proxy { <%= example_resource_name('my-http-proxy') -%>:
   ensure     => present,
   url_map    => <%= example_resource_name('my-url-map') -%>,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -77,6 +77,6 @@ gcompute_global_forwarding_rule { <%= example_resource_name('test1') -%>:
     <%= example_resource_name('my-http-proxy') -%>,
     'google.com:graphite-playground'
   ),
-  project     => 'google.com:graphite-playground',
+  project     => $project, # e.g. 'my-test-project'
   credential  => 'mycred',
 }

--- a/products/compute/examples/puppet/health_check.pp
+++ b/products/compute/examples/puppet/health_check.pp
@@ -31,6 +31,6 @@ gcompute_health_check { <%= example_resource_name('my-app-tcp-hc') -%>:
   healthy_threshold   => 10,
   timeout_sec         => 2,
   unhealthy_threshold => 5,
-  project             => 'google.com:graphite-playground',
+  project             => $project, # e.g. 'my-test-project'
   credential          => 'mycred',
 }

--- a/products/compute/examples/puppet/http_health_check.pp
+++ b/products/compute/examples/puppet/http_health_check.pp
@@ -26,6 +26,6 @@ gcompute_http_health_check { <%= example_resource_name('my-app-http-hc') -%>:
   port                => 8080,
   timeout_sec         => 2,
   unhealthy_threshold => 5,
-  project             => 'google.com:graphite-playground',
+  project             => $project, # e.g. 'my-test-project'
   credential          => 'mycred',
 }

--- a/products/compute/examples/puppet/https_health_check.pp
+++ b/products/compute/examples/puppet/https_health_check.pp
@@ -26,6 +26,6 @@ gcompute_https_health_check { <%= example_resource_name('my-app-https-hc') -%>:
   port                => 8080,
   timeout_sec         => 2,
   unhealthy_threshold => 5,
-  project             => 'google.com:graphite-playground',
+  project             => $project, # e.g. 'my-test-project'
   credential          => 'mycred',
 }

--- a/products/compute/examples/puppet/image.pp
+++ b/products/compute/examples/puppet/image.pp
@@ -20,14 +20,14 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_disk { <%= example_resource_name('data-disk-1') -%>:
   ensure     => present,
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -37,6 +37,6 @@ gcompute_disk { <%= example_resource_name('data-disk-1') -%>:
 gcompute_image { <%= example_resource_name('test-image') -%>:
   ensure      => present,
   source_disk => <%= example_resource_name('data-disk-1') -%>,
-  project     => 'google.com:graphite-playground',
+  project     => $project, # e.g. 'my-test-project'
   credential  => 'mycred'
 }

--- a/products/compute/examples/puppet/instance.pp
+++ b/products/compute/examples/puppet/instance.pp
@@ -20,7 +20,7 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -30,7 +30,7 @@ gcompute_disk { <%= example_resource_name('instance-test-os-1') -%>:
   source_image =>
     'projects/ubuntu-os-cloud/global/images/family/ubuntu-1604-lts',
   zone         => 'us-central1-a',
-  project      => 'google.com:graphite-playground',
+  project      => $project, # e.g. 'my-test-project'
   credential   => 'mycred',
 }
 
@@ -41,12 +41,12 @@ gcompute_disk { <%= example_resource_name('instance-test-os-1') -%>:
 #      network to ensure the traffic can reach your machine
 gcompute_network { <%= example_resource_name('default') -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_region { 'us-central1':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -55,7 +55,7 @@ gcompute_region { 'us-central1':
 # 'n1-standard-1' defined below.
 gcompute_machine_type { 'n1-standard-1':
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -63,7 +63,7 @@ gcompute_machine_type { 'n1-standard-1':
 # exist it will allocate an ephemeral one.
 gcompute_address { <%= example_resource_name('instance-test-ip') -%>:
   region     => 'us-central1',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -109,6 +109,6 @@ gcompute_instance { <%= example_resource_name('instance-test') -%>:
     }
   ],
   zone               => 'us-central1-a',
-  project            => 'google.com:graphite-playground',
+  project            => $project, # e.g. 'my-test-project'
   credential         => 'mycred',
 }

--- a/products/compute/examples/puppet/instance_group.pp
+++ b/products/compute/examples/puppet/instance_group.pp
@@ -25,13 +25,13 @@
 #   - gcompute_network { 'my-network': ensure => present }
 <% else # name == README.md -%>
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_network { <%= example_resource_name('my-network') -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -46,6 +46,6 @@ gcompute_instance_group { <%= example_resource_name('my-puppet-masters') -%>:
   ],
   network     => <%= example_resource_name('my-network') -%>,
   zone        => 'us-central1-a',
-  project     => 'google.com:graphite-playground',
+  project     => $project, # e.g. 'my-test-project'
   credential  => 'mycred',
 }

--- a/products/compute/examples/puppet/instance_group_manager.pp
+++ b/products/compute/examples/puppet/instance_group_manager.pp
@@ -20,19 +20,19 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gcompute_zone { 'us-west1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_machine_type { 'n1-standard-1':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   zone       => 'us-west1-a',
   credential => 'mycred',
 }
 
 gcompute_network { <%= example_resource_name('mynetwork-test') -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -64,7 +64,7 @@ gcompute_instance_template { <%= example_resource_name('instance-template') -%>:
       }
     ]
   },
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -75,6 +75,6 @@ gcompute_instance_group_manager { <%= example_resource_name('test1') -%>:
   instance_template  => <%= example_resource_name('instance-template') -%>,
   target_size        => 3,
   zone               => 'us-west1-a',
-  project            => 'google.com:graphite-playground',
+  project            => $project, # e.g. 'my-test-project'
   credential         => 'mycred',
 }

--- a/products/compute/examples/puppet/instance_template.pp
+++ b/products/compute/examples/puppet/instance_template.pp
@@ -20,12 +20,12 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_machine_type { 'n1-standard-1':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   zone       => 'us-central1-a',
   credential => 'mycred',
 }
@@ -37,13 +37,13 @@ gcompute_machine_type { 'n1-standard-1':
 # |   zone         => 'us-central1-a',
 # |   source_image =>
 # |     gcompute_image_family('ubuntu-1604-lts', 'ubuntu-os-cloud'),
-# |   project      => 'google.com:graphite-playground',
+# |   project      => $project, # e.g. 'my-test-project'
 # |   credential   => 'mycred',
 # | }
 
 gcompute_network { <%= example_resource_name('mynetwork-test') -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -90,6 +90,6 @@ gcompute_instance_template { <%= example_resource_name('instance-template') -%>:
       }
     ]
   },
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/license.pp
+++ b/products/compute/examples/puppet/license.pp
@@ -21,6 +21,6 @@
 
 <% end # name == README.md -%>
 gcompute_license { <%= example_resource_name('test-license') -%>:
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/machine_type.pp
+++ b/products/compute/examples/puppet/machine_type.pp
@@ -20,13 +20,13 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 <% end # name == README.md -%>
 gcompute_machine_type { 'n1-standard-1':
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/network~auto.pp
+++ b/products/compute/examples/puppet/network~auto.pp
@@ -26,7 +26,7 @@
 # |   auto_create_subnetworks => true,
 # |   ipv4_range              => '192.168.0.0/16',
 # |   gateway_ipv4            => '192.168.0.1',
-# |   project                 => 'google.com:graphite-playground',
+# |   project                 => $project, # e.g. 'my-test-project'
 # |   credential              => 'mycred',
 # | }
 
@@ -34,6 +34,6 @@ notice('Creating network with automatically assigned subnetworks')
 <% end # name == README.md -%>
 gcompute_network { <%= example_resource_name('mynetwork-${network_id}') -%>:
   auto_create_subnetworks => true,
-  project                 => 'google.com:graphite-playground',
+  project                 => $project, # e.g. 'my-test-project'
   credential              => 'mycred',
 }

--- a/products/compute/examples/puppet/network~convert_to_custom.pp
+++ b/products/compute/examples/puppet/network~convert_to_custom.pp
@@ -23,6 +23,6 @@ notice('Converting network to Custom')
 <% end # name == README.md -%>
 gcompute_network { <%= example_resource_name('mynetwork-${network_id}') -%>:
   auto_create_subnetworks => false,
-  project                 => 'google.com:graphite-playground',
+  project                 => $project, # e.g. 'my-test-project'
   credential              => 'mycred',
 }

--- a/products/compute/examples/puppet/network~custom.pp
+++ b/products/compute/examples/puppet/network~custom.pp
@@ -23,6 +23,6 @@ notice('Creating network without automatically assigned subnetworks')
 <% end # name == README.md -%>
 gcompute_network { <%= example_resource_name('mynetwork-${network_id}') -%>:
   auto_create_subnetworks => false,
-  project                 => 'google.com:graphite-playground',
+  project                 => $project, # e.g. 'my-test-project'
   credential              => 'mycred',
 }

--- a/products/compute/examples/puppet/network~legacy.pp
+++ b/products/compute/examples/puppet/network~legacy.pp
@@ -27,6 +27,6 @@ gcompute_network { <%= example_resource_name('mynetwork-${network_id}') -%>:
   # | auto_create_subnetworks => false,
   ipv4_range   => '192.168.0.0/16',
   gateway_ipv4 => '192.168.0.1',
-  project      => 'google.com:graphite-playground',
+  project      => $project, # e.g. 'my-test-project'
   credential   => 'mycred',
 }

--- a/products/compute/examples/puppet/region.pp
+++ b/products/compute/examples/puppet/region.pp
@@ -21,6 +21,6 @@
 
 <% end # name == README.md -%>
 gcompute_region { 'us-west1':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/route.pp
+++ b/products/compute/examples/puppet/route.pp
@@ -26,7 +26,7 @@
 <% else # name == README.md -%>
 gcompute_network { <%= example_resource_name('my-network') -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -37,6 +37,6 @@ gcompute_route { <%= example_resource_name('corp-route') -%>:
   next_hop_gateway => 'global/gateways/default-internet-gateway',
   network          => <%= example_resource_name('my-network') -%>,
   tags             => ['backends', 'databases'],
-  project          => 'google.com:graphite-playground',
+  project          => $project, # e.g. 'my-test-project'
   credential       => 'mycred',
 }

--- a/products/compute/examples/puppet/snapshot.pp
+++ b/products/compute/examples/puppet/snapshot.pp
@@ -20,7 +20,7 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -31,7 +31,7 @@ gcompute_disk { <%= example_resource_name('data-disk-1') -%>:
     raw_key => 'SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0=',
   },
   zone                => 'us-central1-a',
-  project             => 'google.com:graphite-playground',
+  project             => $project, # e.g. 'my-test-project'
   credential          => 'mycred',
 }
 
@@ -46,6 +46,6 @@ gcompute_snapshot { <%= example_resource_name('data-disk-snapshot-1') -%>:
   },
   source                     => <%= example_resource_name('data-disk-1') -%>,
   zone                       => 'us-central1-a',
-  project                    => 'google.com:graphite-playground',
+  project                    => $project, # e.g. 'my-test-project'
   credential                 => 'mycred',
 }

--- a/products/compute/examples/puppet/ssl_certificate.pp
+++ b/products/compute/examples/puppet/ssl_certificate.pp
@@ -37,7 +37,7 @@
 gcompute_ssl_certificate { <%= example_resource_name('sample-certificate') -%>:
   ensure      => present,
   description => 'A certificate for test purposes only.',
-  project     => 'google.com:graphite-playground',
+  project     => $project, # e.g. 'my-test-project'
   credential  => 'mycred',
   certificate => '-----BEGIN CERTIFICATE-----
 MIICqjCCAk+gAwIBAgIJAIuJ+0352Kq4MAoGCCqGSM49BAMCMIGwMQswCQYDVQQG

--- a/products/compute/examples/puppet/subnetwork.pp
+++ b/products/compute/examples/puppet/subnetwork.pp
@@ -28,13 +28,13 @@
 gcompute_network { <%= example_resource_name('mynetwork-subnetwork') -%>:
   ensure                  => present,
   auto_create_subnetworks => false,
-  project                 => 'google.com:graphite-playground',
+  project                 => $project, # e.g. 'my-test-project'
   credential              => 'mycred',
 }
 
 gcompute_region { <%= example_resource_name('some-region') -%>:
   name       => 'us-west1',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -44,6 +44,6 @@ gcompute_subnetwork { <%= example_resource_name('servers') -%>:
   ip_cidr_range => '172.16.0.0/16',
   network       => <%= example_resource_name('mynetwork-subnetwork') -%>,
   region        => <%= example_resource_name('some-region') -%>,
-  project       => 'google.com:graphite-playground',
+  project       => $project, # e.g. 'my-test-project'
   credential    => 'mycred',
 }

--- a/products/compute/examples/puppet/target_http_proxy.pp
+++ b/products/compute/examples/puppet/target_http_proxy.pp
@@ -20,14 +20,14 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_instance_group { <%= example_resource_name('my-puppet-masters') -%>:
   ensure     => present,
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -40,14 +40,14 @@ gcompute_backend_service { <%= example_resource_name('my-app-backend') -%>:
   health_checks => [
     gcompute_health_check_ref('another-hc', 'google.com:graphite-playground'),
   ],
-  project       => 'google.com:graphite-playground',
+  project       => $project, # e.g. 'my-test-project'
   credential    => 'mycred',
 }
 
 gcompute_url_map { <%= example_resource_name('my-url-map') -%>:
   ensure          => present,
   default_service => <%= example_resource_name('my-app-backend') -%>,
-  project         => 'google.com:graphite-playground',
+  project         => $project, # e.g. 'my-test-project'
   credential      => 'mycred',
 }
 
@@ -55,6 +55,6 @@ gcompute_url_map { <%= example_resource_name('my-url-map') -%>:
 gcompute_target_http_proxy { <%= example_resource_name('my-http-proxy') -%>:
   ensure     => present,
   url_map    => <%= example_resource_name('my-url-map') -%>,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/target_https_proxy.pp
+++ b/products/compute/examples/puppet/target_https_proxy.pp
@@ -20,14 +20,14 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_instance_group { <%= example_resource_name('my-puppet-masters') -%>:
   ensure     => present,
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -40,14 +40,14 @@ gcompute_backend_service { <%= example_resource_name('my-app-backend') -%>:
   health_checks => [
     gcompute_health_check_ref('another-hc', 'google.com:graphite-playground'),
   ],
-  project       => 'google.com:graphite-playground',
+  project       => $project, # e.g. 'my-test-project'
   credential    => 'mycred',
 }
 
 gcompute_url_map { <%= example_resource_name('my-url-map') -%>:
   ensure          => present,
   default_service => <%= example_resource_name('my-app-backend') -%>,
-  project         => 'google.com:graphite-playground',
+  project         => $project, # e.g. 'my-test-project'
   credential      => 'mycred',
 }
 
@@ -68,7 +68,7 @@ gcompute_url_map { <%= example_resource_name('my-url-map') -%>:
 gcompute_ssl_certificate { <%= example_resource_name('sample-certificate') -%>:
   ensure      => present,
   description => 'A certificate for test purposes only.',
-  project     => 'google.com:graphite-playground',
+  project     => $project, # e.g. 'my-test-project'
   credential  => 'mycred',
   certificate => '-----BEGIN CERTIFICATE-----
 MIICqjCCAk+gAwIBAgIJAIuJ+0352Kq4MAoGCCqGSM49BAMCMIGwMQswCQYDVQQG
@@ -101,6 +101,6 @@ gcompute_target_https_proxy { <%= example_resource_name('my-https-proxy') -%>:
     <%= example_resource_name('sample-certificate') -%>,
   ],
   url_map          => <%= example_resource_name('my-url-map') -%>,
-  project          => 'google.com:graphite-playground',
+  project          => $project, # e.g. 'my-test-project'
   credential       => 'mycred',
 }

--- a/products/compute/examples/puppet/target_pool.pp
+++ b/products/compute/examples/puppet/target_pool.pp
@@ -22,13 +22,13 @@
 <% end # name == README.md -%>
 gcompute_region { <%= example_resource_name('some-region') -%>:
   name       => 'us-west1',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_target_pool { <%= example_resource_name('test1') -%>:
   ensure     => present,
   region     => <%= example_resource_name('some-region') -%>,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/compute/examples/puppet/target_ssl_proxy.pp
+++ b/products/compute/examples/puppet/target_ssl_proxy.pp
@@ -20,14 +20,14 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_instance_group { <%= example_resource_name('my-puppet-masters') -%>:
   ensure     => present,
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -40,7 +40,7 @@ gcompute_backend_service { <%= example_resource_name('my-ssl-backend') -%>:
     gcompute_health_check_ref('another-hc', 'google.com:graphite-playground'),
   ],
   protocol      => 'SSL',
-  project       => 'google.com:graphite-playground',
+  project       => $project, # e.g. 'my-test-project'
   credential    => 'mycred',
 }
 
@@ -61,7 +61,7 @@ gcompute_backend_service { <%= example_resource_name('my-ssl-backend') -%>:
 gcompute_ssl_certificate { <%= example_resource_name('sample-certificate') -%>:
   ensure      => present,
   description => 'A certificate for test purposes only.',
-  project     => 'google.com:graphite-playground',
+  project     => $project, # e.g. 'my-test-project'
   credential  => 'mycred',
   certificate => '-----BEGIN CERTIFICATE-----
 MIICqjCCAk+gAwIBAgIJAIuJ+0352Kq4MAoGCCqGSM49BAMCMIGwMQswCQYDVQQG
@@ -95,6 +95,6 @@ gcompute_target_ssl_proxy { <%= example_resource_name('my-ssl-proxy') -%>:
   ssl_certificates => [
     <%= example_resource_name('sample-certificate') -%>,
   ],
-  project          => 'google.com:graphite-playground',
+  project          => $project, # e.g. 'my-test-project'
   credential       => 'mycred',
 }

--- a/products/compute/examples/puppet/target_tcp_proxy.pp
+++ b/products/compute/examples/puppet/target_tcp_proxy.pp
@@ -20,14 +20,14 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_instance_group { <%= example_resource_name('my-puppet-masters') -%>:
   ensure     => present,
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -40,7 +40,7 @@ gcompute_backend_service { <%= example_resource_name('my-tcp-backend') -%>:
     gcompute_health_check_ref('another-hc', 'google.com:graphite-playground'),
   ],
   protocol      => 'TCP',
-  project       => 'google.com:graphite-playground',
+  project       => $project, # e.g. 'my-test-project'
   credential    => 'mycred',
 }
 
@@ -49,6 +49,6 @@ gcompute_target_tcp_proxy { <%= example_resource_name('my-tcp-proxy') -%>:
   ensure       => present,
   proxy_header => 'PROXY_V1',
   service      => <%= example_resource_name('my-tcp-backend') -%>,
-  project      => 'google.com:graphite-playground',
+  project      => $project, # e.g. 'my-test-project'
   credential   => 'mycred',
 }

--- a/products/compute/examples/puppet/url_map.pp
+++ b/products/compute/examples/puppet/url_map.pp
@@ -20,14 +20,14 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 gcompute_instance_group { <%= example_resource_name('my-puppet-masters') -%>:
   ensure     => present,
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -40,7 +40,7 @@ gcompute_backend_service { <%= example_resource_name('my-app-backend') -%>:
   health_checks => [
     gcompute_health_check_ref('another-hc', 'google.com:graphite-playground'),
   ],
-  project       => 'google.com:graphite-playground',
+  project       => $project, # e.g. 'my-test-project'
   credential    => 'mycred',
 }
 
@@ -48,6 +48,6 @@ gcompute_backend_service { <%= example_resource_name('my-app-backend') -%>:
 gcompute_url_map { <%= example_resource_name('my-url-map') -%>:
   ensure          => present,
   default_service => <%= example_resource_name('my-app-backend') -%>,
-  project         => 'google.com:graphite-playground',
+  project         => $project, # e.g. 'my-test-project'
   credential      => 'mycred',
 }

--- a/products/compute/examples/puppet/zone.pp
+++ b/products/compute/examples/puppet/zone.pp
@@ -21,6 +21,6 @@
 
 <% end # name == README.md -%>
 gcompute_zone { 'us-central1-a':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/container/examples/puppet/cluster.pp
+++ b/products/container/examples/puppet/cluster.pp
@@ -36,6 +36,6 @@ gcontainer_cluster { <%= example_resource_name('mycluster-${cluster_id}') -%>:
     disk_size_gb => 500,             # ... and a lot of disk space
   },
   zone               => 'us-central1-a',
-  project            => 'google.com:graphite-playground',
+  project            => $project, # e.g. 'my-test-project'
   credential         => 'mycred',
 }

--- a/products/container/examples/puppet/delete_cluster.pp
+++ b/products/container/examples/puppet/delete_cluster.pp
@@ -27,6 +27,6 @@ if $cluster_id == undef {
 gcontainer_cluster { <%= example_resource_name('mycluster-${cluster_id}') -%>:
   ensure     => absent,
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/container/examples/puppet/delete_node_pool.pp
+++ b/products/container/examples/puppet/delete_node_pool.pp
@@ -27,7 +27,7 @@ if $cluster_id == undef {
 gcontainer_cluster { <%= example_resource_name(cluster_name) -%>:
   ensure     => present,
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -36,6 +36,6 @@ gcontainer_node_pool { <%= example_resource_name('web-servers') -%>:
   ensure     => absent,
   cluster    => <%= example_resource_name(cluster_name) -%>,
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/container/examples/puppet/kube_config.pp
+++ b/products/container/examples/puppet/kube_config.pp
@@ -35,7 +35,7 @@ gcontainer_cluster { "mycluster-${cluster_id}":
     disk_size_gb => 500,             # ... and a lot of disk space
   },
   zone               => 'us-central1-a',
-  project            => 'google.com:graphite-playground',
+  project            => $project, # e.g. 'my-test-project'
   credential         => 'mycred',
 }
 
@@ -54,7 +54,7 @@ gcontainer_kube_config { '/home/nelsona/.kube/config':
   context    => "gke-mycluster-${cluster_id}",
   cluster    => "mycluster-${cluster_id}",
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -64,6 +64,6 @@ gcontainer_kube_config { '/home/nelsona/.puppetlabs/etc/puppet/kubernetes.conf':
   ensure     => present,
   cluster    => "mycluster-${cluster_id}",
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/container/examples/puppet/node_pool.pp
+++ b/products/container/examples/puppet/node_pool.pp
@@ -27,7 +27,7 @@ if $cluster_id == undef {
 gcontainer_cluster { <%= example_resource_name(cluster_name) -%>:
   ensure     => present,
   zone       => 'us-central1-a',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -40,6 +40,6 @@ gcontainer_node_pool { <%= example_resource_name('web-servers') -%>:
   initial_node_count => 4,
   cluster            => <%= example_resource_name(cluster_name) -%>,
   zone               => 'us-central1-a',
-  project            => 'google.com:graphite-playground',
+  project            => $project, # e.g. 'my-test-project'
   credential         => 'mycred',
 }

--- a/products/dns/examples/puppet/delete_managed_zone.pp
+++ b/products/dns/examples/puppet/delete_managed_zone.pp
@@ -25,27 +25,27 @@
 # Ensures the managed zone is not in the project.
 gdns_managed_zone { <%= example_resource_name('test-example-zone') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 # Ensures the managed zone is not in the project.
 gdns_managed_zone { <%= example_resource_name('testzone-2-com') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 # Ensures the managed zone is not in the project.
 gdns_managed_zone { <%= example_resource_name('id-for-testzone-3-com') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
 <% end # name == README.md -%>
 gdns_managed_zone { <%= example_resource_name('testzone-4-com') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/dns/examples/puppet/delete_resource_record_set.pp
+++ b/products/dns/examples/puppet/delete_resource_record_set.pp
@@ -27,7 +27,7 @@ gdns_managed_zone { <%= example_resource_name('testzone-4-com') -%>:
   name        => 'testzone-4-com',
   dns_name    => 'testzone-4.com.',
   description => 'Test Example Zone',
-  project     => 'google.com:graphite-playground',
+  project     => $project, # e.g. 'my-test-project'
   credential  => 'mycred',
 }
 
@@ -35,7 +35,7 @@ gdns_resource_record_set { <%= example_resource_name('www.testzone-4.com.') -%>:
   ensure       => absent,
   managed_zone => <%= example_resource_name('testzone-4-com') -%>,
   type         => 'A',
-  project      => 'google.com:graphite-playground',
+  project      => $project, # e.g. 'my-test-project'
   credential   => 'mycred',
 }
 
@@ -44,7 +44,7 @@ gdns_resource_record_set { <%= example_resource_name(res_name) -%>:
   ensure       => absent,
   managed_zone => <%= example_resource_name('testzone-4-com') -%>,
   type         => 'CNAME',
-  project      => 'google.com:graphite-playground',
+  project      => $project, # e.g. 'my-test-project'
   credential   => 'mycred',
 }
 
@@ -54,6 +54,6 @@ gdns_resource_record_set { <%= example_resource_name(res_name) -%>:
   ensure       => absent,
   managed_zone => <%= example_resource_name('testzone-4-com') -%>,
   type         => 'A',
-  project      => 'google.com:graphite-playground',
+  project      => $project, # e.g. 'my-test-project'
   credential   => 'mycred',
 }

--- a/products/dns/examples/puppet/managed_zone.pp
+++ b/products/dns/examples/puppet/managed_zone.pp
@@ -47,14 +47,14 @@ gdns_managed_zone { <%= example_resource_name('test-example-zone') -%>:
   # ],
   # creation_time => '2016-12-02T04:59:24.333Z',
 
-  project     => 'google.com:graphite-playground',
+  project     => $project, # e.g. 'my-test-project'
   credential  => 'mycred',
 }
 
 # Ensures a managed zone exists and has the correct values.
 gdns_managed_zone { <%= example_resource_name('testzone-2-com') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -66,6 +66,6 @@ gdns_managed_zone { <%= example_resource_name(res_name) -%>:
   name        => 'testzone-3-com',
   dns_name    => 'test.somewild-example.com.',
   description => 'Test Example Zone',
-  project     => 'google.com:graphite-playground',
+  project     => $project, # e.g. 'my-test-project'
   credential  => 'mycred',
 }

--- a/products/dns/examples/puppet/resource_record_set.pp
+++ b/products/dns/examples/puppet/resource_record_set.pp
@@ -25,7 +25,7 @@ gdns_managed_zone { <%= example_resource_name('some-managed-zone') -%>:
   name        => 'testzone-4-com',
   dns_name    => 'testzone-4.com.',
   description => 'Test Example Zone',
-  project     => 'google.com:graphite-playground',
+  project     => $project, # e.g. 'my-test-project'
   credential  => 'mycred',
 }
 
@@ -40,7 +40,7 @@ gdns_resource_record_set { <%= example_resource_name(res_name) -%>:
     '40.5.6.7',
     '80.9.10.11'
   ],
-  project      => 'google.com:graphite-playground',
+  project      => $project, # e.g. 'my-test-project'
   credential   => 'mycred',
 }
 
@@ -50,7 +50,7 @@ gdns_resource_record_set { <%= example_resource_name(res_name) -%>:
   managed_zone => <%= example_resource_name('some-managed-zone') -%>,
   type         => 'CNAME',
   target       => 'www.testzone-4.com.',
-  project      => 'google.com:graphite-playground',
+  project      => $project, # e.g. 'my-test-project'
   credential   => 'mycred',
 }
 
@@ -59,6 +59,6 @@ gdns_resource_record_set { <%= example_resource_name(res_name) -%>:
   ensure       => absent,
   managed_zone => <%= example_resource_name('some-managed-zone') -%>,
   type         => 'A',
-  project      => 'google.com:graphite-playground',
+  project      => $project, # e.g. 'my-test-project'
   credential   => 'mycred',
 }

--- a/products/iam/examples/puppet/delete_service_account.pp
+++ b/products/iam/examples/puppet/delete_service_account.pp
@@ -27,6 +27,6 @@
 -%>
 giam_service_account { <%= account -%>:
   ensure       => absent,
-  project      => 'google.com:graphite-playground',
+  project      => $project, # e.g. 'my-test-project'
   credential   => 'mycred',
 }

--- a/products/iam/examples/puppet/delete_service_account_key.pp
+++ b/products/iam/examples/puppet/delete_service_account_key.pp
@@ -29,7 +29,7 @@ giam_service_account { 'myaccount':
   name         =>
     <%= account -%>,
   display_name => 'My Puppet test key',
-  project      => 'google.com:graphite-playground',
+  project      => $project, # e.g. 'my-test-project'
   credential   => 'mycred',
 }
 
@@ -47,6 +47,6 @@ giam_service_account_key { 'mykey':
   ensure           => absent,
   key_id           => $key_id,
   service_account  => 'myaccount',
-  project          => 'google.com:graphite-playground',
+  project          => $project, # e.g. 'my-test-project'
   credential       => 'mycred',
 }

--- a/products/iam/examples/puppet/service_account.pp
+++ b/products/iam/examples/puppet/service_account.pp
@@ -28,6 +28,6 @@
 giam_service_account { <%= account -%>:
   ensure       => present,
   display_name => 'My Puppet test key',
-  project      => 'google.com:graphite-playground',
+  project      => $project, # e.g. 'my-test-project'
   credential   => 'mycred',
 }

--- a/products/iam/examples/puppet/service_account_key.pp
+++ b/products/iam/examples/puppet/service_account_key.pp
@@ -29,7 +29,7 @@ giam_service_account { 'myaccount':
   name         =>
     <%= account -%>,
   display_name => 'My Puppet test key',
-  project      => 'google.com:graphite-playground',
+  project      => $project, # e.g. 'my-test-project'
   credential   => 'mycred',
 }
 
@@ -40,6 +40,6 @@ giam_service_account_key { 'test-name':
   path             => '/home/nelsona/test.json',
   key_algorithm    => 'KEY_ALG_RSA_2048',
   private_key_type => 'TYPE_GOOGLE_CREDENTIALS_FILE',
-  project          => 'google.com:graphite-playground',
+  project          => $project, # e.g. 'my-test-project'
   credential       => 'mycred',
 }

--- a/products/pubsub/examples/puppet/delete_subscription.pp
+++ b/products/pubsub/examples/puppet/delete_subscription.pp
@@ -21,7 +21,7 @@
 
 gpubsub_topic { <%= example_resource_name('conversation-1') -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -29,6 +29,6 @@ gpubsub_topic { <%= example_resource_name('conversation-1') -%>:
 gpubsub_subscription { <%= example_resource_name('subscription-1') -%>:
   ensure     => absent,
   topic      => 'conversation-1',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/pubsub/examples/puppet/delete_topic.pp
+++ b/products/pubsub/examples/puppet/delete_topic.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gpubsub_topic { <%= example_resource_name('conversation-1') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/pubsub/examples/puppet/subscription.pp
+++ b/products/pubsub/examples/puppet/subscription.pp
@@ -21,7 +21,7 @@
 
 gpubsub_topic { <%= example_resource_name('conversation-1') -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -33,6 +33,6 @@ gpubsub_subscription { <%= example_resource_name('subscription-1') -%>:
     push_endpoint => 'https://myapp.graphite.cloudnativeapp.com/webhook/sub1',
   },
   ack_deadline_seconds => 300,
-  project              => 'google.com:graphite-playground',
+  project              => $project, # e.g. 'my-test-project'
   credential           => 'mycred',
 }

--- a/products/pubsub/examples/puppet/topic.pp
+++ b/products/pubsub/examples/puppet/topic.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gpubsub_topic { <%= example_resource_name('conversation-1') -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/spanner/examples/puppet/database.pp
+++ b/products/spanner/examples/puppet/database.pp
@@ -6,7 +6,7 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gspanner_instance_config { 'regional-us-central1':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -19,7 +19,7 @@ gspanner_instance { <%= example_resource_name('my-spanner') -%>:
     },
   ],
   config       => 'regional-us-central1',
-  project      => 'google.com:graphite-playground',
+  project      => $project, # e.g. 'my-test-project'
   credential   => 'mycred',
 }
 
@@ -33,6 +33,6 @@ gspanner_database { <%= example_resource_name('webstore') -%>:
      ) PRIMARY KEY (customer_id)',
   ],
   instance         => <%= example_resource_name('my-spanner') -%>,
-  project          => 'google.com:graphite-playground',
+  project          => $project, # e.g. 'my-test-project'
   credential       => 'mycred',
 }

--- a/products/spanner/examples/puppet/delete_instance.pp
+++ b/products/spanner/examples/puppet/delete_instance.pp
@@ -8,6 +8,6 @@
 <% end # name == README.md -%>
 gspanner_instance { <%= example_resource_name('my-spanner') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/spanner/examples/puppet/instance.pp
+++ b/products/spanner/examples/puppet/instance.pp
@@ -6,7 +6,7 @@
 <%= compile 'templates/puppet/examples~credential.pp.erb' -%>
 
 gspanner_instance_config { 'regional-us-central1':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -20,6 +20,6 @@ gspanner_instance { <%= example_resource_name('my-spanner') -%>:
     },
   ],
   config       => 'regional-us-central1',
-  project      => 'google.com:graphite-playground',
+  project      => $project, # e.g. 'my-test-project'
   credential   => 'mycred',
 }

--- a/products/spanner/examples/puppet/instance_config.pp
+++ b/products/spanner/examples/puppet/instance_config.pp
@@ -7,6 +7,6 @@
 
 <% end # name == README.md -%>
 gspanner_instance_config { 'regional-us-central1':
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/sql/examples/puppet/database.pp
+++ b/products/sql/examples/puppet/database.pp
@@ -41,7 +41,7 @@ if !defined('$sql_instance_suffix') {
 
 gsql_instance { <%= example_resource_name(instance_name) -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -52,6 +52,6 @@ gsql_database { <%= example_resource_name('webstore') -%>:
   ensure     => present,
   charset    => 'utf8',
   instance   => <%= example_resource_name(instance_name) -%>,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/sql/examples/puppet/delete_database.pp
+++ b/products/sql/examples/puppet/delete_database.pp
@@ -41,7 +41,7 @@ if !defined('$sql_instance_suffix') {
 
 gsql_instance { <%= example_resource_name(instance_name) -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -51,6 +51,6 @@ gsql_instance { <%= example_resource_name(instance_name) -%>:
 gsql_database { <%= example_resource_name('webstore') -%>:
   ensure     => absent,
   instance   => <%= example_resource_name(instance_name) -%>,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/sql/examples/puppet/delete_instance.pp
+++ b/products/sql/examples/puppet/delete_instance.pp
@@ -40,6 +40,6 @@ if !defined('$sql_instance_suffix') {
 <% instance_name = 'sql-test-${sql_instance_suffix}' -%>
 gsql_instance { <%= example_resource_name(instance_name) -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/sql/examples/puppet/delete_user.pp
+++ b/products/sql/examples/puppet/delete_user.pp
@@ -41,7 +41,7 @@ if !defined('$sql_instance_suffix') {
 
 gsql_instance { <%= example_resource_name(instance_name) -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -55,6 +55,6 @@ gsql_user { 'john.doe':
   ensure     => absent,
   host       => '10.1.2.3',
   instance   => <%= example_resource_name(instance_name) -%>,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/sql/examples/puppet/flag.pp
+++ b/products/sql/examples/puppet/flag.pp
@@ -23,6 +23,6 @@
 gsql_flag { <%= example_resource_name('group_concat_max_len') -%>:
   min_value  => 4,
   max_value  => 4294967295,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/sql/examples/puppet/instance.pp
+++ b/products/sql/examples/puppet/instance.pp
@@ -54,6 +54,6 @@ gsql_instance { <%= example_resource_name(instance_name) -%>:
     tier             => 'db-n1-standard-1'
   },
   region           => 'us-central1',
-  project          => 'google.com:graphite-playground',
+  project          => $project, # e.g. 'my-test-project'
   credential       => 'mycred',
 }

--- a/products/sql/examples/puppet/instance~postgres.pp
+++ b/products/sql/examples/puppet/instance~postgres.pp
@@ -54,6 +54,6 @@ gsql_instance { <%= example_resource_name(instance_name) -%>:
     tier             => 'db-custom-2-8192'
   },
   region           => 'us-central1',
-  project          => 'google.com:graphite-playground',
+  project          => $project, # e.g. 'my-test-project'
   credential       => 'mycred',
 }

--- a/products/sql/examples/puppet/ssl_cert.pp
+++ b/products/sql/examples/puppet/ssl_cert.pp
@@ -41,7 +41,7 @@ if !defined('$sql_instance_suffix') {
 
 gsql_instance { <%= example_resource_name(instance_name) -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -53,6 +53,6 @@ gsql_ssl_cert { <%= example_resource_name('server-certificate') -%>:
   common_name        => 'CN=www.mydb.com,O=Acme',
   sha1_fingerprint   => '8fc295bf77a002db5182e04d92c48258cbc1117a',
   instance           => <%= example_resource_name(instance_name) -%>,
-  project            => 'google.com:graphite-playground',
+  project            => $project, # e.g. 'my-test-project'
   credential         => 'mycred',
 }

--- a/products/sql/examples/puppet/tier.pp
+++ b/products/sql/examples/puppet/tier.pp
@@ -22,6 +22,6 @@
 <% end -%>
 gsql_tier { <%= example_resource_name('D0') -%>:
   ram        => 134217728, # we'll confirm that tier has enough RAM for us
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/sql/examples/puppet/user.pp
+++ b/products/sql/examples/puppet/user.pp
@@ -41,7 +41,7 @@ if !defined('$sql_instance_suffix') {
 
 gsql_instance { <%= example_resource_name(instance_name) -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -56,6 +56,6 @@ gsql_user { 'john.doe':
   password   => 'secret-password',
   host       => '10.1.2.3',
   instance   => <%= example_resource_name(instance_name) -%>,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/storage/examples/puppet/bucket.pp
+++ b/products/storage/examples/puppet/bucket.pp
@@ -25,6 +25,6 @@
 # manifest.
 gstorage_bucket { <%= example_resource_name('puppet-storage-module-test') -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/storage/examples/puppet/bucket_access_control.pp
+++ b/products/storage/examples/puppet/bucket_access_control.pp
@@ -22,7 +22,7 @@
 
 gstorage_bucket { <%= example_resource_name(bucket_name) -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -35,6 +35,6 @@ gstorage_bucket_access_control { <%= example_resource_name(res_name) -%>:
   bucket     => <%= example_resource_name(bucket_name) -%>,
   entity     => 'user-nelsona@google.com',
   role       => 'WRITER',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/storage/examples/puppet/bucket~acl.pp
+++ b/products/storage/examples/puppet/bucket~acl.pp
@@ -36,6 +36,6 @@ gstorage_bucket { <%= example_resource_name('puppet-storage-module-test') -%>:
       role   => 'OWNER',
     },
   ],
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/storage/examples/puppet/default_object_acl.pp
+++ b/products/storage/examples/puppet/default_object_acl.pp
@@ -22,7 +22,7 @@
 
 gstorage_bucket { <%= example_resource_name(bucket_name) -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -35,6 +35,6 @@ gstorage_default_object_acl { <%= example_resource_name(res_name) -%>:
   bucket     => <%= example_resource_name(bucket_name) -%>,
   entity     => 'user-nelsona@google.com',
   role       => 'READER',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/storage/examples/puppet/delete_bucket.pp
+++ b/products/storage/examples/puppet/delete_bucket.pp
@@ -22,6 +22,6 @@
 <% end # name == README.md -%>
 gstorage_bucket { <%= example_resource_name('puppet-storage-module-test') -%>:
   ensure     => absent,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/products/storage/examples/puppet/object_access_control.pp
+++ b/products/storage/examples/puppet/object_access_control.pp
@@ -22,7 +22,7 @@
 
 gstorage_bucket { <%= example_resource_name(bucket_name) -%>:
   ensure     => present,
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }
 
@@ -36,6 +36,6 @@ gstorage_object_access_control { <%= example_resource_name(res_name) -%>:
   object     => 'acl-controlled-file.txt'
   entity     => 'user-nelsona@google.com',
   role       => 'WRITER',
-  project    => 'google.com:graphite-playground',
+  project    => $project, # e.g. 'my-test-project'
   credential => 'mycred',
 }

--- a/templates/puppet/examples~credential.pp.erb
+++ b/templates/puppet/examples~credential.pp.erb
@@ -13,27 +13,29 @@
 # limitations under the License.
 <% end -%>
 <% if name != "README.md" -%>
-# Defines a credential to be used when communicating with Google Cloud
-# Platform. The title of this credential is then used as the 'credential'
-# parameter in the gdns_managed_zone type.
+# The following example requires two environment variables to be set:
+#     * cred_path - a path to a JSON service account file
+#     * project - the name of your GCP project
 #
-# For more information on the gauth_credential parameters and providers please
-# refer to its detailed documentation at:
-#
-#   https://forge.puppet.com/google/gauth
-#
-# For the sake of this example we set the parameter 'path' to point to the file
-# that contains your credential in JSON format. And for convenience this example
-# allows a variable named $cred_path to be provided to it. If running from the
-# command line you can pass it via Facter:
+# If running from the command line you can pass these via Facter:
 #
 #   FACTER_cred_path=/path/to/my/cred.json \
+#   FACTER_project='my-test-project'
 #       puppet apply <%= file_relative %>
 #
 # For convenience you optionally can add it to your ~/.bash_profile (or the
 # respective .profile settings) environment:
 #
 #   export FACTER_cred_path=/path/to/my/cred.json
+#   export FACTER_project='my-test-project'
+#
+# Defines a credential to be used when communicating with Google Cloud
+# Platform.
+#
+# For more information on the gauth_credential parameters and providers please
+# refer to its detailed documentation at:
+#
+#   https://forge.puppet.com/google/gauth
 #
 <% end # name != README.md -%>
 gauth_credential { 'mycred':

--- a/templates/puppet/examples~credential.pp.erb
+++ b/templates/puppet/examples~credential.pp.erb
@@ -13,6 +13,8 @@
 # limitations under the License.
 <% end -%>
 <% if name != "README.md" -%>
+# Getting Started
+# ---------------
 # The following example requires two environment variables to be set:
 #     * cred_path - a path to a JSON service account file
 #     * project - the name of your GCP project
@@ -29,8 +31,10 @@
 #   export FACTER_cred_path=/path/to/my/cred.json
 #   export FACTER_project='my-test-project'
 #
-# Defines a credential to be used when communicating with Google Cloud
-# Platform.
+# Authenticating to GCP
+# ---------------------
+# `gauth_credential` defines a credential to be used when communicating with
+# Google Cloud Platform.
 #
 # For more information on the gauth_credential parameters and providers please
 # refer to its detailed documentation at:


### PR DESCRIPTION
Removing hardcoded project names on Puppet examples

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Removing hardcoded project names on Puppet examples
## [terraform]
## [puppet]
Removing hardcoded project names
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
