### PR TITLE
Bringing gcp_utils up with devel on ansible/ansible

### DIFF
--- a/provider/ansible/gcp_utils.py
+++ b/provider/ansible/gcp_utils.py
@@ -70,9 +70,10 @@ class GcpSession(object):
         self.product = product
         self._validate()
 
-    def get(self, url, body=None):
+    def get(self, url, body=None, **kwargs):
+        kwargs.update({'json': body, 'headers': self._headers()})
         try:
-            return self.session().get(url, json=body, headers=self._headers())
+            return self.session().get(url, **kwargs)
         except getattr(requests.exceptions, 'RequestException') as inst:
             self.module.fail_json(msg=inst.message)
 
@@ -105,12 +106,12 @@ class GcpSession(object):
         if not HAS_GOOGLE_LIBRARIES:
             self.module.fail_json(msg="Please install the google-auth library")
 
-        if self.module.params['service_account_email'] is not None and self.module.params['auth_kind'] != 'machineaccount':
+        if self.module.params.get('service_account_email') is not None and self.module.params['auth_kind'] != 'machineaccount':
             self.module.fail_json(
                 msg="Service Acccount Email only works with Machine Account-based authentication"
             )
 
-        if self.module.params['service_account_file'] is not None and self.module.params['auth_kind'] != 'serviceaccount':
+        if self.module.params.get('service_account_file') is not None and self.module.params['auth_kind'] != 'serviceaccount':
             self.module.fail_json(
                 msg="Service Acccount File only works with Service Account-based authentication"
             )


### PR DESCRIPTION
This code already exists on devel.

We keep a copy on Magic Modules to make it easier to make changes locally. That copy is currently out-of-date.

(This was because of the inventory script, so it's a weird one-time thing)

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Bringing gcp_utils up with devel on ansible/ansible
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
Bringing gcp_utils up with devel on ansible/ansible
