### PR TITLE
No global exclude: true in api.yaml for TargetVpnGateway, SslPolicy

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2540,7 +2540,6 @@ objects:
   - !ruby/object:Api::Resource
     name: 'SslPolicy'
     # TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/173): Enable
-    exclude: true
     kind: 'compute#sslPolicy'
     base_url: projects/{{project}}/global/sslPolicies
     update_verb: :PATCH
@@ -3147,7 +3146,6 @@ objects:
         update_url: 'projects/{{project}}/global/targetTcpProxies/{{name}}/setBackendService'
   - !ruby/object:Api::Resource
     name: 'TargetVpnGateway'
-    exclude: true
     kind: 'compute#targetVpnGateway'
     base_url: projects/{{project}}/regions/{{region}}/targetVpnGateways
     input: true

--- a/products/compute/chef.yaml
+++ b/products/compute/chef.yaml
@@ -69,6 +69,11 @@ overrides: !ruby/object:Provider::ResourceOverrides
   TargetPool: !ruby/object:Provider::Chef::ResourceOverride
     provider_helpers:
       - 'products/compute/helpers/provider_target_pool.rb'
+  # Not yet implemented.
+  SslPolicy: !ruby/object:Provider::Chef::ResourceOverride
+    exclude: true
+  TargetVpnGateway: !ruby/object:Provider::Chef::ResourceOverride
+    exclude: true
 examples: !ruby/object:Api::Resource::HashArray
   Address:
     - address.rb

--- a/products/compute/puppet.yaml
+++ b/products/compute/puppet.yaml
@@ -102,6 +102,11 @@ overrides: !ruby/object:Provider::ResourceOverrides
     # TODO(nelsonjr): Make sure that attempts to create a region fails
     handlers: !ruby/object:Provider::Puppet::Handlers
       flush: raise 'Region cannot be edited' if @dirty
+  # Not yet implemented.
+  TargetVpnGateway: !ruby/object:Provider::Puppet::ResourceOverride
+    exclude: true
+  SslPolicy: !ruby/object:Provider::Puppet::ResourceOverride
+    exclude: true
 functions:
   - !ruby/object:Provider::Config::Function
     name: 'gcompute_address_ip'


### PR DESCRIPTION
No global exclude: true in api.yaml for TargetVpnGateway, SslPolicy

This should be a no-op.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
No global exclude: true in api.yaml for TargetVpnGateway, SslPolicy
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
