### PR TITLE
Ansible: fixing custom metadata helpers for Instances

### DIFF
--- a/products/compute/helpers/python/instance_metadata.py
+++ b/products/compute/helpers/python/instance_metadata.py
@@ -33,7 +33,10 @@ def metadata_encoder(metadata):
     metadata_new = []
     for key in metadata:
         value = metadata[key]
-        metadata_new.append({key: value})
+        metadata_new.append({
+            "key": key,
+            "value": value
+        })
     return {
         'items': metadata_new
     }
@@ -45,5 +48,5 @@ def metadata_decoder(metadata):
     if 'items' in metadata:
         metadata_items = metadata['items']
         for item in metadata_items:
-            items[item.keys()[0]] = item[item.keys()[0]]
+            items[item['key']] = item['value']
     return items


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Ansible: fixing custom metadata helpers for Instances

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
Fixing custom metadata helpers for instances
