### PR TITLE
Ansible: Spanner! and support for custom requests for separate create/update

### DIFF
--- a/products/_bundle/templates/ansible/lookup.erb
+++ b/products/_bundle/templates/ansible/lookup.erb
@@ -103,7 +103,9 @@ class Gcp<%= object.name -%>(object):
     def __init__(self, options):
         self.module = GcpModule(options)
 
+<% if object.kind -%>
         self.kind = <%= quote_string(object.kind) %>
+<% end -%>
         self.link = <%= self_link_url(object) %>.format(**self.module.params)
 
     def _fetch_resource(self):

--- a/products/spanner/ansible.yaml
+++ b/products/spanner/ansible.yaml
@@ -30,6 +30,12 @@ overrides: !ruby/object:Provider::ResourceOverrides
     custom_update_resource: true
     provider_helpers:
       - 'products/spanner/helpers/instance_helpers.py.erb'
+  Database: !ruby/object:Provider::Ansible::ResourceOverride
+    transport: !ruby/object:Api::Resource::Transport
+      encoder: encode_request
+      decoder: decode_response
+    provider_helpers:
+      - 'products/spanner/helpers/database_helpers.py.erb'
   # Virtual => true objects that don't need dedicated resources.
   InstanceConfig: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: true

--- a/products/spanner/ansible.yaml
+++ b/products/spanner/ansible.yaml
@@ -1,0 +1,43 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Ansible::Config
+manifest: !ruby/object:Provider::Ansible::Manifest
+  metadata_version: '1.1'
+  status:
+    - preview
+  supported_by: 'community'
+  requirements:
+    - python >= 2.6
+    - requests >= 2.18.4
+    - google-auth >= 1.3.0
+  version_added: '2.7'
+  author: Google Inc. (@googlecloudplatform)
+# This is where custom code would be defined eventually.
+overrides: !ruby/object:Provider::ResourceOverrides
+  Instance: !ruby/object:Provider::Ansible::ResourceOverride
+    custom_create_resource: true
+    custom_update_resource: true
+    provider_helpers:
+      - 'products/spanner/helpers/instance_helpers.py.erb'
+  # Virtual => true objects that don't need dedicated resources.
+  InstanceConfig: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+examples: !ruby/object:Api::Resource::HashArray
+files: !ruby/object:Provider::Config::Files
+  copy:
+<%= lines(indent(compile('provider/ansible/common~copy.yaml'), 4)) -%>
+  compile:
+<%= lines(indent(compile('provider/ansible/common~compile.yaml'), 4)) -%>
+tests: !ruby/object:Api::Resource::HashArray
+test_data: !ruby/object:Provider::Config::TestData

--- a/products/spanner/ansible.yaml
+++ b/products/spanner/ansible.yaml
@@ -23,7 +23,6 @@ manifest: !ruby/object:Provider::Ansible::Manifest
     - google-auth >= 1.3.0
   version_added: '2.7'
   author: Google Inc. (@googlecloudplatform)
-# This is where custom code would be defined eventually.
 overrides: !ruby/object:Provider::ResourceOverrides
   Instance: !ruby/object:Provider::Ansible::ResourceOverride
     custom_create_resource: true

--- a/products/spanner/examples/ansible/database.yaml
+++ b/products/spanner/examples/ansible/database.yaml
@@ -1,0 +1,45 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- !ruby/object:Provider::Ansible::Example
+dependencies:
+  - !ruby/object:Provider::Ansible::Task
+    name: gcp_spanner_instance
+    code: |
+      name: <%= dependency_name('instance', 'database') %>
+      display_name: 'My Spanner Instance'
+      node_count: 2
+      labels:
+        cost_center: ti-1700004
+      config: regional-us-central1
+      project: <%= ctx[:project] %>
+      auth_kind: <%= ctx[:auth_kind] %>
+      service_account_file: <%= ctx[:service_account_file] %>
+    register: instance
+task: !ruby/object:Provider::Ansible::Task
+    name: gcp_spanner_database
+    code: |
+      name: 'webstore'
+      instance: "{{ instance }}"
+      project: <%= ctx[:project] %>
+      auth_kind: <%= ctx[:auth_kind] %>
+      service_account_file: <%= ctx[:service_account_file] %>
+verifier: !ruby/object:Provider::Ansible::Verifier
+  command: |
+    gcloud spanner databases describe
+      --project="{{ gcp_project }}"
+      --instance="{{ instance.name }}"
+      "webstore"
+  failure: !ruby/object:Provider::Ansible::GrpcFailureCondition
+    single: Database
+    plural: instances/instance-database/databases
+    name: webstore

--- a/products/spanner/examples/ansible/instance.yaml
+++ b/products/spanner/examples/ansible/instance.yaml
@@ -1,0 +1,33 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- !ruby/object:Provider::Ansible::Example
+task: !ruby/object:Provider::Ansible::Task
+  name: gcp_spanner_instance
+  code: |
+    name: <%= ctx[:name] %>
+    display_name: 'My Spanner Instance'
+    node_count: 2
+    labels:
+      cost_center: ti-1700004
+    config: regional-us-central1
+    project: <%= ctx[:project] %>
+    auth_kind: <%= ctx[:auth_kind] %>
+    service_account_file: <%= ctx[:service_account_file] %>
+verifier: !ruby/object:Provider::Ansible::Verifier
+  command: |
+    gcloud spanner instances describe
+      --project="{{ gcp_project }}"
+      "{{ resource_name }}"
+  failure: !ruby/object:Provider::Ansible::GrpcFailureCondition
+    single: Instance
+    plural: instances

--- a/products/spanner/helpers/database_helpers.py.erb
+++ b/products/spanner/helpers/database_helpers.py.erb
@@ -11,7 +11,8 @@ def decode_response(response, module):
     response['name'] = response['name'].split('/')[-1]
     return response
 
+
 def encode_request(request, module):
-    request['create_statement'] = "CREATE DATABASE `{}`".format(module.params['name']) 
+    request['create_statement'] = "CREATE DATABASE `{0}`".format(module.params['name'])
     del request['name']
     return request

--- a/products/spanner/helpers/database_helpers.py.erb
+++ b/products/spanner/helpers/database_helpers.py.erb
@@ -1,0 +1,17 @@
+def decode_response(response, module):
+    if not response:
+        return response
+
+    if 'name' not in response:
+        return response
+
+    if '/operations/' in response['name']:
+        return response
+
+    response['name'] = response['name'].split('/')[-1]
+    return response
+
+def encode_request(request, module):
+    request['create_statement'] = "CREATE DATABASE `{}`".format(module.params['name']) 
+    del request['name']
+    return request

--- a/products/spanner/helpers/instance_config_helpers.py.erb
+++ b/products/spanner/helpers/instance_config_helpers.py.erb
@@ -1,6 +1,6 @@
 def encode_request(request, module):
     request['name'] =
-      "projects/%(project)/instanceConfigs/%(name)" % module.params
+      "projects/%(project)/instanceConfigs/%(name)".format(**module.params)
     return request
 
 def decode_response(response, module):

--- a/products/spanner/helpers/instance_config_helpers.py.erb
+++ b/products/spanner/helpers/instance_config_helpers.py.erb
@@ -1,0 +1,8 @@
+def encode_request(request, module):
+    request['name'] =
+      "projects/%(project)/instanceConfigs/%(name)" % module.params
+    return request
+
+def decode_response(response, module):
+    response['name'] = response['name'].split('/')[-1]
+    return response

--- a/products/spanner/helpers/instance_helpers.py.erb
+++ b/products/spanner/helpers/instance_helpers.py.erb
@@ -1,0 +1,33 @@
+def resource_to_create(module):
+    instance = resource_to_request(module)
+    instance['name'] = "projects/{}/instances/{}".format(module.params['project'],
+                                                         module.params['name'])
+    instance['config'] = "projects/{}/instanceConfigs/{}".format(module.params['project'],
+                                                                 instance['config'])
+    return {
+      'instanceId': module.params['name'],
+      'instance': instance
+    }
+
+def resource_to_update(module):
+    instance = resource_to_request(module)
+    instance['name'] = "projects/{}/instances/{}".format(module.params['project'],
+                                                         module.params['name'])
+    instance['config'] = "projects/{}/instanceConfigs/{}".format(module.params['project'],
+                                                                 instance['config'])
+    return {
+      'instance': instance,
+  <% fields = object.properties.select { |p| !p.output }.map(&:name) -%>
+      'fieldMask': "<%= fields.map { |x| quote_string(x) }.join(' ,') -%>"
+    }
+
+def decode_response(response, module):
+    if not response:
+        return response
+
+    if '/operations/' in response['name']:
+        return response
+
+    response['name'] = response['name'].split('/')[-1]
+    response['config'] = response['config'].split('/')[-1]
+    return response

--- a/products/spanner/helpers/instance_helpers.py.erb
+++ b/products/spanner/helpers/instance_helpers.py.erb
@@ -1,25 +1,27 @@
 def resource_to_create(module):
     instance = resource_to_request(module)
-    instance['name'] = "projects/{}/instances/{}".format(module.params['project'],
-                                                         module.params['name'])
-    instance['config'] = "projects/{}/instanceConfigs/{}".format(module.params['project'],
-                                                                 instance['config'])
+    instance['name'] = "projects/{0}/instances/{1}".format(module.params['project'],
+                                                           module.params['name'])
+    instance['config'] = "projects/{0}/instanceConfigs/{1}".format(module.params['project'],
+                                                                   instance['config'])
     return {
-      'instanceId': module.params['name'],
-      'instance': instance
+        'instanceId': module.params['name'],
+        'instance': instance
     }
+
 
 def resource_to_update(module):
     instance = resource_to_request(module)
-    instance['name'] = "projects/{}/instances/{}".format(module.params['project'],
-                                                         module.params['name'])
-    instance['config'] = "projects/{}/instanceConfigs/{}".format(module.params['project'],
-                                                                 instance['config'])
+    instance['name'] = "projects/{0}/instances/{1}".format(module.params['project'],
+                                                           module.params['name'])
+    instance['config'] = "projects/{0}/instanceConfigs/{1}".format(module.params['project'],
+                                                                   instance['config'])
     return {
-      'instance': instance,
-  <% fields = object.properties.select { |p| !p.output }.map(&:name) -%>
-      'fieldMask': "<%= fields.map { |x| quote_string(x) }.join(' ,') -%>"
+        'instance': instance,
+<% fields = object.properties.select { |p| !p.output }.map(&:name) -%>
+        'fieldMask': "<%= fields.map { |x| quote_string(x) }.join(' ,') -%>"
     }
+
 
 def decode_response(response, module):
     if not response:

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -144,6 +144,23 @@ module Provider
       end
     end
 
+    class GrpcFailureCondition < FailureCondition
+      attr_reader :single
+      attr_reader :plural
+
+      def validate
+        check_optional_property :single, ::String
+        check_optional_property :plural, ::String
+
+        @name ||= '{{ resource_name }}'
+        @error = [
+          "#{single.capitalize} not found:",
+          "projects/{{ gcp_project }}/#{plural}/#{@name}",
+        ].join(' ')
+        super
+      end
+    end
+
     # Class responsible for holding a single Ansible task. This task may create
     # a GCP resource or create a dependent GCP resource.
     class Task < Api::Object

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -144,6 +144,7 @@ module Provider
       end
     end
 
+    # Grpc gcloud commands seem to follow a similar pattern
     class GrpcFailureCondition < FailureCondition
       attr_reader :single
       attr_reader :plural
@@ -155,7 +156,7 @@ module Provider
         @name ||= '{{ resource_name }}'
         @error = [
           "#{single.capitalize} not found:",
-          "projects/{{ gcp_project }}/#{plural}/#{@name}",
+          "projects/{{ gcp_project }}/#{plural}/#{@name}"
         ].join(' ')
         super
       end

--- a/provider/ansible/resource_override.rb
+++ b/provider/ansible/resource_override.rb
@@ -19,6 +19,8 @@ module Provider
     module OverrideProperties
       attr_reader :access_api_results
       attr_reader :collection
+      attr_reader :custom_create_resource
+      attr_reader :custom_update_resource
       attr_reader :create
       attr_reader :delete
       attr_reader :editable
@@ -38,6 +40,8 @@ module Provider
         super
 
         default_value_property :access_api_results, false
+        default_value_property :custom_create_resource, false
+        default_value_property :custom_update_resource, false
         default_value_property :exclude, false
         default_value_property :editable, true
         default_value_property :imports, []
@@ -46,6 +50,8 @@ module Provider
 
         check_property :access_api_results, :boolean
         check_optional_property :collection, ::String
+        check_property :custom_create_resource, :boolean
+        check_property :custom_update_resource, :boolean
         check_optional_property :create, ::String
         check_optional_property :delete, ::String
         check_property :editable, :boolean

--- a/provider/ansible/resource_override.rb
+++ b/provider/ansible/resource_override.rb
@@ -36,6 +36,7 @@ module Provider
     # Product specific overriden properties for Ansible
     class ResourceOverride < Provider::ResourceOverride
       include OverrideProperties
+      # rubocop:disable Metrics/AbcSize
       def validate
         super
 
@@ -64,6 +65,7 @@ module Provider
         check_optional_property :version_added, ::String
       end
       # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/AbcSize
 
       private
 

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -218,7 +218,7 @@ def main():
 -%>
 <%
   update_request = if object.custom_update_resource
-                   'resource_to_update'
+                     'resource_to_update'
                    else
                      'resource_to_request'
                    end

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -191,7 +191,7 @@ def main():
     raise "Ansible does not support create_verb #{object.create_verb}"
   end
   create_request = if object.custom_create_resource
-                   'resource_to_create'
+                     'resource_to_create'
                    else
                      'resource_to_request'
                    end

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -190,13 +190,18 @@ def main():
   else
     raise "Ansible does not support create_verb #{object.create_verb}"
   end
+  create_request = if object.custom_create_resource
+                   'resource_to_create'
+                   else
+                     'resource_to_request'
+                   end
 -%>
 <%
   method = method_call(
     object.async ? 'wait_for_operation' : 'return_if_object',
     ['module',
      method_call("auth#{create_verb}",
-                 ['link', 'resource_to_request(module)']),
+                 ['link', "#{create_request}(module)"]),
      ('kind' if !object.async && object.kind?)
    ]
   )
@@ -211,6 +216,13 @@ def main():
   lines(method_decl('update', ['module', 'link', ('kind' if object.kind?),
                                ('fetch' if object.access_api_results)]))
 -%>
+<%
+  update_request = if object.custom_update_resource
+                   'resource_to_update'
+                   else
+                     'resource_to_request'
+                   end
+-%>
 <% if object.update.nil? -%>
 <%   if !false?(object.editable) -%>
     auth = GcpSession(module, <%= quote_string(prod_name) -%>)
@@ -221,7 +233,7 @@ def main():
     [
      'module',
      method_call("auth.#{update_verb}",
-                 ['link', 'resource_to_request(module)']),
+                 ['link', "#{update_request}(module)"]),
      ('kind' if !object.async && object.kind?)
    ]
   )


### PR DESCRIPTION
Spanner on Ansible

* `create_custom_resource` and `create_update_resource` support (special JSON bodies created for create + update)
* Spanner Instances + helpers
* Spanner Databases + helpers


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Ansible: Spanner! and support for custom requests for separate create/update
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
Spanner Instances + Databases
