### PR TITLE
Generate Route.

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2306,6 +2306,7 @@ objects:
     name: 'Route'
     kind: 'compute#route'
     base_url: projects/{{project}}/global/routes
+    input: true
     description: |
       Represents a Route resource.
 
@@ -2335,6 +2336,7 @@ objects:
         description: |
           The destination range of outgoing packets that this route applies to.
           Only IPv4 is supported.
+        required: true
       - !ruby/object:Api::Type::String
         name: 'description'
         description: |
@@ -2350,12 +2352,14 @@ objects:
           the first character must be a lowercase letter, and all following
           characters must be a dash, lowercase letter, or digit, except the
           last character, which cannot be a dash.
+        required: true
       - !ruby/object:Api::Type::ResourceRef
         name: 'network'
         resource: 'Network'
         imports: 'selfLink'
         description: 'The network that this route applies to.'
         input: true
+        required: true
       - !ruby/object:Api::Type::Integer
         name: 'priority'
         description: |

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2336,6 +2336,11 @@ objects:
           The destination range of outgoing packets that this route applies to.
           Only IPv4 is supported.
       - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          An optional description of this resource. Provide this property
+          when you create the resource.
+      - !ruby/object:Api::Type::String
         name: 'name'
         description: |
           Name of the resource. Provided by the client when the resource is

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -327,7 +327,44 @@ overrides: !ruby/object:Provider::ResourceOverrides
   Region: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   Route: !ruby/object:Provider::Terraform::ResourceOverride
-    exclude: true
+    examples: |
+      ```hcl
+      resource "google_compute_network" "default" {
+        name = "compute-network"
+      }
+
+      resource "google_compute_subnetwork" "default" {
+        name          = "compute-subnetwork"
+        ip_cidr_range = "10.0.0.0/16"
+        network       = "${google_compute_network.default.self_link}"
+        region        = "us-central1"
+      }
+
+      resource "google_compute_route" "default" {
+        name        = "network-route"
+        dest_range  = "15.0.0.0/24"
+        network     = "${google_compute_network.foobar.name}"
+        next_hop_ip = "10.0.1.5"
+        priority    = 100
+      }
+      ```
+    properties:
+      network: !ruby/object:Provider::Terraform::PropertyOverride
+        diff_suppress_func: 'compareSelfLinkOrResourceName'
+      priority: !ruby/object:Provider::Terraform::PropertyOverride
+        default_value: 1000
+      nextHopGateway: !ruby/object:Provider::Terraform::PropertyOverride
+        diff_suppress_func: 'compareSelfLinkOrResourceName'
+        custom_expand: templates/terraform/custom_expand/route_gateway.erb
+      nextHopInstance: !ruby/object:Provider::Terraform::PropertyOverride
+        diff_suppress_func: 'compareSelfLinkOrResourceName'
+        custom_expand: templates/terraform/custom_expand/route_instance.erb
+      tags: !ruby/object:Provider::Terraform::PropertyOverride
+        custom_expand: templates/terraform/custom_expand/set_to_list.erb
+        is_set: true
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      decoder: templates/terraform/decoders/route.erb
+      extra_schema_entry: templates/terraform/extra_schema_entry/route.erb
   Snapshot: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   SslCertificate: !ruby/object:Provider::Terraform::ResourceOverride

--- a/templates/terraform/custom_expand/route_gateway.erb
+++ b/templates/terraform/custom_expand/route_gateway.erb
@@ -1,0 +1,11 @@
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) (interface{}, error) {
+		if v == "default-internet-gateway" {
+				project, err := getProject(d, config)
+				if err != nil {
+						return nil, err
+				}
+				return fmt.Sprintf("projects/%s/global/gateways/default-internet-gateway", project), nil
+		} else {
+				return v, nil
+		}
+}

--- a/templates/terraform/custom_expand/route_instance.erb
+++ b/templates/terraform/custom_expand/route_instance.erb
@@ -1,0 +1,19 @@
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) (interface{}, error) {
+		if v == "" {
+				return v, nil
+		}
+		val, err := parseZonalFieldValue("instances", v.(string), "project", "next_hop_instance_zone", d, config, true)
+		if err != nil {
+				return nil, err
+		}
+		project, err := getProject(d, config)
+		if err != nil {
+				// Can't happen - we wouldn't make it this far if there wasn't a project.
+				return nil, err
+		}
+		nextInstance, err := config.clientCompute.Instances.Get(project, val.Zone, val.Name).Do()
+		if err != nil {
+				return nil, err
+		}
+		return nextInstance.SelfLink, nil
+}

--- a/templates/terraform/custom_expand/set_to_list.erb
+++ b/templates/terraform/custom_expand/set_to_list.erb
@@ -1,0 +1,3 @@
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) (interface{}, error) {
+		return v.(*schema.Set).List(), nil
+}

--- a/templates/terraform/decoders/route.erb
+++ b/templates/terraform/decoders/route.erb
@@ -1,0 +1,10 @@
+if v, ok := res["nextHopInstance"]; ok {
+		val, err := parseZonalFieldValue("instances", v.(string), "project", "next_hop_instance_zone", d, meta.(*Config), true)
+		if err != nil {
+				return nil, err
+		}
+		d.Set("next_hop_instance_zone", val.Zone)
+		res["nextHopInstance"] = val.RelativeLink()
+}
+
+return res, nil

--- a/templates/terraform/extra_schema_entry/route.erb
+++ b/templates/terraform/extra_schema_entry/route.erb
@@ -1,0 +1,5 @@
+"next_hop_instance_zone": &schema.Schema{
+	Type:     schema.TypeString,
+	Optional: true,
+	ForceNew: true,
+},


### PR DESCRIPTION
Adds the 'description' field to Route and marks it as not updateable,
but otherwise it's a pure enablement PR for Route in Terraform.
There's one extra schema entry because we like to allow our users
in Terraform to type things simply, so we let them type the instance
name and zone in separate fields.  This is just to maintain
backwards compatibility and it's not complicated to maintain,
it's just handled in the decoder.

```
TF_ACC=1 go test ./google -v -run=TestAccComputeRoute_ -timeout 120m
=== RUN   TestAccComputeRoute_basic
=== RUN   TestAccComputeRoute_defaultInternetGateway
=== RUN   TestAccComputeRoute_hopInstance
--- PASS: TestAccComputeRoute_hopInstance (117.28s)
--- PASS: TestAccComputeRoute_defaultInternetGateway (29.62s)
--- PASS: TestAccComputeRoute_basic (85.36s)
PASS
ok      github.com/terraform-providers/terraform-provider-google/google 202.658s
```

-----------------------------------------------------------------
# [all]
Add description field to Route resource, make non-updateable.
## [terraform]
Autogenerate Route resource.