### PR TITLE
Ansible doesn't need save_api_results

### DIFF
--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -130,8 +130,7 @@ def main():
 <%
   method = method_call('update', [
                                    'module', 'self_link(module)',
-                                   ('kind' if object.kind?),
-                                   ('fetch' if object.save_api_results?)
+                                   ('kind' if object.kind?)
                                  ])
 -%>
 <%= lines(indent("fetch = #{method}", 16)) -%>
@@ -140,8 +139,7 @@ def main():
 <%
   method = method_call('delete', [
                                    'module', 'self_link(module)',
-                                   ('kind' if object.kind?),
-                                   ('fetch' if object.save_api_results?)
+                                   ('kind' if object.kind?)
                                  ])
 -%>
 <%= lines(indent(method, 12)) -%>
@@ -205,8 +203,7 @@ def main():
 
 
 <%=
-  lines(method_decl('update', ['module', 'link', ('kind' if object.kind?),
-                               ('fetch' if object.save_api_results?)]))
+  lines(method_decl('update', ['module', 'link', ('kind' if object.kind?)]))
 -%>
 <% if object.update.nil? -%>
 <%   if !false?(object.editable) -%>
@@ -233,8 +230,7 @@ def main():
 
 
 <%=
-  lines(method_decl('delete', ['module', 'link', ('kind' if object.kind?),
-                               ('fetch' if object.save_api_results?)]))
+  lines(method_decl('delete', ['module', 'link', ('kind' if object.kind?)]))
 -%>
 <% if object.delete.nil? -%>
     auth = GcpSession(module, <%= quote_string(prod_name) -%>)


### PR DESCRIPTION
Ansible doesn't need save_api_results. The `fetch` result isn't actually used in the codebase anywhere. This leads to spurious changes on Ansible when they aren't needed.


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Ansible doesn't need save_api_results
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
Ansible doesn't need save_api_results
