### PR TITLE
Add notion of fingerprint type.

### DIFF
--- a/api/type.rb
+++ b/api/type.rb
@@ -192,6 +192,19 @@ module Api
       NAME = Api::Type::String.new('name')
     end
 
+    # Represents a fingerprint.  A fingerprint is an output-only
+    # field used for optimistic locking during updates.
+    class Fingerprint < String
+      def validate
+        super
+        @output = true if @output.nil?
+        # Fingerprints are not usually worth including in the
+        # list of output fields.  This should be overridden in
+        # Terraform, where outputting fingerprints is idiomatic.
+        @exclude ||= true
+      end
+    end
+
     # Represents a timestamp
     class Time < Primitive
     end

--- a/api/type.rb
+++ b/api/type.rb
@@ -198,9 +198,8 @@ module Api
       def validate
         super
         @output = true if @output.nil?
-        # Fingerprints are not usually worth including in the
-        # list of output fields.  This should be overridden in
-        # Terraform, where outputting fingerprints is idiomatic.
+        # TODO(ndmckinley): This doesn't work in puppet, chef, or ansible.
+        # Consequently we exclude it by default and override it in Terraform.
         @exclude ||= true
       end
     end

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -700,6 +700,13 @@ objects:
           used.
         output: true
     properties:
+      - !ruby/object:Api::Type::Fingerprint
+        name: 'labelFingerprint'
+        description: |
+          The fingerprint used for optimistic locking of this resource.  Used
+          internally during updates.
+        update_url: 'projects/{{project}}/zones/{{zone}}/disks/{{name}}/setLabels'
+        update_verb: :POST
       - !ruby/object:Api::Type::Time
         name: 'creationTimestamp'
         description: 'Creation timestamp in RFC3339 text format.'

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -124,8 +124,8 @@ overrides: !ruby/object:Provider::ResourceOverrides
         input: true
       licenses: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
-      labels: !ruby/object:Provider::Terraform::PropertyOverride
-        update_statement: templates/terraform/update_statement/use_label_fingerprint.erb
+      labelFingerprint: !ruby/object:Provider::Terraform::PropertyOverride
+        exclude: false
       diskEncryptionKey: !ruby/object:Provider::Terraform::PropertyOverride
         diff_suppress_func:  diskEncryptionKeyDiffSuppress
         custom_expand: templates/terraform/custom_expand/encryption_key_expand.erb
@@ -156,8 +156,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
           `disk_encryption_key.sha256`.  It is deprecated to enhance
           consistency with `source_image_encryption_key` and
           `source_snapshot_encryption_key`.
-        * `label_fingerprint`: The fingerprint of the assigned labels.  Provided
-          when labels are updated to prevent contention (first-write-wins).
     examples: |
       ```hcl
       resource "google_compute_disk" "default" {

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -51,7 +51,8 @@ module Provider
         Api::Type::ResourceRef => 'schema.TypeString',
         Api::Type::NestedObject => 'schema.TypeList',
         Api::Type::Array => 'schema.TypeList',
-        Api::Type::NameValues => 'schema.TypeMap'
+        Api::Type::NameValues => 'schema.TypeMap',
+        Api::Type::Fingerprint => 'schema.TypeString'
       }
     end
 

--- a/templates/terraform/decoders/disk.erb
+++ b/templates/terraform/decoders/disk.erb
@@ -29,6 +29,4 @@ if v, ok := res["sourceSnapshotEncryptionKey"]; ok {
   res["sourceSnapshotEncryptionKey"] = transformed
 }
 
-d.Set("label_fingerprint", res["labelFingerprint"])
-
 return res, nil

--- a/templates/terraform/extra_schema_entry/disk.erb
+++ b/templates/terraform/extra_schema_entry/disk.erb
@@ -12,8 +12,3 @@
 	Computed:   true,
   Deprecated: "Use disk_encryption_key.sha256 instead.",
 },
-
-"label_fingerprint": &schema.Schema{
-	Type:     schema.TypeString,
-	Computed: true,
-},

--- a/templates/terraform/update_statement/use_label_fingerprint.erb
+++ b/templates/terraform/update_statement/use_label_fingerprint.erb
@@ -1,2 +1,0 @@
-<%= property.api_name -%>Prop,
-"labelFingerprint": d.Get("label_fingerprint").(string),


### PR DESCRIPTION
Fingerprint type: automatically exclude from generation and mark as output.
Make disk use this rather than custom code in terraform.
Enables future use of fingerprints on other resources without custom code.

-----------------------------------------------------------------
# [all]
No changes expected
## [terraform]
Minor cleanup of disk's labelFingerprint.