### PR TITLE
AnsibleModule validation should use quotes around default values

### DIFF
--- a/google/python_utils.rb
+++ b/google/python_utils.rb
@@ -1,0 +1,37 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  # Functions to deal with the Python language.
+  module PythonUtils
+    # Prints literal in Python
+    #
+    # For instance, an int is printed as-is and a string is quoted:
+    #  some_key: 80
+    #  other_key: "foo"
+    #
+    # When a yaml file is parsed, strings specified with quotes or without
+    # quotes becomes a ruby string without quotes unless you explicitly set
+    # quotes in the string like "\"foo\"" which is not a pattern we want to
+    # see in our yaml config files.
+    def python_literal(value)
+      if value.is_a?(String) || value.is_a?(Symbol)
+        "'#{value}'"
+      elsif value.is_a?(Numeric)
+        value.to_s
+      else
+        raise "Unsupported Python literal #{value}"
+      end
+    end
+  end
+end

--- a/provider/ansible/module.rb
+++ b/provider/ansible/module.rb
@@ -48,10 +48,17 @@ module Provider
 
       # Returns an array of all base options for a given property.
       # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/AbcSize
       def prop_options(prop, _object, spaces)
+        default = if prop.default_value && prop.is_a?(Api::Type::Integer)
+                    prop.default_value
+                  else
+                    quote_string(prop.default_value.to_s)
+                  end
         [
           ('required=True' if prop.required && !prop.default_value),
-          ("default=#{prop.default_value}" if prop.default_value),
+          ("default=#{default}" if prop.default_value),
           "type=#{quote_string(python_type(prop))}",
           (choices_enum(prop, spaces) if prop.is_a? Api::Type::Enum),
           ("elements=#{quote_string(python_type(prop.item_type))}" \
@@ -61,6 +68,8 @@ module Provider
         ].compact
       end
       # rubocop:enable Metrics/CyclomaticComplexity
+      # rubocop:enable Metrics/PerceivedComplexity
+      # rubocop:enable Metrics/AbcSize
 
       # Returns a formatted string represented the choices of an enum
       # rubocop:disable Metrics/AbcSize

--- a/provider/ansible/module.rb
+++ b/provider/ansible/module.rb
@@ -11,11 +11,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'google/python_utils'
+
 module Provider
   module Ansible
     # Responsible for building out the AnsibleModule code.
     # AnsibleModule is responsible for input validation.
     module Module
+      include Google::PythonUtils
       # Returns the Python dictionary representing a simple property for
       # validation.
       def python_dict_for_property(prop, object, spaces = 0)
@@ -48,17 +51,12 @@ module Provider
 
       # Returns an array of all base options for a given property.
       # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/PerceivedComplexity
       # rubocop:disable Metrics/AbcSize
       def prop_options(prop, _object, spaces)
-        default = if prop.default_value && prop.is_a?(Api::Type::Integer)
-                    prop.default_value
-                  else
-                    quote_string(prop.default_value.to_s)
-                  end
         [
           ('required=True' if prop.required && !prop.default_value),
-          ("default=#{default}" if prop.default_value),
+          ("default=#{python_literal(prop.default_value)}" \
+           if prop.default_value),
           "type=#{quote_string(python_type(prop))}",
           (choices_enum(prop, spaces) if prop.is_a? Api::Type::Enum),
           ("elements=#{quote_string(python_type(prop.item_type))}" \
@@ -68,7 +66,6 @@ module Provider
         ].compact
       end
       # rubocop:enable Metrics/CyclomaticComplexity
-      # rubocop:enable Metrics/PerceivedComplexity
       # rubocop:enable Metrics/AbcSize
 
       # Returns a formatted string represented the choices of an enum

--- a/spec/google_python_spec.rb
+++ b/spec/google_python_spec.rb
@@ -1,0 +1,50 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+require 'google/python_utils'
+
+class Test
+  include Google::PythonUtils
+end
+
+describe Google::PythonUtils do
+  context '#python_literal' do
+    let(:python) { Test.new }
+
+    describe 'string' do
+      subject { python.python_literal('foo') }
+      it { is_expected.to eq '\'foo\'' }
+    end
+
+    describe 'integer' do
+      subject { python.python_literal(123) }
+      it { is_expected.to eq '123' }
+    end
+
+    describe 'float' do
+      subject { python.python_literal(0.987) }
+      it { is_expected.to eq '0.987' }
+    end
+
+    describe 'symbol' do
+      subject { python.python_literal(:NONE) }
+      it { is_expected.to eq '\'NONE\'' }
+    end
+
+    describe 'unknown type' do
+      subject { -> { python.python_literal(Class.new) } }
+      it { is_expected.to raise_error(/Unsupported/) }
+    end
+  end
+end


### PR DESCRIPTION
AnsibleModule validation should use quotes around default values

-----------------------------------------------------------------
# [all]
AnsibleModule validation should use quotes around default values
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
AnsibleModule validation should use quotes around default values
