### PR TITLE
Skip 2 Ansible Storage resources without examples

### DIFF
--- a/products/storage/ansible.yaml
+++ b/products/storage/ansible.yaml
@@ -25,6 +25,10 @@ manifest: !ruby/object:Provider::Ansible::Manifest
   author: Google Inc. (@googlecloudplatform)
 # This is where custom code would be defined eventually.
 objects: !ruby/object:Api::Resource::HashArray
+  ObjectAccessControl: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
+  DefaultObjectACL: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
 examples: !ruby/object:Api::Resource::HashArray
 files: !ruby/object:Provider::Config::Files
   copy:


### PR DESCRIPTION
Skip 2 Ansible Storage resources without examples (in preparation for testing Ansible linters on CI)

-----------------------------------------------------------------
# [all]
Skip 2 Ansible Storage resources without examples
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
Skip 2 Ansible Storage resources without examples
