### PR TITLE
Ansible - Adding back in fetch

### DIFF
--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -130,7 +130,8 @@ def main():
 <%
   method = method_call('update', [
                                    'module', 'self_link(module)',
-                                   ('kind' if object.kind?)
+                                   ('kind' if object.kind?),
+                                   ('fetch' if object.access_api_results)
                                  ])
 -%>
 <%= lines(indent("fetch = #{method}", 16)) -%>
@@ -139,7 +140,8 @@ def main():
 <%
   method = method_call('delete', [
                                    'module', 'self_link(module)',
-                                   ('kind' if object.kind?)
+                                   ('kind' if object.kind?),
+                                   ('fetch' if object.access_api_results)
                                  ])
 -%>
 <%= lines(indent(method, 12)) -%>
@@ -203,7 +205,8 @@ def main():
 
 
 <%=
-  lines(method_decl('update', ['module', 'link', ('kind' if object.kind?)]))
+  lines(method_decl('update', ['module', 'link', ('kind' if object.kind?),
+                               ('fetch' if object.access_api_results)]))
 -%>
 <% if object.update.nil? -%>
 <%   if !false?(object.editable) -%>
@@ -230,7 +233,8 @@ def main():
 
 
 <%=
-  lines(method_decl('delete', ['module', 'link', ('kind' if object.kind?)]))
+  lines(method_decl('delete', ['module', 'link', ('kind' if object.kind?),
+                               ('fetch' if object.access_api_results)]))
 -%>
 <% if object.delete.nil? -%>
     auth = GcpSession(module, <%= quote_string(prod_name) -%>)


### PR DESCRIPTION
This, ladies and gentlemen, is why you always run the linter.

Turns out we were using `fetch` on Ansible. It's just that the templates
used a different property, which led to spurious diffs.

This commit reverts the old `fetch` PR and changes from the
`save_api_results?` method to the `access_api_results` resource override.

<!-- A summary of the changes in this commit goes here -->


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Ansible - adding in fetch
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
Adding fetch back on certain places.
