### PR TITLE
Fixing bundle provider on Puppet/Chef

### DIFF
--- a/products/_bundle/templates/chef/README.md.erb
+++ b/products/_bundle/templates/chef/README.md.erb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 <% end -%>
+<% autogen_exception -%>
 
 Google Cloud Platform for Chef
 --------------------------------

--- a/products/_bundle/templates/puppet/README.md.erb
+++ b/products/_bundle/templates/puppet/README.md.erb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 <% end -%>
+<% autogen_exception -%>
 
 Google Cloud Platform for Puppet
 --------------------------------

--- a/provider/chef/bundle.rb
+++ b/provider/chef/bundle.rb
@@ -45,7 +45,7 @@ module Provider
       end
     end
 
-    def generate(output_folder, _types)
+    def generate(output_folder, _types, _version_name)
       # Let's build all the dependencies off of the products we found on our
       # path and has the corresponding provider.yaml file
       @config.manifest.depends.concat(

--- a/provider/puppet/bundle.rb
+++ b/provider/puppet/bundle.rb
@@ -20,7 +20,7 @@ module Provider
   # A provider to generate the "bundle" module.
   class PuppetBundle < Provider::Core
     # A manifest for the "bundle" module
-    class Manifest < Puppet::Manifest
+    class Manifest < Provider::Puppet::Manifest
       attr_reader :releases
 
       def validate
@@ -40,11 +40,10 @@ module Provider
 
       def validate
         check_property :manifest, Provider::PuppetBundle::Manifest
-        super
       end
     end
 
-    def generate(output_folder, _types)
+    def generate(output_folder, _types, _version_name)
       # Let's build all the dependencies off of the products we found on our
       # path and has the corresponding provider.yaml file
       generate_requirements


### PR DESCRIPTION
The _bundle providers (used for the puppet-google and chef-google repos, which are overviews of all of the Chef + Puppet modules) are currently broken. This will fix them.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Fix Chef + Puppet bundle provider
## [terraform]
## [puppet]
Fix bundle provider
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
Fix bundle provider
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
