### PR TITLE
Puppet support for default values

### DIFF
--- a/google/ruby_utils.rb
+++ b/google/ruby_utils.rb
@@ -1,0 +1,37 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  # Functions to deal with the Ruby language.
+  module RubyUtils
+    # Prints literal in Ruby
+    #
+    # For instance, an int is printed as-is and a string is quoted:
+    #  some_key: 80
+    #  other_key: "foo"
+    #
+    # When a yaml file is parsed, strings specified with quotes or without
+    # quotes becomes a ruby string without quotes unless you explicitly set
+    # quotes in the string like "\"foo\"" which is not a pattern we want to
+    # see in our yaml config files.
+    def ruby_literal(value)
+      if value.is_a?(String) || value.is_a?(Symbol)
+        "'#{value}'"
+      elsif value.is_a?(Numeric)
+        value.to_s
+      else
+        raise "Unsupported Ruby literal #{value}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Puppet support for default values. This is in preparation for default values on scopes.


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Puppet support for default values
## [terraform]
## [puppet]
Support for default values
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
