### PR TITLE
Chef default value support

### DIFF
--- a/provider/chef.rb
+++ b/provider/chef.rb
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'google/ruby_utils'
 require 'provider/config'
 require 'provider/core'
 require 'provider/chef/manifest'
@@ -24,6 +25,8 @@ module Provider
   # Code generator for Chef Cookbooks that manage Google Cloud Platform
   # resources.
   class Chef < Provider::Core
+    include Google::RubyUtils
+
     RESERVED_WORDS = %w[deprecated updated].freeze
     TEST_FOLDER = 'recipes'.freeze
 

--- a/templates/chef/resource.erb
+++ b/templates/chef/resource.erb
@@ -53,6 +53,7 @@ module Google
     prop_name = "property :#{label_name(object)}" if prop.out_name == 'name'
     prop_attrs = [
       ('name_property: true' if prop.out_name == 'name'),
+      ("default: #{ruby_literal(prop.default_value)}" if prop.default_value),
       'desired_state: true'
     ].compact
 -%>


### PR DESCRIPTION
Chef default value support. Same as Puppet. Prep for default scopes.


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Chef default value support
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
Default value support
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
