### PR TITLE
Generate VPN Tunnel in Magic Modules, and enable TargetVPNGateway.

### DIFF
--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -143,8 +143,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
   TargetPool: !ruby/object:Provider::Ansible::ResourceOverride
     provider_helpers:
       - 'products/compute/helpers/python/provider_target_pool.py'
-  TargetVpnGateway: !ruby/object:Provider::Ansible::ResourceOverride
-    exclude: false
   # Not yet implemented.
   Snapshot: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: true

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -3473,6 +3473,100 @@ objects:
                 A reference to expected BackendService resource the given URL
                 should be mapped to.
   - !ruby/object:Api::Resource
+    name: 'VpnTunnel'
+    kind: 'compute#vpnTunnel'
+    description: 'VPN tunnel resource.'
+    input: true
+    base_url: projects/{{project}}/regions/{{region}}/vpnTunnels
+    exports:
+      - !ruby/object:Api::Type::SelfLink
+        name: 'selfLink'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Cloud VPN Overview': 'https://cloud.google.com/vpn/docs/concepts/overview'
+        'Networks and Tunnel Routing': 'https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing'
+      api: 'https://cloud.google.com/compute/docs/reference/rest/v1/vpnTunnels'
+<%= indent(compile_file({}, 'templates/regional_async.yaml.erb'), 4) %>
+    parameters:
+      - !ruby/object:Api::Type::ResourceRef
+        name: 'region'
+        resource: 'Region'
+        imports: 'selfLink'
+        description: 'The region where the tunnel is located.'
+        output: true
+    properties:
+      - !ruby/object:Api::Type::Time
+        name: 'creationTimestamp'
+        description: 'Creation timestamp in RFC3339 text format.'
+        output: true
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Name of the resource. Provided by the client when the resource is
+          created. The name must be 1-63 characters long, and comply with
+          RFC1035. Specifically, the name must be 1-63 characters long and
+          match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which
+          means the first character must be a lowercase letter, and all
+          following characters must be a dash, lowercase letter, or digit,
+          except the last character, which cannot be a dash.
+        required: true
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          An optional description of this resource.
+        input: true
+      - !ruby/object:Api::Type::ResourceRef
+        name: 'targetVpnGateway'
+        description: |
+          URL of the Target VPN gateway with which this VPN tunnel is
+          associated. Provided by the client when the VPN tunnel is created.
+        resource: 'TargetVpnGateway'
+        imports: 'selfLink'
+        input: true
+        required: true
+      # TODO(ndmckinley): Make this a resource refefence
+      - !ruby/object:Api::Type::String
+        name: 'router'
+        description: |
+          URL of router resource to be used for dynamic routing.
+        input: true
+      - !ruby/object:Api::Type::String
+        name: 'peerIp'
+        description: |
+          IP address of the peer VPN gateway. Only IPv4 is supported.
+      - !ruby/object:Api::Type::String
+        name: 'sharedSecret'
+        description: |
+          Shared secret used to set the secure session between the Cloud VPN
+          gateway and the peer VPN gateway.
+      - !ruby/object:Api::Type::String
+        name: 'sharedSecretHash'
+        description: |
+          Hash of the shared secret.
+        output: true
+      - !ruby/object:Api::Type::Integer
+        name: 'ikeVersion'
+        description: |
+          IKE protocol version to use when establishing the VPN tunnel with
+          peer VPN gateway.
+          Acceptable IKE versions are 1 or 2. Default version is 2.
+      - !ruby/object:Api::Type::Array
+        name: 'localTrafficSelector'
+        description: |
+          Local traffic selector to use when establishing the VPN tunnel with
+          peer VPN gateway. The value should be a CIDR formatted string, 
+          for example `192.168.0.0/16`. The ranges should be disjoint.
+          Only IPv4 is supported.
+        item_type: Api::Type::String
+      - !ruby/object:Api::Type::Array
+        name: 'remoteTrafficSelector'
+        description: |
+          Remote traffic selector to use when establishing the VPN tunnel with
+          peer VPN gateway. The value should be a CIDR formatted string, 
+          for example `192.168.0.0/16`. The ranges should be disjoint.
+          Only IPv4 is supported.
+        item_type: Api::Type::String
+  - !ruby/object:Api::Resource
     name: 'Zone'
     kind: 'compute#zone'
     base_url: projects/{{project}}/zones

--- a/products/compute/chef.yaml
+++ b/products/compute/chef.yaml
@@ -72,8 +72,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
   # Not yet implemented.
   SslPolicy: !ruby/object:Provider::Chef::ResourceOverride
     exclude: true
-  TargetVpnGateway: !ruby/object:Provider::Chef::ResourceOverride
-    exclude: true
 examples: !ruby/object:Api::Resource::HashArray
   Address:
     - address.rb
@@ -162,9 +160,13 @@ examples: !ruby/object:Api::Resource::HashArray
   TargetTcpProxy:
     - delete_target_tcp_proxy.rb
     - target_tcp_proxy.rb
+  TargetVpnGateway:
+    - target_vpn_gateway.rb
   UrlMap:
     - delete_url_map.rb
     - url_map.rb
+  VpnTunnel:
+    - vpn_tunnel.rb
   Zone:
     - zone.rb
 files: !ruby/object:Provider::Config::Files

--- a/products/compute/examples/chef/target_vpn_gateway.rb
+++ b/products/compute/examples/chef/target_vpn_gateway.rb
@@ -1,0 +1,43 @@
+<% if false # the license inside this if block assertains to this file -%>
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+<% end -%>
+<% unless name == 'README.md' -%>
+
+<%= compile 'templates/license.erb' -%>
+
+<%= lines(autogen_notice :chef) -%>
+
+<%= compile 'templates/chef/example~auth.rb.erb' -%>
+<% end -%>
+gcompute_network <%= example_resource_name('mynetwork') -%> do
+  action :create
+  auto_create_subnetworks false
+  project ENV['PROJECT'] # ex: 'my-test-project'
+  credential 'mycred'
+end
+
+gcompute_region <%= example_resource_name('some-region') -%> do
+  action :create
+  r_label 'us-west1'
+  project ENV['PROJECT'] # ex: 'my-test-project'
+  credential 'mycred'
+end
+
+gcompute_target_vpn_gateway <%= example_resource_name('mygateway') -%> do
+  action :create
+  project ENV['PROJECT'] # ex: 'my-test-project'
+  credential 'mycred'
+  network <%= example_resource_name('mynetwork') %>
+  region <%= example_resource_name('some-region') %>
+end

--- a/products/compute/examples/chef/vpn_tunnel.rb
+++ b/products/compute/examples/chef/vpn_tunnel.rb
@@ -1,0 +1,51 @@
+<% if false # the license inside this if block assertains to this file -%>
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+<% end -%>
+<% unless name == 'README.md' -%>
+
+<%= compile 'templates/license.erb' -%>
+
+<%= lines(autogen_notice :chef) -%>
+
+<%= compile 'templates/chef/example~auth.rb.erb' -%>
+<% end -%>
+gcompute_network <%= example_resource_name('mynetwork') -%> do
+  action :create
+  auto_create_subnetworks false
+  project ENV['PROJECT'] # ex: 'my-test-project'
+  credential 'mycred'
+end
+
+gcompute_region <%= example_resource_name('some-region') -%> do
+  action :create
+  r_label 'us-west1'
+  project ENV['PROJECT'] # ex: 'my-test-project'
+  credential 'mycred'
+end
+
+gcompute_target_vpn_gateway <%= example_resource_name('mygateway') -%> do
+  action :create
+  project ENV['PROJECT'] # ex: 'my-test-project'
+  credential 'mycred'
+  network <%= example_resource_name('mynetwork') %>
+  region <%= example_resource_name('some-region') %>
+end
+
+gcompute_vpn_tunnel <%= example_resource_name('mytunnel') -%> do
+  action :create
+  project ENV['PROJECT'] # ex: 'my-test-project'
+  credential 'mycred'
+  target_vpn_gateway <%= example_resource_name('mygateway') %>
+  region <%= example_resource_name('some-region') %>
+end

--- a/products/compute/examples/puppet/target_vpn_gateway.pp
+++ b/products/compute/examples/puppet/target_vpn_gateway.pp
@@ -1,0 +1,40 @@
+<% if false # the license inside this if block assertains to this file -%>
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+<% end -%>
+<% unless name == "README.md" -%>
+<%= compile 'templates/license.erb' -%>
+
+<%= lines(autogen_notice :puppet) -%>
+
+<%= compile 'templates/puppet/examples~credential.pp.erb' -%>
+
+<% end # name == README.md -%>
+
+gcompute_region { <%= example_resource_name('some-region') -%>:
+  name       => 'us-west1',
+  project    => $project, # e.g. 'my-test-project'
+  credential => 'mycred',
+}
+
+gcompute_network { <%= example_resource_name('mynetwork-${network_id}') -%>:
+  auto_create_subnetworks => false,
+  project                 => $project, # e.g. 'my-test-project'
+  credential              => 'mycred',
+}
+
+gcompute_target_vpn_gateway { <%= example_resource_name('my-gateway-${gateway_id}') -%>:
+  project     => $project,
+  credential  => 'mycred',
+  network     => <%= example_resource_name('mynetwork-${network_id}') -%>
+}

--- a/products/compute/examples/puppet/vpn_tunnel.pp
+++ b/products/compute/examples/puppet/vpn_tunnel.pp
@@ -1,0 +1,46 @@
+<% if false # the license inside this if block assertains to this file -%>
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+<% end -%>
+<% unless name == "README.md" -%>
+<%= compile 'templates/license.erb' -%>
+
+<%= lines(autogen_notice :puppet) -%>
+
+<%= compile 'templates/puppet/examples~credential.pp.erb' -%>
+
+<% end # name == README.md -%>
+
+gcompute_region { <%= example_resource_name('some-region') -%>:
+  name       => 'us-west1',
+  project    => $project, # e.g. 'my-test-project'
+  credential => 'mycred',
+}
+
+gcompute_network { <%= example_resource_name('mynetwork-${network_id}') -%>:
+  auto_create_subnetworks => false,
+  project                 => $project, # e.g. 'my-test-project'
+  credential              => 'mycred',
+}
+
+gcompute_target_vpn_gateway { <%= example_resource_name('my-gateway-${gateway_id}') -%>:
+  project     => $project,
+  credential  => 'mycred',
+  network     => <%= example_resource_name('mynetwork-${network_id}') -%>
+}
+
+gcompute_vpn_tunnel { <%= example_resource_name('my-tunnel-${gateway_id}') -%>:
+  project     => $project,
+  credential  => 'mycred',
+  target_vpn_gateway => <%= example_resource_name('my-gateway-${network_id}') -%>
+}

--- a/products/compute/puppet.yaml
+++ b/products/compute/puppet.yaml
@@ -103,8 +103,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
     handlers: !ruby/object:Provider::Puppet::Handlers
       flush: raise 'Region cannot be edited' if @dirty
   # Not yet implemented.
-  TargetVpnGateway: !ruby/object:Provider::Puppet::ResourceOverride
-    exclude: true
   SslPolicy: !ruby/object:Provider::Puppet::ResourceOverride
     exclude: true
 functions:
@@ -543,11 +541,13 @@ examples: !ruby/object:Api::Resource::HashArray
   TargetSslProxy:
     - delete_target_ssl_proxy.pp
     - target_ssl_proxy.pp
-  # TargetVpnGateway
+  TargetVpnGateway:
+    - target_vpn_gateway.pp
   UrlMap:
     - delete_url_map.pp
     - url_map.pp
-  # VpnTunnel
+  VpnTunnel:
+    - vpn_tunnel.pp
   # ZoneOperation -- not useful for state convergence
   Zone:
     - zone.pp


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
This PR generates the VPN Tunnel resource in all four downstreams, and enables TargetVPNGateway everywhere where it wasn't already (Puppet, Chef, Ansible).

TODO:
- [ ] Ansible examples
- [ ] Confirm required-ness of fields in VPN Tunnel.
- [ ] Make sure tests pass for puppet/chef/ansible.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Autogenerate VPN Tunnel resource
## [puppet]
### [puppet-compute]
Add VPN Tunnel and Target VPN Gateway.
## [chef]
### [chef-compute]
Add VPN Tunnel and Target VPN Gateway.
## [ansible]
Add VPN Tunnel and Target VPN Gateway.