### PR TITLE
Support Redis config

### DIFF
--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 80.37
+    "covered_percent": 80.43
   }
 }

--- a/products/redis/api.yaml
+++ b/products/redis/api.yaml
@@ -94,6 +94,11 @@ objects:
         description: Resource labels to represent user provided metadata.
         key_type: Api::Type::String
         value_type: Api::Type::String
+      - !ruby/object:Api::Type::NameValues
+        name: 'redisConfigs'
+        description: Redis configuration parameters, according to http://redis.io/topics/config.
+        key_type: Api::Type::String
+        value_type: Api::Type::String
       - !ruby/object:Api::Type::String
         name: locationId
         description: |

--- a/templates/terraform/pre_update/redis_instance.erb
+++ b/templates/terraform/pre_update/redis_instance.erb
@@ -8,7 +8,7 @@ if d.HasChange("labels") {
 if d.HasChange("memory_size_gb") {
 	updateMask = append(updateMask, "memorySizeGb")
 }
-if d.HasChange("redisConfigs") {
+if d.HasChange("redis_configs") {
 	updateMask = append(updateMask, "redisConfigs")
 }
 // updateMask is a URL parameter but not present in the schema, so replaceVars

--- a/templates/terraform/pre_update/redis_instance.erb
+++ b/templates/terraform/pre_update/redis_instance.erb
@@ -8,6 +8,9 @@ if d.HasChange("labels") {
 if d.HasChange("memory_size_gb") {
 	updateMask = append(updateMask, "memorySizeGb")
 }
+if d.HasChange("redisConfigs") {
+	updateMask = append(updateMask, "redisConfigs")
+}
 // updateMask is a URL parameter but not present in the schema, so replaceVars
 // won't set it
 url, err = addQueryParams(url, map[string]string{"updateMask": strings.Join(updateMask, ",")})

--- a/templates/terraform/tests/resource_redis_instance_test.go
+++ b/templates/terraform/tests/resource_redis_instance_test.go
@@ -131,8 +131,8 @@ resource "google_redis_instance" "test" {
 	}
 
 	redis_configs {
-		maxmemory_policy       = "allkeys-lru"
-		notify_keyspace_events = "KEA"
+		maxmemory-policy       = "allkeys-lru"
+		notify-keyspace-events = "KEA"
 	}
 }`, name)
 }
@@ -150,8 +150,8 @@ resource "google_redis_instance" "test" {
 	}
 
 	redis_configs {
-		maxmemory_policy       = "noeviction"
-		notify_keyspace_events = ""
+		maxmemory-policy       = "noeviction"
+		notify-keyspace-events = ""
 	}
 }`, name)
 }
@@ -183,8 +183,8 @@ resource "google_redis_instance" "test" {
 	}
 
 	redis_configs {
-		maxmemory_policy       = "allkeys-lru"
-		notify_keyspace_events = "KEA"
+		maxmemory-policy       = "allkeys-lru"
+		notify-keyspace-events = "KEA"
 	}
 }`, network, name)
 }

--- a/templates/terraform/tests/resource_redis_instance_test.go
+++ b/templates/terraform/tests/resource_redis_instance_test.go
@@ -130,7 +130,7 @@ resource "google_redis_instance" "test" {
 		other_key = "other_val"
 	}
 
-	redisConfigs {
+	redis_configs {
 		maxmemory_policy       = "allkeys-lru"
 		notify_keyspace_events = "KEA"
 	}
@@ -149,7 +149,7 @@ resource "google_redis_instance" "test" {
 		other_key = "new_val"
 	}
 
-	redisConfigs {
+	redis_configs {
 		maxmemory_policy       = "noeviction"
 		notify_keyspace_events = ""
 	}
@@ -182,7 +182,7 @@ resource "google_redis_instance" "test" {
 		other_key = "other_val"
 	}
 
-	redisConfigs {
+	redis_configs {
 		maxmemory_policy       = "allkeys-lru"
 		notify_keyspace_events = "KEA"
 	}

--- a/templates/terraform/tests/resource_redis_instance_test.go
+++ b/templates/terraform/tests/resource_redis_instance_test.go
@@ -129,6 +129,11 @@ resource "google_redis_instance" "test" {
 		my_key    = "my_val"
 		other_key = "other_val"
 	}
+
+	redisConfigs {
+		maxmemory_policy       = "allkeys-lru"
+		notify_keyspace_events = "KEA"
+	}
 }`, name)
 }
 
@@ -142,6 +147,11 @@ resource "google_redis_instance" "test" {
 	labels {
 		my_key    = "my_val"
 		other_key = "new_val"
+	}
+
+	redisConfigs {
+		maxmemory_policy       = "noeviction"
+		notify_keyspace_events = ""
 	}
 }`, name)
 }
@@ -170,6 +180,11 @@ resource "google_redis_instance" "test" {
 	labels {
 		my_key    = "my_val"
 		other_key = "other_val"
+	}
+
+	redisConfigs {
+		maxmemory_policy       = "allkeys-lru"
+		notify_keyspace_events = "KEA"
 	}
 }`, network, name)
 }


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->

This attempts to provide support for the redisConfigs block for providing redis configuration parameters.

Helps with https://github.com/terraform-providers/terraform-provider-google/issues/1547

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
