### PR TITLE
Ansible default scopes

### DIFF
--- a/google/python_utils.rb
+++ b/google/python_utils.rb
@@ -29,6 +29,8 @@ module Google
         "'#{value}'"
       elsif value.is_a?(Numeric)
         value.to_s
+      elsif value.is_a?(Array)
+        "[#{value.map { |x| python_literal(x) }.join(' ,')}]"
       else
         raise "Unsupported Python literal #{value}"
       end

--- a/provider/ansible/gcp_doc_frag.py
+++ b/provider/ansible/gcp_doc_frag.py
@@ -31,7 +31,6 @@ options:
     scopes:
       description:
           - Array of scopes to be used.
-      required: true
 notes:
   - For authentication, you can set service_account_file using the
     C(GCP_SERVICE_ACCOUNT_FILE) env variable.

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -101,6 +101,9 @@ def main():
         )
     )
 
+    if not module.params['scopes']:
+        module.params['scopes'] = <%= python_literal(object.__product.scopes) %>
+
     state = module.params['state']
 <% if object.kind? -%>
     kind = <%= lines(quote_string(object.kind)) -%>


### PR DESCRIPTION
Ansible currently has a notion of "scopes" similar to Puppet/Chef.

Except, I don't like the Ansible model at all. We should have default scopes and users shouldn't have to think about them unless they absolutely want to.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Ansible default scopes
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
Default scopes
