### PR TITLE
removing state from shared doc frag on Ansible

### DIFF
--- a/provider/ansible/gcp_doc_frag.py
+++ b/provider/ansible/gcp_doc_frag.py
@@ -6,12 +6,6 @@ class ModuleDocFragment(object):
         # GCP doc fragment.
         DOCUMENTATION = '''
 options:
-    state:
-        description:
-            - Whether the given zone should or should not be present.
-        required: true
-        choices: ["present", "absent"]
-        default: "present"
     project:
         description:
             - The Google Cloud Platform project to use.


### PR DESCRIPTION
Ansible has a shared documentation fragment that's used across all modules.

The inventory plugin should be using the doc frag, but it isn't because the documentation fragment contains too much information. This is going to rectify that.


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
removing state from shared doc frag on Ansible
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
Removing state from shared doc frag
