### PR TITLE
Autogenerated unit tests should always use default values for simplicity

### DIFF
--- a/provider/test_data/generator.rb
+++ b/provider/test_data/generator.rb
@@ -33,6 +33,7 @@ module Provider
       end
 
       def value(for_type, property, seed)
+        return property.default_value if property.default_value
         if for_type == Api::Type::Array
           for_type = [Api::Type::Array, property.item_type_class]
         end


### PR DESCRIPTION
Strange edge cases can occur when ResourceRef'd objects use the default values
and those values are not expected.

<!-- A summary of the changes in this commit goes here -->


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Autogenerated unit tests should always use default values for simplicity
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
