### PR TITLE
Tool to authorize only a single rev of a PR.

### DIFF
--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -61,6 +61,13 @@ resources:
           uri: git@github.com:GoogleCloudPlatform/magic-modules.git
           private_key: ((repo-key.private_key))
 
+    - name: magic-modules-external-prs
+      type: github-pull-request
+      source:
+          repo: GoogleCloudPlatform/magic-modules
+          private_key: ((repo-key.private_key))
+          access_token: ((github-account.password))
+
     - name: magic-modules-new-prs
       type: github-pull-request
       source:
@@ -148,6 +155,16 @@ resources:
         location: America/Los_Angeles
 
 jobs:
+    - name: authorize-single-rev
+      plan:
+          - get: magic-modules-external-prs
+            version: every
+            trigger: false
+          - put: magic-modules-new-prs
+            params:
+                status: pending
+                path: magic-modules-external-prs
+
     - name: mm-generate
       plan:
           - aggregate:


### PR DESCRIPTION
The way that this works is a little silly - when you put to a resource the rev you put is assumed to belong there.  A little hacky, but I tested it on `seven` and it works.  :)

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
No changes expected.
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
