### PR TITLE
Push to non-GCP branches if necessary.

### DIFF
--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -41,7 +41,7 @@ resource_types:
       type: docker-image
       source:
           repository: nmckinley/concourse-github-pr-resource
-          tag: v0.1.7
+          tag: v0.1.8
 
     - name: gcs-resource
       type: docker-image

--- a/.ci/magic-modules/merge-pr.sh
+++ b/.ci/magic-modules/merge-pr.sh
@@ -15,6 +15,7 @@ pushd mm-approved-prs
 ID=$(git config --get pullrequest.id)
 # We need to know what branch to check out for the update.
 BRANCH=$(git config --get pullrequest.branch)
+REPO=$(git config --get pullrequest.repo)
 popd
 
 cp -r mm-approved-prs/* mm-output
@@ -28,7 +29,7 @@ git config --global user.name "Modular Magician"
 ssh-agent bash -c "ssh-add ~/github_private_key; git submodule update --remote --init $ALL_SUBMODULES"
 
 # Word-splitting here is intentional.
-git add $ALL_SUBMODULES 
+git add $ALL_SUBMODULES
 
 # It's okay for the commit to fail if there's no changes.
 set +e
@@ -36,3 +37,16 @@ git commit -m "Update tracked submodules -> HEAD on $(date)
 
 Tracked submodules are $ALL_SUBMODULES."
 echo "Merged PR #$ID." > ./commit_message
+
+# If the repo isn't 'GoogleCloudPlatform/magic-modules', then the PR has been
+# opened from someone's fork.  We ought to have push rights to that fork, no
+# problem, but if we don't, that's also okay.
+
+set +e
+if [ "$REPO" != "GoogleCloudPlatform/magic-modules" ]; then
+  git remote add push-target "git@github.com:$REPO"
+  # We know we have a commit, so all the machinery of the git resources is
+  # unnecessary.  We can just try to push directly, without forcing.
+  ssh-agent bash -c "ssh-add ~/github_private_key; git push push-target $BRANCH"
+fi
+set -e


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
This is a CI-only change to support people who want to merge into MagicModules from a fork.  This is necessary for any non-Google contributor to MagicModules.

The major trick here was getting the `repo` parameter into the PR resource - that's not in this PR, that'll be opened against the PR resource.


-----------------------------------------------------------------
# [all]
No changes.