### PR TITLE
Update terraform.yaml

### DIFF
--- a/products/redis/terraform.yaml
+++ b/products/redis/terraform.yaml
@@ -44,6 +44,8 @@ overrides: !ruby/object:Provider::ResourceOverrides
         region                  = "us-central1"
         location_id             = "us-central1-a"
         alternative_location_id = "us-central1-f"
+        
+        authorized_network = "${google_compute_network.test.self_link}"
 
         redis_version     = "REDIS_3_2"
         display_name      = "Terraform Test Instance"


### PR DESCRIPTION
Full example contains google_compute_network resource but doesn't use it. We need to fix it.