### PR TITLE
Fixing to_s function on Puppet NestedObjects

### DIFF
--- a/templates/puppet/property/nested_object.rb.erb
+++ b/templates/puppet/property/nested_object.rb.erb
@@ -87,7 +87,7 @@ module Google
           [
             "#{prop.out_name}: ['[',",
             indent([
-              "#{prop.out_name}.map(&:to_json).join(', '),",
+              "(#{prop.out_name} || []).map(&:to_json).join(', '),",
               "']'].join(' ')"
             ], prop.out_name.length + 3), # 3 = ": ["
           ]


### PR DESCRIPTION
Fixing to_s function on Puppet NestedObjects

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Fixing to_s function on Puppet NestedObjects
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
