### PR TITLE
We should apply patches with --3way.

### DIFF
--- a/.ci/magic-modules/helpers.sh
+++ b/.ci/magic-modules/helpers.sh
@@ -7,7 +7,7 @@ function apply_patches {
   shopt -s nullglob
   for patch in "$1"/*; do
     # This is going to apply the patch as at least 1 commit, possibly more.
-    git am --signoff "$patch"
+    git am --3way --signoff "$patch"
   done
   shopt -u nullglob
   # Now, collapse the patch commits into one.


### PR DESCRIPTION
Also, that should be the git default, dang!  The big problem this avoids is a fun one.

1)  We add a new resource to Terraform.  This adds a file, `google/resource_compute_foo.go`, that was previously handwritten.
2)  We merge the Terraform change, but not the MagicModules one, for valid reasons (like, puppet is taking a little longer).
3)  We run `mm-generate`, which works correctly, overriding the changes made to every file _except_ `google/resource_compute_foo.go` (since the code in MagicModules still has `exclude: true` for that file).
4)  We attempt to apply the patch from step 1... except, oh no, the patch doesn't apply!  The patch doesn't apply because the default behavior of `git am` is to freak out and die if it's trying to apply a patch to code that doesn't exactly match the pre-patch state ... and one file in our code matches the _post_-patch state.
5)  So we use `--3way`, which conducts a 3-way merge, like so:  
```
$ git am --signoff ../../../patches/terraform-providers/terraform-provider-google/1699.patch --3way                      
Applying: Autogenerate VPN Tunnel resource                                                                                                                    
Using index info to reconstruct a base tree...                     
M       google/resource_compute_vpn_tunnel.go                                    
M       website/docs/r/compute_vpn_tunnel.html.markdown                                                                                                       
Falling back to patching base and 3-way merge...                                                     
```

Ding ding ding!  Problem solved.

-----------------------------------------------------------------
# [all]
CI change only - should not generate a PR.