### PR TITLE
Instance templates can't be updated.

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -1432,6 +1432,7 @@ objects:
   - !ruby/object:Api::Resource
     name: 'InstanceTemplate'
     kind: 'compute#instanceTemplate'
+    input: true
     base_url: projects/{{project}}/global/instanceTemplates
     exports:
       - !ruby/object:Api::Type::SelfLink


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates shows delete, get, and insert only.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Remove non-existent update feature from instance templates.
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
