### PR TITLE
Puppet should be able to reference things created outside a manifest.

### DIFF
--- a/products/compute/examples/puppet/instance_group_manager.pp
+++ b/products/compute/examples/puppet/instance_group_manager.pp
@@ -30,11 +30,7 @@ gcompute_machine_type { 'n1-standard-1':
   credential => 'mycred',
 }
 
-gcompute_network { <%= example_resource_name('mynetwork-test') -%>:
-  ensure     => present,
-  project    => $project, # e.g. 'my-test-project'
-  credential => 'mycred',
-}
+gcompute_external_resource('gcompute_network', {name=> 'default', self_link=>"projects/$project/global/networks/default"})
 
 gcompute_instance_template { <%= example_resource_name('instance-template') -%>:
   ensure     => present,
@@ -60,7 +56,7 @@ gcompute_instance_template { <%= example_resource_name('instance-template') -%>:
           type => 'ONE_TO_ONE_NAT',
           },
         ],
-        network        => <%= example_resource_name('mynetwork-test') %>,
+        network        => 'default',
       }
     ]
   },

--- a/products/compute/puppet.yaml
+++ b/products/compute/puppet.yaml
@@ -569,6 +569,8 @@ files: !ruby/object:Provider::Config::Files
       templates/puppet/bolt~task_load_params.rb.erb
     lib/puppet/functions/gcompute_task_validate_param.rb:
       templates/puppet/bolt~task_validate_param.rb.erb
+    lib/puppet/functions/gcompute_external_resource.rb:
+      templates/puppet/add_object.rb
 <%= indent(include('provider/puppet/common~compile~before.yaml'), 4) %>
 <%= indent(include('provider/puppet/common~compile~after.yaml'), 4) %>
 <% # common~compile~after.yaml should be the last line of compile: section -%>

--- a/templates/puppet/add_object.rb
+++ b/templates/puppet/add_object.rb
@@ -1,0 +1,50 @@
+<% if false # the license inside this if block assertains to this file -%>
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+<% end -%>
+<%= compile 'templates/license.erb' -%>
+
+<%= lines(autogen_notice :ruby) -%>
+
+require 'puppet'
+
+# Constructs a referenceable object without that object needing to
+# be defined by puppet.  Inserts the object into the local state so
+# that resource references work without further modification.
+class ReferenceableObject
+  def initialize(attrs)
+    @attrs = attrs
+  end
+
+  def method_missing(method_name, *arguments, &block)
+    @attrs[method_name]
+  end
+
+  def exports
+    @attrs
+  end
+end
+
+Puppet::Functions.create_function(:gcompute_external_resource) do
+  dispatch :gcompute_external_resource do
+    param 'String', :type
+    param 'Hash', :attributes
+  end
+
+  def gcompute_external_resource(type, attributes)
+    attributes['title'] = attributes['name'] unless attributes['name'].nil?
+    sym_attrs = {}
+    attributes.each { |k, v| sym_attrs[k.to_sym] = v }
+    Google::ObjectStore.instance.add(type.to_sym, ReferenceableObject.new(sym_attrs))
+  end
+end


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
We got a very sensible customer request about this:

>Need to define network object alongside with instances in Puppet
>catalog in `google-gcompute`.
>
>According to the doc I must define the following resources somewhere
>in Puppet catalog for `gcompute_instance` to work:
>
>      c) gcompute_network (to be used in 'network_interfaces' property)
>      d) gcompute_subnetwork (to be used in the 'subnetwork' property)
>
>I would like to separate my instances and my network objects in
>different manifests (different `.pp` files). I don't want to touch my
>network while I'm adding new instances and so on.

I agree!  I don't want folks to touch their networks by mistake when they're really just trying to touch their new instances, that's a little scary.  This provides a working example and a function, `gcompute_external_resource`, which just makes that possible by allowing you to specify the exported attributes of your resource rather than having the whole thing in there.  Kind of like a template variable, but with the additional semantic checks that `resourceref`s already provide.

What do you think about this?  Where would you document it?

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
Adds 'gcompute_external_resource', a function to register an object that exists outside of the manifest.
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
