### PR TITLE
All parameters should be `required: true`

### DIFF
--- a/api/resource.rb
+++ b/api/resource.rb
@@ -256,6 +256,8 @@ module Api
       check_property_list :properties, Api::Type
 
       check_identity unless @identity.nil?
+
+      @parameters&.each { |para| para.instance_variable_set(:@required, true) }
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
All parameters should be `required: true`

This will probably make some changes.

Should I change the api.yaml to get rid of redundant `required: true` values? I was going back and forth on this.


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
All parameters should be 'required: true'
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
