### PR TITLE
Have timeouts for tests.

### DIFF
--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -297,6 +297,7 @@ jobs:
           passed: [mm-generate]
         - task: test
           file: magic-modules/.ci/unit-tests/task.yml
+          timeout: 30m
           on_failure:
               do:
               - get: magic-modules-new-prs
@@ -318,6 +319,7 @@ jobs:
           passed: [mm-generate]
         - task: test
           file: magic-modules/.ci/unit-tests/ansible.yml
+          timeout: 30m
           on_failure:
               do:
               - get: magic-modules-new-prs
@@ -343,6 +345,7 @@ jobs:
           {% for module in puppet_modules %}
           - task: test-{{module}}
             file: magic-modules/.ci/unit-tests/puppet.yml
+            timeout: 30m
             params:
               PRODUCT: {{module}}
             {%- if puppet_test_excludes.get(module) %}
@@ -374,6 +377,7 @@ jobs:
           {% for module in chef_modules %}
           - task: test-{{module}}
             file: magic-modules/.ci/unit-tests/chef.yml
+            timeout: 30m
             params:
               PRODUCT: {{module}}
             {%- if chef_test_excludes.get(module) %}


### PR DESCRIPTION
Some of the puppet tests started stalling forever for some reason - we should definitely not let them run forever.  Kill them after ~30m, that should be plenty of time even when concourse gets overloaded.  Raise it later if necessary.  :)

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
