### PR TITLE
'input' means the same thing as editable here.

### DIFF
--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -224,7 +224,7 @@ def main():
                    end
 -%>
 <% if object.update.nil? -%>
-<%   if !false?(object.editable) -%>
+<%   if object.editable || !object.input -%>
     auth = GcpSession(module, <%= quote_string(prod_name) -%>)
 <%
   update_verb = object.update_verb.to_s.downcase
@@ -239,9 +239,9 @@ def main():
   )
 -%>
     return <%= method %>
-<%   else # !false?(object.editable) -%>
+<%   else # object.editable || !object.input -%>
     module.fail_json(msg="<%= object.name -%> cannot be edited")
-<%   end # !false?(object.editable) -%>
+<%   end # object.editable || !object.input -%>
 <% else # object.update.nil? -%>
 <%= lines(indent(object.update, 4)) -%>
 <% end # object.update.nil? -%>


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
!input means 'editable' - Ansible should use the same definition as everything else.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
Convert to using 'input' like Terraform does.