### PR TITLE
Bigquery: Dataset support

### DIFF
--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -1,5 +1,5 @@
 {% set chef_modules = ['compute', 'sql', 'storage', 'container', 'dns'] %}
-{% set puppet_modules = ['compute', 'sql', 'storage', 'container', 'dns', 'pubsub', 'resourcemanager'] %}
+{% set puppet_modules = ['bigquery', 'compute', 'sql', 'storage', 'container', 'dns', 'pubsub', 'resourcemanager'] %}
 {% set terraform_enabled = true %}
 {% set ansible_enabled = true %}
 {% macro names_as_list(repo, names) -%}

--- a/.gitmodules
+++ b/.gitmodules
@@ -72,3 +72,6 @@
 	path = build/terraform
 	url = git@github.com:terraform-providers/terraform-provider-google.git
 	branch = master
+[submodule "build/puppet/bigquery"]
+	path = build/puppet/bigquery
+	url = git@github.com:GoogleCloudPlatform/puppet-google-bigquery.git

--- a/api/type.rb
+++ b/api/type.rb
@@ -446,6 +446,8 @@ module Api
         @description = 'A nested object resource' if @description.nil?
         @name = @__name if @name.nil?
         super
+
+        raise "Properties missing on #{name}" if @properties.nil?
         @properties.each do |p|
           p.set_variable(@__resource, :__resource)
           p.set_variable(self, :__parent)

--- a/products/bigquery/api.yaml
+++ b/products/bigquery/api.yaml
@@ -1,0 +1,566 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: Google Cloud BigQuery
+prefix: gbigquery
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: https://www.googleapis.com/bigquery/v2/
+    default: true
+scopes:
+  - https://www.googleapis.com/auth/bigquery
+objects:
+  - !ruby/object:Api::Resource
+    name: 'Dataset'
+    kind: 'bigquery#dataset'
+    base_url: projects/{{project}}/datasets
+    description: >
+      Datasets allow you to organize and control access to your tables.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: 'Dataset name'
+      - !ruby/object:Api::Type::Array
+        name: 'access'
+        description: 'Access controls on the bucket.'
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'domain'
+              description: >
+                A domain to grant access to. Any users signed in with the
+                domain specified will be granted the specified access
+            - !ruby/object:Api::Type::String
+              name: 'groupByEmail'
+              description: An email address of a Google Group to grant access to
+            - !ruby/object:Api::Type::Enum
+              name: 'role'
+              description: >
+                Describes the rights granted to the user specified by the other
+                member of the access object
+              values:
+                - :READER
+                - :WRITER
+                - :OWNER
+            - !ruby/object:Api::Type::String
+              name: 'specialGroup'
+              description: A special group to grant access to.
+            - !ruby/object:Api::Type::String
+              name: 'userByEmail'
+              description: >
+                An email address of a user to grant access to. For example:
+                fred@example.com
+            - !ruby/object:Api::Type::NestedObject
+              name: 'view'
+              description: >
+                A view from a different dataset to grant access to. Queries
+                executed against that view will have read access to tables in
+                this dataset. The role field is not required when this field is
+                set. If that view is updated by any user, access to the view
+                needs to be granted again via an update operation.
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'datasetId'
+                  description: The ID of the dataset containing this table.
+                  required: true
+                - !ruby/object:Api::Type::String
+                  name: 'projectId'
+                  description: The ID of the project containing this table.
+                  required: true
+                - !ruby/object:Api::Type::String
+                  name: 'tableId'
+                  description: >
+                    The ID of the table. The ID must contain only letters (a-z,
+                    A-Z), numbers (0-9), or underscores (_). The maximum length
+                    is 1,024 characters.
+                  required: true
+      - !ruby/object:Api::Type::Integer
+        name: 'creationTime'
+        output: true
+        description: >
+          The time when this dataset was created, in milliseconds since the
+          epoch.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'datasetReference'
+        description: 'A reference that identifies the dataset.'
+        required: true
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'datasetId'
+            description: >
+              A unique ID for this dataset, without the project name. The ID
+              must contain only letters (a-z, A-Z), numbers (0-9), or
+              underscores (_). The maximum length is 1,024 characters.
+            required: true
+          - !ruby/object:Api::Type::String
+            name: 'projectId'
+            description: The ID of the project containing this dataset.
+      - !ruby/object:Api::Type::Integer
+        name: 'defaultTableExpirationMs'
+        description: >
+          The default lifetime of all tables in the dataset, in milliseconds
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: A user-friendly description of the dataset
+      - !ruby/object:Api::Type::String
+        name: 'friendlyName'
+        description: A descriptive name for the dataset
+      - !ruby/object:Api::Type::String
+        name: 'id'
+        output: true
+        description: >
+          The fully-qualified unique name of the dataset in the format
+          projectId:datasetId. The dataset name without the project name is
+          given in the datasetId field
+      - !ruby/object:Api::Type::NameValues
+        name: 'labels'
+        description: >
+          The labels associated with this dataset. You can use these to
+          organize and group your datasets
+        key_type: Api::Type::String
+        value_type: Api::Type::String
+      - !ruby/object:Api::Type::Integer
+        name: 'lastModifiedTime'
+        description: >
+          The date when this dataset or any of its tables was last modified, in
+          milliseconds since the epoch.
+        output: true
+      - !ruby/object:Api::Type::String
+        name: 'location'
+        description: >
+          The geographic location where the dataset should reside. Possible
+          values include EU and US. The default value is US.
+        default_value: US
+  - !ruby/object:Api::Resource
+    name: 'Table'
+    kind: 'bigquery#table'
+    base_url: projects/{{project}}/datasets/{{dataset}}/tables
+    exclude: true
+    description: >
+      A Table that belongs to a Dataset
+    parameters:
+      # TODO: Convert to ResourceRef when multi-layered exports exist
+      - !ruby/object:Api::Type::String
+        name: 'dataset'
+        description: The dataset this table belongs to.
+    properties:
+      - !ruby/object:Api::Type::Integer
+        name: 'creationTime'
+        output: true
+        description: >
+          The time when this dataset was created, in milliseconds since the
+          epoch.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: A user-friendly description of the dataset
+      - !ruby/object:Api::Type::String
+        name: 'friendlyName'
+        description: A descriptive name for this table
+      - !ruby/object:Api::Type::String
+        name: 'id'
+        description: 'An opaque ID uniquely identifying the table.'
+        output: true
+      - !ruby/object:Api::Type::NameValues
+        name: 'labels'
+        description: >
+          The labels associated with this dataset. You can use these to
+          organize and group your datasets
+        key_type: Api::Type::String
+        value_type: Api::Type::String
+      - !ruby/object:Api::Type::Integer
+        name: 'lastModifiedTime'
+        description: >
+          The time when this table was last modified, in milliseconds since the
+          epoch.
+        output: true
+      - !ruby/object:Api::Type::String
+        name: 'location'
+        description: >
+          The geographic location where the table resides. This value is
+          inherited from the dataset.
+        output: true
+      - !ruby/object:Api::Type::Integer
+        name: 'numBytes'
+        description: >
+          The size of this table in bytes, excluding any data in the streaming
+          buffer.
+        output: true
+      - !ruby/object:Api::Type::Integer
+        name: 'numLongTermBytes'
+        description: >
+          The number of bytes in the table that are considered "long-term
+          storage".
+        output: true
+      - !ruby/object:Api::Type::Integer
+        name: 'numRows'
+        description: >
+          The number of rows of data in this table, excluding any data in the
+          streaming buffer.
+        output: true
+      - !ruby/object:Api::Type::Enum
+        name: 'type'
+        description: 'Describes the table type'
+        values:
+          - :TABLE
+          - :VIEW
+          - :EXTERNAL
+        output: true
+      - !ruby/object:Api::Type::NestedObject
+        name: 'view'
+        description: The view definition.
+        properties:
+          - !ruby/object:Api::Type::Boolean
+            name: 'useLegacySql'
+            description: >
+              Specifies whether to use BigQuery's legacy SQL for this view
+          - !ruby/object:Api::Type::Array
+            name: 'userDefinedFunctionResources'
+            description: >
+              Describes user-defined function resources used in the query.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'inlineCode'
+                  description: >
+                    An inline resource that contains code for a user-defined
+                    function (UDF). Providing a inline code resource is
+                    equivalent to providing a URI for a file containing the
+                    same code.
+                # TODO: Convert into cross-product ResourceRef
+                - !ruby/object:Api::Type::String
+                  name: 'resourceUri'
+                  description: >
+                    A code resource to load from a Google Cloud Storage URI
+                    (gs://bucket/path).
+      - !ruby/object:Api::Type::NestedObject
+        name: 'timePartitioning'
+        description: >
+          If specified, configures time-based partitioning for this table.
+        properties:
+          - !ruby/object:Api::Type::Integer
+            name: 'expirationMs'
+            description: >
+              Number of milliseconds for which to keep the storage for a
+              partition.
+          - !ruby/object:Api::Type::Enum
+            name: 'type'
+            description: >
+              The only type supported is DAY, which will generate one partition
+              per day.
+            values:
+              - :DAY
+      - !ruby/object:Api::Type::NestedObject
+        name: 'streamingBuffer'
+        description: >
+          Contains information regarding this table's streaming buffer, if one
+          is present. This field will be absent if the table is not being
+          streamed to or if there is no data in the streaming buffer.
+        output: true
+        properties:
+          - !ruby/object:Api::Type::Integer
+            name: 'estimatedBytes'
+            description: >
+              A lower-bound estimate of the number of bytes currently in the
+              streaming buffer.
+            output: true
+          - !ruby/object:Api::Type::Integer
+            name: 'estimatedRows'
+            description: >
+              A lower-bound estimate of the number of rows currently in the
+              streaming buffer.
+            output: true
+          - !ruby/object:Api::Type::Integer
+            name: 'oldestEntryTime'
+            description: >
+              Contains the timestamp of the oldest entry in the streaming
+              buffer, in milliseconds since the epoch, if the streaming buffer
+              is available.
+            output: true
+      - !ruby/object:Api::Type::NestedObject
+        name: 'schema'
+        description: Describes the schema of this table
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: 'fields'
+            description: Describes the fields in a table.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'description'
+                  description: >
+                    The field description. The maximum length is 1,024
+                    characters.
+                - !ruby/object:Api::Type::Array
+                  name: 'fields'
+                  description: >
+                    Describes the nested schema fields if the type property is
+                    set to RECORD.
+                  item_type: Api::Type::String
+                - !ruby/object:Api::Type::Enum
+                  name: 'mode'
+                  description: The field mode
+                  values:
+                    - :NULLABLE
+                    - :REQUIRED
+                    - :REPEATED
+                - !ruby/object:Api::Type::String
+                  name: 'name'
+                  description: The field name
+                - !ruby/object:Api::Type::Enum
+                  name: 'type'
+                  description: 'The field data type'
+                  values:
+                    - :STRING
+                    - :BYTES
+                    - :INTEGER
+                    - :FLOAT
+                    - :TIMESTAMP
+                    - :DATE
+                    - :TIME
+                    - :DATETIME
+                    - :RECORD
+      - !ruby/object:Api::Type::NestedObject
+        name: 'encryptionConfiguration'
+        description: Custom encryption configuration
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'kmsKeyName'
+            description: >
+              Describes the Cloud KMS encryption key that will be used to
+              protect destination BigQuery table. The BigQuery Service Account
+              associated with your project requires access to this encryption
+              key.
+      - !ruby/object:Api::Type::Integer
+        name: 'expirationTime'
+        description: >
+          The time when this table expires, in milliseconds since the epoch. If
+          not present, the table will persist indefinitely.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'externalDataConfiguration'
+        description: >
+          Describes the data format, location, and other properties of a table
+          stored outside of BigQuery. By defining these properties, the data
+          source can then be queried as if it were a standard BigQuery table.
+        properties:
+          - !ruby/object:Api::Type::Boolean
+            name: 'autodetect'
+            description: >
+              Try to detect schema and format options automatically. Any option
+              specified explicitly will be honored.
+          - !ruby/object:Api::Type::Enum
+            name: 'compression'
+            description: The compression type of the data source
+            values:
+              - :GZIP
+              - :NONE
+          - !ruby/object:Api::Type::Boolean
+            name: 'ignoreUnknownValues'
+            description: >
+              Indicates if BigQuery should allow extra values that are not
+              represented in the table schema
+          - !ruby/object:Api::Type::Integer
+            name: 'maxBadRecords'
+            description: >
+              The maximum number of bad records that BigQuery can ignore when reading data
+            default_value: 0
+          - !ruby/object:Api::Type::Enum
+            name: 'sourceFormat'
+            description: The data format
+            values:
+              - :CSV
+              - :GOOGLE_SHEETS
+              - :NEWLINE_DELIMITED_JSON
+              - :AVRO
+              - :DATASTORE_BACKUP
+              - :BIGTABLE
+          # TODO: Investigate if this is feasable as a ResourceRef
+          # This is a very complicated ResourceRef (one-to-many, where the many are cross-product).
+          - !ruby/object:Api::Type::Array
+            name: 'sourceUris'
+            description: >
+              The fully-qualified URIs that point to your data in Google Cloud.
+              For Google Cloud Storage URIs: Each URI can contain one '*'
+              wildcard character and it must come after the 'bucket' name. Size
+              limits related to load jobs apply to external data sources. For
+              Google Cloud Bigtable URIs: Exactly one URI can be specified and it
+              has be a fully specified and valid HTTPS URL for a Google Cloud
+              Bigtable table. For Google Cloud Datastore backups, exactly one
+              URI can be specified. Also, the '*' wildcard character is not
+              allowed.
+            item_type: Api::Type::String
+          - !ruby/object:Api::Type::NestedObject
+            name: 'schema'
+            description: 'The schema for the data. Schema is required for CSV and JSON formats'
+            properties:
+              - !ruby/object:Api::Type::Array
+                name: 'fields'
+                description: 'Describes the fields in a table.'
+                item_type: !ruby/object:Api::Type::NestedObject
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: 'description'
+                      description: The field description
+                    - !ruby/object:Api::Type::Array
+                      name: 'fields'
+                      description: >
+                        Describes the nested schema fields if the type property
+                        is set to RECORD
+                      item_type: Api::Type::String
+                    - !ruby/object:Api::Type::Enum
+                      name: 'mode'
+                      description: Field mode.
+                      values:
+                        - :NULLABLE
+                        - :REQUIRED
+                        - :REPEATED
+                    - !ruby/object:Api::Type::String
+                      name: 'name'
+                      description: Field name
+                    - !ruby/object:Api::Type::Enum
+                      name: 'type'
+                      description: Field data type
+                      values:
+                        - :STRING
+                        - :BYTES
+                        - :INTEGER
+                        - :FLOAT
+                        - :TIMESTAMP
+                        - :DATE
+                        - :TIME
+                        - :DATETIME
+                        - :RECORD
+          - !ruby/object:Api::Type::NestedObject
+            name: 'googleSheetsOptions'
+            description: 'Additional options if sourceFormat is set to GOOGLE_SHEETS.'
+            properties:
+              - !ruby/object:Api::Type::Integer
+                name: 'skipLeadingRows'
+                description: >
+                  The number of rows at the top of a Google Sheet that BigQuery
+                  will skip when reading the data.
+                default_value: 0
+          - !ruby/object:Api::Type::NestedObject
+            name: 'csvOptions'
+            description: Additional properties to set if sourceFormat is set to CSV.
+            properties:
+              - !ruby/object:Api::Type::Boolean
+                name: 'allowJaggedRows'
+                description: >
+                  Indicates if BigQuery should accept rows that are missing
+                  trailing optional columns
+              - !ruby/object:Api::Type::Boolean
+                name: 'allowQuotedNewlines'
+                description: >
+                  Indicates if BigQuery should allow quoted data sections that
+                  contain newline characters in a CSV file
+              - !ruby/object:Api::Type::Enum
+                name: 'encoding'
+                description: 'The character encoding of the data'
+                values:
+                  - :UTF-8
+                  - :ISO-8859-1
+              - !ruby/object:Api::Type::String
+                name: 'fieldDelimiter'
+                description: 'The separator for fields in a CSV file'
+              - !ruby/object:Api::Type::String
+                name: 'quote'
+                description: 'The value that is used to quote data sections in a CSV file'
+              - !ruby/object:Api::Type::Integer
+                name: 'skipLeadingRows'
+                description: >
+                  The number of rows at the top of a CSV file that BigQuery
+                  will skip when reading the data.
+                default_value: 0
+          - !ruby/object:Api::Type::NestedObject
+            name: 'bigtableOptions'
+            description: 'Additional options if sourceFormat is set to BIGTABLE.'
+            properties:
+              - !ruby/object:Api::Type::Boolean
+                name: 'ignoreUnspecifiedColumnFamilies'
+                description: >
+                  If field is true, then the column families that are not specified in
+                  columnFamilies list are not exposed in the table schema
+              - !ruby/object:Api::Type::Boolean
+                name: 'readRowkeyAsString'
+                description: >
+                  If field is true, then the rowkey column families will be
+                  read and converted to string.
+              - !ruby/object:Api::Type::Array
+                name: 'columnFamilies'
+                description: >
+                  List of column families to expose in the table schema along
+                  with their types.
+                item_type: !ruby/object:Api::Type::NestedObject
+                  properties:
+                    - !ruby/object:Api::Type::Array
+                      name: 'columns'
+                      description: >
+                         Lists of columns that should be exposed as individual
+                         fields as opposed to a list of (column name, value) pairs.
+                      item_type: !ruby/object:Api::Type::NestedObject
+                        properties:
+                          - !ruby/object:Api::Type::Enum
+                            name: 'encoding'
+                            description: The encoding of the values when the type is not STRING
+                            values:
+                              - :TEXT
+                              - :BINARY
+                          - !ruby/object:Api::Type::String
+                             name: 'fieldName'
+                             description: >
+                               If the qualifier is not a valid BigQuery field
+                               identifier, a valid identifier must be provided as
+                               the column field name and is used as field name in
+                               queries.
+                          - !ruby/object:Api::Type::Boolean
+                             name: 'onlyReadLatest'
+                             description: >
+                               If this is set, only the latest version of value in this column are exposed
+                          - !ruby/object:Api::Type::String
+                             name: 'qualifierString'
+                             description: Qualifier of the column
+                             required: true
+                          - !ruby/object:Api::Type::Enum
+                             name: 'type'
+                             description: The type to convert the value in cells of this column
+                             values:
+                               - :BYTES
+                               - :STRING
+                               - :INTEGER
+                               - :FLOAT
+                               - :BOOLEAN
+                    - !ruby/object:Api::Type::Enum
+                      name: 'encoding'
+                      description: The encoding of the values when the type is not STRING
+                      values:
+                        - :TEXT
+                        - :BINARY
+                    - !ruby/object:Api::Type::String
+                      name: 'familyId'
+                      description: Identifier of the column family.
+                    - !ruby/object:Api::Type::Boolean
+                      name: 'onlyReadLatest'
+                      description: >
+                        If this is set only the latest version of value are
+                        exposed for all columns in this column family
+                    - !ruby/object:Api::Type::Enum
+                      name: 'type'
+                      description: The type to convert the value in cells of this column family
+                      values:
+                        - :BYTES
+                        - :STRING
+                        - :INTEGER
+                        - :FLOAT
+                        - :BOOLEAN

--- a/products/bigquery/examples/puppet/dataset.pp
+++ b/products/bigquery/examples/puppet/dataset.pp
@@ -1,0 +1,30 @@
+<% if false # the license inside this if block assertains to this file -%>
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+<% end -%>
+<% unless name == "README.md" -%>
+<%= compile 'templates/license.erb' -%>
+
+<%= lines(autogen_notice :puppet) -%>
+
+<%= compile 'templates/puppet/examples~credential.pp.erb' -%>
+
+<% end # name == README.md -%>
+gbigquery_dataset { <%= example_resource_name('example_dataset') -%>:
+  ensure            => present,
+  dataset_reference => {
+    dataset_id => 'example_dataset'
+  },
+  project           => $project, # e.g. 'my-test-project'
+  credential        => 'mycred',
+}

--- a/products/bigquery/examples/puppet/delete_dataset.pp
+++ b/products/bigquery/examples/puppet/delete_dataset.pp
@@ -1,0 +1,27 @@
+<% if false # the license inside this if block assertains to this file -%>
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+<% end -%>
+<% unless name == "README.md" -%>
+<%= compile 'templates/license.erb' -%>
+
+<%= lines(autogen_notice :puppet) -%>
+
+<%= compile 'templates/puppet/examples~credential.pp.erb' -%>
+
+<% end # name == README.md -%>
+gbigquery_dataset { <%= example_resource_name('example_dataset') -%>:
+  ensure     => absent,
+  project    => $project, # e.g. 'my-test-project'
+  credential => 'mycred',
+}

--- a/products/bigquery/examples/puppet/table.pp
+++ b/products/bigquery/examples/puppet/table.pp
@@ -1,0 +1,37 @@
+<% if false # the license inside this if block assertains to this file -%>
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+<% end -%>
+<% unless name == "README.md" -%>
+<%= compile 'templates/license.erb' -%>
+
+<%= lines(autogen_notice :puppet) -%>
+
+<%= compile 'templates/puppet/examples~credential.pp.erb' -%>
+
+<% end # name == README.md -%>
+gbigquery_dataset { <%= example_resource_name('example_dataset') -%>:
+  ensure            => present,
+  dataset_reference => {
+    dataset_id => 'example_dataset'
+  },
+  project           => $project, # e.g. 'my-test-project'
+  credential        => 'mycred',
+}
+
+gbigquery_table { <%= example_resource_name('example_table') -%>:
+  ensure     => present,
+  dataset    => <%= example_resource_name('example_dataset') -%>,
+  project    => $project, # e.g. 'my-test-project'
+  credential => 'mycred',
+}

--- a/products/bigquery/puppet.yaml
+++ b/products/bigquery/puppet.yaml
@@ -1,0 +1,51 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Puppet::Config
+manifest: !ruby/object:Provider::Puppet::Manifest
+  version: '0.2.0'
+  source: 'https://github.com/GoogleCloudPlatform/puppet-google-bigquery'
+  homepage: 'https://github.com/GoogleCloudPlatform/puppet-google-bigquery'
+  issues:
+    'https://github.com/GoogleCloudPlatform/puppet-google-bigquery/issues'
+  summary: 'A Puppet module to manage Google Cloud BigQuery resources'
+  tags:
+    - google
+    - cloud
+    - storage
+  requires:
+    - !ruby/object:Provider::Config::Requirements
+      name: 'google/gauth'
+      versions: '>= 0.2.0 < 0.3.0'
+  operating_systems:
+<%= indent(include('provider/puppet/common~operating_systems.yaml'), 4) %>
+overrides: !ruby/object:Provider::ResourceOverrides
+examples: !ruby/object:Api::Resource::HashArray
+  Dataset:
+    - delete_dataset.pp
+    - dataset.pp
+  Table:
+    - table.pp
+files: !ruby/object:Provider::Config::Files
+  copy:
+<%= indent(compile('provider/puppet/common~copy.yaml'), 4) %>
+  compile:
+<%= indent(include('provider/puppet/common~compile~before.yaml'), 4) %>
+<%= indent(include('provider/puppet/common~compile~after.yaml'), 4) %>
+<% # common~compile~after.yaml should be the last line of compile: section -%>
+style:
+changelog:
+  - !ruby/object:Provider::Config::Changelog
+    version: '0.1.0'
+    date: 2018-07-10T09:00:00-0700
+    general: 'Initial release'


### PR DESCRIPTION
Support for Datasets on BigQuery.

Currently, this only supports Puppet.


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Bigquery: Dataset support on Puppet
## [terraform]
## [puppet]
Bigquery: Dataset support
### [puppet-compute]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-sql]
### [chef-storage]
## [ansible]
