### PR TITLE
fix terraform nested object handling

### DIFF
--- a/templates/terraform/expand_property_method.erb
+++ b/templates/terraform/expand_property_method.erb
@@ -17,7 +17,7 @@
                            prefix: prefix,
                            property: property)) -%>
 <% else -%>
-<% if property.is_a?(Api::Type::NameValues) -%>
+<%   if property.is_a?(Api::Type::NameValues) -%>
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) (map[string]string, error) {
   if v == nil {
     return map[string]string{}, nil
@@ -28,39 +28,49 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
   }
   return m, nil
 }
-<% elsif tf_types.include?(property.class) -%>
+<%   elsif tf_types.include?(property.class) -%>
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) (interface{}, error) {
-<% if property.is_set -%>
+<%     if property.is_set -%>
   v = v.(*schema.Set).List()
-<% end -%>
+<%     end -%>
 <%
-  if !nested_properties(property).empty?
-    nested_properties = nested_properties(property)
+       if !nested_properties(property).empty?
+         nested_properties = nested_properties(property)
 -%>
   l := v.([]interface{})
+<%       if property.is_a?(Api::Type::Array) -%>
   req := make([]interface{}, 0, len(l))
   for _, raw := range l {
+<%       else -%>
+  if len(l) == 0 {
+    return nil, nil
+  }
+  raw := l[0]
+<%       end -%>
     original := raw.(map[string]interface{})
     transformed := make(map[string]interface{})
 
-    <% nested_properties.each do |prop| -%>
+<%       nested_properties.each do |prop| -%>
       transformed<%= titlelize_property(prop) -%>, err := expand<%= prefix -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(original["<%= Google::StringUtils.underscore(prop.name) -%>"], d, config)
       if err != nil {
         return nil, err
       }
       transformed["<%= prop.api_name -%>"] = transformed<%= titlelize_property(prop) -%>
 
-    <% end -%>
-
+<%       end -%>
+<%       if property.is_a?(Api::Type::Array) -%>
     req = append(req, transformed)
   }
   return req, nil
+<%       else -%>
+  return transformed, nil
+<%       end -%>
 }
 
-  <% nested_properties.each do |prop| -%>
-    <%= lines(build_expand_method(prefix + titlelize_property(property), prop), 1) -%>
-  <% end -%>
-<% elsif property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::ResourceRef) -%>
+<%       nested_properties.each do |prop| -%>
+<%=        lines(build_expand_method(prefix + titlelize_property(property), prop), 1) -%>
+<%       end -%>
+<%     elsif property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::ResourceRef) -%>
   l := v.([]interface{})
   req := make([]interface{}, 0, len(l))
   for _, raw := range l {
@@ -72,21 +82,21 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
   }
   return req, nil
 }
-<% else -%>
-  <% if property.is_a?(Api::Type::ResourceRef) -%>
+<%     else -%>
+<%       if property.is_a?(Api::Type::ResourceRef) -%>
   f, err := <%= build_expand_resource_ref('v.(string)', property) %>
   if err != nil {
     return nil, fmt.Errorf("Invalid value for <%= Google::StringUtils.underscore(property.name) -%>: %s", err)
   }
   return f.RelativeLink(), nil
 }
-  <% else -%>
+<%       else -%>
   return v, nil
 }
-  <% end -%>
-<% end -%>
-<% else -%>
+<%       end -%>
+<%     end # nested_properties, array of resourcerefs, else -%>
+<%   else -%>
   // TODO: Property '<%= property.name -%>' of type <%= property.class -%> is not supported
 }
-<% end # tf_types.include?(property.class) -%>
+<%   end # tf_types.include?(property.class) -%>
 <% end # custom_code check -%>


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Also added some whitespace to make it a bit clearer which statements line up with each other.
Fixes #300. This has been working just fine until now since, for some reason, the compute api is totally fine with taking a list of size 1 when it should have just been an object.
<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Fix nested object handling in generated code
## [puppet]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-sql]
### [chef-storage]
## [ansible]
