### PR TITLE
Changing version_added on resources to appease Ansible

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -67,7 +67,7 @@
 [submodule "build/ansible"]
 	path = build/ansible
 	url = git@github.com:modular-magician/ansible
-	branch = devel
+	branch = rebase
 [submodule "build/terraform"]
 	path = build/terraform
 	url = git@github.com:terraform-providers/terraform-provider-google.git

--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -101,6 +101,12 @@ datasources: !ruby/object:Provider::ResourceOverrides
   Zone: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: true
 overrides: !ruby/object:Provider::ResourceOverrides
+  Address: !ruby/object:Provider::Ansible::ResourceOverride
+    properties:
+      addressType: !ruby/object:Provider::Ansible::PropertyOverride
+        version_added: '2.7'
+      subnetwork: !ruby/object:Provider::Ansible::PropertyOverride
+        version_added: '2.7'
   BackendService: !ruby/object:Provider::Ansible::ResourceOverride
     properties:
       timeoutSec: !ruby/object:Provider::Ansible::PropertyOverride
@@ -108,6 +114,11 @@ overrides: !ruby/object:Provider::ResourceOverrides
           - timeout_seconds
   Disk: !ruby/object:Provider::Ansible::ResourceOverride
     editable: false
+    properties:
+      labels: !ruby/object:Provider::Ansible::PropertyOverride
+        version_added: '2.7'
+      type: !ruby/object:Provider::Ansible::PropertyOverride
+        version_added: '2.7'
   ForwardingRule: !ruby/object:Provider::Ansible::ResourceOverride
     properties:
       IPAddress:  !ruby/object:Provider::Ansible::PropertyOverride
@@ -204,6 +215,8 @@ overrides: !ruby/object:Provider::ResourceOverrides
       - 'products/compute/helpers/python/instance_metadata.py'
   Route: !ruby/object:Provider::Ansible::ResourceOverride
     properties:
+      description: !ruby/object:Provider::Ansible::PropertyOverride
+        version_added: '2.7'
       nextHopGateway: !ruby/object:Provider::Ansible::PropertyOverride
         description: |
           URL to a gateway that should handle matching packets.
@@ -214,13 +227,21 @@ overrides: !ruby/object:Provider::ResourceOverrides
           * https://www.googleapis.com/compute/v1/projects/project/global/gateways/default-internet-gateway
           * projects/project/global/gateways/default-internet-gateway
           * global/gateways/default-internet-gateway
+  Router: !ruby/object:Provider::Ansible::ResourceOverride
+    version_added: '2.7'
   SslPolicy: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: false
+    version_added: '2.7'
   TargetPool: !ruby/object:Provider::Ansible::ResourceOverride
     provider_helpers:
       - 'products/compute/helpers/python/provider_target_pool.py'
+  TargetHttpsProxy: !ruby/object:Provider::Ansible::ResourceOverride
+    properties:
+      quicOverride: !ruby/object:Provider::Ansible::PropertyOverride
+        version_added: '2.7'
   TargetVpnGateway: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: false
+    version_added: '2.7'
   # Not yet implemented.
   Autoscaler: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: true

--- a/products/sql/ansible.yaml
+++ b/products/sql/ansible.yaml
@@ -21,7 +21,7 @@ manifest: !ruby/object:Provider::Ansible::Manifest
     - python >= 2.6
     - requests >= 2.18.4
     - google-auth >= 1.3.0
-  version_added: '2.6'
+  version_added: '2.7'
   author: Google Inc. (@googlecloudplatform)
 # This is where custom code would be defined eventually.
 overrides: !ruby/object:Provider::ResourceOverrides

--- a/products/storage/ansible.yaml
+++ b/products/storage/ansible.yaml
@@ -25,6 +25,10 @@ manifest: !ruby/object:Provider::Ansible::Manifest
   author: Google Inc. (@googlecloudplatform)
 # This is where custom code would be defined eventually.
 overrides: !ruby/object:Provider::ResourceOverrides
+  Bucket: !ruby/object:Provider::Ansible::ResourceOverride
+    properties:
+      defaultObjectAcl: !ruby/object:Provider::Ansible::PropertyOverride
+        version_added: '2.7'
   ObjectAccessControl: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: true
   DefaultObjectACL: !ruby/object:Provider::Ansible::ResourceOverride

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -142,6 +142,8 @@ module Provider
 
       # Builds out the minimal YAML block for DOCUMENTATION
       # rubocop:disable Metrics/CyclomaticComplexity
+      # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/AbcSize
       def minimal_doc_block(prop, _object, spaces)
         required = prop.required && !prop.default_value ? 'true' : 'false'
         [
@@ -151,6 +153,7 @@ module Provider
             ("default: #{prop.default_value}" if prop.default_value),
             ('type: bool' if prop.is_a? Api::Type::Boolean),
             ("aliases: [#{prop.aliases.join(', ')}]" if prop.aliases),
+            ("version_added: #{prop.version_added}" if prop.version_added),
             (if prop.is_a? Api::Type::Enum
                [
                  'choices:',
@@ -161,7 +164,8 @@ module Provider
         ]
       end
       # rubocop:enable Metrics/CyclomaticComplexity
-      # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/PerceivedComplexity
 
       # Builds out the minimal YAML block for RETURNS
       def minimal_return_block(prop, spaces)

--- a/provider/ansible/manifest.rb
+++ b/provider/ansible/manifest.rb
@@ -35,8 +35,9 @@ module Provider
       end
 
       # Get value from config and fallback to manifest.
-      def get(value, config)
-        return config[value] unless config[value].nil?
+      def get(value, object)
+        return object.instance_variable_get("@#{value}".to_sym) \
+          unless object.instance_variable_get("@#{value}".to_sym).nil?
         instance_variable_get("@#{value}".to_sym)
       end
     end

--- a/provider/ansible/property_override.rb
+++ b/provider/ansible/property_override.rb
@@ -21,6 +21,7 @@ module Provider
     # Ansible. All fields should be `attr_reader :<property>`
     module OverrideFields
       attr_reader :aliases
+      attr_reader :version_added
     end
 
     # Ansible-specific overrides to api.yaml.
@@ -30,6 +31,7 @@ module Provider
         super
 
         check_optional_property :aliases, ::Array
+        check_optional_property :version_added, ::String
       end
 
       private

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -14,11 +14,11 @@ __metaclass__ = type
 
 <%
   metadata_version = quote_string(@config.manifest.get('metadata_version',
-                                                       config))
-  supported_by = quote_string(@config.manifest.get('supported_by', config))
+                                                       object))
+  supported_by = quote_string(@config.manifest.get('supported_by', object))
 -%>
 ANSIBLE_METADATA = {'metadata_version': <%= metadata_version -%>,
-                    'status': <%= @config.manifest.get('status', config) -%>,
+                    'status': <%= @config.manifest.get('status', object) -%>,
                     'supported_by': <%= supported_by -%>}
 
 DOCUMENTATION = '''
@@ -27,10 +27,10 @@ module: <%= module_name(object) %>
 description:
 <%= lines(indent(bullet_lines(object.description, 4), 4)) -%>
 short_description: Creates a GCP <%= object.name %>
-version_added: <%= lines(@config.manifest.get('version_added', config)) -%>
-author: <%= lines(@config.manifest.get('author', config)) -%>
+version_added: <%= lines(@config.manifest.get('version_added', object)) -%>
+author: <%= lines(@config.manifest.get('author', object)) -%>
 requirements:
-<% @config.manifest.get('requirements', config).each do |line| -%>
+<% @config.manifest.get('requirements', object).each do |line| -%>
 <%= lines(indent(bullet_line(line, 4, false, false), 4)) -%>
 <% end -%>
 options:


### PR DESCRIPTION
Changing version_added on resources to appease Ansible

Because of the rebase, there should be resources that Ansible doesn't necessarily like.

These linters are a pain because I'm not entirely convinced that the Magician is running everything the same as Shippable is.


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Changing version_added on resources to appease Ansible
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-sql]
### [chef-storage]
## [ansible]
Changing version_added on some resources
