### PR TITLE
Turn off logs on compiler unless you use --debug flag

### DIFF
--- a/compiler.rb
+++ b/compiler.rb
@@ -24,6 +24,7 @@ Dir.chdir(File.dirname(__FILE__))
 ENV['TZ'] = 'UTC'
 
 require 'api/compiler'
+require 'google/logger'
 require 'optparse'
 require 'provider/ansible'
 require 'provider/ansible/bundle'
@@ -42,6 +43,7 @@ types_to_generate = []
 version = nil
 
 ARGV << '-h' if ARGV.empty?
+Google::LOGGER.level = Logger::WARN
 
 OptionParser.new do |opt|
   opt.on('-p', '--product PRODUCT', 'Folder with product catalog') do |p|
@@ -62,6 +64,9 @@ OptionParser.new do |opt|
   opt.on('-h', '--help', 'Show this message') do
     puts opt
     exit
+  end
+  opt.on('-d', '--debug', 'Show all debug logs') do |debug|
+    Google::LOGGER.level = Logger::INFO
   end
 end.parse!
 


### PR DESCRIPTION
Turn off logs on compiler unless you use --debug flag

This turns off all `INFO` log lines (basically all of them) unless you have the `--debug` flag activated.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Turn off logs on compiler unless you use --debug flag
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-sql]
### [chef-storage]
## [ansible]
