### PR TITLE
Support unordered lists in Terraform.

### DIFF
--- a/.ci/containers/puppet-forge/Dockerfile
+++ b/.ci/containers/puppet-forge/Dockerfile
@@ -1,0 +1,64 @@
+from alpine:latest as resource
+
+# Install Ruby from source.
+RUN apk update
+RUN apk add --no-cache --virtual .ruby-builddeps \
+		autoconf \
+		bash \
+		bison \
+		bzip2 \
+		bzip2-dev \
+		ca-certificates \
+		coreutils \
+		dpkg-dev dpkg \
+		gcc \
+		g++ \
+		gdbm-dev \
+		git \
+		glib-dev \
+		libc-dev \
+		libffi-dev \
+		libressl \
+		libressl-dev \
+		libxml2-dev \
+		libxslt-dev \
+		linux-headers \
+		make \
+		ncurses-dev \
+		openssh-client \
+		procps \
+		readline-dev \
+		ruby \
+		tar \
+		xz \
+		yaml-dev \
+		zlib-dev
+ENV RUBY_VERSION 2.5.0
+ENV RUBYGEMS_VERSION 2.7.4
+ENV BUNDLER_VERSION 1.16.1
+
+# Set up Github SSH cloning.
+RUN ssh-keyscan github.com >> /known_hosts
+RUN echo "UserKnownHostsFile /known_hosts" >> /etc/ssh/ssh_config
+
+RUN git clone https://github.com/rbenv/ruby-build.git
+RUN PREFIX=/usr/local ./ruby-build/install.sh
+ENV RUBY_CONFIGURE_OPTS="ac_cv_func_isnan=yes ac_cv_func_isinf=yes"
+RUN ruby-build "$RUBY_VERSION" /usr/
+
+RUN gem update --system "$RUBYGEMS_VERSION"
+RUN gem install bundler --version "$BUNDLER_VERSION" --force
+
+ENV GEM_HOME /usr/local/bundle
+ENV BUNDLE_PATH="$GEM_HOME" \
+	BUNDLE_BIN="$GEM_HOME/bin" \
+	BUNDLE_SILENCE_ROOT_WARNING=1 \
+	BUNDLE_APP_CONFIG="$GEM_HOME"
+ENV PATH $BUNDLE_BIN:$PATH
+RUN mkdir -p "$GEM_HOME" "$BUNDLE_BIN" \
+	&& chmod 777 "$GEM_HOME" "$BUNDLE_BIN"
+COPY in.rb /opt/resource/in
+COPY check.rb /opt/resource/check
+COPY out.rb /opt/resource/out
+COPY Gemfile /opt/resource/Gemfile
+RUN cd /opt/resource/ && bundle install

--- a/.ci/containers/puppet-forge/Gemfile
+++ b/.ci/containers/puppet-forge/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'puppet_forge'
+gem 'puppet-blacksmith'

--- a/.ci/containers/puppet-forge/check.rb
+++ b/.ci/containers/puppet-forge/check.rb
@@ -1,0 +1,27 @@
+#! /usr/bin/env ruby
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'puppet_forge'
+require 'json'
+
+config = JSON.parse(STDIN.read)
+raise 'You need to define `module_name`' unless config['source'].key? 'module_name'
+m = PuppetForge::Module.find(config['source']['module_name'])
+releases = m.releases.map! { |r| { 'release' => r.version } }
+
+if config.key? 'version'
+  releases = releases[0..releases.index(config['version'])]
+end
+
+puts JSON.dump(releases)

--- a/.ci/containers/puppet-forge/in.rb
+++ b/.ci/containers/puppet-forge/in.rb
@@ -1,0 +1,32 @@
+#! /usr/bin/env ruby
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'puppet_forge'
+require 'json'
+
+config = JSON.parse(STDIN.read)
+unless config['source'].key? 'module_name'
+  raise 'You need to define `module_name`'
+end
+raise 'Surprised by lack of directory.' if ARGV.empty?
+
+release_slug = "#{config['source']['module_name']}-" \
+    "#{config['version']['release']}"
+release = PuppetForge::Release.find(release_slug)
+release_tarball = release_slug + '.tar.gz'
+release.download(Pathname(release_tarball))
+release.verify(Pathname(release_tarball))
+PuppetForge::Unpacker.unpack(release_tarball, ARGV[0], '/tmp/resource_download')
+
+puts JSON.dump('version' => { 'release' => release.version })

--- a/.ci/containers/puppet-forge/out.rb
+++ b/.ci/containers/puppet-forge/out.rb
@@ -1,0 +1,57 @@
+#! /usr/bin/env ruby
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'puppet_forge'
+require 'puppet_blacksmith'
+require 'json'
+
+config = JSON.parse(STDIN.read)
+unless config['source'].key? 'module_name'
+  raise 'You need to define `module_name`'
+end
+raise 'This is being called without an output directory.' if ARGV.empty?
+
+module_name = config['source']['module_name']
+release = PuppetForge::Module.find(module_name).releases.first.version
+major, minor, patch = release.split('.')
+
+if major.nil? || minor.nil? || patch.nil?
+  raise "Cowardly refusing to work with non-semver release ID #{release}"
+end
+
+if config['params']['patch_bump'] == true
+  patch += 1
+else
+  patch = 0
+  minor += 1
+end
+
+output_folder = ARGV[0]
+metadata = JSON.parse(File.open(File.join(output_folder, 'metadata.json')).read)
+unless metadata['name'] == module_name
+  raise "Cowardly refusing to push #{metadata['name']} to #{module_name}"
+end
+metadata['version'] = "#{major}.#{minor}.#{patch}"
+File.write(File.join(output_folder, 'metadata.json'), JSON.dump(metadata))
+
+Dir.chdir(output_folder) { %x(puppet module build) }
+
+Blacksmith::Forge.initialize(config['source']['username'],
+                             config['source']['password'])
+Blacksmith::Forge.push!(metadata['name'].split('-').last,
+                        File.join(output_folder,
+                                  'pkg',
+                                  "#{metadata['name']}-#{metadata['version']}" \
+                                  '.tar.gz'))
+puts JSON.dump('version' => { 'release' => metadata['version'] })

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 language: ruby # ruby version defined in .ruby-version will be used
 
-before_install:
-# some ruby versions come with a broken version of rubygems, update to
-# consistent version
-- gem update --system 2.7.6
-- gem install bundler -v '>= 1.16.1'
-
 script:
 - bundle exec rake test:rubocop
 - bundle exec rake test:spec

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -657,6 +657,8 @@ overrides: !ruby/object:Provider::ResourceOverrides
           function: 'validateGCPName'
       secondaryIpRanges: !ruby/object:Provider::Terraform::PropertyOverride
         name: secondaryIpRange
+        unordered_list: true
+        default_from_api: true
       secondaryIpRanges.rangeName: !ruby/object:Provider::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateGCPName'

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -24,6 +24,8 @@ module Provider
       attr_reader :state_func # Adds a StateFunc to the schema
       attr_reader :sensitive # Adds `Sensitive: true` to the schema
       attr_reader :validation # Adds a ValidateFunc to the schema
+      # Indicates that this is an Array that should have Set diff semantics.
+      attr_reader :unordered_list
 
       attr_reader :is_set # Uses a Set instead of an Array
       # Optional function to determine the unique ID of an item in the set
@@ -92,6 +94,7 @@ module Provider
         # Ensures boolean values are set to false if nil
         @sensitive ||= false
         @is_set ||= false
+        @unordered_list ||= false
         @default_from_api ||= false
 
         check_property :sensitive, :boolean

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -36,6 +36,13 @@ func resource<%= resource_name -%>() *schema.Resource {
 		Update: resource<%= resource_name -%>Update,
 		<% end -%>
 		Delete: resource<%= resource_name -%>Delete,
+        <% if settable_properties.any? {|p| p.unordered_list} && !object.custom_code.resource_definition -%>
+        CustomizeDiff: customdiff.All(
+            <%= settable_properties.select { |p| p.unordered_list }
+                                    .map { |p| "resource#{resource_name}#{Google::StringUtils.camelize(p.name, :upper)}SetStyleDiff"}
+                                    .join(",\n")-%>
+        ),
+        <% end -%>
 
 		Importer: &schema.ResourceImporter{
 			State: resource<%= resource_name -%>Import,
@@ -74,6 +81,13 @@ func resource<%= resource_name -%>() *schema.Resource {
 		},
 	}
 }
+<% settable_properties.select {|p| p.unordered_list}.each do |prop| -%>
+func resource<%= resource_name -%><%= Google::StringUtils.camelize(prop.name, :upper) -%>SetStyleDiff(diff *schema.ResourceDiff, meta interface{}) error {
+<%= compile_template('templates/terraform/unordered_list_customize_diff.erb',
+                     prop: prop,
+                     resource_name: resource_name) -%>
+}
+<% end -%>
 
 func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)

--- a/templates/terraform/resource_definition/subnetwork.erb
+++ b/templates/terraform/resource_definition/subnetwork.erb
@@ -1,3 +1,4 @@
 CustomizeDiff: customdiff.All(
-		customdiff.ForceNewIfChange("ip_cidr_range", isShrinkageIpCidr),
+        customdiff.ForceNewIfChange("ip_cidr_range", isShrinkageIpCidr),
+        resourceComputeSubnetworkSecondaryIpRangeSetStyleDiff,
 ),

--- a/templates/terraform/unordered_list_customize_diff.erb
+++ b/templates/terraform/unordered_list_customize_diff.erb
@@ -1,0 +1,39 @@
+keys := diff.GetChangedKeysPrefix(<%= go_literal(Google::StringUtils.underscore(prop.name)) -%>)
+if len(keys) == 0 {
+    return nil
+}
+oldCount, newCount := diff.GetChange("<%= Google::StringUtils.underscore(prop.name) -%>.#")
+var count int
+// There could be duplicates - worth continuing even if the counts are unequal.
+if oldCount.(int) < newCount.(int) {
+    count = newCount.(int)
+} else {
+    count = oldCount.(int)
+}
+
+if count < 1 {
+    return nil
+}
+old := make([]interface{}, count)
+new := make([]interface{}, count)
+for i := 0; i < count; i++ {
+    o, n := diff.GetChange(fmt.Sprintf("<%= Google::StringUtils.underscore(prop.name) -%>.%d", i))
+
+    if o != nil {
+        old = append(old, o)
+    }
+    if n != nil {
+        new = append(new, n)
+    }
+}
+
+oldSet := schema.NewSet(schema.HashResource(resource<%= resource_name -%>().Schema[<%= go_literal(Google::StringUtils.underscore(prop.name)) -%>].Elem.(*schema.Resource)), old)
+newSet := schema.NewSet(schema.HashResource(resource<%= resource_name -%>().Schema[<%= go_literal(Google::StringUtils.underscore(prop.name)) -%>].Elem.(*schema.Resource)), new)
+
+if oldSet.Equal(newSet) {
+    if err := diff.Clear(<%= go_literal(Google::StringUtils.underscore(prop.name)) -%>); err != nil {
+        return err
+    }
+}
+
+return nil


### PR DESCRIPTION
Some things are not ordered on the server side.  This supports a customizediff for lists that are not ordered, and applies that to subnetwork's secondary IP ranges.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Support unordered list on subnetwork secondary IP range.
## [puppet]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-sql]
### [chef-storage]
## [ansible]
