### PR TITLE
Hide away the scopes

### DIFF
--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -27,8 +27,8 @@ module Provider
     }.freeze
 
     EXAMPLE_DEFAULTS = {
-      name: 'testObject',
-      project: 'testProject',
+      name: 'test_object',
+      project: 'test_project',
       auth_kind: 'service_account',
       service_account_file: '/tmp/auth.pem'
     }.freeze

--- a/templates/ansible/tasks/task.yaml.erb
+++ b/templates/ansible/tasks/task.yaml.erb
@@ -11,10 +11,6 @@
 <%=
   lines(indent(compile_string(hash, @code.to_yaml.gsub('---', '').strip), 6))
 -%>
-      scopes:
-<% (@scopes || object.__product.scopes).each do |scope| -%>
-        - <%= scope %>
-<% end -%>
 <% if state && state != 'facts' -%>
       state: <%= state %>
 <% end # if state -%>


### PR DESCRIPTION
Scopes is totally optional at this point. I don't want to keep showing it off on Ansible.


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-sql]
### [chef-storage]
## [ansible]
