### PR TITLE
Auth "autogenerated" + Default Scopes

### DIFF
--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -1,5 +1,5 @@
-{% set chef_modules = ['compute', 'sql', 'storage', 'spanner', 'container', 'dns'] %}
-{% set puppet_modules = ['bigquery', 'compute', 'sql', 'storage', 'spanner', 'container', 'dns', 'pubsub', 'resourcemanager'] %}
+{% set chef_modules = ['auth', 'compute', 'sql', 'storage', 'spanner', 'container', 'dns'] %}
+{% set puppet_modules = ['auth', 'bigquery', 'compute', 'sql', 'storage', 'spanner', 'container', 'dns', 'pubsub', 'resourcemanager'] %}
 {% set terraform_enabled = true %}
 {% set ansible_enabled = true %}
 {% macro names_as_list(repo, names) -%}

--- a/products/auth/api.yaml
+++ b/products/auth/api.yaml
@@ -1,0 +1,21 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Bundle
+name: Google Cloud Auth
+prefix: gauth
+versions:
+  - !ruby/object:Api::Product::Version
+    name: v1
+    base_url: 'dummy_url'
+    default: true

--- a/products/auth/chef.yaml
+++ b/products/auth/chef.yaml
@@ -1,0 +1,59 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO(alexstephen): Match all objects w/ Puppet.
+# TODO(alexstephen): Match all special behavior Puppet <=> Chef, e.g. cannot
+# edit InstanceGroup
+--- !ruby/object:Provider::Chef::Config
+manifest: !ruby/object:Provider::Chef::Manifest
+  version: '0.1.1'
+  source: 'https://github.com/GoogleCloudPlatform/chef-google-auth'
+  issues: 'https://github.com/GoogleCloudPlatform/chef-google-auth/issues'
+  summary: 'Installs/Configures gauth'
+  description: |
+    Installs/Configures gauth
+  additional_info:
+    - gem 'googleauth'
+    - gem 'google-api-client', '0.10.1'
+  operating_systems:
+<%= indent(include('provider/chef/common~operating_systems.yaml'), 4) %>
+files: !ruby/object:Provider::Config::Files
+  copy:
+    'libraries/google/functions/gauth_credential_serviceaccount_for_function.rb':
+      'products/auth/chef/libraries/google/functions/gauth_credential_serviceaccount_for_function.rb'
+    'Gemfile.lock': 'templates/chef/Gemfile.lock'
+    'LICENSE': 'templates/LICENSE'
+    'README.md': 'products/auth/chef/README.md'
+    'recipes/default.rb': 'products/auth/chef/recipes/default.rb'
+    'resources/credential.rb': 'products/auth/chef/resources/credential.rb'
+    'resources/google/authorization.rb': 'products/auth/chef/resources/google/authorization.rb'
+    'test/smoke/default/default_test.rb': 'products/auth/chef/test/smoke/default/default_test.rb'
+  compile:
+    '.gitignore': 'templates/dot~gitignore'
+    '.rubocop.yml': 'templates/chef/dot~rubocop~root.yml'
+    'Berksfile': 'templates/chef/Berksfile.erb'
+    'Gemfile': 'templates/chef/Gemfile.erb'
+    'chefignore': 'templates/chef/chefignore.erb'
+    'libraries/__init__.rb': 'templates/chef/init_library_path.rb.erb'
+    'metadata.rb': 'templates/chef/metadata.rb.erb'
+    'CONTRIBUTING.md': 'templates/CONTRIBUTING.md.erb'
+changelog:
+  - !ruby/object:Provider::Config::Changelog
+    version: '0.1.1'
+    date: 2017-10-16T18:30:00-0700
+    features:
+      - Added `gauth_credential_serviceaccount_for_function` client function.
+  - !ruby/object:Provider::Config::Changelog
+    version: '0.1.0'
+    date: 2017-10-04T10:00:00-0700
+    general: 'Initial release'

--- a/products/auth/chef/README.md
+++ b/products/auth/chef/README.md
@@ -1,0 +1,137 @@
+# Google Authentication Chef Cookbook
+
+## Module Description
+
+This cookbook provides the resources to authenticate with Google Cloud Platform.
+
+When executing operations on Google Cloud Platform, e.g. creating a virtual
+machine, a SQL database, etc., you need to be authenticated to be able to carry
+on with the request.
+
+All Google Cloud Platform cookbooks use an unified authentication mechanism,
+provided by this cookbook.
+
+## Example
+
+```chef
+gauth_credential 'mycred' do
+  action :serviceaccount
+  path '/home/nelsonjr/my_account.json'
+  scopes [
+    'https://www.googleapis.com/auth/compute'
+  ]
+end
+```
+
+## Setup
+
+To install this cookbook using `knife` tool:
+
+    knife cookbook site install google-gauth
+    knife cookbook site download google-gauth
+
+_Note: Google Cloud Platform cookbooks that require authentication will
+automatically install this cookbook, as it will be listed in their
+dependencies._
+
+## Platforms
+
+### Supported Operating Systems
+
+This cookbook was tested on the following operating systems:
+
+* RedHat 6, 7
+* CentOS 6, 7
+* Debian 7, 8
+* Ubuntu 12.04, 14.04, 16.04, 16.10
+* SLES 11-sp4, 12-sp2
+* openSUSE 13
+* Windows Server 2008 R2, 2012 R2, 2012 R2 Core, 2016 R2, 2016 R2 Core
+
+## About Service Accounts
+
+This cookbook uses [service accounts][doc-accounts] to authenticate with Google
+Cloud Platform. Google Cloud Platform project administrators manage service
+accounts.  They can create, modify and delete accounts and grant account
+specific privileges on the projects. Those privileges will be used by Chef to
+carry on the operations on behalf of the user.
+
+### Getting a Service Account key
+
+The provider uses the JSON version of the service account key file. When in the
+[IAM & Admin][iam-admin] section of the [Developer Console][console] the
+administrator can retrieve a key file. Select the JSON as the key format.
+
+The file you download is the one provided in the `path` property.
+
+## Providers
+
+### `gauth_credential`
+
+#### `provider`
+
+- `serviceaccount` **[preferred]**
+	This is the preferred method of specifying credentials, because it does not
+	rely on any pre-existing system configuration that Chef can't track. You'll
+	need a credential file, but you can easily manage that with a `file do .. end`
+	resource.
+
+- `defaultuseraccount`
+  If you have [`gcloud`][gcloud] setup you can piggyback on the account
+  currently set as active for the user running Chef.
+
+	_Warning! Please be aware that the account is subject to whichever account is
+	set as active on `gcloud` tool, so the results will not be always consistent
+	if they change under Chef by the user._
+
+#### `scopes`
+
+The scopes your authentication request will be limited to. When executing
+actions against Google Cloud Platform you should choose the minimum amount of
+privileges to carry on the operations to avoid accidentally affecting other
+resources. For example if I want to manage virtual machines you should request
+only "Compute R/W". That way you don't accidentally modify your DNS records.
+
+Google's Chef cookbooks for Google Cloud Platform list the scopes you can use in
+their Chef Supermarket documentation page. You can alternatively look at Google
+Cloud Platform documentation for the product you're interacting with.
+
+A few examples:
+
+<table>
+  <tr>
+    <th>Product</th>
+    <th colspan='2'>Scope</th>
+  </tr>
+  <tr>
+    <td>Compute Engine (VMs, Disks, ...)</td>
+    <td>Read Write</td>
+    <td><code>https://www.googleapis.com/auth/compute</code></td>
+  </tr>
+  <tr>
+    <td>Cloud SQL</td>
+    <td>Read Write</td>
+    <td><code>https://www.googleapis.com/auth/sqlservice.admin</code></td>
+  </tr>
+  <tr>
+    <td rowspan='2'>Cloud DNS</td>
+    <td>Read Only</td>
+    <td><code>https://www.googleapis.com/auth/ndev.clouddns.readonly</code></td>
+  </tr>
+  <tr>
+    <td>Read Write</td>
+    <td><code>https://www.googleapis.com/auth/ndev.clouddns.readwrite</code></td>
+  </tr>
+</table>
+
+
+#### `path`
+
+If you specify the `serviceaccount` provider this property points to an absolute
+path of the service account file (in JSON format).
+
+
+[gcloud]: https://cloud.google.com/sdk
+[console]: https://cloud.google.com/console
+[doc-accounts]: https://cloud.google.com/compute/docs/access/service-accounts
+[iam-admin]: https://console.cloud.google.com/iam-admin/serviceaccounts/project

--- a/products/auth/chef/libraries/google/functions/gauth_credential_serviceaccount_for_function.rb
+++ b/products/auth/chef/libraries/google/functions/gauth_credential_serviceaccount_for_function.rb
@@ -1,0 +1,31 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Ensure we can load 'google/' libraries
+auth_libraries = File.expand_path('../../../resources', __dir__)
+$LOAD_PATH.unshift(auth_libraries) unless $LOAD_PATH.include?(auth_libraries)
+
+require 'google/authorization'
+
+module Google
+  # Module that holds gauth_credential_serviceaccount_for_function
+  module Functions
+    def self.gauth_credential_serviceaccount_for_function(path, scopes)
+      ::Google::Authorization.new.for!(scopes).from_service_account_json!(path)
+    end
+
+    def gauth_credential_serviceaccount_for_function(path, scopes)
+      self.class.gauth_credential_serviceaccount_for_function(path, scopes)
+    end
+  end
+end

--- a/products/auth/chef/recipes/default.rb
+++ b/products/auth/chef/recipes/default.rb
@@ -1,0 +1,18 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Cookbook:: gauth
+# Recipe:: default
+#
+# Copyright:: 2016, The Authors, All Rights Reserved.

--- a/products/auth/chef/resources/credential.rb
+++ b/products/auth/chef/resources/credential.rb
@@ -1,0 +1,65 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'chef/resource'
+require_relative 'google/authorization'
+
+module Google
+  module Auth
+    # Chef Resource to authenticate to GCP
+    class Credential < Chef::Resource::LWRPBase
+      resource_name :gauth_credential
+
+      default_action :nothing
+
+      property :name, String, identity: true, desired_state: false
+      property :path, String, desired_state: false
+      property :scopes, Array, desired_state: false,
+                               default: ['https://www.googleapis.com/auth/compute']
+      property :__auth, ::Google::Authorization, desired_state: false
+
+      action :serviceaccount do
+        if new_resource.path.nil?
+          raise ["Missing 'path' parameter in",
+                 "gauth_credential[#{new_resource.name}]"].join(' ')
+        end
+
+        if new_resource.scopes.nil?
+          raise ["Missing 'scopes' parameter in",
+                 "gauth_credential[#{new_resource.name}]"].join(' ')
+        end
+
+        # TODO: How do define a private property, or better, how to store a
+        # variable only for this instance
+        new_resource.__auth ::Google::Authorization.new.for!(
+          new_resource.scopes
+        ).from_service_account_json!(
+          new_resource.path
+        )
+      end
+
+      action :defaultuseraccount do
+        __auth ::Google::Authorization.new.from_user_credential!
+      end
+
+      action :nothing do
+        raise 'An action for a provider is required: service_account'
+      end
+
+      def authorization
+        raise "Failed to authenticate gauth_credential[#{name}]" if __auth.nil?
+        __auth
+      end
+    end
+  end
+end

--- a/products/auth/chef/resources/google/authorization.rb
+++ b/products/auth/chef/resources/google/authorization.rb
@@ -1,0 +1,150 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Public: Authorizes access to Google API objects.
+#
+# Examples
+#
+#   * Uses user credential stored in ~/.config/gcloud
+#
+#     api = Google::Authorization.new
+#         .for!('https://www.googleapis.com/auth/compute.readonly')
+#         .from_user_credential!
+#         .authorize Google::Apis::ComputeV1::ComputeService.new
+#
+#   * Uses service account specified by the :file argument (in JSON format)
+#
+#     api = Google::Authorization.new
+#         .for!('https://www.googleapis.com/auth/compute.readonly')
+#         .from_service_account_json!(
+#             File.join(File.expand_path('~'), "my_account.json"))
+#         .authorize Google::Apis::ComputeV1::ComputeService.new
+
+require 'googleauth'
+require 'json'
+require 'net/http'
+
+# Google authorization handler module.
+module Google
+  # A helper class to determine if we have Ruby 2
+  class Ruby
+    def self.two?
+      Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
+    end
+
+    # rubocop:disable Performance/Caller
+    def self.ensure_two!
+      callee = caller[0][/`([^']*)'/, 1]
+      raise "Ruby ~> 2.0.0 required for '#{callee}'" unless Ruby.two?
+    end
+    # rubocop:enable Performance/Caller
+  end
+
+  require 'google/api_client/client_secrets' if Google::Ruby.two?
+
+  # A class to aquire credentials and authorize Google API calls.
+  class Authorization
+    def initialize
+      @authorization = nil
+      @scopes = []
+    end
+
+    def authorize(obj)
+      raise ArgumentError, 'A from_* method needs to be called before' \
+        unless @authorization
+
+      if obj.class <= URI::HTTPS || obj.class <= URI::HTTP
+        authorize_uri obj
+      elsif obj.class < Net::HTTPRequest
+        authorize_http obj
+      else
+        obj.authorization = @authorization
+        obj
+      end
+    end
+
+    def for!(*scopes)
+      @scopes = scopes
+      self
+    end
+
+    def from_user_credential!
+      Google::Ruby.ensure_two!
+      hash = make_secrets_hash(find_credential)
+      @authorization = Google::APIClient::ClientSecrets.new(hash)
+                                                       .to_authorization
+      self
+    end
+
+    def from_service_account_json!(service_account_file)
+      raise 'Missing argument for scopes' if @scopes.empty?
+      @authorization = Google::Auth::ServiceAccountCredentials.make_creds(
+        json_key_io: File.open(service_account_file),
+        scope: @scopes
+      )
+      self
+    end
+
+    def from_application_default_credentials!
+      raise NotImplementedError, ':application_default_credentials'
+    end
+
+    private
+
+    def authorize_uri(obj)
+      http = Net::HTTP.new(obj.host, obj.port)
+      http.use_ssl = obj.instance_of?(URI::HTTPS)
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      [http, authorize_http(Net::HTTP::Get.new(obj.request_uri))]
+    end
+
+    def authorize_http(req)
+      req.extend TokenProperty
+      auth = {}
+      @authorization.apply!(auth)
+      req['Authorization'] = auth[:authorization]
+      req.token = auth[:authorization].split(' ')[1]
+      req
+    end
+
+    def credentials
+      JSON.parse(
+        File.read(File.join(ENV['HOME'], '.config', 'gcloud', 'credentials'))
+      )
+    end
+
+    def find_credential
+      credentials['data'].each do |entry|
+        return entry['credential'] if entry['credential']['_class'] == 'OAuth2Credentials'
+      end
+
+      raise "Credential not found in '#{file}'"
+    end
+
+    def make_secrets_hash(cred)
+      {
+        'installed' => {
+          'client_id' => cred['client_id'],
+          'client_secret' => cred['client_secret'],
+          'refresh_token' => cred['refresh_token']
+        }
+      }
+    end
+  end
+
+  # Extension methods to enable retrieving the authentication token.
+  module TokenProperty
+    attr_reader :token
+    attr_writer :token
+  end
+end

--- a/products/auth/chef/test/smoke/default/default_test.rb
+++ b/products/auth/chef/test/smoke/default/default_test.rb
@@ -1,0 +1,28 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Inspec test for recipe gauth::default
+
+# The Inspec reference, with examples and extensive documentation, can be
+# found at http://inspec.io/docs/reference/resources/
+
+unless os.windows?
+  describe user('root') do
+    it { should exist }
+    skip 'This is an example test, replace with your own test.'
+  end
+end
+
+describe port(80) do
+  it { should_not be_listening }
+  skip 'This is an example test, replace with your own test.'
+end

--- a/products/auth/puppet.yaml
+++ b/products/auth/puppet.yaml
@@ -1,0 +1,55 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Puppet::Config
+manifest: !ruby/object:Provider::Puppet::Manifest
+  version: '0.2.0'
+  source: 'https://github.com/GoogleCloudPlatform/puppet-google-auth'
+  homepage: 'https://github.com/GoogleCloudPlatform/puppet-google-auth'
+  issues:
+    'https://github.com/GoogleCloudPlatform/puppet-google-auth/issues'
+  summary: 'Authenticates Puppet on Google Cloud Platform'
+  tags:
+    - google
+    - cloud
+    - compute
+    - engine
+    - gce
+  operating_systems:
+<%= indent(include('provider/puppet/common~operating_systems.yaml'), 4) %>
+files: !ruby/object:Provider::Config::Files
+  copy:
+    'LICENSE': 'templates/LICENSE'
+    'Gemfile': 'products/auth/puppet/Gemfile'
+    'Gemfile.lock': 'products/auth/puppet/Gemfile.lock'
+    'README.md': 'products/auth/puppet/README.md'
+    'lib/': 'products/auth/puppet/lib/'
+    'lib/google/object_store.rb': 'google/object_store.rb'
+    'spec/': 'products/auth/puppet/spec/'
+  compile:
+    '.gitignore': 'templates/dot~gitignore'
+    '.rubocop.yml': 'templates/dot~rubocop~root.yml'
+    'metadata.json': 'templates/puppet/metadata.json.erb'
+    'CONTRIBUTING.md': 'templates/CONTRIBUTING.md.erb'
+<% # common~compile~after.yaml should be the last line of compile: section -%>
+changelog:
+  - !ruby/object:Provider::Config::Changelog
+    version: '0.1.1'
+    date: 2017-10-10T09:00:00-0700
+    features:
+      - Added `gauth_credential_serviceaccount_for_function` client function.
+      - Added `Google::Auth::GAuthCredential` function for access from Ruby.
+  - !ruby/object:Provider::Config::Changelog
+    version: '0.1.0'
+    date: 2017-08-22T09:00:00-0700
+    general: 'Initial release'

--- a/products/auth/puppet/Gemfile
+++ b/products/auth/puppet/Gemfile
@@ -1,0 +1,33 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source 'https://rubygems.org'
+
+gem 'google-api-client'
+gem 'googleauth'
+
+group :test do
+  gem 'fakeweb'
+  gem 'parallel_tests'
+  gem 'puppet', ENV['PUPPET_GEM_VERSION'] || '~> 4.2.0'
+  gem 'puppet-lint'
+  gem 'puppet-lint-unquoted_string-check'
+  gem 'puppet-syntax'
+  gem 'puppetlabs_spec_helper'
+  gem 'rake', '~> 10.0'
+  gem 'rspec'
+  gem 'rspec-mocks'
+  gem 'rspec-puppet'
+  gem 'rubocop'
+  gem 'simplecov'
+end

--- a/products/auth/puppet/Gemfile.lock
+++ b/products/auth/puppet/Gemfile.lock
@@ -1,0 +1,135 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
+    ast (2.4.0)
+    diff-lcs (1.3)
+    docile (1.1.5)
+    facter (2.4.6)
+    fakeweb (1.3.0)
+    faraday (0.10.0)
+      multipart-post (>= 1.2, < 3)
+    google-api-client (0.9.20)
+      addressable (~> 2.3)
+      googleauth (~> 0.5)
+      httpclient (~> 2.7)
+      hurley (~> 0.1)
+      memoist (~> 0.11)
+      mime-types (>= 1.6)
+      representable (~> 2.3.0)
+      retriable (~> 2.0)
+    googleauth (0.5.1)
+      faraday (~> 0.9)
+      jwt (~> 1.4)
+      logging (~> 2.0)
+      memoist (~> 0.12)
+      multi_json (~> 1.11)
+      os (~> 0.9)
+      signet (~> 0.7)
+    hiera (3.3.1)
+    httpclient (2.8.2.4)
+    hurley (0.2)
+    jaro_winkler (1.5.1)
+    json (2.0.3)
+    json_pure (2.0.3)
+    jwt (1.5.6)
+    little-plugger (1.1.4)
+    logging (2.1.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
+    memoist (0.15.0)
+    metaclass (0.0.4)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    mocha (1.2.1)
+      metaclass (~> 0.0.1)
+    multi_json (1.12.1)
+    multipart-post (2.0.0)
+    os (0.9.6)
+    parallel (1.12.1)
+    parallel_tests (2.22.0)
+      parallel
+    parser (2.5.1.2)
+      ast (~> 2.4.0)
+    powerpack (0.1.2)
+    public_suffix (2.0.4)
+    puppet (4.2.3)
+      facter (> 2.0, < 4)
+      hiera (>= 2.0, < 4)
+      json_pure
+    puppet-lint (2.1.1)
+    puppet-lint-unquoted_string-check (0.3.0)
+      puppet-lint (>= 1.0, < 3.0)
+    puppet-syntax (2.4.0)
+      rake
+    puppetlabs_spec_helper (2.1.0)
+      mocha (~> 1.0)
+      puppet-lint (~> 2.0)
+      puppet-syntax (~> 2.0)
+      rspec-puppet (~> 2.0)
+    rainbow (3.0.0)
+    rake (10.5.0)
+    representable (2.3.0)
+      uber (~> 0.0.7)
+    retriable (2.1.0)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-puppet (2.5.0)
+      rspec
+    rspec-support (3.5.0)
+    rubocop (0.58.2)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.9.0)
+    signet (0.7.3)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (~> 1.5)
+      multi_json (~> 1.10)
+    simplecov (0.14.0)
+      docile (~> 1.1.0)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
+    uber (0.0.15)
+    unicode-display_width (1.4.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  fakeweb
+  google-api-client
+  googleauth
+  parallel_tests
+  puppet (~> 4.2.0)
+  puppet-lint
+  puppet-lint-unquoted_string-check
+  puppet-syntax
+  puppetlabs_spec_helper
+  rake (~> 10.0)
+  rspec
+  rspec-mocks
+  rspec-puppet
+  rubocop
+  simplecov
+
+BUNDLED WITH
+   1.16.1

--- a/products/auth/puppet/README.md
+++ b/products/auth/puppet/README.md
@@ -1,0 +1,205 @@
+# Google Authentication Puppet Module
+
+## Module Description
+
+This module provides the types to authenticate with Google Cloud Platform.
+
+When executing operations on Google Cloud Platform, e.g. creating a virtual
+machine, a SQL database, etc., you need to be authenticated to be able to carry
+on with the request.
+
+All Google Cloud Platform modules use an unified authentication mechanism,
+provided by this module.
+
+## Setup
+
+To install this module on your Puppet Master (or Puppet Client/Agent), use the
+Puppet module installer:
+
+    puppet module install google-gauth
+
+_Note: Google Cloud Platform modules that require authentication will
+automatically install this module, as it will be listed in their dependencies._
+
+### Required gem (libraries)
+
+The authentication module depends on a gem released by Google. Puppet does not
+install gems automatically as it is to change the underlying system without
+administrator consent. To install it run:
+
+    gem install googleauth google-api-client
+
+As everything related to system configuration, you can install the gem using
+Puppet itself ;-)...
+
+```puppet
+package { [
+    'googleauth',
+    'google-api-client',
+  ]:
+    ensure   => present,
+    provider => gem,
+}
+```
+
+#### Installing gems for Puppet Agent/Master only
+
+In case you wish to use Google gems exclusively on Puppet you can install them
+into the Puppet Ruby sandbox. That will have less requirement burden, as it will
+not require to have `rubygems` and other Ruby packages to be installed on the
+host.
+
+    puppet resource package googleauth ensure=present provider=puppet_gem
+    puppet resource package google-api-client ensure=present provider=puppet_gem
+
+Once executed it will output the confirmation and version installed:
+
+    Notice: /Package[googleauth]/ensure: created
+    package { 'googleauth':
+      ensure => ['0.6.2'],
+    }
+
+    Notice: /Package[google-api-client]/ensure: created
+    package { 'google-api-client':
+      ensure => ['0.19.8'],
+    }
+
+## Usage
+
+```puppet
+gauth_credential { 'mycred':
+  path     => $cred_path, # e.g. '/home/nelsonjr/my_account.json'
+  provider => serviceaccount,
+  scopes   => [
+    'https://www.googleapis.com/auth/ndev.clouddns.readwrite',
+  ],
+}
+```
+
+## About Service Accounts
+
+This module uses [service accounts][doc-accounts] to authenticate with Google
+Cloud Platform. Google Cloud Platform project administrators manage service
+accounts.  They can create, modify and delete accounts and grant account
+specific privileges on the projects. Those privileges will be used by Puppet to
+carry on the operations on behalf of the user.
+
+### Getting a Service Account key
+
+This module uses the JSON version of the service account key file. When in the
+[IAM & Admin][iam-admin] section of the [Developer Console][console] the
+administrator can retrieve a key file. Select the JSON as the key format.
+
+The file you download is the one provided in the `path` property.
+
+
+## Reference
+
+### Parameters
+
+#### `gauth_credential`
+
+##### `provider`
+
+- `serviceaccount` **[preferred]**
+	This is the preferred method of specifying credentials, because it does not
+	rely on any pre-existing system configuration that Puppet can't track. You'll
+	need a credential file, but you can easily manage that with a `file { }`
+	resource.
+
+- `defaultuseraccount`
+  If you have [`gcloud`][gcloud] setup you can piggyback on the account
+  currently set as active for the user running Puppet.
+
+	_Warning! Please be aware that the account is subject to whichever account is
+	set as active on `gcloud` tool, so the results will not be always consistent
+	if they change under Puppet by the user._
+
+##### `scopes`
+
+The scopes your authentication request will be limited to. When executing
+actions against Google Cloud Platform you should choose the minimum amount of
+privileges to carry on the operations to avoid accidentally affecting other
+resources. For example if I want to manage virtual machines you should request
+only "Compute R/W". That way you don't accidentally modify your DNS records.
+
+Google's Puppet modules for Google Cloud Platform list the scopes you can use in
+their Puppet Forge documentation page. You can alternatively look at Google
+Cloud Platform documentation for the product you're interacting with.
+
+A few examples:
+
+<table>
+  <tr>
+    <th>Product</th>
+    <th colspan='2'>Scope</th>
+  </tr>
+  <tr>
+    <td>Compute Engine (VMs, Disks, ...)</td>
+    <td>Read Write</td>
+    <td><code>https://www.googleapis.com/auth/compute</code></td>
+  </tr>
+  <tr>
+    <td>Cloud SQL</td>
+    <td>Read Write</td>
+    <td><code>https://www.googleapis.com/auth/sqlservice.admin</code></td>
+  </tr>
+  <tr>
+    <td rowspan='2'>Cloud DNS</td>
+    <td>Read Only</td>
+    <td><code>https://www.googleapis.com/auth/ndev.clouddns.readonly</code></td>
+  </tr>
+  <tr>
+    <td>Read Write</td>
+    <td><code>https://www.googleapis.com/auth/ndev.clouddns.readwrite</code></td>
+  </tr>
+</table>
+
+
+##### `path`
+
+If you specify the `serviceaccount` provider this property points to an absolute
+path of the service account file (in JSON format).
+
+
+### Functions
+
+#### `gauth_credential_serviceaccount_for_function`
+
+  Creates the credential token required by other client-side functions to
+  retrieve Google Cloud Platform resource properties, e.g. Compute Instance IP
+  address.
+
+  This function uses a service account JSON file to provide credentials. A
+  service account can be created an managed using Google Cloud IAM service.
+
+  It is common to require dynamic data to be fetched and used by depedent
+  resources, for example to lock down a database to a specific machines you
+  require the machine's IP address. However the IP address is dynamic and cannot
+  be determined upfront, so we need to provide the means to retrieve it
+  programmatically. To allow such access GCP requires credentials. This function
+  builds such credentials.
+
+##### Arguments
+
+  - `path`:
+    the path for the service account credential JSON file
+
+  - `scopes`:
+    an array of scopes to allow access to. The service account privileges will
+    be constrained to the list provided in this parameter.
+
+##### Examples
+
+```puppet
+$fn_auth = gauth_credential_serviceaccount_for_function(
+  '/root/my_account.json', ['https://www.googleapis.com/auth/sqlservice.admin']
+)
+```
+
+
+
+[gcloud]: https://cloud.google.com/sdk
+[console]: https://cloud.google.com/console
+[doc-accounts]: https://cloud.google.com/compute/docs/access/service-accounts
+[iam-admin]: https://console.cloud.google.com/iam-admin/serviceaccounts/project

--- a/products/auth/puppet/lib/google/auth/gauth_credential.rb
+++ b/products/auth/puppet/lib/google/auth/gauth_credential.rb
@@ -1,0 +1,29 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'google/authorization'
+
+module Google
+  module Auth
+    # A helper class to allocate credential for Google Cloud Platform access.
+    class GAuthCredential
+      def self.serviceaccount_for_function(credential_file, scopes)
+        fn_name = :gauth_credential_serviceaccount_for_function
+        Puppet::Parser::Compiler.new(Puppet::Node.new(:function))
+                                .context_overrides[:global_scope]
+                                .call_function(fn_name,
+                                               [credential_file, scopes])
+      end
+    end
+  end
+end

--- a/products/auth/puppet/lib/google/authorization.rb
+++ b/products/auth/puppet/lib/google/authorization.rb
@@ -1,0 +1,149 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Public: Authorizes access to Google API objects.
+#
+# Examples
+#
+#   * Uses user credential stored in ~/.config/gcloud
+#
+#     api = Google::Authorization.new
+#         .for!('https://www.googleapis.com/auth/compute.readonly')
+#         .from_user_credential!
+#         .authorize Google::Apis::ComputeV1::ComputeService.new
+#
+#   * Uses service account specified by the :file argument (in JSON format)
+#
+#     api = Google::Authorization.new
+#         .for!('https://www.googleapis.com/auth/compute.readonly')
+#         .from_service_account_json!(
+#             File.join(File.expand_path('~'), "my_account.json"))
+#         .authorize Google::Apis::ComputeV1::ComputeService.new
+#
+# TODO(nelsona): Add support gcloud's beta "app default credential"
+
+require 'googleauth'
+require 'json'
+require 'net/http'
+
+# Google authorization handler module.
+module Google
+  # A helper class to determine if we have Ruby 2
+  class Ruby
+    def self.two?
+      Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0.0')
+    end
+
+    def self.ensure_two!
+      callee = caller(1..1).first[/`([^']*)'/, 1]
+      raise "Ruby ~> 2.0.0 required for '#{callee}'" unless Ruby.two?
+    end
+  end
+
+  require 'google/api_client/client_secrets' if Google::Ruby.two?
+
+  # A class to aquire credentials and authorize Google API calls.
+  class Authorization
+    def initialize
+      @authorization = nil
+      @scopes = []
+    end
+
+    def authorize(obj)
+      raise ArgumentError, 'A from_* method needs to be called before' \
+        unless @authorization
+
+      if obj.class <= URI::HTTPS || obj.class <= URI::HTTP
+        authorize_uri obj
+      elsif obj.class < Net::HTTPRequest
+        authorize_http obj
+      else
+        obj.authorization = @authorization
+        obj
+      end
+    end
+
+    def for!(*scopes)
+      @scopes = scopes
+      self
+    end
+
+    def from_user_credential!
+      Google::Ruby.ensure_two! # TODO(nelsona): Ensure we can run with Ruby 1.9
+      hash = make_secrets_hash(find_credential)
+      @authorization = Google::APIClient::ClientSecrets.new(hash)
+                                                       .to_authorization
+      self
+    end
+
+    def from_service_account_json!(service_account_file)
+      raise 'Missing argument for scopes' if @scopes.empty?
+      @authorization = Google::Auth::ServiceAccountCredentials.make_creds(
+        json_key_io: File.open(service_account_file),
+        scope: @scopes
+      )
+      self
+    end
+
+    def from_application_default_credentials!
+      raise NotImplementedError, ':application_default_credentials'
+    end
+
+    private
+
+    def authorize_uri(obj)
+      http = Net::HTTP.new(obj.host, obj.port)
+      http.use_ssl = obj.instance_of?(URI::HTTPS)
+      http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+      [http, authorize_http(Net::HTTP::Get.new(obj.request_uri))]
+    end
+
+    def authorize_http(req)
+      req.extend TokenProperty
+      auth = {}
+      @authorization.apply!(auth)
+      req['Authorization'] = auth[:authorization]
+      req.token = auth[:authorization].split(' ')[1]
+      req
+    end
+
+    def credentials
+      JSON.parse(File.read(File.join(ENV['HOME'], '.config', 'gcloud',
+                                     'credentials')))
+    end
+
+    def find_credential
+      credentials['data'].each do |entry|
+        return entry['credential'] if entry['credential']['_class'] == 'OAuth2Credentials'
+      end
+
+      raise "Credential not found in '#{file}'"
+    end
+
+    def make_secrets_hash(cred)
+      {
+        'installed' => {
+          'client_id' => cred['client_id'],
+          'client_secret' => cred['client_secret'],
+          'refresh_token' => cred['refresh_token']
+        }
+      }
+    end
+  end
+
+  # Extension methods to enable retrieving the authentication token.
+  module TokenProperty
+    attr_reader :token
+    attr_writer :token
+  end
+end

--- a/products/auth/puppet/lib/puppet/functions/gauth_credential_serviceaccount_for_function.rb
+++ b/products/auth/puppet/lib/puppet/functions/gauth_credential_serviceaccount_for_function.rb
@@ -1,0 +1,33 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'puppet'
+require 'puppet/pops'
+require 'puppet/functions'
+
+require 'google/authorization'
+
+Puppet::Functions.create_function(
+  :gauth_credential_serviceaccount_for_function
+) do
+  dispatch :gauth_credential_serviceaccount_for_function do
+    param 'String', :path
+    param 'Array', :scopes
+  end
+
+  def gauth_credential_serviceaccount_for_function(path, scopes)
+    Google::Authorization.new
+                         .for!(scopes)
+                         .from_service_account_json!(path)
+  end
+end

--- a/products/auth/puppet/lib/puppet/provider/gauth_credential/default.rb
+++ b/products/auth/puppet/lib/puppet/provider/gauth_credential/default.rb
@@ -1,0 +1,42 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'google/object_store'
+require 'puppet'
+
+# A dummy provider that tells the user to specify a provider.
+Puppet::Type.type(:gauth_credential).provide(:default) do
+  def self.init
+    @resource_collector = Google::ObjectStore.instance
+  end
+
+  init
+
+  def self.instances
+    @resource_collector[:gauth_credential].map(&:provider)
+  end
+
+  def self.prefetch(resources)
+    resources.each_key do |title|
+      raise "gauth_credential[#{title}] does not have a provider"
+    end
+  end
+
+  def self.default?
+    true
+  end
+
+  def authorization
+    raise 'default credential does not provide authorization'
+  end
+end

--- a/products/auth/puppet/lib/puppet/provider/gauth_credential/defaultuseraccount.rb
+++ b/products/auth/puppet/lib/puppet/provider/gauth_credential/defaultuseraccount.rb
@@ -1,0 +1,48 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'google/authorization'
+require 'google/object_store'
+require 'puppet'
+
+# A Puppet provider that implements authenticating requests using a Google Cloud
+# Platform default user account.
+Puppet::Type.type(:gauth_credential).provide(:defaultuseraccount) do
+  has_feature :defaultuseraccount
+
+  def self.init
+    @resource_collector = Google::ObjectStore.instance
+  end
+
+  init
+
+  def self.instances
+    @resource_collector[:gauth_credential].select do |resource|
+      resource.provider == 'defaultuseraccount'
+    end.map(&:provider)
+  end
+
+  def self.prefetch(resources)
+    resources.each do |title, resource|
+      resource.provider = new(title: title,
+                              provider: :defaultuseraccount)
+      debug "Created resource #{resource}"
+      Google::ObjectStore.instance.add(:gauth_credential, resource)
+    end
+  end
+
+  def authorization
+    debug "Acquiring authorization for #{@resource}"
+    Google::Authorization.new.from_user_credential!
+  end
+end

--- a/products/auth/puppet/lib/puppet/provider/gauth_credential/serviceaccount.rb
+++ b/products/auth/puppet/lib/puppet/provider/gauth_credential/serviceaccount.rb
@@ -1,0 +1,60 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'google/authorization'
+require 'google/object_store'
+require 'puppet'
+
+# A Puppet provider that implements authenticating requests using a Google Cloud
+# Platform service account.
+# rubocop:disable Metrics/BlockLength
+Puppet::Type.type(:gauth_credential).provide(:serviceaccount) do
+  has_feature :serviceaccount
+
+  def self.init
+    @resource_collector = Google::ObjectStore.instance
+  end
+
+  init
+
+  def self.instances
+    @resource_collector[:gauth_credential].select do |resource|
+      resource.provider == 'serviceaccount'
+    end.map(&:provider)
+  end
+
+  def self.prefetch(resources)
+    resources.each do |title, resource|
+      resource.provider = new(title: title,
+                              path: resource[:path],
+                              scopes: resource[:scopes],
+                              provider: :serviceaccount)
+      Puppet.debug "Created resource #{resource}"
+      Google::ObjectStore.instance.add(:gauth_credential, resource)
+    end
+  end
+
+  def authorization
+    path = get(:path)
+    scopes = get(:scopes)
+
+    raise ArgumentError, 'Missing path parameter' if path == :absent
+    raise ArgumentError, 'Missing scopes parameter' if scopes == :absent
+
+    Puppet.debug "Acquiring authorization for #{@resource}"
+    Google::Authorization.new
+                         .for!(scopes)
+                         .from_service_account_json!(path)
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/products/auth/puppet/lib/puppet/type/gauth_credential.rb
+++ b/products/auth/puppet/lib/puppet/type/gauth_credential.rb
@@ -1,0 +1,67 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A Puppet resource that specifies the credentials and authentication method to
+# use when authorizing Google Cloud Platform API requests.
+# rubocop:disable Metrics/BlockLength
+Puppet::Type.newtype(:gauth_credential) do
+  @doc = "Authentication for Google Cloud Platform.
+
+  gauth_credential { 'myuser':
+    path     => '/private/my_credentials.json',
+    provider => serviceaccount,
+  }
+
+  Then you add 'credential' to your type to have access to the object:
+
+  gcompute_instance { 'myvm':
+    ensure     => present,
+    credential => 'myuser',
+    ...
+    ...
+  }
+  "
+
+  feature :serviceaccount, 'Authenticate using a service_account.json file'
+  feature :defaultuseraccount, 'Authenticate using user default credential'
+
+  newparam :title, namevar: true
+  newparam :path, feature: :serviceaccount
+
+  newparam :scopes, feature: :serviceaccount,
+                    defaultto: ['https://www.googleapis.com/auth/compute']
+
+  def authorization
+    provider.authorization
+  end
+
+  # Fetch the authorization for the resource passed as parameter.
+  def self.fetch(resource)
+    id = get_id(resource)
+    Puppet::Type.type(:gauth_credential).instances.each do |entry|
+      return entry.authorization if entry.title == id
+    end
+    raise ArgumentError, \
+          "gauth_credential[#{id}] required to authenticate #{resource}"
+  end
+
+  private
+
+  def self.get_id(resource)
+    id = resource[:credential] if resource.class <= Hash
+    id = resource.value(:credential) unless resource.class <= Hash
+    raise ArgumentError, "#{resource} lacks 'credential' parameter" if id.nil?
+    id
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/products/bigquery/puppet.yaml
+++ b/products/bigquery/puppet.yaml
@@ -24,9 +24,7 @@ manifest: !ruby/object:Provider::Puppet::Manifest
     - cloud
     - storage
   requires:
-    - !ruby/object:Provider::Config::Requirements
-      name: 'google/gauth'
-      versions: '>= 0.2.0 < 0.3.0'
+<%= indent(compile('provider/puppet/common~requires.yaml'), 4) %>
   operating_systems:
 <%= indent(include('provider/puppet/common~operating_systems.yaml'), 4) %>
 overrides: !ruby/object:Provider::ResourceOverrides

--- a/products/compute/chef.yaml
+++ b/products/compute/chef.yaml
@@ -24,9 +24,7 @@ manifest: !ruby/object:Provider::Chef::Manifest
     This cookbook provides the built-in types and services for Chef to manage
     Google Cloud Compute resources, as native Chef types.
   depends:
-    - !ruby/object:Provider::Config::Requirements
-      name: 'google-gauth'
-      versions: '< 0.2.0'
+<%= indent(compile('provider/chef/common~depends.yaml'), 4) %>
   operating_systems:
 <%= indent(include('provider/chef/common~operating_systems.yaml'), 4) %>
 overrides: !ruby/object:Provider::ResourceOverrides

--- a/products/compute/puppet.yaml
+++ b/products/compute/puppet.yaml
@@ -26,9 +26,7 @@ manifest: !ruby/object:Provider::Puppet::Manifest
     - engine
     - gce
   requires:
-    - !ruby/object:Provider::Config::Requirements
-      name: 'google/gauth'
-      versions: '>= 0.2.0 < 0.3.0'
+<%= indent(compile('provider/puppet/common~requires.yaml'), 4) %>
   operating_systems:
 <%= indent(include('provider/puppet/common~operating_systems.yaml'), 4) %>
 # TODO(nelsonjr): Match all special behavior Puppet <=> Chef.

--- a/products/container/chef.yaml
+++ b/products/container/chef.yaml
@@ -21,9 +21,7 @@ manifest: !ruby/object:Provider::Chef::Manifest
     This cookbook provides the built-in types and services for Chef to manage
     Google Container Engine resources, as native Chef types.
   depends:
-    - !ruby/object:Provider::Config::Requirements
-      name: 'google-gauth'
-      versions: '< 0.2.0'
+<%= indent(compile('provider/chef/common~depends.yaml'), 4) %>
   operating_systems:
 <%= indent(include('provider/chef/common~operating_systems.yaml'), 4) %>
 overrides: !ruby/object:Provider::ResourceOverrides

--- a/products/container/puppet.yaml
+++ b/products/container/puppet.yaml
@@ -26,9 +26,7 @@ manifest: !ruby/object:Provider::Puppet::Manifest
     - engine
     - gke
   requires:
-    - !ruby/object:Provider::Config::Requirements
-      name: 'google/gauth'
-      versions: '>= 0.2.0 < 0.3.0'
+<%= indent(compile('provider/puppet/common~requires.yaml'), 4) %>
   operating_systems:
 <%= indent(include('provider/puppet/common~operating_systems.yaml'), 4) %>
 overrides: !ruby/object:Provider::ResourceOverrides

--- a/products/dns/chef.yaml
+++ b/products/dns/chef.yaml
@@ -21,9 +21,7 @@ manifest: !ruby/object:Provider::Chef::Manifest
     This cookbook provides the built-in types and services for Chef to manage
     Google Cloud DNS resources, as native Chef types.
   depends:
-    - !ruby/object:Provider::Config::Requirements
-      name: 'google-gauth'
-      versions: '< 0.2.0'
+<%= indent(compile('provider/chef/common~depends.yaml'), 4) %>
   operating_systems:
 <%= indent(include('provider/chef/common~operating_systems.yaml'), 4) %>
 overrides: !ruby/object:Provider::ResourceOverrides

--- a/products/dns/puppet.yaml
+++ b/products/dns/puppet.yaml
@@ -23,9 +23,7 @@ manifest: !ruby/object:Provider::Puppet::Manifest
     - cloud
     - dns
   requires:
-    - !ruby/object:Provider::Config::Requirements
-      name: 'google/gauth'
-      versions: '>= 0.2.0 < 0.3.0'
+<%= indent(compile('provider/puppet/common~requires.yaml'), 4) %>
   operating_systems:
 <%= indent(include('provider/puppet/common~operating_systems.yaml'), 4) %>
 overrides: !ruby/object:Provider::ResourceOverrides

--- a/products/iam/puppet.yaml
+++ b/products/iam/puppet.yaml
@@ -24,9 +24,7 @@ manifest: !ruby/object:Provider::Puppet::Manifest
     - cloud
     - iam
   requires:
-    - !ruby/object:Provider::Config::Requirements
-      name: 'google/gauth'
-      versions: '>= 0.2.0 < 0.3.0'
+<%= indent(compile('provider/puppet/common~requires.yaml'), 4) %>
   operating_systems:
 <%= indent(include('provider/puppet/common~operating_systems.yaml'), 4) %>
 # TODO(nelsonjr): Match all special behavior Puppet <=> Chef.

--- a/products/pubsub/chef.yaml
+++ b/products/pubsub/chef.yaml
@@ -21,9 +21,7 @@ manifest: !ruby/object:Provider::Chef::Manifest
     This cookbook provides the built-in types and services for Chef to manage
     Google Pubsub resources, as native Chef types.
   depends:
-    - !ruby/object:Provider::Config::Requirements
-      name: 'google-gauth'
-      versions: '< 0.2.0'
+<%= indent(compile('provider/chef/common~depends.yaml'), 4) %>
   operating_systems:
 <%= indent(include('provider/chef/common~operating_systems.yaml'), 4) %>
 overrides: !ruby/object:Provider::ResourceOverrides

--- a/products/pubsub/puppet.yaml
+++ b/products/pubsub/puppet.yaml
@@ -24,9 +24,7 @@ manifest: !ruby/object:Provider::Puppet::Manifest
     - cloud
     - pubsub
   requires:
-    - !ruby/object:Provider::Config::Requirements
-      name: 'google/gauth'
-      versions: '>= 0.2.0 < 0.3.0'
+<%= indent(compile('provider/puppet/common~requires.yaml'), 4) %>
   operating_systems:
 <%= indent(include('provider/puppet/common~operating_systems.yaml'), 4) %>
 overrides: !ruby/object:Provider::ResourceOverrides

--- a/products/resourcemanager/chef.yaml
+++ b/products/resourcemanager/chef.yaml
@@ -21,9 +21,7 @@ manifest: !ruby/object:Provider::Chef::Manifest
     This cookbook provides the built-in types and services for Chef to manage
     Google Cloud Resource Manager resources, as native Chef types.
   depends:
-    - !ruby/object:Provider::Config::Requirements
-      name: 'google-gauth'
-      versions: '< 0.2.0'
+<%= indent(compile('provider/chef/common~depends.yaml'), 4) %>
   operating_systems:
 <%= indent(include('provider/chef/common~operating_systems.yaml'), 4) %>
 overrides: !ruby/object:Provider::ResourceOverrides

--- a/products/resourcemanager/puppet.yaml
+++ b/products/resourcemanager/puppet.yaml
@@ -25,9 +25,7 @@ manifest: !ruby/object:Provider::Puppet::Manifest
     - cloud
     - resourcemanager
   requires:
-    - !ruby/object:Provider::Config::Requirements
-      name: 'google/gauth'
-      versions: '>= 0.2.0 < 0.3.0'
+<%= indent(compile('provider/puppet/common~requires.yaml'), 4) %>
   operating_systems:
 <%= indent(include('provider/puppet/common~operating_systems.yaml'), 4) %>
 overrides: !ruby/object:Provider::ResourceOverrides

--- a/products/spanner/chef.yaml
+++ b/products/spanner/chef.yaml
@@ -21,9 +21,7 @@ manifest: !ruby/object:Provider::Chef::Manifest
     This cookbook provides the built-in types and services for Chef to manage
     Google Cloud Spanner resources, as native Chef types.
   depends:
-    - !ruby/object:Provider::Config::Requirements
-      name: 'google-gauth'
-      versions: '< 0.2.0'
+<%= indent(compile('provider/chef/common~depends.yaml'), 4) %>
   operating_systems:
 <%= indent(include('provider/chef/common~operating_systems.yaml'), 4) %>
 overrides: !ruby/object:Provider::ResourceOverrides

--- a/products/spanner/puppet.yaml
+++ b/products/spanner/puppet.yaml
@@ -24,9 +24,7 @@ manifest: !ruby/object:Provider::Puppet::Manifest
     - cloud
     - spanner
   requires:
-    - !ruby/object:Provider::Config::Requirements
-      name: 'google/gauth'
-      versions: '>= 0.2.0 < 0.3.0'
+<%= indent(compile('provider/puppet/common~requires.yaml'), 4) %>
   operating_systems:
 <%= indent(include('provider/puppet/common~operating_systems.yaml'), 4) %>
 overrides: !ruby/object:Provider::ResourceOverrides

--- a/products/sql/chef.yaml
+++ b/products/sql/chef.yaml
@@ -21,9 +21,7 @@ manifest: !ruby/object:Provider::Chef::Manifest
     This cookbook provides the built-in types and services for Chef to manage
     Google Cloud Compute resources, as native Chef types.
   depends:
-    - !ruby/object:Provider::Config::Requirements
-      name: 'google-gauth'
-      versions: '< 0.2.0'
+<%= indent(compile('provider/chef/common~depends.yaml'), 4) %>
   operating_systems:
 <%= indent(include('provider/chef/common~operating_systems.yaml'), 4) %>
 overrides: !ruby/object:Provider::ResourceOverrides

--- a/products/sql/puppet.yaml
+++ b/products/sql/puppet.yaml
@@ -24,9 +24,7 @@ manifest: !ruby/object:Provider::Puppet::Manifest
     - cloud
     - sql
   requires:
-    - !ruby/object:Provider::Config::Requirements
-      name: 'google/gauth'
-      versions: '>= 0.2.0 < 0.3.0'
+<%= indent(compile('provider/puppet/common~requires.yaml'), 4) %>
   operating_systems:
 <%= indent(include('provider/puppet/common~operating_systems.yaml'), 4) %>
 overrides: !ruby/object:Provider::ResourceOverrides

--- a/products/storage/chef.yaml
+++ b/products/storage/chef.yaml
@@ -24,9 +24,7 @@ manifest: !ruby/object:Provider::Chef::Manifest
     This cookbook provides the built-in types and services for Chef to manage
     Google Cloud Storage resources, as native Chef types.
   depends:
-    - !ruby/object:Provider::Config::Requirements
-      name: 'google-gauth'
-      versions: '< 0.2.0'
+<%= indent(compile('provider/chef/common~depends.yaml'), 4) %>
   operating_systems:
 <%= indent(include('provider/chef/common~operating_systems.yaml'), 4) %>
 examples: !ruby/object:Api::Resource::HashArray

--- a/products/storage/puppet.yaml
+++ b/products/storage/puppet.yaml
@@ -24,9 +24,7 @@ manifest: !ruby/object:Provider::Puppet::Manifest
     - cloud
     - storage
   requires:
-    - !ruby/object:Provider::Config::Requirements
-      name: 'google/gauth'
-      versions: '>= 0.2.0 < 0.3.0'
+<%= indent(compile('provider/puppet/common~requires.yaml'), 4) %>
   operating_systems:
 <%= indent(include('provider/puppet/common~operating_systems.yaml'), 4) %>
 overrides: !ruby/object:Provider::ResourceOverrides

--- a/provider/chef/common~depends.yaml
+++ b/provider/chef/common~depends.yaml
@@ -1,0 +1,25 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These files contains code that needs to be compiled before being delivered to
+# the final module tree structure:
+
+# Contributing file has to be last, as it has references to other
+# automatically generated files.
+<%
+  config = Provider::Config.parse('products/auth/chef.yaml')
+-%>
+- !ruby/object:Provider::Config::Requirements
+  name: 'google-gauth'
+  versions: '< <%= next_version(config.manifest.version) -%>'
+

--- a/provider/chef/manifest.rb
+++ b/provider/chef/manifest.rb
@@ -17,6 +17,7 @@ module Provider
   class Chef < Provider::Core
     # Metadata for manifest.json
     class Manifest < Api::Object
+      attr_reader :additional_info
       attr_reader :depends
       attr_reader :description
       attr_reader :issues
@@ -27,7 +28,8 @@ module Provider
       attr_reader :version
 
       def validate
-        check_property :depends, Array
+        check_optional_property :additional_info, Array
+        check_optional_property :depends, Array
         check_property :description, String
         check_property :issues, String
         check_property :operating_systems, Array

--- a/provider/config.rb
+++ b/provider/config.rb
@@ -218,6 +218,10 @@ module Provider
       raise "#{self.class}#provider not implemented"
     end
 
+    def self.next_version(version)
+      [Gem::Version.new(version).bump, 0].join('.')
+    end
+
     def validate
       super
 

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -97,7 +97,7 @@ module Provider
         @sourced << relative_path(target_file, output_folder)
         Google::LOGGER.info "Copying #{source} => #{target}"
         FileUtils.mkpath target_dir unless Dir.exist?(target_dir)
-        FileUtils.cp source, target_file
+        FileUtils.copy_entry source, target_file
       end
     end
 
@@ -215,9 +215,10 @@ module Provider
 
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
+    # rubocop:disable Metrics/AbcSize
     def generate_objects(output_folder, types, version)
       @api.set_properties_based_on_version(version)
-      @api.objects.each do |object|
+      (@api.objects || []).each do |object|
         if !types.empty? && !types.include?(object.name)
           Google::LOGGER.info "Excluding #{object.name} per user request"
         elsif types.empty? && object.exclude
@@ -231,6 +232,7 @@ module Provider
     end
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/AbcSize
 
     def generate_object(object, output_folder, version)
       data = build_object_data(object, output_folder, version)

--- a/provider/puppet/common~requires.yaml
+++ b/provider/puppet/common~requires.yaml
@@ -1,0 +1,25 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# These files contains code that needs to be compiled before being delivered to
+# the final module tree structure:
+
+# Contributing file has to be last, as it has references to other
+# automatically generated files.
+<%
+  config = Provider::Config.parse('products/auth/puppet.yaml')
+-%>
+- !ruby/object:Provider::Config::Requirements
+  name: 'google/gauth'
+  versions: '>= <%= config.manifest.version -%> < <%= next_version(config.manifest.version) -%>'
+

--- a/provider/puppet/manifest.rb
+++ b/provider/puppet/manifest.rb
@@ -28,7 +28,7 @@ module Provider
         check_property :homepage, String
         check_property :issues, String
         check_property :operating_systems, Array
-        check_property :requires, Array
+        check_optional_property :requires, Array
         check_property :source, String
         check_property :summary, String
         check_property :tags, Array

--- a/provider/resource_overrides.rb
+++ b/provider/resource_overrides.rb
@@ -153,7 +153,7 @@ module Provider
     end
 
     def populate_nonoverridden_objects
-      @__api.objects.each do |object|
+      (@__api.objects || []).each do |object|
         var_name = "@#{object.name}".to_sym
         instance_variable_set(var_name, @__config.resource_override.new) \
           unless instance_variables.include?(var_name)

--- a/templates/chef/metadata.rb.erb
+++ b/templates/chef/metadata.rb.erb
@@ -24,7 +24,7 @@ description '<%= manifest.summary -%>'
 long_description '
 <%= indent(wrap_field(manifest.description, 4), 2) -%>'
 version '<%= manifest.version -%>'
-<% manifest.depends.each do |dep| -%>
+<% (manifest.depends || []).each do |dep| -%>
 depends '<%= dep.name -%>', '<%= dep.versions -%>'
 <% end -%>
 <%= lines(emit_rubocop(binding, :attribute, 'issues_url', :disabled)) -%>
@@ -33,6 +33,7 @@ issues_url '<%= manifest.issues -%>' \
 <%= lines(emit_rubocop(binding, :attribute, 'issues_url', :enabled)) -%>
 source_url '<%= manifest.source -%>' \
   if respond_to?(:source_url)
+<%= lines(manifest.additional_info) if manifest.additional_info -%>
 
 supports 'centos'
 supports 'debian'

--- a/templates/puppet/metadata.json.erb
+++ b/templates/puppet/metadata.json.erb
@@ -1,11 +1,11 @@
 <% autogen_exception -%>
 <% require 'json' -%>
 <%
-  os_support = manifest.operating_systems.map do |os|
+  os_support = (manifest.operating_systems || []).map do |os|
     { operatingsystem: os.name, operatingsystemrelease: os.versions }
   end
 
-  requirements = manifest.requires.map do |req|
+  requirements = (manifest.requires || []).map do |req|
     { name: req.name, version_requirement: req.versions }
   end
 


### PR DESCRIPTION
You know what I find super annoying?

Scopes. People shouldn't have to specify scopes unless they really, really want to.

You know what else I find annoying?

The Auth modules. They're handwritten (that's not gonna change), but they have some autogenerated + shared code with the other modules (Changelogs, Rubocop rules, Gemfiles). Yet, because they're handwritten, none of those files ever get changed because there's no auth product.

This is going to fix both of those things.

Chef + Puppet Auth code is now stored in MM and will be "autogenerated" (files moved around) into the auth submodule. This means that the very out-of-date Chef + Puppet auth code gets some updates for free. It also makes it harder for us to forget that the auth modules exist (something I forget all the time)

I also added the master `cloudplatform` scopes as default on `gauth_credential` for both Puppet + Chef.

Scopes are now optional across all of MM!


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-sql]
### [chef-storage]
## [ansible]
