### PR TITLE
Object.input should == noneditable on P/C/A

### DIFF
--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -214,8 +214,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
     provider_helpers:
       - 'products/compute/helpers/python/provider_instance.py'
       - 'products/compute/helpers/python/instance_metadata.py'
-  InstanceGroup: !ruby/object:Provider::Ansible::ResourceOverride
-    editable: false
   InstanceTemplate: !ruby/object:Provider::Ansible::ResourceOverride
     provider_helpers:
       - 'products/compute/helpers/python/provider_instance.py'

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -1767,6 +1767,7 @@ objects:
       use an instance template. Unlike managed instance groups, you must create
       and add instances to an instance group manually.
 <%= indent(compile_file({}, 'templates/zonal_async.yaml.erb'), 4) %>
+    input: true
     parameters:
       - !ruby/object:Api::Type::ResourceRef
         name: 'zone'

--- a/products/compute/chef.yaml
+++ b/products/compute/chef.yaml
@@ -30,42 +30,13 @@ manifest: !ruby/object:Provider::Chef::Manifest
 overrides: !ruby/object:Provider::ResourceOverrides
   DiskType: !ruby/object:Provider::Chef::ResourceOverride
     deprecated: true
-    handlers: !ruby/object:Provider::Chef::Handlers
-      update: |
-        message = 'DiskType cannot be edited'
-        Chef::Log.fatal message
-        raise message
     provider_helpers:
       - 'products/compute/helpers/ruby/provider_disk_type.rb'
-  Disk: !ruby/object:Provider::Chef::ResourceOverride
-    handlers: !ruby/object:Provider::Chef::Handlers
-      update: |
-        message = 'Disk cannot be edited'
-        Chef::Log.fatal message
-        raise message
-  Instance: !ruby/object:Provider::Chef::ResourceOverride
-    handlers: !ruby/object:Provider::Chef::Handlers
-      update: |
-        message = 'Instance cannot be edited'
-        Chef::Log.fatal message
-        raise message
   Network: !ruby/object:Provider::Chef::ResourceOverride
-    handlers: !ruby/object:Provider::Chef::Handlers
-      # TODO(alexstephen): Better editing from auto to custom
-      # This should mimic Puppet.
-      update: |
-        message = 'Network cannot be edited'
-        Chef::Log.fatal message
-        raise message
     provider_helpers:
       - 'products/compute/helpers/ruby/provider_network.rb'
   Region: !ruby/object:Provider::Chef::ResourceOverride
     deprecated: true
-    handlers: !ruby/object:Provider::Chef::Handlers
-      update: |
-        message = 'Region cannot be edited'
-        Chef::Log.fatal message
-        raise message
   TargetPool: !ruby/object:Provider::Chef::ResourceOverride
     provider_helpers:
       - 'products/compute/helpers/ruby/provider_target_pool.rb'

--- a/products/compute/puppet.yaml
+++ b/products/compute/puppet.yaml
@@ -59,11 +59,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
     provider_helpers:
       - 'products/compute/helpers/ruby/provider_instance.rb'
       - 'products/compute/helpers/ruby/instance_metadata.rb'
-  InstanceGroup: !ruby/object:Provider::Puppet::ResourceOverride
-    # TODO(nelsonjr): Implement specific actions, such as addInstance and
-    # setNamedPorts.
-    handlers: !ruby/object:Provider::Puppet::Handlers
-      flush: raise 'InstanceGroup cannot be edited.'
   InstanceTemplate: !ruby/object:Provider::Puppet::ResourceOverride
     provider_helpers:
       - 'products/compute/helpers/ruby/provider_instance_template.rb'
@@ -97,10 +92,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
   TargetPool: !ruby/object:Provider::Puppet::ResourceOverride
     provider_helpers:
       - 'products/compute/helpers/ruby/provider_target_pool.rb'
-  Region: !ruby/object:Provider::Puppet::ResourceOverride
-    # TODO(nelsonjr): Make sure that attempts to create a region fails
-    handlers: !ruby/object:Provider::Puppet::Handlers
-      flush: raise 'Region cannot be edited' if @dirty
   # Not yet implemented.
   Autoscaler: !ruby/object:Provider::Puppet::ResourceOverride
     exclude: true

--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -31,6 +31,7 @@ objects:
     name: 'ManagedZone'
     kind: 'dns#managedZone'
     base_url: 'projects/{{project}}/managedZones'
+    input: true
     description: |
       A zone is a subtree of the DNS namespace under one administrative
       responsibility. A ManagedZone is a resource that represents a DNS zone

--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -87,6 +87,7 @@ objects:
       including Cloud DNS ManagedZones.
     base_url: 'projects'
     readonly: true
+    input: true
     properties:
       - !ruby/object:Api::Type::Integer
         name: 'number'

--- a/products/dns/chef.yaml
+++ b/products/dns/chef.yaml
@@ -25,12 +25,6 @@ manifest: !ruby/object:Provider::Chef::Manifest
   operating_systems:
 <%= indent(include('provider/chef/common~operating_systems.yaml'), 4) %>
 overrides: !ruby/object:Provider::ResourceOverrides
-  ManagedZone: !ruby/object:Provider::Chef::ResourceOverride
-    handlers: !ruby/object:Provider::Chef::Handlers
-      update: |
-        message = 'ManagedZone cannot be edited'
-        Chef::Log.fatal message
-        raise message
   ResourceRecordSet: !ruby/object:Provider::Chef::ResourceOverride
     handlers: !ruby/object:Provider::Chef::Handlers
       create: |
@@ -59,11 +53,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
     unwrap_resource: false
   Project: !ruby/object:Provider::Chef::ResourceOverride
     deprecated: true
-    handlers: !ruby/object:Provider::Chef::Handlers
-      update: |
-        message = 'Project cannot be edited'
-        Chef::Log.fatal message
-        raise message
 tests: !ruby/object:Api::Resource::HashArray
 <%= indent(include('products/dns/test.yaml'), 2) %>
 properties:

--- a/products/dns/puppet.yaml
+++ b/products/dns/puppet.yaml
@@ -27,9 +27,6 @@ manifest: !ruby/object:Provider::Puppet::Manifest
   operating_systems:
 <%= indent(include('provider/puppet/common~operating_systems.yaml'), 4) %>
 overrides: !ruby/object:Provider::ResourceOverrides
-  ManagedZone: !ruby/object:Provider::Puppet::ResourceOverride
-    handlers: !ruby/object:Provider::Puppet::Handlers
-      flush: raise 'DNS Managed Zone cannot be edited' if @dirty
   ResourceRecordSet: !ruby/object:Provider::Puppet::ResourceOverride
     access_api_results: true
     handlers: !ruby/object:Provider::Puppet::Handlers
@@ -62,8 +59,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
     unwrap_resource: false
   Project: !ruby/object:Provider::Puppet::ResourceOverride
     deprecated: true
-    handlers: !ruby/object:Provider::Puppet::Handlers
-      flush: raise 'DNS Project cannot be edited' if @dirty
 tests: !ruby/object:Api::Resource::HashArray
 <%= indent(include('products/dns/test.yaml'), 2) %>
 examples: !ruby/object:Api::Resource::HashArray

--- a/products/pubsub/api.yaml
+++ b/products/pubsub/api.yaml
@@ -42,6 +42,7 @@ objects:
     description: |
       A named resource representing the stream of messages from a single,
       specific topic, to be delivered to the subscribing application.
+    input: true
     transport: !ruby/object:Api::Resource::Transport
       decoder: decode_request
     properties:

--- a/products/pubsub/puppet.yaml
+++ b/products/pubsub/puppet.yaml
@@ -30,9 +30,6 @@ manifest: !ruby/object:Provider::Puppet::Manifest
 overrides: !ruby/object:Provider::ResourceOverrides
   Subscription: !ruby/object:Provider::Puppet::ResourceOverride
     handlers: !ruby/object:Provider::Puppet::Handlers
-      flush:
-        # TODO(nelsonjr): Implement calling custom methods to update pushConfig.
-        raise 'Subscription cannot be edited.'
       # TODO(alexstephen): Remove when b/66233673 fixed.
       self_link: |
         URI.join(

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -240,7 +240,9 @@ def main():
                    end
 -%>
 <% if object.update.nil? -%>
-<%   if !false?(object.input) -%>
+<%   if object.input -%>
+    module.fail_json(msg="<%= object.name -%> cannot be edited")
+<%   else # object.input -%>
     auth = GcpSession(module, <%= quote_string(prod_name) -%>)
 <%
   update_verb = object.update_verb.to_s.downcase
@@ -255,9 +257,7 @@ def main():
   )
 -%>
     return <%= method %>
-<%   else # !false?(object.input) -%>
-    module.fail_json(msg="<%= object.name -%> cannot be edited")
-<%   end # !false?(object.input) -%>
+<%   end # if object.input -%>
 <% else # object.update.nil? -%>
 <%= lines(indent(object.update, 4)) -%>
 <% end # object.update.nil? -%>

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -240,7 +240,7 @@ def main():
                    end
 -%>
 <% if object.update.nil? -%>
-<%   if !false?(object.editable) -%>
+<%   if !false?(object.input) -%>
     auth = GcpSession(module, <%= quote_string(prod_name) -%>)
 <%
   update_verb = object.update_verb.to_s.downcase
@@ -255,9 +255,9 @@ def main():
   )
 -%>
     return <%= method %>
-<%   else # !false?(object.editable) -%>
+<%   else # !false?(object.input) -%>
     module.fail_json(msg="<%= object.name -%> cannot be edited")
-<%   end # !false?(object.editable) -%>
+<%   end # !false?(object.input) -%>
 <% else # object.update.nil? -%>
 <%= lines(indent(object.update, 4)) -%>
 <% end # object.update.nil? -%>

--- a/templates/chef/resource.erb
+++ b/templates/chef/resource.erb
@@ -435,6 +435,11 @@ module Google
             # TODO(nelsonjr): Check w/ Chef... can we print this in red?
             puts # making a newline until we find a better way TODO: find!
             compute_changes.each { |log| puts "    - #{log.strip}\n" }
+<% if object.input -%>
+            message = '<%= object.name -%> cannot be edited'
+            Chef::Log.fatal message
+            raise message
+<% else # if object.input -%>
 <% if object&.handlers&.update.nil? -%>
 <% 
   put_new = ["::Google::#{product_ns}::Network",
@@ -465,6 +470,7 @@ module Google
 <% else # object&.handlers&.update.nil? -%>
 <%= lines(indent(object.handlers.update, 12)) -%>
 <% end # object&.handlers&.update.nil? -%>
+<% end # if object.input -%>
           end
         end
 <% unless object.all_resourcerefs.empty? -%>

--- a/templates/puppet/resource.erb
+++ b/templates/puppet/resource.erb
@@ -318,6 +318,9 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
     # return on !@dirty is for aiding testing (puppet already guarantees that)
     return if @created || @deleted || !@dirty
 <% if object&.handlers&.flush.nil? -%>
+<% if object.input -%>
+    raise '<%= object.name -%> cannot be edited.'
+<% else # if object.input -%>
 <%
   put_new = ["Google::#{product_ns}::Network",
              "#{object.update_verb.to_s.capitalize}.new"
@@ -339,6 +342,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   <% obj_kind = object.kind? ? ", '#{object.kind}'" : '' -%>
   <%= fetch_assign -%>return_if_object update_req.send<%= obj_kind %>
 <%   end # object.async -%>
+<% end # object.input -%>
 <% else # object&.handlers&.flush.nil? -%>
 <%= lines(indent(object.handlers.flush, 4)) -%>
 <% end # object&.handlers&.flush.nil? -%>


### PR DESCRIPTION
Object.input should == noneditable on P/C/A


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Object.input should == noneditable on P/C/A
## [terraform]
## [puppet]
Object.input should == noneditable
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
Object.input should == noneditable
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-sql]
### [chef-storage]
## [ansible]
Object.input should == noneditable
