### PR TITLE
Default key_type is Api::Type::String

### DIFF
--- a/api/type.rb
+++ b/api/type.rb
@@ -494,6 +494,7 @@ module Api
 
       def validate
         super
+        default_value_property :key_type, Api::Type::String.to_s
         check_property :key_type, ::String
         check_property :value_type, ::String
         raise "Invalid type #{@key_type}" unless type?(@key_type)

--- a/products/bigquery/api.yaml
+++ b/products/bigquery/api.yaml
@@ -129,7 +129,6 @@ objects:
         description: >
           The labels associated with this dataset. You can use these to
           organize and group your datasets
-        key_type: Api::Type::String
         value_type: Api::Type::String
       - !ruby/object:Api::Type::Integer
         name: 'lastModifiedTime'
@@ -177,7 +176,6 @@ objects:
         description: >
           The labels associated with this dataset. You can use these to
           organize and group your datasets
-        key_type: Api::Type::String
         value_type: Api::Type::String
       - !ruby/object:Api::Type::Integer
         name: 'lastModifiedTime'

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -890,7 +890,6 @@ objects:
         name: 'labels'
         description: |
           Labels to apply to this forwarding rule.  A list of key->value pairs.
-        key_type: Api::Type::String
         value_type: Api::Type::String
         update_verb: :POST
         update_url: 'projects/{{project}}/regions/{{region}}/forwardingRules/{{name}}/setLabels'

--- a/products/compute/disks.yaml
+++ b/products/compute/disks.yaml
@@ -42,7 +42,6 @@
   name: 'labels'
   description: |
     Labels to apply to this disk.  A list of key->value pairs.
-  key_type: Api::Type::String
   value_type: Api::Type::String
   update_verb: :POST
   update_url: 'projects/{{project}}/<%= ctx[:location] -%>s/{{<%= ctx[:location] -%>}}/disks/{{name}}/setLabels'

--- a/products/compute/instance_metadata.yaml
+++ b/products/compute/instance_metadata.yaml
@@ -37,5 +37,4 @@
     The metadata key/value pairs to assign to instances that are
     created from this template. These pairs can consist of custom
     metadata or predefined keys.
-  key_type: Api::Type::String
   value_type: Api::Type::String

--- a/products/container/node_config.yaml
+++ b/products/container/node_config.yaml
@@ -56,7 +56,6 @@
     account is used.
 - !ruby/object:Api::Type::NameValues
   name: 'metadata'
-  key_type: Api::Type::String
   value_type: Api::Type::String
   description: |
     The metadata key/value pairs assigned to instances in the cluster.
@@ -84,7 +83,6 @@
     type, the latest version of it will be used.
 - !ruby/object:Api::Type::NameValues
   name: 'labels'
-  key_type: Api::Type::String
   value_type: Api::Type::String
   description: |
     The map of Kubernetes labels (key/value pairs) to be applied to

--- a/products/redis/api.yaml
+++ b/products/redis/api.yaml
@@ -92,12 +92,10 @@ objects:
       - !ruby/object:Api::Type::NameValues
         name: 'labels'
         description: Resource labels to represent user provided metadata.
-        key_type: Api::Type::String
         value_type: Api::Type::String
       - !ruby/object:Api::Type::NameValues
         name: 'redisConfigs'
         description: Redis configuration parameters, according to http://redis.io/topics/config.
-        key_type: Api::Type::String
         value_type: Api::Type::String
       - !ruby/object:Api::Type::String
         name: locationId

--- a/products/resourcemanager/api.yaml
+++ b/products/resourcemanager/api.yaml
@@ -67,7 +67,6 @@ objects:
         output: true
       - !ruby/object:Api::Type::NameValues
         name: 'labels'
-        key_type: Api::Type::String
         value_type: Api::Type::String
         description: |
           The labels associated with this Project.

--- a/products/spanner/api.yaml
+++ b/products/spanner/api.yaml
@@ -81,7 +81,6 @@ objects:
       # 'state' not suitable for state convergeance.
       - !ruby/object:Api::Type::NameValues
         name: 'labels'
-        key_type: Api::Type::String
         value_type: Api::Type::String
         description: |
           Cloud Labels are a flexible and lightweight mechanism for organizing


### PR DESCRIPTION
Default key_type is Api::Type::String.

We can override, but we use Api::Type::String in all examples so far (and it seems strange to use anything else for JSON requests)


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Default key_type is Api::Type::String
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-sql]
### [chef-storage]
## [ansible]
