### PR TITLE
Create docker images which speed up MM generation.

### DIFF
--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -125,13 +125,20 @@ resources:
           check_dependent_prs: true
           label: downstream-generated
 
-    - name: nmckinley-pr
+    - name: generate-terraform-image
       type: docker-image
       source:
-        repository: ((dockerhub-account.username))/concourse-github-pr-resource
+        repository: ((dockerhub-account.username))/generate-terraform
         username: ((dockerhub-account.username))
         password: ((dockerhub-account.password))
-        
+
+    - name: installed-magic-modules-image
+      type: docker-image
+      source:
+        repository: ((dockerhub-account.username))/installed-magic-modules
+        username: ((dockerhub-account.username))
+        password: ((dockerhub-account.password))
+
     - name: terraform-pr
       type: github-pull-request
       source:
@@ -539,13 +546,6 @@ jobs:
                     method: squash
                     commit_msg: mm-output/commit_message
 
-    - name: create-pr-image
-      plan:
-          - get: magic-modules
-          - put: nmckinley-pr
-            params:
-              build: magic-modules/.ci/containers/pull-request
-
     - name: test-terraform-pr
       plan:
           - aggregate:
@@ -584,3 +584,21 @@ jobs:
             params:
               file: dist/terraform-provider-google.{{arch}}
           {% endfor %}
+
+    - name: generate-images
+      plan:
+        - get: magic-modules-gcp
+          trigger: true
+          params:
+            submodules: [build/terraform]
+        - put: installed-magic-modules-image
+          params:
+            build: magic-modules-gcp
+            dockerfile: magic-modules-gcp/.ci/containers/installed-magic-modules/Dockerfile
+            tag_as_latest: true
+        - put: generate-terraform-image
+          params:
+            build: magic-modules-gcp
+            dockerfile: magic-modules-gcp/.ci/containers/generate-terraform/Dockerfile
+            tag_as_latest: true
+

--- a/.ci/containers/generate-terraform/Dockerfile
+++ b/.ci/containers/generate-terraform/Dockerfile
@@ -1,0 +1,8 @@
+FROM nmckinley/installed-magic-modules:latest
+
+RUN export GOPATH="/go" && \
+    mkdir -p "${GOPATH}/src/github.com/terraform-providers"
+ADD build/terraform/ /go/src/github.com/terraform-providers/terraform-provider-google/
+RUN cd "${GOPATH}/src/github.com/terraform-providers/terraform-provider-google" && \
+    go get && \
+    rm -rf "${GOPATH}/src/github.com/terraform-providers/terraform-provider-google"

--- a/.ci/containers/installed-magic-modules/Dockerfile
+++ b/.ci/containers/installed-magic-modules/Dockerfile
@@ -1,0 +1,4 @@
+FROM nmckinley/go-ruby-python:1.9-2.5-2.7
+
+ADD ./Gemfile /base-magic-modules/Gemfile
+RUN cd /base-magic-modules && bundle install

--- a/.ci/magic-modules/generate-ansible.yml
+++ b/.ci/magic-modules/generate-ansible.yml
@@ -7,8 +7,8 @@ platform: linux
 image_resource:
     type: docker-image
     source:
-        repository: nmckinley/go-ruby-python
-        tag: '1.9-2.5-2.7'
+        repository: nmckinley/installed-magic-modules
+        tag: 'latest'
 
 inputs:
     - name: magic-modules-branched

--- a/.ci/magic-modules/generate-chef.yml
+++ b/.ci/magic-modules/generate-chef.yml
@@ -7,8 +7,8 @@ platform: linux
 image_resource:
     type: docker-image
     source:
-        repository: nmckinley/go-ruby-python
-        tag: '1.9-2.5-2.7'
+        repository: nmckinley/installed-magic-modules
+        tag: 'latest'
 
 inputs:
     - name: magic-modules-branched

--- a/.ci/magic-modules/generate-puppet.yml
+++ b/.ci/magic-modules/generate-puppet.yml
@@ -7,8 +7,8 @@ platform: linux
 image_resource:
     type: docker-image
     source:
-        repository: nmckinley/go-ruby-python
-        tag: '1.9-2.5-2.7'
+        repository: nmckinley/installed-magic-modules
+        tag: 'latest'
 
 inputs:
     - name: magic-modules-branched

--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -11,7 +11,7 @@ PATCH_DIR="$(pwd)/patches"
 # Create $GOPATH structure - in order to successfully run Terraform codegen, we need to run
 # it with a correctly-set-up $GOPATH.  It calls out to `goimports`, which means that
 # we need to have all the dependencies correctly downloaded.
-export GOPATH="${PWD}/go"
+export GOPATH="/go"
 mkdir -p "${GOPATH}/src/github.com/terraform-providers"
 
 pushd magic-modules-branched
@@ -19,7 +19,7 @@ ln -s "${PWD}/build/terraform/" "${GOPATH}/src/github.com/terraform-providers/te
 popd
 
 pushd "${GOPATH}/src/github.com/terraform-providers/terraform-provider-google"
-go get
+go get -v
 popd
 
 pushd magic-modules-branched

--- a/.ci/magic-modules/generate-terraform.yml
+++ b/.ci/magic-modules/generate-terraform.yml
@@ -7,8 +7,8 @@ platform: linux
 image_resource:
     type: docker-image
     source:
-        repository: nmckinley/go-ruby-python
-        tag: '1.9-2.5-2.7'
+        repository: nmckinley/generate-terraform
+        tag: 'latest'
 
 inputs:
     - name: magic-modules-branched


### PR DESCRIPTION
The trick here is, every time Magic Modules gets a new commit merged in,
we'll generate some new docker images based on that commit.  The idea
is, we'll create images which already have the necessary dependencies
installed (most of the time).  We'll still run `go get` in the
generate-terraform script, but ideally it won't turn out to grab
anything, because the container will already have everything it needs.
Same story with the other generators - we'll run `bundle install`
beforehand so that we can save some time since everything will be there
already.

-----------------------------------------------------------------
# [all]
CI Changes only