### PR TITLE
Write tiny bash script to test Terraform submodule.

### DIFF
--- a/tasks/submodules.rb
+++ b/tasks/submodules.rb
@@ -19,11 +19,11 @@ TEST_RUNNER = {
   ansible: 'exit 1',
   # Terraform is more complicated since go tests need to be run from within
   # a GOPATH.
-  terraform: 'flock /tmp/tf-test -c "rm -rf /tmp/go;'\
-             'mkdir -p /tmp/go/src/github.com/terraform-providers/;'\
-             'ln -s $PWD /tmp/go/src/github.com/terraform-providers/terraform-provider-google;'\
-             'cd /tmp/go/src/github.com/terraform-providers/terraform-provider-google;'\
-             'GOPATH=/tmp/go go get; GOPATH=/tmp/go make test"'
+  terraform: 'GOPATH=`mktemp -d`/go;'\
+             'mkdir -p $GOPATH/src/github.com/terraform-providers/;'\
+             'ln -s $PWD $GOPATH/src/github.com/terraform-providers/terraform-provider-google;'\
+             'cd $GOPATH/src/github.com/terraform-providers/terraform-provider-google;'\
+             'go get; make test'
 }.freeze
 
 def test_module(provider, mod)

--- a/tasks/submodules.rb
+++ b/tasks/submodules.rb
@@ -16,7 +16,14 @@ require 'tasks/common'
 TEST_RUNNER = {
   puppet: 'rake test',
   chef: 'rake test',
-  ansible: 'exit 1'
+  ansible: 'exit 1',
+  # Terraform is more complicated since go tests need to be run from within
+  # a GOPATH.
+  terraform: 'flock /tmp/tf-test -c "rm -rf /tmp/go;'\
+             'mkdir -p /tmp/go/src/github.com/terraform-providers/;'\
+             'ln -s $PWD /tmp/go/src/github.com/terraform-providers/terraform-provider-google;'\
+             'cd /tmp/go/src/github.com/terraform-providers/terraform-provider-google;'\
+             'GOPATH=/tmp/go go get; GOPATH=/tmp/go make test"'
 }.freeze
 
 def test_module(provider, mod)


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Rake is crashing on `rake test_mod:terraform` because there's no command to run to test Terraform.  Here's one!  A little complicated, but that's life in go.  :)

`flock` is in there because `rake test_mod:terraform` runs the tests 3 times - probably worth figuring that out if we decide to integrate `rake test_mod:` anyplace significant and worry about speed.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
No downstream changes expected.