### PR TITLE
Add StringUtils methods directly to the String class

### DIFF
--- a/api/object.rb
+++ b/api/object.rb
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'google/extensions'
 require 'google/logger'
 require 'google/yaml_validator'
 
@@ -40,7 +41,7 @@ module Api
     end
 
     def out_name
-      Google::StringUtils.underscore(@name)
+      @name.underscore
     end
   end
 end

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -198,7 +198,7 @@ module Api
     end
 
     def out_name
-      [@__product.prefix, Google::StringUtils.underscore(@name)].join('_')
+      [@__product.prefix, @name.underscore].join('_')
     end
 
     def identity

--- a/api/type.rb
+++ b/api/type.rb
@@ -145,8 +145,7 @@ module Api
       num_parts = name_parts.flatten.size
       shrunk_names = recurse_shrink_name(name_parts,
                                          (1.0 * MAX_NAME / num_parts).round)
-      type_name = Google::StringUtils.camelize(shrunk_names.flatten.join('_'),
-                                               :upper)
+      type_name = shrunk_names.flatten.join('_').camelize(:upper)
       property_ns_prefix.concat([type_name])
     end
 
@@ -158,9 +157,9 @@ module Api
     def shrink_type_name_parts(type)
       type.map do |t|
         if t.is_a?(::Array)
-          t.map { |u| Google::StringUtils.underscore(u).split('_') }
+          t.map { |u| u.underscore.split('_') }
         else
-          Google::StringUtils.underscore(t).split('_')
+          t.underscore.split('_')
         end
       end
     end
@@ -315,7 +314,7 @@ module Api
         if !generate_unique_enum_class
           super
         else
-          camelized_name = Google::StringUtils.camelize(@name, :upper)
+          camelized_name = @name.camelize(:upper)
           property_ns_prefix.concat(["#{camelized_name}Enum"]).join('::')
         end
       end
@@ -329,7 +328,7 @@ module Api
         else
           File.join(
             'google', @__resource.__product.prefix[1..-1], 'property',
-            Google::StringUtils.underscore("#{@__resource.name}_#{@name}")
+            "#{@__resource.name}_#{@name}".underscore
           ).downcase
         end
       end
@@ -360,7 +359,7 @@ module Api
       end
 
       def out_name
-        Google::StringUtils.underscore(EXPORT_KEY)
+        EXPORT_KEY.underscore
       end
     end
 
@@ -468,7 +467,7 @@ module Api
       def property_file
         File.join(
           'google', @__resource.__product.prefix[1..-1], 'property',
-          [@__resource.name, Google::StringUtils.underscore(@name)].join('_')
+          [@__resource.name, @name.underscore].join('_')
         ).downcase
       end
 
@@ -513,8 +512,7 @@ module Api
     def property_ns_prefix
       [
         'Google',
-        Google::StringUtils.camelize(@__resource.__product.prefix[1..-1],
-                                     :upper),
+        @__resource.__product.prefix[1..-1].camelize(:upper),
         'Property'
       ]
     end

--- a/google/extensions.rb
+++ b/google/extensions.rb
@@ -12,9 +12,10 @@
 # limitations under the License.
 require 'google/string_utils'
 
+# The Ruby String class. It's being extended to add StringUtils methods.
 class String
   def underscore
-    Google::StringUtils.underscore(self) 
+    Google::StringUtils.underscore(self)
   end
 
   def camelize(style = :lower)

--- a/google/extensions.rb
+++ b/google/extensions.rb
@@ -1,0 +1,35 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+require 'google/string_utils'
+
+class String
+  def underscore
+    Google::StringUtils.underscore(self) 
+  end
+
+  def camelize(style = :lower)
+    Google::StringUtils.camelize(self, style)
+  end
+
+  def uncombine
+    Google::StringUtils.uncombine(self)
+  end
+
+  def symbolize
+    Google::StringUtils.symbolize(self)
+  end
+
+  def first_sentence
+    Google::StringUtils.first_sentence(self)
+  end
+end

--- a/products/_bundle/templates/ansible/lookup.erb
+++ b/products/_bundle/templates/ansible/lookup.erb
@@ -35,7 +35,7 @@ options:
                      .reject { |obj| obj.exports.nil? }
 -%>
 <% readonlys.each do |virt| -%>
-      - <%= Google::StringUtils.underscore(virt.name) %>
+      - <%= virt.name.underscore %>
 <% end -%>
   return:
     description: An optional value to describe what part of the attribute should
@@ -144,7 +144,7 @@ class Gcp<%= object.name -%>(object):
       if object.exports[0].is_a? String
         default = object.exports[0]
       else
-        default = Google::StringUtils.underscore(object.exports[0].name)
+        default = object.exports[0].name.underscore
       end
     end
 -%>

--- a/products/_bundle/templates/ansible/lookup.erb
+++ b/products/_bundle/templates/ansible/lookup.erb
@@ -161,7 +161,7 @@ class LookupModule(LookupBase):
 <%
   opts_code = []
   readonlys.each do |object|
-    name = Google::StringUtils.underscore(object.name)
+    name = object.name.underscore
     opts_code << "#{quote_string(name)}: Gcp#{object.name}"
   end
 -%>

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -114,14 +114,14 @@ module Provider
       # Example: gcp_dns_managed_zone
       def module_name(object)
         ["gcp_#{object.__product.prefix[1..-1]}",
-         Google::StringUtils.underscore(object.name)].join('_')
+         object.name.underscore].join('_')
       end
 
       def build_object_data(object, output_folder, version)
         # Method is overriden to add Ansible example objects to the data object.
         data = super
 
-        prod_name = Google::StringUtils.underscore(data[:object].name)
+        prod_name = data[:object].name.underscore
         path = ["products/#{data[:product_name]}",
                 "examples/ansible/#{prod_name}.yaml"].join('/')
 
@@ -180,7 +180,7 @@ module Provider
       def rrefs_in_link(link, object)
         props_in_link = link.scan(/{([a-z_]*)}/).flatten
         (object.parameters || []).select do |p|
-          props_in_link.include?(Google::StringUtils.underscore(p.name)) && \
+          props_in_link.include?(p.name.underscore) && \
             p.is_a?(Api::Type::ResourceRef) && !p.resource_ref.readonly
         end.any?
       end
@@ -191,7 +191,7 @@ module Provider
         props = props_in_link.map do |p|
           # Select a resourceref if it exists.
           rref = (object.parameters || []).select do |prop|
-            Google::StringUtils.underscore(prop.name) == p && \
+            prop.name.underscore == p && \
               prop.is_a?(Api::Type::ResourceRef) && !prop.resource_ref.readonly
           end
           if rref.any?
@@ -277,7 +277,7 @@ module Provider
       end
 
       def example_defaults(data)
-        obj_name = Google::StringUtils.underscore(data[:object].name)
+        obj_name = data[:object].name.underscore
         path = ["products/#{data[:product_name]}",
                 "examples/ansible/#{obj_name}.yaml"].join('/')
 
@@ -285,7 +285,7 @@ module Provider
       end
 
       def generate_resource_tests(data)
-        prod_name = Google::StringUtils.underscore(data[:object].name)
+        prod_name = data[:object].name.underscore
         path = ["products/#{data[:product_name]}",
                 "examples/ansible/#{prod_name}.yaml"].join('/')
 

--- a/provider/ansible/common~compile.yaml
+++ b/provider/ansible/common~compile.yaml
@@ -26,7 +26,7 @@
                     .select { |o| !o.exclude_if_not_in_version(version) }
                     .map do |object|
                       ["gcp_#{object.__product.prefix[1..-1]}",
-                      Google::StringUtils.underscore(object.name)].join('_')
+                       object.name.underscore].join('_')
                     end
 -%>
 <% object_names.each do |obj_name| -%>

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -186,7 +186,7 @@ module Provider
       # at the end.
       def minimal_yaml(prop, spaces)
         [
-          "#{Google::StringUtils.underscore(prop.name)}:",
+          "#{prop.name.underscore}:",
           indent(
             [
               'description:',

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -263,7 +263,7 @@ module Provider
       def build_test(state, object, noop = false)
         @code = build_code(object, INTEGRATION_TEST_DEFAULTS)
         @name = ["gcp_#{object.__product.prefix[1..-1]}",
-                 Google::StringUtils.underscore(object.name),
+                 object.name.underscore,
                  'facts'].join('_')
         super(state, object, noop)
       end
@@ -271,7 +271,7 @@ module Provider
       def build_example(state, object)
         @code = build_code(object, EXAMPLE_DEFAULTS)
         @name = ["gcp_#{object.__product.prefix[1..-1]}",
-                 Google::StringUtils.underscore(object.name),
+                 object.name.underscore,
                  'facts'].join('_')
         super(state, object)
       end

--- a/provider/ansible/module.rb
+++ b/provider/ansible/module.rb
@@ -28,7 +28,7 @@ module Provider
         elsif prop.is_a? Api::Type::NestedObject
           nested_obj_dict(prop, object, prop.properties, spaces)
         else
-          name = Google::StringUtils.underscore(prop.out_name)
+          name = prop.out_name.underscore
           "#{name}=dict(#{prop_options(prop, object, spaces).join(', ')})"
         end
       end
@@ -38,7 +38,7 @@ module Provider
       # Creates a Python dictionary representing a nested object property
       # for validation.
       def nested_obj_dict(prop, object, properties, spaces)
-        name = Google::StringUtils.underscore(prop.out_name)
+        name = prop.out_name.underscore
         options = prop_options(prop, object, spaces).join(', ')
         [
           "#{name}=dict(#{options}, options=dict(",
@@ -71,7 +71,7 @@ module Provider
       # Returns a formatted string represented the choices of an enum
       # rubocop:disable Metrics/AbcSize
       def choices_enum(prop, spaces)
-        name = Google::StringUtils.underscore(prop.out_name)
+        name = prop.out_name.underscore
         type = "type=#{quote_string(python_type(prop))}"
         # + 6 for =dict(
         choices_indent = spaces + name.length + type.length + 6

--- a/provider/ansible/request.rb
+++ b/provider/ansible/request.rb
@@ -129,7 +129,7 @@ module Provider
             ", #{module_name}).to_request()"
           ].join
         elsif prop.is_a?(Api::Type::ResourceRef) && !prop.resource_ref.readonly
-          prop_name = Google::StringUtils.underscore(prop.name)
+          prop_name = prop.name.underscore
           [
             "replace_resource_dict(#{hash_name}",
             ".get(#{unicode_string(prop_name)}, {}), ",
@@ -145,7 +145,7 @@ module Provider
         elsif prop.is_a?(Api::Type::Array) && \
               prop.item_type.is_a?(Api::Type::ResourceRef) && \
               !prop.item_type.resource_ref.readonly
-          prop_name = Google::StringUtils.underscore(prop.name)
+          prop_name = prop.name.underscore
           [
             "replace_resource_dict(#{hash_name}",
             ".get(#{quote_string(prop_name)}, []), ",

--- a/provider/ansible/request.rb
+++ b/provider/ansible/request.rb
@@ -137,7 +137,7 @@ module Provider
           ].join
         elsif prop.is_a?(Api::Type::ResourceRef) && \
               prop.resource_ref.readonly && prop.imports == 'selfLink'
-          func = "#{Google::StringUtils.underscore(prop.resource)}_selflink"
+          func = "#{prop.resource.underscore}_selflink"
           [
             "#{func}(#{hash_name}.get(#{quote_string(prop.out_name)}),",
             "#{module_name}.params)"

--- a/provider/ansible/resourceref.rb
+++ b/provider/ansible/resourceref.rb
@@ -63,7 +63,7 @@ module Provider
       def path_for_rref(rref)
         past_values = []
         until rref.nil?
-          past_values << Google::StringUtils.underscore(rref.name)
+          past_values << rref.name.underscore
           # TODO(alexstephen): Investigate a better way to handle parent
           # pointers on Arrays of NestedObjects
           rref = if rref.is_a?(Api::Type::NestedObject) && \

--- a/provider/ansible/selflink.rb
+++ b/provider/ansible/selflink.rb
@@ -51,7 +51,7 @@ module Provider
                                      .gsub('{name}', '[a-z1-9\-]*')
         lines([
                 method_decl(
-                  "#{Google::StringUtils.underscore(resource.name)}_selflink",
+                  "#{resource.name.underscore}_selflink",
                   %w[name params]
                 ),
                 indent(
@@ -78,7 +78,7 @@ module Provider
       def path_for_rref(rref)
         past_values = []
         until rref.nil?
-          past_values << Google::StringUtils.underscore(rref.name)
+          past_values << rref.name.underscore
           # TODO(alexstephen): Investigate a better way to handle parent
           # pointers on Arrays of NestedObjects
           rref = if rref.is_a?(Api::Type::NestedObject) && \

--- a/provider/chef.rb
+++ b/provider/chef.rb
@@ -116,11 +116,11 @@ module Provider
     # rubocop:enable Metrics/PerceivedComplexity
 
     def label_name(product)
-      Google::StringUtils.underscore(product.name)
-                         .split('_')
-                         .map { |x| x[0] }
-                         .join
-                         .concat('_label')
+      product.name.underscore
+                  .split('_')
+                  .map { |x| x[0] }
+                  .join
+                  .concat('_label')
     end
 
     # Returns a list of all resource types being tested
@@ -238,7 +238,7 @@ module Provider
 
     def generate_typed_array(data, prop)
       type = Module.const_get(prop.item_type).new(prop.name).type
-      file = Google::StringUtils.underscore(type)
+      file = type.underscore
       prop_map = []
       prop_map << {
         source: File.join('templates', 'chef', 'property',
@@ -275,9 +275,9 @@ module Provider
 
     def emit_nested_object_overrides(data)
       data.clone.merge(
-        api_name: Google::StringUtils.camelize(data[:api_name], :upper),
-        object_type: Google::StringUtils.camelize(data[:obj_name], :upper),
-        product_ns: Google::StringUtils.camelize(data[:product_name], :upper),
+        api_name: data[:api_name].camelize(:upper),
+        object_type: data[:obj_name].camelize(:upper),
+        product_ns: data[:product_name].camelize(:upper),
         class_name: if data[:emit_array]
                       data[:property].item_type.property_class.last
                     else
@@ -289,7 +289,7 @@ module Provider
     def generate_resource(data)
       target_folder = File.join(data[:output_folder], 'resources')
       FileUtils.mkpath target_folder
-      name = Google::StringUtils.underscore(data[:object].name)
+      name = data[:object].name.underscore
       generate_resource_file data.clone.merge(
         default_template: provider_template_source(data),
         out_file: File.join(target_folder, "#{name}.rb")
@@ -298,7 +298,7 @@ module Provider
 
     def provider_template_source(data)
       if data[:object].manual
-        object_name = Google::StringUtils.underscore(data[:object].name)
+        object_name = data[:object].name.underscore
         File.join('products', data[:product_name], 'files',
                   "provider~chef~#{object_name}.rb")
       else
@@ -309,7 +309,7 @@ module Provider
     def generate_resource_tests(data)
       target_folder = File.join(data[:output_folder], 'spec')
       FileUtils.mkpath target_folder
-      name = Google::StringUtils.underscore(data[:object].name)
+      name = data[:object].name.underscore
       generate_resource_file data.clone.merge(
         default_template: 'templates/chef/resource_spec.erb',
         out_file: File.join(target_folder, "#{name}_spec.rb")
@@ -397,9 +397,7 @@ module Provider
         p.is_a?(Api::Type::Enum) && !p.default_value.nil?
       end
       default_enums.map do |p|
-        prop_name = Google::StringUtils.underscore(
-          "#{p.__resource.name}_#{p.name}"
-        )
+        prop_name = "#{p.__resource.name}_#{p.name}".underscore
         {
           source: File.join('templates', 'chef',
                             'property', 'enum_with_default.rb.erb'),

--- a/provider/chef.rb
+++ b/provider/chef.rb
@@ -117,10 +117,10 @@ module Provider
 
     def label_name(product)
       product.name.underscore
-                  .split('_')
-                  .map { |x| x[0] }
-                  .join
-                  .concat('_label')
+             .split('_')
+             .map { |x| x[0] }
+             .join
+             .concat('_label')
     end
 
     # Returns a list of all resource types being tested

--- a/provider/chef/test_catalog.rb
+++ b/provider/chef/test_catalog.rb
@@ -53,7 +53,7 @@ module Provider
     # Generates a resource block for a resource ref.
     # Requires the ResourceRef and an index.
     def generate_ref(ref, index)
-      ref_name = Google::StringUtils.underscore(ref.name)
+      ref_name = ref.name.underscore
       generate_object(ref, "resource(#{ref_name},#{index})", :resource,
                       index, action: ':create')
     end

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -14,6 +14,7 @@
 require 'compile/core'
 require 'dependencies/dependency_graph'
 require 'fileutils'
+require 'google/extensions'
 require 'google/logger'
 require 'pathname'
 require 'provider/properties'
@@ -120,7 +121,7 @@ module Provider
         output_folder,
         @config.test_data.network,
         lambda do |object, file|
-          type = Google::StringUtils.underscore(object.name)
+          type = object.name.underscore
           ["spec/data/network/#{object.out_name}/#{file}.yaml",
            "products/#{@api.prefix[1..-1]}/files/spec~#{type}~#{file}.yaml"]
         end
@@ -170,7 +171,7 @@ module Provider
       create_object_list(
         test_data,
         lambda do |object, file|
-          type = Google::StringUtils.underscore(object.name)
+          type = object.name.underscore
           ["spec/data/network/#{object.out_name}/#{file}.yaml",
            "products/#{@api.prefix[1..-1]}/files/spec~#{type}~#{file}.yaml"]
         end

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -203,7 +203,7 @@ module Provider
             output_folder: output_folder,
             out_file: target_file,
             prop_ns_dir: @api.prefix[1..-1].downcase,
-            product_ns: Google::StringUtils.camelize(@api.prefix[1..-1], :upper)
+            product_ns: @api.prefix[1..-1].camelize(:upper)
           )
         )
 
@@ -347,8 +347,7 @@ module Provider
 
     def generate_resource_file(data)
       product_ns = if @config.name.nil?
-                     Google::StringUtils.camelize(data[:object].__product
-                       .prefix[1..-1], :upper)
+                     data[:object].__product.prefix[1..-1].camelize(:upper)
                    else
                      @config.name
                    end
@@ -703,9 +702,8 @@ module Provider
     end
 
     def emit_user_agent(product, extra, notes, file_name)
-      prov_text = Google::StringUtils.camelize(self.class.name.split('::').last,
-                                               :upper)
-      prod_text = Google::StringUtils.camelize(product, :upper)
+      prov_text = self.class.name.split('::').last.camelize(:upper)
+      prod_text = product.camelize(:upper)
       ua_generator = notes.map { |n| "# #{n}" }.concat(
         [
           "version = '1.0.0'",

--- a/provider/example.rb
+++ b/provider/example.rb
@@ -34,7 +34,7 @@ module Provider
     def generate_resource(data)
       target_folder = data[:output_folder]
       FileUtils.mkpath target_folder
-      name = Google::StringUtils.underscore(data[:object].name)
+      name = data[:object].name.underscore
       generate_resource_file data.clone.merge(
         default_template: 'templates/example/resource.erb',
         out_file: File.join(target_folder, "#{name}.rb")

--- a/provider/properties.rb
+++ b/provider/properties.rb
@@ -39,8 +39,7 @@ module Provider
           data[:output_folder],
           { prop[:target] => prop[:source] },
           {
-            product_ns: Google::StringUtils.camelize(data[:product_name],
-                                                     :upper),
+            product_ns: data[:product_name].camelize(:upper),
             prop_ns_dir: data[:product_name].downcase
           }.merge((prop[:overrides] || {}))
         )
@@ -102,7 +101,7 @@ module Provider
           api_name: prop.name.underscore,
           property: prop,
           nested_properties: prop.properties,
-          obj_name: Google::StringUtils.underscore(data[:object].name)
+          obj_name: data[:object].name.underscore
         )
       )
 
@@ -120,7 +119,7 @@ module Provider
           api_name: prop.name.underscore,
           property: prop,
           nested_properties: prop.item_type.properties,
-          obj_name: Google::StringUtils.underscore(data[:object].name)
+          obj_name: data[:object].name.underscore
         )
       )
 
@@ -135,7 +134,7 @@ module Provider
     end
 
     def generate_resourceref_object(data, prop)
-      resource = Google::StringUtils.underscore(prop.resource_ref.name)
+      resource = prop.resource_ref.name.underscore
       imports = prop.imports.underscore
       return if resourceref_tracker.key?([resource, imports])
       resourceref_tracker[[resource, imports]] = false
@@ -151,7 +150,7 @@ module Provider
     end
 
     def generate_resourceref_array(data, prop)
-      resource = Google::StringUtils.underscore(prop.resource_ref.name)
+      resource = prop.resource_ref.name.underscore
       imports = prop.imports.underscore
       return if resourceref_tracker.key?([resource, imports]) \
         && resourceref_tracker[[resource, imports]] == true

--- a/provider/properties.rb
+++ b/provider/properties.rb
@@ -99,7 +99,7 @@ module Provider
       prop_map << emit_nested_object(
         data.clone.merge(
           emit_array: false,
-          api_name: Google::StringUtils.underscore(prop.name),
+          api_name: prop.name.underscore,
           property: prop,
           nested_properties: prop.properties,
           obj_name: Google::StringUtils.underscore(data[:object].name)
@@ -117,7 +117,7 @@ module Provider
       prop_map << emit_nested_object(
         data.clone.merge(
           emit_array: true,
-          api_name: Google::StringUtils.underscore(prop.name),
+          api_name: prop.name.underscore,
           property: prop,
           nested_properties: prop.item_type.properties,
           obj_name: Google::StringUtils.underscore(data[:object].name)
@@ -136,7 +136,7 @@ module Provider
 
     def generate_resourceref_object(data, prop)
       resource = Google::StringUtils.underscore(prop.resource_ref.name)
-      imports = Google::StringUtils.underscore(prop.imports)
+      imports = prop.imports.underscore
       return if resourceref_tracker.key?([resource, imports])
       resourceref_tracker[[resource, imports]] = false
 
@@ -152,7 +152,7 @@ module Provider
 
     def generate_resourceref_array(data, prop)
       resource = Google::StringUtils.underscore(prop.resource_ref.name)
-      imports = Google::StringUtils.underscore(prop.imports)
+      imports = prop.imports.underscore
       return if resourceref_tracker.key?([resource, imports]) \
         && resourceref_tracker[[resource, imports]] == true
       resourceref_tracker[[resource, imports]] = true

--- a/provider/puppet.rb
+++ b/provider/puppet.rb
@@ -380,7 +380,7 @@ module Provider
 
     def generate_typed_array(data, prop)
       type = Module.const_get(prop.item_type).new(prop.name).type
-      file = Google::StringUtils.underscore(type)
+      file = type.underscore
       prop_map = []
       prop_map << {
         source: File.join('templates', 'puppet', 'property',
@@ -423,9 +423,9 @@ module Provider
 
     def emit_nested_object_overrides(data)
       data.clone.merge(
-        api_name: Google::StringUtils.camelize(data[:api_name], :upper),
-        object_type: Google::StringUtils.camelize(data[:obj_name], :upper),
-        product_ns: Google::StringUtils.camelize(data[:product_name], :upper),
+        api_name: data[:api_name].camelize(:upper),
+        object_type: data[:obj_name].camelize(:upper),
+        product_ns: data[:product_name].camelize(:upper),
         class_name: if data[:emit_array]
                       data[:property].item_type.property_class.last
                     else
@@ -540,9 +540,7 @@ module Provider
         p.is_a?(Api::Type::Enum) && !p.default_value.nil?
       end
       default_enums.map do |p|
-        prop_name = Google::StringUtils.underscore(
-          "#{p.__resource.name}_#{p.name}"
-        )
+        prop_name = "#{p.__resource.name}_#{p.name}".underscore
         {
           source: File.join('templates', 'puppet',
                             'property', 'enum_with_default.rb.erb'),

--- a/provider/puppet/codegen.rb
+++ b/provider/puppet/codegen.rb
@@ -56,7 +56,7 @@ module Provider
       end
 
       def provider_template_source(data)
-        object_name = Google::StringUtils.underscore(data[:object].name)
+        object_name = data[:object].name.underscore
         if true?(data[:object].manual)
           File.join('products', data[:product_name], 'files',
                     "provider~#{object_name}.rb")

--- a/provider/puppet/test_manifest.rb
+++ b/provider/puppet/test_manifest.rb
@@ -62,7 +62,7 @@ module Provider
     # Generates a resource block for a resource ref.
     # Requires the ResourceRef and an index.
     def generate_ref(ref, index)
-      ref_name = Google::StringUtils.underscore(ref.name)
+      ref_name = ref.name.underscore
       generate_object(ref, "resource(#{ref_name},#{index})", :resource,
                       index, ensure: 'present')
     end

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -134,8 +134,8 @@ module Provider
     def generate_resource(data)
       target_folder = File.join(data[:output_folder], 'google')
       FileUtils.mkpath target_folder
-      name = Google::StringUtils.underscore(data[:object].name)
-      product_name = Google::StringUtils.underscore(data[:product_name])
+      name = data[:object].name.underscore
+      product_name = data[:product_name].underscore
       filepath = File.join(target_folder, "resource_#{product_name}_#{name}.go")
       generate_resource_file data.clone.merge(
         default_template: 'templates/terraform/resource.erb',
@@ -151,8 +151,8 @@ module Provider
       target_folder = data[:output_folder]
       target_folder = File.join(target_folder, 'website', 'docs', 'r')
       FileUtils.mkpath target_folder
-      name = Google::StringUtils.underscore(data[:object].name)
-      product_name = Google::StringUtils.underscore(data[:product_name])
+      name = data[:object].name.underscore
+      product_name = data[:product_name].underscore
       filepath =
         File.join(target_folder, "#{product_name}_#{name}.html.markdown")
       generate_resource_file data.clone.merge(

--- a/provider/terraform/import.rb
+++ b/provider/terraform/import.rb
@@ -33,7 +33,7 @@ module Provider
         if resource.import_format.nil? || resource.import_format.empty?
           underscored_base_url = resource.base_url.gsub(
             /{{[[:word:]]+}}/
-          ) { |api_name| Google::StringUtils.underscore(api_name) }
+          ) { |api_name| api_name.underscore }
 
           # We assume that all resources have a name field
           id_formats = [underscored_base_url + '/{{name}}']

--- a/provider/terraform/import.rb
+++ b/provider/terraform/import.rb
@@ -32,8 +32,8 @@ module Provider
       def import_id_formats(resource)
         if resource.import_format.nil? || resource.import_format.empty?
           underscored_base_url = resource.base_url.gsub(
-            /{{[[:word:]]+}}/
-          ) { |api_name| api_name.underscore }
+            /{{[[:word:]]+}}/, &:underscore
+          )
 
           # We assume that all resources have a name field
           id_formats = [underscored_base_url + '/{{name}}']

--- a/provider/test_data/create_data.rb
+++ b/provider/test_data/create_data.rb
@@ -119,8 +119,8 @@ module Provider
 
       def expect_array_item_rref(item, seed = 0)
         size = @data_gen.object_size(item, seed, true)
-        imports = Google::StringUtils.underscore(item.item_type.imports)
-        resource = Google::StringUtils.underscore(item.item_type.resource)
+        imports = item.item_type.imports.underscore
+        resource = item.item_type.resource.underscore
         @provider.indent_list(
           (0..size - 1).map do |index|
             "'#{imports.tr('_', '')}(resource(#{resource},#{index}))'"

--- a/provider/test_data/expectations.rb
+++ b/provider/test_data/expectations.rb
@@ -62,7 +62,7 @@ module Provider
             # We need to verify that only resourcerefs directly belonging to
             # this object are inserted into the expectation.
             next unless ref.is_a? Api::Type::ResourceRef
-            name = Google::StringUtils.underscore(ref.resource_ref.name)
+            name = ref.resource_ref.name.underscore
             value = @data_gen.value(ref.property.class, ref.property, 0)
             { name => value }
           end
@@ -150,7 +150,7 @@ module Provider
 
           rrefs.each do |ref|
             next if ref.object == object
-            name = Google::StringUtils.underscore(ref.object.name)
+            name = ref.object.name.underscore
             # Puppet style refs include a seed
             code << create_expectation("expect_network_get_success_#{name}",
                                        true, ref.object, 12, [],
@@ -192,7 +192,7 @@ module Provider
           # We need to verify that only resourcerefs directly belonging to this
           # object are inserted into the expectation.
           next unless ref.is_a? Api::Type::ResourceRef
-          name = Google::StringUtils.underscore(ref.resource_ref.name)
+          name = ref.resource_ref.name.underscore
           value = @data_gen.value(ref.property.class, ref.property, id - 1)
           { name => value }
         end
@@ -232,7 +232,7 @@ module Provider
           # with same ID objects
           next if ref.object == object
 
-          ref_name = Google::StringUtils.underscore(ref.object.name)
+          ref_name = ref.object.name.underscore
 
           # Find the machine resource to safity the object's dependency. If an
           # object required by the object being tested in turn requires 1+ other

--- a/provider/test_data/formatter.rb
+++ b/provider/test_data/formatter.rb
@@ -121,7 +121,7 @@ module Provider
 
       # Returns the title of the block being referenced
       def emit_resource(prop, seed, _ctx)
-        name = Google::StringUtils.underscore(prop.resource_ref.name)
+        name = prop.resource_ref.name.underscore
         "resource(#{name},#{seed % MAX_ARRAY_SIZE})"
       end
 

--- a/provider/test_data/generator.rb
+++ b/provider/test_data/generator.rb
@@ -143,7 +143,7 @@ module Provider
       end
 
       def selflink_value(prop, seed)
-        name = Google::StringUtils.underscore(prop.resource.name)
+        name = prop.resource.name.underscore
         "selflink(resource(#{name},#{seed}))"
       end
 
@@ -152,7 +152,7 @@ module Provider
       end
 
       def resource_value(prop, seed)
-        name = Google::StringUtils.underscore(prop.resource_ref.name)
+        name = prop.resource_ref.name.underscore
         "'resource(#{name},#{seed})'"
       end
 
@@ -190,7 +190,7 @@ module Provider
             if hash[:exported_values]
               # Return the exported value.
               imports = prop.item_type.imports.downcase
-              resource = Google::StringUtils.underscore(prop.item_type.resource)
+              resource = prop.item_type.resource.underscore
               "#{imports}(resource(#{resource},#{index}))"
             else
               resource_value(prop.item_type, index)

--- a/provider/test_data/spec_formatter.rb
+++ b/provider/test_data/spec_formatter.rb
@@ -51,7 +51,7 @@ module Provider
 
       def generate(object, _, kind, seed, extra)
         props = object.all_user_properties
-        name = Google::StringUtils.underscore(object.name)
+        name = object.name.underscore
 
         extra = extra.merge(
           project: "'test project\##{seed} data'",

--- a/templates/ansible/integration_test.erb
+++ b/templates/ansible/integration_test.erb
@@ -8,7 +8,7 @@
 <% end # if example.dependencies -%>
 <%= lines(example.task.build_test('absent', object, false)) -%>
 #----------------------------------------------------------
-<% resource_name = Google::StringUtils.uncombine(object.name).downcase -%>
+<% resource_name = object.name.uncombine.downcase -%>
 <%= lines(example.task.build_test('present', object, false)) -%>
   register: result
 <% if object.readonly -%>

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -56,7 +56,7 @@ notes:
 
 <% if example -%>
 EXAMPLES = '''
-<% res_readable_name = Google::StringUtils.uncombine(object.name) -%>
+<% res_readable_name = object.name.uncombine -%>
 <% if example.dependencies -%>
 <%   example.dependencies.each do |depend| -%>
 <%= lines(depend.build_test('present', object, false)) -%>

--- a/templates/ansible/verifiers/bash.yaml.erb
+++ b/templates/ansible/verifiers/bash.yaml.erb
@@ -1,4 +1,4 @@
-- name: verify that <%= Google::StringUtils.underscore(object.name) -%> was <%= lines(verbs[state.to_sym]) -%>
+- name: verify that <%= object.name.underscore -%> was <%= lines(verbs[state.to_sym]) -%>
   shell: |
 <%= lines(indent(@command.tr("\n", ''), 4)) -%>
   register: results

--- a/templates/ansible/verifiers/facts.yaml.erb
+++ b/templates/ansible/verifiers/facts.yaml.erb
@@ -1,9 +1,9 @@
 <%
   module_name = ["gcp_#{object.__product.prefix[1..-1]}",
-                 Google::StringUtils.underscore(object.name),
+                 object.name.underscore,
                  'facts'].join('_')
 -%>
-- name: verify that <%= Google::StringUtils.underscore(object.name) -%> was <%= lines(verbs[_state.to_sym]) -%>
+- name: verify that <%= object.name.underscore -%> was <%= lines(verbs[_state.to_sym]) -%>
   <%= module_name -%>:
       filters:
          - name = "{{ resource_name }}"

--- a/templates/chef/README.md.erb
+++ b/templates/chef/README.md.erb
@@ -79,7 +79,7 @@ For complete details of the authentication cookbook, visit the
 
 ```ruby
 <%= compile ["products/#{@api.prefix[1..-1]}/examples/chef/",
-             "#{Google::StringUtils.underscore(object.name)}.rb"].join('') %>
+             "#{object.name.underscore}.rb"].join('') %>
 ```
 
 #### Reference

--- a/templates/chef/property/enum_with_default.rb.erb
+++ b/templates/chef/property/enum_with_default.rb.erb
@@ -23,7 +23,7 @@ module Google
       # default.  The default is important because GCP sometimes
       # does not return the default value for an enum, but we need
       # to avoid detecting a diff if it is explicitly set.
-      class <%= Google::StringUtils.camelize(prop.name, :upper) -%>Enum
+      class <%= prop.name.camelize(:upper) -%>Enum
 <%= emit_coerce(product_ns, 'Enum', 8) -%>
         def self.api_parse(value)
           return "<%= prop.default_value -%>" if value.nil?

--- a/templates/chef/resourceref_expandvars.erb
+++ b/templates/chef/resourceref_expandvars.erb
@@ -16,7 +16,7 @@
 <% object.all_resourcerefs.each do |ref| -%>
 <%
   prop_ref = ref.resource_ref
-  ref_underscore_name = Google::StringUtils.underscore(ref.resource)
+  ref_underscore_name = ref.resource.underscore
 -%>
 def expand_variables_<%= ref_underscore_name -%>(template, data, ext_dat = {})
 <% prefix = object.__product.prefix.upcase -%>

--- a/templates/puppet/README.md.erb
+++ b/templates/puppet/README.md.erb
@@ -118,7 +118,7 @@ required gems.
 
 ```puppet
 <%= compile File.join('products', @api.prefix[1..-1], 'examples', 'puppet',
-                      "#{Google::StringUtils.underscore(object.name)}.pp") %>
+                      "#{object.name.underscore}.pp") %>
 ```
 
 <% end # objects.each -%>
@@ -169,7 +169,7 @@ change by asserting it in the manifest.
 
 ```puppet
 <%= compile File.join('products', @api.prefix[1..-1], 'examples', 'puppet',
-                      "#{Google::StringUtils.underscore(object.name)}.pp") %>
+                      "#{object.name.underscore}.pp") %>
 ```
 
 #### Reference

--- a/templates/puppet/function.erb
+++ b/templates/puppet/function.erb
@@ -26,7 +26,7 @@ Puppet::Functions.create_function(:<%= fn.name -%>) do
 <% fn.arguments.each do |arg| -%>
 <% type_parts = arg.type.split('::') -%>
 <% if type_parts[0, 2] == %w[Api Type] -%>
-<% type = Google::StringUtils.camelize(type_parts.last, :upper) -%>
+<% type = type_parts.last.camelize(:upper) -%>
     param '<%= type -%>', :<%= arg.name %>
 <% else # arg.type.starts_with?('Api::Type') -%>
     param 'Runtime[ruby, "<%= arg.type -%>"]', :<%= arg.name %>

--- a/templates/puppet/property/enum_with_default.rb.erb
+++ b/templates/puppet/property/enum_with_default.rb.erb
@@ -26,7 +26,7 @@ module Google
       # Since default values for enums are not returned from the GCP API,
       # we need to return true from `insync?` if the property is absent
       # in the response but set to the default in the config.
-      class <%= Google::StringUtils.camelize(prop.name, :upper) -%>Enum < Google::<%= product_ns %>::Property::Enum
+      class <%= prop.name.camelize(:upper) -%>Enum < Google::<%= product_ns %>::Property::Enum
         def insync?(is)
           debug("insync enum? #{name}: '#{is}' == '#{should}'")
           if is == :absent && should == '<%= prop.default_value %>'

--- a/templates/puppet/resourceref_expandvars.erb
+++ b/templates/puppet/resourceref_expandvars.erb
@@ -2,7 +2,7 @@
 <% object.all_resourcerefs.each do |ref| -%>
 <%
   prop_ref = ref.resource_ref
-  ref_underscore_name = Google::StringUtils.underscore(ref.resource)
+  ref_underscore_name = ref.resource.underscore
 -%>
 def expand_variables_<%= ref_underscore_name -%>(template, data, ext_dat = {})
   Puppet::Type.type(:<%= prop_ref.out_name -%>).provider(:google)

--- a/templates/resourceref_mocks.erb
+++ b/templates/resourceref_mocks.erb
@@ -17,7 +17,7 @@
 <% object.all_resourcerefs.each do |ref| -%>
 <%
   prop_ref = ref.resource_ref
-  ref_underscore_name = Google::StringUtils.underscore(ref.resource)
+  ref_underscore_name = ref.resource.underscore
   ref_index ||= 0
   ref_name = "resource(#{ref_underscore_name},#{ref_index})"
 -%>

--- a/templates/terraform/custom_expand/compute_full_url.erb
+++ b/templates/terraform/custom_expand/compute_full_url.erb
@@ -15,7 +15,7 @@
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) (interface{}, error) {
   f, err := <%= build_expand_resource_ref('v.(string)', property) %>
   if err != nil {
-    return nil, fmt.Errorf("Invalid value for <%= Google::StringUtils.underscore(property.name) -%>: %s", err)
+    return nil, fmt.Errorf("Invalid value for <%= property.name.underscore -%>: %s", err)
   }
   return "https://www.googleapis.com/compute/v1/" + f.RelativeLink(), nil
 }

--- a/templates/terraform/expand_property_method.erb
+++ b/templates/terraform/expand_property_method.erb
@@ -51,7 +51,7 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
     transformed := make(map[string]interface{})
 
 <%       nested_properties.each do |prop| -%>
-      transformed<%= titlelize_property(prop) -%>, err := expand<%= prefix -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(original["<%= Google::StringUtils.underscore(prop.name) -%>"], d, config)
+      transformed<%= titlelize_property(prop) -%>, err := expand<%= prefix -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(original["<%= prop.name.underscore -%>"], d, config)
       if err != nil {
         return nil, err
       }

--- a/templates/terraform/expand_property_method.erb
+++ b/templates/terraform/expand_property_method.erb
@@ -76,7 +76,7 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
   for _, raw := range l {
     f, err := <%= build_expand_resource_ref('raw.(string)', property.item_type) %>
     if err != nil {
-      return nil, fmt.Errorf("Invalid value for <%= Google::StringUtils.underscore(property.name) -%>: %s", err)
+      return nil, fmt.Errorf("Invalid value for <%= property.name.underscore -%>: %s", err)
     }
     req = append(req, f.RelativeLink())
   }
@@ -86,7 +86,7 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
 <%       if property.is_a?(Api::Type::ResourceRef) -%>
   f, err := <%= build_expand_resource_ref('v.(string)', property) %>
   if err != nil {
-    return nil, fmt.Errorf("Invalid value for <%= Google::StringUtils.underscore(property.name) -%>: %s", err)
+    return nil, fmt.Errorf("Invalid value for <%= property.name.underscore -%>: %s", err)
   }
   return f.RelativeLink(), nil
 }

--- a/templates/terraform/flatten_property_method.erb
+++ b/templates/terraform/flatten_property_method.erb
@@ -26,7 +26,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) in
   original := v.(map[string]interface{})
   transformed := make(map[string]interface{})
   <% property.properties.each do |prop| -%>
-    transformed["<%= Google::StringUtils.underscore(prop.name) -%>"] =
+    transformed["<%= prop.name.underscore -%>"] =
     flatten<%= prefix -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(original["<%= prop.api_name -%>"])
   <% end -%>
   return []interface{}{transformed}
@@ -40,7 +40,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) in
     original := raw.(map[string]interface{})
     transformed = append(transformed, map[string]interface{}{
     <% property.item_type.properties.each do |prop| -%>
-      "<%= Google::StringUtils.underscore(prop.name) -%>": flatten<%= prefix -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(original["<%= prop.api_name -%>"]),
+      "<%= prop.name.underscore -%>": flatten<%= prefix -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(original["<%= prop.api_name -%>"]),
     <% end -%>
     })
   }

--- a/templates/terraform/nested_property_documentation.erb
+++ b/templates/terraform/nested_property_documentation.erb
@@ -2,7 +2,7 @@
   nested_properties = nested_properties(property)
   if !nested_properties.empty?
 -%>
-The `<%= Google::StringUtils.underscore(property.name) -%>` block <%= if property.output then "contains" else "supports" end -%>:
+The `<%= property.name.underscore -%>` block <%= if property.output then "contains" else "supports" end -%>:
 <% nested_properties.each do |prop| -%>
 <%= lines(build_property_documentation(prop)) -%>
 <% end -%>

--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -1,5 +1,5 @@
 
-* `<%= Google::StringUtils.underscore(property.name) -%>` -
+* `<%= property.name.underscore -%>` -
 <% if property.required -%>
   (Required)
 <% elsif !property.output -%>

--- a/templates/terraform/provider_gen.erb
+++ b/templates/terraform/provider_gen.erb
@@ -26,6 +26,6 @@ end -%>
 var Generated<%= product_ns -%>ResourcesMap = map[string]*schema.Resource{
 <% product.objects.reject { |r| r.exclude }.each do |object| -%>
 <% resource_name = product_ns + object.name -%>
-	"google_<%= Google::StringUtils.underscore(resource_name) -%>": resource<%= resource_name -%>(),
+	"google_<%= resource_name.underscore -%>": resource<%= resource_name -%>(),
 <% end -%>
 }

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -39,7 +39,7 @@ func resource<%= resource_name -%>() *schema.Resource {
         <% if settable_properties.any? {|p| p.unordered_list} && !object.custom_code.resource_definition -%>
         CustomizeDiff: customdiff.All(
             <%= settable_properties.select { |p| p.unordered_list }
-                                    .map { |p| "resource#{resource_name}#{Google::StringUtils.camelize(p.name, :upper)}SetStyleDiff"}
+                                    .map { |p| "resource#{resource_name}#{p.name.camelize(:upper)}SetStyleDiff"}
                                     .join(",\n")-%>
         ),
         <% end -%>
@@ -82,7 +82,7 @@ func resource<%= resource_name -%>() *schema.Resource {
 	}
 }
 <% settable_properties.select {|p| p.unordered_list}.each do |prop| -%>
-func resource<%= resource_name -%><%= Google::StringUtils.camelize(prop.name, :upper) -%>SetStyleDiff(diff *schema.ResourceDiff, meta interface{}) error {
+func resource<%= resource_name -%><%= prop.name.camelize(:upper) -%>SetStyleDiff(diff *schema.ResourceDiff, meta interface{}) error {
 <%= compile_template('templates/terraform/unordered_list_customize_diff.erb',
                      prop: prop,
                      resource_name: resource_name) -%>

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -101,13 +101,13 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 
 	obj := make(map[string]interface{})
 <% settable_properties.each do |prop| -%>
-	<%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>"), d, config)
+	<%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= prop.name.underscore -%>"), d, config)
 	if err != nil {
 		return err
 	<% unless prop.send_empty_value -%>
-	} else if v, ok := d.GetOkExists("<%= Google::StringUtils.underscore(prop.name) -%>"); !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
+	} else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
 	<% else -%>
-	} else if v, ok := d.GetOkExists("<%= Google::StringUtils.underscore(prop.name) -%>"); ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop) {
+	} else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop) {
 	<% end -%>
 		obj["<%= prop.api_name -%>"] = <%= prop.api_name -%>Prop
 	}
@@ -212,7 +212,7 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
 
 
 <% properties.each do |prop| -%>
-  if err := d.Set("<%= Google::StringUtils.underscore(prop.name) -%>", flatten<%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.api_name -%>"])); err != nil {
+  if err := d.Set("<%= prop.name.underscore -%>", flatten<%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.api_name -%>"])); err != nil {
 		return fmt.Errorf("Error reading <%= object.name -%>: %s", err)
 	}
 <% end -%>
@@ -249,11 +249,11 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 	d.Partial(true)
 
 	<% properties_by_custom_update(properties).each do |key, props| -%>
-	if <%= props.map { |prop| "d.HasChange(\"#{Google::StringUtils.underscore(prop.name)}\")" }.join ' || ' -%> {
+	if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' || ' -%> {
 		obj := make(map[string]interface{})
 		<% props.each do |prop| -%>
 			<% if settable_properties.include? prop -%>
-				<%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>"), d, config)
+				<%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= prop.name.underscore -%>"), d, config)
 			if err != nil {
 			return err
 			<%# There is some nuance in when we choose to send a value to an update function.
@@ -274,9 +274,9 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 					in question is go's literal nil.
 			-%>
 			<% unless prop.send_empty_value -%>
-			} else if v, ok := d.GetOkExists("<%= Google::StringUtils.underscore(prop.name) -%>"); !isEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
+			} else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
 			<% else -%>
-			} else if v, ok := d.GetOkExists("<%= Google::StringUtils.underscore(prop.name) -%>"); ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop) {
+			} else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop) {
 			<% end -%>
 			<% if prop.update_statement -%>
 					obj["<%= prop.api_name -%>"] = <%= compile_template(prop.update_statement,
@@ -287,7 +287,7 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
       <% end -%>
 			}
 			<% else -%>
-			<%= prop.api_name -%>Prop := d.Get("<%= Google::StringUtils.underscore(prop.name) -%>")
+			<%= prop.api_name -%>Prop := d.Get("<%= prop.name.underscore -%>")
 			obj["<%= prop.api_name -%>"] = <%= prop.api_name -%>Prop
 			<% end -%>
 		<% end -%>
@@ -327,7 +327,7 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 		<% end -%>
 
 		<% props.each do |prop|	-%>
-		d.SetPartial("<%= Google::StringUtils.underscore(prop.name) -%>")
+		d.SetPartial("<%= prop.name.underscore -%>")
 		<% end -%>
 	}
 	<% end -%>
@@ -336,13 +336,13 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 	<% else # if object.input -%>
 	obj := make(map[string]interface{})
 	<% settable_properties.each do |prop| -%>
-		<%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>"), d, config)
+		<%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= prop.name.underscore -%>"), d, config)
 		if err != nil {
 				return err
 		<% unless prop.send_empty_value -%>
-		} else if v, ok := d.GetOkExists("<%= Google::StringUtils.underscore(prop.name) -%>"); !isEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
+		} else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
 		<% else -%>
-		} else if v, ok := d.GetOkExists("<%= Google::StringUtils.underscore(prop.name) -%>"); ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop) {
+		} else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop) {
 		<% end -%>
 			obj["<%= prop.api_name -%>"] = <%= prop.api_name -%>Prop
 		}

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -37,7 +37,7 @@
 -%>
 <%
   api_name_lower = product_ns.downcase
-  resource_name = Google::StringUtils.underscore(object.name)
+  resource_name = object.name.underscore
   properties = object.all_user_properties
 -%>
 ---

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -46,7 +46,7 @@ layout: "google"
 page_title: "Google: google_<%= api_name_lower -%>_<%= resource_name -%>"
 sidebar_current: "docs-google-<%= api_name_lower -%>-<%= resource_name.gsub("_", "-") -%>"
 description: |-
-<%= indent(Google::StringUtils.first_sentence(object.description), 2) %>
+<%= indent(object.description.first_sentence, 2) %>
 ---
 
 # google\_<%= api_name_lower -%>\_<%= resource_name.gsub("_", "\\_") %>

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -13,7 +13,7 @@
   # limitations under the License.
 <% end -%>
 <% if tf_types.include?(property.class) -%>
-"<%= Google::StringUtils.underscore(property.name) -%>": {
+"<%= property.name.underscore -%>": {
   <% if property.is_set -%>
   Type: schema.TypeSet,
   <% else -%>

--- a/templates/terraform/self_link_query.erb
+++ b/templates/terraform/self_link_query.erb
@@ -12,12 +12,12 @@
 	for _, item := range listObj {
 	<% object.identity.each do |prop| -%>
 		<% if settable_properties.include?(prop) -%>
-		this<%= titlelize_property(prop) -%>, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= Google::StringUtils.underscore(prop.name) -%>"), d, config)
+		this<%= titlelize_property(prop) -%>, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= prop.name.underscore -%>"), d, config)
 		if err != nil {
 			return err
 		}
 		<% else -%>
-			this<%= titlelize_property(prop) -%> := d.Get("<%= Google::StringUtils.underscore(prop.name) -%>")
+			this<%= titlelize_property(prop) -%> := d.Get("<%= prop.name.underscore -%>")
 		<% end -%>
 		that<%= titlelize_property(prop) -%> := flatten<%= resource_name -%><%= titlelize_property(prop) -%>(item["<%= prop.api_name -%>"])
 		log.Printf("[DEBUG] Checking equality of %#v, %#v", that<%= titlelize_property(prop) -%>, this<%= titlelize_property(prop) -%>)

--- a/templates/terraform/unordered_list_customize_diff.erb
+++ b/templates/terraform/unordered_list_customize_diff.erb
@@ -1,8 +1,8 @@
-keys := diff.GetChangedKeysPrefix(<%= go_literal(Google::StringUtils.underscore(prop.name)) -%>)
+keys := diff.GetChangedKeysPrefix(<%= go_literal(prop.name.underscore) -%>)
 if len(keys) == 0 {
     return nil
 }
-oldCount, newCount := diff.GetChange("<%= Google::StringUtils.underscore(prop.name) -%>.#")
+oldCount, newCount := diff.GetChange("<%= prop.name.underscore -%>.#")
 var count int
 // There could be duplicates - worth continuing even if the counts are unequal.
 if oldCount.(int) < newCount.(int) {
@@ -17,7 +17,7 @@ if count < 1 {
 old := make([]interface{}, count)
 new := make([]interface{}, count)
 for i := 0; i < count; i++ {
-    o, n := diff.GetChange(fmt.Sprintf("<%= Google::StringUtils.underscore(prop.name) -%>.%d", i))
+    o, n := diff.GetChange(fmt.Sprintf("<%= prop.name.underscore -%>.%d", i))
 
     if o != nil {
         old = append(old, o)
@@ -27,11 +27,11 @@ for i := 0; i < count; i++ {
     }
 }
 
-oldSet := schema.NewSet(schema.HashResource(resource<%= resource_name -%>().Schema[<%= go_literal(Google::StringUtils.underscore(prop.name)) -%>].Elem.(*schema.Resource)), old)
-newSet := schema.NewSet(schema.HashResource(resource<%= resource_name -%>().Schema[<%= go_literal(Google::StringUtils.underscore(prop.name)) -%>].Elem.(*schema.Resource)), new)
+oldSet := schema.NewSet(schema.HashResource(resource<%= resource_name -%>().Schema[<%= go_literal(prop.name.underscore) -%>].Elem.(*schema.Resource)), old)
+newSet := schema.NewSet(schema.HashResource(resource<%= resource_name -%>().Schema[<%= go_literal(prop.name.underscore) -%>].Elem.(*schema.Resource)), new)
 
 if oldSet.Equal(newSet) {
-    if err := diff.Clear(<%= go_literal(Google::StringUtils.underscore(prop.name)) -%>); err != nil {
+    if err := diff.Clear(<%= go_literal(prop.name.underscore) -%>); err != nil {
         return err
     }
 }


### PR DESCRIPTION
Putting Google::StringUtils on every string method is annoying.

I added all of those methods directly to the ::String class so we can just do "my-string".underscore.

So much easier this way.

This should be a no-op.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-sql]
### [chef-storage]
## [ansible]
