### PR TITLE
Adding base branch flag to Ansible tests

### DIFF
--- a/.ci/unit-tests/ansible.sh
+++ b/.ci/unit-tests/ansible.sh
@@ -7,4 +7,4 @@ pushd "magic-modules/build/ansible"
 pip install tox
 
 source hacking/env-setup
-ansible-test sanity -v --tox --python 2.7 $(find test/integration/targets -name "gcp_*" -printf '%P ')
+ansible-test sanity -v --tox --python 2.7 --base-branch origin/devel $(find test/integration/targets -name "gcp_*" -printf '%P ')

--- a/.gitmodules
+++ b/.gitmodules
@@ -67,7 +67,7 @@
 [submodule "build/ansible"]
 	path = build/ansible
 	url = git@github.com:modular-magician/ansible
-	branch = rebase
+	branch = devel
 [submodule "build/terraform"]
 	path = build/terraform
 	url = git@github.com:terraform-providers/terraform-provider-google.git

--- a/api/product.rb
+++ b/api/product.rb
@@ -45,7 +45,7 @@ module Api
       attr_reader :default
       attr_reader :name
 
-      ORDER = %w[v1 beta alpha].freeze
+      ORDER = %w[ga beta alpha].freeze
 
       def validate
         super

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 80.04
+    "covered_percent": 79.44
   }
 }

--- a/products/bigquery/api.yaml
+++ b/products/bigquery/api.yaml
@@ -16,7 +16,7 @@ name: Google Cloud BigQuery
 prefix: gbigquery
 versions:
   - !ruby/object:Api::Product::Version
-    name: v1
+    name: ga
     base_url: https://www.googleapis.com/bigquery/v2/
     default: true
 scopes:

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -18,7 +18,7 @@ name: Google Compute Engine
 prefix: gcompute
 versions:
   - !ruby/object:Api::Product::Version
-    name: v1
+    name: ga
     base_url: https://www.googleapis.com/compute/v1/
     default: true
   - !ruby/object:Api::Product::Version

--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -16,7 +16,7 @@ name: Google Container Engine
 prefix: gcontainer
 versions:
   - !ruby/object:Api::Product::Version
-    name: v1
+    name: ga
     base_url: https://container.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform

--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -16,7 +16,7 @@ name: Google Cloud DNS
 prefix: gdns
 versions:
   - !ruby/object:Api::Product::Version
-    name: v1
+    name: ga
     base_url: https://www.googleapis.com/dns/v1/
 scopes:
   - https://www.googleapis.com/auth/ndev.clouddns.readwrite

--- a/products/iam/api.yaml
+++ b/products/iam/api.yaml
@@ -18,7 +18,7 @@ name: Google Cloud IAM
 prefix: giam
 versions:
   - !ruby/object:Api::Product::Version
-    name: v1
+    name: ga
     base_url: https://iam.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/iam

--- a/products/pubsub/api.yaml
+++ b/products/pubsub/api.yaml
@@ -16,7 +16,7 @@ name: Google Cloud Pub/Sub
 prefix: gpubsub
 versions:
   - !ruby/object:Api::Product::Version
-    name: v1
+    name: ga
     base_url: https://pubsub.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/pubsub

--- a/products/resourcemanager/api.yaml
+++ b/products/resourcemanager/api.yaml
@@ -16,7 +16,7 @@ name: Google Cloud Resource Manager
 prefix: gresourcemanager
 versions:
   - !ruby/object:Api::Product::Version
-    name: v1
+    name: ga
     base_url: https://cloudresourcemanager.googleapis.com/v1/
 scopes:
   # All access is needed to create projects.

--- a/products/spanner/api.yaml
+++ b/products/spanner/api.yaml
@@ -16,7 +16,7 @@ name: Google Spanner
 prefix: gspanner
 versions:
   - !ruby/object:Api::Product::Version
-    name: v1
+    name: ga
     base_url: https://spanner.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/spanner.admin

--- a/products/sql/api.yaml
+++ b/products/sql/api.yaml
@@ -16,7 +16,7 @@ name: Google Cloud SQL
 prefix: gsql
 versions:
   - !ruby/object:Api::Product::Version
-    name: v1
+    name: ga
     base_url: https://www.googleapis.com/sql/v1beta4/
 scopes:
   - https://www.googleapis.com/auth/sqlservice.admin

--- a/products/storage/api.yaml
+++ b/products/storage/api.yaml
@@ -16,7 +16,7 @@ name: Google Cloud Storage
 prefix: gstorage
 versions:
   - !ruby/object:Api::Product::Version
-    name: v1
+    name: ga
     base_url: https://www.googleapis.com/storage/v1/
 scopes:
   - https://www.googleapis.com/auth/devstorage.full_control

--- a/spec/data/good-export-file.yaml
+++ b/spec/data/good-export-file.yaml
@@ -16,7 +16,7 @@ name: My Product
 prefix: myproduct
 versions:
   - !ruby/object:Api::Product::Version
-    name: v1
+    name: ga
     base_url: http://myproduct.google.com/api
 scopes:
   - http://scope-to-my-api/

--- a/spec/data/good-file.yaml
+++ b/spec/data/good-file.yaml
@@ -16,7 +16,7 @@ name: My Product
 prefix: myproduct
 versions:
   - !ruby/object:Api::Product::Version
-    name: v1
+    name: ga
     base_url: http://myproduct.google.com/api/
     default: true
   - !ruby/object:Api::Product::Version

--- a/spec/data/good-longuri.yaml
+++ b/spec/data/good-longuri.yaml
@@ -16,7 +16,7 @@ name: My Product
 prefix: myproduct
 versions:
   - !ruby/object:Api::Product::Version
-    name: v1
+    name: ga
     base_url: http://myproduct.google.com/myapi/v123
 scopes:
   - http://scope-to-my-api/

--- a/spec/data/good-multi-file.yaml
+++ b/spec/data/good-multi-file.yaml
@@ -16,7 +16,7 @@ name: My Product
 prefix: multiproduct
 versions:
   - !ruby/object:Api::Product::Version
-    name: v1
+    name: ga
     base_url: http://myproduct.google.com/api
 scopes:
   - http://scope-to-my-api/

--- a/spec/data/good-multi2-file.yaml
+++ b/spec/data/good-multi2-file.yaml
@@ -16,7 +16,7 @@ name: My Product
 prefix: multiproduct
 versions:
   - !ruby/object:Api::Product::Version
-    name: v1
+    name: ga
     base_url: http://myproduct.google.com/api
 scopes:
   - http://scope-to-my-api/

--- a/spec/data/good-single-file.yaml
+++ b/spec/data/good-single-file.yaml
@@ -16,7 +16,7 @@ name: My Product
 prefix: myproduct
 versions:
   - !ruby/object:Api::Product::Version
-    name: v1
+    name: ga
     base_url: http://myproduct.google.com/api
 scopes:
   - http://scope-to-my-api/

--- a/spec/data/good-single-readonly-file.yaml
+++ b/spec/data/good-single-readonly-file.yaml
@@ -16,7 +16,7 @@ name: My Product
 prefix: myproduct
 versions:
   - !ruby/object:Api::Product::Version
-    name: v1
+    name: ga
     base_url: http://myproduct.google.com/api
 scopes:
   - http://scope-to-my-api/

--- a/spec/data/resourceref-missingimports.yaml
+++ b/spec/data/resourceref-missingimports.yaml
@@ -15,7 +15,7 @@
 name: My Product
 prefix: myproduct
 versions:
-  - name: v1
+  - name: ga
     base_url: http://myproduct.google.com/api
 scopes:
   - http://scope-to-my-api/

--- a/spec/data/resourceref-missingresource.yaml
+++ b/spec/data/resourceref-missingresource.yaml
@@ -15,7 +15,7 @@
 name: My Product
 prefix: myproduct
 versions:
-  - name: v1
+  - name: ga
     base_url: http://myproduct.google.com/api
 scopes:
   - http://scope-to-my-api/

--- a/spec/product_spec.rb
+++ b/spec/product_spec.rb
@@ -25,7 +25,7 @@ describe Api::Product do
         product('name: "foo"',
                 'versions:',
                 '  - !ruby/object:Api::Product::Version',
-                '    name: v1',
+                '    name: ga',
                 '    base_url: "http://foo/var/"',
                 'objects:',
                 '  - !ruby/object:Api::Resource',
@@ -74,7 +74,7 @@ describe Api::Product do
                 'prefix: "bar"',
                 'versions:',
                 '  - !ruby/object:Api::Product::Version',
-                '    name: v1',
+                '    name: ga',
                 '    base_url: "http://foo/var/v1"',
                 '    default: true',
                 '  - !ruby/object:Api::Product::Version',
@@ -109,7 +109,7 @@ describe Api::Product do
                 'prefix: "bar"',
                 'versions:',
                 '  - !ruby/object:Api::Product::Version',
-                '    name: v1',
+                '    name: ga',
                 '    base_url: "http://foo/var/v1"',
                 '  - !ruby/object:Api::Product::Version',
                 '    name: beta',
@@ -140,7 +140,7 @@ describe Api::Product do
                 'prefix: "bar"',
                 'versions:',
                 '  - !ruby/object:Api::Product::Version',
-                '    name: v1',
+                '    name: ga',
                 '    base_url: "baz"').validate
       end
     end
@@ -154,7 +154,7 @@ describe Api::Product do
                 'prefix: "bar"',
                 'versions:',
                 '  - !ruby/object:Api::Product::Version',
-                '    name: v1',
+                '    name: ga',
                 '    base_url: "baz"',
                 'objects:',
                 '  - bah. bad object!').validate

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -24,9 +24,9 @@ describe Api::Resource do
       product.objects.find { |o| o.name == 'AnotherResource' }
     end
 
-    context 'v1' do
+    context 'ga' do
       it do
-        version = product.version_obj('v1')
+        version = product.version_obj('ga')
         subject.exclude_if_not_in_version(version)
         is_expected.not_to(contain_property_with_name('beta-property'))
         is_expected.to(contain_property_with_name('property1'))


### PR DESCRIPTION
Adding base branch flag to Ansible tests. This turns on some additional tests on the Ansible linter system.

(It's super flakey because it doesn't always recognize git repos properly, so I'm mostly doing this to see what happens)


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
Adding base branch flag to Ansible tests
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-sql]
### [chef-storage]
## [ansible]
