### PR TITLE
Add create/delete urls and verbs

### DIFF
--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -157,8 +157,13 @@ def main():
                 changed = True
         else:
 <%
+  if object.delete_url.nil?
+    delete_url = 'self_link(module)'
+  else
+    delete_url = 'delete_link(module)'
+  end
   method = method_call('delete', [
-                                   'module', 'self_link(module)',
+                                   'module', delete_url,
                                    ('kind' if object.kind?),
                                    ('fetch' if object.access_api_results)
                                  ])
@@ -169,11 +174,14 @@ def main():
     else:
         if state == 'present':
 <%
-  if object.create_verb.nil? || object.create_verb == :POST
-    create_link = 'collection(module)'
+  if !object.create_url.nil?
+    create_link = 'create_link(module)'
+  elsif object.create_verb.nil? || object.create_verb == :POST
+      create_link = 'collection(module)'
   elsif object.create_verb == :PUT
-    create_link = 'self_link(module)'
+      create_link = 'self_link(module)'
   end
+
   create_verb = ".#{object.create_verb.to_s.downcase}"
   method = method_call('create', ['module', create_link,
                                   ('kind' if object.kind?)])
@@ -262,10 +270,15 @@ def main():
 <% if object.delete.nil? -%>
     auth = GcpSession(module, <%= quote_string(prod_name) -%>)
 <%
+  delete_verb = 'delete'
+  unless object.delete_verb.nil?
+    delete_verb = object.delete_verb.to_s.downcase
+  end
+
   method = method_call(
     object.async ? 'wait_for_operation' : 'return_if_object',
     ['module',
-     method_call("auth.delete", ['link']),
+     method_call("auth.#{delete_verb}", ['link']),
      ('kind' if !object.async && object.kind?)
    ]
   )
@@ -334,6 +347,12 @@ def unwrap_resource(result, module):
 <%= lines(compile('templates/ansible/transport.erb'), 2) -%>
 <%= lines(emit_link('self_link', build_url(object.self_link_url), object), 2) -%>
 <%= lines(emit_link('collection', build_url(object.collection_url), object), 2) -%>
+<%- unless object.create_url.nil? -%>
+<%=lines(emit_link('create_link', build_url(object.full_create_url), object), 2)-%>
+<% end -%>
+<% unless object.delete_url.nil? -%>
+<%= lines(emit_link('delete_link', build_url(object.full_delete_url), object), 2) -%>
+<% end -%>
 <%=
   lines(method_decl('return_if_object', ['module', 'response',
                                          ('kind' if object.kind?)]))

--- a/templates/chef/resource.erb
+++ b/templates/chef/resource.erb
@@ -159,11 +159,14 @@ module Google
             compute_changes.each { |log| puts "    - #{log.strip}\n" }
 <% if object&.handlers&.create.nil? -%>
 <%
-     if object.create_verb.nil? || object.create_verb == :POST
+     if !object.create_url.nil?
+       body_new = 'create_link(@new_resource)'
+     elsif object.create_verb.nil? || object.create_verb == :POST
        body_new = 'collection(@new_resource)'
      elsif object.create_verb == :PUT
        body_new = 'self_link(@new_resource)'
      end
+
      request_new = ["::Google::#{product_ns}::Network",
                     "#{object.create_verb.to_s.capitalize}"
                    ].join('::')
@@ -301,8 +304,20 @@ module Google
   ], 10, 0))
 -%>
 <% if object&.handlers&.delete.nil? -%>
-            delete_req = ::Google::<%= product_ns -%>::Network::Delete.new(
-              self_link(@new_resource), fetch_auth(@new_resource)
+<%
+     request_new = "::Google::#{product_ns}::Network::Delete"
+     if object.delete_verb == :POST
+       request_new = "::Google::#{product_ns}::Network::Post"
+     end
+
+     if object.delete_url.nil?
+        body_new = 'self_link(@new_resource)'
+     else
+        body_new = 'delete_link(@new_resource)'
+     end
+-%>
+            delete_req = <%= request_new -%>.new(
+              <%= body_new -%>, fetch_auth(@new_resource)
             )
 <%   unless object.async -%>
 <%     obj_kind = object.kind? ? ", '#{object.kind}'" : '' -%>
@@ -596,6 +611,12 @@ module Google
   lines(indent(emit_link('self_link', object.handlers.self_link, true), 8), 1)
 -%>
 <% end # object&.handlers&.self_link.nil? -%>
+<%- unless object.create_url.nil? -%>
+<%= lines(indent(emit_link('create_link', build_url(object.full_create_url), true), 8), 1)-%>
+<%- end # object.create_url.nil? -%>
+<%- unless object.delete_url.nil? -%>
+<%= lines(indent(emit_link('delete_link', build_url(object.full_delete_url), true), 8), 1)-%>
+<%- end # object.delete_url.nil? -%>
 <% if object&.handlers&.return_if_object.nil? -%>
 <%= lines(indent(compile('templates/return_if_object.erb'), 8)) %>
 <% else # object&.handlers&.return_if_object.nil? -%>

--- a/templates/puppet/resource.erb
+++ b/templates/puppet/resource.erb
@@ -239,7 +239,9 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
     @created = true
 <% if object&.handlers&.create.nil? -%>
 <%
-     if object.create_verb.nil? || object.create_verb == :POST
+     if !object.create_url.nil?
+        body_new = 'create_link(@resource)'
+     elsif object.create_verb.nil? || object.create_verb == :POST
        body_new = 'collection(@resource)'
      elsif object.create_verb == :PUT
        body_new = 'self_link(@resource)'
@@ -278,12 +280,23 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
     debug('destroy')
     @deleted = true
 <% if object&.handlers&.delete.nil? -%>
-<%   dele_new = "Google::#{product_ns}::Network::Delete.new" -%>
+<%
+     if object.delete_verb.nil? || object.delete_verb == :DELETE
+       request_new = "Google::#{product_ns}::Network::Delete.new"
+     elsif object.delete_verb == :POST
+       request_new = "Google::#{product_ns}::Network::Post.new"
+     end
+     if object.delete_url.nil?
+        body_new = 'self_link(@resource)'
+     else
+        body_new = 'delete_url(@resource)'
+     end
+-%>
 <%=
-  lines(indent_list(["delete_req = #{dele_new}(self_link(@resource)"].concat(
+  lines(indent_list(["delete_req = #{request_new}(#{body_new}"].concat(
     indent([
       'fetch_auth(@resource))'
-    ], dele_new.length + 14).split("\n") # 14 = 'delete_req = ' + '('
+    ], request_new.length + 14).split("\n") # 14 = 'delete_req = ' + '('
   ), 4))
 -%>
 <% kind_param = object.kind? ? ", '#{object.kind}'" : '' -%>
@@ -513,6 +526,20 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
   )
 -%>
 <% end # object&.handlers&.self_link.nil? -%>
+<% unless object.create_url.nil? -%>
+<%=
+  lines_before(
+    lines(indent(emit_link('create_link', build_url(object.full_create_url), true), 2))
+  )
+-%>
+<% end # object.create_url.nil? -%>
+<% unless object.delete_url.nil? -%>
+<%=
+  lines_before(
+    lines(indent(emit_link('delete_link', build_url(object.full_delete_url), true), 2))
+  )
+-%>
+<% end # object.delete_url.nil? -%>
 <% if object&.handlers&.return_if_object.nil? -%>
 <%=
   lines_before(lines(indent(compile('templates/return_if_object.erb'), 2)))

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -129,13 +129,13 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 	defer mutexKV.Unlock(lockName)
 <% end -%>
 
-	url, err := replaceVars(d, config, "<%= build_url(object.collection_url) -%>")
+	url, err := replaceVars(d, config, "<%= build_url(object.full_create_url) -%>")
 	if err != nil {
 		return err
 	}
 
 	log.Printf("[DEBUG] Creating new <%= object.name -%>: %#v", obj)
-	res, err := Post(config, url, obj)
+	res, err := <%= object.create_verb.to_s.capitalize -%>(config, url, obj)
 	if err != nil {
 		return fmt.Errorf("Error creating <%= object.name -%>: %s", err)
 	}
@@ -418,14 +418,14 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
 	defer mutexKV.Unlock(lockName)
 <% end -%>
 
-	url, err := replaceVars(d, config, "<%= build_url(object.self_link_url) -%>")
+	url, err := replaceVars(d, config, "<%= build_url(object.full_delete_url) -%>")
 	if err != nil {
 		return err
 	}
 
 <%= lines(compile(object.custom_code.pre_delete)) if object.custom_code.pre_delete -%>
 	log.Printf("[DEBUG] Deleting <%= object.name -%> %q", d.Id())
-	res, err := Delete(config, url)
+	res, err := <%= object.delete_verb.to_s.capitalize -%>(config, url)
 	if err != nil {
 		return handleNotFoundError(err, d, "<%= object.name -%>")
 	}


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
* Add create_url, delete_url, delete_verb attributes to resources
* Fixed Terraform resource to use create_verb

Part 1 of changes to add signed URL keys; this shouldn't affect downstream repos. This was mostly tested by hand-generating using config for signed URL keys (to be included in a follow-up PR). 
Note if-blocks guarding changes to ansible/puppet/chef are mostly to prevent changes to downstream repos. 
<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-sql]
### [chef-storage]
## [ansible]
