### PR TITLE
Remove request helpers from terraform resource

### DIFF
--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -135,7 +135,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 	}
 
 	log.Printf("[DEBUG] Creating new <%= object.name -%>: %#v", obj)
-	res, err := <%= object.create_verb.to_s.capitalize -%>(config, url, obj)
+	res, err := sendRequest(config, "<%= object.create_verb.to_s.upcase -%>", url, obj)
 	if err != nil {
 		return fmt.Errorf("Error creating <%= object.name -%>: %s", err)
 	}
@@ -187,7 +187,7 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	res, err := Get(config, url)
+	res, err := sendRequest(config, "GET", url, nil)
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("<%= resource_name -%> %q", d.Id()))
 	}
@@ -425,7 +425,7 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
 
 <%= lines(compile(object.custom_code.pre_delete)) if object.custom_code.pre_delete -%>
 	log.Printf("[DEBUG] Deleting <%= object.name -%> %q", d.Id())
-	res, err := <%= object.delete_verb.to_s.capitalize -%>(config, url)
+	res, err := sendRequest(config, "<%= object.delete_verb.to_s.upcase -%>", url, nil)
 	if err != nil {
 		return handleNotFoundError(err, d, "<%= object.name -%>")
 	}

--- a/templates/terraform/transport.go
+++ b/templates/terraform/transport.go
@@ -30,22 +30,6 @@ func isEmptyValue(v reflect.Value) bool {
 	return false
 }
 
-func Post(config *Config, rawurl string, body map[string]interface{}) (map[string]interface{}, error) {
-	return sendRequest(config, "POST", rawurl, body)
-}
-
-func Get(config *Config, rawurl string) (map[string]interface{}, error) {
-	return sendRequest(config, "GET", rawurl, nil)
-}
-
-func Put(config *Config, rawurl string, body map[string]interface{}) (map[string]interface{}, error) {
-	return sendRequest(config, "PUT", rawurl, body)
-}
-
-func Delete(config *Config, rawurl string) (map[string]interface{}, error) {
-	return sendRequest(config, "DELETE", rawurl, nil)
-}
-
 func sendRequest(config *Config, method, rawurl string, body map[string]interface{}) (map[string]interface{}, error) {
 	reqHeaders := make(http.Header)
 	reqHeaders.Set("User-Agent", config.userAgent)


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
- Remove request helper methods
- Use sendRequest in resource template

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Remove request helper methods.

Since we added custom verbs for a lot of resources, we should just use sendRequest directly.
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
