### PR TITLE
Method calls on P/C

### DIFF
--- a/google/python_utils.rb
+++ b/google/python_utils.rb
@@ -35,5 +35,17 @@ module Google
         raise "Unsupported Python literal #{value}"
       end
     end
+
+    # Generates a method declaration with function name `name` and args `args`
+    # Arguments may have nils and will be ignored.
+    def method_decl(name, args)
+      "def #{name}(#{args.compact.join(', ')}):"
+    end
+
+    # Generates a method call to function name `name` and args `args`
+    # Arguments may have nils and will be ignored.
+    def method_call(name, args)
+      "#{name}(#{args.compact.join(', ')})"
+    end
   end
 end

--- a/google/ruby_utils.rb
+++ b/google/ruby_utils.rb
@@ -33,5 +33,32 @@ module Google
         raise "Unsupported Ruby literal #{value}"
       end
     end
+
+    def method_decl(name, args)
+      ["def #{name}", ("(#{args.compact.join(', ')})" unless args.empty?)].compact.join
+    end
+
+    # rubocop:disable Metrics/AbcSize
+    def method_call(name, args, indent = 0)
+      args = args.compact
+      format([
+               # All on one line.
+               [
+                 [name.to_s, ("(#{args.join(', ')})" unless args.empty?)].compact.join
+               ],
+               # All but first on one line.
+               [
+                 [name.to_s, ("(#{args[0..-1].join(', ')}" unless args.empty?)].compact.join,
+                 "#{indent(args.last, indent + name.length + 2)})"
+               ],
+               # All on separate lines.
+               [
+                 "#{name}(#{args.first},",
+                 indent_list(args.slice(1..-2), indent + name.length + 1, true),
+                 indent("#{args.last})", indent + name.length + 1)
+               ]
+             ], 0, indent)
+    end
+    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -214,18 +214,6 @@ module Provider
         "[#{path.split('/').map { |x| "'#{x}'" }.join(', ')}]"
       end
 
-      # Generates a method declaration with function name `name` and args `args`
-      # Arguments may have nils and will be ignored.
-      def method_decl(name, args)
-        "def #{name}(#{args.compact.join(', ')}):"
-      end
-
-      # Generates a method call to function name `name` and args `args`
-      # Arguments may have nils and will be ignored.
-      def method_call(name, args)
-        "#{name}(#{args.compact.join(', ')})"
-      end
-
       # TODO(alexstephen): Standardize on one version and move to provider/core
       # https://github.com/GoogleCloudPlatform/magic-modules/issues/30
       def wrap_field(field, spaces)

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -479,7 +479,7 @@ module Provider
         # All on separate lines.
         [
           "#{name}(#{args.first},",
-          indent_list(args.slice(1..-2), indent + name.length + 1),
+          indent_list(args.slice(1..-2), indent + name.length + 1, args.slice(1..-2).length() <= 1),
           indent("#{args.last})", indent + name.length + 1)
         ]
       ], 0, indent)

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -480,8 +480,7 @@ module Provider
                # All on separate lines.
                [
                  "#{name}(#{args.first},",
-                 indent_list(args.slice(1..-2), indent + name.length + 1,
-                             args.slice(1..-2).length <= 1),
+                 indent_list(args.slice(1..-2), indent + name.length + 1, true),
                  indent("#{args.last})", indent + name.length + 1)
                ]
              ], 0, indent)

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -464,26 +464,29 @@ module Provider
       ["def #{name}", ("(#{args.compact.join(', ')})" unless args.empty?)].compact.join
     end
 
+    # rubocop:disable Metrics/AbcSize
     def method_call(name, args, indent = 0)
       args = args.compact
       format([
-        # All on one line.
-        [
-          ["#{name}", ("(#{args.join(', ')})" unless args.empty?)].compact.join
-        ],
-        # All but first on one line.
-        [
-          ["#{name}", ("(#{args[0..-1].join(', ')}" unless args.empty?)].compact.join,
-          "#{indent(args.last, indent + name.length + 2)})"
-        ],
-        # All on separate lines.
-        [
-          "#{name}(#{args.first},",
-          indent_list(args.slice(1..-2), indent + name.length + 1, args.slice(1..-2).length() <= 1),
-          indent("#{args.last})", indent + name.length + 1)
-        ]
-      ], 0, indent)
+               # All on one line.
+               [
+                 [name.to_s, ("(#{args.join(', ')})" unless args.empty?)].compact.join
+               ],
+               # All but first on one line.
+               [
+                 [name.to_s, ("(#{args[0..-1].join(', ')}" unless args.empty?)].compact.join,
+                 "#{indent(args.last, indent + name.length + 2)})"
+               ],
+               # All on separate lines.
+               [
+                 "#{name}(#{args.first},",
+                 indent_list(args.slice(1..-2), indent + name.length + 1,
+                             args.slice(1..-2).length <= 1),
+                 indent("#{args.last})", indent + name.length + 1)
+               ]
+             ], 0, indent)
     end
+    # rubocop:enable Metrics/AbcSize
 
     def emit_rubo_pair(file_name, name, opts = {})
       [

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -461,25 +461,27 @@ module Provider
     end
 
     def method_decl(name, args)
-      ["def #{name}", ("(#{args.join(', ')})" unless args.empty?)].compact.join
+      ["def #{name}", ("(#{args.compact.join(', ')})" unless args.empty?)].compact.join
     end
 
     def method_call(name, args, indent = 0)
+      args = args.compact
       format([
         # All on one line.
         [
-          ["#{name}", ("(#{args.compact.join(', ')})" unless args.empty?)].compact.join
+          ["#{name}", ("(#{args.join(', ')})" unless args.empty?)].compact.join
         ],
         # All but first on one line.
         [
-          ["#{name}", ("(#{args.compact[0..-1].join(', ')}" unless args.empty?)].compact.join,
+          ["#{name}", ("(#{args[0..-1].join(', ')}" unless args.empty?)].compact.join,
           "#{indent(args.last, indent + name.length + 2)})"
         ],
-        # All but first two on one line.
+        # All on separate lines.
         [
-          ["#{name}", ("(#{args.compact[0..-3].join(', ')}" unless args.empty?)].compact.join,
-          "#{indent(args.compact[-2..args.length].join(', '), indent + name.length + 1)})"
-        ],
+          "#{name}(#{args.first},",
+          indent_list(args.slice(1..-2), indent + name.length + 1),
+          indent("#{args.last})", indent + name.length + 1)
+        ]
       ], 0, indent)
     end
 

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -466,13 +466,16 @@ module Provider
 
     def method_call(name, args, indent = 0)
       format([
+        # All on one line.
         [
           ["#{name}", ("(#{args.compact.join(', ')})" unless args.empty?)].compact.join
         ],
+        # All but first on one line.
         [
           ["#{name}", ("(#{args.compact[0..-1].join(', ')}" unless args.empty?)].compact.join,
           "#{indent(args.last, indent + name.length + 2)})"
         ],
+        # All but first two on one line.
         [
           ["#{name}", ("(#{args.compact[0..-3].join(', ')}" unless args.empty?)].compact.join,
           "#{indent(args.compact[-2..args.length].join(', '), indent + name.length + 1)})"

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -470,8 +470,12 @@ module Provider
           ["#{name}", ("(#{args.compact.join(', ')})" unless args.empty?)].compact.join
         ],
         [
-          ["#{name}", ("(#{args.compact.drop(1).join(', ')}" unless args.empty?)].compact.join,
-           "#{indent(args.last, indent + name.length + 2)})"
+          ["#{name}", ("(#{args.compact[0..-1].join(', ')}" unless args.empty?)].compact.join,
+          "#{indent(args.last, indent + name.length + 2)})"
+        ],
+        [
+          ["#{name}", ("(#{args.compact[0..-3].join(', ')}" unless args.empty?)].compact.join,
+          "#{indent(args.compact[-2..args.length].join(', '), indent + name.length + 1)})"
         ],
       ], 0, indent)
     end

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -464,6 +464,18 @@ module Provider
       ["def #{name}", ("(#{args.join(', ')})" unless args.empty?)].compact.join
     end
 
+    def method_call(name, args, indent = 0)
+      format([
+        [
+          ["#{name}", ("(#{args.compact.join(', ')})" unless args.empty?)].compact.join
+        ],
+        [
+          ["#{name}", ("(#{args.compact.drop(1).join(', ')}" unless args.empty?)].compact.join,
+           "#{indent(args.last, indent + name.length + 2)})"
+        ],
+      ], 0, indent)
+    end
+
     def emit_rubo_pair(file_name, name, opts = {})
       [
         emit_rubo_item(file_name, name, :disabled, opts),

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -460,33 +460,6 @@ module Provider
       ].compact.join("\n")
     end
 
-    def method_decl(name, args)
-      ["def #{name}", ("(#{args.compact.join(', ')})" unless args.empty?)].compact.join
-    end
-
-    # rubocop:disable Metrics/AbcSize
-    def method_call(name, args, indent = 0)
-      args = args.compact
-      format([
-               # All on one line.
-               [
-                 [name.to_s, ("(#{args.join(', ')})" unless args.empty?)].compact.join
-               ],
-               # All but first on one line.
-               [
-                 [name.to_s, ("(#{args[0..-1].join(', ')}" unless args.empty?)].compact.join,
-                 "#{indent(args.last, indent + name.length + 2)})"
-               ],
-               # All on separate lines.
-               [
-                 "#{name}(#{args.first},",
-                 indent_list(args.slice(1..-2), indent + name.length + 1, true),
-                 indent("#{args.last})", indent + name.length + 1)
-               ]
-             ], 0, indent)
-    end
-    # rubocop:enable Metrics/AbcSize
-
     def emit_rubo_pair(file_name, name, opts = {})
       [
         emit_rubo_item(file_name, name, :disabled, opts),

--- a/templates/async.erb
+++ b/templates/async.erb
@@ -2,26 +2,17 @@ def expand_variables(template, var_data, extra_data = {})
   self.class.expand_variables(template, var_data, extra_data)
 end
 
-<% if object.kind? -%>
-def fetch_resource(resource, self_link, kind)
-  self.class.fetch_resource(resource, self_link, kind)
+<%= method_decl('fetch_resource', ['resource', 'self_link',
+                                   ('kind' if object.kind?)]) %>
+<%= indent(method_call('self.class.fetch_resource', ['resource', 'self_link',
+                                              ('kind' if object.kind?)]), 2) %>
 end
-<% else # object.kind? -%>
-def fetch_resource(resource, self_link)
-  self.class.fetch_resource(resource, self_link)
-end
-<% end # object.kind? -%>
 
 <%= lines(emit_link('async_op_url', build_url(object.async_operation_url, true), false,
                     true)) -%>
 
 def wait_for_operation(response, resource)
-<% if object.kind? -%>
-<%   op_kind = object.async.operation.kind -%>
-  op_result = return_if_object(response, '<%= op_kind -%>')
-<% else # object.kind? -%>
-  op_result = return_if_object(response)
-<% end # object.kind? -%>
+  op_result = <%= method_call('return_if_object', ['response', ("'#{object.async.operation.kind}'" if object.kind?)]) %>
   return if op_result.nil?
 <%   stat_path = Google::HashUtils.path2navigate(object.async.status.path) -%>
   status = ::Google::HashUtils.navigate(op_result, <%= stat_path -%>)
@@ -105,7 +96,7 @@ def wait_for_completion(status, op_result, resource)
     raise "Invalid result '#{status}' on <%= object.out_name -%>." \
       unless %w[<%= allowed_states.join(' ') -%>].include?(status)
 <% if object.kind? -%>
-    op_result = fetch_resource(resource, op_uri, '<%= op_kind -%>')
+    op_result = fetch_resource(resource, op_uri, '<%= object.async.operation.kind -%>')
 <% else # object.kind? -%>
     op_result = fetch_resource(resource, op_uri)
 <% end # object.kind? -%>

--- a/templates/async.erb
+++ b/templates/async.erb
@@ -51,34 +51,9 @@ def wait_for_operation(response, resource)
 -%>
 <% else # object.self_link_query.nil? -%>
   wait_for_completion status, op_result, resource
-<% obj_kind = object.kind? ? "'#{object.kind}'," : '' -%>
-<%=
-  lines(format(
-    [
-      [
-        "fetch_wrapped_resource(resource, #{obj_kind}",
-        ("'#{object.self_link_query.kind}'," if object.self_link_query.kind?),
-        "'#{object.self_link_query.items}')"
-      ].join(' '),
-      [
-        [
-         "fetch_wrapped_resource(resource, #{obj_kind}",
-         ("'#{object.self_link_query.kind}'," if object.self_link_query.kind?)
-        ].join(' '),
-        indent([
-          "'#{object.self_link_query.items}')"
-        ], 23) # 23 = align with ( previous line
-      ],
-      [
-        "fetch_wrapped_resource(resource, #{obj_kind}",
-        indent([
-          "'#{object.self_link_query.kind}',",
-          "'#{object.self_link_query.items}')"
-        ], 23) # 31 = align with ( previous line
-      ]
-    ], 2, inside_indent
-  ))
--%>
+<%= indent(method_call('fetch_wrapped_resource', ['resource', ("'#{object.kind}'" if object.kind?),
+                                           ("'#{object.self_link_query.kind}'" if object.self_link_query.kind?),
+                                           "'#{object.self_link_query.items}'"], 2), 2) %>
 <% end # object.self_link_query.nil? -%>
 end
 
@@ -95,11 +70,7 @@ def wait_for_completion(status, op_result, resource)
 <%   allowed_states = object.async.status.allowed -%>
     raise "Invalid result '#{status}' on <%= object.out_name -%>." \
       unless %w[<%= allowed_states.join(' ') -%>].include?(status)
-<% if object.kind? -%>
-    op_result = fetch_resource(resource, op_uri, '<%= object.async.operation.kind -%>')
-<% else # object.kind? -%>
-    op_result = fetch_resource(resource, op_uri)
-<% end # object.kind? -%>
+    op_result = <%= method_call('fetch_resource', ['resource', 'op_uri', ("'#{object.async.operation.kind}'" if object.kind?)]) %>
     status = ::Google::HashUtils.navigate(op_result, <%= stat_path -%>)
   end
   op_result

--- a/templates/chef/resource.erb
+++ b/templates/chef/resource.erb
@@ -282,10 +282,9 @@ module Google
         fetch = <%= method_call('fetch_resource', ['@new_resource', 'self_link(@new_resource)',
                                                    ("'#{object.kind}'" if object.kind?)], 16) %>
 <% else # object.self_link_query.nil? -%>
-<% obj_kind = object.kind? ? "'#{object.kind}'," : '' -%>
         fetch = <%= method_call('fetch_wrapped_resource', ['@new_resource', ("'#{object.kind}'" if object.kind?),
-                                                           ("'#{object.self_link_query.kind}'" if object.self_link_query.kind.nil?),
-                                                           "'#{object.self_link_query.items}'"], 8) %>
+                                                           "'#{object.self_link_query.kind}'",
+                                                           "'#{object.self_link_query.items}'"], 16) %>
 <% end # object.self_link_query.nil? -%>
         unless fetch.nil?
 <%=
@@ -603,7 +602,7 @@ module Google
                   .authorization
         end
 
-<%= indent(method_decl('fetch_resource', ['resource', 'self_link', ('kind' if object.kind?)], 8), 8) %>
+<%= indent(method_decl('fetch_resource', ['resource', 'self_link', ('kind' if object.kind?)]), 8) %>
 <%= indent(method_call('self.class.fetch_resource', ['resource', 'self_link', ('kind' if object.kind?)], 10), 10) %>
         end
 

--- a/templates/chef/resource.erb
+++ b/templates/chef/resource.erb
@@ -135,12 +135,8 @@ module Google
 <% if object&.handlers&.prefetch  -%>
 <%= lines(indent(object.handlers.prefetch, 8)) -%>
 <% else # object.handlers -%>
-<% if object.kind? -%>
-        fetch = fetch_resource(@new_resource, self_link(@new_resource),
-                               '<%= object.kind -%>')
-<% else # object.kind? -%>
-        fetch = fetch_resource(@new_resource, self_link(@new_resource))
-<% end # object.kind? -%>
+        fetch = <%= method_call('fetch_resource', ['@new_resource', 'self_link(@new_resource)',
+                                                   ("'#{object.kind}'" if object.kind?)], 16) %>
 <% end # object.handlers.prefetch -%>
 <% else # object.self_link_query.nil? -%>
         fetch = fetch_wrapped_resource(@new_resource, '<%= object.kind -%>',
@@ -283,22 +279,13 @@ module Google
 
       action :delete do
 <% if object.self_link_query.nil? -%>
-<% if object.kind? -%>
-        fetch = fetch_resource(@new_resource, self_link(@new_resource),
-                               '<%= object.kind -%>')
-<% else # object.kind? -%>
-        fetch = fetch_resource(@new_resource, self_link(@new_resource))
-<% end # object.kind? -%>
+        fetch = <%= method_call('fetch_resource', ['@new_resource', 'self_link(@new_resource)',
+                                                   ("'#{object.kind}'" if object.kind?)], 16) %>
 <% else # object.self_link_query.nil? -%>
 <% obj_kind = object.kind? ? "'#{object.kind}'," : '' -%>
-<% if object.self_link_query.kind.nil? -%>
-        fetch = fetch_wrapped_resource(@new_resource, <%= obj_kind %>
-                                       '<%= object.self_link_query.items -%>')
-<% else #object.self_link_query.kind.nil? -%>
-        fetch = fetch_wrapped_resource(@new_resource, <%= obj_kind %>
-                                       '<%= object.self_link_query.kind -%>',
-                                       '<%= object.self_link_query.items -%>')
-<% end #object.self_link_query.kind.nil? -%>
+        fetch = <%= method_call('fetch_wrapped_resource', ['@new_resource', ("'#{object.kind}'" if object.kind?),
+                                                           ("'#{object.self_link_query.kind}'" if object.self_link_query.kind.nil?),
+                                                           "'#{object.self_link_query.items}'"], 8) %>
 <% end # object.self_link_query.nil? -%>
         unless fetch.nil?
 <%=
@@ -616,15 +603,9 @@ module Google
                   .authorization
         end
 
-<% if object.kind? -%>
-        def fetch_resource(resource, self_link, kind)
-          self.class.fetch_resource(resource, self_link, kind)
+<%= indent(method_decl('fetch_resource', ['resource', 'self_link', ('kind' if object.kind?)], 8), 8) %>
+<%= indent(method_call('self.class.fetch_resource', ['resource', 'self_link', ('kind' if object.kind?)], 10), 10) %>
         end
-<% else -%>
-        def fetch_resource(resource, self_link)
-          self.class.fetch_resource(resource, self_link)
-        end
-<% end -%>
 
         def debug(message)
           Chef::Log.debug(message)

--- a/templates/puppet/resource.erb
+++ b/templates/puppet/resource.erb
@@ -86,11 +86,10 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
                                                         "'#{object.self_link_query.items}'"
                                                        ], 14) %>
 <%   end # object.self_link_query.nil? -%>
-<%   if has_input -%>
-      resource.provider = present(name, fetch, resource) unless fetch.nil?
-<%   else # has_input -%>
-      resource.provider = present(name, fetch) unless fetch.nil?
-<%   end # has_input -%>
+      resource.provider = <%= method_call('present', ['name',
+                                                      'fetch',
+                                                      ('resource' if has_input)
+      ]) -%> unless fetch.nil?
 <%   unless object.exports.nil? -%>
       Google::ObjectStore.instance.add(:<%= object.out_name -%>, resource)
 <%   end # object.exports.nil? -%>

--- a/templates/puppet/resource.erb
+++ b/templates/puppet/resource.erb
@@ -77,37 +77,14 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
       fetch = <%= method_call('fetch_resource', ['resource',
                                                  'self_link(resource)',
                                                  ("'#{object.kind}'" if object.kind?)
-      ], 14) %>
+                                                ], 14) %>
 <%   else # object.self_link_query.nil? -%>
-<%
-  self_link_kind = !object.self_link_query.kind.nil? ? \
-  "'#{object.self_link_query.kind}'," : ''
-
-  obj_kind = object.kind? ? "'#{object.kind}'," : ''
--%>
-<%=
-  lines(format(
-    [
-      ["fetch = fetch_wrapped_resource(resource, #{obj_kind}",
-       "#{self_link_kind}",
-       "'#{object.self_link_query.items}')"].join(' '),
-      [
-        ["fetch = fetch_wrapped_resource(resource, #{obj_kind}",
-         "#{self_link_kind}"].join(' '),
-        indent([
-          "'#{object.self_link_query.items}')"
-        ], 31) # 31 = align with ( previous line
-      ],
-      [
-        "fetch = fetch_wrapped_resource(resource, #{obj_kind}",
-        indent([
-          "#{self_link_kind}",
-          "'#{object.self_link_query.items}')"
-        ], 31) # 31 = align with ( previous line
-      ]
-    ], 6
-  ))
--%>
+      fetch = <%= method_call('fetch_wrapped_resource', ['resource',
+                                                        ("'#{object.kind}'" if object.kind?),
+                                                        ("'#{object.self_link_query.kind}'" \
+                                                          unless object.self_link_query.kind.nil?),
+                                                        "'#{object.self_link_query.items}'"
+                                                       ], 14) %>
 <%   end # object.self_link_query.nil? -%>
 <%   if has_input -%>
       resource.provider = present(name, fetch, resource) unless fetch.nil?

--- a/templates/puppet/resource.erb
+++ b/templates/puppet/resource.erb
@@ -74,20 +74,10 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
       debug("prefetch #{name}") if project.nil?
       debug("prefetch #{name} @ #{project}") unless project.nil?
 <%   if object.self_link_query.nil? -%>
-<%=
-  lines(format(
-    [
-      ('fetch = fetch_resource(resource, self_link(resource))' \
-       unless object.kind?),
-      ['fetch = fetch_resource(resource, self_link(resource),',
-       "'#{object.kind}')"].join(' '),
-      [
-        'fetch = fetch_resource(resource, self_link(resource),',
-        indent("'#{object.kind}')", 23) # 23 = align previous until (
-      ]
-    ].compact, 6
-  ))
--%>
+      fetch = <%= method_call('fetch_resource', ['resource',
+                                                 'self_link(resource)',
+                                                 ("'#{object.kind}'" if object.kind?)
+      ], 14) %>
 <%   else # object.self_link_query.nil? -%>
 <%
   self_link_kind = !object.self_link_query.kind.nil? ? \

--- a/templates/return_if_object.erb
+++ b/templates/return_if_object.erb
@@ -16,11 +16,7 @@ def self.return_if_object(response)
 <% if !object.decoder? -%>
   result = JSON.parse(response.body)
 <% else # !object.decoder? -%>
-<%   if object.kind? -%>
-  result = <%= object.transport.decoder -%>(response, kind)
-<%   else # object.kind? -%>
-  result = <%= object.transport.decoder -%>(response)
-<%   end # object.kind? -%>
+  result = <%= method_call(object.transport.decoder, ['response', ('kind' if object.kind?)]) %>
 <% end # !object.decoder? -%>
 <% end # object.transport.nil? -%>
   raise_if_errors result, %w[error errors], 'message'


### PR DESCRIPTION
We've got a bunch of format + if/else logic to handle this particular case:

What if I have a method call that needs 3 arguments in one case + just 2 in all other cases? What if adding this argument sometimes causes us to go > 100 characters? What if it's 4 arguments and 2 are optional?

Ansible solved this with the `method_decl` and `method_call` functions: Ruby functions that take in a method name and list of arguments and return either a function declaration or a method call. These functions can be given nil arguments that will be ignored and the functions handle all of the formatting issues (what if it's over 100 characters). Formatting function calls is pretty easy for a computer to do.

This is mostly a no-op change. There will be a couple of consistent P/C changes, but they're just formatting changes.


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
