### PR TITLE
Docs change for liens - resourcemanager -> resource_manager.

### DIFF
--- a/products/resourcemanager/terraform.yaml
+++ b/products/resourcemanager/terraform.yaml
@@ -30,7 +30,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
         name = "A very important project!"
       }
 
-      resource "google_resourcemanager_lien" "lien" {
+      resource "google_resource_manager_lien" "lien" {
         parent = "projects/${google_project.project.number}"
         restrictions = ["resourcemanager.projects.delete"]
         origin = "machine-readable-explanation"


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
This fixes https://github.com/terraform-providers/terraform-provider-google/issues/1897, a typo in documentation.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Fix documentation for resource manager lien.