### PR TITLE
Fix Terraform autoscaler tests disk image

### DIFF
--- a/templates/terraform/tests/resource_compute_autoscaler_test.go
+++ b/templates/terraform/tests/resource_compute_autoscaler_test.go
@@ -221,6 +221,11 @@ func testAccCheckComputeAutoscalerUpdated(n string, max int64) resource.TestChec
 
 func testAccComputeAutoscaler_scaffolding(it_name, tp_name, igm_name string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-9"
+	project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "foobar" {
 	name = "%s"
 	machine_type = "n1-standard-1"
@@ -228,7 +233,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		boot = true
 	}

--- a/templates/terraform/tests/resource_compute_region_autoscaler_test.go
+++ b/templates/terraform/tests/resource_compute_region_autoscaler_test.go
@@ -152,6 +152,11 @@ func testAccCheckComputeRegionAutoscalerUpdated(n string, max int64) resource.Te
 
 func testAccComputeRegionAutoscaler_basic(it_name, tp_name, igm_name, autoscaler_name string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-9"
+	project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "foobar" {
 	name = "%s"
 	machine_type = "n1-standard-1"
@@ -159,7 +164,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		boot = true
 	}
@@ -212,6 +217,11 @@ resource "google_compute_region_autoscaler" "foobar" {
 
 func testAccComputeRegionAutoscaler_update(it_name, tp_name, igm_name, autoscaler_name string) string {
 	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-9"
+	project = "debian-cloud"
+}
+
 resource "google_compute_instance_template" "foobar" {
 	name = "%s"
 	machine_type = "n1-standard-1"
@@ -219,7 +229,7 @@ resource "google_compute_instance_template" "foobar" {
 	tags = ["foo", "bar"]
 
 	disk {
-		source_image = "debian-cloud/debian-8-jessie-v20160803"
+		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		boot = true
 	}


### PR DESCRIPTION
Fix the upstream Terraform autoscaler tests disk image so we don't diff against Terraform in our PRs (or undo the changes awayfrom debian 8!)

-----------------------------------------------------------------
# [all]
This should be a no-op
## [terraform]
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
