### PR TITLE
Add beta attribute enableLogging for compute firewalls

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -803,6 +803,14 @@ objects:
           is unspecified, the firewall rule will be enabled.
         min_version: beta
         send_empty_value: true
+      - !ruby/object:Api::Type::Boolean
+        name: 'enableLogging'
+        description: |
+          This field denotes whether to enable logging for a particular
+          firewall rule. If logging is enabled, logs will be exported to
+          Stackdriver.
+        min_version: beta
+        send_empty_value: true
       - !ruby/object:Api::Type::Integer
         name: 'id'
         description: 'The unique identifier for the resource.'

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1285,6 +1285,8 @@ files: !ruby/object:Provider::Config::Files
       'templates/terraform/tests/resource_compute_address_test.go'
     'google/resource_compute_autoscaler_test.go':
       'templates/terraform/tests/resource_compute_autoscaler_test.go'
+    'google/resource_compute_firewall_test.go':
+      'templates/terraform/tests/resource_compute_firewall_test.go'
     'google/resource_compute_global_address_test.go':
       'templates/terraform/tests/resource_compute_global_address_test.go'
     'google/resource_compute_health_check_test.go':

--- a/templates/terraform/tests/resource_compute_firewall_test.go
+++ b/templates/terraform/tests/resource_compute_firewall_test.go
@@ -7,11 +7,17 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+
+	"strings"
+
+	computeBeta "google.golang.org/api/compute/v0.beta"
+	"google.golang.org/api/compute/v1"
 )
 
 func TestAccComputeFirewall_basic(t *testing.T) {
 	t.Parallel()
 
+	var firewall compute.Firewall
 	networkName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 	firewallName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 
@@ -22,6 +28,11 @@ func TestAccComputeFirewall_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccComputeFirewall_basic(networkName, firewallName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeFirewallExists(
+						"google_compute_firewall.foobar", &firewall),
+					testAccCheckComputeFirewallApiVersion(&firewall),
+				),
 			},
 			resource.TestStep{
 				ResourceName:      "google_compute_firewall.foobar",
@@ -35,6 +46,7 @@ func TestAccComputeFirewall_basic(t *testing.T) {
 func TestAccComputeFirewall_update(t *testing.T) {
 	t.Parallel()
 
+	var firewall compute.Firewall
 	networkName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 	firewallName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 
@@ -45,6 +57,11 @@ func TestAccComputeFirewall_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccComputeFirewall_basic(networkName, firewallName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeFirewallExists(
+						"google_compute_firewall.foobar", &firewall),
+					testAccCheckComputeFirewallApiVersion(&firewall),
+				),
 			},
 			{
 				ResourceName:      "google_compute_firewall.foobar",
@@ -53,6 +70,13 @@ func TestAccComputeFirewall_update(t *testing.T) {
 			},
 			resource.TestStep{
 				Config: testAccComputeFirewall_update(networkName, firewallName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeFirewallExists(
+						"google_compute_firewall.foobar", &firewall),
+					testAccCheckComputeFirewallPorts(
+						&firewall, "80-255"),
+					testAccCheckComputeFirewallApiVersion(&firewall),
+				),
 			},
 			{
 				ResourceName:      "google_compute_firewall.foobar",
@@ -61,6 +85,11 @@ func TestAccComputeFirewall_update(t *testing.T) {
 			},
 			resource.TestStep{
 				Config: testAccComputeFirewall_basic(networkName, firewallName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeFirewallExists(
+						"google_compute_firewall.foobar", &firewall),
+					testAccCheckComputeFirewallApiVersion(&firewall),
+				),
 			},
 			{
 				ResourceName:      "google_compute_firewall.foobar",
@@ -74,6 +103,7 @@ func TestAccComputeFirewall_update(t *testing.T) {
 func TestAccComputeFirewall_priority(t *testing.T) {
 	t.Parallel()
 
+	var firewall compute.Firewall
 	networkName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 	firewallName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 
@@ -84,6 +114,12 @@ func TestAccComputeFirewall_priority(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccComputeFirewall_priority(networkName, firewallName, 1001),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeFirewallExists(
+						"google_compute_firewall.foobar", &firewall),
+					testAccCheckComputeFirewallHasPriority(&firewall, 1001),
+					testAccCheckComputeFirewallApiVersion(&firewall),
+				),
 			},
 			{
 				ResourceName:      "google_compute_firewall.foobar",
@@ -97,6 +133,7 @@ func TestAccComputeFirewall_priority(t *testing.T) {
 func TestAccComputeFirewall_noSource(t *testing.T) {
 	t.Parallel()
 
+	var firewall compute.Firewall
 	networkName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 	firewallName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 
@@ -107,6 +144,11 @@ func TestAccComputeFirewall_noSource(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccComputeFirewall_noSource(networkName, firewallName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeFirewallExists(
+						"google_compute_firewall.foobar", &firewall),
+					testAccCheckComputeFirewallApiVersion(&firewall),
+				),
 			},
 			resource.TestStep{
 				ResourceName:      "google_compute_firewall.foobar",
@@ -120,6 +162,7 @@ func TestAccComputeFirewall_noSource(t *testing.T) {
 func TestAccComputeFirewall_denied(t *testing.T) {
 	t.Parallel()
 
+	var firewall compute.Firewall
 	networkName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 	firewallName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 
@@ -130,6 +173,11 @@ func TestAccComputeFirewall_denied(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccComputeFirewall_denied(networkName, firewallName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeFirewallExists("google_compute_firewall.foobar", &firewall),
+					testAccCheckComputeFirewallDenyPorts(&firewall, "22"),
+					testAccCheckComputeFirewallApiVersion(&firewall),
+				),
 			},
 			resource.TestStep{
 				ResourceName:      "google_compute_firewall.foobar",
@@ -143,6 +191,7 @@ func TestAccComputeFirewall_denied(t *testing.T) {
 func TestAccComputeFirewall_egress(t *testing.T) {
 	t.Parallel()
 
+	var firewall compute.Firewall
 	networkName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 	firewallName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 
@@ -153,6 +202,11 @@ func TestAccComputeFirewall_egress(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccComputeFirewall_egress(networkName, firewallName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeFirewallExists("google_compute_firewall.foobar", &firewall),
+					testAccCheckComputeFirewallEgress(&firewall),
+					testAccCheckComputeFirewallApiVersion(&firewall),
+				),
 			},
 			resource.TestStep{
 				ResourceName:      "google_compute_firewall.foobar",
@@ -166,11 +220,15 @@ func TestAccComputeFirewall_egress(t *testing.T) {
 func TestAccComputeFirewall_serviceAccounts(t *testing.T) {
 	t.Parallel()
 
+	var firewall compute.Firewall
 	networkName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 	firewallName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 
 	sourceSa := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
 	targetSa := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
+	project := getTestProjectFromEnv()
+	sourceSaEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", sourceSa, project)
+	targetSaEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", targetSa, project)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -179,6 +237,11 @@ func TestAccComputeFirewall_serviceAccounts(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccComputeFirewall_serviceAccounts(sourceSa, targetSa, networkName, firewallName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeFirewallExists("google_compute_firewall.foobar", &firewall),
+					testAccCheckComputeFirewallServiceAccounts(sourceSaEmail, targetSaEmail, &firewall),
+					testAccCheckComputeFirewallApiVersion(&firewall),
+				),
 			},
 			resource.TestStep{
 				ResourceName:      "google_compute_firewall.foobar",
@@ -220,6 +283,48 @@ func TestAccComputeFirewall_disabled(t *testing.T) {
 	})
 }
 
+func TestAccComputeFirewall_enableLogging(t *testing.T) {
+	t.Parallel()
+
+	var firewall computeBeta.Firewall
+	networkName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
+	firewallName := fmt.Sprintf("firewall-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeFirewallDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeFirewall_enableLogging(networkName, firewallName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBetaFirewallExists("google_compute_firewall.foobar", &firewall),
+					testAccCheckComputeFirewallLoggingEnabled(&firewall, false),
+				),
+			},
+			{
+				ResourceName:      "google_compute_firewall.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeFirewall_enableLogging(networkName, firewallName, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBetaFirewallExists("google_compute_firewall.foobar", &firewall),
+					testAccCheckComputeFirewallLoggingEnabled(&firewall, true),
+				),
+			},
+			{
+				Config: testAccComputeFirewall_enableLogging(networkName, firewallName, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBetaFirewallExists("google_compute_firewall.foobar", &firewall),
+					testAccCheckComputeFirewallLoggingEnabled(&firewall, false),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeFirewallDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -238,6 +343,158 @@ func testAccCheckComputeFirewallDestroy(s *terraform.State) error {
 	return nil
 }
 
+func testAccCheckComputeFirewallExists(n string, firewall *compute.Firewall) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		found, err := config.clientCompute.Firewalls.Get(
+			config.Project, rs.Primary.ID).Do()
+		if err != nil {
+			return err
+		}
+
+		if found.Name != rs.Primary.ID {
+			return fmt.Errorf("Firewall not found")
+		}
+
+		*firewall = *found
+
+		return nil
+	}
+}
+
+func testAccCheckComputeBetaFirewallExists(n string, firewall *computeBeta.Firewall) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		found, err := config.clientComputeBeta.Firewalls.Get(
+			config.Project, rs.Primary.ID).Do()
+		if err != nil {
+			return err
+		}
+
+		if found.Name != rs.Primary.ID {
+			return fmt.Errorf("Firewall not found")
+		}
+
+		*firewall = *found
+
+		return nil
+	}
+}
+
+func testAccCheckComputeFirewallHasPriority(firewall *compute.Firewall, priority int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if firewall.Priority != int64(priority) {
+			return fmt.Errorf("Priority for firewall does not match: expected %d, found %d", priority, firewall.Priority)
+		}
+		return nil
+	}
+}
+
+func testAccCheckComputeFirewallPorts(
+	firewall *compute.Firewall, ports string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if len(firewall.Allowed) == 0 {
+			return fmt.Errorf("no allowed rules")
+		}
+
+		if firewall.Allowed[0].Ports[0] != ports {
+			return fmt.Errorf("bad: %#v", firewall.Allowed[0].Ports)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeFirewallDenyPorts(firewall *compute.Firewall, ports string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if len(firewall.Denied) == 0 {
+			return fmt.Errorf("no denied rules")
+		}
+
+		if firewall.Denied[0].Ports[0] != ports {
+			return fmt.Errorf("bad: %#v", firewall.Denied[0].Ports)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeFirewallEgress(firewall *compute.Firewall) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if firewall.Direction != "EGRESS" {
+			return fmt.Errorf("firewall not EGRESS")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeFirewallServiceAccounts(sourceSa, targetSa string, firewall *compute.Firewall) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if len(firewall.SourceServiceAccounts) != 1 || firewall.SourceServiceAccounts[0] != sourceSa {
+			return fmt.Errorf("Expected sourceServiceAccount of %s, got %v", sourceSa, firewall.SourceServiceAccounts)
+		}
+		if len(firewall.TargetServiceAccounts) != 1 || firewall.TargetServiceAccounts[0] != targetSa {
+			return fmt.Errorf("Expected targetServiceAccount of %s, got %v", targetSa, firewall.TargetServiceAccounts)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeFirewallBetaApiVersion(firewall *computeBeta.Firewall) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// The self-link of the network field is used to determine which API was used when fetching
+		// the state from the API.
+		if !strings.Contains(firewall.Network, "compute/beta") {
+			return fmt.Errorf("firewall beta API was not used")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeFirewallApiVersion(firewall *compute.Firewall) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// The self-link of the network field is used to determine which API was used when fetching
+		// the state from the API.
+		if !strings.Contains(firewall.Network, "compute/v1") {
+			return fmt.Errorf("firewall v1 API was not used")
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeFirewallLoggingEnabled(firewall *computeBeta.Firewall, enabled bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if firewall == nil || firewall.EnableLogging != enabled {
+			return fmt.Errorf("expected firewall enable_logging to be %t, got %t", enabled, firewall.EnableLogging)
+		}
+		return nil
+	}
+}
+
 func testAccComputeFirewall_basic(network, firewall string) string {
 	return fmt.Sprintf(`
 	resource "google_compute_network" "foobar" {
@@ -247,7 +504,7 @@ func testAccComputeFirewall_basic(network, firewall string) string {
 	}
 
 	resource "google_compute_firewall" "foobar" {
-		name = "%s"
+		name = "firewall-test-%s"
 		description = "Resource created for Terraform acceptance testing"
 		network = "${google_compute_network.foobar.name}"
 		source_tags = ["foo"]
@@ -267,18 +524,16 @@ func testAccComputeFirewall_update(network, firewall string) string {
 	}
 
 	resource "google_compute_firewall" "foobar" {
-		name = "%s"
-		description = "New description"
+		name = "firewall-test-%s"
+		description = "Resource created for Terraform acceptance testing"
 		network = "${google_compute_network.foobar.self_link}"
-		source_service_accounts = ["sa@fake-project.iam.gserviceaccount.com"]
-		priority = 2000
+		source_tags = ["foo"]
+		target_tags = ["bar"]
 
-		deny {
+		allow {
 			protocol = "tcp"
 			ports = ["80-255"]
 		}
-
-		disabled = true
 	}`, network, firewall)
 }
 
@@ -291,7 +546,7 @@ func testAccComputeFirewall_priority(network, firewall string, priority int) str
 	}
 
 	resource "google_compute_firewall" "foobar" {
-		name = "%s"
+		name = "firewall-test-%s"
 		description = "Resource created for Terraform acceptance testing"
 		network = "${google_compute_network.foobar.name}"
 		source_tags = ["foo"]
@@ -312,7 +567,7 @@ func testAccComputeFirewall_noSource(network, firewall string) string {
 	}
 
 	resource "google_compute_firewall" "foobar" {
-		name = "%s"
+		name = "firewall-test-%s"
 		description = "Resource created for Terraform acceptance testing"
 		network = "${google_compute_network.foobar.name}"
 
@@ -332,7 +587,7 @@ func testAccComputeFirewall_denied(network, firewall string) string {
 	}
 
 	resource "google_compute_firewall" "foobar" {
-		name = "%s"
+		name = "firewall-test-%s"
 		description = "Resource created for Terraform acceptance testing"
 		network = "${google_compute_network.foobar.name}"
 		source_tags = ["foo"]
@@ -353,7 +608,7 @@ func testAccComputeFirewall_egress(network, firewall string) string {
 	}
 
 	resource "google_compute_firewall" "foobar" {
-		name = "%s"
+		name = "firewall-test-%s"
 		direction = "EGRESS"
 		description = "Resource created for Terraform acceptance testing"
 		network = "${google_compute_network.foobar.name}"
@@ -380,7 +635,7 @@ func testAccComputeFirewall_serviceAccounts(sourceSa, targetSa, network, firewal
 	}
 
 	resource "google_compute_firewall" "foobar" {
-		name = "%s"
+		name = "firewall-test-%s"
 		description = "Resource created for Terraform acceptance testing"
 		network = "${google_compute_network.foobar.name}"
 
@@ -402,7 +657,7 @@ func testAccComputeFirewall_disabled(network, firewall string) string {
 	}
 
 	resource "google_compute_firewall" "foobar" {
-		name = "%s"
+		name = "firewall-test-%s"
 		description = "Resource created for Terraform acceptance testing"
 		network = "${google_compute_network.foobar.name}"
 		source_tags = ["foo"]
@@ -413,4 +668,30 @@ func testAccComputeFirewall_disabled(network, firewall string) string {
 
 		disabled = true
 	}`, network, firewall)
+}
+
+func testAccComputeFirewall_enableLogging(network, firewall string, enableLogging bool) string {
+	enableLoggingCfg := ""
+	if enableLogging {
+		enableLoggingCfg = "enable_logging= true"
+	}
+	return fmt.Sprintf(`
+	resource "google_compute_network" "foobar" {
+		name = "%s"
+		auto_create_subnetworks = false
+		ipv4_range = "10.0.0.0/16"
+	}
+
+	resource "google_compute_firewall" "foobar" {
+		name = "firewall-test-%s"
+		description = "Resource created for Terraform acceptance testing"
+		network = "${google_compute_network.foobar.name}"
+		source_tags = ["foo"]
+
+		allow {
+			protocol = "icmp"
+		}
+
+		%s
+	}`, network, firewall, enableLoggingCfg)
 }


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Related to https://github.com/terraform-providers/terraform-provider-google/issues/1914

Some test changes are magic-module only and should not show up in Terraform, this should sync tests to Terraform test.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Closes https://github.com/terraform-providers/terraform-provider-google/issues/1914

## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
