### PR TITLE
Grammar nitpick enforced by sed.

### DIFF
--- a/TEMPLATE_SDK.md
+++ b/TEMPLATE_SDK.md
@@ -761,7 +761,7 @@ line #1 by compiling the license template:
 To ensure no doubts exist on the readers' minds, we recommend that you mark the
 copyright notice on the template with a ERB block:
 
-    <% if false # the license inside this if block assertains to this file -%>
+    <% if false # the license inside this if block pertains to this file -%>
     # Copyright 2017 Google Inc.
     ...
     ...

--- a/products/_bundle/templates/chef/README.md.erb
+++ b/products/_bundle/templates/chef/README.md.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/_bundle/templates/puppet/README.md.erb
+++ b/products/_bundle/templates/puppet/README.md.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/bigquery/examples/puppet/dataset.pp
+++ b/products/bigquery/examples/puppet/dataset.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/bigquery/examples/puppet/delete_dataset.pp
+++ b/products/bigquery/examples/puppet/delete_dataset.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/bigquery/examples/puppet/table.pp
+++ b/products/bigquery/examples/puppet/table.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/address.rb
+++ b/products/compute/examples/chef/address.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/backend_bucket.rb
+++ b/products/compute/examples/chef/backend_bucket.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/backend_service.rb
+++ b/products/compute/examples/chef/backend_service.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_address.rb
+++ b/products/compute/examples/chef/delete_address.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_backend_bucket.rb
+++ b/products/compute/examples/chef/delete_backend_bucket.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_backend_service.rb
+++ b/products/compute/examples/chef/delete_backend_service.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_disk.rb
+++ b/products/compute/examples/chef/delete_disk.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_firewall.rb
+++ b/products/compute/examples/chef/delete_firewall.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_forwarding_rule.rb
+++ b/products/compute/examples/chef/delete_forwarding_rule.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_global_address.rb
+++ b/products/compute/examples/chef/delete_global_address.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_global_forwarding_rule.rb
+++ b/products/compute/examples/chef/delete_global_forwarding_rule.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_health_check.rb
+++ b/products/compute/examples/chef/delete_health_check.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_http_health_check.rb
+++ b/products/compute/examples/chef/delete_http_health_check.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_https_health_check.rb
+++ b/products/compute/examples/chef/delete_https_health_check.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_image.rb
+++ b/products/compute/examples/chef/delete_image.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_instance.rb
+++ b/products/compute/examples/chef/delete_instance.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_instance_group.rb
+++ b/products/compute/examples/chef/delete_instance_group.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_instance_group_manager.rb
+++ b/products/compute/examples/chef/delete_instance_group_manager.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_instance_template.rb
+++ b/products/compute/examples/chef/delete_instance_template.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_network.rb
+++ b/products/compute/examples/chef/delete_network.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_route.rb
+++ b/products/compute/examples/chef/delete_route.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_router.rb
+++ b/products/compute/examples/chef/delete_router.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2018 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_snapshot.rb
+++ b/products/compute/examples/chef/delete_snapshot.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_ssl_certificate.rb
+++ b/products/compute/examples/chef/delete_ssl_certificate.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_subnetwork.rb
+++ b/products/compute/examples/chef/delete_subnetwork.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_target_http_proxy.rb
+++ b/products/compute/examples/chef/delete_target_http_proxy.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_target_https_proxy.rb
+++ b/products/compute/examples/chef/delete_target_https_proxy.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_target_ssl_proxy.rb
+++ b/products/compute/examples/chef/delete_target_ssl_proxy.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_target_tcp_proxy.rb
+++ b/products/compute/examples/chef/delete_target_tcp_proxy.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/delete_url_map.rb
+++ b/products/compute/examples/chef/delete_url_map.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/disk.rb
+++ b/products/compute/examples/chef/disk.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/disk_type.rb
+++ b/products/compute/examples/chef/disk_type.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/firewall.rb
+++ b/products/compute/examples/chef/firewall.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/firewall~change1.rb
+++ b/products/compute/examples/chef/firewall~change1.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/forwarding_rule.rb
+++ b/products/compute/examples/chef/forwarding_rule.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/global_address.rb
+++ b/products/compute/examples/chef/global_address.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/global_forwarding_rule.rb
+++ b/products/compute/examples/chef/global_forwarding_rule.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/health_check.rb
+++ b/products/compute/examples/chef/health_check.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/http_health_check.rb
+++ b/products/compute/examples/chef/http_health_check.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/https_health_check.rb
+++ b/products/compute/examples/chef/https_health_check.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/image.rb
+++ b/products/compute/examples/chef/image.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/instance.rb
+++ b/products/compute/examples/chef/instance.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/instance_group.rb
+++ b/products/compute/examples/chef/instance_group.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/instance_group_manager.rb
+++ b/products/compute/examples/chef/instance_group_manager.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/instance_template.rb
+++ b/products/compute/examples/chef/instance_template.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/license.rb
+++ b/products/compute/examples/chef/license.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/machine_type.rb
+++ b/products/compute/examples/chef/machine_type.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/network.rb
+++ b/products/compute/examples/chef/network.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/network~auto.rb
+++ b/products/compute/examples/chef/network~auto.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/network~convert_to_custom.rb
+++ b/products/compute/examples/chef/network~convert_to_custom.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/network~custom.rb
+++ b/products/compute/examples/chef/network~custom.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/network~legacy.rb
+++ b/products/compute/examples/chef/network~legacy.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/readme.rb
+++ b/products/compute/examples/chef/readme.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/region.rb
+++ b/products/compute/examples/chef/region.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/route.rb
+++ b/products/compute/examples/chef/route.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/router.rb
+++ b/products/compute/examples/chef/router.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2018 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/snapshot.rb
+++ b/products/compute/examples/chef/snapshot.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/ssl_certificate.rb
+++ b/products/compute/examples/chef/ssl_certificate.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/subnetwork.rb
+++ b/products/compute/examples/chef/subnetwork.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/target_http_proxy.rb
+++ b/products/compute/examples/chef/target_http_proxy.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/target_https_proxy.rb
+++ b/products/compute/examples/chef/target_https_proxy.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/target_pool.rb
+++ b/products/compute/examples/chef/target_pool.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/target_ssl_proxy.rb
+++ b/products/compute/examples/chef/target_ssl_proxy.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/target_tcp_proxy.rb
+++ b/products/compute/examples/chef/target_tcp_proxy.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/target_vpn_gateway.rb
+++ b/products/compute/examples/chef/target_vpn_gateway.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/url_map.rb
+++ b/products/compute/examples/chef/url_map.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/vpn_tunnel.rb
+++ b/products/compute/examples/chef/vpn_tunnel.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/chef/zone.rb
+++ b/products/compute/examples/chef/zone.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/address.pp
+++ b/products/compute/examples/puppet/address.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/backend_bucket.pp
+++ b/products/compute/examples/puppet/backend_bucket.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/backend_service.pp
+++ b/products/compute/examples/puppet/backend_service.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_address.pp
+++ b/products/compute/examples/puppet/delete_address.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_backend_bucket.pp
+++ b/products/compute/examples/puppet/delete_backend_bucket.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_backend_service.pp
+++ b/products/compute/examples/puppet/delete_backend_service.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_disk.pp
+++ b/products/compute/examples/puppet/delete_disk.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_firewall.pp
+++ b/products/compute/examples/puppet/delete_firewall.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_forwarding_rule.pp
+++ b/products/compute/examples/puppet/delete_forwarding_rule.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_global_address.pp
+++ b/products/compute/examples/puppet/delete_global_address.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_global_forwarding_rule.pp
+++ b/products/compute/examples/puppet/delete_global_forwarding_rule.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_health_check.pp
+++ b/products/compute/examples/puppet/delete_health_check.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_http_health_check.pp
+++ b/products/compute/examples/puppet/delete_http_health_check.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_https_health_check.pp
+++ b/products/compute/examples/puppet/delete_https_health_check.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_image.pp
+++ b/products/compute/examples/puppet/delete_image.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_instance.pp
+++ b/products/compute/examples/puppet/delete_instance.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_instance_group.pp
+++ b/products/compute/examples/puppet/delete_instance_group.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_instance_group_manager.pp
+++ b/products/compute/examples/puppet/delete_instance_group_manager.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_instance_template.pp
+++ b/products/compute/examples/puppet/delete_instance_template.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_network.pp
+++ b/products/compute/examples/puppet/delete_network.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_route.pp
+++ b/products/compute/examples/puppet/delete_route.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_router.pp
+++ b/products/compute/examples/puppet/delete_router.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2018 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_snapshot.pp
+++ b/products/compute/examples/puppet/delete_snapshot.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_ssl_certificate.pp
+++ b/products/compute/examples/puppet/delete_ssl_certificate.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_subnetwork.pp
+++ b/products/compute/examples/puppet/delete_subnetwork.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_target_http_proxy.pp
+++ b/products/compute/examples/puppet/delete_target_http_proxy.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_target_https_proxy.pp
+++ b/products/compute/examples/puppet/delete_target_https_proxy.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_target_pool.pp
+++ b/products/compute/examples/puppet/delete_target_pool.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_target_ssl_proxy.pp
+++ b/products/compute/examples/puppet/delete_target_ssl_proxy.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_target_tcp_proxy.pp
+++ b/products/compute/examples/puppet/delete_target_tcp_proxy.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/delete_url_map.pp
+++ b/products/compute/examples/puppet/delete_url_map.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/disk.pp
+++ b/products/compute/examples/puppet/disk.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/disk_type.pp
+++ b/products/compute/examples/puppet/disk_type.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/firewall.pp
+++ b/products/compute/examples/puppet/firewall.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/firewall~change1.pp
+++ b/products/compute/examples/puppet/firewall~change1.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/forwarding_rule.pp
+++ b/products/compute/examples/puppet/forwarding_rule.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/global_address.pp
+++ b/products/compute/examples/puppet/global_address.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/global_forwarding_rule.pp
+++ b/products/compute/examples/puppet/global_forwarding_rule.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/health_check.pp
+++ b/products/compute/examples/puppet/health_check.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/http_health_check.pp
+++ b/products/compute/examples/puppet/http_health_check.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/https_health_check.pp
+++ b/products/compute/examples/puppet/https_health_check.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/image.pp
+++ b/products/compute/examples/puppet/image.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/instance.pp
+++ b/products/compute/examples/puppet/instance.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/instance_group.pp
+++ b/products/compute/examples/puppet/instance_group.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/instance_group_manager.pp
+++ b/products/compute/examples/puppet/instance_group_manager.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/instance_template.pp
+++ b/products/compute/examples/puppet/instance_template.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/license.pp
+++ b/products/compute/examples/puppet/license.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/machine_type.pp
+++ b/products/compute/examples/puppet/machine_type.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/network.pp
+++ b/products/compute/examples/puppet/network.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/network~auto.pp
+++ b/products/compute/examples/puppet/network~auto.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/network~convert_to_custom.pp
+++ b/products/compute/examples/puppet/network~convert_to_custom.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/network~custom.pp
+++ b/products/compute/examples/puppet/network~custom.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/network~legacy.pp
+++ b/products/compute/examples/puppet/network~legacy.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/region.pp
+++ b/products/compute/examples/puppet/region.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/route.pp
+++ b/products/compute/examples/puppet/route.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/router.pp
+++ b/products/compute/examples/puppet/router.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2018 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/snapshot.pp
+++ b/products/compute/examples/puppet/snapshot.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/ssl_certificate.pp
+++ b/products/compute/examples/puppet/ssl_certificate.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/subnetwork.pp
+++ b/products/compute/examples/puppet/subnetwork.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/target_http_proxy.pp
+++ b/products/compute/examples/puppet/target_http_proxy.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/target_https_proxy.pp
+++ b/products/compute/examples/puppet/target_https_proxy.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/target_pool.pp
+++ b/products/compute/examples/puppet/target_pool.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/target_ssl_proxy.pp
+++ b/products/compute/examples/puppet/target_ssl_proxy.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/target_tcp_proxy.pp
+++ b/products/compute/examples/puppet/target_tcp_proxy.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/target_vpn_gateway.pp
+++ b/products/compute/examples/puppet/target_vpn_gateway.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/url_map.pp
+++ b/products/compute/examples/puppet/url_map.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/vpn_tunnel.pp
+++ b/products/compute/examples/puppet/vpn_tunnel.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/examples/puppet/zone.pp
+++ b/products/compute/examples/puppet/zone.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/compute/files/tasks~instance.pp
+++ b/products/compute/files/tasks~instance.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/container/examples/chef/cluster.rb
+++ b/products/container/examples/chef/cluster.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/container/examples/chef/delete_cluster.rb
+++ b/products/container/examples/chef/delete_cluster.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/container/examples/chef/delete_node_pool.rb
+++ b/products/container/examples/chef/delete_node_pool.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/container/examples/chef/kube_config.rb
+++ b/products/container/examples/chef/kube_config.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/container/examples/chef/node_pool.rb
+++ b/products/container/examples/chef/node_pool.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/container/examples/chef/readme.rb
+++ b/products/container/examples/chef/readme.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/container/examples/puppet/cluster.pp
+++ b/products/container/examples/puppet/cluster.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/container/examples/puppet/delete_cluster.pp
+++ b/products/container/examples/puppet/delete_cluster.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/container/examples/puppet/delete_node_pool.pp
+++ b/products/container/examples/puppet/delete_node_pool.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/container/examples/puppet/kube_config.pp
+++ b/products/container/examples/puppet/kube_config.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/container/examples/puppet/node_pool.pp
+++ b/products/container/examples/puppet/node_pool.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/examples/chef/delete_managed_zone.rb
+++ b/products/dns/examples/chef/delete_managed_zone.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/examples/chef/delete_resource_record_set.rb
+++ b/products/dns/examples/chef/delete_resource_record_set.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/examples/chef/managed_zone.rb
+++ b/products/dns/examples/chef/managed_zone.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/examples/chef/project.rb
+++ b/products/dns/examples/chef/project.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/examples/chef/readme.rb
+++ b/products/dns/examples/chef/readme.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/examples/chef/resource_record_set.rb
+++ b/products/dns/examples/chef/resource_record_set.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/examples/puppet/delete_managed_zone.pp
+++ b/products/dns/examples/puppet/delete_managed_zone.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/examples/puppet/delete_resource_record_set.pp
+++ b/products/dns/examples/puppet/delete_resource_record_set.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/examples/puppet/managed_zone.pp
+++ b/products/dns/examples/puppet/managed_zone.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/examples/puppet/project.pp
+++ b/products/dns/examples/puppet/project.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/examples/puppet/resource_record_set.pp
+++ b/products/dns/examples/puppet/resource_record_set.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/files/spec~resource_record_set~create~name.yaml
+++ b/products/dns/files/spec~resource_record_set~create~name.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/files/spec~resource_record_set~create~title.yaml
+++ b/products/dns/files/spec~resource_record_set~create~title.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/files/spec~resource_record_set~delete~name.yaml
+++ b/products/dns/files/spec~resource_record_set~delete~name.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/files/spec~resource_record_set~delete~title.yaml
+++ b/products/dns/files/spec~resource_record_set~delete~title.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/files/spec~resource_record_set~soa1-111.yaml
+++ b/products/dns/files/spec~resource_record_set~soa1-111.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/files/spec~resource_record_set~soa1-222.yaml
+++ b/products/dns/files/spec~resource_record_set~soa1-222.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/files/spec~resource_record_set~soa1-555.yaml
+++ b/products/dns/files/spec~resource_record_set~soa1-555.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/files/spec~resource_record_set~soa1-666.yaml
+++ b/products/dns/files/spec~resource_record_set~soa1-666.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/files/spec~resource_record_set~success1~name.yaml
+++ b/products/dns/files/spec~resource_record_set~success1~name.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/files/spec~resource_record_set~success1~title.yaml
+++ b/products/dns/files/spec~resource_record_set~success1~title.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/files/spec~resource_record_set~success2~name.yaml
+++ b/products/dns/files/spec~resource_record_set~success2~name.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/files/spec~resource_record_set~success2~title.yaml
+++ b/products/dns/files/spec~resource_record_set~success2~title.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/files/spec~resource_record_set~success3~name.yaml
+++ b/products/dns/files/spec~resource_record_set~success3~name.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/files/spec~resource_record_set~success3~title.yaml
+++ b/products/dns/files/spec~resource_record_set~success3~title.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/helpers/ansible/provider_resource_set.py.erb
+++ b/products/dns/helpers/ansible/provider_resource_set.py.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/helpers/chef/provider_resource_set.rb.erb
+++ b/products/dns/helpers/chef/provider_resource_set.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/helpers/puppet/provider_resource_set.rb.erb
+++ b/products/dns/helpers/puppet/provider_resource_set.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/dns/helpers/ruby/provider_resource_set.rb.erb
+++ b/products/dns/helpers/ruby/provider_resource_set.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/iam/examples/chef/delete_service_account.rb
+++ b/products/iam/examples/chef/delete_service_account.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/iam/examples/chef/delete_service_account_key.rb
+++ b/products/iam/examples/chef/delete_service_account_key.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/iam/examples/chef/readme.rb
+++ b/products/iam/examples/chef/readme.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/iam/examples/chef/service_account.rb
+++ b/products/iam/examples/chef/service_account.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/iam/examples/chef/service_account_key.rb
+++ b/products/iam/examples/chef/service_account_key.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/iam/examples/puppet/delete_service_account.pp
+++ b/products/iam/examples/puppet/delete_service_account.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/iam/examples/puppet/delete_service_account_key.pp
+++ b/products/iam/examples/puppet/delete_service_account_key.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/iam/examples/puppet/service_account.pp
+++ b/products/iam/examples/puppet/service_account.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/iam/examples/puppet/service_account_key.pp
+++ b/products/iam/examples/puppet/service_account_key.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/pubsub/examples/chef/delete_subscription.rb
+++ b/products/pubsub/examples/chef/delete_subscription.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/pubsub/examples/chef/delete_topic.rb
+++ b/products/pubsub/examples/chef/delete_topic.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/pubsub/examples/chef/readme.rb
+++ b/products/pubsub/examples/chef/readme.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/pubsub/examples/chef/subscription.rb
+++ b/products/pubsub/examples/chef/subscription.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/pubsub/examples/chef/topic.rb
+++ b/products/pubsub/examples/chef/topic.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/pubsub/examples/puppet/delete_subscription.pp
+++ b/products/pubsub/examples/puppet/delete_subscription.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/pubsub/examples/puppet/delete_topic.pp
+++ b/products/pubsub/examples/puppet/delete_topic.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/pubsub/examples/puppet/subscription.pp
+++ b/products/pubsub/examples/puppet/subscription.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/pubsub/examples/puppet/topic.pp
+++ b/products/pubsub/examples/puppet/topic.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/resourcemanager/examples/chef/delete_project.rb
+++ b/products/resourcemanager/examples/chef/delete_project.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/resourcemanager/examples/chef/project.rb
+++ b/products/resourcemanager/examples/chef/project.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/resourcemanager/examples/chef/readme.rb
+++ b/products/resourcemanager/examples/chef/readme.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/resourcemanager/examples/puppet/delete_project.pp
+++ b/products/resourcemanager/examples/puppet/delete_project.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/resourcemanager/examples/puppet/project.pp
+++ b/products/resourcemanager/examples/puppet/project.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/spanner/examples/chef/database.rb
+++ b/products/spanner/examples/chef/database.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/spanner/examples/chef/delete_instance.rb
+++ b/products/spanner/examples/chef/delete_instance.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/spanner/examples/chef/instance.rb
+++ b/products/spanner/examples/chef/instance.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/spanner/examples/chef/instance_config.rb
+++ b/products/spanner/examples/chef/instance_config.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/spanner/examples/chef/readme.rb
+++ b/products/spanner/examples/chef/readme.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/chef/database.rb
+++ b/products/sql/examples/chef/database.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/chef/delete_database.rb
+++ b/products/sql/examples/chef/delete_database.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/chef/delete_instance.rb
+++ b/products/sql/examples/chef/delete_instance.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/chef/delete_user.rb
+++ b/products/sql/examples/chef/delete_user.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/chef/flag.rb
+++ b/products/sql/examples/chef/flag.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/chef/instance.rb
+++ b/products/sql/examples/chef/instance.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/chef/instance~postgres.rb
+++ b/products/sql/examples/chef/instance~postgres.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/chef/readme.rb
+++ b/products/sql/examples/chef/readme.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/chef/ssl_cert.rb
+++ b/products/sql/examples/chef/ssl_cert.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/chef/tier.rb
+++ b/products/sql/examples/chef/tier.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/chef/user.rb
+++ b/products/sql/examples/chef/user.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/puppet/database.pp
+++ b/products/sql/examples/puppet/database.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/puppet/delete_database.pp
+++ b/products/sql/examples/puppet/delete_database.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/puppet/delete_instance.pp
+++ b/products/sql/examples/puppet/delete_instance.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/puppet/delete_user.pp
+++ b/products/sql/examples/puppet/delete_user.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/puppet/flag.pp
+++ b/products/sql/examples/puppet/flag.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/puppet/instance.pp
+++ b/products/sql/examples/puppet/instance.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/puppet/instance~postgres.pp
+++ b/products/sql/examples/puppet/instance~postgres.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/puppet/ssl_cert.pp
+++ b/products/sql/examples/puppet/ssl_cert.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/puppet/tier.pp
+++ b/products/sql/examples/puppet/tier.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/examples/puppet/user.pp
+++ b/products/sql/examples/puppet/user.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/files/spec~user~success1~name.yaml
+++ b/products/sql/files/spec~user~success1~name.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/files/spec~user~success1~title.yaml
+++ b/products/sql/files/spec~user~success1~title.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/files/spec~user~success2~name.yaml
+++ b/products/sql/files/spec~user~success2~name.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/files/spec~user~success2~title.yaml
+++ b/products/sql/files/spec~user~success2~title.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/files/spec~user~success3~name.yaml
+++ b/products/sql/files/spec~user~success3~name.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/sql/files/spec~user~success3~title.yaml
+++ b/products/sql/files/spec~user~success3~title.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/storage/examples/chef/bucket.rb
+++ b/products/storage/examples/chef/bucket.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/storage/examples/chef/bucket_access_control.rb
+++ b/products/storage/examples/chef/bucket_access_control.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/storage/examples/chef/bucket~acl.rb
+++ b/products/storage/examples/chef/bucket~acl.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/storage/examples/chef/default_object_acl.rb
+++ b/products/storage/examples/chef/default_object_acl.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/storage/examples/chef/delete_bucket.rb
+++ b/products/storage/examples/chef/delete_bucket.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/storage/examples/chef/object_access_control.rb
+++ b/products/storage/examples/chef/object_access_control.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/storage/examples/chef/readme.rb
+++ b/products/storage/examples/chef/readme.rb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/storage/examples/puppet/bucket.pp
+++ b/products/storage/examples/puppet/bucket.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/storage/examples/puppet/bucket_access_control.pp
+++ b/products/storage/examples/puppet/bucket_access_control.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/storage/examples/puppet/bucket~acl.pp
+++ b/products/storage/examples/puppet/bucket~acl.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/storage/examples/puppet/default_object_acl.pp
+++ b/products/storage/examples/puppet/default_object_acl.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/storage/examples/puppet/delete_bucket.pp
+++ b/products/storage/examples/puppet/delete_bucket.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/products/storage/examples/puppet/object_access_control.pp
+++ b/products/storage/examples/puppet/object_access_control.pp
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/provider/ansible/blank_file.yaml
+++ b/provider/ansible/blank_file.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/provider/ansible/test_template.yaml
+++ b/provider/ansible/test_template.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/CONTRIBUTING.md.erb
+++ b/templates/CONTRIBUTING.md.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/ansible/defaults_main.yaml
+++ b/templates/ansible/defaults_main.yaml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/ansible/transport.erb
+++ b/templates/ansible/transport.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/bundle.rb.erb
+++ b/templates/bundle.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/Berksfile.erb
+++ b/templates/chef/Berksfile.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/Gemfile.erb
+++ b/templates/chef/Gemfile.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/README.md.erb
+++ b/templates/chef/README.md.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/chefignore.erb
+++ b/templates/chef/chefignore.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/credential.erb
+++ b/templates/chef/credential.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/dot~rubocop~root.yml
+++ b/templates/chef/dot~rubocop~root.yml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/example~auth.rb.erb
+++ b/templates/chef/example~auth.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/foodcritic_spec.rb.erb
+++ b/templates/chef/foodcritic_spec.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/function.erb
+++ b/templates/chef/function.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/google-gauth~metadata.rb.erb
+++ b/templates/chef/google-gauth~metadata.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/init_library_path.rb.erb
+++ b/templates/chef/init_library_path.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/metadata.rb.erb
+++ b/templates/chef/metadata.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/property/array.rb.erb
+++ b/templates/chef/property/array.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/property/array_typed.rb.erb
+++ b/templates/chef/property/array_typed.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/property/boolean.rb.erb
+++ b/templates/chef/property/boolean.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/property/double.rb.erb
+++ b/templates/chef/property/double.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/property/enum.rb.erb
+++ b/templates/chef/property/enum.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/property/enum_with_default.rb.erb
+++ b/templates/chef/property/enum_with_default.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/property/integer.rb.erb
+++ b/templates/chef/property/integer.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/property/namevalues.rb.erb
+++ b/templates/chef/property/namevalues.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/property/nested_object.rb.erb
+++ b/templates/chef/property/nested_object.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/property/resourceref.rb.erb
+++ b/templates/chef/property/resourceref.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/property/string.rb.erb
+++ b/templates/chef/property/string.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/property/time.rb.erb
+++ b/templates/chef/property/time.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/recipe_README.md.erb
+++ b/templates/chef/recipe_README.md.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/resource.erb
+++ b/templates/chef/resource.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/resource_spec.erb
+++ b/templates/chef/resource_spec.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/resourceref_expandvars.erb
+++ b/templates/chef/resourceref_expandvars.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/chef/spec_helper.rb.erb
+++ b/templates/chef/spec_helper.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/dot~gitignore
+++ b/templates/dot~gitignore
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/dot~rubocop~root.yml
+++ b/templates/dot~rubocop~root.yml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/dot~rubocop~spec.yml
+++ b/templates/dot~rubocop~spec.yml
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/example/compiled_file
+++ b/templates/example/compiled_file
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/example/resource.erb
+++ b/templates/example/resource.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/fake_auth.erb
+++ b/templates/fake_auth.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/network/base.rb.erb
+++ b/templates/network/base.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/network/delete.rb.erb
+++ b/templates/network/delete.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/network/delete_spec.rb.erb
+++ b/templates/network/delete_spec.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/network/get.rb.erb
+++ b/templates/network/get.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/network/get_spec.rb.erb
+++ b/templates/network/get_spec.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/network/network_blocker.rb.erb
+++ b/templates/network/network_blocker.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/network/network_blocker_spec.rb.erb
+++ b/templates/network/network_blocker_spec.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/network/patch.rb.erb
+++ b/templates/network/patch.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/network/patch_spec.rb.erb
+++ b/templates/network/patch_spec.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/network/post.rb.erb
+++ b/templates/network/post.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/network/post_spec.rb.erb
+++ b/templates/network/post_spec.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/network/put.rb.erb
+++ b/templates/network/put.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/network/put_spec.rb.erb
+++ b/templates/network/put_spec.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/network_spec.yaml.erb
+++ b/templates/network_spec.yaml.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/Gemfile
+++ b/templates/puppet/Gemfile
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/README.md.erb
+++ b/templates/puppet/README.md.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/bolt~task.json.erb
+++ b/templates/puppet/bolt~task.json.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/bolt~task.pp.erb
+++ b/templates/puppet/bolt~task.pp.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/bolt~task.rb.erb
+++ b/templates/puppet/bolt~task.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/examples~credential.pp.erb
+++ b/templates/puppet/examples~credential.pp.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/function.erb
+++ b/templates/puppet/function.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/property/array.rb.erb
+++ b/templates/puppet/property/array.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/property/array_typed.rb.erb
+++ b/templates/puppet/property/array_typed.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/property/base.rb.erb
+++ b/templates/puppet/property/base.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/property/boolean.rb.erb
+++ b/templates/puppet/property/boolean.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/property/double.rb.erb
+++ b/templates/puppet/property/double.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/property/enum.rb.erb
+++ b/templates/puppet/property/enum.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/property/enum_with_default.rb.erb
+++ b/templates/puppet/property/enum_with_default.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/property/integer.rb.erb
+++ b/templates/puppet/property/integer.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/property/namevalues.rb.erb
+++ b/templates/puppet/property/namevalues.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/property/nested_object.rb.erb
+++ b/templates/puppet/property/nested_object.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/property/resourceref.rb.erb
+++ b/templates/puppet/property/resourceref.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/property/string.rb.erb
+++ b/templates/puppet/property/string.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/property/time.rb.erb
+++ b/templates/puppet/property/time.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/provider_spec.erb
+++ b/templates/puppet/provider_spec.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/puppetlint_spec.rb.erb
+++ b/templates/puppet/puppetlint_spec.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/resource.erb
+++ b/templates/puppet/resource.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/run-tests-steps.erb
+++ b/templates/puppet/run-tests-steps.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/spec_helper.rb.erb
+++ b/templates/puppet/spec_helper.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/test~absent~delete.erb
+++ b/templates/puppet/test~absent~delete.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/test~absent~no_action.erb
+++ b/templates/puppet/test~absent~no_action.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/test~present~create.erb
+++ b/templates/puppet/test~present~create.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/test~present~no_changes.erb
+++ b/templates/puppet/test~present~no_changes.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/puppet/type.erb
+++ b/templates/puppet/type.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/resourceref_mocks.erb
+++ b/templates/resourceref_mocks.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/test_constants.rb.erb
+++ b/templates/test_constants.rb.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/templates/transport.erb
+++ b/templates/transport.erb
@@ -1,4 +1,4 @@
-<% if false # the license inside this if block assertains to this file -%>
+<% if false # the license inside this if block pertains to this file -%>
 # Copyright 2017 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
'Assertains' is not a word.  'Ascertain' is a word, but it means 'to make certain'.  'Pertain' is the closest word which means the right thing: 'to be applicable'.

`find . -type f | xargs sed -i 's/block assertains to this/block pertains to this/g'`

-----------------------------------------------------------------
# [all]
Word choice change only.