### PR TITLE
Add interpolated Terraform tests for google_compute_address.

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -18,11 +18,13 @@ overrides: !ruby/object:Provider::ResourceOverrides
     example:
      - !ruby/object:Provider::Terraform::Examples
       name: "address_basic"
-      vars_documentation:
+      primary_resource_id: "ip_address"
+      vars:
         address_name: "my-address"
      - !ruby/object:Provider::Terraform::Examples
       name: "address_with_subnetwork"
-      vars_documentation:
+      primary_resource_id: "internal_with_subnet_and_address"
+      vars:
         address_name: "my-internal-address"
         network_name: "my-network"
         subnetwork_name: "my-subnet"

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -23,6 +23,7 @@ require 'google/golang_utils'
 module Provider
   # Code generator for Terraform Resources that manage Google Cloud Platform
   # resources.
+  # rubocop:disable Metrics/ClassLength
   class Terraform < Provider::AbstractCore
     include Provider::Terraform::Import
     include Provider::Terraform::SubTemplate
@@ -144,5 +145,28 @@ module Provider
         out_file: filepath
       )
     end
+
+    # rubocop:disable Metrics/AbcSize
+    def generate_resource_tests(data)
+      return if data[:object].example.nil?
+
+      target_folder = File.join(data[:output_folder], 'google')
+      FileUtils.mkpath target_folder
+      name = data[:object].name.underscore
+      product_name = data[:product_name].underscore
+      filepath =
+        File.join(
+          target_folder,
+          "resource_#{product_name}_#{name}_generated_test.go"
+        )
+      generate_resource_file data.clone.merge(
+        product: data[:product_name].camelize(:upper),
+        resource_name: data[:object].name.camelize(:upper),
+        default_template: 'templates/terraform/examples/base_configs/test_file.go.erb',
+        out_file: filepath
+      )
+    end
+    # rubocop:enable Metrics/AbcSize
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/templates/terraform/examples/address_basic.tf.erb
+++ b/templates/terraform/examples/address_basic.tf.erb
@@ -1,3 +1,3 @@
-resource "google_compute_address" "default" {
-  name = "<%= ctx["address_name"] %>"
+resource "google_compute_address" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]["address_name"] %>"
 }

--- a/templates/terraform/examples/address_with_subnetwork.tf.erb
+++ b/templates/terraform/examples/address_with_subnetwork.tf.erb
@@ -1,16 +1,16 @@
 resource "google_compute_network" "default" {
-  name = "<%= ctx["network_name"] %>"
+  name = "<%= ctx[:vars]["network_name"] %>"
 }
 
 resource "google_compute_subnetwork" "default" {
-  name          = "<%= ctx["subnetwork_name"] %>"
+  name          = "<%= ctx[:vars]["subnetwork_name"] %>"
   ip_cidr_range = "10.0.0.0/16"
   region        = "us-central1"
   network       = "${google_compute_network.default.self_link}"
 }
 
-resource "google_compute_address" "internal_with_subnet_and_address" {
-  name         = "<%= ctx["address_name"] %>"
+resource "google_compute_address" "<%= ctx[:primary_resource_id] %>" {
+  name         = "<%= ctx[:vars]["address_name"] %>"
   subnetwork   = "${google_compute_subnetwork.default.self_link}"
   address_type = "INTERNAL"
   address      = "10.0.42.42"

--- a/templates/terraform/examples/base_configs/test_body.go.erb
+++ b/templates/terraform/examples/base_configs/test_body.go.erb
@@ -1,0 +1,4 @@
+	return fmt.Sprintf(`
+<%= ctx[:content] -%>
+`,<%= " val," * ctx[:count] %>
+	)

--- a/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/templates/terraform/examples/base_configs/test_file.go.erb
@@ -1,0 +1,41 @@
+<%= lines(autogen_notice :go) -%>
+
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+<% object.example.each do |example| -%>
+<%
+	# {Compute}{Address}_{addressBasic}
+	test_slug = "#{product}#{resource_name}_#{example.name.camelize}Example"
+-%>
+
+func TestAcc<%= test_slug -%>(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheck<%= "#{product}#{resource_name}" -%>Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAcc<%= test_slug -%>(acctest.RandString(10)),
+			},
+			{
+				ResourceName:      "<%= "google_#{product.downcase}_#{resource_name.downcase}" -%>.<%= example.primary_resource_id -%>",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAcc<%= test_slug -%>(val string) string {
+<%= example.config_test -%>
+}
+<%- end %>


### PR DESCRIPTION
Add interpolated Terraform tests for google_compute_address.

-----------------------------------------------------------------
# [all]
No-Op Expected
## [terraform]
Add tests based on google_compute_address examples.
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
