### PR TITLE
Reverting Overrides

### DIFF
--- a/provider/config.rb
+++ b/provider/config.rb
@@ -211,6 +211,7 @@ module Provider
       config.default_overrides
       config.spread_api config, api, [], '' unless api.nil?
       config.validate
+      config.overrides.apply
       config
     end
 

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -249,7 +249,9 @@ module Provider
     # rubocop:disable Metrics/PerceivedComplexity
     def generate_datasources(output_folder, types, version)
       # We need to apply overrides for datasources
+      @config.overrides.revert
       @config.datasources.validate
+      @config.datasources.apply
 
       @api.set_properties_based_on_version(version)
       @api.objects.each do |object|

--- a/provider/resource_overrides.rb
+++ b/provider/resource_overrides.rb
@@ -47,8 +47,11 @@ module Provider
       return if @__api.nil?
       populate_nonoverridden_objects
       convert_findings_to_hash
-      override_objects
       super
+    end
+
+    def apply
+      override_objects
     end
 
     def [](index)

--- a/provider/resource_overrides.rb
+++ b/provider/resource_overrides.rb
@@ -54,6 +54,10 @@ module Provider
       override_objects
     end
 
+    def revert
+      revert_objects
+    end
+
     def [](index)
       @__objects[index]
     end
@@ -128,6 +132,13 @@ module Provider
       end
     end
 
+    def revert_objects
+      @__objects.each do |name, override|
+        api_object = @__api.objects.find { |o| o.name == name }
+        override.revert api_object
+      end
+    end
+
     def find_property(api_entity, property_path)
       property_name = property_path[0]
       properties = get_properties api_entity
@@ -157,6 +168,9 @@ module Provider
       end
     end
 
+    # All resources need an override object, even if it was
+    # not specificed in provider.yaml
+    # This is because of default values.
     def populate_nonoverridden_objects
       (@__api.objects || []).each do |object|
         var_name = "@#{object.name}".to_sym
@@ -165,6 +179,9 @@ module Provider
       end
     end
 
+    # All resources need an override object, even if it was
+    # not specificed in provider.yaml
+    # This is because of default values.
     def populate_nonoverridden_properties(api_entity, override)
       api_entity.all_user_properties.each do |prop|
         override.properties[prop.name] = @__config.property_override.new \
@@ -173,6 +190,9 @@ module Provider
       end
     end
 
+    # All resources on nested objects need an override object, even if it was
+    # not specificed in provider.yaml
+    # This is because of default values.
     def populate_nonoverriden_nested_properties(prefix, property, override)
       nested_properties = get_properties(property)
       return if nested_properties.nil?


### PR DESCRIPTION
Ansible has two sets of overrides:

* Regular overrides
* Datasource overrides

(TF will have this too sooner or later)

Ansible applies these overrides one on top of another. This means that regular override values may leak into datasources. This isn't intentional. It isn't a problem now, but I find it hard to believe it won't be a problem at some point.


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
