### PR TITLE
API Unit Testing POC

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'binding_of_caller'
 gem 'rake'
 
 group :test do
+  gem "factory_bot", "~> 4.0"
   gem 'mocha'
   gem 'parallel_tests'
   gem 'rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'binding_of_caller'
 gem 'rake'
 
 group :test do
-  gem "factory_bot", "~> 4.0"
+  gem 'factory_bot', '~> 4.0'
   gem 'mocha'
   gem 'parallel_tests'
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     ast (2.4.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
+    concurrent-ruby (1.0.5)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
     docile (1.1.5)
+    factory_bot (4.11.1)
+      activesupport (>= 3.0.0)
+    i18n (1.1.0)
+      concurrent-ruby (~> 1.0)
     json (2.1.0)
     metaclass (0.0.4)
+    minitest (5.11.3)
     mocha (1.3.0)
       metaclass (~> 0.0.1)
     parallel (1.12.1)
@@ -45,6 +56,9 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     unicode-display_width (1.3.0)
 
 PLATFORMS
@@ -52,6 +66,7 @@ PLATFORMS
 
 DEPENDENCIES
   binding_of_caller
+  factory_bot (~> 4.0)
   mocha
   parallel_tests
   rake
@@ -60,4 +75,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,0 +1,52 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FactoryBot.define do
+  # Using YAML parsing short circuits the object lifecycle.
+  # We don't have proper initialize methods, because our
+  # objects just appear post-YAML parsing with
+  # all of the correct values.
+  #
+  # FactoryBot should create its test objects in the 
+  # same manner.
+  initialize_with do
+    obj = new
+    attributes.each { |k, v| obj.instance_variable_set("@#{k.id2name}", v) }
+    # TODO(alexstephen): Build out a better default factory that can successfully
+    # validate.
+    #obj.validate
+    obj
+  end
+  to_create {}
+  
+  factory :product, class: Api::Product do
+    name { "Google TestSpec Engine" }
+    prefix { "gspec" }
+    objects { [] }
+    scopes { [] }
+  end
+
+  factory :resource, class: Api::Resource do
+    association :__product, factory: :product
+  end
+
+  factory :string, class: Api::Type::String do
+    name { "string-property" }
+    description { "Description for a test property" }
+    output { false }
+    required { false }
+    input { false }
+
+    association :__resource, factory: :resource
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -27,6 +27,9 @@ FactoryBot.define do
     # obj.validate
     obj
   end
+
+  # FactoryBot tries to call .save! on all objects, which is a Rails
+  # paradigm. This seems to be the best way to turn that off.
   to_create {}
 
   factory :product, class: Api::Product do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -17,21 +17,21 @@ FactoryBot.define do
   # objects just appear post-YAML parsing with
   # all of the correct values.
   #
-  # FactoryBot should create its test objects in the 
+  # FactoryBot should create its test objects in the
   # same manner.
   initialize_with do
     obj = new
     attributes.each { |k, v| obj.instance_variable_set("@#{k.id2name}", v) }
     # TODO(alexstephen): Build out a better default factory that can successfully
     # validate.
-    #obj.validate
+    # obj.validate
     obj
   end
   to_create {}
-  
+
   factory :product, class: Api::Product do
-    name { "Google TestSpec Engine" }
-    prefix { "gspec" }
+    name { 'Google TestSpec Engine' }
+    prefix { 'gspec' }
     objects { [] }
     scopes { [] }
   end
@@ -41,8 +41,8 @@ FactoryBot.define do
   end
 
   factory :string, class: Api::Type::String do
-    name { "string-property" }
-    description { "Description for a test property" }
+    name { 'string-property' }
+    description { 'Description for a test property' }
     output { false }
     required { false }
     input { false }

--- a/spec/new_type_spec.rb
+++ b/spec/new_type_spec.rb
@@ -16,7 +16,7 @@ require 'spec_helper'
 context Api::Type::String do
   context 'requires' do
     subject(:string) { build(:string) }
-    
+
     it 'should have the proper requires filename' do
       expect(string.requires).to eq('google/spec/property/string')
     end

--- a/spec/new_type_spec.rb
+++ b/spec/new_type_spec.rb
@@ -1,0 +1,24 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+context Api::Type::String do
+  context 'requires' do
+    subject(:string) { build(:string) }
+    
+    it 'should have the proper requires filename' do
+      expect(string.requires).to eq('google/spec/property/string')
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,8 +14,18 @@
 require 'simplecov'
 SimpleCov.start unless ENV['DISABLE_COVERAGE']
 
+require 'factory_bot'
+
 RSpec.configure do |config|
+  # Mocha configuration
   config.mock_with :mocha
+
+  # FactoryBot configuration
+  config.include FactoryBot::Syntax::Methods
+
+  config.before(:suite) do
+    FactoryBot.find_definitions
+  end
 end
 
 $LOAD_PATH.unshift(File.expand_path('.'))


### PR DESCRIPTION
@SirGitsalot brought up a great point. We don't have any units tests for `api/`.

With how MM is designed, unit tests for everything in `api/` should be the easiest part. (Sidebar: My web-dev brain tells me that api = Model, provider = Controller, templates = Views. In my mind Model >>> Controller >>> Views when it comes to how easy it is to test).

With that web-dev metaphor in mind, I put together a POC of what potential `api/` tests could look like.

Instead of starting straight from YAML, I thought it might be a better idea to start with [FactoryBot](https://github.com/thoughtbot/factory_bot/). FactoryBot is a Ruby fixtures builder, which seems like exactly what we want. It's super, super popular in the Ruby community (particularly in Rails-land).

I built up a couple factories for objects in api/ and a small test of the `requires()` function because it's the easiest thing to quickly test.

This is more meant to be food for thought. Next MM sync?

Couple notes:

* We would want to build out better factories that have all of the properties.
* Is the FactoryBot model too much overhead? I'm inclined to think no because it sets us up to write real tests with a lot of flexibility. The alternative would be to build out a TON of Yaml files, which is a super messy, manual process that will potentially bog us down.
* FactoryBot has full support for testing outside of Rails-land. But, it seems to be pretty Rails-centric, so there's some boilerplate to turn off Rails features that isn't ideal. Put in comments to explain when this happens.
* YAML is weird. I had to fiddle a little bit with how FactoryBot creates objects to better replicate how we create objects when parsing from YAML. Comments on those as well.


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
