### PR TITLE
Add missing quotation marks to SslCertificate tests

### DIFF
--- a/templates/terraform/tests/resource_compute_ssl_certificate_test.go
+++ b/templates/terraform/tests/resource_compute_ssl_certificate_test.go
@@ -78,7 +78,7 @@ func TestAccComputeSslCertificate_name_prefix(t *testing.T) {
 				ResourceName:            "google_compute_ssl_certificate.foobar",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"private_key, name_prefix"},
+				ImportStateVerifyIgnore: []string{"private_key", "name_prefix"},
 			},
 		},
 	})


### PR DESCRIPTION
Accidentally didn't merge some quotation marks I was missing after testing locally.

-----------------------------------------------------------------
# [all]
## [terraform]
Add missing quotation marks to compute_ssl_certificate tests
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
