### PR TITLE
Changing MM logging to favor debug over info

### DIFF
--- a/compile/core.rb
+++ b/compile/core.rb
@@ -142,7 +142,7 @@ module Compile
       has_erbout = ctx.local_variables.include?(:_erbout)
       content = ctx.local_variable_get(:_erbout) if has_erbout # save code
       ctx.local_variable_set(:compiler, compiler)
-      Google::LOGGER.info "Compiling #{file}"
+      Google::LOGGER.debug "Compiling #{file}"
       input = ERB.new get_helper_file(file), nil, '-%>'
       compiled = input.result(ctx)
       ctx.local_variable_set(:_erbout, content) if has_erbout # restore code

--- a/compiler.rb
+++ b/compiler.rb
@@ -43,7 +43,7 @@ types_to_generate = []
 version = nil
 
 ARGV << '-h' if ARGV.empty?
-Google::LOGGER.level = Logger::WARN
+Google::LOGGER.level = Logger::INFO
 
 OptionParser.new do |opt|
   opt.on('-p', '--product PRODUCT', 'Folder with product catalog') do |p|
@@ -66,7 +66,7 @@ OptionParser.new do |opt|
     exit
   end
   opt.on('-d', '--debug', 'Show all debug logs') do |_debug|
-    Google::LOGGER.level = Logger::INFO
+    Google::LOGGER.level = Logger::DEBUG
   end
 end.parse!
 

--- a/google/yaml_validator.rb
+++ b/google/yaml_validator.rb
@@ -33,12 +33,12 @@ module Google
     end
 
     def validate
-      Google::LOGGER.info "Validating #{self.class} '#{@name}'"
+      Google::LOGGER.debug "Validating #{self.class} '#{@name}'"
       check_extraneous_properties
     end
 
     def set_variable(value, property)
-      Google::LOGGER.info "Setting variable of #{value} to #{self}"
+      Google::LOGGER.debug "Setting variable of #{value} to #{self}"
       ensure_property_does_not_exist property
       instance_variable_set("@#{property}", value)
     end
@@ -66,9 +66,9 @@ module Google
 
     def log_check_type(object)
       if object.respond_to?(:name)
-        Google::LOGGER.info "Checking object #{object.name}"
+        Google::LOGGER.debug "Checking object #{object.name}"
       else
-        Google::LOGGER.info "Checking object #{object}"
+        Google::LOGGER.debug "Checking object #{object}"
       end
     end
 
@@ -83,7 +83,7 @@ module Google
     end
 
     def check_property_value(property, prop_value, type)
-      Google::LOGGER.info "Checking '#{property}' on #{object_display_name}"
+      Google::LOGGER.debug "Checking '#{property}' on #{object_display_name}"
       raise "Missing '#{property}' on #{object_display_name}" if prop_value.nil?
       check_type property, prop_value, type unless type.nil?
       prop_value.validate if prop_value.is_a?(Api::Object)
@@ -98,7 +98,7 @@ module Google
       instance_variables.each do |variable|
         var_name = variable.id2name[1..-1]
         next if var_name.start_with?('__')
-        Google::LOGGER.info "Validating '#{var_name}' on #{object_display_name}"
+        Google::LOGGER.debug "Validating '#{var_name}' on #{object_display_name}"
         raise "Extraneous variable '#{var_name}' in #{object_display_name}" \
           unless methods.include?(var_name.intern)
       end
@@ -107,9 +107,9 @@ module Google
     def check_property_list(name, type = nil)
       obj_list = instance_variable_get("@#{name}")
       if obj_list.nil?
-        Google::LOGGER.info "No next level @ #{object_display_name}: #{name}"
+        Google::LOGGER.debug "No next level @ #{object_display_name}: #{name}"
       else
-        Google::LOGGER.info \
+        Google::LOGGER.debug \
           "Checking next level for #{object_display_name}: #{name}"
         obj_list.each { |o| check_property_value "#{name}:item", o, type }
       end

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -96,7 +96,7 @@ module Provider
         target_file = File.join(output_folder, target)
         target_dir = File.dirname(target_file)
         @sourced << relative_path(target_file, output_folder)
-        Google::LOGGER.info "Copying #{source} => #{target}"
+        Google::LOGGER.debug "Copying #{source} => #{target}"
         FileUtils.mkpath target_dir unless Dir.exist?(target_dir)
         FileUtils.copy_entry source, target_file
       end
@@ -183,7 +183,7 @@ module Provider
     # rubocop:disable Metrics/AbcSize
     def compile_file_list(output_folder, files, data = {})
       files.each do |target, source|
-        Google::LOGGER.info "Compiling #{source} => #{target}"
+        Google::LOGGER.debug "Compiling #{source} => #{target}"
         target_file = File.join(output_folder, target)
                           .gsub('{{product_name}}', @api.prefix[1..-1])
 
@@ -632,7 +632,7 @@ module Provider
 
     def generate_file_write(ctx, data)
       enforce_file_expectations data[:out_file] do
-        Google::LOGGER.info "Generating #{data[:name]} #{data[:type]}"
+        Google::LOGGER.debug "Generating #{data[:name]} #{data[:type]}"
         write_file data[:out_file], compile_file(ctx, data[:template])
       end
     end


### PR DESCRIPTION
The INFO logs are getting filled with what looks like debug level information.
When compiling 1 product for 1 provider there are 16k INFO statements and zero
DEBUG level logs. This makes it difficult to show anything important in the
standard logging without escalating to WARN.

This change will move most of the output to debug level and set the default
logging level to INFO. The -d flag will still show all 16K lines of output but
at INFO there will only be a message for what is getting generated and what is
going to be excluded.

This will require a bit of a paradigm shift for people to start using debug
going forward where info was previously used.

<!-- A summary of the changes in this commit goes here -->


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
