### PR TITLE
Ensure that Ansible always returns full resource after update + no-op

### DIFF
--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -155,7 +155,13 @@ def main():
                                    ('fetch' if object.access_api_results || !update_props.empty?)
                                  ])
 -%>
-<%= lines(indent("fetch = #{method}", 16)) -%>
+<%= lines(indent("#{method}", 16)) -%>
+<%
+  method = method_call('fetch_resource', ['module', 'self_link(module)',
+                                          ('kind' if object.kind?),
+                                         ])
+-%>
+                fetch = <%= method %>
                 changed = True
         else:
 <%
@@ -193,8 +199,6 @@ def main():
 <%= lines(indent(object.post_create, 12)) -%>
 <% end # ifobject.post_create -%>
             changed = True
-        else:
-            fetch = {}
 
 <% if object.post_action -%>
 <%= lines(indent(object.post_action, 4)) -%>


### PR DESCRIPTION
Some update calls don't return the full resource, which means that Ansible won't return them (bad!)

Also, there's a bug where Ansible doesn't always return the resource on no-ops (bad!)

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
