### PR TITLE
Discover the list of types/resources by version

### DIFF
--- a/api/product.rb
+++ b/api/product.rb
@@ -91,6 +91,20 @@ module Api
     end
     # rubocop:enable Naming/AccessorMethodName
 
+    # Checks if the resource or any of its properties or paramters has been
+    # flagged for a specific version and returns only those that match.
+    def objects_by_version(version)
+      filtered_objects = @objects.select do |o|
+        obj_is_version = o.min_version == version
+        obj_is_version ||= o.parameters.any? { |p| p.min_version == version }
+        obj_is_version ||= o.properties.any? { |p| p.min_version == version }
+
+        obj_is_version
+      end
+
+      filtered_objects
+    end
+
     private
 
     def check_versions

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -218,6 +218,13 @@ module Provider
     # rubocop:disable Metrics/PerceivedComplexity
     # rubocop:disable Metrics/AbcSize
     def generate_objects(output_folder, types, version)
+      # When generating a version in advance of the resource's default version
+      # we should not generate every resource by default. eg: if generating beta
+      # resources for products/compute we should only generate the resources
+      # that are explicitly marked as beta
+      types = @api.objects_by_version(version) \
+        if types.empty? && version > @api.default_version
+
       @api.set_properties_based_on_version(version)
       (@api.objects || []).each do |object|
         if !types.empty? && !types.include?(object.name)


### PR DESCRIPTION
Rather then needing to specify a list of a targets to generate for beta/alpha
this will determine the list of types to generate (if not explicitly passed) by
inspecting the api definition.

Basically we won't have to pass `-t Address,Firewall,ForwardingRule,...` when using the `-v beta` flag and it will only generate beta resources.

<!-- A summary of the changes in this commit goes here -->


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
