### PR TITLE
Do not send empty values for nested properties

### DIFF
--- a/templates/terraform/expand_property_method.erb
+++ b/templates/terraform/expand_property_method.erb
@@ -83,8 +83,9 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
       transformed<%= titlelize_property(prop) -%>, err := expand<%= prefix -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(original["<%= prop.name.underscore -%>"], d, config)
       if err != nil {
         return nil, err
+      } else if val := reflect.ValueOf(transformed<%= titlelize_property(prop) -%>); val.IsValid() && !isEmptyValue(val) {
+        transformed["<%= prop.api_name -%>"] = transformed<%= titlelize_property(prop) -%>
       }
-      transformed["<%= prop.api_name -%>"] = transformed<%= titlelize_property(prop) -%>
 
 <%       end -%>
 <%       if property.is_a?(Api::Type::Array) -%>


### PR DESCRIPTION
Top level terraform properties do are removed from the api payload if they are
not set in the terraform config. However this behavior is different for any
properties nested past the top level. This results in empty objects getting
sent in payloads where every sub property has been defaulted to its empty state.
This causes problems for more complicated apis that have deeper nesting such as
the stack driver apis.

This change will remove any property from the payload if it is not defined in
the terraform config.

<!-- A summary of the changes in this commit goes here -->


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Do not send empty values for nested properties
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
