### PR TITLE
Terraform Route example fix

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -478,7 +478,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
         vars:
           route_name: "network-route"
           network_name: "compute-network"
-          subnetwork_name: "compute-subnetwork"
     properties:
       name: !ruby/object:Provider::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation

--- a/templates/terraform/examples/route_basic.tf.erb
+++ b/templates/terraform/examples/route_basic.tf.erb
@@ -2,17 +2,10 @@ resource "google_compute_route" "default" {
   name        = "<%= ctx[:vars]["route_name"] %>"
   dest_range  = "15.0.0.0/24"
   network     = "${google_compute_network.default.name}"
-  next_hop_ip = "10.0.1.5"
+  next_hop_ip = "10.132.1.5"
   priority    = 100
 }
 
 resource "google_compute_network" "default" {
   name = "<%= ctx[:vars]["network_name"] %>"
-}
-
-resource "google_compute_subnetwork" "default" {
-  name          = "<%= ctx[:vars]["subnetwork_name"] %>"
-  ip_cidr_range = "10.0.0.0/16"
-  network       = "${google_compute_network.default.self_link}"
-  region        = "us-central1"
 }


### PR DESCRIPTION
Fixes a Terraform example / test in CI.

-----------------------------------------------------------------
# [all]
## [terraform]
Fix TestAccComputeRoute_routeBasicExample
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
