### PR TITLE
Replace NameValues with KeyValuePairs, Map

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -158,7 +158,9 @@ Currently MM supports the following types:
    specified by the `values` property.
 -  `Api::Type::Integer`: An integer number.
 -  `Api::Type::Long`: A long number
--  Api::Type::NameValues
+-  `Api::Type::KeyValuePairs`: A string -> string key -> value pair such as
+   labels
+-  `Api::Type::Map`: A string -> `Api::Type::NestedObject` map.
 -  `Api::Type::NestedObject`: A composite field, composed of inner fields. This
    is used for structures that are nested.
 -  <a id="resource-ref"></a>`Api::Type::ResourceRef`: A reference to another object described in the

--- a/api/object.rb
+++ b/api/object.rb
@@ -43,16 +43,5 @@ module Api
     def out_name
       @name.underscore
     end
-
-    # Utility class for Objects
-    module ObjectUtils
-      module_function
-
-      def string_to_object_map?(property)
-        property.is_a?(Api::Type::NameValues) &&
-          property.key_type == 'Api::Type::String' &&
-          property.value_type.is_a?(Api::Type::NestedObject)
-      end
-    end
   end
 end

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 78.57
+    "covered_percent": 77.95
   }
 }

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 78.81
+    "covered_percent": 78.57
   }
 }

--- a/products/bigquery/api.yaml
+++ b/products/bigquery/api.yaml
@@ -124,12 +124,11 @@ objects:
           The fully-qualified unique name of the dataset in the format
           projectId:datasetId. The dataset name without the project name is
           given in the datasetId field
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: >
           The labels associated with this dataset. You can use these to
           organize and group your datasets
-        value_type: Api::Type::String
       - !ruby/object:Api::Type::Integer
         name: 'lastModifiedTime'
         description: >
@@ -184,12 +183,11 @@ objects:
         name: 'id'
         description: 'An opaque ID uniquely identifying the table.'
         output: true
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: >
           The labels associated with this dataset. You can use these to
           organize and group your datasets
-        value_type: Api::Type::String
       - !ruby/object:Api::Type::Integer
         name: 'lastModifiedTime'
         description: >

--- a/products/binaryauthorization/api.yaml
+++ b/products/binaryauthorization/api.yaml
@@ -138,7 +138,7 @@ objects:
                 `registry/path/to/image`. This supports a trailing * as a
                 wildcard, but this is allowed only in text after the registry/
                 part.
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::Map
         name: clusterAdmissionRules
         description: |
           Per-cluster admission rules. An admission rule specifies either that
@@ -151,7 +151,6 @@ objects:
           Identifier format: `{{location}}.{{clusterId}}`.
           A location is either a compute zone (e.g. `us-central1-a`) or a region
           (e.g. `us-central1`).
-        key_type: Api::Type::String
         key_name: cluster
         value_type: !ruby/object:Api::Type::NestedObject
           name: clusterAdmissionRule

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -132,12 +132,10 @@ objects:
         description: 'The URLs of the resources that are using this address.'
         item_type: Api::Type::String
         output: true
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: |
           Labels to apply to this address.  A list of key->value pairs.
-        key_type: Api::Type::String
-        value_type: Api::Type::String
         update_verb: :POST
         update_url: 'projects/{{project}}/regions/{{region}}/addresses/{{name}}/setLabels'
         min_version: beta
@@ -987,11 +985,10 @@ objects:
         update_verb: :POST
         update_url:
           'projects/{{project}}/regions/{{region}}/forwardingRules/{{name}}/setTarget'
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: |
           Labels to apply to this forwarding rule.  A list of key->value pairs.
-        value_type: Api::Type::String
         update_verb: :POST
         update_url: 'projects/{{project}}/regions/{{region}}/forwardingRules/{{name}}/setLabels'
         min_version: beta
@@ -1088,12 +1085,10 @@ objects:
           characters must be a dash, lowercase letter, or digit, except the last
           character, which cannot be a dash.
         required: true
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: |
           Labels to apply to this address.  A list of key->value pairs.
-        key_type: Api::Type::String
-        value_type: Api::Type::String
         update_verb: :POST
         update_url: 'projects/{{project}}/global/addresses/{{name}}/setLabels'
         min_version: beta
@@ -4264,11 +4259,9 @@ objects:
           for example `192.168.0.0/16`. The ranges should be disjoint.
           Only IPv4 is supported.
         item_type: Api::Type::String
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: Labels to apply to this VpnTunnel.
-        key_type: Api::Type::String
-        value_type: Api::Type::String
         update_verb: :POST
         update_url: 'projects/{{project}}/regions/{{region}}/vpnTunnels/{{name}}/setLabels'
       - !ruby/object:Api::Type::Fingerprint

--- a/products/compute/disks.yaml
+++ b/products/compute/disks.yaml
@@ -38,11 +38,10 @@
   name: 'lastDetachTimestamp'
   description: 'Last dettach timestamp in RFC3339 text format.'
   output: true
-- !ruby/object:Api::Type::NameValues
+- !ruby/object:Api::Type::KeyValuePairs
   name: 'labels'
   description: |
     Labels to apply to this disk.  A list of key->value pairs.
-  value_type: Api::Type::String
   update_verb: :POST
   update_url: 'projects/{{project}}/<%= ctx[:location] -%>s/{{<%= ctx[:location] -%>}}/disks/{{name}}/setLabels'
 - !ruby/object:Api::Type::Array

--- a/products/compute/instance_metadata.yaml
+++ b/products/compute/instance_metadata.yaml
@@ -31,10 +31,9 @@
 # adding the 'fingerprint' of the last metadata to allow update.
 #
 # To comply with the API please add an encoder: and decoder: to the provider.
-- !ruby/object:Api::Type::NameValues
+- !ruby/object:Api::Type::KeyValuePairs
   name: 'metadata'
   description: |
     The metadata key/value pairs to assign to instances that are
     created from this template. These pairs can consist of custom
     metadata or predefined keys.
-  value_type: Api::Type::String

--- a/products/container/node_config.yaml
+++ b/products/container/node_config.yaml
@@ -54,9 +54,8 @@
     The Google Cloud Platform Service Account to be used by the node
     VMs.  If no Service Account is specified, the "default" service
     account is used.
-- !ruby/object:Api::Type::NameValues
+- !ruby/object:Api::Type::KeyValuePairs
   name: 'metadata'
-  value_type: Api::Type::String
   description: |
     The metadata key/value pairs assigned to instances in the cluster.
 
@@ -81,9 +80,8 @@
   description: |
     The image type to use for this node.  Note that for a given image
     type, the latest version of it will be used.
-- !ruby/object:Api::Type::NameValues
+- !ruby/object:Api::Type::KeyValuePairs
   name: 'labels'
-  value_type: Api::Type::String
   description: |
     The map of Kubernetes labels (key/value pairs) to be applied to
     each node. These will added in addition to any default label(s)

--- a/products/container/puppet.yaml
+++ b/products/container/puppet.yaml
@@ -94,7 +94,7 @@ bolt_tasks:
       end
 properties:
   - array
-  - namevalues
+  - keyvaluepairs
   - enum
   - integer
   - string

--- a/products/filestore/api.yaml
+++ b/products/filestore/api.yaml
@@ -98,12 +98,10 @@ objects:
           - TIER_UNSPECIFIED
           - STANDARD
           - PREMIUM
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: |
           Resource labels to represent user-provided metadata.
-        key_type: Api::Type::String
-        value_type: Api::Type::String
       - !ruby/object:Api::Type::Array
         name: 'fileShares'
         required: true

--- a/products/redis/api.yaml
+++ b/products/redis/api.yaml
@@ -97,14 +97,12 @@ objects:
           Hostname or IP address of the exposed Redis endpoint used by clients
           to connect to the service.
         output: true
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: Resource labels to represent user provided metadata.
-        value_type: Api::Type::String
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'redisConfigs'
         description: Redis configuration parameters, according to http://redis.io/topics/config.
-        value_type: Api::Type::String
       - !ruby/object:Api::Type::String
         name: locationId
         description: |

--- a/products/resourcemanager/api.yaml
+++ b/products/resourcemanager/api.yaml
@@ -65,9 +65,8 @@ objects:
         name: 'createTime'
         description: 'Time of creation'
         output: true
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
-        value_type: Api::Type::String
         description: |
           The labels associated with this Project.
 

--- a/products/spanner/api.yaml
+++ b/products/spanner/api.yaml
@@ -79,9 +79,8 @@ objects:
         name: 'nodeCount'
         description: 'The number of nodes allocated to this instance.'
       # 'state' not suitable for state convergeance.
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
-        value_type: Api::Type::String
         description: |
           Cloud Labels are a flexible and lightweight mechanism for organizing
           cloud resources into groups that reflect a customer's organizational

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -37,7 +37,7 @@ module Provider
         'Api::Type::Array' => 'list',
         'Api::Type::Boolean' => 'bool',
         'Api::Type::Integer' => 'int',
-        'Api::Type::NameValues' => 'dict',
+        'Api::Type::KeyValuePairs' => 'dict',
         'Provider::Ansible::FilterProp' => 'list'
       }.freeze
 

--- a/provider/chef.rb
+++ b/provider/chef.rb
@@ -76,7 +76,7 @@ module Provider
       end
 
       return "[Hash, ::#{prop.property_type}]" \
-        if prop.is_a? Api::Type::NameValues
+        if prop.is_a?(Api::Type::KeyValuePairs) || prop.is_a?(Api::Type::Map)
 
       return "[String, ::#{prop.property_type}]" \
         if prop.is_a?(Api::Type::Fingerprint)

--- a/provider/chef/test_catalog.rb
+++ b/provider/chef/test_catalog.rb
@@ -132,7 +132,8 @@ module Provider
         Api::Type::Time => ->(v) { quote_string(v.iso8601) },
         Api::Type::Array => ->(v) { format_values('[', v, ']') },
         Api::Type::NestedObject => ->(v) { format_values('{', v, '}') },
-        Api::Type::NameValues => ->(v) { format_values('{', v, '}') },
+        Api::Type::KeyValuePairs => ->(v) { format_values('{', v, '}') },
+        Api::Type::Map => ->(v) { format_values('{', v, '}') },
         Api::Type::ResourceRef => ->(v) { quote_string(v) },
         Api::Type::Array::STRING_ARRAY_TYPE =>
           ->(v) { ['[', v.map { |e| quote_string(e) }.join(', '), ']'].join },

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -40,7 +40,6 @@ module Provider
     include Compile::Core
     include Provider::Properties
     include Provider::End2End::Core
-    include Api::Object::ObjectUtils
 
     attr_reader :test_data
 

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -122,7 +122,7 @@ module Provider
     end
 
     # Figuring out if a property is a primitive ruby type is a hassle. But it is important
-    # Fingerprints are strings, NameValues are hashes, and arrays of primitives are arrays
+    # Fingerprints are strings, KeyValuePairs and Maps are hashes, and arrays of primitives are arrays
     # Arrays of NestedObjects need to have their contents parsed and returned in an array
     # ResourceRefs are strings
     def primitive?(property)
@@ -130,7 +130,8 @@ module Provider
         && !property.item_type.is_a?(::Api::Type::NestedObject))
       property.is_a?(::Api::Type::Primitive)\
         || array_primitive\
-        || property.is_a?(::Api::Type::NameValues)\
+        || property.is_a?(::Api::Type::KeyValuePairs)\
+        || property.is_a?(::Api::Type::Map)\
         || property.is_a?(::Api::Type::Fingerprint)\
         || property.is_a?(::Api::Type::ResourceRef)
     end

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -122,9 +122,10 @@ module Provider
     end
 
     # Figuring out if a property is a primitive ruby type is a hassle. But it is important
-    # Fingerprints are strings, KeyValuePairs and Maps are hashes, and arrays of primitives are arrays
-    # Arrays of NestedObjects need to have their contents parsed and returned in an array
+    # Fingerprints are strings, KeyValuePairs and Maps are hashes, and arrays of primitives are
+    # arrays. Arrays of NestedObjects need to have their contents parsed and returned in an array
     # ResourceRefs are strings
+    # rubocop:disable Metrics/CyclomaticComplexity
     def primitive?(property)
       array_primitive = (property.is_a?(Api::Type::Array)\
         && !property.item_type.is_a?(::Api::Type::NestedObject))
@@ -135,6 +136,7 @@ module Provider
         || property.is_a?(::Api::Type::Fingerprint)\
         || property.is_a?(::Api::Type::ResourceRef)
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     # Arrays of nested objects need special requires statements
     def typed_array?(property)

--- a/provider/properties.rb
+++ b/provider/properties.rb
@@ -26,7 +26,7 @@ module Provider
       prop_map << generate_array_properties(data, properties)
       prop_map << generate_nested_object_properties(data, properties)
       prop_map << generate_resourceref_properties(data, properties)
-      prop_map << generate_namevalues_properties(data, properties)
+      prop_map << generate_keyvaluepairs_properties(data, properties)
       prop_map << generate_enum_properties(data, properties)
 
       generate_property_files(prop_map, data)
@@ -82,8 +82,8 @@ module Provider
     end
     # rubocop:enable Metrics/AbcSize
 
-    def generate_namevalues_properties(data, properties)
-      properties.select { |p| p.is_a?(Api::Type::NameValues) }
+    def generate_keyvaluepairs_properties(data, properties)
+      properties.select { |p| p.is_a?(Api::Type::KeyValuePairs) }
                 .map { |p| generate_simple_property p.type.downcase, data }
     end
 

--- a/provider/property_override.rb
+++ b/provider/property_override.rb
@@ -33,7 +33,8 @@ module Provider
     include Api::Type::Fields
     # To allow overrides for type-specific fields, include those type's
     # fields with an 'include' directive here.
-    include Api::Type::NameValues::Fields
+    include Api::Type::KeyValuePairs::Fields
+    include Api::Type::Map::Fields
     include Api::Type::ResourceRef::Fields
 
     # Apply this override to property inheriting from Api::Type
@@ -79,7 +80,8 @@ module Provider
     def our_override_modules
       self.class.included_modules.select do |mod|
         [Api::Type::Fields,
-         Api::Type::NameValues::Fields,
+         Api::Type::KeyValuePairs::Fields,
+         Api::Type::Map::Fields,
          Api::Type::ResourceRef::Fields].include?(mod) \
           || mod.name.split(':').last == 'OverrideFields'
       end

--- a/provider/puppet/test_manifest.rb
+++ b/provider/puppet/test_manifest.rb
@@ -121,7 +121,8 @@ module Provider
           ->(v) { ['[', v.map { |e| quote_string(e) }.join(', '), ']'].join },
         Api::Type::Array::RREF_ARRAY_TYPE =>
           ->(v) { ['[', v.call(exported_values: false).join(', '), ']'].join },
-        Api::Type::NameValues => ->(v) { format_values('{', v, '}') }
+        Api::Type::KeyValuePairs => ->(v) { format_values('{', v, '}') },
+        Api::Type::Map => ->(v) { format_values('{', v, '}') }
       }.freeze
     end
     # rubocop:enable Metrics/MethodLength

--- a/provider/resource_overrides.rb
+++ b/provider/resource_overrides.rb
@@ -149,7 +149,7 @@ module Provider
       elsif api_entity.is_a?(Api::Type::Array) &&
             api_entity.item_type.is_a?(Api::Type::NestedObject)
         api_entity.item_type.all_properties
-      elsif ObjectUtils.string_to_object_map?(api_entity)
+      elsif api_entity.is_a?(Api::Type::Map)
         api_entity.value_type.all_properties
       end
     end

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -38,7 +38,6 @@ module Provider
     end
 
     def tf_type(property)
-      return 'schema.TypeSet' if string_to_object_map?(property)
       tf_types[property.class]
     end
 
@@ -57,7 +56,8 @@ module Provider
         Api::Type::ResourceRef => 'schema.TypeString',
         Api::Type::NestedObject => 'schema.TypeList',
         Api::Type::Array => 'schema.TypeList',
-        Api::Type::NameValues => 'schema.TypeMap',
+        Api::Type::KeyValuePairs => 'schema.TypeMap',
+        Api::Type::Map => 'schema.TypeSet',
         Api::Type::Fingerprint => 'schema.TypeString'
       }
     end
@@ -104,7 +104,7 @@ module Provider
       elsif property.is_a?(Api::Type::Array) &&
             property.item_type.is_a?(Api::Type::NestedObject)
         property.item_type.properties
-      elsif string_to_object_map?(property)
+      elsif property.is_a?(Api::Type::Map)
         property.value_type.properties
       else
         []

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -130,10 +130,10 @@ module Provider
         end
 
         unless api_property.is_a?(Api::Type::Array) ||
-               ObjectUtils.string_to_object_map?(api_property)
+               api_property.is_a?(Api::Type::Map)
           if @is_set
             raise 'Set can only be specified for Api::Type::Array ' \
-                  'or Api::Type::NameValues<String, NestedObject>. ' \
+                  'or Api::Type:Map. ' \
                   "Type is #{api_property.class} for property "\
                   "'#{api_property.name}'"
           end

--- a/provider/test_data/formatter.rb
+++ b/provider/test_data/formatter.rb
@@ -83,8 +83,8 @@ module Provider
           else
             [name, formatter(type, emit_resource(prop, seed, ctx))]
           end
-        elsif prop.is_a?(Api::Type::NameValues)
-          [name, formatter(type, emit_namevalues(prop, seed, ctx))]
+        elsif prop.is_a?(Api::Type::KeyValuePairs)
+          [name, formatter(type, emit_keyvaluepairs(prop, seed, ctx))]
         else
           raise "Unknown property type: #{prop.class}"
         end
@@ -133,7 +133,7 @@ module Provider
                        seed % MAX_ARRAY_SIZE)
       end
 
-      def emit_namevalues(prop, seed, _ctx)
+      def emit_keyvaluepairs(prop, seed, _ctx)
         values = @datagen.value(prop.class, prop, seed)
         max_key = values.max_by { |k, _v| k }.first.length
         values.map do |k, v|

--- a/provider/test_data/generator.rb
+++ b/provider/test_data/generator.rb
@@ -41,7 +41,7 @@ module Provider
         values[for_type].call(property, seed)
       end
 
-      # NameValues and Arrays require a size.
+      # KeyValuePairs and Arrays require a size.
       # This function returns the size of a property of arbitrary size.
       # Use inside_array to manually specify that this object is being created
       # inside of an array (for resourceref counting purposes)
@@ -83,7 +83,7 @@ module Provider
           Api::Type::Array::STRING_ARRAY_TYPE => method(:array_string),
           Api::Type::Array::NESTED_ARRAY_TYPE => method(:array_nested_cb),
           Api::Type::Array::RREF_ARRAY_TYPE => method(:array_rref_cb),
-          Api::Type::NameValues => method(:name_values),
+          Api::Type::KeyValuePairs => method(:key_value_pairs),
           Api::Type::ResourceRef => method(:resource_value),
           Api::Type::NestedObject => method(:nested_value)
         }
@@ -98,7 +98,7 @@ module Provider
           Api::Type::Enum => 'eq',
           Api::Type::FetchedExternal => 'eq',
           Api::Type::Integer => 'eq',
-          Api::Type::NameValues => 'eq',
+          Api::Type::KeyValuePairs => 'eq',
           Api::Type::NestedObject => 'eq',
           Api::Type::ResourceRef => 'eq',
           Api::Type::String => 'eq',
@@ -159,7 +159,7 @@ module Provider
         "'resource(#{name},#{seed})'"
       end
 
-      def name_values(prop, seed)
+      def key_value_pairs(prop, seed)
         size = object_size(prop, seed)
         Hash[(1..size).map do |i|
                [string_value(prop, seed + i),

--- a/provider/test_data/property.rb
+++ b/provider/test_data/property.rb
@@ -36,15 +36,15 @@ module Provider
 
         if prop.class <= Api::Type::ResourceRef
           resourceref_property(prop, value, name_override)
-        elsif prop.class <= Api::Type::NameValues
-          namevalues_property(prop, value, name_override)
+        elsif prop.class <= Api::Type::KeyValuePairs
+          keyvaluepairs_property(prop, value, name_override)
+        elsif prop.class <= Api::Type::Map
+          map_property(prop, value, name_override)
         elsif prop.class <= Api::Type::NestedObject
           nested_property(prop, value, name_override)
         elsif prop.class <= Api::Type::Array \
           && prop.item_type != 'Api::Type::String'
           array_property(prop, value, name_override)
-        elsif prop.class <= Api::Type::NameValues
-          namevalue_property(prop, value, name_override)
         else
           single_property(prop, value, start_indent, name_override)
         end
@@ -130,16 +130,6 @@ module Provider
         ]
       end
 
-      def namevalues_property(prop, _value, name_override)
-        name = name_override || prop.name
-        [
-          '# TODO(nelsonjr): Implement complex namevalues property test.',
-          "# it '#{name}' do",
-          '#   # Add test code here',
-          '# end'
-        ]
-      end
-
       def nested_property(prop, _value, name_override)
         name = name_override || prop.name
         [
@@ -160,10 +150,20 @@ module Provider
         ]
       end
 
-      def namevalue_property(prop, _value, name_override)
+      def keyvaluepairs_property(prop, _value, name_override)
         name = name_override || prop.name
         [
-          '# TODO(alexstephen): Implement name values test.',
+          '# TODO(alexstephen): Implement keyvaluepairs test.',
+          "# it '#{name}' do",
+          '#   # Add test code here',
+          '# end'
+        ]
+      end
+
+      def map_property(prop, _value, name_override)
+        name = name_override || prop.name
+        [
+          '# TODO(alexstephen): Implement map test.',
           "# it '#{name}' do",
           '#   # Add test code here',
           '# end'

--- a/provider/test_data/spec_formatter.rb
+++ b/provider/test_data/spec_formatter.rb
@@ -104,7 +104,7 @@ module Provider
 
       # Emits a name value
       # Should be a standard Hash, unlike other formatters.
-      def emit_namevalues(prop, seed, _ctx)
+      def emit_keyvaluepairs(prop, seed, _ctx)
         @datagen.value(prop.class, prop, seed)
       end
 
@@ -138,7 +138,8 @@ module Provider
             ->(v) { v.map { |e| e } },
           Api::Type::Array::RREF_ARRAY_TYPE =>
             ->(v) { v.call(exported_values: true) },
-          Api::Type::NameValues => ->(v) { v }
+          Api::Type::KeyValuePairs => ->(v) { v },
+          Api::Type::Map => ->(v) { v }
         }.freeze
       end
       # rubocop:enable Metrics/AbcSize

--- a/templates/chef/property/keyvaluepairs.rb.erb
+++ b/templates/chef/property/keyvaluepairs.rb.erb
@@ -19,9 +19,9 @@
 module Google
   module <%= product_ns %>
     module Property
-      # A class to handle serialization of NameValues items.
-      class NameValues
-<%= emit_coerce(product_ns, 'NameValues', 8) -%>
+      # A class to handle serialization of KeyValuePairs items.
+      class KeyValuePairs
+<%= emit_coerce(product_ns, 'KeyValuePairs', 8) -%>
         def self.api_parse(value)
           value
         end

--- a/templates/puppet/property/keyvaluepairs.rb.erb
+++ b/templates/puppet/property/keyvaluepairs.rb.erb
@@ -22,7 +22,7 @@ module Google
   module <%= product_ns %>
     module Property
       # A Puppet property that holds a string
-      class NameValues < Google::<%= product_ns %>::Property::Base
+      class KeyValuePairs < Google::<%= product_ns %>::Property::Base
         def self.api_munge(value)
           return if value.nil?
           value

--- a/templates/terraform/expand_property_method.erb
+++ b/templates/terraform/expand_property_method.erb
@@ -17,7 +17,7 @@
                            prefix: prefix,
                            property: property)) -%>
 <% else -%>
-<%   if string_to_object_map?(property) -%>
+<%   if property.is_a?(Api::Type::Map) -%>
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) (map[string]interface{}, error) {
   if v == nil {
     return map[string]interface{}{}, nil
@@ -46,7 +46,7 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
 <%     next if prop.name == property.key_name -%>
 <%=      lines(build_expand_method(prefix + titlelize_property(property), prop), 1) -%>
 <%   end -%>
-<%   elsif property.is_a?(Api::Type::NameValues) -%>
+<%   elsif property.is_a?(Api::Type::KeyValuePairs) -%>
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) (map[string]string, error) {
   if v == nil {
     return map[string]string{}, nil

--- a/templates/terraform/flatten_property_method.erb
+++ b/templates/terraform/flatten_property_method.erb
@@ -45,7 +45,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) in
     })
   }
   return transformed
-<% elsif string_to_object_map?(property) -%>
+<% elsif property.is_a?(Api::Type::Map) -%>
   if v == nil {
     return v
   }

--- a/templates/terraform/nested_property_documentation.erb
+++ b/templates/terraform/nested_property_documentation.erb
@@ -4,7 +4,7 @@
   if !nested_properties.empty?
 -%>
 The `<%= property.name.underscore -%>` block <%= if property.output then "contains" else "supports" end -%>:
-<%- if string_to_object_map?(property) %>
+<%- if property.is_a?(Api::Type::Map) %>
 * `<%= property.key_name.underscore -%>` - (Required) The identifier for this object. Format specified above.
 <% end -%>
 <% nested_properties.each do |prop| -%>

--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -6,6 +6,6 @@
   (Optional)
 <% end -%>
 <%= indent(property.description.strip.gsub("\n\n", "\n"), 2) -%>
-<% if property.is_a?(Api::Type::NestedObject) || string_to_object_map?(property) || (property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::NestedObject)) -%>
+<% if property.is_a?(Api::Type::NestedObject) || property.is_a?(Api::Type::Map) || (property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::NestedObject)) -%>
   Structure is documented below.
 <% end -%>

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -102,32 +102,26 @@
     // Default schema.HashSchema is used.
   <% end -%>
 	<% end -%>
-<% elsif property.is_a?(Api::Type::NameValues) -%>
-  <% if property.key_type == 'Api::Type::String' && property.value_type == 'Api::Type::String' -%>
+<% elsif property.is_a?(Api::Type::KeyValuePairs) -%>
   Elem: &schema.Schema{Type: schema.TypeString},
-  <% elsif string_to_object_map?(property) -%>
-  Elem: &schema.Resource{
-    Schema: map[string]*schema.Schema{
-      "<%= property.key_name -%>": {
-        Type:     schema.TypeString,
-        Required: true,
-        <% if force_new?(property, object) -%>
-        ForceNew: true,
-        <% end -%>
-      },
-      <% order_properties(property.value_type.properties).each do |prop| -%>
-        <%= lines(build_schema_property(prop, object)) -%>
-      <% end -%>
-    },
-  },
-  <% if !property.set_hash_func.nil? -%>
-  Set: <%= property.set_hash_func -%>,
-  <% end -%>
-  <% else -%>
-    // TODO(magic-modules): Handle this map specially - Terraform maps are String->String only,
-    // and support has been added for the String->Object case,
-    // but this map is marked as being <%= property.key_type -%>-><%= property.value_type -%>.
-  <% end -%>
+<% elsif property.is_a?(Api::Type::Map) -%>
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"<%= property.key_name -%>": {
+				Type:     schema.TypeString,
+				Required: true,
+				<% if force_new?(property, object) -%>
+				ForceNew: true,
+				<% end -%>
+			},
+			<% order_properties(property.value_type.properties).each do |prop| -%>
+				<%= lines(build_schema_property(prop, object)) -%>
+			<% end -%>
+		},
+	},
+	<% if !property.set_hash_func.nil? -%>
+	Set: <%= property.set_hash_func -%>,
+	<% end -%>
 <% end -%>
 <% if property.sensitive -%>
     Sensitive: true,


### PR DESCRIPTION
Remove NameValues, and add
* Map for complex string -> object cases (replacing `string_to_object_map` with a real type)
* KeyValuePairs for arrays/sets of key -> value pairs like `labels`

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
