### PR TITLE
Terraform: Add interpolated examples for non-compute resources.

### DIFF
--- a/products/binaryauthorization/terraform.yaml
+++ b/products/binaryauthorization/terraform.yaml
@@ -16,43 +16,14 @@ name: BinaryAuthorization
 overrides: !ruby/object:Provider::ResourceOverrides
   Attestor: !ruby/object:Provider::Terraform::ResourceOverride
     import_format: ["projects/{{project}}/attestors/{{name}}"]
-    examples: |
-      ```hcl
-      resource "google_container_analysis_note" "note" {
-        name = "test-attestor-note"
-        attestation_authority {
-          hint {
-            human_readable_name = "Attestor Note"
-          }
-        }
-      }
-
-      resource "google_binary_authorization_attestor" "attestor" {
-        name = "test-attestor"
-        attestation_authority_note {
-          note_reference = "${google_container_analysis_note.note.name}"
-          public_keys {
-            ascii_armored_pgp_public_key = <<EOF
-      mQENBFtP0doBCADF+joTiXWKVuP8kJt3fgpBSjT9h8ezMfKA4aXZctYLx5wslWQl
-      bB7Iu2ezkECNzoEeU7WxUe8a61pMCh9cisS9H5mB2K2uM4Jnf8tgFeXn3akJDVo0
-      oR1IC+Dp9mXbRSK3MAvKkOwWlG99sx3uEdvmeBRHBOO+grchLx24EThXFOyP9Fk6
-      V39j6xMjw4aggLD15B4V0v9JqBDdJiIYFzszZDL6pJwZrzcP0z8JO4rTZd+f64bD
-      Mpj52j/pQfA8lZHOaAgb1OrthLdMrBAjoDjArV4Ek7vSbrcgYWcI6BhsQrFoxKdX
-      83TZKai55ZCfCLIskwUIzA1NLVwyzCS+fSN/ABEBAAG0KCJUZXN0IEF0dGVzdG9y
-      IiA8ZGFuYWhvZmZtYW5AZ29vZ2xlLmNvbT6JAU4EEwEIADgWIQRfWkqHt6hpTA1L
-      uY060eeM4dc66AUCW0/R2gIbLwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRA6
-      0eeM4dc66HdpCAC4ot3b0OyxPb0Ip+WT2U0PbpTBPJklesuwpIrM4Lh0N+1nVRLC
-      51WSmVbM8BiAFhLbN9LpdHhds1kUrHF7+wWAjdR8sqAj9otc6HGRM/3qfa2qgh+U
-      WTEk/3us/rYSi7T7TkMuutRMIa1IkR13uKiW56csEMnbOQpn9rDqwIr5R8nlZP5h
-      MAU9vdm1DIv567meMqTaVZgR3w7bck2P49AO8lO5ERFpVkErtu/98y+rUy9d789l
-      +OPuS1NGnxI1YKsNaWJF4uJVuvQuZ1twrhCbGNtVorO2U12+cEq+YtUxj7kmdOC1
-      qoIRW6y0+UlAc+MbqfL0ziHDOAmcqz1GnROg
-      =6Bvm
-      EOF
-          }
-        }
-      }
-      ```
+    example:
+     - !ruby/object:Provider::Terraform::Examples
+      name: "binary_authorization_attestor_basic"
+      primary_resource_id: "attestor"
+      skip_test: true
+      vars:
+        attestor_name: "test-attestor"
+        note_name: "test-attestor-note"
     properties:
       name: !ruby/object:Provider::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
@@ -73,42 +44,14 @@ overrides: !ruby/object:Provider::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: 'templates/terraform/constants/binaryauthorization_policy.erb'
       pre_delete: 'templates/terraform/pre_delete/restore_default_binaryauthorization_policy.erb'
-    examples: |
-      ```hcl
-      resource "google_container_analysis_note" "note" {
-        name = "test-attestor-note"
-        attestation_authority {
-          hint {
-            human_readable_name = "My attestor"
-          }
-        }
-      }
-
-      resource "google_binary_authorization_attestor" "attestor" {
-        name = "test-attestor"
-        attestation_authority_note {
-          note_reference = "${google_container_analysis_note.note.name}"
-        }
-      }
-
-      resource "google_binary_authorization_policy" "policy" {
-        admission_whitelist_patterns {
-          name_pattern= "gcr.io/google_containers/*"
-        }
-
-        default_admission_rule {
-          evaluation_mode = "ALWAYS_ALLOW"
-          enforcement_mode = "ENFORCED_BLOCK_AND_AUDIT_LOG"
-        }
-
-        cluster_admission_rules {
-          cluster = "us-central1-a.prod-cluster"
-          evaluation_mode = "REQUIRE_ATTESTATION"
-          enforcement_mode = "ENFORCED_BLOCK_AND_AUDIT_LOG"
-          require_attestations_by = ["${google_binary_authorization_attestor.attestor.name}"]
-        }
-      }
-      ```
+    example:
+     - !ruby/object:Provider::Terraform::Examples
+      name: "binary_authorization_policy_basic"
+      primary_resource_id: "policy"
+      skip_test: true
+      vars:
+        attestor_name: "test-attestor"
+        note_name: "test-attestor-note"
     properties:
       clusterAdmissionRules: !ruby/object:Provider::Terraform::PropertyOverride
         is_set: true

--- a/products/containeranalysis/terraform.yaml
+++ b/products/containeranalysis/terraform.yaml
@@ -18,17 +18,12 @@ overrides: !ruby/object:Provider::ResourceOverrides
     import_format: ["projects/{{project}}/notes/{{name}}"]
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_update: 'templates/terraform/pre_update/containeranalysis_note.erb'
-    examples: |
-      ```hcl
-      resource "google_container_analysis_note" "note" {
-        name = "test-attestor-note"
-        attestation_authority {
-          hint {
-            human_readable_name = "Attestor Note"
-          }
-        }
-      }
-      ```
+    example:
+     - !ruby/object:Provider::Terraform::Examples
+      name: "container_analysis_note_basic"
+      primary_resource_id: "note"
+      vars:
+        note_name: "test-attestor-note"
     properties:
       name: !ruby/object:Provider::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'

--- a/products/filestore/terraform.yaml
+++ b/products/filestore/terraform.yaml
@@ -17,23 +17,12 @@ overrides: !ruby/object:Provider::ResourceOverrides
     exclude: false
     id_format: "{{project}}/{{zone}}/{{name}}"
     import_format: ["projects/{{project}}/locations/{{zone}}/instances/{{name}}"]
-    examples: |
-      ### Basic Usage
-      ```hcl
-        resource "google_file_instance" "instance" {
-          name = "test-instance"
-          zone = "us-central1-b"
-          file_shares {
-            capacity_gb = 2660
-            name = "share1"
-          }
-          networks {
-            network = "default"
-            modes = ["MODE_IPV4"]
-          }
-          tier = "PREMIUM"
-        }
-      ```
+    example:
+     - !ruby/object:Provider::Terraform::Examples
+      name: "filestore_instance_basic"
+      primary_resource_id: "instance"
+      vars:
+        instance_name: "test-instance"
     properties:
       name: !ruby/object:Provider::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'

--- a/products/redis/terraform.yaml
+++ b/products/redis/terraform.yaml
@@ -19,42 +19,18 @@ overrides: !ruby/object:Provider::ResourceOverrides
     import_format: ["projects/{{project}}/locations/{{region}}/instances/{{name}}"]
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_update: 'templates/terraform/pre_update/redis_instance.erb'
-    examples: |
-      ### Basic Usage
-      ```hcl
-      resource "google_redis_instance" "test" {
-        name           = "%s"
-        memory_size_gb = 1
-      }
-      ```
-
-      ### Full Usage
-      ```hcl
-      resource "google_compute_network" "test" {
-        name = "%s"
-      }
-
-      resource "google_redis_instance" "test" {
-        name           = "%s"
-        tier           = "STANDARD_HA"
-        memory_size_gb = 1
-
-        region                  = "us-central1"
-        location_id             = "us-central1-a"
-        alternative_location_id = "us-central1-f"
-        
-        authorized_network = "${google_compute_network.test.self_link}"
-
-        redis_version     = "REDIS_3_2"
-        display_name      = "Terraform Test Instance"
-        reserved_ip_range = "192.168.0.0/29"
-
-        labels {
-          my_key    = "my_val"
-          other_key = "other_val"
-        }
-      }
-      ```
+    example:
+     - !ruby/object:Provider::Terraform::Examples
+      name: "redis_instance_basic"
+      primary_resource_id: "cache"
+      vars:
+        instance_name: "memory-cache"
+     - !ruby/object:Provider::Terraform::Examples
+      name: "redis_instance_full"
+      primary_resource_id: "cache"
+      vars:
+        instance_name: "ha-memory-cache"
+        network_name: "authorized-network"
     properties:
       alternativeLocationId: !ruby/object:Provider::Terraform::PropertyOverride
         default_from_api: true

--- a/products/resourcemanager/terraform.yaml
+++ b/products/resourcemanager/terraform.yaml
@@ -19,24 +19,13 @@ overrides: !ruby/object:Provider::ResourceOverrides
   Lien: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: false
     import_format: ["{{parent}}/{{name}}"]
-    examples: |
-      ```hcl
-      resource "random_id" "r" {
-        byte_length = 8
-      }
-
-      resource "google_project" "project" {
-        project_id = "project-${random_id.r.hex}"
-        name = "A very important project!"
-      }
-
-      resource "google_resource_manager_lien" "lien" {
-        parent = "projects/${google_project.project.number}"
-        restrictions = ["resourcemanager.projects.delete"]
-        origin = "machine-readable-explanation"
-        reason = "This project is very important to me!"
-      }
-      ```
+    example:
+    - !ruby/object:Provider::Terraform::Examples
+      name: "resource_manager_lien"
+      skip_test: true
+      primary_resource_id: "lien"
+      vars:
+        project_id: "staging-project"
     properties:
       name: !ruby/object:Provider::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -148,7 +148,7 @@ module Provider
 
     # rubocop:disable Metrics/AbcSize
     def generate_resource_tests(data)
-      return if data[:object].example.empty?
+      return if data[:object].example.reject(&:skip_test).empty?
 
       target_folder = File.join(data[:output_folder], 'google')
       FileUtils.mkpath target_folder

--- a/provider/terraform/custom_code.rb
+++ b/provider/terraform/custom_code.rb
@@ -72,6 +72,9 @@ module Provider
       # These properties will likely be custom code.
       attr_reader :ignore_read_extra
 
+      # Whether to skip generating tests for this resource
+      attr_reader :skip_test
+
       def config_documentation
         body = lines(compile_file(
                        {
@@ -128,9 +131,9 @@ module Provider
 
         check_property :name, String
         check_property :primary_resource_id, String
-
         check_optional_property :vars, Hash
         check_optional_property_list :ignore_read_extra, String
+        check_optional_property :skip_test, TrueClass
       end
     end
 

--- a/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/templates/terraform/examples/base_configs/test_file.go.erb
@@ -9,11 +9,12 @@ import (
   "github.com/hashicorp/terraform/helper/acctest"
   "github.com/hashicorp/terraform/helper/resource"
 )
-<% object.example.each do |example| -%>
+<% object.example.reject(&:skip_test).each do |example| -%>
 <%
-  # {Compute}{Address}_{addressBasic}
-  test_slug = "#{product}#{resource_name}_#{example.name.camelize}Example"
-  ignore_read = data[:object].all_user_properties
+	resource_name = product_ns + object.name
+	# {Compute}{Address}_{addressBasic}
+	test_slug = "#{resource_name}_#{example.name.camelize}Example"
+	  ignore_read = data[:object].all_user_properties
                  .select(&:ignore_read)
                  .map { |p| p.name.underscore }
                  .concat(example.ignore_read_extra)
@@ -22,24 +23,24 @@ import (
 func TestAcc<%= test_slug -%>(t *testing.T) {
   t.Parallel()
 
-  resource.Test(t, resource.TestCase{
-    PreCheck:     func() { testAccPreCheck(t) },
-    Providers:    testAccProviders,
-    CheckDestroy: testAccCheck<%= "#{product}#{resource_name}" -%>Destroy,
-    Steps: []resource.TestStep{
-      {
-        Config: testAcc<%= test_slug -%>(acctest.RandString(10)),
-      },
-      {
-        ResourceName:            "<%= "google_#{product.downcase}_#{resource_name.underscore}" -%>.<%= example.primary_resource_id -%>",
-        ImportState:             true,
-        ImportStateVerify:       true,
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheck<%= "#{resource_name}" -%>Destroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAcc<%= test_slug -%>(acctest.RandString(10)),
+			},
+			{
+				ResourceName:      "<%= "google_#{resource_name.underscore}" -%>.<%= example.primary_resource_id -%>",
+				ImportState:       true,
+				ImportStateVerify: true,
         <%- unless ignore_read.empty? -%>
         ImportStateVerifyIgnore: <%= go_literal(ignore_read) %>,
         <%- end -%>
-      },
-    },
-  })
+			},
+		},
+	})
 }
 
 func testAcc<%= test_slug -%>(val string) string {

--- a/templates/terraform/examples/binary_authorization_attestor_basic.tf.erb
+++ b/templates/terraform/examples/binary_authorization_attestor_basic.tf.erb
@@ -1,0 +1,34 @@
+resource "google_binary_authorization_attestor" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]["attestor_name"] %>"
+  attestation_authority_note {
+    note_reference = "${google_container_analysis_note.note.name}"
+    public_keys {
+      ascii_armored_pgp_public_key = <<EOF
+mQENBFtP0doBCADF+joTiXWKVuP8kJt3fgpBSjT9h8ezMfKA4aXZctYLx5wslWQl
+bB7Iu2ezkECNzoEeU7WxUe8a61pMCh9cisS9H5mB2K2uM4Jnf8tgFeXn3akJDVo0
+oR1IC+Dp9mXbRSK3MAvKkOwWlG99sx3uEdvmeBRHBOO+grchLx24EThXFOyP9Fk6
+V39j6xMjw4aggLD15B4V0v9JqBDdJiIYFzszZDL6pJwZrzcP0z8JO4rTZd+f64bD
+Mpj52j/pQfA8lZHOaAgb1OrthLdMrBAjoDjArV4Ek7vSbrcgYWcI6BhsQrFoxKdX
+83TZKai55ZCfCLIskwUIzA1NLVwyzCS+fSN/ABEBAAG0KCJUZXN0IEF0dGVzdG9y
+IiA8ZGFuYWhvZmZtYW5AZ29vZ2xlLmNvbT6JAU4EEwEIADgWIQRfWkqHt6hpTA1L
+uY060eeM4dc66AUCW0/R2gIbLwULCQgHAgYVCgkICwIEFgIDAQIeAQIXgAAKCRA6
+0eeM4dc66HdpCAC4ot3b0OyxPb0Ip+WT2U0PbpTBPJklesuwpIrM4Lh0N+1nVRLC
+51WSmVbM8BiAFhLbN9LpdHhds1kUrHF7+wWAjdR8sqAj9otc6HGRM/3qfa2qgh+U
+WTEk/3us/rYSi7T7TkMuutRMIa1IkR13uKiW56csEMnbOQpn9rDqwIr5R8nlZP5h
+MAU9vdm1DIv567meMqTaVZgR3w7bck2P49AO8lO5ERFpVkErtu/98y+rUy9d789l
++OPuS1NGnxI1YKsNaWJF4uJVuvQuZ1twrhCbGNtVorO2U12+cEq+YtUxj7kmdOC1
+qoIRW6y0+UlAc+MbqfL0ziHDOAmcqz1GnROg
+=6Bvm
+EOF
+    }
+  }
+}
+
+resource "google_container_analysis_note" "note" {
+  name = "<%= ctx[:vars]["note_name"] %>"
+  attestation_authority {
+    hint {
+      human_readable_name = "Attestor Note"
+    }
+  }
+}

--- a/templates/terraform/examples/binary_authorization_policy_basic.tf.erb
+++ b/templates/terraform/examples/binary_authorization_policy_basic.tf.erb
@@ -1,0 +1,33 @@
+resource "google_binary_authorization_policy" "<%= ctx[:primary_resource_id] %>" {
+  admission_whitelist_patterns {
+    name_pattern= "gcr.io/google_containers/*"
+  }
+
+  default_admission_rule {
+    evaluation_mode = "ALWAYS_ALLOW"
+    enforcement_mode = "ENFORCED_BLOCK_AND_AUDIT_LOG"
+  }
+
+  cluster_admission_rules {
+    cluster = "us-central1-a.prod-cluster"
+    evaluation_mode = "REQUIRE_ATTESTATION"
+    enforcement_mode = "ENFORCED_BLOCK_AND_AUDIT_LOG"
+    require_attestations_by = ["${google_binary_authorization_attestor.attestor.name}"]
+  }
+}
+
+resource "google_container_analysis_note" "note" {
+  name = "<%= ctx[:vars]["note_name"] %>"
+  attestation_authority {
+    hint {
+      human_readable_name = "My attestor"
+    }
+  }
+}
+
+resource "google_binary_authorization_attestor" "attestor" {
+  name = "<%= ctx[:vars]["attestor_name"] %>"
+  attestation_authority_note {
+    note_reference = "${google_container_analysis_note.note.name}"
+  }
+}

--- a/templates/terraform/examples/container_analysis_note_basic.tf.erb
+++ b/templates/terraform/examples/container_analysis_note_basic.tf.erb
@@ -1,0 +1,8 @@
+resource "google_container_analysis_note" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]["note_name"] %>"
+  attestation_authority {
+    hint {
+      human_readable_name = "Attestor Note"
+    }
+  }
+}

--- a/templates/terraform/examples/filestore_instance_basic.tf.erb
+++ b/templates/terraform/examples/filestore_instance_basic.tf.erb
@@ -1,0 +1,15 @@
+resource "google_filestore_instance" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]["instance_name"] %>"
+  zone = "us-central1-b"
+  tier = "PREMIUM"
+
+  file_shares {
+    capacity_gb = 2660
+    name        = "share1"
+  }
+
+  networks {
+    network = "default"
+    modes   = ["MODE_IPV4"]
+  }
+}

--- a/templates/terraform/examples/redis_instance_basic.tf.erb
+++ b/templates/terraform/examples/redis_instance_basic.tf.erb
@@ -1,0 +1,4 @@
+resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
+  name           = "<%= ctx[:vars]["instance_name"] %>"
+  memory_size_gb = 1
+}

--- a/templates/terraform/examples/redis_instance_full.tf.erb
+++ b/templates/terraform/examples/redis_instance_full.tf.erb
@@ -1,0 +1,23 @@
+resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
+  name           = "<%= ctx[:vars]["instance_name"] %>"
+  tier           = "STANDARD_HA"
+  memory_size_gb = 1
+
+  location_id             = "us-central1-a"
+  alternative_location_id = "us-central1-f"
+
+  authorized_network = "${google_compute_network.auto-network.self_link}"
+
+  redis_version     = "REDIS_3_2"
+  display_name      = "Terraform Test Instance"
+  reserved_ip_range = "192.168.0.0/29"
+
+  labels {
+    my_key    = "my_val"
+    other_key = "other_val"
+  }
+}
+
+resource "google_compute_network" "auto-network" {
+  name = "<%= ctx[:vars]["network_name"] %>"
+}

--- a/templates/terraform/examples/resource_manager_lien.tf.erb
+++ b/templates/terraform/examples/resource_manager_lien.tf.erb
@@ -1,0 +1,12 @@
+resource "google_resource_manager_lien" "<%= ctx[:primary_resource_id] %>" {
+  parent = "projects/${google_project.project.number}"
+  restrictions = ["resourcemanager.projects.delete"]
+  origin = "machine-readable-explanation"
+  reason = "This project is an important environment"
+}
+
+resource "google_project" "project" {
+  project_id = "<%= ctx[:vars]["project_id"] %>"
+  name = "A very important project!"
+}
+


### PR DESCRIPTION
Add interpolated examples + tests for all non-Compute resources.

Added `skip_test` param to skip testing some resources. It's intended for Interconnects when they land in MM, but BinAuth and RM Liens look involved to test so I'm leaving those untested for now, and will briefly look into them when this lands.

-----------------------------------------------------------------
# [all]
## [terraform]
Add example tests for Redis, Filestore, ContainerAnalysis
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
