### PR TITLE
Create a provider for runnable Terraform examples 

### DIFF
--- a/provider/terraform/custom_code.rb
+++ b/provider/terraform/custom_code.rb
@@ -98,6 +98,16 @@ module Provider
         ))
       end
 
+      def config_example
+        lines(compile_file(
+                {
+                  vars: vars.map { |k, str| [k, "#{str}-${local.name_suffix}"] }.to_h,
+                  primary_resource_id: primary_resource_id
+                },
+                "templates/terraform/examples/#{name}.tf.erb"
+        ))
+      end
+
       def validate
         super
         check_property :name, String

--- a/provider/terraform_example.rb
+++ b/provider/terraform_example.rb
@@ -1,0 +1,60 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'provider/terraform'
+
+module Provider
+  # Code generator for runnable Terraform Examples
+  class TerraformExample < Provider::Terraform
+
+    # We don't want *any* static generation, so we override generate to only
+    # generate objects.
+    def generate(output_folder, types, version_name)
+      version = @api.version_obj_or_default(version_name)
+      generate_objects(output_folder, types, version)
+    end
+
+    # Create a directory of examples per resource
+    def generate_resource(data)
+      return if data[:object].example.nil?
+
+      data[:object].example.each do |example|
+        target_folder = data[:output_folder]
+        target_folder = File.join(target_folder, example.name)
+        FileUtils.mkpath target_folder
+
+        generate_resource_file data.clone.merge(
+          example: example,
+          default_template: 'templates/terraform/examples/base_configs/example_file.tf.erb',
+          out_file: File.join(target_folder, 'main.tf')
+        )
+
+        generate_resource_file data.clone.merge(
+          default_template: 'templates/terraform/examples/base_configs/example_backing_file.tf.erb',
+          out_file: File.join(target_folder, 'name_prefix.tf')
+        )
+      end
+    end
+
+    # rubocop:disable Layout/EmptyLineBetweenDefs
+    # We don't want to generate anything but the resource.
+    def generate_resource_tests(data) end
+    def generate_network_datas(data, object) end
+    def generate_base_property(data) end
+    def generate_simple_property(type, data) end
+    def emit_nested_object(data) end
+    def emit_resourceref_object(data) end
+    def generate_typed_array(data, prop) end
+    # rubocop:enable Layout/EmptyLineBetweenDefs
+  end
+end

--- a/templates/terraform/examples/base_configs/example_backing_file.tf.erb
+++ b/templates/terraform/examples/base_configs/example_backing_file.tf.erb
@@ -1,0 +1,8 @@
+<% autogen_exception -%>
+locals {
+  name_suffix = "${random_pet.suffix.id}"
+}
+
+resource "random_pet" "suffix" {
+  length = 2
+}

--- a/templates/terraform/examples/base_configs/example_file.tf.erb
+++ b/templates/terraform/examples/base_configs/example_file.tf.erb
@@ -1,0 +1,2 @@
+<% autogen_exception -%>
+<%= example.config_example -%>


### PR DESCRIPTION
Adds a provider for runnable Terraform examples based on our documentation examples.

This is pretty hacky right now because we need the Terraform Config / `terraform.yaml` properties but *not* the Terraform provider. I'd like to merge this with a workaround like `force_provider`, and then solving the problem that we need only the config and not the generator for an engine separately.

Looking for a review w/o a merge at this time - we'll need a place to output these examples before adding them to ci. 

Examples are generated locally with:

`bundle exec compiler -a -e terraform -f "examples" -o "${GOPATH}/src/github.com/terraform-providers/terraform-provider-google/"`

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
