### PR TITLE
We can't read the region from the redis API.

### DIFF
--- a/products/binaryauthorization/api.yaml
+++ b/products/binaryauthorization/api.yaml
@@ -126,10 +126,9 @@ objects:
       - !ruby/object:Api::Type::Array
         name: admissionWhitelistPatterns
         description: |
-          Admission policy whitelisting. A matching admission request will
-          always be permitted. This feature is typically used to exclude Google
-          or third-party infrastructure images from Binary Authorization
-          policies.
+          A whitelist of image patterns to exclude from admission rules. If an
+          image's name matches a whitelist pattern, the image's admission
+          requests will always be permitted regardless of your admission rules.
         item_type: !ruby/object:Api::Type::NestedObject
           properties:
             - !ruby/object:Api::Type::String
@@ -142,10 +141,16 @@ objects:
       - !ruby/object:Api::Type::NameValues
         name: clusterAdmissionRules
         description: |
-          Admission policy whitelisting. A matching admission request will
-          always be permitted. This feature is typically used to exclude Google
-          or third-party infrastructure images from Binary Authorization
-          policies.
+          Per-cluster admission rules. An admission rule specifies either that
+          all container images used in a pod creation request must be attested
+          to by one or more attestors, that all pod creations will be allowed,
+          or that all pod creations will be denied. There can be at most one
+          admission rule per cluster spec.
+
+
+          Identifier format: `{{location}}.{{clusterId}}`.
+          A location is either a compute zone (e.g. `us-central1-a`) or a region
+          (e.g. `us-central1`).
         key_type: Api::Type::String
         key_name: cluster
         value_type: !ruby/object:Api::Type::NestedObject

--- a/products/redis/terraform.yaml
+++ b/products/redis/terraform.yaml
@@ -70,6 +70,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
       redisVersion: !ruby/object:Provider::Terraform::PropertyOverride
         default_from_api: true
       region: !ruby/object:Provider::Terraform::PropertyOverride
+        ignore_read: true
         required: false
         default_from_api: true
       reservedIpRange: !ruby/object:Provider::Terraform::PropertyOverride

--- a/templates/terraform/nested_property_documentation.erb
+++ b/templates/terraform/nested_property_documentation.erb
@@ -4,6 +4,9 @@
   if !nested_properties.empty?
 -%>
 The `<%= property.name.underscore -%>` block <%= if property.output then "contains" else "supports" end -%>:
+<%- if string_to_object_map?(property) %>
+* `<%= property.key_name.underscore -%>` - (Required) The identifier for this object. Format specified above.
+<% end -%>
 <% nested_properties.each do |prop| -%>
 <%= lines(build_property_documentation(prop)) -%>
 <% end -%>

--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -6,6 +6,6 @@
   (Optional)
 <% end -%>
 <%= indent(property.description.strip.gsub("\n\n", "\n"), 2) -%>
-<% if property.is_a?(Api::Type::NestedObject) || (property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::NestedObject)) -%>
+<% if property.is_a?(Api::Type::NestedObject) || string_to_object_map?(property) || (property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::NestedObject)) -%>
   Structure is documented below.
 <% end -%>

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -206,7 +206,7 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
 <%  end -%>
 
 
-<%  properties.select { |p| !p.ignore_read }.each do |prop| -%>
+<%  properties.reject(&:ignore_read).each do |prop| -%>
     if err := d.Set("<%= prop.name.underscore -%>", flatten<%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.api_name -%>"])); err != nil {
         return fmt.Errorf("Error reading <%= object.name -%>: %s", err)
     }
@@ -479,7 +479,7 @@ func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{
 <% end -%>
 }
 
-<% properties.each do |prop| -%>
+<% properties.reject(&:ignore_read).each do |prop| -%>
 <%= lines(build_flatten_method(resource_name, prop), 1) -%>
 <% end -%>
 


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
We need to ignore the read because redis has what's called a `location` instead of `region`, and doesn't return either from the API.

-----------------------------------------------------------------
# [all]
## [terraform]
Bugfix: Stop reading region from Redis API.