### PR TITLE
Linting api.yaml with the Discovery Docs

### DIFF
--- a/tools/linter/README.md
+++ b/tools/linter/README.md
@@ -1,0 +1,10 @@
+# api.yaml linter
+
+The idea of this linter is to lint api.yaml against the Discovery docs.
+
+Because api.yaml is handwritten, it will inevitably veer away from the Discovery docs
+(the source of truth) or just be inputted incorrectly.
+
+## How to run
+All tests live in tools/linter/tests.rb
+Run `ruby tests/linter/tests.rb` to run.

--- a/tools/linter/api.rb
+++ b/tools/linter/api.rb
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'api/async'
 require 'api/compiler'
 require 'api/product'
@@ -5,8 +18,8 @@ require 'api/resource'
 require 'api/type'
 require 'google/yaml_validator'
 
+# Responsbible for grabbing api.yaml and getting resources from it
 class ProductApi
-
   attr_reader :api
 
   def initialize(product_name)
@@ -24,6 +37,6 @@ class ProductApi
   private
 
   def get_api(product_name)
-    Api::Compiler.new("products/#{product_name}/api.yaml").run 
+    Api::Compiler.new("products/#{product_name}/api.yaml").run
   end
 end

--- a/tools/linter/api.rb
+++ b/tools/linter/api.rb
@@ -1,0 +1,29 @@
+require 'api/async'
+require 'api/compiler'
+require 'api/product'
+require 'api/resource'
+require 'api/type'
+require 'google/yaml_validator'
+
+class ProductApi
+
+  attr_reader :api
+
+  def initialize(product_name)
+    @api = get_api(product_name)
+  end
+
+  def resource(name)
+    @api.objects.select { |obj| obj.name == name }.first
+  end
+
+  def all_resource_names
+    @api.objects.map(&:name)
+  end
+
+  private
+
+  def get_api
+    Api::Compiler.new("products/#{product_name}/api.yaml").run 
+  end
+end

--- a/tools/linter/api.rb
+++ b/tools/linter/api.rb
@@ -23,7 +23,7 @@ class ProductApi
 
   private
 
-  def get_api
+  def get_api(product_name)
     Api::Compiler.new("products/#{product_name}/api.yaml").run 
   end
 end

--- a/tools/linter/discovery.rb
+++ b/tools/linter/discovery.rb
@@ -1,6 +1,20 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 require 'net/http'
 require 'json'
 
+# Responsible for grabbing Discovery Docs and getting resources from it
 class Discovery
   attr_reader :results
 
@@ -21,6 +35,8 @@ class Discovery
   end
 end
 
+# Holds information about discovery objects
+# Two sections: schema (properties) and methods
 class DiscoveryObject
   attr_reader :schema
 

--- a/tools/linter/discovery.rb
+++ b/tools/linter/discovery.rb
@@ -1,0 +1,31 @@
+require 'net/http'
+require 'json'
+
+class Discovery
+  attr_reader :results
+
+  def initialize(url)
+    @url = url
+    @results = send_request(url)
+  end
+
+  def resource(name)
+    DiscoveryObject.new(
+      @results['schemas'][name]
+    )
+  end
+
+  private
+
+  def send_request(url)
+    JSON.parse(Net::HTTP.get(URI(url)))
+  end
+end
+
+class DiscoveryObject
+  attr_reader :schema
+
+  def initialize(schema, methods)
+    @schema = schema
+  end
+end

--- a/tools/linter/discovery.rb
+++ b/tools/linter/discovery.rb
@@ -10,9 +10,8 @@ class Discovery
   end
 
   def resource(name)
-    DiscoveryObject.new(
-      @results['schemas'][name]
-    )
+    schema = @results['schemas'][name]
+    DiscoveryObject.new(schema)
   end
 
   private
@@ -25,7 +24,11 @@ end
 class DiscoveryObject
   attr_reader :schema
 
-  def initialize(schema, methods)
+  def initialize(schema)
     @schema = schema
+  end
+
+  def exists?
+    !@schema.nil?
   end
 end

--- a/tools/linter/test_helpers.rb
+++ b/tools/linter/test_helpers.rb
@@ -1,0 +1,4 @@
+def loop_resources_in_api(api, discovery, &block)
+  names = api.all_resource_names
+  names.each { yield api.resource(name), discovery.resource(name) }
+end

--- a/tools/linter/test_helpers.rb
+++ b/tools/linter/test_helpers.rb
@@ -1,4 +1,4 @@
 def loop_resources_in_api(api, discovery, &block)
   names = api.all_resource_names
-  names.each { yield api.resource(name), discovery.resource(name) }
+  names.each { |name| yield api.resource(name), discovery.resource(name) }
 end

--- a/tools/linter/test_helpers.rb
+++ b/tools/linter/test_helpers.rb
@@ -1,4 +1,17 @@
-def loop_resources_in_api(api, discovery, &block)
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def loop_resources_in_api(api, discovery)
   names = api.all_resource_names
   names.each { |name| yield api.resource(name), discovery.resource(name) }
 end

--- a/tools/linter/tests.rb
+++ b/tools/linter/tests.rb
@@ -3,7 +3,17 @@ $LOAD_PATH.unshift File.join(File.dirname(__FILE__), "../../")
 Dir.chdir(File.join(File.dirname(__FILE__), "../../"))
 
 require 'tools/linter/discovery'
+require 'tools/linter/api'
+require 'tools/linter/test_helpers'
 
 COMPUTE_DISCOVERY_URL = 'https://www.googleapis.com/discovery/v1/apis/compute/v1/rest'
 discovery = Discovery.new(COMPUTE_DISCOVERY_URL)
-puts discovery.results
+api = ProductApi.new('compute')
+
+# Print out all properties in discovery, but not in api.
+loop_resources_in_api(api, discovery) do |api_obj, disc_obj|
+  api_prop_names = api_object.all_user_properties.map(&:name)
+  disc_prop_names = disc_obj['properties'].keys
+  missing_props = Set.new(disc_prop_names) - Set.new(api_prop_names)
+  print "#{api_obj.name}: #{missing_props} are in discovery, but not API"
+end

--- a/tools/linter/tests.rb
+++ b/tools/linter/tests.rb
@@ -1,6 +1,19 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Load everything from MM root.
-$LOAD_PATH.unshift File.join(File.dirname(__FILE__), "../../")
-Dir.chdir(File.join(File.dirname(__FILE__), "../../"))
+$LOAD_PATH.unshift File.join(File.dirname(__FILE__), '../../')
+Dir.chdir(File.join(File.dirname(__FILE__), '../../'))
 
 require 'tools/linter/discovery'
 require 'tools/linter/api'
@@ -8,12 +21,12 @@ require 'tools/linter/test_helpers'
 
 require 'set'
 
-COMPUTE_DISCOVERY_URL = 'https://www.googleapis.com/discovery/v1/apis/compute/v1/rest'
+COMPUTE_DISCOVERY_URL = 'https://www.googleapis.com/discovery/v1/apis/compute/v1/rest'.freeze
 discovery = Discovery.new(COMPUTE_DISCOVERY_URL)
 api = ProductApi.new('compute')
 
 # Print out all properties in discovery, but not in api.
-puts "INFO: Finding all missing top level properties on api.yaml"
+puts 'INFO: Finding all missing top level properties on api.yaml'
 
 loop_resources_in_api(api, discovery) do |api_obj, disc_obj|
   unless disc_obj.exists?

--- a/tools/linter/tests.rb
+++ b/tools/linter/tests.rb
@@ -6,14 +6,24 @@ require 'tools/linter/discovery'
 require 'tools/linter/api'
 require 'tools/linter/test_helpers'
 
+require 'set'
+
 COMPUTE_DISCOVERY_URL = 'https://www.googleapis.com/discovery/v1/apis/compute/v1/rest'
 discovery = Discovery.new(COMPUTE_DISCOVERY_URL)
 api = ProductApi.new('compute')
 
 # Print out all properties in discovery, but not in api.
+puts "INFO: Finding all missing top level properties on api.yaml"
+
 loop_resources_in_api(api, discovery) do |api_obj, disc_obj|
-  api_prop_names = api_object.all_user_properties.map(&:name)
-  disc_prop_names = disc_obj['properties'].keys
-  missing_props = Set.new(disc_prop_names) - Set.new(api_prop_names)
-  print "#{api_obj.name}: #{missing_props} are in discovery, but not API"
+  unless disc_obj.exists?
+    puts "WARN: #{api_obj.name} - not found in Discovery"
+    next
+  end
+  api_prop_names = api_obj.all_user_properties.map(&:name)
+  disc_prop_names = disc_obj.schema['properties'].keys
+  missing_props = (Set.new(disc_prop_names) - Set.new(api_prop_names)) - Set.new(%w[kind selfLink])
+  unless missing_props.to_a.empty?
+    puts "ERROR: #{api_obj.name}- #{missing_props.to_a.join(', ')} are in discovery, but not API"
+  end
 end

--- a/tools/linter/tests.rb
+++ b/tools/linter/tests.rb
@@ -1,0 +1,9 @@
+# Load everything from MM root.
+$LOAD_PATH.unshift File.join(File.dirname(__FILE__), "../../")
+Dir.chdir(File.join(File.dirname(__FILE__), "../../"))
+
+require 'tools/linter/discovery'
+
+COMPUTE_DISCOVERY_URL = 'https://www.googleapis.com/discovery/v1/apis/compute/v1/rest'
+discovery = Discovery.new(COMPUTE_DISCOVERY_URL)
+puts discovery.results


### PR DESCRIPTION
api.yaml isn't always up-to-date with Discovery docs.

Examples:
- Discovery has properties that api.yaml doesn't
- api.yaml references updates URLs that don't exist (just ran into this problem!)

If we're not auto-generating api.yaml, we need some way to verify that api.yaml is accurate. This is a small test POC to show how we could build a test that compares Discovery to api.yaml and does comparisons.

I've currently written out one test: look for top-level properties on Discovery that are not in api.yaml. Turns out, there's quite a few of them...

Test output:
```
ERROR: Address- ipVersion, status are in discovery, but not API
ERROR: Autoscaler- region, status, statusDetails are in discovery, but not API
ERROR: BackendBucket- cdnPolicy are in discovery, but not API
ERROR: BackendService- fingerprint, port, securityPolicy are in discovery, but not API
ERROR: DiskType- region are in discovery, but not API
ERROR: Disk- guestOsFeatures, licenseCodes, options, region, replicaZones, status are in discovery, but not API
WARN: GlobalAddress - not found in Discovery
WARN: GlobalForwardingRule - not found in Discovery
ERROR: InstanceTemplate- sourceInstance, sourceInstanceParams are in discovery, but not API
ERROR: License- creationTimestamp, description, id, licenseCode, resourceRequirements, transferable are in discovery, but not API
ERROR: Image- labelFingerprint, labels, licenseCodes, sourceImage, sourceImageEncryptionKey, sourceImageId, sourceSnapshot, sourceSnapshotEncryptionKey, sourceSnapshotId, status are in discovery, but not API
ERROR: Instance- deletionProtection, description, labels, startRestricted are in discovery, but not API
ERROR: InstanceGroup- fingerprint, size are in discovery, but not API
ERROR: InstanceGroupManager- distributionPolicy, fingerprint are in discovery, but not API
ERROR: MachineType- imageSpaceGb, scratchDisks are in discovery, but not API
ERROR: Network- IPv4Range, gatewayIPv4, peerings, routingConfig are in discovery, but not API
ERROR: Region- quotas, status are in discovery, but not API
WARN: RegionAutoscaler - not found in Discovery
WARN: RegionDiskType - not found in Discovery
WARN: RegionDisk - not found in Discovery
ERROR: Route- creationTimestamp, id, nextHopPeering, warnings are in discovery, but not API
ERROR: Router- bgpPeers, interfaces are in discovery, but not API
ERROR: Snapshot- labelFingerprint, licenseCodes, sourceDisk, sourceDiskId, status, storageBytesStatus are in discovery, but not API
ERROR: TargetHttpsProxy- sslPolicy are in discovery, but not API
ERROR: TargetPool- healthChecks are in discovery, but not API
ERROR: TargetSslProxy- sslPolicy are in discovery, but not API
ERROR: TargetVpnGateway- status are in discovery, but not API
ERROR: UrlMap- fingerprint are in discovery, but not API
ERROR: VpnTunnel- detailedStatus, id, status are in discovery, but not API
ERROR: Zone- availableCpuPlatforms are in discovery, but not API

```


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
