### PR TITLE
Better error message if export is called before fetch.

### DIFF
--- a/templates/puppet/resource.erb
+++ b/templates/puppet/resource.erb
@@ -348,6 +348,7 @@ Puppet::Type.type(:<%= object.out_name -%>).provide(:google) do
 <% unless object.exports.nil? -%>
 <%
   exp_list = [
+    'raise "Must fetch before accessing exported values." if @fetched.nil?',
     '{',
     indent_list(object.exported_properties.map do |p|
       if p.is_a?(Api::Type::FetchedExternal)


### PR DESCRIPTION
We should raise a sensible error message if we are not able to access exports due to not having fetched the resource yet.  This is one of the most common errors we see, and it's rendered right now as something along the lines of `nilClass does not have method []`, which is not obvious.

-----------------------------------------------------------------
# [all]
## [puppet]
Better error messages for export fetch failure.
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
