### PR TITLE
Terraform: Add an Address example with a VM instance.

### DIFF
--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 79.24
+    "covered_percent": 78.81
   }
 }

--- a/google/golang_utils.rb
+++ b/google/golang_utils.rb
@@ -24,14 +24,20 @@ module Google
     # quotes becomes a ruby string without quotes unless you explicitly set
     # quotes in the string like "\"foo\"" which is not a pattern we want to
     # see in our yaml config files.
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity
     def go_literal(value)
       if value.is_a?(String) || value.is_a?(Symbol)
         "\"#{value}\""
       elsif value.is_a?(Numeric)
         value.to_s
+      elsif value.is_a?(Array) && value.all? { |v| v.is_a?(String) || v.is_a?(Symbol) }
+        "[]string{#{value.map(&method(:go_literal)).join(', ')}}"
       else
         raise "Unsupported go literal #{value}"
       end
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/PerceivedComplexity
   end
 end

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -28,6 +28,13 @@ overrides: !ruby/object:Provider::ResourceOverrides
         address_name: "my-internal-address"
         network_name: "my-network"
         subnetwork_name: "my-subnet"
+    # TODO(rileykarson): Remove this example when instance is supported
+     - !ruby/object:Provider::Terraform::Examples
+       name: "instance_with_ip"
+       primary_resource_id: "static"
+       vars:
+         address_name: "ipv4-address"
+         instance_name: "vm-instance"
     properties:
       address: !ruby/object:Provider::Terraform::PropertyOverride
         default_from_api: true

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -551,72 +551,25 @@ overrides: !ruby/object:Provider::ResourceOverrides
       optional_properties: |
         * `name_prefix` - (Optional) Creates a unique name beginning with the
          specified prefix. Conflicts with `name`.
-    examples: |
-      ```hcl
-      resource "google_compute_ssl_certificate" "default" {
-        name_prefix = "my-certificate-"
-        description = "a description"
-        private_key = "${file("path/to/private.key")}"
-        certificate = "${file("path/to/certificate.crt")}"
-
-        lifecycle {
-          create_before_destroy = true
-        }
-      }
-
-      # You may also want to control name generation explicitly:
-
-      resource "random_id" "certificate" {
-        byte_length = 4
-        prefix      = "my-certificate-"
-
-        # For security, do not expose raw certificate values in the output
-        keepers {
-          private_key = "${base64sha256(file("path/to/private.key"))}"
-          certificate = "${base64sha256(file("path/to/certificate.crt"))}"
-        }
-      }
-
-      resource "google_compute_ssl_certificate" "default" {
-        # The name will contain 8 random hex digits,
-        # e.g. "my-certificate-48ab27cd2a"
-        name        = "${random_id.certificate.hex}"
-        private_key = "${file("path/to/private.key")}"
-        certificate = "${file("path/to/certificate.crt")}"
-
-        lifecycle {
-          create_before_destroy = true
-        }
-      }
-      ```
-      ```hcl
-      // Using with Target HTTPS Proxies
-      //
-      // SSL certificates cannot be updated after creation. In order to apply
-      // the specified configuration, Terraform will destroy the existing
-      // resource and create a replacement. To effectively use an SSL
-      // certificate resource with a Target HTTPS Proxy resource, it's
-      // recommended to specify create_before_destroy in a lifecycle block.
-      // Either omit the Instance Template name attribute, specify a partial
-      // name with name_prefix, or use random_id resource. Example:
-
-      resource "google_compute_ssl_certificate" "default" {
-        name_prefix = "my-certificate-"
-        description = "a description"
-        private_key = "${file("path/to/private.key")}"
-        certificate = "${file("path/to/certificate.crt")}"
-
-        lifecycle {
-          create_before_destroy = true
-        }
-      }
-
-      resource "google_compute_target_https_proxy" "my_proxy" {
-        name             = "public-proxy"
-        url_map          = # ...
-        ssl_certificates = ["${google_compute_ssl_certificate.default.self_link}"]
-      }
-      ```
+    example:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "ssl_certificate_basic"
+        primary_resource_id: "default"
+        ignore_read_extra:
+          - "name_prefix"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "ssl_certificate_random_provider"
+        primary_resource_id: "default"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "ssl_certificate_target_https_proxies"
+        primary_resource_id: "default"
+        vars:
+          target_https_proxy_name: "test-proxy"
+          url_map_name: "url-map"
+          backend_service_name: "backend-service"
+          http_health_check_name: "http-health-check"
+        ignore_read_extra:
+          - "name_prefix"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       extra_schema_entry: templates/terraform/extra_schema_entry/ssl_certificate.erb
     properties:
@@ -721,110 +674,29 @@ overrides: !ruby/object:Provider::ResourceOverrides
           subnetwork_name: "test-subnetwork"
           network_name: "test-network"
   TargetHttpProxy: !ruby/object:Provider::Terraform::ResourceOverride
-    examples: |
-      ```hcl
-      resource "google_compute_target_http_proxy" "default" {
-        name        = "test-proxy"
-        description = "a description"
-        url_map     = "${google_compute_url_map.default.self_link}"
-      }
-
-      resource "google_compute_url_map" "default" {
-        name        = "url-map"
-        description = "a description"
-
-        default_service = "${google_compute_backend_service.default.self_link}"
-
-        host_rule {
-          hosts        = ["mysite.com"]
-          path_matcher = "allpaths"
-        }
-
-        path_matcher {
-          name            = "allpaths"
-          default_service = "${google_compute_backend_service.default.self_link}"
-
-          path_rule {
-            paths   = ["/*"]
-            service = "${google_compute_backend_service.default.self_link}"
-          }
-        }
-      }
-
-      resource "google_compute_backend_service" "default" {
-        name        = "default-backend"
-        port_name   = "http"
-        protocol    = "HTTP"
-        timeout_sec = 10
-
-        health_checks = ["${google_compute_http_health_check.default.self_link}"]
-      }
-
-      resource "google_compute_http_health_check" "default" {
-        name               = "test"
-        request_path       = "/"
-        check_interval_sec = 1
-        timeout_sec        = 1
-      }
-      ```
+    example:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "target_http_proxy_basic"
+        primary_resource_id: "default"
+        vars:
+          target_http_proxy_name: "test-proxy"
+          url_map_name: "url-map"
+          backend_service_name: "backend-service"
+          http_health_check_name: "http-health-check"
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
         name: proxyId
   TargetHttpsProxy: !ruby/object:Provider::Terraform::ResourceOverride
-    examples: |
-      ```hcl
-      resource "google_compute_target_https_proxy" "default" {
-        name             = "test-proxy"
-        description      = "a description"
-        url_map          = "${google_compute_url_map.default.self_link}"
-        ssl_certificates = ["${google_compute_ssl_certificate.default.self_link}"]
-      }
-
-      resource "google_compute_ssl_certificate" "default" {
-        name        = "my-certificate"
-        description = "a description"
-        private_key = "${file("path/to/private.key")}"
-        certificate = "${file("path/to/certificate.crt")}"
-      }
-
-      resource "google_compute_url_map" "default" {
-        name        = "url-map"
-        description = "a description"
-
-        default_service = "${google_compute_backend_service.default.self_link}"
-
-        host_rule {
-          hosts        = ["mysite.com"]
-          path_matcher = "allpaths"
-        }
-
-        path_matcher {
-          name            = "allpaths"
-          default_service = "${google_compute_backend_service.default.self_link}"
-
-          path_rule {
-            paths   = ["/*"]
-            service = "${google_compute_backend_service.default.self_link}"
-          }
-        }
-      }
-
-      resource "google_compute_backend_service" "default" {
-        name        = "default-backend"
-        port_name   = "http"
-        protocol    = "HTTP"
-        timeout_sec = 10
-
-        health_checks = ["${google_compute_http_health_check.default.self_link}"]
-      }
-
-      resource "google_compute_http_health_check" "default" {
-        name               = "test"
-        request_path       = "/"
-        check_interval_sec = 1
-        timeout_sec        = 1
-      }
-      ```
+    example:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "target_https_proxy_basic"
+        primary_resource_id: "default"
+        vars:
+          target_https_proxy_name: "test-proxy"
+          ssl_certificate_name: "my-certificate"
+          url_map_name: "url-map"
+          backend_service_name: "backend-service"
+          http_health_check_name: "http-health-check"
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
         name: proxyId
@@ -864,35 +736,15 @@ overrides: !ruby/object:Provider::ResourceOverrides
       # TODO: Custom code needed for updating `instances` and `healthCheck`.
       #       Update methods are (add|remove)Instance, (add/remove)HealthCheck
   TargetSslProxy: !ruby/object:Provider::Terraform::ResourceOverride
-    examples: |
-      ```hcl
-      resource "google_compute_target_ssl_proxy" "default" {
-        name = "test"
-        backend_service = "${google_compute_backend_service.default.self_link}"
-        ssl_certificates = ["${google_compute_ssl_certificate.default.self_link}"]
-      }
-
-      resource "google_compute_ssl_certificate" "default" {
-        name = "default-cert"
-        private_key = "${file("path/to/test.key")}"
-        certificate = "${file("path/to/test.crt")}"
-      }
-
-      resource "google_compute_backend_service" "default" {
-        name = "default-backend"
-        protocol    = "SSL"
-        health_checks = ["${google_compute_health_check.default.self_link}"]
-      }
-
-      resource "google_compute_health_check" "default" {
-        name = "default-health-check"
-        check_interval_sec = 1
-        timeout_sec = 1
-        tcp_health_check {
-          port = "443"
-        }
-      }
-      ```
+    example:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "target_ssl_proxy_basic"
+        primary_resource_id: "default"
+        vars:
+          target_ssl_proxy_name: "test-proxy"
+          ssl_certificate_name: "default-cert"
+          backend_service_name: "backend-service"
+          health_check_name: "health-check"
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
         name: proxyId
@@ -903,32 +755,14 @@ overrides: !ruby/object:Provider::ResourceOverrides
       sslPolicy: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: false
   TargetTcpProxy: !ruby/object:Provider::Terraform::ResourceOverride
-    examples: |
-      ```hcl
-      resource "google_compute_target_tcp_proxy" "default" {
-        name = "test"
-        description = "test"
-        backend_service = "${google_compute_backend_service.default.self_link}"
-      }
-
-      resource "google_compute_backend_service" "default" {
-        name        = "default-backend"
-        protocol    = "TCP"
-        timeout_sec = 10
-
-        health_checks = ["${google_compute_health_check.default.self_link}"]
-      }
-
-      resource "google_compute_health_check" "default" {
-        name = "default"
-        timeout_sec        = 1
-        check_interval_sec = 1
-
-        tcp_health_check {
-          port = "443"
-        }
-      }
-      ```
+    example:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "target_tcp_proxy_basic"
+        primary_resource_id: "default"
+        vars:
+          target_tcp_proxy_name: "test-proxy"
+          backend_service_name: "backend-service"
+          health_check_name: "health-check"
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
         name: proxyId
@@ -939,74 +773,19 @@ overrides: !ruby/object:Provider::ResourceOverrides
   TargetVpnGateway: !ruby/object:Provider::Terraform::ResourceOverride
     name: 'VpnGateway'
     exclude: false
-    examples: |
-      ```hcl
-      resource "google_compute_network" "network1" {
-        name       = "network1"
-        ipv4_range = "10.120.0.0/16"
-      }
-
-      resource "google_compute_vpn_gateway" "target_gateway" {
-        name    = "vpn1"
-        network = "${google_compute_network.network1.self_link}"
-        region  = "${var.region}"
-      }
-
-      resource "google_compute_address" "vpn_static_ip" {
-        name   = "vpn-static-ip"
-        region = "${var.region}"
-      }
-
-      resource "google_compute_forwarding_rule" "fr_esp" {
-        name        = "fr-esp"
-        region      = "${var.region}"
-        ip_protocol = "ESP"
-        ip_address  = "${google_compute_address.vpn_static_ip.address}"
-        target      = "${google_compute_vpn_gateway.target_gateway.self_link}"
-      }
-
-      resource "google_compute_forwarding_rule" "fr_udp500" {
-        name        = "fr-udp500"
-        region      = "${var.region}"
-        ip_protocol = "UDP"
-        port_range  = "500"
-        ip_address  = "${google_compute_address.vpn_static_ip.address}"
-        target      = "${google_compute_vpn_gateway.target_gateway.self_link}"
-      }
-
-      resource "google_compute_forwarding_rule" "fr_udp4500" {
-        name        = "fr-udp4500"
-        region      = "${var.region}"
-        ip_protocol = "UDP"
-        port_range  = "4500"
-        ip_address  = "${google_compute_address.vpn_static_ip.address}"
-        target      = "${google_compute_vpn_gateway.target_gateway.self_link}"
-      }
-
-      resource "google_compute_vpn_tunnel" "tunnel1" {
-        name          = "tunnel1"
-        region        = "${var.region}"
-        peer_ip       = "15.0.0.120"
-        shared_secret = "a secret message"
-
-        target_vpn_gateway = "${google_compute_vpn_gateway.target_gateway.self_link}"
-
-        depends_on = [
-          "google_compute_forwarding_rule.fr_esp",
-          "google_compute_forwarding_rule.fr_udp500",
-          "google_compute_forwarding_rule.fr_udp4500",
-        ]
-      }
-
-      resource "google_compute_route" "route1" {
-        name       = "route1"
-        network    = "${google_compute_network.network1.name}"
-        dest_range = "15.0.0.0/24"
-        priority   = 1000
-
-        next_hop_vpn_tunnel = "${google_compute_vpn_tunnel.tunnel1.self_link}"
-      }
-      ```
+    example:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "target_vpn_gateway_basic"
+        primary_resource_id: "target_gateway"
+        vars:
+          target_vpn_gateway_name: "vpn1"
+          network_name: "network1"
+          address_name: "vpn-static-ip"
+          esp_forwarding_rule_name: "fr-esp"
+          udp500_forwarding_rule_name: "fr-udp500"
+          udp4500_forwarding_rule_name: "fr-udp4500"
+          vpn_tunnel_name: "tunnel1"
+          route_name: "route1"
     properties:
       id: !ruby/object:Provider::Terraform::PropertyOverride
         exclude: true
@@ -1021,79 +800,19 @@ overrides: !ruby/object:Provider::ResourceOverrides
   UrlMap: !ruby/object:Provider::Terraform::ResourceOverride
     exclude: true
   VpnTunnel: !ruby/object:Provider::Terraform::ResourceOverride
-    examples: |
-      ```hcl
-      resource "google_compute_network" "network1" {
-        name = "network1"
-      }
-
-      resource "google_compute_subnetwork" "subnet1" {
-        name          = "subnet1"
-        network       = "${google_compute_network.network1.self_link}"
-        ip_cidr_range = "10.120.0.0/16"
-        region        = "us-central1"
-      }
-
-      resource "google_compute_vpn_gateway" "target_gateway" {
-        name    = "vpn1"
-        network = "${google_compute_network.network1.self_link}"
-        region  = "${google_compute_subnetwork.subnet1.region}"
-      }
-
-      resource "google_compute_address" "vpn_static_ip" {
-        name   = "vpn-static-ip"
-        region = "${google_compute_subnetwork.subnet1.region}"
-      }
-
-      resource "google_compute_forwarding_rule" "fr_esp" {
-        name        = "fr-esp"
-        ip_protocol = "ESP"
-        ip_address  = "${google_compute_address.vpn_static_ip.address}"
-        target      = "${google_compute_vpn_gateway.target_gateway.self_link}"
-      }
-
-      resource "google_compute_forwarding_rule" "fr_udp500" {
-        name        = "fr-udp500"
-        ip_protocol = "UDP"
-        port_range  = "500-500"
-        ip_address  = "${google_compute_address.vpn_static_ip.address}"
-        target      = "${google_compute_vpn_gateway.target_gateway.self_link}"
-      }
-
-      resource "google_compute_forwarding_rule" "fr_udp4500" {
-        name        = "fr-udp4500"
-        ip_protocol = "UDP"
-        port_range  = "4500-4500"
-        ip_address  = "${google_compute_address.vpn_static_ip.address}"
-        target      = "${google_compute_vpn_gateway.target_gateway.self_link}"
-      }
-
-      resource "google_compute_vpn_tunnel" "tunnel1" {
-        name          = "tunnel1"
-        peer_ip       = "15.0.0.120"
-        shared_secret = "a secret message"
-
-        target_vpn_gateway = "${google_compute_vpn_gateway.target_gateway.self_link}"
-
-        local_traffic_selector  = ["${google_compute_subnetwork.subnet1.ip_cidr_range}"]
-        remote_traffic_selector = ["172.16.0.0/12"]
-
-        depends_on = [
-          "google_compute_forwarding_rule.fr_esp",
-          "google_compute_forwarding_rule.fr_udp500",
-          "google_compute_forwarding_rule.fr_udp4500",
-        ]
-      }
-
-      resource "google_compute_route" "route1" {
-        name       = "route1"
-        network    = "${google_compute_network.network1.name}"
-        dest_range = "15.0.0.0/24"
-        priority   = 1000
-
-        next_hop_vpn_tunnel = "${google_compute_vpn_tunnel.tunnel1.self_link}"
-      }
-      ```
+    example:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "vpn_tunnel_basic"
+        primary_resource_id: "tunnel1"
+        vars:
+          vpn_tunnel_name: "tunnel1"
+          target_vpn_gateway_name: "vpn1"
+          network_name: "network1"
+          address_name: "vpn-static-ip"
+          esp_forwarding_rule_name: "fr-esp"
+          udp500_forwarding_rule_name: "fr-udp500"
+          udp4500_forwarding_rule_name: "fr-udp4500"
+          route_name: "route1"
     docs: !ruby/object:Provider::Terraform::Docs
       warning: |
         All arguments including the shared secret will be stored in the raw

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -128,7 +128,6 @@ module Provider
       )
       # TODO: error check goimports
       %x(goimports -w #{filepath})
-
       generate_documentation(data)
     end
 
@@ -138,6 +137,7 @@ module Provider
       FileUtils.mkpath target_folder
       name = data[:object].name.underscore
       product_name = data[:product_name].underscore
+
       filepath =
         File.join(target_folder, "#{product_name}_#{name}.html.markdown")
       generate_resource_file data.clone.merge(
@@ -148,7 +148,7 @@ module Provider
 
     # rubocop:disable Metrics/AbcSize
     def generate_resource_tests(data)
-      return if data[:object].example.nil?
+      return if data[:object].example.empty?
 
       target_folder = File.join(data[:output_folder], 'google')
       FileUtils.mkpath target_folder
@@ -165,6 +165,8 @@ module Provider
         default_template: 'templates/terraform/examples/base_configs/test_file.go.erb',
         out_file: filepath
       )
+      # TODO: error check goimports
+      %x(goimports -w #{filepath})
     end
     # rubocop:enable Metrics/AbcSize
   end

--- a/provider/terraform/custom_code.rb
+++ b/provider/terraform/custom_code.rb
@@ -13,6 +13,7 @@
 
 require 'api/object'
 require 'compile/core'
+require 'google/golang_utils'
 require 'provider/abstract_core'
 require 'provider/property_override'
 
@@ -47,6 +48,7 @@ module Provider
     # from a shared template
     class Examples < Api::Object
       include Compile::Core
+      include Google::GolangUtils
 
       # The name of the example in lower snake_case.
       # Generally takes the form of the resource name followed by some detail
@@ -66,6 +68,10 @@ module Provider
       # vars is a Hash from template variable names to output variable names
       attr_reader :vars
 
+      # Extra properties to ignore read on during import.
+      # These properties will likely be custom code.
+      attr_reader :ignore_read_extra
+
       def config_documentation
         body = lines(compile_file(
                        {
@@ -81,6 +87,7 @@ module Provider
       end
 
       def config_test
+        @vars ||= []
         body = lines(compile_file(
                        {
                          vars: vars.map { |k, str| [k, "#{str}-%s"] }.to_h,
@@ -88,6 +95,8 @@ module Provider
                        },
                        "templates/terraform/examples/#{name}.tf.erb"
         ))
+
+        body = substitute_test_paths body
 
         lines(compile_file(
                 {
@@ -108,11 +117,20 @@ module Provider
         ))
       end
 
+      def substitute_test_paths(config)
+        config = config.gsub('path/to/private.key', 'test-fixtures/ssl_cert/test.key')
+        config.gsub('path/to/certificate.crt', 'test-fixtures/ssl_cert/test.crt')
+      end
+
       def validate
         super
+        @ignore_read_extra ||= []
+
         check_property :name, String
         check_property :primary_resource_id, String
-        check_property :vars, Hash
+
+        check_optional_property :vars, Hash
+        check_optional_property_list :ignore_read_extra, String
       end
     end
 

--- a/provider/terraform/resource_override.rb
+++ b/provider/terraform/resource_override.rb
@@ -52,11 +52,12 @@ module Provider
         @import_format ||= []
         @custom_code ||= Provider::Terraform::CustomCode.new
         @docs ||= Provider::Terraform::Docs.new
+        @example ||= []
 
         check_property :id_format, String
 
         check_optional_property :examples, String
-        check_optional_property :example, Array
+        check_optional_property_list :example, Provider::Terraform::Examples
 
         check_optional_property :custom_code, Provider::Terraform::CustomCode
         check_optional_property :docs, Provider::Terraform::Docs

--- a/spec/google_golang_spec.rb
+++ b/spec/google_golang_spec.rb
@@ -42,6 +42,26 @@ describe Google::GolangUtils do
       it { is_expected.to eq '"NONE"' }
     end
 
+    describe 'empty_array' do
+      subject { golang.go_literal([]) }
+      it { is_expected.to eq '[]string{}' }
+    end
+
+    describe 'string_array_single' do
+      subject { golang.go_literal(['abc']) }
+      it { is_expected.to eq '[]string{"abc"}' }
+    end
+
+    describe 'string_array_multiple' do
+      subject { golang.go_literal(%w[abc def]) }
+      it { is_expected.to eq '[]string{"abc", "def"}' }
+    end
+
+    describe 'int_array' do
+      subject { -> { golang.go_literal([1, 2]) } }
+      it { is_expected.to raise_error(/Unsupported/) }
+    end
+
     describe 'unknown type' do
       subject { -> { golang.go_literal(Class.new) } }
       it { is_expected.to raise_error(/Unsupported/) }

--- a/templates/terraform/examples/address_basic.tf.erb
+++ b/templates/terraform/examples/address_basic.tf.erb
@@ -1,3 +1,3 @@
 resource "google_compute_address" "<%= ctx[:primary_resource_id] %>" {
-  name = "<%= ctx[:vars]["address_name"] %>"
+  name = "<%= ctx[:vars]['address_name'] %>"
 }

--- a/templates/terraform/examples/address_with_subnetwork.tf.erb
+++ b/templates/terraform/examples/address_with_subnetwork.tf.erb
@@ -1,16 +1,16 @@
 resource "google_compute_network" "default" {
-  name = "<%= ctx[:vars]["network_name"] %>"
+  name = "<%= ctx[:vars]['network_name'] %>"
 }
 
 resource "google_compute_subnetwork" "default" {
-  name          = "<%= ctx[:vars]["subnetwork_name"] %>"
+  name          = "<%= ctx[:vars]['subnetwork_name'] %>"
   ip_cidr_range = "10.0.0.0/16"
   region        = "us-central1"
   network       = "${google_compute_network.default.self_link}"
 }
 
 resource "google_compute_address" "<%= ctx[:primary_resource_id] %>" {
-  name         = "<%= ctx[:vars]["address_name"] %>"
+  name         = "<%= ctx[:vars]['address_name'] %>"
   subnetwork   = "${google_compute_subnetwork.default.self_link}"
   address_type = "INTERNAL"
   address      = "10.0.42.42"

--- a/templates/terraform/examples/autoscaler_basic.tf.erb
+++ b/templates/terraform/examples/autoscaler_basic.tf.erb
@@ -1,5 +1,5 @@
 resource "google_compute_autoscaler" "foobar" {
-  name   = "<%= ctx[:vars]["autoscaler_name"] %>"
+  name   = "<%= ctx[:vars]['autoscaler_name'] %>"
   zone   = "us-central1-f"
   target = "${google_compute_instance_group_manager.foobar.self_link}"
 
@@ -15,7 +15,7 @@ resource "google_compute_autoscaler" "foobar" {
 }
 
 resource "google_compute_instance_template" "foobar" {
-  name           = "<%= ctx[:vars]["instance_template_name"] %>"
+  name           = "<%= ctx[:vars]['instance_template_name'] %>"
   machine_type   = "n1-standard-1"
   can_ip_forward = false
 
@@ -39,11 +39,11 @@ resource "google_compute_instance_template" "foobar" {
 }
 
 resource "google_compute_target_pool" "foobar" {
-  name = "<%= ctx[:vars]["target_pool_name"] %>"
+  name = "<%= ctx[:vars]['target_pool_name'] %>"
 }
 
 resource "google_compute_instance_group_manager" "foobar" {
-  name = "<%= ctx[:vars]["igm_name"] %>"
+  name = "<%= ctx[:vars]['igm_name'] %>"
   zone = "us-central1-f"
 
   instance_template  = "${google_compute_instance_template.foobar.self_link}"

--- a/templates/terraform/examples/backend_bucket_basic.tf.erb
+++ b/templates/terraform/examples/backend_bucket_basic.tf.erb
@@ -1,11 +1,11 @@
 resource "google_compute_backend_bucket" "image_backend" {
-  name        = "<%= ctx[:vars]["backend_bucket_name"] %>"
+  name        = "<%= ctx[:vars]['backend_bucket_name'] %>"
   description = "Contains beautiful images"
   bucket_name = "${google_storage_bucket.image_bucket.name}"
   enable_cdn  = true
 }
 
 resource "google_storage_bucket" "image_bucket" {
-  name     = "<%= ctx[:vars]["bucket_name"] %>"
+  name     = "<%= ctx[:vars]['bucket_name'] %>"
   location = "EU"
 }

--- a/templates/terraform/examples/base_configs/test_body.go.erb
+++ b/templates/terraform/examples/base_configs/test_body.go.erb
@@ -1,4 +1,4 @@
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 <%= ctx[:content] -%>
 `,<%= " val," * ctx[:count] %>
-	)
+  )

--- a/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/templates/terraform/examples/base_configs/test_file.go.erb
@@ -3,36 +3,43 @@
 package google
 
 import (
-	"fmt"
-	"testing"
+  "fmt"
+  "testing"
 
-	"github.com/hashicorp/terraform/helper/acctest"
-	"github.com/hashicorp/terraform/helper/resource"
+  "github.com/hashicorp/terraform/helper/acctest"
+  "github.com/hashicorp/terraform/helper/resource"
 )
 <% object.example.each do |example| -%>
 <%
-	# {Compute}{Address}_{addressBasic}
-	test_slug = "#{product}#{resource_name}_#{example.name.camelize}Example"
+  # {Compute}{Address}_{addressBasic}
+  test_slug = "#{product}#{resource_name}_#{example.name.camelize}Example"
+  ignore_read = data[:object].all_user_properties
+                 .select(&:ignore_read)
+                 .map { |p| p.name.underscore }
+                 .concat(example.ignore_read_extra)
 -%>
 
 func TestAcc<%= test_slug -%>(t *testing.T) {
-	t.Parallel()
+  t.Parallel()
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheck<%= "#{product}#{resource_name}" -%>Destroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAcc<%= test_slug -%>(acctest.RandString(10)),
-			},
-			{
-				ResourceName:      "<%= "google_#{product.downcase}_#{resource_name.underscore}" -%>.<%= example.primary_resource_id -%>",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
+  resource.Test(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testAccCheck<%= "#{product}#{resource_name}" -%>Destroy,
+    Steps: []resource.TestStep{
+      {
+        Config: testAcc<%= test_slug -%>(acctest.RandString(10)),
+      },
+      {
+        ResourceName:            "<%= "google_#{product.downcase}_#{resource_name.underscore}" -%>.<%= example.primary_resource_id -%>",
+        ImportState:             true,
+        ImportStateVerify:       true,
+        <%- unless ignore_read.empty? -%>
+        ImportStateVerifyIgnore: <%= go_literal(ignore_read) %>,
+        <%- end -%>
+      },
+    },
+  })
 }
 
 func testAcc<%= test_slug -%>(val string) string {

--- a/templates/terraform/examples/disk_basic.tf.erb
+++ b/templates/terraform/examples/disk_basic.tf.erb
@@ -1,5 +1,5 @@
 resource "google_compute_disk" "default" {
-  name  = "<%= ctx[:vars]["disk_name"] %>"
+  name  = "<%= ctx[:vars]['disk_name'] %>"
   type  = "pd-ssd"
   zone  = "us-central1-a"
   image = "debian-8-jessie-v20170523"

--- a/templates/terraform/examples/firewall_basic.tf.erb
+++ b/templates/terraform/examples/firewall_basic.tf.erb
@@ -1,5 +1,5 @@
 resource "google_compute_firewall" "default" {
-  name    = "<%= ctx[:vars]["firewall_name"] %>"
+  name    = "<%= ctx[:vars]['firewall_name'] %>"
   network = "${google_compute_network.default.name}"
 
   allow {
@@ -15,5 +15,5 @@ resource "google_compute_firewall" "default" {
 }
 
 resource "google_compute_network" "default" {
-  name = "<%= ctx[:vars]["network_name"] %>"
+  name = "<%= ctx[:vars]['network_name'] %>"
 }

--- a/templates/terraform/examples/forwarding_rule_basic.tf.erb
+++ b/templates/terraform/examples/forwarding_rule_basic.tf.erb
@@ -1,9 +1,9 @@
 resource "google_compute_forwarding_rule" "default" {
-  name       = "<%= ctx[:vars]["forwarding_rule_name"] %>"
+  name       = "<%= ctx[:vars]['forwarding_rule_name'] %>"
   target     = "${google_compute_target_pool.default.self_link}"
   port_range = "80"
 }
 
 resource "google_compute_target_pool" "default" {
-  name = "<%= ctx[:vars]["target_pool_name"] %>"
+  name = "<%= ctx[:vars]['target_pool_name'] %>"
 }

--- a/templates/terraform/examples/global_address_basic.tf.erb
+++ b/templates/terraform/examples/global_address_basic.tf.erb
@@ -1,3 +1,3 @@
 resource "google_compute_global_address" "default" {
-  name = "<%= ctx[:vars]["global_address_name"] %>"
+  name = "<%= ctx[:vars]['global_address_name'] %>"
 }

--- a/templates/terraform/examples/health_check_basic.tf.erb
+++ b/templates/terraform/examples/health_check_basic.tf.erb
@@ -1,5 +1,5 @@
 resource "google_compute_health_check" "internal-health-check" {
- name = "<%= ctx[:vars]["health_check_name"] %>"
+ name = "<%= ctx[:vars]['health_check_name'] %>"
 
  timeout_sec        = 1
  check_interval_sec = 1

--- a/templates/terraform/examples/http_health_check_basic.tf.erb
+++ b/templates/terraform/examples/http_health_check_basic.tf.erb
@@ -1,5 +1,5 @@
 resource "google_compute_http_health_check" "default" {
-  name         = "<%= ctx[:vars]["http_health_check_name"] %>"
+  name         = "<%= ctx[:vars]['http_health_check_name'] %>"
   request_path = "/health_check"
 
   timeout_sec        = 1

--- a/templates/terraform/examples/https_health_check_basic.tf.erb
+++ b/templates/terraform/examples/https_health_check_basic.tf.erb
@@ -1,5 +1,5 @@
 resource "google_compute_https_health_check" "default" {
-  name         = "<%= ctx[:vars]["https_health_check_name"] %>"
+  name         = "<%= ctx[:vars]['https_health_check_name'] %>"
   request_path = "/health_check"
 
   timeout_sec        = 1

--- a/templates/terraform/examples/instance_with_ip.tf.erb
+++ b/templates/terraform/examples/instance_with_ip.tf.erb
@@ -1,0 +1,27 @@
+resource "google_compute_address" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['address_name'] %>"
+}
+
+data "google_compute_image" "debian_image" {
+	family  = "debian-9"
+	project = "debian-cloud"
+}
+
+resource "google_compute_instance" "instance_with_ip" {
+	name         = "<%= ctx[:vars]['instance_name'] %>"
+	machine_type = "f1-micro"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		initialize_params{
+			image = "${data.google_compute_image.debian_image.self_link}"
+		}
+	}
+
+	network_interface {
+		network = "default"
+		access_config {
+			nat_ip = "${google_compute_address.static.address}"
+		}
+	}
+}

--- a/templates/terraform/examples/region_autoscaler_basic.tf.erb
+++ b/templates/terraform/examples/region_autoscaler_basic.tf.erb
@@ -1,5 +1,5 @@
 resource "google_compute_region_autoscaler" "foobar" {
-  name   = "<%= ctx[:vars]["region_autoscaler_name"] %>"
+  name   = "<%= ctx[:vars]['region_autoscaler_name'] %>"
   region = "us-central1"
   target = "${google_compute_region_instance_group_manager.foobar.self_link}"
 
@@ -15,7 +15,7 @@ resource "google_compute_region_autoscaler" "foobar" {
 }
 
 resource "google_compute_instance_template" "foobar" {
-  name           = "<%= ctx[:vars]["instance_template_name"] %>"
+  name           = "<%= ctx[:vars]['instance_template_name'] %>"
   machine_type   = "n1-standard-1"
   can_ip_forward = false
 
@@ -39,11 +39,11 @@ resource "google_compute_instance_template" "foobar" {
 }
 
 resource "google_compute_target_pool" "foobar" {
-  name = "<%= ctx[:vars]["target_pool_name"] %>"
+  name = "<%= ctx[:vars]['target_pool_name'] %>"
 }
 
 resource "google_compute_region_instance_group_manager" "foobar" {
-  name   = "<%= ctx[:vars]["rigm_name"] %>"
+  name   = "<%= ctx[:vars]['rigm_name'] %>"
   region = "us-central1"
 
   instance_template  = "${google_compute_instance_template.foobar.self_link}"

--- a/templates/terraform/examples/region_disk_basic.tf.erb
+++ b/templates/terraform/examples/region_disk_basic.tf.erb
@@ -1,5 +1,5 @@
 resource "google_compute_region_disk" "regiondisk" {
-  name = "<%= ctx[:vars]["region_disk_name"] %>"
+  name = "<%= ctx[:vars]['region_disk_name'] %>"
   snapshot = "${google_compute_snapshot.snapdisk.self_link}"
   type = "pd-ssd"
   region = "us-central1"
@@ -8,7 +8,7 @@ resource "google_compute_region_disk" "regiondisk" {
 }
 
 resource "google_compute_disk" "disk" {
-  name = "<%= ctx[:vars]["disk_name"] %>"
+  name = "<%= ctx[:vars]['disk_name'] %>"
   image = "debian-cloud/debian-9"
   size = 50
   type = "pd-ssd"
@@ -16,7 +16,7 @@ resource "google_compute_disk" "disk" {
 }
 
 resource "google_compute_snapshot" "snapdisk" {
-  name = "<%= ctx[:vars]["snapshot_name"] %>"
+  name = "<%= ctx[:vars]['snapshot_name'] %>"
   source_disk = "${google_compute_disk.disk.name}"
   zone = "us-central1-a"
 }

--- a/templates/terraform/examples/route_basic.tf.erb
+++ b/templates/terraform/examples/route_basic.tf.erb
@@ -1,5 +1,5 @@
 resource "google_compute_route" "default" {
-  name        = "<%= ctx[:vars]["route_name"] %>"
+  name        = "<%= ctx[:vars]['route_name'] %>"
   dest_range  = "15.0.0.0/24"
   network     = "${google_compute_network.default.name}"
   next_hop_ip = "10.132.1.5"
@@ -7,5 +7,5 @@ resource "google_compute_route" "default" {
 }
 
 resource "google_compute_network" "default" {
-  name = "<%= ctx[:vars]["network_name"] %>"
+  name = "<%= ctx[:vars]['network_name'] %>"
 }

--- a/templates/terraform/examples/router_basic.tf.erb
+++ b/templates/terraform/examples/router_basic.tf.erb
@@ -1,5 +1,5 @@
 resource "google_compute_router" "foobar" {
-  name    = "<%= ctx[:vars]["router_name"] %>"
+  name    = "<%= ctx[:vars]['router_name'] %>"
   network = "${google_compute_network.foobar.name}"
   bgp {
     asn               = 64514
@@ -15,7 +15,7 @@ resource "google_compute_router" "foobar" {
 }
 
 resource "google_compute_network" "foobar" {
-  name = "<%= ctx[:vars]["network_name"] %>"
+  name = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks = false
 }
 

--- a/templates/terraform/examples/ssl_certificate_basic.tf.erb
+++ b/templates/terraform/examples/ssl_certificate_basic.tf.erb
@@ -1,0 +1,10 @@
+resource "google_compute_ssl_certificate" "default" {
+  name_prefix = "my-certificate-"
+  description = "a description"
+  private_key = "${file("path/to/private.key")}"
+  certificate = "${file("path/to/certificate.crt")}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/templates/terraform/examples/ssl_certificate_random_provider.tf.erb
+++ b/templates/terraform/examples/ssl_certificate_random_provider.tf.erb
@@ -1,0 +1,23 @@
+# You may also want to control name generation explicitly:
+resource "google_compute_ssl_certificate" "default" {
+  # The name will contain 8 random hex digits,
+  # e.g. "my-certificate-48ab27cd2a"
+  name        = "${random_id.certificate.hex}"
+  private_key = "${file("path/to/private.key")}"
+  certificate = "${file("path/to/certificate.crt")}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "random_id" "certificate" {
+  byte_length = 4
+  prefix      = "my-certificate-"
+
+  # For security, do not expose raw certificate values in the output
+  keepers {
+    private_key = "${base64sha256(file("path/to/private.key"))}"
+    certificate = "${base64sha256(file("path/to/certificate.crt"))}"
+  }
+}

--- a/templates/terraform/examples/ssl_certificate_target_https_proxies.tf.erb
+++ b/templates/terraform/examples/ssl_certificate_target_https_proxies.tf.erb
@@ -1,0 +1,63 @@
+// Using with Target HTTPS Proxies
+//
+// SSL certificates cannot be updated after creation. In order to apply
+// the specified configuration, Terraform will destroy the existing
+// resource and create a replacement. To effectively use an SSL
+// certificate resource with a Target HTTPS Proxy resource, it's
+// recommended to specify create_before_destroy in a lifecycle block.
+// Either omit the Instance Template name attribute, specify a partial
+// name with name_prefix, or use random_id resource. Example:
+
+resource "google_compute_ssl_certificate" "default" {
+  name_prefix = "my-certificate-"
+  private_key = "${file("path/to/private.key")}"
+  certificate = "${file("path/to/certificate.crt")}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "google_compute_target_https_proxy" "default" {
+  name             = "<%= ctx[:vars]['target_https_proxy_name'] %>"
+  url_map          = "${google_compute_url_map.default.self_link}"
+  ssl_certificates = ["${google_compute_ssl_certificate.default.self_link}"]
+}
+
+resource "google_compute_url_map" "default" {
+  name        = "<%= ctx[:vars]['url_map_name'] %>"
+  description = "a description"
+
+  default_service = "${google_compute_backend_service.default.self_link}"
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
+    default_service = "${google_compute_backend_service.default.self_link}"
+
+    path_rule {
+      paths   = ["/*"]
+      service = "${google_compute_backend_service.default.self_link}"
+    }
+  }
+}
+
+resource "google_compute_backend_service" "default" {
+  name        = "<%= ctx[:vars]['backend_service_name'] %>"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = ["${google_compute_http_health_check.default.self_link}"]
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "<%= ctx[:vars]['http_health_check_name'] %>"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}

--- a/templates/terraform/examples/ssl_policy_basic.tf.erb
+++ b/templates/terraform/examples/ssl_policy_basic.tf.erb
@@ -1,16 +1,16 @@
 resource "google_compute_ssl_policy" "prod-ssl-policy" {
-  name    = "<%= ctx[:vars]["production_ssl_policy_name"] %>"
+  name    = "<%= ctx[:vars]['production_ssl_policy_name'] %>"
   profile = "MODERN"
 }
 
 resource "google_compute_ssl_policy" "nonprod-ssl-policy" {
-  name            = "<%= ctx[:vars]["nonprod_ssl_policy_name"] %>"
+  name            = "<%= ctx[:vars]['nonprod_ssl_policy_name'] %>"
   profile         = "MODERN"
   min_tls_version = "TLS_1_2"
 }
 
 resource "google_compute_ssl_policy" "custom-ssl-policy" {
-  name            = "<%= ctx[:vars]["custom_ssl_policy_name"] %>"
+  name            = "<%= ctx[:vars]['custom_ssl_policy_name'] %>"
   min_tls_version = "TLS_1_2"
   profile         = "CUSTOM"
   custom_features = ["TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"]

--- a/templates/terraform/examples/subnetwork_basic.tf.erb
+++ b/templates/terraform/examples/subnetwork_basic.tf.erb
@@ -1,5 +1,5 @@
 resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" {
-  name          = "<%= ctx[:vars]["subnetwork_name"] %>"
+  name          = "<%= ctx[:vars]['subnetwork_name'] %>"
   ip_cidr_range = "10.2.0.0/16"
   region        = "us-central1"
   network       = "${google_compute_network.custom-test.self_link}"
@@ -10,7 +10,7 @@ resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" 
 }
 
 resource "google_compute_network" "custom-test" {
-  name                    = "<%= ctx[:vars]["network_name"] %>"
+  name                    = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks = false
 }
 

--- a/templates/terraform/examples/target_http_proxy_basic.tf.erb
+++ b/templates/terraform/examples/target_http_proxy_basic.tf.erb
@@ -1,0 +1,40 @@
+resource "google_compute_target_http_proxy" "default" {
+  name        = "<%= ctx[:vars]['target_http_proxy_name'] %>"
+  url_map     = "${google_compute_url_map.default.self_link}"
+}
+
+resource "google_compute_url_map" "default" {
+  name        = "<%= ctx[:vars]['url_map_name'] %>"
+  default_service = "${google_compute_backend_service.default.self_link}"
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
+    default_service = "${google_compute_backend_service.default.self_link}"
+
+    path_rule {
+      paths   = ["/*"]
+      service = "${google_compute_backend_service.default.self_link}"
+    }
+  }
+}
+
+resource "google_compute_backend_service" "default" {
+  name        = "<%= ctx[:vars]['backend_service_name'] %>"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = ["${google_compute_http_health_check.default.self_link}"]
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "<%= ctx[:vars]['http_health_check_name'] %>"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}

--- a/templates/terraform/examples/target_https_proxy_basic.tf.erb
+++ b/templates/terraform/examples/target_https_proxy_basic.tf.erb
@@ -1,0 +1,49 @@
+resource "google_compute_target_https_proxy" "default" {
+  name             = "<%= ctx[:vars]['target_https_proxy_name'] %>"
+  url_map          = "${google_compute_url_map.default.self_link}"
+  ssl_certificates = ["${google_compute_ssl_certificate.default.self_link}"]
+}
+
+resource "google_compute_ssl_certificate" "default" {
+  name        = "<%= ctx[:vars]['ssl_certificate_name'] %>"
+  private_key = "${file("path/to/private.key")}"
+  certificate = "${file("path/to/certificate.crt")}"
+}
+
+resource "google_compute_url_map" "default" {
+  name        = "<%= ctx[:vars]['url_map_name'] %>"
+  description = "a description"
+
+  default_service = "${google_compute_backend_service.default.self_link}"
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
+    default_service = "${google_compute_backend_service.default.self_link}"
+
+    path_rule {
+      paths   = ["/*"]
+      service = "${google_compute_backend_service.default.self_link}"
+    }
+  }
+}
+
+resource "google_compute_backend_service" "default" {
+  name        = "<%= ctx[:vars]['backend_service_name'] %>"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = ["${google_compute_http_health_check.default.self_link}"]
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "<%= ctx[:vars]['http_health_check_name'] %>"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}

--- a/templates/terraform/examples/target_ssl_proxy_basic.tf.erb
+++ b/templates/terraform/examples/target_ssl_proxy_basic.tf.erb
@@ -1,0 +1,26 @@
+resource "google_compute_target_ssl_proxy" "default" {
+  name             = "<%= ctx[:vars]['target_ssl_proxy_name'] %>"
+  backend_service  = "${google_compute_backend_service.default.self_link}"
+  ssl_certificates = ["${google_compute_ssl_certificate.default.self_link}"]
+}
+
+resource "google_compute_ssl_certificate" "default" {
+  name        = "<%= ctx[:vars]['ssl_certificate_name'] %>"
+  private_key = "${file("path/to/private.key")}"
+  certificate = "${file("path/to/certificate.crt")}"
+}
+
+resource "google_compute_backend_service" "default" {
+  name          = "<%= ctx[:vars]['backend_service_name'] %>"
+  protocol      = "SSL"
+  health_checks = ["${google_compute_health_check.default.self_link}"]
+}
+
+resource "google_compute_health_check" "default" {
+  name               = "<%= ctx[:vars]['health_check_name'] %>"
+  check_interval_sec = 1
+  timeout_sec        = 1
+  tcp_health_check {
+    port = "443"
+  }
+}

--- a/templates/terraform/examples/target_tcp_proxy_basic.tf.erb
+++ b/templates/terraform/examples/target_tcp_proxy_basic.tf.erb
@@ -1,0 +1,22 @@
+resource "google_compute_target_tcp_proxy" "default" {
+  name            = "<%= ctx[:vars]['target_tcp_proxy_name'] %>"
+  backend_service = "${google_compute_backend_service.default.self_link}"
+}
+
+resource "google_compute_backend_service" "default" {
+  name          = "<%= ctx[:vars]['backend_service_name'] %>"
+  protocol      = "TCP"
+  timeout_sec   = 10
+
+  health_checks = ["${google_compute_health_check.default.self_link}"]
+}
+
+resource "google_compute_health_check" "default" {
+  name               = "<%= ctx[:vars]['health_check_name'] %>"
+  timeout_sec        = 1
+  check_interval_sec = 1
+
+  tcp_health_check {
+    port = "443"
+  }
+}

--- a/templates/terraform/examples/target_vpn_gateway_basic.tf.erb
+++ b/templates/terraform/examples/target_vpn_gateway_basic.tf.erb
@@ -1,0 +1,58 @@
+resource "google_compute_vpn_gateway" "target_gateway" {
+  name    = "<%= ctx[:vars]['target_vpn_gateway_name'] %>"
+  network = "${google_compute_network.network1.self_link}"
+}
+
+resource "google_compute_network" "network1" {
+  name       = "<%= ctx[:vars]['network_name'] %>"
+}
+
+resource "google_compute_address" "vpn_static_ip" {
+  name   = "<%= ctx[:vars]['address_name'] %>"
+}
+
+resource "google_compute_forwarding_rule" "fr_esp" {
+  name        = "<%= ctx[:vars]['esp_forwarding_rule_name'] %>"
+  ip_protocol = "ESP"
+  ip_address  = "${google_compute_address.vpn_static_ip.address}"
+  target      = "${google_compute_vpn_gateway.target_gateway.self_link}"
+}
+
+resource "google_compute_forwarding_rule" "fr_udp500" {
+  name        = "<%= ctx[:vars]['udp500_forwarding_rule_name'] %>"
+  ip_protocol = "UDP"
+  port_range  = "500"
+  ip_address  = "${google_compute_address.vpn_static_ip.address}"
+  target      = "${google_compute_vpn_gateway.target_gateway.self_link}"
+}
+
+resource "google_compute_forwarding_rule" "fr_udp4500" {
+  name        = "<%= ctx[:vars]['udp4500_forwarding_rule_name'] %>"
+  ip_protocol = "UDP"
+  port_range  = "4500"
+  ip_address  = "${google_compute_address.vpn_static_ip.address}"
+  target      = "${google_compute_vpn_gateway.target_gateway.self_link}"
+}
+
+resource "google_compute_vpn_tunnel" "tunnel1" {
+  name          = "<%= ctx[:vars]['vpn_tunnel_name'] %>"
+  peer_ip       = "15.0.0.120"
+  shared_secret = "a secret message"
+
+  target_vpn_gateway = "${google_compute_vpn_gateway.target_gateway.self_link}"
+
+  depends_on = [
+    "google_compute_forwarding_rule.fr_esp",
+    "google_compute_forwarding_rule.fr_udp500",
+    "google_compute_forwarding_rule.fr_udp4500",
+  ]
+}
+
+resource "google_compute_route" "route1" {
+  name       = "<%= ctx[:vars]['route_name'] %>"
+  network    = "${google_compute_network.network1.name}"
+  dest_range = "15.0.0.0/24"
+  priority   = 1000
+
+  next_hop_vpn_tunnel = "${google_compute_vpn_tunnel.tunnel1.self_link}"
+}

--- a/templates/terraform/examples/vpn_tunnel_basic.tf.erb
+++ b/templates/terraform/examples/vpn_tunnel_basic.tf.erb
@@ -1,0 +1,58 @@
+resource "google_compute_vpn_tunnel" "tunnel1" {
+  name          = "<%= ctx[:vars]['vpn_tunnel_name'] %>"
+  peer_ip       = "15.0.0.120"
+  shared_secret = "a secret message"
+
+  target_vpn_gateway = "${google_compute_vpn_gateway.target_gateway.self_link}"
+
+  depends_on = [
+    "google_compute_forwarding_rule.fr_esp",
+    "google_compute_forwarding_rule.fr_udp500",
+    "google_compute_forwarding_rule.fr_udp4500",
+  ]
+}
+
+resource "google_compute_vpn_gateway" "target_gateway" {
+  name    = "<%= ctx[:vars]['target_vpn_gateway_name'] %>"
+  network = "${google_compute_network.network1.self_link}"
+}
+
+resource "google_compute_network" "network1" {
+  name       = "<%= ctx[:vars]['network_name'] %>"
+}
+
+resource "google_compute_address" "vpn_static_ip" {
+  name   = "<%= ctx[:vars]['address_name'] %>"
+}
+
+resource "google_compute_forwarding_rule" "fr_esp" {
+  name        = "<%= ctx[:vars]['esp_forwarding_rule_name'] %>"
+  ip_protocol = "ESP"
+  ip_address  = "${google_compute_address.vpn_static_ip.address}"
+  target      = "${google_compute_vpn_gateway.target_gateway.self_link}"
+}
+
+resource "google_compute_forwarding_rule" "fr_udp500" {
+  name        = "<%= ctx[:vars]['udp500_forwarding_rule_name'] %>"
+  ip_protocol = "UDP"
+  port_range  = "500"
+  ip_address  = "${google_compute_address.vpn_static_ip.address}"
+  target      = "${google_compute_vpn_gateway.target_gateway.self_link}"
+}
+
+resource "google_compute_forwarding_rule" "fr_udp4500" {
+  name        = "<%= ctx[:vars]['udp4500_forwarding_rule_name'] %>"
+  ip_protocol = "UDP"
+  port_range  = "4500"
+  ip_address  = "${google_compute_address.vpn_static_ip.address}"
+  target      = "${google_compute_vpn_gateway.target_gateway.self_link}"
+}
+
+resource "google_compute_route" "route1" {
+  name       = "<%= ctx[:vars]['route_name'] %>"
+  network    = "${google_compute_network.network1.name}"
+  dest_range = "15.0.0.0/24"
+  priority   = 1000
+
+  next_hop_vpn_tunnel = "${google_compute_vpn_tunnel.tunnel1.self_link}"
+}

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -80,7 +80,7 @@ To get more information about <%= object.name -%>, see:
 <%= "\n" + object.examples -%>
 
 <% end -%>
-<% unless object.example.nil? -%>
+<% unless object.example.empty? -%>
 ## Example Usage
 
 <% object.example.each do |example| -%>


### PR DESCRIPTION
Since VM instances won't be added for a while, we should include one of them in a different resource's example. Let's use one with Address, by adding a static ip to a vm.

-----------------------------------------------------------------
# [all]
## [terraform]
Add an address example with a VM instance
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
