### PR TITLE
allow sending empty values for router fields

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2768,6 +2768,7 @@ objects:
         name: description
         description: |
           An optional description of this resource.
+        send_empty_value: true
       - !ruby/object:Api::Type::ResourceRef
         name: network
         resource: Network
@@ -2817,6 +2818,7 @@ objects:
 
               This enum field has the one valid value: ALL_SUBNETS
             item_type: Api::Type::String # TODO(#324): enum?
+            send_empty_value: true
           - !ruby/object:Api::Type::Array
             name: advertisedIpRanges
             description: |
@@ -2825,6 +2827,7 @@ objects:
               is CUSTOM and is advertised to all peers of the router. These IP
               ranges will be advertised in addition to any specified groups.
               Leave this field blank to advertise no custom IP ranges.
+            send_empty_value: true
             item_type: !ruby/object:Api::Type::NestedObject
                 properties:
                   - !ruby/object:Api::Type::String
@@ -2832,10 +2835,12 @@ objects:
                     description: |
                       The IP range to advertise. The value must be a
                       CIDR-formatted string.
+                    send_empty_value: true
                   - !ruby/object:Api::Type::String
                     name: description
                     description: |
                       User-specified description for the IP range.
+                    send_empty_value: true
   - !ruby/object:Api::Resource
     name: 'Snapshot'
     kind: 'compute#snapshot'

--- a/templates/terraform/expand_property_method.erb
+++ b/templates/terraform/expand_property_method.erb
@@ -83,8 +83,13 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
       transformed<%= titlelize_property(prop) -%>, err := expand<%= prefix -%><%= titlelize_property(property) -%><%= titlelize_property(prop) -%>(original["<%= prop.name.underscore -%>"], d, config)
       if err != nil {
         return nil, err
+<%         unless prop.send_empty_value -%>
       } else if val := reflect.ValueOf(transformed<%= titlelize_property(prop) -%>); val.IsValid() && !isEmptyValue(val) {
         transformed["<%= prop.api_name -%>"] = transformed<%= titlelize_property(prop) -%>
+<%         else -%>
+      } else {
+        transformed["<%= prop.api_name -%>"] = transformed<%= titlelize_property(prop) -%>
+<%         end -%>
       }
 
 <%       end -%>


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Since router uses PATCH, only fields that appear in the request get updated. This means that we need to be able to send empty fields so that they can be reset back to empty, otherwise GCP will assume we just don't want to update them, vs we want them to be unset.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
allow sending empty values for router fields
## [terraform]
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
