### PR TITLE
Fix false failures in Terraform redis tests.

### DIFF
--- a/templates/terraform/tests/resource_redis_instance_test.go
+++ b/templates/terraform/tests/resource_redis_instance_test.go
@@ -115,6 +115,7 @@ func testAccRedisInstance_basic(name string) string {
 resource "google_redis_instance" "test" {
 	name           = "%s"
 	memory_size_gb = 1
+	region         = "us-central1"
 }`, name)
 }
 
@@ -124,6 +125,7 @@ resource "google_redis_instance" "test" {
 	name           = "%s"
 	display_name   = "pre-update"
 	memory_size_gb = 1
+	region         = "us-central1"
 
 	labels {
 		my_key    = "my_val"


### PR DESCRIPTION
We read the `region` in Redis properly now, so we were getting failures from `ImportStateVerify` when `Read` saw a region upstream but didn't see one in the state inferred from the config. We can `ImportStateVerifyIgnore` `region` or set it - I chose to set it because that is what we do for every other test.

-----------------------------------------------------------------
# [all]
## [terraform]
Fix false ImportStateVerify failures in redis tests.
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
