### PR TITLE
Attempting to fix Travis

### DIFF
--- a/provider/puppet/manifest.rb
+++ b/provider/puppet/manifest.rb
@@ -11,6 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'provider/core'
+
 module Provider
   class Puppet < Provider::Core
     # Metadata for manifest.json


### PR DESCRIPTION
Attempting to fix Travis

My theory on why Travis broke:

In the `spec/spec_helper.rb,` we load every file in magic-modules through a wildcard statement. We do this so the tests can run. We're assuming that loading those files will happen in a predictable, reproducible order. I have the feeling that Travis is loading files in a different order than our laptops, leading to a requires error. Right now, `provider/puppet/manifest.rb` is being loaded before `provider/core.rb` on Travis, leading to an error.


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
