### PR TITLE
Add documentation support to the stackdriver alertPolicy

### DIFF
--- a/products/monitoring/api.yaml
+++ b/products/monitoring/api.yaml
@@ -704,6 +704,27 @@ objects:
         name: 'labels'
         description: 'User-supplied key/value data to be used for organizing AlertPolicy objects.'
         item_type: Api::Type::String
+      - !ruby/object:Api::Type::NestedObject
+        name: documentation
+        description: |
+          A short name or phrase used to identify the policy in dashboards,
+          notifications, and incidents. To avoid confusion, don't use the same
+          display name for multiple policies in the same project. The name is
+          limited to 512 Unicode characters.
+        properties:
+          - !ruby/object:Api::Type::String
+           name: content
+           description: |
+            The text of the documentation, interpreted according to mimeType.
+            The content may not exceed 8,192 Unicode characters and may not
+            exceed more than 10,240 bytes when encoded in UTF-8 format,
+            whichever is smaller.
+          - !ruby/object:Api::Type::String
+            name: mimeType
+            default_value: text/markdown
+            description: |
+              The format of the content field. Presently, only the value
+              "text/markdown" is supported.
 
 
   - !ruby/object:Api::Resource

--- a/templates/terraform/tests/resource_monitoring_alert_policy_test.go
+++ b/templates/terraform/tests/resource_monitoring_alert_policy_test.go
@@ -206,6 +206,11 @@ resource "google_monitoring_alert_policy" "full" {
       display_name = "%s"
     },
   ]
+
+  documentation {
+    content = "test content"
+    mime_type = "text/markdown"
+  }
 }
 `, alertName, conditionName1, conditionName2)
 }


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Add documentation support to the stackdriver alertPolicy
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
