### PR TITLE
Terraform Example Provider: Generate OiCS examples.

### DIFF
--- a/provider/terraform/custom_code.rb
+++ b/provider/terraform/custom_code.rb
@@ -111,18 +111,26 @@ module Provider
       end
 
       def config_example
-        lines(compile_file(
-                {
-                  vars: vars.map { |k, str| [k, "#{str}-${local.name_suffix}"] }.to_h,
-                  primary_resource_id: primary_resource_id
-                },
-                "templates/terraform/examples/#{name}.tf.erb"
+        @vars ||= []
+        body = lines(compile_file(
+                       {
+                         vars: vars.map { |k, str| [k, "#{str}-${local.name_suffix}"] }.to_h,
+                         primary_resource_id: primary_resource_id
+                       },
+                       "templates/terraform/examples/#{name}.tf.erb"
         ))
+
+        substitute_example_paths body
       end
 
       def substitute_test_paths(config)
         config = config.gsub('path/to/private.key', 'test-fixtures/ssl_cert/test.key')
         config.gsub('path/to/certificate.crt', 'test-fixtures/ssl_cert/test.crt')
+      end
+
+      def substitute_example_paths(config)
+        config = config.gsub('path/to/private.key', '../static/ssl_cert/test.key')
+        config.gsub('path/to/certificate.crt', '../static/ssl_cert/test.crt')
       end
 
       def validate

--- a/provider/terraform_example.rb
+++ b/provider/terraform_example.rb
@@ -24,8 +24,9 @@ module Provider
     end
 
     # Create a directory of examples per resource
+    # rubocop:disable Metrics/AbcSize
     def generate_resource(data)
-      return if data[:object].example.nil?
+      return if data[:object].example.reject(&:skip_test).empty?
 
       data[:object].example.each do |example|
         target_folder = data[:output_folder]
@@ -39,11 +40,23 @@ module Provider
         )
 
         generate_resource_file data.clone.merge(
+          example: example,
+          default_template: 'templates/terraform/examples/base_configs/tutorial.md.erb',
+          out_file: File.join(target_folder, 'tutorial.md')
+        )
+
+        generate_resource_file data.clone.merge(
           default_template: 'templates/terraform/examples/base_configs/example_backing_file.tf.erb',
-          out_file: File.join(target_folder, 'name_prefix.tf')
+          out_file: File.join(target_folder, 'backing_file.tf')
+        )
+
+        generate_resource_file data.clone.merge(
+          default_template: 'templates/terraform/examples/static/motd',
+          out_file: File.join(target_folder, 'motd')
         )
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     # rubocop:disable Layout/EmptyLineBetweenDefs
     # We don't want to generate anything but the resource.

--- a/templates/terraform/examples/base_configs/example_backing_file.tf.erb
+++ b/templates/terraform/examples/base_configs/example_backing_file.tf.erb
@@ -1,8 +1,16 @@
 <% autogen_exception -%>
+# This file has some scaffolding to make sure that names are unique and that
+# a region and zone are selected when you try to create your Terraform resources.
+
 locals {
   name_suffix = "${random_pet.suffix.id}"
 }
 
 resource "random_pet" "suffix" {
   length = 2
+}
+
+provider "google" {
+  region = "us-central1"
+  zone   = "us-central1-c"
 }

--- a/templates/terraform/examples/base_configs/tutorial.md.erb
+++ b/templates/terraform/examples/base_configs/tutorial.md.erb
@@ -1,0 +1,80 @@
+<% autogen_exception -%>
+<%= "# #{example.name.camelize(:upper).uncombine} - Terraform" %>
+
+## Setup
+
+<walkthrough-author name="rileykarson@google.com" analyticsId="UA-125550242-1" tutorialName="<%= "#{example.name.underscore}" %>" repositoryUrl="https://github.com/terraform-google-modules/docs-examples"></walkthrough-author>
+
+Welcome to Terraform in Google Cloud Shell! We need you to let us know what project you'd like to use with Terraform.
+
+<walkthrough-project-billing-setup></walkthrough-project-billing-setup>
+
+Terraform provisions real GCP resources, so anything you create in this session will be billed against this project.
+
+## Terraforming!
+
+Let's use {{project-id}} with Terraform! Click the Cloud Shell icon below to copy the command
+to your shell, and then run it from the shell by pressing Enter/Return. Terraform will pick up
+the project name from the environment variable.
+
+```bash
+export GOOGLE_CLOUD_PROJECT={{project-id}}
+```
+
+After that, let's get Terraform started. Run the following to pull in the providers.
+
+```bash
+terraform init
+```
+
+With the providers downloaded and a project set, you're ready to use Terraform. Go ahead!
+
+```bash
+terraform apply
+```
+
+Terraform will show you what it plans to do, and prompt you to accept. Type "yes" to accept the plan.
+
+```bash
+yes
+```
+
+
+## Post-Apply
+
+### Editing your config
+
+Now you've provisioned your resources in GCP! If you run a "plan", you should see no changes needed.
+
+```bash
+terraform plan
+```
+
+So let's make a change! Try editing a number, or appending a value to the name in the editor. Then,
+run a 'plan' again.
+
+```bash
+terraform plan
+```
+
+Afterwards you can run an apply, which implicitly does a plan and shows you the intended changes
+at the 'yes' prompt.
+
+```bash
+terraform apply
+```
+
+```bash
+yes
+```
+
+## Cleanup
+
+Run the following to remove the resources Terraform provisioned:
+
+```bash
+terraform destroy
+```
+```bash
+yes
+```

--- a/templates/terraform/examples/static/motd
+++ b/templates/terraform/examples/static/motd
@@ -1,0 +1,8 @@
+<% autogen_exception -%>
+===
+
+These examples use real resources that will be billed to the
+Google Cloud Platform project you use - so make sure that you
+run "terraform destroy" before quitting!
+
+===


### PR DESCRIPTION
Add the OiCS content to the examples generated by the Terraform Example provider (also this is the time to review the content itself)

The example provider isn't in CI yet - waiting on #502 so I can copy what @danawillow does.

Generation command (~ doesn't work in MM paths):

```bash
bundle exec compiler -a -e terraform -f "examples" -o "/Users/$user/docs-examples"
```

Output: 

https://github.com/rileykarson/docs-examples/tree/sample


-----------------------------------------------------------------
# [all]
No-op
## [terraform]
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
