### PR TITLE
Fix empty TypeList expands in Terraform.

### DIFF
--- a/templates/terraform/expand_property_method.erb
+++ b/templates/terraform/expand_property_method.erb
@@ -74,7 +74,7 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
       continue
     }
 <%       else -%>
-  if len(l) == 0 {
+  if len(l) == 0 || l[0] == nil{
     return nil, nil
   }
   raw := l[0]


### PR DESCRIPTION
https://github.com/terraform-providers/terraform-provider-google/pull/2229

-----------------------------------------------------------------
# [all]
## [terraform]
Fix empty TypeList expands in generated resources
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
