### PR TITLE
Moving raw_key properties back to 'Removed'

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -123,6 +123,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
       post_import: templates/terraform/post_import/disk.erb
       constants: templates/terraform/constants/disk.erb
       encoder: templates/terraform/encoders/disk.erb
+      extra_schema_entry: templates/terraform/extra_schema_entry/disk.erb
       decoder: templates/terraform/decoders/disk.erb
       resource_definition: templates/terraform/resource_definition/disk.erb
     docs: !ruby/object:Provider::Terraform::Docs

--- a/templates/terraform/extra_schema_entry/disk.erb
+++ b/templates/terraform/extra_schema_entry/disk.erb
@@ -1,0 +1,13 @@
+"disk_encryption_key_raw": &schema.Schema{
+        Type:             schema.TypeString,
+        Optional:         true,
+        ForceNew:         true,
+        Sensitive:        true,
+        Removed:       "Use disk_encryption_key.raw_key instead.",
+},
+
+"disk_encryption_key_sha256": &schema.Schema{
+	Type:       schema.TypeString,
+	Computed:   true,
+  Removed: "Use disk_encryption_key.sha256 instead.",
+},


### PR DESCRIPTION
Adding back the compute disk raw_key fields but marking as 'removed' instead of just deleting them from code

<!-- A summary of the changes in this commit goes here -->


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Moving raw_key properties back to 'Removed'
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
