### PR TITLE
Ansible module for storage upload/download

### DIFF
--- a/api/type.rb
+++ b/api/type.rb
@@ -198,6 +198,9 @@ module Api
       end
     end
 
+    class Path < Primitive
+    end
+
     # Represents a fingerprint.  A fingerprint is an output-only
     # field used for optimistic locking during updates.
     # They are fetched from the GCP response.

--- a/products/storage/ansible.yaml
+++ b/products/storage/ansible.yaml
@@ -44,6 +44,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
     exclude: false
     template: 'products/storage/helpers/ansible/object_template.erb'
     version_added: '2.8'
+    has_tests: false
   ObjectAccessControl: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: true
   DefaultObjectACL: !ruby/object:Provider::Ansible::ResourceOverride

--- a/products/storage/ansible.yaml
+++ b/products/storage/ansible.yaml
@@ -42,6 +42,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
         version_added: '2.7'
   Object: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: false
+    template: 'products/storage/helpers/ansible/object_template.erb'
   ObjectAccessControl: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: true
   DefaultObjectACL: !ruby/object:Provider::Ansible::ResourceOverride

--- a/products/storage/ansible.yaml
+++ b/products/storage/ansible.yaml
@@ -43,6 +43,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
   Object: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: false
     template: 'products/storage/helpers/ansible/object_template.erb'
+    version_added: '2.8'
   ObjectAccessControl: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: true
   DefaultObjectACL: !ruby/object:Provider::Ansible::ResourceOverride

--- a/products/storage/ansible.yaml
+++ b/products/storage/ansible.yaml
@@ -29,6 +29,8 @@ datasources: !ruby/object:Provider::ResourceOverrides
     exclude: true
   Bucket: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: true
+  Object: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: true
   ObjectAccessControl: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: true
   DefaultObjectACL: !ruby/object:Provider::Ansible::ResourceOverride
@@ -38,6 +40,8 @@ overrides: !ruby/object:Provider::ResourceOverrides
     properties:
       defaultObjectAcl: !ruby/object:Provider::Ansible::PropertyOverride
         version_added: '2.7'
+  Object: !ruby/object:Provider::Ansible::ResourceOverride
+    exclude: false
   ObjectAccessControl: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: true
   DefaultObjectACL: !ruby/object:Provider::Ansible::ResourceOverride

--- a/products/storage/api.yaml
+++ b/products/storage/api.yaml
@@ -40,7 +40,6 @@ objects:
           'Overwrite the file on the bucket/local machine. If overwrite is
           false and a difference exists between GCS + local, module will fail
           with error'
-        exclude: true
       - !ruby/object:Api::Type::Path
         name: 'src'
         description: Source location of file (may be local machine or cloud depending on action)

--- a/products/storage/api.yaml
+++ b/products/storage/api.yaml
@@ -33,12 +33,14 @@ objects:
         values:
           - :download
           - :upload
+      # TODO(alexstephen): Figure out why MD5 hashes are different local vs. remote
       - !ruby/object:Api::Type::Boolean
         name: 'overwrite'
         description: >
           'Overwrite the file on the bucket/local machine. If overwrite is
           false and a difference exists between GCS + local, module will fail
           with error'
+        exclude: true
       - !ruby/object:Api::Type::Path
         name: 'src'
         description: Source location of file (may be local machine or cloud depending on action)

--- a/products/storage/api.yaml
+++ b/products/storage/api.yaml
@@ -33,7 +33,6 @@ objects:
         values:
           - :download
           - :upload
-      # TODO(alexstephen): Figure out why MD5 hashes are different local vs. remote
       - !ruby/object:Api::Type::Boolean
         name: 'overwrite'
         description: >

--- a/products/storage/api.yaml
+++ b/products/storage/api.yaml
@@ -22,6 +22,30 @@ scopes:
   - https://www.googleapis.com/auth/devstorage.full_control
 objects:
   - !ruby/object:Api::Resource
+    name: 'Object'
+    base_url: b/{{bucket}}/o/
+    description: Upload or download a file from a GCS bucket.
+    exclude: true
+    parameters:
+      - !ruby/object:Api::Type::Enum
+        name: 'action'
+        description: 'Upload or download from the bucket'
+        values:
+          - :download
+          - :upload
+      - !ruby/object:Api::Type::Boolean
+        name: 'overwrite'
+        description: >
+          'Overwrite the file on the bucket/local machine. If overwrite is
+          false and a difference exists between GCS + local, module will fail
+          with error'
+      - !ruby/object:Api::Type::String
+        name: 'src'
+        description: Source location of file (may be local machine or cloud depending on action)
+      - !ruby/object:Api::Type::String
+        name: 'dest'
+        description: Destination location of file (may be local machine or cloud depending on action)
+  - !ruby/object:Api::Resource
     name: 'Bucket'
     kind: 'storage#bucket'
     base_url: b?project={{project}}

--- a/products/storage/api.yaml
+++ b/products/storage/api.yaml
@@ -39,10 +39,10 @@ objects:
           'Overwrite the file on the bucket/local machine. If overwrite is
           false and a difference exists between GCS + local, module will fail
           with error'
-      - !ruby/object:Api::Type::String
+      - !ruby/object:Api::Type::Path
         name: 'src'
         description: Source location of file (may be local machine or cloud depending on action)
-      - !ruby/object:Api::Type::String
+      - !ruby/object:Api::Type::Path
         name: 'dest'
         description: Destination location of file (may be local machine or cloud depending on action)
   - !ruby/object:Api::Resource

--- a/products/storage/api.yaml
+++ b/products/storage/api.yaml
@@ -45,6 +45,9 @@ objects:
       - !ruby/object:Api::Type::Path
         name: 'dest'
         description: Destination location of file (may be local machine or cloud depending on action)
+      - !ruby/object:Api::Type::String
+        name: 'bucket'
+        description: 'The name of the bucket'
   - !ruby/object:Api::Resource
     name: 'Bucket'
     kind: 'storage#bucket'

--- a/products/storage/examples/ansible/object.yaml
+++ b/products/storage/examples/ansible/object.yaml
@@ -19,6 +19,6 @@ task: !ruby/object:Provider::Ansible::Task
     bucket: ansible-bucket
     src: modules.zip
     dest: ~/modules.zip
-    project: google.com:graphite-playground
-    auth_kind: serviceaccount
-    service_account_file: /Users/alexstephen/serviceaccounts/graphite_playground.json
+    project: <%= ctx[:project] %>
+    auth_kind: <%= ctx[:auth_kind] %>
+    service_account_file: <%= ctx[:service_account_file] %>

--- a/products/storage/examples/ansible/object.yaml
+++ b/products/storage/examples/ansible/object.yaml
@@ -1,0 +1,24 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- !ruby/object:Provider::Ansible::Example
+task: !ruby/object:Provider::Ansible::Task
+  name: gcp_storage_object
+  code:
+    name: 'ansible-storage-module'
+    action: download
+    bucket: ansible-bucket
+    src: modules.zip
+    dest: ~/modules.zip
+    project: google.com:graphite-playground
+    auth_kind: serviceaccount
+    service_account_file: /Users/alexstephen/serviceaccounts/graphite_playground.json

--- a/products/storage/helpers/ansible/object_template.erb
+++ b/products/storage/helpers/ansible/object_template.erb
@@ -30,6 +30,7 @@ __metaclass__ = type
 import json
 import os
 import mimetypes
+import hashlib
 <%
   imports = object.imports || []
   imports << 'time' if object.async
@@ -64,9 +65,15 @@ def main():
 
     auth = GcpSession(module, 'storage')
     if module.params['action'] == 'download':
+        if get_md5_local(module.params['dest']) != get_md5_remote(module):
+            if not module.params['overwrite']:
+                module.fail_json(msg="Remote file is different from local file and local file could be overwritten")
         # Get file from API
         results = upload_file(module)
     else:
+        if get_md5_local(module.params['src']) != get_md5_remote(module):
+            if not module.params['overwrite']:
+                module.fail_json(msg="Local file is different from remote file and remote file could be overwritten")
         # Get contents of file
         results = download_file(module)
 
@@ -90,6 +97,18 @@ def download_file(module):
     f.close()
     results['changed'] = True
     return results
+
+def get_md5_local(path):
+    md5 = hashlib.md5()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(4096), b""):
+            md5.update(chunk)
+    return md5.hexdigest()
+
+
+def get_md5_remote(module):
+    resource = fetch_resource(module, self_link(module))
+    return resource.get('md5Hash')
 
 
 def fetch_resource(module, link, allow_not_found=True):

--- a/products/storage/helpers/ansible/object_template.erb
+++ b/products/storage/helpers/ansible/object_template.erb
@@ -31,6 +31,7 @@ import json
 import os
 import mimetypes
 import hashlib
+import base64
 <%
   imports = object.imports || []
   imports << 'time' if object.async
@@ -65,15 +66,9 @@ def main():
 
     auth = GcpSession(module, 'storage')
     if module.params['action'] == 'download':
-        if get_md5_local(module.params['dest']) != get_md5_remote(module):
-            if not module.params['overwrite']:
-                module.fail_json(msg="Remote file is different from local file and local file could be overwritten")
         # Get file from API
         results = upload_file(module)
     else:
-        if get_md5_local(module.params['src']) != get_md5_remote(module):
-            if not module.params['overwrite']:
-                module.fail_json(msg="Local file is different from remote file and remote file could be overwritten")
         # Get contents of file
         results = download_file(module)
 
@@ -103,7 +98,7 @@ def get_md5_local(path):
     with open(path, "rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):
             md5.update(chunk)
-    return md5.hexdigest()
+    return base64.b64encode(md5.hexdigest())
 
 
 def get_md5_remote(module):

--- a/products/storage/helpers/ansible/object_template.erb
+++ b/products/storage/helpers/ansible/object_template.erb
@@ -72,7 +72,6 @@ def main():
     if module.params['action'] == 'upload' and not local_file_exists:
         module.fail_json(msg="File does not exist on disk")
 
-
     # Check if we'll be overwriting files.
     if not module.params['overwrite']:
         remote_object['changed'] = False
@@ -105,17 +104,15 @@ def main():
 def download_file(module):
     auth = GcpSession(module, 'storage')
     data = auth.get(media_link(module))
-    f = open(module.params['dest'], 'w')
-    f.write(data.text.encode('utf8'))
-    f.close()
+    with open(module.params['dest'], 'w') as f:
+        f.write(data.text.encode('utf8'))
     return fetch_resource(module, self_link(module))
 
 
 def upload_file(module):
     auth = GcpSession(module, 'storage')
-    f = open(module.params['src'], 'r')
-    results = return_if_object(module, auth.post_contents(upload_link(module), f, object_headers(module)))
-    f.close()
+    with open(module.params['src'], 'r') as f:
+        results = return_if_object(module, auth.post_contents(upload_link(module), f, object_headers(module)))
     results['changed'] = True
     return results
 
@@ -143,6 +140,7 @@ def self_link(module):
         return "https://www.googleapis.com/storage/v1/b/{bucket}/o/{src}".format(**module.params)
     else:
         return "https://www.googleapis.com/storage/v1/b/{bucket}/o/{dest}".format(**module.params)
+
 
 def local_file_path(module):
     if module.params['action'] == 'download':

--- a/products/storage/helpers/ansible/object_template.erb
+++ b/products/storage/helpers/ansible/object_template.erb
@@ -1,0 +1,143 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017 Google
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+<%= lines(autogen_notice :python) -%>
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+<%= lines(compile('templates/ansible/documentation.erb'), 1) -%>
+################################################################################
+# Imports
+################################################################################
+<%
+  readonly_selflink_rrefs = object.all_resourcerefs
+                                  .select { |prop| prop.resource_ref.readonly }
+                                  .select { |prop| prop.imports == 'selfLink' }
+                                  .map(&:resource_ref)
+                                  .uniq
+-%>
+
+<%
+  update_props = properties_by_custom_update(object.all_user_properties)
+  import = 'from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest'
+  import += ', remove_nones_from_dict' unless properties_with_classes(object.all_user_properties).empty?
+  import += ', replace_resource_dict' if nonreadonly_rrefs(object)
+-%>
+<%= lines(import) -%>
+import json
+<%
+  imports = object.imports || []
+  imports << 'time' if object.async
+  imports << 're' unless readonly_selflink_rrefs.empty?
+-%>
+<%= lines(imports.sort.uniq.map { |i| "import #{i}" }) -%>
+
+################################################################################
+# Main
+################################################################################
+
+
+def main():
+    """Main function"""
+
+<%
+  mod_props = object.all_user_properties.reject(&:output).map do |prop|
+    python_dict_for_property(prop, object)
+  end
+-%>
+    module = GcpModule(
+        argument_spec=dict(
+            state=dict(default='present', choices=['present', 'absent'], type='str'),
+<%= lines(indent_list(mod_props, 12)) -%>
+        )
+    )
+
+    if not module.params['scopes']:
+        module.params['scopes'] = <%= python_literal(object.__product.scopes) %>
+
+    results = module.params
+
+    auth = GcpSession(module, 'storage')
+    if module.params['action'] == 'download':
+        # Get file from API
+        results = upload_file(module)
+    else:
+        # Get contents of file
+        results = download_file(module)
+
+    module.exit_json(**results)
+
+
+def upload_file(module):
+    data = auth.get(media_link(module))
+    f = open(module.params['dest'], 'w')
+    f.write(data.text.encode('utf8'))
+    f.close()
+    return fetch_resource(module, self_link(module))
+
+def download_file(module):
+    f = open(module.params['src'], 'r')
+    src = f.read()
+    results = return_if_object(module, auth.post(upload_link(module), src, headers=object_headers(module)))
+    f.close()
+    results['changed'] = True
+    return results
+    
+
+def fetch_resource(module, link, allow_not_found=True):
+    auth = GcpSession(module, 'storage')
+    return return_if_object(module, auth.get(link), allow_not_found)
+
+
+def self_link(module):
+    if module.params['action'] == 'download':
+        return "https://www.googleapis.com/storage/v1/b/{bucket}/o/{src}".format(**module.params)
+    else:
+        return "https://www.googleapis.com/storage/v1/b/{bucket}/o/{dest}".format(**module.params)
+
+def media_link(module):
+    if module.params['action'] == 'download':
+        return "https://www.googleapis.com/storage/v1/b/{bucket}/o/{src}?alt=media".format(**module.params)
+    else:
+        return "https://www.googleapis.com/storage/v1/b/{bucket}/o/{dest}?alt=media".format(**module.params)
+
+def upload_link(module):
+    return "https://www.googleapis.com/upload/storage/v1/b/{bucket}/o?uploadType=media&name={dest}".format(**module.params)
+
+
+def return_if_object(module, response, allow_not_found=False):
+    # If not found, return nothing.
+    if allow_not_found and response.status_code == 404:
+        return None
+
+    # If no content, return nothing.
+    if response.status_code == 204:
+        return None
+
+    try:
+        module.raise_for_status(response)
+        result = response.json()
+    except getattr(json.decoder, 'JSONDecodeError', ValueError) as inst:
+        module.fail_json(msg="Invalid JSON response with error: %s" % inst)
+
+    if navigate_hash(result, ['error', 'errors']):
+        module.fail_json(msg=navigate_hash(result, ['error', 'errors']))
+
+    return result
+
+
+# Remove unnecessary properties from the response.
+# This is for doing comparisons with Ansible's current parameters.
+def object_headers(module):
+    return {
+        "name": module.params['dest'],
+        "Content-Type": mimetypes.guess_type(module.params['src'])[0],
+        "Content-Length": str(os.path.getsize(module.params['src']))
+    }
+
+
+if __name__ == '__main__':
+    main()

--- a/products/storage/helpers/ansible/object_template.erb
+++ b/products/storage/helpers/ansible/object_template.erb
@@ -76,7 +76,7 @@ def main():
 def upload_file(module):
     auth = GcpSession(module, 'storage')
     data = auth.get(media_link(module))
-    f = open(os.path.expanduser(module.params['dest']), 'w')
+    f = open(module.params['dest'], 'w')
     f.write(data.text.encode('utf8'))
     f.close()
     return fetch_resource(module, self_link(module))
@@ -84,7 +84,7 @@ def upload_file(module):
 
 def download_file(module):
     auth = GcpSession(module, 'storage')
-    f = open(os.path.expanduser(module.params['src']), 'r')
+    f = open(module.params['src']), 'r')
     src = f.read()
     results = return_if_object(module, auth.post(upload_link(module), src, headers=object_headers(module)))
     f.close()

--- a/products/storage/helpers/ansible/object_template.erb
+++ b/products/storage/helpers/ansible/object_template.erb
@@ -62,20 +62,38 @@ def main():
     if not module.params['scopes']:
         module.params['scopes'] = <%= python_literal(object.__product.scopes) %>
 
-    results = module.params
+    remote_object = fetch_resource(module, self_link(module))
+    local_file_exists = os.path.isfile(local_file_path(module))
 
+    # Check if files exist.
+    if module.params['action'] == 'download' and not remote_object:
+        module.fail_json(msg="File does not exist in bucket")
+
+    if module.params['action'] == 'upload' and not local_file_exists:
+        module.fail_json(msg="File does not exist on disk")
+
+
+    # Check if we'll be overwriting files.
+    if not module.params['overwrite']:
+      if module.params['action'] == 'download' and local_file_exists:
+          if get_md5_local(local_file_path(module)) != remote_object['md5Hash']:
+              module.fail_json(msg="Local file is different than remote file")
+
+      elif module.params['action'] == 'upload' and remote_object:
+          if get_md5_local(local_file_path(module)) != remote_object['md5Hash']:
+              module.fail_json(msg="Local file is different than remote file")
+
+    # Upload/download the files
     auth = GcpSession(module, 'storage')
     if module.params['action'] == 'download':
-        # Get file from API
-        results = upload_file(module)
-    else:
-        # Get contents of file
         results = download_file(module)
+    else:
+        results = upload_file(module)
 
     module.exit_json(**results)
 
 
-def upload_file(module):
+def download_file(module):
     auth = GcpSession(module, 'storage')
     data = auth.get(media_link(module))
     f = open(module.params['dest'], 'w')
@@ -84,7 +102,7 @@ def upload_file(module):
     return fetch_resource(module, self_link(module))
 
 
-def download_file(module):
+def upload_file(module):
     auth = GcpSession(module, 'storage')
     f = open(module.params['src'], 'r')
     src = f.read()
@@ -99,7 +117,7 @@ def get_md5_local(path):
     with open(path, "rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):
             md5.update(chunk)
-    return base64.b64encode(md5.hexdigest())
+    return base64.b64encode(md5.digest())
 
 
 def get_md5_remote(module):
@@ -117,6 +135,12 @@ def self_link(module):
         return "https://www.googleapis.com/storage/v1/b/{bucket}/o/{src}".format(**module.params)
     else:
         return "https://www.googleapis.com/storage/v1/b/{bucket}/o/{dest}".format(**module.params)
+
+def local_file_path(module):
+    if module.params['action'] == 'download':
+        return module.params['dest']
+    else:
+        return module.params['src']
 
 
 def media_link(module):

--- a/products/storage/helpers/ansible/object_template.erb
+++ b/products/storage/helpers/ansible/object_template.erb
@@ -28,6 +28,8 @@ __metaclass__ = type
 -%>
 <%= lines(import) -%>
 import json
+import os
+import mimetypes
 <%
   imports = object.imports || []
   imports << 'time' if object.async
@@ -72,20 +74,23 @@ def main():
 
 
 def upload_file(module):
+    auth = GcpSession(module, 'storage')
     data = auth.get(media_link(module))
-    f = open(module.params['dest'], 'w')
+    f = open(os.path.expanduser(module.params['dest']), 'w')
     f.write(data.text.encode('utf8'))
     f.close()
     return fetch_resource(module, self_link(module))
 
+
 def download_file(module):
-    f = open(module.params['src'], 'r')
+    auth = GcpSession(module, 'storage')
+    f = open(os.path.expanduser(module.params['src']), 'r')
     src = f.read()
     results = return_if_object(module, auth.post(upload_link(module), src, headers=object_headers(module)))
     f.close()
     results['changed'] = True
     return results
-    
+
 
 def fetch_resource(module, link, allow_not_found=True):
     auth = GcpSession(module, 'storage')
@@ -98,11 +103,13 @@ def self_link(module):
     else:
         return "https://www.googleapis.com/storage/v1/b/{bucket}/o/{dest}".format(**module.params)
 
+
 def media_link(module):
     if module.params['action'] == 'download':
         return "https://www.googleapis.com/storage/v1/b/{bucket}/o/{src}?alt=media".format(**module.params)
     else:
         return "https://www.googleapis.com/storage/v1/b/{bucket}/o/{dest}?alt=media".format(**module.params)
+
 
 def upload_link(module):
     return "https://www.googleapis.com/upload/storage/v1/b/{bucket}/o?uploadType=media&name={dest}".format(**module.params)

--- a/products/storage/helpers/ansible/object_template.erb
+++ b/products/storage/helpers/ansible/object_template.erb
@@ -84,7 +84,7 @@ def upload_file(module):
 
 def download_file(module):
     auth = GcpSession(module, 'storage')
-    f = open(module.params['src']), 'r')
+    f = open(module.params['src'], 'r')
     src = f.read()
     results = return_if_object(module, auth.post(upload_link(module), src, headers=object_headers(module)))
     f.close()

--- a/products/storage/helpers/ansible/object_template.erb
+++ b/products/storage/helpers/ansible/object_template.erb
@@ -93,6 +93,7 @@ def download_file(module):
     results['changed'] = True
     return results
 
+
 def get_md5_local(path):
     md5 = hashlib.md5()
     with open(path, "rb") as f:

--- a/products/storage/helpers/ansible/object_template.erb
+++ b/products/storage/helpers/ansible/object_template.erb
@@ -75,22 +75,22 @@ def main():
 
     # Check if we'll be overwriting files.
     if not module.params['overwrite']:
-      remote_object['changed'] = False
-      if module.params['action'] == 'download' and local_file_exists:
-          # If files differ, throw an error
-          if get_md5_local(local_file_path(module)) != remote_object['md5Hash']:
-              module.fail_json(msg="Local file is different than remote file")
-          # If files are the same, module is done running.
-          else:
-              module.exit_json(**remote_object)
+        remote_object['changed'] = False
+        if module.params['action'] == 'download' and local_file_exists:
+            # If files differ, throw an error
+            if get_md5_local(local_file_path(module)) != remote_object['md5Hash']:
+                module.fail_json(msg="Local file is different than remote file")
+            # If files are the same, module is done running.
+            else:
+                module.exit_json(**remote_object)
 
-      elif module.params['action'] == 'upload' and remote_object:
-          # If files differ, throw an error
-          if get_md5_local(local_file_path(module)) != remote_object['md5Hash']:
-              module.fail_json(msg="Local file is different than remote file")
-          # If files are the same, module is done running.
-          else:
-              module.exit_json(**remote_object)
+        elif module.params['action'] == 'upload' and remote_object:
+            # If files differ, throw an error
+            if get_md5_local(local_file_path(module)) != remote_object['md5Hash']:
+                module.fail_json(msg="Local file is different than remote file")
+            # If files are the same, module is done running.
+            else:
+                module.exit_json(**remote_object)
 
     # Upload/download the files
     auth = GcpSession(module, 'storage')

--- a/products/storage/helpers/ansible/object_template.erb
+++ b/products/storage/helpers/ansible/object_template.erb
@@ -75,13 +75,22 @@ def main():
 
     # Check if we'll be overwriting files.
     if not module.params['overwrite']:
+      remote_object['changed'] = False
       if module.params['action'] == 'download' and local_file_exists:
+          # If files differ, throw an error
           if get_md5_local(local_file_path(module)) != remote_object['md5Hash']:
               module.fail_json(msg="Local file is different than remote file")
+          # If files are the same, module is done running.
+          else:
+              module.exit_json(**remote_object)
 
       elif module.params['action'] == 'upload' and remote_object:
+          # If files differ, throw an error
           if get_md5_local(local_file_path(module)) != remote_object['md5Hash']:
               module.fail_json(msg="Local file is different than remote file")
+          # If files are the same, module is done running.
+          else:
+              module.exit_json(**remote_object)
 
     # Upload/download the files
     auth = GcpSession(module, 'storage')
@@ -105,8 +114,7 @@ def download_file(module):
 def upload_file(module):
     auth = GcpSession(module, 'storage')
     f = open(module.params['src'], 'r')
-    src = f.read()
-    results = return_if_object(module, auth.post(upload_link(module), src, headers=object_headers(module)))
+    results = return_if_object(module, auth.post_contents(upload_link(module), f, object_headers(module)))
     f.close()
     results['changed'] = True
     return results

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -218,7 +218,7 @@ module Provider
         FileUtils.mkpath target_folder
         name = module_name(data[:object])
         generate_resource_file data.clone.merge(
-          default_template: 'templates/ansible/resource.erb',
+          default_template: data[:object].template || 'templates/ansible/resource.erb',
           out_file: File.join(target_folder,
                               "lib/ansible/modules/cloud/google/#{name}.py")
         )

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -37,7 +37,8 @@ module Provider
         'Api::Type::Boolean' => 'bool',
         'Api::Type::Integer' => 'int',
         'Api::Type::KeyValuePairs' => 'dict',
-        'Provider::Ansible::FilterProp' => 'list'
+        'Provider::Ansible::FilterProp' => 'list',
+        'Api::Type::Path' => 'path'
       }.freeze
 
       include Provider::Ansible::Documentation

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -64,6 +64,8 @@ module Provider
       # This will eventually be converted to YAML
       def returns_for_property(prop)
         type = python_type(prop)
+        # Type is a valid AnsibleModule type, but not a valid return type
+        type = 'str' if type == 'path'
         # Complex types only mentioned in reference to RETURNS YAML block
         # Complex types are nested objects traditionally, but arrays of nested
         # objects will be included to avoid linting errors.

--- a/provider/ansible/gcp_utils.py
+++ b/provider/ansible/gcp_utils.py
@@ -84,6 +84,12 @@ class GcpSession(object):
         except getattr(requests.exceptions, 'RequestException') as inst:
             self.module.fail_json(msg=inst.message)
 
+    def post_contents(self, url, file_contents=None, headers={}, **kwargs):
+        try:
+            return self.session().post(url, data=file_contents, headers=self._headers())
+        except getattr(requests.exceptions, 'RequestException') as inst:
+            self.module.fail_json(msg=inst.message)
+
     def delete(self, url, body=None):
         try:
             return self.session().delete(url, json=body, headers=self._headers())

--- a/provider/ansible/gcp_utils.py
+++ b/provider/ansible/gcp_utils.py
@@ -77,7 +77,8 @@ class GcpSession(object):
         except getattr(requests.exceptions, 'RequestException') as inst:
             self.module.fail_json(msg=inst.message)
 
-    def post(self, url, body=None):
+    def post(self, url, body=None, headers={}, **kwargs):
+        kwargs.update({'json': body, 'headers': self._merge_dictionaries(headers, self._headers())})
         try:
             return self.session().post(url, json=body, headers=self._headers())
         except getattr(requests.exceptions, 'RequestException') as inst:
@@ -141,6 +142,11 @@ class GcpSession(object):
         return {
             'User-Agent': "Google-Ansible-MM-{0}".format(self.product)
         }
+
+    def _merge_dictionaries(self, a, b):
+        new = a.copy()
+        new.update(b)
+        return new
 
 
 class GcpModule(AnsibleModule):

--- a/provider/ansible/resource_override.rb
+++ b/provider/ansible/resource_override.rb
@@ -32,6 +32,7 @@ module Provider
       attr_reader :post_action
       attr_reader :provider_helpers
       attr_reader :return_if_object
+      attr_reader :template
       attr_reader :unwrap_resource
       attr_reader :update
       attr_reader :version_added
@@ -69,6 +70,7 @@ module Provider
         check_optional_property :post_action, ::String
         check_property :provider_helpers, ::Array
         check_optional_property :return_if_object, ::String
+        check_optional_property :template, ::String
         check_optional_property :update, ::String
         check_optional_property :unwrap_resource, :boolean
         check_optional_property :version_added, ::String

--- a/templates/ansible/documentation.erb
+++ b/templates/ansible/documentation.erb
@@ -6,7 +6,6 @@
   metadata_version = quote_string(@config.manifest.get('metadata_version',
                                                        object))
   supported_by = quote_string(@config.manifest.get('supported_by', object))
-  update_props = properties_by_custom_update(object.all_user_properties)
 -%>
 ANSIBLE_METADATA = {'metadata_version': <%= metadata_version -%>,
                     'status': <%= @config.manifest.get('status', object) -%>,

--- a/templates/ansible/documentation.erb
+++ b/templates/ansible/documentation.erb
@@ -1,0 +1,58 @@
+################################################################################
+# Documentation
+################################################################################
+
+<%
+  metadata_version = quote_string(@config.manifest.get('metadata_version',
+                                                       object))
+  supported_by = quote_string(@config.manifest.get('supported_by', object))
+  supported_by = quote_string(@config.manifest.get('supported_by', config))
+-%>
+ANSIBLE_METADATA = {'metadata_version': <%= metadata_version -%>,
+                    'status': <%= @config.manifest.get('status', object) -%>,
+                    'supported_by': <%= supported_by -%>}
+
+DOCUMENTATION = '''
+---
+<%= to_yaml({
+  'module' => module_name(object),
+  'description' => format_description(object.description),
+  'short_description' => "Creates a GCP #{object.name}",
+  'version_added' => @config.manifest.get('version_added', object).to_f,
+  'author' => @config.manifest.get('author', object),
+  'requirements' => @config.manifest.get('requirements', object),
+  'options' => [
+    {
+      'state' => {
+        'description' => ['Whether the given object should exist in GCP'],
+        'choices' => ['present', 'absent'],
+        'default' => 'present'
+      },
+    },
+    object.all_user_properties.reject(&:output).map { |p| documentation_for_property(p) }
+  ].flatten.compact.reduce({}, :merge),
+  'extends_documentation_fragment' => 'gcp',
+  'notes' => (
+    [
+      ("API Reference: U(#{object.references.api})" if object.references.api),
+      object.references.guides.map { |guide, link| "#{guide}: U(#{link})" }
+    ].flatten.compact if object.references
+  )
+})-%>
+'''
+
+<% if example -%>
+EXAMPLES = '''
+<% res_readable_name = object.name.uncombine -%>
+<% if example.dependencies -%>
+<%   example.dependencies.each do |depend| -%>
+<%= lines(depend.build_test('present', object, false), 1) -%>
+<%   end # example.dependencies.each -%>
+<% end # if example.dependencies -%>
+<%= lines(example.task.build_example('present', object)) -%>
+'''
+<% end -%>
+
+RETURN = '''
+<%= to_yaml(object.all_user_properties.map { |p| returns_for_property(p) }.reduce({}, :merge)) -%>
+'''

--- a/templates/ansible/documentation.erb
+++ b/templates/ansible/documentation.erb
@@ -6,7 +6,7 @@
   metadata_version = quote_string(@config.manifest.get('metadata_version',
                                                        object))
   supported_by = quote_string(@config.manifest.get('supported_by', object))
-  supported_by = quote_string(@config.manifest.get('supported_by', config))
+  update_props = properties_by_custom_update(object.all_user_properties)
 -%>
 ANSIBLE_METADATA = {'metadata_version': <%= metadata_version -%>,
                     'status': <%= @config.manifest.get('status', object) -%>,

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -8,7 +8,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-<%= lines(compile('templates/ansible/documentation.erb'), 1) -%>
+<%= lines(compile('templates/ansible/documentation.erb', 1) -%>
 ################################################################################
 # Imports
 ################################################################################
@@ -21,7 +21,6 @@ __metaclass__ = type
 -%>
 
 <%
-  update_props = properties_by_custom_update(object.all_user_properties)
   import = 'from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest'
   import += ', remove_nones_from_dict' unless properties_with_classes(object.all_user_properties).empty?
   import += ', replace_resource_dict' if nonreadonly_rrefs(object)

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -8,7 +8,8 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-<%= lines(compile('templates/ansible/documentation.erb', 1) -%>
+
+<%= lines(compile('templates/ansible/documentation.erb', 1)) -%>
 ################################################################################
 # Imports
 ################################################################################
@@ -18,6 +19,8 @@ __metaclass__ = type
                                   .select { |prop| prop.imports == 'selfLink' }
                                   .map(&:resource_ref)
                                   .uniq
+
+  update_props = properties_by_custom_update(object.all_user_properties)
 -%>
 
 <%

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -8,65 +8,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-################################################################################
-# Documentation
-################################################################################
-
-<%
-  metadata_version = quote_string(@config.manifest.get('metadata_version',
-                                                       object))
-  supported_by = quote_string(@config.manifest.get('supported_by', object))
-  update_props = properties_by_custom_update(object.all_user_properties)
--%>
-ANSIBLE_METADATA = {'metadata_version': <%= metadata_version -%>,
-                    'status': <%= @config.manifest.get('status', object) -%>,
-                    'supported_by': <%= supported_by -%>}
-
-DOCUMENTATION = '''
----
-<%= to_yaml({
-  'module' => module_name(object),
-  'description' => format_description(object.description),
-  'short_description' => "Creates a GCP #{object.name}",
-  'version_added' => @config.manifest.get('version_added', object).to_f,
-  'author' => @config.manifest.get('author', object),
-  'requirements' => @config.manifest.get('requirements', object),
-  'options' => [
-    {
-      'state' => {
-        'description' => ['Whether the given object should exist in GCP'],
-        'choices' => ['present', 'absent'],
-        'default' => 'present'
-      },
-    },
-    object.all_user_properties.reject(&:output).map { |p| documentation_for_property(p) }
-  ].flatten.compact.reduce({}, :merge),
-  'extends_documentation_fragment' => 'gcp',
-  'notes' => (
-    [
-      ("API Reference: U(#{object.references.api})" if object.references.api),
-      object.references.guides.map { |guide, link| "#{guide}: U(#{link})" }
-    ].flatten.compact if object.references
-  )
-})-%>
-'''
-
-<% if example -%>
-EXAMPLES = '''
-<% res_readable_name = object.name.uncombine -%>
-<% if example.dependencies -%>
-<%   example.dependencies.each do |depend| -%>
-<%= lines(depend.build_test('present', object, false), 1) -%>
-<%   end # example.dependencies.each -%>
-<% end # if example.dependencies -%>
-<%= lines(example.task.build_example('present', object)) -%>
-'''
-<% end -%>
-
-RETURN = '''
-<%= to_yaml(object.all_user_properties.map { |p| returns_for_property(p) }.reduce({}, :merge)) -%>
-'''
-
+<%= lines(compile('templates/ansible/documentation.erb'), 1) -%>
 ################################################################################
 # Imports
 ################################################################################
@@ -79,6 +21,7 @@ RETURN = '''
 -%>
 
 <%
+  update_props = properties_by_custom_update(object.all_user_properties)
   import = 'from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest'
   import += ', remove_nones_from_dict' unless properties_with_classes(object.all_user_properties).empty?
   import += ', replace_resource_dict' if nonreadonly_rrefs(object)

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -8,8 +8,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-
-<%= lines(compile('templates/ansible/documentation.erb', 1)) -%>
+<%= lines(compile('templates/ansible/documentation.erb'), 1) -%>
 ################################################################################
 # Imports
 ################################################################################


### PR DESCRIPTION
Lots of custom code in this module! I took an approach of building a new "template" specifically for this module.

This new template uses the building blocks of the regular Ansible modules (so we get autoupdating documentation, arg parsing for free), but ignores all of the other stuff.

This PR contains:
* Moving documentation into a new file so it can be easily reused by the object upload/download module
* API.yaml info for the module
* Support for specifying which template should be used
* A object_storage template with a bunch of custom code.

This module currently uploads/downloads a file. It doesn't handle overwrite logic. That'll come next.


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
