### PR TITLE
Set exclude for versions recursively on objects/arrays

### DIFF
--- a/api/type.rb
+++ b/api/type.rb
@@ -310,6 +310,12 @@ module Api
         end
         [property_file]
       end
+
+      def exclude_if_not_in_version(version)
+        super
+        @item_type.exclude_if_not_in_version(version) \
+          if @item_type.is_a? NestedObject
+      end
     end
 
     # Represents an enum, and store is valid values
@@ -498,6 +504,11 @@ module Api
 
       def properties
         @properties.reject(&:exclude)
+      end
+
+      def exclude_if_not_in_version(version)
+        super
+        @properties.each { |p| p.exclude_if_not_in_version(version) }
       end
     end
 


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Currently this property (Type) method only gets called on direct resource @properties/@parameters. 

I'm not sure if this will change other providers, but if it does, they were probably wrong to start with. 

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
## [inspec]
