### PR TITLE
TF: enable underscores for google_spanner_database.name

### DIFF
--- a/provider/terraform/resources/resource_spanner_database.go
+++ b/provider/terraform/resources/resource_spanner_database.go
@@ -41,9 +41,9 @@ func resourceSpannerDatabase() *schema.Resource {
 						errors = append(errors, fmt.Errorf(
 							"%q must be between 2 and 30 characters in length", k))
 					}
-					if !regexp.MustCompile("^[a-z0-9-]+$").MatchString(value) {
+					if !regexp.MustCompile("^[a-z0-9-_]+$").MatchString(value) {
 						errors = append(errors, fmt.Errorf(
-							"%q can only contain lowercase letters, numbers and hyphens", k))
+							"%q can only contain lowercase letters, numbers, hyphens, and underscores", k))
 					}
 					if !regexp.MustCompile("^[a-z]").MatchString(value) {
 						errors = append(errors, fmt.Errorf(


### PR DESCRIPTION
closes gh-583

<!-- A summary of the changes in this commit goes here -->


<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
## [terraform]
* Enable underscores to be used in google_spanner_database.name values