### PR TITLE
Add filter for stackdriver metrics to compute autoscaler properties (beta)

### DIFF
--- a/products/compute/autoscaler_properties.yaml
+++ b/products/compute/autoscaler_properties.yaml
@@ -136,6 +136,42 @@
             - :DELTA_PER_SECOND
             - :DELTA_PER_MINUTE
           required: true
+        - !ruby/object:Api::Type::String
+          name: 'filter'
+          description: |
+            A filter string to be used as the filter string for
+            a Stackdriver Monitoring TimeSeries.list API call.
+            This filter is used to select a specific TimeSeries for
+            the purpose of autoscaling and to determine whether the metric
+            is exporting per-instance or per-group data.
+
+            You can only use the AND operator for joining selectors.
+            You can only use direct equality comparison operator (=) without
+            any functions for each selector.
+            You can specify the metric in both the filter string and in the
+            metric field. However, if specified in both places, the metric must
+            be identical.
+
+            The monitored resource type determines what kind of values are
+            expected for the metric. If it is a gce_instance, the autoscaler
+            expects the metric to include a separate TimeSeries for each
+            instance in a group. In such a case, you cannot filter on resource
+            labels.
+
+            If the resource type is any other value, the autoscaler expects
+            this metric to contain values that apply to the entire autoscaled
+            instance group and resource label filtering can be performed to
+            point autoscaler at the correct TimeSeries to scale upon.
+            This is called a per-group metric for the purpose of autoscaling.
+
+            If not specified, the type defaults to gce_instance.
+
+            You should provide a filter that is selective enough to pick just
+            one TimeSeries for the autoscaled group or for each of the instances
+            (if you are using gce_instance resource type). If multiple
+            TimeSeries are returned upon the query execution, the autoscaler
+            will sum their respective values to obtain its scaling value.
+          min_version: beta
     - !ruby/object:Api::Type::NestedObject
       name: 'loadBalancingUtilization'
       description: |


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
Add (beta) filter to autoscaler properties

## [puppet]
### [puppet-bigquery]
### [puppet-compute]
### [puppet-container]
### [puppet-dns]
### [puppet-logging]
### [puppet-pubsub]
### [puppet-resourcemanager]
### [puppet-sql]
### [puppet-storage]
## [chef]
### [chef-compute]
### [chef-container]
### [chef-dns]
### [chef-logging]
### [chef-spanner]
### [chef-sql]
### [chef-storage]
## [ansible]
## [inspec]
