### PR TITLE
[Terraform]: Make google_project_iam_policy authoritative.

### DIFF
--- a/provider/terraform/tests/resource_google_project_iam_policy_test.go
+++ b/provider/terraform/tests/resource_google_project_iam_policy_test.go
@@ -13,213 +13,6 @@ import (
 	"google.golang.org/api/cloudresourcemanager/v1"
 )
 
-func TestSubtractIamPolicy(t *testing.T) {
-	table := []struct {
-		a      *cloudresourcemanager.Policy
-		b      *cloudresourcemanager.Policy
-		expect cloudresourcemanager.Policy
-	}{
-		{
-			a: &cloudresourcemanager.Policy{
-				Bindings: []*cloudresourcemanager.Binding{
-					{
-						Role: "a",
-						Members: []string{
-							"1",
-							"2",
-						},
-					},
-					{
-						Role: "b",
-						Members: []string{
-							"1",
-							"2",
-						},
-					},
-				},
-			},
-			b: &cloudresourcemanager.Policy{
-				Bindings: []*cloudresourcemanager.Binding{
-					{
-						Role: "a",
-						Members: []string{
-							"3",
-							"4",
-						},
-					},
-					{
-						Role: "b",
-						Members: []string{
-							"1",
-							"2",
-						},
-					},
-				},
-			},
-			expect: cloudresourcemanager.Policy{
-				Bindings: []*cloudresourcemanager.Binding{
-					{
-						Role: "a",
-						Members: []string{
-							"1",
-							"2",
-						},
-					},
-				},
-			},
-		},
-		{
-			a: &cloudresourcemanager.Policy{
-				Bindings: []*cloudresourcemanager.Binding{
-					{
-						Role: "a",
-						Members: []string{
-							"1",
-							"2",
-						},
-					},
-					{
-						Role: "b",
-						Members: []string{
-							"1",
-							"2",
-						},
-					},
-				},
-			},
-			b: &cloudresourcemanager.Policy{
-				Bindings: []*cloudresourcemanager.Binding{
-					{
-						Role: "a",
-						Members: []string{
-							"1",
-							"2",
-						},
-					},
-					{
-						Role: "b",
-						Members: []string{
-							"1",
-							"2",
-						},
-					},
-				},
-			},
-			expect: cloudresourcemanager.Policy{
-				Bindings: []*cloudresourcemanager.Binding{},
-			},
-		},
-		{
-			a: &cloudresourcemanager.Policy{
-				Bindings: []*cloudresourcemanager.Binding{
-					{
-						Role: "a",
-						Members: []string{
-							"1",
-							"2",
-							"3",
-						},
-					},
-					{
-						Role: "b",
-						Members: []string{
-							"1",
-							"2",
-							"3",
-						},
-					},
-				},
-			},
-			b: &cloudresourcemanager.Policy{
-				Bindings: []*cloudresourcemanager.Binding{
-					{
-						Role: "a",
-						Members: []string{
-							"1",
-							"3",
-						},
-					},
-					{
-						Role: "b",
-						Members: []string{
-							"1",
-							"2",
-							"3",
-						},
-					},
-				},
-			},
-			expect: cloudresourcemanager.Policy{
-				Bindings: []*cloudresourcemanager.Binding{
-					{
-						Role: "a",
-						Members: []string{
-							"2",
-						},
-					},
-				},
-			},
-		},
-		{
-			a: &cloudresourcemanager.Policy{
-				Bindings: []*cloudresourcemanager.Binding{
-					{
-						Role: "a",
-						Members: []string{
-							"1",
-							"2",
-							"3",
-						},
-					},
-					{
-						Role: "b",
-						Members: []string{
-							"1",
-							"2",
-							"3",
-						},
-					},
-				},
-			},
-			b: &cloudresourcemanager.Policy{
-				Bindings: []*cloudresourcemanager.Binding{
-					{
-						Role: "a",
-						Members: []string{
-							"1",
-							"2",
-							"3",
-						},
-					},
-					{
-						Role: "b",
-						Members: []string{
-							"1",
-							"2",
-							"3",
-						},
-					},
-				},
-			},
-			expect: cloudresourcemanager.Policy{
-				Bindings: []*cloudresourcemanager.Binding{},
-			},
-		},
-	}
-
-	for _, test := range table {
-		c := subtractIamPolicy(test.a, test.b)
-		sort.Sort(sortableBindings(c.Bindings))
-		for i, _ := range c.Bindings {
-			sort.Strings(c.Bindings[i].Members)
-		}
-
-		if !reflect.DeepEqual(derefBindings(c.Bindings), derefBindings(test.expect.Bindings)) {
-			t.Errorf("\ngot %+v\nexpected %+v", derefBindings(c.Bindings), derefBindings(test.expect.Bindings))
-		}
-	}
-}
-
 // Test that an IAM policy can be applied to a project
 func TestAccProjectIamPolicy_basic(t *testing.T) {
 	t.Parallel()
@@ -241,52 +34,10 @@ func TestAccProjectIamPolicy_basic(t *testing.T) {
 			// merges policies, so we validate the expected state.
 			resource.TestStep{
 				Config: testAccProjectAssociatePolicyBasic(pid, pname, org),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleProjectIamPolicyIsMerged("google_project_iam_policy.acceptance", "data.google_iam_policy.admin", pid),
-				),
 			},
 			resource.TestStep{
 				ResourceName: "google_project_iam_policy.acceptance",
 				ImportState:  true,
-				// Skipping the normal "ImportStateVerify" - Unfortunately, it's not
-				// really possible to make the imported policy match exactly, since
-				// the policy depends on the service account being used to create the
-				// project.
-			},
-			// Finally, remove the custom IAM policy from config and apply, then
-			// confirm that the project is in its original state.
-			resource.TestStep{
-				Config: testAccProject_create(pid, pname, org),
-				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
-				),
-			},
-		},
-	})
-}
-
-// Test that an IAM policy can be applied to a project when no project is set in the resource
-func TestAccProjectIamPolicy_defaultProject(t *testing.T) {
-	t.Parallel()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			// Create a new project
-			resource.TestStep{
-				Config: testAccProjectDefaultAssociatePolicyBasic(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(getTestProjectFromEnv()),
-				),
-			},
-			// Apply an IAM policy from a data source. The application
-			// merges policies, so we validate the expected state.
-			resource.TestStep{
-				Config: testAccProjectDefaultAssociatePolicyBasic(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleProjectIamPolicyIsMerged("google_project_iam_policy.acceptance", "data.google_iam_policy.admin", getTestProjectFromEnv()),
-				),
 			},
 		},
 	})
@@ -371,280 +122,6 @@ func testAccCheckGoogleProjectIamPolicyExists(projectRes, policyRes, pid string)
 	}
 }
 
-func testAccCheckGoogleProjectIamPolicyIsMerged(projectRes, policyRes, pid string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		err := testAccCheckGoogleProjectIamPolicyExists(projectRes, policyRes, pid)(s)
-		if err != nil {
-			return err
-		}
-
-		projectPolicy, err := getGoogleProjectIamPolicyFromState(s, projectRes, pid)
-		if err != nil {
-			return fmt.Errorf("Error retrieving IAM policy for project from state: %s", err)
-		}
-
-		// Merge the project policy in Terraform state with the policy the project had before the config was applied
-		var expected []*cloudresourcemanager.Binding
-		expected = append(expected, originalPolicy.Bindings...)
-		expected = append(expected, projectPolicy.Bindings...)
-		expected = mergeBindings(expected)
-
-		// Retrieve the actual policy from the project
-		c := testAccProvider.Meta().(*Config)
-		actual, err := getProjectIamPolicy(pid, c)
-		if err != nil {
-			return fmt.Errorf("Failed to retrieve IAM Policy for project %q: %s", pid, err)
-		}
-		// The bindings should match, indicating the policy was successfully applied and merged
-		if !compareBindings(actual.Bindings, expected) {
-			return fmt.Errorf("Actual and expected project policies do not match: actual policy is %+v, expected policy is  %+v", derefBindings(actual.Bindings), derefBindings(expected))
-		}
-
-		return nil
-	}
-}
-
-func TestIamRolesToMembersBinding(t *testing.T) {
-	table := []struct {
-		expect []*cloudresourcemanager.Binding
-		input  map[string]map[string]bool
-	}{
-		{
-			expect: []*cloudresourcemanager.Binding{
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-1",
-						"member-2",
-					},
-				},
-			},
-			input: map[string]map[string]bool{
-				"role-1": map[string]bool{
-					"member-1": true,
-					"member-2": true,
-				},
-			},
-		},
-		{
-			expect: []*cloudresourcemanager.Binding{
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-1",
-						"member-2",
-					},
-				},
-			},
-			input: map[string]map[string]bool{
-				"role-1": map[string]bool{
-					"member-1": true,
-					"member-2": true,
-				},
-			},
-		},
-		{
-			expect: []*cloudresourcemanager.Binding{
-				{
-					Role:    "role-1",
-					Members: []string{},
-				},
-			},
-			input: map[string]map[string]bool{
-				"role-1": map[string]bool{},
-			},
-		},
-	}
-
-	for _, test := range table {
-		got := rolesToMembersBinding(test.input)
-
-		sort.Sort(sortableBindings(got))
-		for i, _ := range got {
-			sort.Strings(got[i].Members)
-		}
-
-		if !reflect.DeepEqual(derefBindings(got), derefBindings(test.expect)) {
-			t.Errorf("got %+v, expected %+v", derefBindings(got), derefBindings(test.expect))
-		}
-	}
-}
-func TestIamRolesToMembersMap(t *testing.T) {
-	table := []struct {
-		input  []*cloudresourcemanager.Binding
-		expect map[string]map[string]bool
-	}{
-		{
-			input: []*cloudresourcemanager.Binding{
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-1",
-						"member-2",
-					},
-				},
-			},
-			expect: map[string]map[string]bool{
-				"role-1": map[string]bool{
-					"member-1": true,
-					"member-2": true,
-				},
-			},
-		},
-		{
-			input: []*cloudresourcemanager.Binding{
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-1",
-						"member-2",
-						"member-1",
-						"member-2",
-					},
-				},
-			},
-			expect: map[string]map[string]bool{
-				"role-1": map[string]bool{
-					"member-1": true,
-					"member-2": true,
-				},
-			},
-		},
-		{
-			input: []*cloudresourcemanager.Binding{
-				{
-					Role: "role-1",
-				},
-			},
-			expect: map[string]map[string]bool{
-				"role-1": map[string]bool{},
-			},
-		},
-	}
-
-	for _, test := range table {
-		got := rolesToMembersMap(test.input)
-		if !reflect.DeepEqual(got, test.expect) {
-			t.Errorf("got %+v, expected %+v", got, test.expect)
-		}
-	}
-}
-
-func TestIamMergeBindings(t *testing.T) {
-	table := []struct {
-		input  []*cloudresourcemanager.Binding
-		expect []cloudresourcemanager.Binding
-	}{
-		{
-			input: []*cloudresourcemanager.Binding{
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-1",
-						"member-2",
-					},
-				},
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-3",
-					},
-				},
-			},
-			expect: []cloudresourcemanager.Binding{
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-1",
-						"member-2",
-						"member-3",
-					},
-				},
-			},
-		},
-		{
-			input: []*cloudresourcemanager.Binding{
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-3",
-						"member-4",
-					},
-				},
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-2",
-						"member-1",
-					},
-				},
-				{
-					Role: "role-2",
-					Members: []string{
-						"member-1",
-					},
-				},
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-5",
-					},
-				},
-				{
-					Role: "role-3",
-					Members: []string{
-						"member-1",
-					},
-				},
-				{
-					Role: "role-2",
-					Members: []string{
-						"member-2",
-					},
-				},
-				{Role: "empty-role", Members: []string{}},
-			},
-			expect: []cloudresourcemanager.Binding{
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-1",
-						"member-2",
-						"member-3",
-						"member-4",
-						"member-5",
-					},
-				},
-				{
-					Role: "role-2",
-					Members: []string{
-						"member-1",
-						"member-2",
-					},
-				},
-				{
-					Role: "role-3",
-					Members: []string{
-						"member-1",
-					},
-				},
-			},
-		},
-	}
-
-	for _, test := range table {
-		got := mergeBindings(test.input)
-		sort.Sort(sortableBindings(got))
-		for i, _ := range got {
-			sort.Strings(got[i].Members)
-		}
-
-		if !reflect.DeepEqual(derefBindings(got), test.expect) {
-			t.Errorf("\ngot %+v\nexpected %+v", derefBindings(got), test.expect)
-		}
-	}
-}
-
 func derefBindings(b []*cloudresourcemanager.Binding) []cloudresourcemanager.Binding {
 	db := make([]cloudresourcemanager.Binding, len(b))
 
@@ -671,29 +148,6 @@ func testAccProjectExistingPolicy(pid string) resource.TestCheckFunc {
 	}
 }
 
-func testAccProjectDefaultAssociatePolicyBasic() string {
-	return fmt.Sprintf(`
-resource "google_project_iam_policy" "acceptance" {
-    policy_data = "${data.google_iam_policy.admin.policy_data}"
-}
-data "google_iam_policy" "admin" {
-  binding {
-    role = "roles/storage.objectViewer"
-    members = [
-      "user:evanbrown@google.com",
-    ]
-  }
-  binding {
-    role = "roles/compute.instanceAdmin"
-    members = [
-      "user:evanbrown@google.com",
-      "user:evandbrown@gmail.com",
-    ]
-  }
-}
-`)
-}
-
 func testAccProjectAssociatePolicyBasic(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
@@ -701,10 +155,12 @@ resource "google_project" "acceptance" {
     name = "%s"
     org_id = "%s"
 }
+
 resource "google_project_iam_policy" "acceptance" {
     project = "${google_project.acceptance.id}"
     policy_data = "${data.google_iam_policy.admin.policy_data}"
 }
+
 data "google_iam_policy" "admin" {
   binding {
     role = "roles/storage.objectViewer"
@@ -723,14 +179,6 @@ data "google_iam_policy" "admin" {
 `, pid, name, org)
 }
 
-func testAccProject_createWithoutOrg(pid, name string) string {
-	return fmt.Sprintf(`
-resource "google_project" "acceptance" {
-    project_id = "%s"
-    name = "%s"
-}`, pid, name)
-}
-
 func testAccProject_create(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
@@ -738,16 +186,6 @@ resource "google_project" "acceptance" {
     name = "%s"
     org_id = "%s"
 }`, pid, name, org)
-}
-
-func testAccProject_createBilling(pid, name, org, billing string) string {
-	return fmt.Sprintf(`
-resource "google_project" "acceptance" {
-    project_id = "%s"
-    name = "%s"
-    org_id = "%s"
-    billing_account = "%s"
-}`, pid, name, org, billing)
 }
 
 func testAccProjectAssociatePolicyExpanded(pid, name, org string) string {
@@ -760,8 +198,8 @@ resource "google_project" "acceptance" {
 resource "google_project_iam_policy" "acceptance" {
     project = "${google_project.acceptance.id}"
     policy_data = "${data.google_iam_policy.expanded.policy_data}"
-    authoritative = false
 }
+
 data "google_iam_policy" "expanded" {
     binding {
         role = "roles/viewer"

--- a/provider/terraform/tests/resource_google_project_test.go
+++ b/provider/terraform/tests/resource_google_project_test.go
@@ -431,6 +431,24 @@ func testAccCheckGoogleProjectHasNoLabels(r, pid string) resource.TestCheckFunc 
 	}
 }
 
+func testAccProject_createWithoutOrg(pid, name string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+    project_id = "%s"
+    name = "%s"
+}`, pid, name)
+}
+
+func testAccProject_createBilling(pid, name, org, billing string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+    project_id = "%s"
+    name = "%s"
+    org_id = "%s"
+    billing_account = "%s"
+}`, pid, name, org, billing)
+}
+
 func testAccProject_labels(pid, name, org string, labels map[string]string) string {
 	r := fmt.Sprintf(`
 resource "google_project" "acceptance" {

--- a/provider/terraform/website/docs/r/google_project_iam.html.markdown
+++ b/provider/terraform/website/docs/r/google_project_iam.html.markdown
@@ -21,7 +21,11 @@ Three different resources help you manage your IAM policy for a project. Each of
 ## google\_project\_iam\_policy
 
 ~> **Be careful!** You can accidentally lock yourself out of your project
-   using this resource. Proceed with caution.
+   using this resource. Deleting a `google_project_iam_policy` removes access
+   from anyone without organization-level access to the project. Proceed with caution.
+   It's not recommended to use `google_project_iam_policy` with your provider project
+   to avoid locking yourself out, and it should generally only be used with projects
+   fully managed by Terraform.
 
 ```hcl
 resource "google_project_iam_policy" "project" {
@@ -86,28 +90,13 @@ The following arguments are supported:
 
     Changing this updates the policy.
 
-    Deleting this removes the policy, but leaves the original project policy
-    intact. If there are overlapping `binding` entries between the original
-    project policy and the data source policy, they will be removed.
+    Deleting this removes all policies from the project, locking out users without
+    organization-level access.
 
-* `project` - (Optional) The project ID. If not specified, uses the
-    ID of the project configured with the provider.
-
-* `authoritative` - (DEPRECATED) (Optional, only for `google_project_iam_policy`)
-    A boolean value indicating if this policy
-    should overwrite any existing IAM policy on the project. When set to true,
-    **any policies not in your config file will be removed**. This can **lock
-    you out** of your project until an Organization Administrator grants you
-    access again, so please exercise caution. If this argument is `true` and you
-    want to delete the resource, you must set the `disable_project` argument to
-    `true`, acknowledging that the project will be inaccessible to anyone but the
-    Organization Admins, as it will no longer have an IAM policy. Rather than using
-    this, you should use `google_project_iam_binding` and
-    `google_project_iam_member`.
-
-* `disable_project` - (DEPRECATED) (Optional, only for `google_project_iam_policy`)
-    A boolean value that must be set to `true`
-    if you want to delete a `google_project_iam_policy` that is authoritative.
+* `project` - (Optional) The project ID. If not specified for `google_project_iam_binding`
+or `google_project_iam_member`, uses the ID of the project configured with the provider.
+Required for `google_project_iam_policy` - you must explicitly set the project, and it
+will not be inferred from the provider.
     
 ## Attributes Reference
 
@@ -116,9 +105,6 @@ exported:
 
 * `etag` - (Computed) The etag of the project's IAM policy.
 
-* `restore_policy` - (DEPRECATED) (Computed, only for `google_project_iam_policy`)
-    The IAM policy that will be restored when a
-    non-authoritative policy resource is deleted.
 
 ## Import
 


### PR DESCRIPTION
Supersedes #581 because of the tpg/tpgb split

Part of https://github.com/terraform-providers/terraform-provider-google/issues/1167, https://github.com/terraform-providers/terraform-provider-google/issues/1203

Remove the `getProject` feature - `policy` is really really dangerous now and users probably do not want to use this resource on their primary/provider project, so let's make them explicitly specify it if they do.

-----------------------------------------------------------------
# [all]
## [terraform]
Make google_project_iam_policy authoritative.
### [terraform-beta]
## [ansible]
## [inspec]
