### PR TITLE
[Terraform]: Make google_storage_object_acl authoritative

### DIFF
--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -167,6 +167,7 @@ module Provider
         default_template: 'templates/terraform/examples/base_configs/test_file.go.erb',
         out_file: filepath
       )
+
       # TODO: error check goimports
       %x(goimports -w #{filepath})
     end

--- a/provider/terraform/resources/resource_cloudfunctions_function.go
+++ b/provider/terraform/resources/resource_cloudfunctions_function.go
@@ -169,6 +169,12 @@ func resourceCloudFunctionsFunction() *schema.Resource {
 				Optional: true,
 			},
 
+			"runtime": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"environment_variables": {
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -293,6 +299,7 @@ func resourceCloudFunctionsCreate(d *schema.ResourceData, meta interface{}) erro
 
 	function := &cloudfunctions.CloudFunction{
 		Name:            cloudFuncId.cloudFunctionId(),
+		Runtime:         d.Get("runtime").(string),
 		ForceSendFields: []string{},
 	}
 
@@ -376,6 +383,7 @@ func resourceCloudFunctionsRead(d *schema.ResourceData, meta interface{}) error 
 	}
 	d.Set("timeout", timeout)
 	d.Set("labels", function.Labels)
+	d.Set("runtime", function.Runtime)
 	d.Set("environment_variables", function.EnvironmentVariables)
 	if function.SourceArchiveUrl != "" {
 		// sourceArchiveUrl should always be a Google Cloud Storage URL (e.g. gs://bucket/object)
@@ -456,6 +464,11 @@ func resourceCloudFunctionsUpdate(d *schema.ResourceData, meta interface{}) erro
 	if d.HasChange("labels") {
 		function.Labels = expandLabels(d)
 		updateMaskArr = append(updateMaskArr, "labels")
+	}
+
+	if d.HasChange("runtime") {
+		function.Runtime = d.Get("runtime").(string)
+		updateMaskArr = append(updateMaskArr, "runtime")
 	}
 
 	if d.HasChange("environment_variables") {

--- a/provider/terraform/resources/resource_storage_object_acl.go
+++ b/provider/terraform/resources/resource_storage_object_acl.go
@@ -2,11 +2,10 @@ package google
 
 import (
 	"fmt"
-	"log"
-
 	"github.com/hashicorp/terraform/helper/schema"
-
+	"github.com/hashicorp/terraform/helper/validation"
 	"google.golang.org/api/storage/v1"
+	"strings"
 )
 
 func resourceStorageObjectAcl() *schema.Resource {
@@ -15,35 +14,83 @@ func resourceStorageObjectAcl() *schema.Resource {
 		Read:          resourceStorageObjectAclRead,
 		Update:        resourceStorageObjectAclUpdate,
 		Delete:        resourceStorageObjectAclDelete,
-		CustomizeDiff: resourceStorageRoleEntityCustomizeDiff,
+		CustomizeDiff: resourceStorageObjectAclDiff,
 
 		Schema: map[string]*schema.Schema{
-			"bucket": &schema.Schema{
+			"bucket": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"object": &schema.Schema{
+			"object": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"predefined_acl": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+			"predefined_acl": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"role_entity"},
+				ValidateFunc:  validation.StringInSlice([]string{"private", "bucketOwnerRead", "bucketOwnerFullControl", "projectPrivate", "authenticatedRead", "publicRead", ""}, false),
 			},
 
-			"role_entity": &schema.Schema{
-				Type:     schema.TypeList,
+			"role_entity": {
+				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateRoleEntityPair,
+				},
+				ConflictsWith: []string{"predefined_acl"},
 			},
 		},
 	}
+}
+
+// We can't edit the object owner (at risk of 403 errors), and users will always see a diff if they
+// don't explicitly specify that it has OWNER permissions.
+// Suppressing it means their configs won't be *strictly* correct as they will be missing the object
+// owner having OWNER. It's impossible to remove that permission though, so this custom diff
+// makes configs with or without that line indistinguishable.
+func resourceStorageObjectAclDiff(diff *schema.ResourceDiff, meta interface{}) error {
+	config := meta.(*Config)
+	bucket := diff.Get("bucket").(string)
+	object := diff.Get("object").(string)
+
+	sObject, err := config.clientStorage.Objects.Get(bucket, object).Projection("full").Do()
+	if err != nil {
+		// Failing here is OK! Generally, it means we are at Create although it could mean the resource is gone.
+		// Create won't show the object owner being given
+		return nil
+	}
+
+	objectOwner := sObject.Owner.Entity
+	ownerRole := fmt.Sprintf("%s:%s", "OWNER", objectOwner)
+	oldRoleEntity, newRoleEntity := diff.GetChange("role_entity")
+
+	// We can fail at plan time if the object owner/creator is being set to
+	// a reader
+	for _, v := range newRoleEntity.(*schema.Set).List() {
+		res := getValidatedRoleEntityPair(v.(string))
+
+		if res.Entity == objectOwner && res.Role != "OWNER" {
+			return fmt.Errorf("New state tried setting object owner entity (%s) to non-'OWNER' role", objectOwner)
+		}
+	}
+
+	// Diffs won't match in Plan and Apply pre-create if we naively add the RE
+	// every time. So instead, we check to see if the old state (upstream/gcp
+	// because we will have just done a refresh) contains it first.
+	if oldRoleEntity.(*schema.Set).Contains(ownerRole) &&
+		!newRoleEntity.(*schema.Set).Contains(ownerRole) {
+		newRoleEntity.(*schema.Set).Add(ownerRole)
+		return diff.SetNew("role_entity", newRoleEntity)
+	}
+
+	return nil
 }
 
 func getObjectAclId(object string) string {
@@ -56,61 +103,45 @@ func resourceStorageObjectAclCreate(d *schema.ResourceData, meta interface{}) er
 	bucket := d.Get("bucket").(string)
 	object := d.Get("object").(string)
 
-	predefined_acl := ""
-	role_entity := make([]interface{}, 0)
-
-	if v, ok := d.GetOk("predefined_acl"); ok {
-		predefined_acl = v.(string)
-	}
-
-	if v, ok := d.GetOk("role_entity"); ok {
-		role_entity = v.([]interface{})
-	}
-
-	if len(predefined_acl) > 0 {
-		if len(role_entity) > 0 {
-			return fmt.Errorf("Error, you cannot specify both " +
-				"\"predefined_acl\" and \"role_entity\"")
-		}
-
+	// If we're using a predefined acl we just use the canned api.
+	if predefinedAcl, ok := d.GetOk("predefined_acl"); ok {
 		res, err := config.clientStorage.Objects.Get(bucket, object).Do()
-
 		if err != nil {
-			return fmt.Errorf("Error reading object %s: %v", bucket, err)
+			return fmt.Errorf("Error reading object %s in %s: %v", object, bucket, err)
 		}
 
-		res, err = config.clientStorage.Objects.Update(bucket, object,
-			res).PredefinedAcl(predefined_acl).Do()
-
+		res, err = config.clientStorage.Objects.Update(bucket, object, res).PredefinedAcl(predefinedAcl.(string)).Do()
 		if err != nil {
-			return fmt.Errorf("Error updating object %s: %v", bucket, err)
+			return fmt.Errorf("Error updating object %s in %s: %v", object, bucket, err)
 		}
 
 		return resourceStorageObjectAclRead(d, meta)
-	} else if len(role_entity) > 0 {
-		for _, v := range role_entity {
-			pair, err := getRoleEntityPair(v.(string))
+	} else if reMap := d.Get("role_entity").(*schema.Set); reMap.Len() > 0 {
+		sObject, err := config.clientStorage.Objects.Get(bucket, object).Projection("full").Do()
+		if err != nil {
+			return fmt.Errorf("Error reading object %s in %s: %v", object, bucket, err)
+		}
 
-			objectAccessControl := &storage.ObjectAccessControl{
-				Role:   pair.Role,
-				Entity: pair.Entity,
-			}
+		objectOwner := sObject.Owner.Entity
+		roleEntitiesUpstream, err := getRoleEntitiesAsStringsFromApi(config, bucket, object)
+		if err != nil {
+			return fmt.Errorf("Error reading object %s in %s: %v", object, bucket, err)
+		}
 
-			log.Printf("[DEBUG]: setting role = %s, entity = %s", pair.Role, pair.Entity)
+		create, update, remove, err := getRoleEntityChange(roleEntitiesUpstream, convertStringSet(reMap), objectOwner)
+		if err != nil {
+			return fmt.Errorf("Error reading object %s in %s. Invalid schema: %v", object, bucket, err)
+		}
 
-			_, err = config.clientStorage.ObjectAccessControls.Insert(bucket,
-				object, objectAccessControl).Do()
-
-			if err != nil {
-				return fmt.Errorf("Error setting ACL for %s on object %s: %v", pair.Entity, object, err)
-			}
+		err = performStorageObjectRoleEntityOperations(create, update, remove, config, bucket, object)
+		if err != nil {
+			return fmt.Errorf("Error creating object %s in %s: %v", object, bucket, err)
 		}
 
 		return resourceStorageObjectAclRead(d, meta)
 	}
 
-	return fmt.Errorf("Error, you must specify either " +
-		"\"predefined_acl\" or \"role_entity\"")
+	return fmt.Errorf("Error, you must specify either \"predefined_acl\" or \"role_entity\"")
 }
 
 func resourceStorageObjectAclRead(d *schema.ResourceData, meta interface{}) error {
@@ -119,41 +150,14 @@ func resourceStorageObjectAclRead(d *schema.ResourceData, meta interface{}) erro
 	bucket := d.Get("bucket").(string)
 	object := d.Get("object").(string)
 
-	// Predefined ACLs cannot easily be parsed once they have been processed
-	// by the GCP server
-	if _, ok := d.GetOk("predefined_acl"); !ok {
-		role_entity := make([]interface{}, 0)
-		re_local := d.Get("role_entity").([]interface{})
-		re_local_map := make(map[string]string)
-		for _, v := range re_local {
-			res, err := getRoleEntityPair(v.(string))
+	roleEntities, err := getRoleEntitiesAsStringsFromApi(config, bucket, object)
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("Storage Object ACL for Bucket %q", d.Get("bucket").(string)))
+	}
 
-			if err != nil {
-				return fmt.Errorf(
-					"Old state has malformed Role/Entity pair: %v", err)
-			}
-
-			re_local_map[res.Entity] = res.Role
-		}
-
-		res, err := config.clientStorage.ObjectAccessControls.List(bucket, object).Do()
-
-		if err != nil {
-			return handleNotFoundError(err, d, fmt.Sprintf("Storage Object ACL for Bucket %q", d.Get("bucket").(string)))
-		}
-
-		for _, v := range res.Items {
-			role := v.Role
-			entity := v.Entity
-			if _, in := re_local_map[entity]; in {
-				role_entity = append(role_entity, fmt.Sprintf("%s:%s", role, entity))
-				log.Printf("[DEBUG]: saving re %s-%s", role, entity)
-			}
-		}
-
-		d.Set("role_entity", role_entity)
-	} else {
-		d.Set("role_entity", nil)
+	err = d.Set("role_entity", roleEntities)
+	if err != nil {
+		return err
 	}
 
 	d.SetId(getObjectAclId(object))
@@ -166,61 +170,42 @@ func resourceStorageObjectAclUpdate(d *schema.ResourceData, meta interface{}) er
 	bucket := d.Get("bucket").(string)
 	object := d.Get("object").(string)
 
-	if d.HasChange("role_entity") {
+	if _, ok := d.GetOk("predefined_acl"); d.HasChange("predefined_acl") && ok {
+		res, err := config.clientStorage.Objects.Get(bucket, object).Do()
+		if err != nil {
+			return fmt.Errorf("Error reading object %s in %s: %v", object, bucket, err)
+		}
+
+		res, err = config.clientStorage.Objects.Update(bucket, object, res).PredefinedAcl(d.Get("predefined_acl").(string)).Do()
+		if err != nil {
+			return fmt.Errorf("Error updating object %s in %s: %v", object, bucket, err)
+		}
+
+		return resourceStorageObjectAclRead(d, meta)
+	} else {
+		sObject, err := config.clientStorage.Objects.Get(bucket, object).Projection("full").Do()
+		if err != nil {
+			return fmt.Errorf("Error reading object %s in %s: %v", object, bucket, err)
+		}
+
+		objectOwner := sObject.Owner.Entity
+
 		o, n := d.GetChange("role_entity")
-		old_re, new_re := o.([]interface{}), n.([]interface{})
-
-		old_re_map := make(map[string]string)
-		for _, v := range old_re {
-			res, err := getRoleEntityPair(v.(string))
-
-			if err != nil {
-				return fmt.Errorf(
-					"Old state has malformed Role/Entity pair: %v", err)
-			}
-
-			old_re_map[res.Entity] = res.Role
+		create, update, remove, err := getRoleEntityChange(
+			convertStringSet(o.(*schema.Set)),
+			convertStringSet(n.(*schema.Set)),
+			objectOwner)
+		if err != nil {
+			return fmt.Errorf("Error reading object %s in %s. Invalid schema: %v", object, bucket, err)
 		}
 
-		for _, v := range new_re {
-			pair, err := getRoleEntityPair(v.(string))
-
-			objectAccessControl := &storage.ObjectAccessControl{
-				Role:   pair.Role,
-				Entity: pair.Entity,
-			}
-
-			// If the old state is missing this entity, it needs to
-			// be created. Otherwise it is updated
-			if _, ok := old_re_map[pair.Entity]; ok {
-				_, err = config.clientStorage.ObjectAccessControls.Update(
-					bucket, object, pair.Entity, objectAccessControl).Do()
-			} else {
-				_, err = config.clientStorage.ObjectAccessControls.Insert(
-					bucket, object, objectAccessControl).Do()
-			}
-
-			// Now we only store the keys that have to be removed
-			delete(old_re_map, pair.Entity)
-
-			if err != nil {
-				return fmt.Errorf("Error updating ACL for object %s: %v", bucket, err)
-			}
-		}
-
-		for entity, _ := range old_re_map {
-			log.Printf("[DEBUG]: removing entity %s", entity)
-			err := config.clientStorage.ObjectAccessControls.Delete(bucket, object, entity).Do()
-
-			if err != nil {
-				return fmt.Errorf("Error updating ACL for object %s: %v", bucket, err)
-			}
+		err = performStorageObjectRoleEntityOperations(create, update, remove, config, bucket, object)
+		if err != nil {
+			return fmt.Errorf("Error updating object %s in %s: %v", object, bucket, err)
 		}
 
 		return resourceStorageObjectAclRead(d, meta)
 	}
-
-	return nil
 }
 
 func resourceStorageObjectAclDelete(d *schema.ResourceData, meta interface{}) error {
@@ -229,25 +214,134 @@ func resourceStorageObjectAclDelete(d *schema.ResourceData, meta interface{}) er
 	bucket := d.Get("bucket").(string)
 	object := d.Get("object").(string)
 
-	re_local := d.Get("role_entity").([]interface{})
-	for _, v := range re_local {
-		res, err := getRoleEntityPair(v.(string))
-		if err != nil {
-			return err
+	res, err := config.clientStorage.Objects.Get(bucket, object).Do()
+	if err != nil {
+		return fmt.Errorf("Error reading object %s in %s: %v", object, bucket, err)
+	}
+
+	res, err = config.clientStorage.Objects.Update(bucket, object, res).PredefinedAcl("private").Do()
+	if err != nil {
+		return fmt.Errorf("Error updating object %s in %s: %v", object, bucket, err)
+	}
+
+	return nil
+}
+
+func getRoleEntitiesAsStringsFromApi(config *Config, bucket string, object string) ([]string, error) {
+	var roleEntities []string
+	res, err := config.clientStorage.ObjectAccessControls.List(bucket, object).Do()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, roleEntity := range res.Items {
+		role := roleEntity.Role
+		entity := roleEntity.Entity
+		roleEntities = append(roleEntities, fmt.Sprintf("%s:%s", role, entity))
+	}
+
+	return roleEntities, nil
+}
+
+// Creates 3 lists of changes we need to make to go from one set of entities to another- which entities need to be created, update, and deleted
+// Not resource specific
+func getRoleEntityChange(old []string, new []string, owner string) (create, update, remove []*RoleEntity, err error) {
+	newEntitiesUsed := make(map[string]struct{})
+	for _, v := range new {
+		res := getValidatedRoleEntityPair(v)
+		if _, ok := newEntitiesUsed[res.Entity]; ok {
+			return nil, nil, nil, fmt.Errorf("New state has duplicate Entity: %v", res.Entity)
 		}
 
-		entity := res.Entity
+		newEntitiesUsed[res.Entity] = struct{}{}
+	}
 
-		log.Printf("[DEBUG]: removing entity %s", entity)
+	oldEntitiesUsed := make(map[string]string)
+	for _, v := range old {
+		res := getValidatedRoleEntityPair(v)
 
-		err = config.clientStorage.ObjectAccessControls.Delete(bucket, object,
-			entity).Do()
+		// Updating the owner will error out, so let's avoid it.
+		if res.Entity == owner {
+			continue
+		}
 
+		oldEntitiesUsed[res.Entity] = res.Role
+	}
+
+	for _, re := range new {
+		res := getValidatedRoleEntityPair(re)
+
+		// Updating the owner will error out, so let's never do it.
+		if res.Entity == owner {
+			continue
+		}
+
+		if v, ok := oldEntitiesUsed[res.Entity]; ok {
+			if res.Role != v {
+				update = append(update, res)
+			}
+
+			delete(oldEntitiesUsed, res.Entity)
+		} else {
+			create = append(create, res)
+		}
+	}
+
+	for _, v := range old {
+		res := getValidatedRoleEntityPair(v)
+
+		if _, ok := oldEntitiesUsed[res.Entity]; ok {
+			remove = append(remove, res)
+		}
+	}
+
+	return create, update, remove, nil
+}
+
+// Takes in lists of changes to make to a Storage Object's ACL and makes those changes
+func performStorageObjectRoleEntityOperations(create []*RoleEntity, update []*RoleEntity, remove []*RoleEntity, config *Config, bucket string, object string) error {
+	for _, v := range create {
+		objectAccessControl := &storage.ObjectAccessControl{
+			Role:   v.Role,
+			Entity: v.Entity,
+		}
+		_, err := config.clientStorage.ObjectAccessControls.Insert(bucket, object, objectAccessControl).Do()
 		if err != nil {
-			return fmt.Errorf("Error deleting entity %s ACL: %s",
-				entity, err)
+			return fmt.Errorf("Error inserting ACL item %s for object %s in %s: %v", v.Entity, object, bucket, err)
+		}
+	}
+
+	for _, v := range update {
+		objectAccessControl := &storage.ObjectAccessControl{
+			Role:   v.Role,
+			Entity: v.Entity,
+		}
+		_, err := config.clientStorage.ObjectAccessControls.Update(bucket, object, v.Entity, objectAccessControl).Do()
+		if err != nil {
+			return fmt.Errorf("Error updating ACL item %s for object %s in %s: %v", v.Entity, object, bucket, err)
+		}
+	}
+
+	for _, v := range remove {
+		err := config.clientStorage.ObjectAccessControls.Delete(bucket, object, v.Entity).Do()
+		if err != nil {
+			return fmt.Errorf("Error deleting ACL item %s for object %s in %s: %v", v.Entity, object, bucket, err)
 		}
 	}
 
 	return nil
+}
+
+func validateRoleEntityPair(v interface{}, k string) (ws []string, errors []error) {
+	split := strings.Split(v.(string), ":")
+	if len(split) != 2 {
+		errors = append(errors, fmt.Errorf("Role entity pairs must be formatted as 'ROLE:entity': %s", v))
+	}
+
+	return
+}
+
+func getValidatedRoleEntityPair(roleEntity string) *RoleEntity {
+	split := strings.Split(roleEntity, ":")
+	return &RoleEntity{Role: split[0], Entity: split[1]}
 }

--- a/provider/terraform/tests/resource_cloudfunctions_function_test.go
+++ b/provider/terraform/tests/resource_cloudfunctions_function_test.go
@@ -106,6 +106,11 @@ func TestAccCloudFunctionsFunction_update(t *testing.T) {
 				),
 			},
 			{
+				ResourceName:      funcResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccCloudFunctionsFunction_updated(functionName, bucketName, zipFileUpdatePath),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCloudFunctionsFunctionExists(
@@ -123,6 +128,11 @@ func TestAccCloudFunctionsFunction_update(t *testing.T) {
 					testAccCloudFunctionsFunctionHasEnvironmentVariable("NEW_ENV_VARIABLE",
 						"new-env-variable-value", &function),
 				),
+			},
+			{
+				ResourceName:      funcResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -394,6 +404,7 @@ resource "google_cloudfunctions_function" "function" {
   source_archive_bucket = "${google_storage_bucket.bucket.name}"
   source_archive_object = "${google_storage_bucket_object.archive.name}"
   trigger_http          = true
+  runtime               = "nodejs8"
   timeout               = 91
   entry_point           = "helloGET"
   labels {

--- a/provider/terraform/tests/resource_compute_address_test.go
+++ b/provider/terraform/tests/resource_compute_address_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccComputeAddress_basic(t *testing.T) {
@@ -77,26 +76,6 @@ func TestAccComputeAddress_internal(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckComputeAddressDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_address" {
-			continue
-		}
-
-		addressId, err := parseComputeAddressId(rs.Primary.ID, config)
-
-		_, err = config.clientCompute.Addresses.Get(
-			config.Project, addressId.Region, addressId.Name).Do()
-		if err == nil {
-			return fmt.Errorf("Address still exists")
-		}
-	}
-
-	return nil
 }
 
 func testAccComputeAddress_basic(i string) string {

--- a/provider/terraform/tests/resource_compute_autoscaler_test.go.erb
+++ b/provider/terraform/tests/resource_compute_autoscaler_test.go.erb
@@ -105,26 +105,6 @@ func TestAccComputeAutoscaler_multicondition(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeAutoscalerDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_autoscaler" {
-			continue
-		}
-
-		idParts := strings.Split(rs.Primary.ID, "/")
-		zone, name := idParts[0], idParts[1]
-		_, err := config.clientCompute.Autoscalers.Get(
-			config.Project, zone, name).Do()
-		if err == nil {
-			return fmt.Errorf("Autoscaler still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeAutoscalerExists(n string, ascaler *compute.Autoscaler) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_backend_bucket_test.go
+++ b/provider/terraform/tests/resource_compute_backend_bucket_test.go
@@ -78,24 +78,6 @@ func TestAccComputeBackendBucket_basicModified(t *testing.T) {
 	}
 }
 
-func testAccCheckComputeBackendBucketDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_backend_bucket" {
-			continue
-		}
-
-		_, err := config.clientCompute.BackendBuckets.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("Backend bucket %s still exists", rs.Primary.ID)
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeBackendBucketExists(n string, svc *compute.BackendBucket) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_disk_test.go.erb
+++ b/provider/terraform/tests/resource_compute_disk_test.go.erb
@@ -504,24 +504,6 @@ func TestAccComputeDisk_computeDiskUserRegex(t *testing.T) {
 
 }
 
-func testAccCheckComputeDiskDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_disk" {
-			continue
-		}
-
-		_, err := config.clientCompute.Disks.Get(
-			config.Project, rs.Primary.Attributes["zone"], rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("Disk still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeDiskExists(n, p string, disk *compute.Disk) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_disk_test.go.erb
+++ b/provider/terraform/tests/resource_compute_disk_test.go.erb
@@ -343,7 +343,7 @@ func TestAccComputeDisk_encryption(t *testing.T) {
 	})
 }
 
-<% unless version.nil? || version == 'beta' -%>
+<% unless version.nil? || version == 'ga' -%>
 func TestAccComputeDisk_encryptionKMS(t *testing.T) {
 	t.Parallel()
 

--- a/provider/terraform/tests/resource_compute_firewall_test.go
+++ b/provider/terraform/tests/resource_compute_firewall_test.go
@@ -325,24 +325,6 @@ func TestAccComputeFirewall_enableLogging(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeFirewallDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_firewall" {
-			continue
-		}
-
-		_, err := config.clientCompute.Firewalls.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("Firewall still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeFirewallExists(n string, firewall *compute.Firewall) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_forwarding_rule_test.go
+++ b/provider/terraform/tests/resource_compute_forwarding_rule_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccComputeForwardingRule_update(t *testing.T) {
@@ -140,24 +139,6 @@ func TestAccComputeForwardingRule_networkTier(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckComputeForwardingRuleDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_forwarding_rule" {
-			continue
-		}
-
-		_, err := config.clientCompute.ForwardingRules.Get(
-			config.Project, config.Region, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("ForwardingRule still exists")
-		}
-	}
-
-	return nil
 }
 
 func testAccComputeForwardingRule_basic(poolName, ruleName string) string {

--- a/provider/terraform/tests/resource_compute_global_address_test.go
+++ b/provider/terraform/tests/resource_compute_global_address_test.go
@@ -87,24 +87,6 @@ func TestAccComputeGlobalAddress_internal(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeGlobalAddressDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_global_address" {
-			continue
-		}
-
-		_, err := config.clientCompute.GlobalAddresses.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("Address still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeGlobalAddressExists(n string, addr *compute.Address) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_health_check_test.go
+++ b/provider/terraform/tests/resource_compute_health_check_test.go
@@ -215,24 +215,6 @@ func TestAccComputeHealthCheck_tcpAndSsl_shouldFail(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeHealthCheckDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_health_check" {
-			continue
-		}
-
-		_, err := config.clientCompute.HealthChecks.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("HealthCheck %s still exists", rs.Primary.ID)
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeHealthCheckExists(n string, healthCheck *compute.HealthCheck) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_http_health_check_test.go
+++ b/provider/terraform/tests/resource_compute_http_health_check_test.go
@@ -80,24 +80,6 @@ func TestAccComputeHttpHealthCheck_update(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeHttpHealthCheckDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_http_health_check" {
-			continue
-		}
-
-		_, err := config.clientCompute.HttpHealthChecks.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("HttpHealthCheck still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeHttpHealthCheckExists(n string, healthCheck *compute.HttpHealthCheck) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_https_health_check_test.go
+++ b/provider/terraform/tests/resource_compute_https_health_check_test.go
@@ -80,24 +80,6 @@ func TestAccComputeHttpsHealthCheck_update(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeHttpsHealthCheckDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_https_health_check" {
-			continue
-		}
-
-		_, err := config.clientCompute.HttpsHealthChecks.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("HttpsHealthCheck still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeHttpsHealthCheckExists(n string, healthCheck *compute.HttpsHealthCheck) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_region_autoscaler_test.go.erb
+++ b/provider/terraform/tests/resource_compute_region_autoscaler_test.go.erb
@@ -74,25 +74,6 @@ func TestAccComputeRegionAutoscaler_update(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeRegionAutoscalerDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_region_autoscaler" {
-			continue
-		}
-
-		idParts := strings.Split(rs.Primary.ID, "/")
-		region, name := idParts[0], idParts[1]
-		_, err := config.clientCompute.RegionAutoscalers.Get(config.Project, region, name).Do()
-		if err == nil {
-			return fmt.Errorf("Autoscaler still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeRegionAutoscalerExists(n string, ascaler *compute.Autoscaler) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_region_disk_test.go
+++ b/provider/terraform/tests/resource_compute_region_disk_test.go
@@ -175,24 +175,6 @@ func TestAccComputeRegionDisk_deleteDetach(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeRegionDiskDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_region_disk" {
-			continue
-		}
-
-		_, err := config.clientComputeBeta.RegionDisks.Get(
-			config.Project, rs.Primary.Attributes["region"], rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("RegionDisk still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeRegionDiskExists(n string, disk *computeBeta.Disk) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		p := getTestProjectFromEnv()

--- a/provider/terraform/tests/resource_compute_route_test.go
+++ b/provider/terraform/tests/resource_compute_route_test.go
@@ -95,24 +95,6 @@ func TestAccComputeRoute_hopInstance(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeRouteDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_route" {
-			continue
-		}
-
-		_, err := config.clientCompute.Routes.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("Route still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeRouteExists(n string, route *compute.Route) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_router_test.go
+++ b/provider/terraform/tests/resource_compute_router_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccComputeRouter_basic(t *testing.T) {
@@ -110,39 +109,6 @@ func TestAccComputeRouter_update(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckComputeRouterDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	routersService := config.clientCompute.Routers
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_router" {
-			continue
-		}
-
-		project, err := getTestProject(rs.Primary, config)
-		if err != nil {
-			return err
-		}
-
-		region, err := getTestRegion(rs.Primary, config)
-		if err != nil {
-			return err
-		}
-
-		name := rs.Primary.Attributes["name"]
-
-		_, err = routersService.Get(project, region, name).Do()
-
-		if err == nil {
-			return fmt.Errorf("Error, Router %s in region %s still exists",
-				name, region)
-		}
-	}
-
-	return nil
 }
 
 func testAccComputeRouterBasic(testId, resourceRegion string) string {

--- a/provider/terraform/tests/resource_compute_ssl_certificate_test.go
+++ b/provider/terraform/tests/resource_compute_ssl_certificate_test.go
@@ -84,24 +84,6 @@ func TestAccComputeSslCertificate_name_prefix(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeSslCertificateDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_ssl_certificate" {
-			continue
-		}
-
-		_, err := config.clientCompute.SslCertificates.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("SslCertificate still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeSslCertificateExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_ssl_policy_test.go
+++ b/provider/terraform/tests/resource_compute_ssl_policy_test.go
@@ -308,24 +308,6 @@ func testAccCheckComputeSslPolicyExists(n string, sslPolicy *compute.SslPolicy) 
 	}
 }
 
-func testAccCheckComputeSslPolicyDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_ssl_policy" {
-			continue
-		}
-
-		_, err := config.clientCompute.SslPolicies.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("SSL Policy still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccComputeSslPolicyBasic(resourceName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_ssl_policy" "basic" {

--- a/provider/terraform/tests/resource_compute_subnetwork_test.go
+++ b/provider/terraform/tests/resource_compute_subnetwork_test.go
@@ -216,25 +216,6 @@ func TestAccComputeSubnetwork_flowLogs(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeSubnetworkDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_subnetwork" {
-			continue
-		}
-
-		region, subnet_name := splitSubnetID(rs.Primary.ID)
-		_, err := config.clientCompute.Subnetworks.Get(
-			config.Project, region, subnet_name).Do()
-		if err == nil {
-			return fmt.Errorf("Network still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeSubnetworkExists(n string, subnetwork *compute.Subnetwork) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_target_http_proxy_test.go
+++ b/provider/terraform/tests/resource_compute_target_http_proxy_test.go
@@ -72,24 +72,6 @@ func TestAccComputeTargetHttpProxy_update(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeTargetHttpProxyDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_target_http_proxy" {
-			continue
-		}
-
-		_, err := config.clientCompute.TargetHttpProxies.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("TargetHttpProxy still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeTargetHttpProxyExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_target_https_proxy_test.go
+++ b/provider/terraform/tests/resource_compute_target_https_proxy_test.go
@@ -78,24 +78,6 @@ func TestAccComputeTargetHttpsProxy_update(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeTargetHttpsProxyDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_target_https_proxy" {
-			continue
-		}
-
-		_, err := config.clientCompute.TargetHttpsProxies.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("TargetHttpsProxy still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeTargetHttpsProxyExists(n string, proxy *compute.TargetHttpsProxy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_target_ssl_proxy_test.go
+++ b/provider/terraform/tests/resource_compute_target_ssl_proxy_test.go
@@ -69,24 +69,6 @@ func TestAccComputeTargetSslProxy_update(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeTargetSslProxyDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_target_ssl_proxy" {
-			continue
-		}
-
-		_, err := config.clientCompute.TargetSslProxies.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("TargetSslProxy still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeTargetSslProxy(n, proxyHeader, sslCert string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_target_tcp_proxy_test.go
+++ b/provider/terraform/tests/resource_compute_target_tcp_proxy_test.go
@@ -67,24 +67,6 @@ func TestAccComputeTargetTcpProxy_update(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeTargetTcpProxyDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_target_tcp_proxy" {
-			continue
-		}
-
-		_, err := config.clientCompute.TargetTcpProxies.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("TargetTcpProxy still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeTargetTcpProxyExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_url_map_test.go
+++ b/provider/terraform/tests/resource_compute_url_map_test.go
@@ -123,24 +123,6 @@ func TestAccComputeUrlMap_noPathRulesWithUpdate(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeUrlMapDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_url_map" {
-			continue
-		}
-
-		_, err := config.clientCompute.UrlMaps.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("Url map still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeUrlMapExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_vpn_gateway_test.go
+++ b/provider/terraform/tests/resource_compute_vpn_gateway_test.go
@@ -32,31 +32,6 @@ func TestAccComputeVpnGateway_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeVpnGatewayDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-	project := config.Project
-
-	vpnGatewaysService := compute.NewTargetVpnGatewaysService(config.clientCompute)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_network" {
-			continue
-		}
-
-		region := rs.Primary.Attributes["region"]
-		name := rs.Primary.Attributes["name"]
-
-		_, err := vpnGatewaysService.Get(project, region, name).Do()
-
-		if err == nil {
-			return fmt.Errorf("Error, VPN Gateway %s in region %s still exists",
-				name, region)
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeVpnGatewayExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_vpn_tunnel_test.go
+++ b/provider/terraform/tests/resource_compute_vpn_tunnel_test.go
@@ -6,9 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
-
-	"google.golang.org/api/compute/v1"
 )
 
 func TestAccComputeVpnTunnel_basic(t *testing.T) {
@@ -73,31 +70,6 @@ func TestAccComputeVpnTunnel_defaultTrafficSelectors(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckComputeVpnTunnelDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-	project := config.Project
-
-	vpnTunnelsService := compute.NewVpnTunnelsService(config.clientCompute)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_network" {
-			continue
-		}
-
-		region := rs.Primary.Attributes["region"]
-		name := rs.Primary.Attributes["name"]
-
-		_, err := vpnTunnelsService.Get(project, region, name).Do()
-
-		if err == nil {
-			return fmt.Errorf("Error, VPN Tunnel %s in region %s still exists",
-				name, region)
-		}
-	}
-
-	return nil
 }
 
 func testAccComputeVpnTunnel_basic() string {

--- a/provider/terraform/tests/resource_redis_instance_test.go
+++ b/provider/terraform/tests/resource_redis_instance_test.go
@@ -2,12 +2,10 @@ package google
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccRedisInstance_basic(t *testing.T) {
@@ -83,31 +81,6 @@ func TestAccRedisInstance_full(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckRedisInstanceDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_redis_instance" {
-			continue
-		}
-
-		redisIdParts := strings.Split(rs.Primary.ID, "/")
-		if len(redisIdParts) != 3 {
-			return fmt.Errorf("Unexpected resource ID %s, expected {project}/{region}/{name}", rs.Primary.ID)
-		}
-
-		project, region, inst := redisIdParts[0], redisIdParts[1], redisIdParts[2]
-
-		name := fmt.Sprintf("projects/%s/locations/%s/instances/%s", project, region, inst)
-		_, err := config.clientRedis.Projects.Locations.Get(name).Do()
-		if err == nil {
-			return fmt.Errorf("Redis instance still exists")
-		}
-	}
-
-	return nil
 }
 
 func testAccRedisInstance_basic(name string) string {

--- a/provider/terraform/tests/resource_storage_object_acl_test.go
+++ b/provider/terraform/tests/resource_storage_object_acl_test.go
@@ -176,6 +176,72 @@ func TestAccStorageObjectAcl_predefined(t *testing.T) {
 	})
 }
 
+func TestAccStorageObjectAcl_predefinedToExplicit(t *testing.T) {
+	t.Parallel()
+
+	bucketName := testBucketName()
+	objectName := testAclObjectName()
+	objectData := []byte("data data data")
+	ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			if errObjectAcl != nil {
+				panic(errObjectAcl)
+			}
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccStorageObjectAclDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testGoogleStorageObjectsAclPredefined(bucketName, objectName),
+			},
+			resource.TestStep{
+				Config: testGoogleStorageObjectsAclBasic1(bucketName, objectName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleStorageObjectAcl(bucketName,
+						objectName, roleEntityBasic1),
+					testAccCheckGoogleStorageObjectAcl(bucketName,
+						objectName, roleEntityBasic2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccStorageObjectAcl_explicitToPredefined(t *testing.T) {
+	t.Parallel()
+
+	bucketName := testBucketName()
+	objectName := testAclObjectName()
+	objectData := []byte("data data data")
+	ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644)
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			if errObjectAcl != nil {
+				panic(errObjectAcl)
+			}
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccStorageObjectAclDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testGoogleStorageObjectsAclBasic1(bucketName, objectName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleStorageObjectAcl(bucketName,
+						objectName, roleEntityBasic1),
+					testAccCheckGoogleStorageObjectAcl(bucketName,
+						objectName, roleEntityBasic2),
+				),
+			},
+			resource.TestStep{
+				Config: testGoogleStorageObjectsAclPredefined(bucketName, objectName),
+			},
+		},
+	})
+}
+
 // Test that we allow the API to reorder our role entities without perma-diffing.
 func TestAccStorageObjectAcl_unordered(t *testing.T) {
 	t.Parallel()

--- a/provider/terraform/website/docs/d/datasource_cloudfunctions_function.html.markdown
+++ b/provider/terraform/website/docs/d/datasource_cloudfunctions_function.html.markdown
@@ -45,11 +45,10 @@ exported:
 * `description` - Description of the function.
 * `available_memory_mb` - Available memory (in MB) to the function.
 * `timeout` - Function execution timeout (in seconds).
+* `runtime` - The runtime in which the function is running.
 * `entry_point` - Name of a JavaScript function that will be executed when the Google Cloud Function is triggered.
 * `trigger_http` - If function is triggered by HTTP, this boolean is set.
 * `event_trigger` - A source that fires events in response to a condition in another service. Structure is documented below.
-* `trigger_bucket` - If function is triggered by bucket, bucket name is set here. Deprecated. Use `event_trigger` instead.
-* `trigger_topic` - If function is triggered by Pub/Sub topic, name of topic is set here. Deprecated. Use `event_trigger` instead.
 * `https_trigger_url` - If function is triggered by HTTP, trigger URL is set here.
 * `labels` - A map of labels applied to this function.
 

--- a/provider/terraform/website/docs/r/cloudfunctions_function.html.markdown
+++ b/provider/terraform/website/docs/r/cloudfunctions_function.html.markdown
@@ -76,6 +76,8 @@ Deprecated. Use `event_trigger` instead.
 
 * `labels` - (Optional) A set of key/value label pairs to assign to the function.
 
+* `runtime` - (Optional) The runtime in which the function is going to run. If empty, defaults to `"nodejs6"`.
+
 * `environment_variables` - (Optional) A set of key/value environment variable pairs to assign to the function.
 
 * `retry_on_failure` - (Optional) Whether the function should be retried on failure. This only applies to bucket and topic triggers, not HTTPS triggers.

--- a/provider/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/provider/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -286,6 +286,20 @@ The `disk` block supports:
 * `type` - (Optional) The type of GCE disk, can be either `"SCRATCH"` or
     `"PERSISTENT"`.
 
+* `disk_encryption_key` - (Optional) Encrypts or decrypts a disk using a customer-supplied encryption key.
+
+    If you are creating a new disk, this field encrypts the new disk using an encryption key that you provide. If you are attaching an existing disk that is already encrypted, this field decrypts the disk using the customer-supplied encryption key.
+
+    If you encrypt a disk using a customer-supplied key, you must provide the same key again when you attempt to use this resource at a later time. For example, you must provide the key when you create a snapshot or an image from the disk or when you attach the disk to a virtual machine instance.
+
+    If you do not provide an encryption key, then the disk will be encrypted using an automatically generated key and you do not need to provide a key to use the disk later.
+
+    Instance templates do not store customer-supplied encryption keys, so you cannot use your own keys to encrypt disks in a managed instance group.
+
+The `disk_encryption_key` block supports:
+
+* `kms_key_self_link` - (Optional) The self link of the encryption key that is stored in Google Cloud KMS
+
 The `network_interface` block supports:
 
 * `network` - (Optional) The name or self_link of the network to attach this interface to.

--- a/provider/terraform/website/docs/r/storage_object_acl.html.markdown
+++ b/provider/terraform/website/docs/r/storage_object_acl.html.markdown
@@ -8,10 +8,17 @@ description: |-
 
 # google\_storage\_object\_acl
 
-Creates a new object ACL in Google cloud storage service (GCS). For more information see 
+Authoritatively manages the access control list (ACL) for an object in a Google
+Cloud Storage (GCS) bucket. Removing a `google_storage_object_acl` sets the
+acl to the `private` [predefined ACL](https://cloud.google.com/storage/docs/access-control#predefined-acl).
+
+For more information see
 [the official documentation](https://cloud.google.com/storage/docs/access-control/lists) 
 and 
 [API](https://cloud.google.com/storage/docs/json_api/v1/objectAccessControls).
+
+-> Want fine-grained control over object ACLs? Use `google_storage_object_access_control` to control individual
+role entity pairs.
 
 ## Example Usage
 
@@ -42,15 +49,21 @@ resource "google_storage_object_acl" "image-store-acl" {
 
 ## Argument Reference
 
-* `bucket` - (Required) The name of the bucket it applies to.
+* `bucket` - (Required) The name of the bucket the object is stored in.
 
-* `object` - (Required) The name of the object it applies to.
+* `object` - (Required) The name of the object to apply the acl to.
 
 - - -
 
-* `predefined_acl` - (Optional) The [canned GCS ACL](https://cloud.google.com/storage/docs/access-control#predefined-acl) to apply. Must be set if `role_entity` is not.
+* `predefined_acl` - (Optional) The "canned" [predefined ACL](https://cloud.google.com/storage/docs/access-control#predefined-acl) to apply. Must be set if `role_entity` is not.
 
-* `role_entity` - (Optional) List of role/entity pairs in the form `ROLE:entity`. See [GCS Object ACL documentation](https://cloud.google.com/storage/docs/json_api/v1/objectAccessControls) for more details. Must be set if `predefined_acl` is not.
+* `role_entity` - (Optional) List of role/entity pairs in the form `ROLE:entity`. See [GCS Object ACL documentation](https://cloud.google.com/storage/docs/json_api/v1/objectAccessControls) for more details.
+Must be set if `predefined_acl` is not.
+
+-> The object's creator will always have `OWNER` permissions for their object, and any attempt to modify that permission would return an error. Instead, Terraform automatically
+adds that role/entity pair to your `terraform plan` results when it is omitted in your config; `terraform plan` will show the correct final state at every point except for at
+`Create` time, where the object role/entity pair is omitted if not explicitly set.
+
 
 ## Attributes Reference
 

--- a/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/templates/terraform/examples/base_configs/test_file.go.erb
@@ -9,9 +9,13 @@ import (
   "github.com/hashicorp/terraform/helper/acctest"
   "github.com/hashicorp/terraform/helper/resource"
 )
+<%
+  api_name = @config.name || product_ns
+	resource_name = api_name + object.name
+  terraform_name = "google_" + resource_name.underscore
+%>
 <% object.example.reject(&:skip_test).each do |example| -%>
 <%
-	resource_name = product_ns + object.name
 	# {Compute}{Address}_{addressBasic}
 	test_slug = "#{resource_name}_#{example.name.camelize}Example"
 	  ignore_read = data[:object].all_user_properties
@@ -32,7 +36,7 @@ func TestAcc<%= test_slug -%>(t *testing.T) {
 				Config: testAcc<%= test_slug -%>(acctest.RandString(10)),
 			},
 			{
-				ResourceName:      "<%= "google_#{resource_name.underscore}" -%>.<%= example.primary_resource_id -%>",
+				ResourceName:      "<%= terraform_name -%>.<%= example.primary_resource_id -%>",
 				ImportState:       true,
 				ImportStateVerify: true,
         <%- unless ignore_read.empty? -%>
@@ -47,3 +51,25 @@ func testAcc<%= test_slug -%>(val string) string {
 <%= example.config_test -%>
 }
 <%- end %>
+
+func testAccCheck<%= resource_name -%>Destroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "<%= terraform_name -%>" {
+			continue
+		}
+
+	config := testAccProvider.Meta().(*Config)
+
+	url, err := replaceVarsForTest(rs, "<%= build_url(object.self_link_url) -%>")
+	if err != nil {
+		return err
+	}
+
+	_, err = sendRequest(config, "GET", url, nil)
+	if err == nil {
+			return fmt.Errorf("<%= resource_name -%> still exists at %s", url)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Supersedes #585 due to tpg/tpgb split

Note: This doesn't include import even though it's possible now - we can add it as a separate change, because it will take an `id` migration to support new-style imports and this PR is already large enough.

`resource_storage_object_acl` now authoritatively manages a storage object's access control list, setting it to a "`private`" ACL when removed.

Instead of requiring users to explicitly define a role/entity pair for the object owner granting an OWNER role every time, Terraform implicitly adds the re pair using a `CustomizeDiff`.

Part of https://github.com/terraform-providers/terraform-provider-google/issues/1167, these changes (specifically `getRoleEntityChange`) will be mirrored to `google_storage_default_object_acl.role_entity`.

-----------------------------------------------------------------
# [all]
## [terraform]
Make google_storage_object_acl authoritative
### [terraform-beta]
## [ansible]
## [inspec]
