### PR TITLE
[Terraform]: Autogenerate {{Resource}}Destroy in tests.

### DIFF
--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -167,6 +167,7 @@ module Provider
         default_template: 'templates/terraform/examples/base_configs/test_file.go.erb',
         out_file: filepath
       )
+
       # TODO: error check goimports
       %x(goimports -w #{filepath})
     end

--- a/provider/terraform/tests/resource_compute_address_test.go
+++ b/provider/terraform/tests/resource_compute_address_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccComputeAddress_basic(t *testing.T) {
@@ -77,26 +76,6 @@ func TestAccComputeAddress_internal(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckComputeAddressDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_address" {
-			continue
-		}
-
-		addressId, err := parseComputeAddressId(rs.Primary.ID, config)
-
-		_, err = config.clientCompute.Addresses.Get(
-			config.Project, addressId.Region, addressId.Name).Do()
-		if err == nil {
-			return fmt.Errorf("Address still exists")
-		}
-	}
-
-	return nil
 }
 
 func testAccComputeAddress_basic(i string) string {

--- a/provider/terraform/tests/resource_compute_autoscaler_test.go.erb
+++ b/provider/terraform/tests/resource_compute_autoscaler_test.go.erb
@@ -105,26 +105,6 @@ func TestAccComputeAutoscaler_multicondition(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeAutoscalerDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_autoscaler" {
-			continue
-		}
-
-		idParts := strings.Split(rs.Primary.ID, "/")
-		zone, name := idParts[0], idParts[1]
-		_, err := config.clientCompute.Autoscalers.Get(
-			config.Project, zone, name).Do()
-		if err == nil {
-			return fmt.Errorf("Autoscaler still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeAutoscalerExists(n string, ascaler *compute.Autoscaler) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_backend_bucket_test.go
+++ b/provider/terraform/tests/resource_compute_backend_bucket_test.go
@@ -78,24 +78,6 @@ func TestAccComputeBackendBucket_basicModified(t *testing.T) {
 	}
 }
 
-func testAccCheckComputeBackendBucketDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_backend_bucket" {
-			continue
-		}
-
-		_, err := config.clientCompute.BackendBuckets.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("Backend bucket %s still exists", rs.Primary.ID)
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeBackendBucketExists(n string, svc *compute.BackendBucket) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_disk_test.go.erb
+++ b/provider/terraform/tests/resource_compute_disk_test.go.erb
@@ -504,24 +504,6 @@ func TestAccComputeDisk_computeDiskUserRegex(t *testing.T) {
 
 }
 
-func testAccCheckComputeDiskDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_disk" {
-			continue
-		}
-
-		_, err := config.clientCompute.Disks.Get(
-			config.Project, rs.Primary.Attributes["zone"], rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("Disk still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeDiskExists(n, p string, disk *compute.Disk) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_firewall_test.go
+++ b/provider/terraform/tests/resource_compute_firewall_test.go
@@ -325,24 +325,6 @@ func TestAccComputeFirewall_enableLogging(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeFirewallDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_firewall" {
-			continue
-		}
-
-		_, err := config.clientCompute.Firewalls.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("Firewall still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeFirewallExists(n string, firewall *compute.Firewall) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_forwarding_rule_test.go
+++ b/provider/terraform/tests/resource_compute_forwarding_rule_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccComputeForwardingRule_update(t *testing.T) {
@@ -140,24 +139,6 @@ func TestAccComputeForwardingRule_networkTier(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckComputeForwardingRuleDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_forwarding_rule" {
-			continue
-		}
-
-		_, err := config.clientCompute.ForwardingRules.Get(
-			config.Project, config.Region, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("ForwardingRule still exists")
-		}
-	}
-
-	return nil
 }
 
 func testAccComputeForwardingRule_basic(poolName, ruleName string) string {

--- a/provider/terraform/tests/resource_compute_global_address_test.go
+++ b/provider/terraform/tests/resource_compute_global_address_test.go
@@ -87,24 +87,6 @@ func TestAccComputeGlobalAddress_internal(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeGlobalAddressDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_global_address" {
-			continue
-		}
-
-		_, err := config.clientCompute.GlobalAddresses.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("Address still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeGlobalAddressExists(n string, addr *compute.Address) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_health_check_test.go
+++ b/provider/terraform/tests/resource_compute_health_check_test.go
@@ -215,24 +215,6 @@ func TestAccComputeHealthCheck_tcpAndSsl_shouldFail(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeHealthCheckDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_health_check" {
-			continue
-		}
-
-		_, err := config.clientCompute.HealthChecks.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("HealthCheck %s still exists", rs.Primary.ID)
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeHealthCheckExists(n string, healthCheck *compute.HealthCheck) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_http_health_check_test.go
+++ b/provider/terraform/tests/resource_compute_http_health_check_test.go
@@ -80,24 +80,6 @@ func TestAccComputeHttpHealthCheck_update(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeHttpHealthCheckDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_http_health_check" {
-			continue
-		}
-
-		_, err := config.clientCompute.HttpHealthChecks.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("HttpHealthCheck still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeHttpHealthCheckExists(n string, healthCheck *compute.HttpHealthCheck) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_https_health_check_test.go
+++ b/provider/terraform/tests/resource_compute_https_health_check_test.go
@@ -80,24 +80,6 @@ func TestAccComputeHttpsHealthCheck_update(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeHttpsHealthCheckDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_https_health_check" {
-			continue
-		}
-
-		_, err := config.clientCompute.HttpsHealthChecks.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("HttpsHealthCheck still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeHttpsHealthCheckExists(n string, healthCheck *compute.HttpsHealthCheck) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_region_autoscaler_test.go.erb
+++ b/provider/terraform/tests/resource_compute_region_autoscaler_test.go.erb
@@ -74,25 +74,6 @@ func TestAccComputeRegionAutoscaler_update(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeRegionAutoscalerDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_region_autoscaler" {
-			continue
-		}
-
-		idParts := strings.Split(rs.Primary.ID, "/")
-		region, name := idParts[0], idParts[1]
-		_, err := config.clientCompute.RegionAutoscalers.Get(config.Project, region, name).Do()
-		if err == nil {
-			return fmt.Errorf("Autoscaler still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeRegionAutoscalerExists(n string, ascaler *compute.Autoscaler) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_region_disk_test.go
+++ b/provider/terraform/tests/resource_compute_region_disk_test.go
@@ -175,24 +175,6 @@ func TestAccComputeRegionDisk_deleteDetach(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeRegionDiskDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_region_disk" {
-			continue
-		}
-
-		_, err := config.clientComputeBeta.RegionDisks.Get(
-			config.Project, rs.Primary.Attributes["region"], rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("RegionDisk still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeRegionDiskExists(n string, disk *computeBeta.Disk) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		p := getTestProjectFromEnv()

--- a/provider/terraform/tests/resource_compute_route_test.go
+++ b/provider/terraform/tests/resource_compute_route_test.go
@@ -95,24 +95,6 @@ func TestAccComputeRoute_hopInstance(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeRouteDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_route" {
-			continue
-		}
-
-		_, err := config.clientCompute.Routes.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("Route still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeRouteExists(n string, route *compute.Route) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_router_test.go
+++ b/provider/terraform/tests/resource_compute_router_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccComputeRouter_basic(t *testing.T) {
@@ -110,39 +109,6 @@ func TestAccComputeRouter_update(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckComputeRouterDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	routersService := config.clientCompute.Routers
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_router" {
-			continue
-		}
-
-		project, err := getTestProject(rs.Primary, config)
-		if err != nil {
-			return err
-		}
-
-		region, err := getTestRegion(rs.Primary, config)
-		if err != nil {
-			return err
-		}
-
-		name := rs.Primary.Attributes["name"]
-
-		_, err = routersService.Get(project, region, name).Do()
-
-		if err == nil {
-			return fmt.Errorf("Error, Router %s in region %s still exists",
-				name, region)
-		}
-	}
-
-	return nil
 }
 
 func testAccComputeRouterBasic(testId, resourceRegion string) string {

--- a/provider/terraform/tests/resource_compute_ssl_certificate_test.go
+++ b/provider/terraform/tests/resource_compute_ssl_certificate_test.go
@@ -84,24 +84,6 @@ func TestAccComputeSslCertificate_name_prefix(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeSslCertificateDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_ssl_certificate" {
-			continue
-		}
-
-		_, err := config.clientCompute.SslCertificates.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("SslCertificate still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeSslCertificateExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_ssl_policy_test.go
+++ b/provider/terraform/tests/resource_compute_ssl_policy_test.go
@@ -308,24 +308,6 @@ func testAccCheckComputeSslPolicyExists(n string, sslPolicy *compute.SslPolicy) 
 	}
 }
 
-func testAccCheckComputeSslPolicyDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_ssl_policy" {
-			continue
-		}
-
-		_, err := config.clientCompute.SslPolicies.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("SSL Policy still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccComputeSslPolicyBasic(resourceName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_ssl_policy" "basic" {

--- a/provider/terraform/tests/resource_compute_subnetwork_test.go
+++ b/provider/terraform/tests/resource_compute_subnetwork_test.go
@@ -216,25 +216,6 @@ func TestAccComputeSubnetwork_flowLogs(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeSubnetworkDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_subnetwork" {
-			continue
-		}
-
-		region, subnet_name := splitSubnetID(rs.Primary.ID)
-		_, err := config.clientCompute.Subnetworks.Get(
-			config.Project, region, subnet_name).Do()
-		if err == nil {
-			return fmt.Errorf("Network still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeSubnetworkExists(n string, subnetwork *compute.Subnetwork) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_target_http_proxy_test.go
+++ b/provider/terraform/tests/resource_compute_target_http_proxy_test.go
@@ -72,24 +72,6 @@ func TestAccComputeTargetHttpProxy_update(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeTargetHttpProxyDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_target_http_proxy" {
-			continue
-		}
-
-		_, err := config.clientCompute.TargetHttpProxies.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("TargetHttpProxy still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeTargetHttpProxyExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_target_https_proxy_test.go
+++ b/provider/terraform/tests/resource_compute_target_https_proxy_test.go
@@ -78,24 +78,6 @@ func TestAccComputeTargetHttpsProxy_update(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeTargetHttpsProxyDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_target_https_proxy" {
-			continue
-		}
-
-		_, err := config.clientCompute.TargetHttpsProxies.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("TargetHttpsProxy still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeTargetHttpsProxyExists(n string, proxy *compute.TargetHttpsProxy) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_target_ssl_proxy_test.go
+++ b/provider/terraform/tests/resource_compute_target_ssl_proxy_test.go
@@ -69,24 +69,6 @@ func TestAccComputeTargetSslProxy_update(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeTargetSslProxyDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_target_ssl_proxy" {
-			continue
-		}
-
-		_, err := config.clientCompute.TargetSslProxies.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("TargetSslProxy still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeTargetSslProxy(n, proxyHeader, sslCert string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_target_tcp_proxy_test.go
+++ b/provider/terraform/tests/resource_compute_target_tcp_proxy_test.go
@@ -67,24 +67,6 @@ func TestAccComputeTargetTcpProxy_update(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeTargetTcpProxyDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_target_tcp_proxy" {
-			continue
-		}
-
-		_, err := config.clientCompute.TargetTcpProxies.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("TargetTcpProxy still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeTargetTcpProxyExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_url_map_test.go
+++ b/provider/terraform/tests/resource_compute_url_map_test.go
@@ -123,24 +123,6 @@ func TestAccComputeUrlMap_noPathRulesWithUpdate(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeUrlMapDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_url_map" {
-			continue
-		}
-
-		_, err := config.clientCompute.UrlMaps.Get(
-			config.Project, rs.Primary.ID).Do()
-		if err == nil {
-			return fmt.Errorf("Url map still exists")
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeUrlMapExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_vpn_gateway_test.go
+++ b/provider/terraform/tests/resource_compute_vpn_gateway_test.go
@@ -32,31 +32,6 @@ func TestAccComputeVpnGateway_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckComputeVpnGatewayDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-	project := config.Project
-
-	vpnGatewaysService := compute.NewTargetVpnGatewaysService(config.clientCompute)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_network" {
-			continue
-		}
-
-		region := rs.Primary.Attributes["region"]
-		name := rs.Primary.Attributes["name"]
-
-		_, err := vpnGatewaysService.Get(project, region, name).Do()
-
-		if err == nil {
-			return fmt.Errorf("Error, VPN Gateway %s in region %s still exists",
-				name, region)
-		}
-	}
-
-	return nil
-}
-
 func testAccCheckComputeVpnGatewayExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/provider/terraform/tests/resource_compute_vpn_tunnel_test.go
+++ b/provider/terraform/tests/resource_compute_vpn_tunnel_test.go
@@ -6,9 +6,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
-
-	"google.golang.org/api/compute/v1"
 )
 
 func TestAccComputeVpnTunnel_basic(t *testing.T) {
@@ -73,31 +70,6 @@ func TestAccComputeVpnTunnel_defaultTrafficSelectors(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckComputeVpnTunnelDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-	project := config.Project
-
-	vpnTunnelsService := compute.NewVpnTunnelsService(config.clientCompute)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_network" {
-			continue
-		}
-
-		region := rs.Primary.Attributes["region"]
-		name := rs.Primary.Attributes["name"]
-
-		_, err := vpnTunnelsService.Get(project, region, name).Do()
-
-		if err == nil {
-			return fmt.Errorf("Error, VPN Tunnel %s in region %s still exists",
-				name, region)
-		}
-	}
-
-	return nil
 }
 
 func testAccComputeVpnTunnel_basic() string {

--- a/provider/terraform/tests/resource_redis_instance_test.go
+++ b/provider/terraform/tests/resource_redis_instance_test.go
@@ -2,12 +2,10 @@ package google
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccRedisInstance_basic(t *testing.T) {
@@ -83,31 +81,6 @@ func TestAccRedisInstance_full(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckRedisInstanceDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_redis_instance" {
-			continue
-		}
-
-		redisIdParts := strings.Split(rs.Primary.ID, "/")
-		if len(redisIdParts) != 3 {
-			return fmt.Errorf("Unexpected resource ID %s, expected {project}/{region}/{name}", rs.Primary.ID)
-		}
-
-		project, region, inst := redisIdParts[0], redisIdParts[1], redisIdParts[2]
-
-		name := fmt.Sprintf("projects/%s/locations/%s/instances/%s", project, region, inst)
-		_, err := config.clientRedis.Projects.Locations.Get(name).Do()
-		if err == nil {
-			return fmt.Errorf("Redis instance still exists")
-		}
-	}
-
-	return nil
 }
 
 func testAccRedisInstance_basic(name string) string {

--- a/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/templates/terraform/examples/base_configs/test_file.go.erb
@@ -9,9 +9,13 @@ import (
   "github.com/hashicorp/terraform/helper/acctest"
   "github.com/hashicorp/terraform/helper/resource"
 )
+<%
+  api_name = @config.name || product_ns
+	resource_name = api_name + object.name
+  terraform_name = "google_" + resource_name.underscore
+%>
 <% object.example.reject(&:skip_test).each do |example| -%>
 <%
-	resource_name = product_ns + object.name
 	# {Compute}{Address}_{addressBasic}
 	test_slug = "#{resource_name}_#{example.name.camelize}Example"
 	  ignore_read = data[:object].all_user_properties
@@ -32,7 +36,7 @@ func TestAcc<%= test_slug -%>(t *testing.T) {
 				Config: testAcc<%= test_slug -%>(acctest.RandString(10)),
 			},
 			{
-				ResourceName:      "<%= "google_#{resource_name.underscore}" -%>.<%= example.primary_resource_id -%>",
+				ResourceName:      "<%= terraform_name -%>.<%= example.primary_resource_id -%>",
 				ImportState:       true,
 				ImportStateVerify: true,
         <%- unless ignore_read.empty? -%>
@@ -47,3 +51,25 @@ func testAcc<%= test_slug -%>(val string) string {
 <%= example.config_test -%>
 }
 <%- end %>
+
+func testAccCheck<%= resource_name -%>Destroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "<%= terraform_name -%>" {
+			continue
+		}
+
+	config := testAccProvider.Meta().(*Config)
+
+	url, err := replaceVarsForTest(rs, "<%= build_url(object.self_link_url) -%>")
+	if err != nil {
+		return err
+	}
+
+	_, err = sendRequest(config, "GET", url, nil)
+	if err == nil {
+			return fmt.Errorf("<%= resource_name -%> still exists at %s", url)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Supersedes #579 because of tpg/tpgb

Writing `Destroy` checks is boring and in the case of `VpnTunnel` also wrong. Let's use MM to autogenerate them!

Every `Read` is the same:

```go
    config := meta.(*Config)

    url, err := replaceVars(d, config, "<%= build_url(object.self_link_url) -%>")
    if err != nil {
        return err
    }

    res, err := sendRequest(config, "GET", url, nil)
    if err != nil {
        return handleNotFoundError(err, d, fmt.Sprintf("<%= resource_name -%> %q", d.Id()))
    }
```

and this method is the opposite of that. So this should work - I smoke tested it with `GlobalAddress` and `Address` as global and regional resources, I trust that if it is terribly broken in some way we will catch that in a CI run.

-----------------------------------------------------------------
# [all]
## [terraform]
Autogenerate {{Resource}}Destroy in tests.
### [terraform-beta]
## [ansible]
## [inspec]
