### PR TITLE
Add doc generation for InSpec

### DIFF
--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -21,6 +21,7 @@ require 'active_support/inflector'
 module Provider
   # Code generator for Example Cookbooks that manage Google Cloud Platform
   # resources.
+  # rubocop:disable Metrics/ClassLength
   class Inspec < Provider::Core
     include Google::RubyUtils
     # Settings for the provider
@@ -53,6 +54,17 @@ module Provider
         default_template: 'templates/inspec/plural_resource.erb',
         out_file: \
           File.join(target_folder, "google_#{data[:product_name]}_#{name}".pluralize + '.rb')
+      )
+      generate_documentation(data)
+    end
+
+    # Generates InSpec markdown documents for the resource
+    def generate_documentation(data)
+      name = data[:object].name.underscore
+      docs_folder = File.join(data[:output_folder], 'docs', 'resources')
+      generate_resource_file data.clone.merge(
+        default_template: 'templates/inspec/doc-template.md.erb',
+        out_file: File.join(docs_folder, "google_#{data[:product_name]}_#{name}.md")
       )
     end
 
@@ -161,5 +173,23 @@ module Provider
         [nested_object_type.__resource.name, nested_object_type.name.underscore].join('_')
       ).downcase
     end
+
+    def resource_name(object, product_ns)
+      "google_#{product_ns.downcase}_#{object.name.underscore}"
+    end
+
+    def sub_property_descriptions(property)
+      if nested_object?(property)
+        property.properties.map { |prop| markdown_format(prop) }.join("\n\n") + "\n\n"
+      elsif typed_array?(property)
+        property.item_type.properties.map { |prop| markdown_format(prop) }.join("\n\n") + "\n\n"
+      end
+    end
+
+    def markdown_format(property)
+      "    * `#{property.name}`: #{property.description.split("\n").join(' ')}"
+    end
+    # rubocop:enable Style/GuardClause
   end
+  # rubocop:enable Metrics/ClassLength
 end

--- a/templates/inspec/doc-template.md.erb
+++ b/templates/inspec/doc-template.md.erb
@@ -1,0 +1,21 @@
+<% autogen_exception -%>
+
+---
+title: About the <%= object.name -%> resource
+platform: gcp2
+---
+
+## Syntax
+A `<%= resource_name(object, product_ns) -%>` is used to test a Google <%= object.name -%> resource
+
+TODO: Examples
+
+## Properties
+Properties that can be accessed from the `<%= resource_name(object, product_ns) -%>` resource:
+
+<% object.properties.each do |prop| -%>
+  * `<%= "#{prop.out_name}" -%>`: <%= "#{prop.description.split("\n").join(' ')}" -%>
+
+
+<%= sub_property_descriptions(prop) -%>
+<% end -%>

--- a/templates/inspec/nested_object.erb
+++ b/templates/inspec/nested_object.erb
@@ -16,6 +16,10 @@
 
 <%= lines(autogen_notice :ruby) -%>
 
+<%
+  requires = generate_requires(nested_properties)
+-%>
+<%= lines(emit_requires(requires)) -%>
 module Google
   module <%= product_ns %>
     module Property

--- a/templates/inspec/singular_resource.erb
+++ b/templates/inspec/singular_resource.erb
@@ -30,7 +30,7 @@
 # A provider to manage <%= @api.name -%> resources.
 class <%= object.name -%> < Inspec.resource(1)
 
-  name 'google_<%= product_ns.downcase -%>_<%= object.name.underscore -%>'
+  name '<%= resource_name(object, product_ns) -%>'
   desc '<%= object.name -%>'
   supports platform: 'gcp2'
 


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Requires additions for nested objects. Adding docs generation for InSpec
<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
Doc generation, requires for nested objects
