### PR TITLE
Moving Ansible to share the same LIST api fields as InSpec

### DIFF
--- a/api/resource.rb
+++ b/api/resource.rb
@@ -104,7 +104,9 @@ module Api
 
       def validate
         super
-        check_property :kind, String
+        default_value_property :items, 'items'
+
+        check_optional_property :kind, String
         check_property :items, String
       end
 
@@ -250,6 +252,12 @@ module Api
       check_optional_property :readonly, :boolean
       check_optional_property :transport, Transport
       check_optional_property :references, ReferenceLinks
+
+      default_value_property :collection_url_response,
+        Api::Resource::ResponseList.new
+      check_property :collection_url_response, Api::Resource::ResponseList
+      default_value_property :collection_url_response,
+        Api::Resource::ResponseList.new
 
       check_property_oneof_default :create_verb, %i[POST PUT], :POST, Symbol
       check_property_oneof_default \

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -254,10 +254,10 @@ module Api
       check_optional_property :references, ReferenceLinks
 
       default_value_property :collection_url_response,
-        Api::Resource::ResponseList.new
+                             Api::Resource::ResponseList.new
       check_property :collection_url_response, Api::Resource::ResponseList
       default_value_property :collection_url_response,
-        Api::Resource::ResponseList.new
+                             Api::Resource::ResponseList.new
 
       check_property_oneof_default :create_verb, %i[POST PUT], :POST, Symbol
       check_property_oneof_default \

--- a/products/container/ansible.yaml
+++ b/products/container/ansible.yaml
@@ -28,12 +28,10 @@ datasources: !ruby/object:Provider::ResourceOverrides
     version_added: '2.8'
     facts: !ruby/object:Provider::Ansible::FactsOverride
       has_filters: false
-      list_key: 'clusters'
   NodePool: !ruby/object:Provider::Ansible::ResourceOverride
     version_added: '2.8'
     facts: !ruby/object:Provider::Ansible::FactsOverride
       has_filters: false
-      list_key: 'nodePools'
   KubeConfig: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: true
 overrides: !ruby/object:Provider::ResourceOverrides

--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -34,6 +34,8 @@ objects:
     description: 'A Google Container Engine cluster.'
     transport: !ruby/object:Api::Resource::Transport
       encoder: encode_request
+    collection_url_response: !ruby/object:Api::Resource::ResponseList
+      items: 'clusters'
     parameters:
       - !ruby/object:Api::Type::String
         name: 'zone'
@@ -285,6 +287,8 @@ objects:
       accommodate the workload.
     transport: !ruby/object:Api::Resource::Transport
       encoder: encode_request
+    collection_url_response: !ruby/object:Api::Resource::ResponseList
+      items: 'nodePools'
     parameters:
       - !ruby/object:Api::Type::ResourceRef
         name: 'cluster'

--- a/products/dns/ansible.yaml
+++ b/products/dns/ansible.yaml
@@ -33,7 +33,6 @@ datasources: !ruby/object:Provider::ResourceOverrides
     version_added: '2.8'
     facts: !ruby/object:Provider::Ansible::FactsOverride
       has_filters: false
-      list_key: 'rrsets'
       test: results['items'] | length >= 2
     collection: "https://www.googleapis.com/dns/v1/projects/{project}/managedZones/{managed_zone}/rrsets"
   ManagedZone: !ruby/object:Provider::Ansible::ResourceOverride
@@ -42,7 +41,6 @@ datasources: !ruby/object:Provider::ResourceOverrides
       filter: !ruby/object:Provider::Ansible::FilterProp
         name: dnsName
         description: Restricts the list to return only zones with this domain name.
-      list_key: 'managedZones'
       query_options: false
       filter_api_param: dnsName
 overrides: !ruby/object:Provider::ResourceOverrides

--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -38,6 +38,8 @@ objects:
       hosted by the Cloud DNS service.
     exports:
       - name
+    collection_url_response: !ruby/object:Api::Resource::ResponseList
+      items: 'managedZones'
     properties:
       - !ruby/object:Api::Type::String
         name: 'description'
@@ -149,6 +151,8 @@ objects:
       ?name={{name}}&type={{type}}
     self_link_query: !ruby/object:Api::Resource::ResponseList
       kind: 'dns#resourceRecordSetsListResponse'
+      items: 'rrsets'
+    collection_url_response: !ruby/object:Api::Resource::ResponseList
       items: 'rrsets'
     identity:
       - name

--- a/products/pubsub/ansible.yaml
+++ b/products/pubsub/ansible.yaml
@@ -27,12 +27,10 @@ datasources: !ruby/object:Provider::ResourceOverrides
   Topic: !ruby/object:Provider::Ansible::ResourceOverride
     version_added: '2.8'
     facts: !ruby/object:Provider::Ansible::FactsOverride
-      list_key: 'topics'
       has_filters: false
   Subscription: !ruby/object:Provider::Ansible::ResourceOverride
     version_added: '2.8'
     facts: !ruby/object:Provider::Ansible::FactsOverride
-      list_key: 'subscriptions'
       has_filters: false
 overrides: !ruby/object:Provider::ResourceOverrides
   Topic: !ruby/object:Provider::Ansible::ResourceOverride

--- a/products/pubsub/api.yaml
+++ b/products/pubsub/api.yaml
@@ -35,6 +35,8 @@ objects:
         description: 'Name of the topic.'
     transport: !ruby/object:Api::Resource::Transport
       decoder: decode_request
+    collection_url_response: !ruby/object:Api::Resource::ResponseList
+      items: 'topics'
   - !ruby/object:Api::Resource
     name: 'Subscription'
     base_url: projects/{{project}}/subscriptions
@@ -45,6 +47,8 @@ objects:
     input: true
     transport: !ruby/object:Api::Resource::Transport
       decoder: decode_request
+    collection_url_response: !ruby/object:Api::Resource::ResponseList
+      items: 'subscriptions'
     properties:
       - !ruby/object:Api::Type::String
         name: 'name'

--- a/products/spanner/ansible.yaml
+++ b/products/spanner/ansible.yaml
@@ -28,12 +28,10 @@ datasources: !ruby/object:Provider::ResourceOverrides
     version_added: '2.8'
     facts: !ruby/object:Provider::Ansible::FactsOverride
       has_filters: false
-      list_key: 'instances'
   Database: !ruby/object:Provider::Ansible::ResourceOverride
     version_added: '2.8'
     facts: !ruby/object:Provider::Ansible::FactsOverride
       has_filters: false
-      list_key: 'databases'
   # Virtual => true objects that don't need dedicated resources.
   InstanceConfig: !ruby/object:Provider::Ansible::ResourceOverride
     exclude: true

--- a/products/spanner/api.yaml
+++ b/products/spanner/api.yaml
@@ -56,6 +56,8 @@ objects:
       - name
     transport: !ruby/object:Api::Resource::Transport
       decoder: decode_response
+    collection_url_response: !ruby/object:Api::Resource::ResponseList
+      items: 'instances'
     properties:
       - !ruby/object:Api::Type::String
         name: 'name'
@@ -116,6 +118,8 @@ objects:
       A Cloud Spanner Database which is hosted on a Spanner instance.
     transport: !ruby/object:Api::Resource::Transport
       decoder: decode_response
+    collection_url_response: !ruby/object:Api::Resource::ResponseList
+      items: 'databases'
     parameters:
       - !ruby/object:Api::Type::ResourceRef
         name: 'instance'

--- a/provider/ansible/facts_override.rb
+++ b/provider/ansible/facts_override.rb
@@ -17,7 +17,6 @@ module Provider
   module Ansible
     # Ansible specific properties to be added to Api::Resource
     class FactsOverride < Api::Object
-      attr_reader :list_key
       attr_reader :has_filters
       attr_reader :filter
       attr_reader :query_options
@@ -26,13 +25,11 @@ module Provider
 
       def validate
         super
-        default_value_property :list_key, 'items'
         default_value_property :has_filters, true
         default_value_property :filter, FilterProp.new
         default_value_property :query_options, true
         default_value_property :filter_api_param, 'filter'
 
-        check_property :list_key, ::String
         check_property :has_filters, :boolean
         check_property :filter, Api::Object
         check_property :query_options, :boolean

--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -103,8 +103,8 @@ def main():
   end
 -%>
     items = <%= method_call('fetch_list', ['module', 'collection(module)', query_param]) %>
-    if items.get(<%= quote_string(object.facts.list_key) -%>):
-        items = items.get(<%= quote_string(object.facts.list_key) -%>)
+    if items.get(<%= quote_string(object.collection_url_response.items) -%>):
+        items = items.get(<%= quote_string(object.collection_url_response.items) -%>)
     else:
         items = []
     return_value = {


### PR DESCRIPTION
Moving Ansible to share the same LIST api fields as InSpec

This should be a no-op.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
Moving Ansible to share the same LIST api fields as InSpec
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
