### PR TITLE
Remove merge markers from compute_disk_test.go.erb

### DIFF
--- a/provider/terraform/tests/resource_compute_disk_test.go.erb
+++ b/provider/terraform/tests/resource_compute_disk_test.go.erb
@@ -343,11 +343,7 @@ func TestAccComputeDisk_encryption(t *testing.T) {
 	})
 }
 
-<<<<<<< HEAD
 <% unless version.nil? || version == 'ga' -%>
-=======
-<% unless version.nil? || version == 'ga' %>
->>>>>>> properly remove kms tests from GA provider
 func TestAccComputeDisk_encryptionKMS(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
