### PR TITLE
Terraform: only run testAccComputeGlobalAddress_internal in the beta provider

### DIFF
--- a/provider/terraform/tests/resource_compute_global_address_test.go.erb
+++ b/provider/terraform/tests/resource_compute_global_address_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package google
 
 import (
@@ -67,6 +68,7 @@ func TestAccComputeGlobalAddress_ipv6(t *testing.T) {
 	})
 }
 
+<% unless version.nil? || version == 'ga' -%>
 func TestAccComputeGlobalAddress_internal(t *testing.T) {
 	t.Parallel()
 
@@ -86,6 +88,7 @@ func TestAccComputeGlobalAddress_internal(t *testing.T) {
 		},
 	})
 }
+<% end -%>
 
 func testAccCheckComputeGlobalAddressExists(n string, addr *compute.Address) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -159,6 +162,7 @@ resource "google_compute_global_address" "foobar" {
 }`, acctest.RandString(10))
 }
 
+<% unless version.nil? || version == 'ga' -%>
 func testAccComputeGlobalAddress_internal() string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
@@ -174,3 +178,4 @@ resource "google_compute_global_address" "foobar" {
   network = "${google_compute_network.foobar.self_link}"
 }`, acctest.RandString(10), acctest.RandString(10))
 }
+<% end -%>


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
only run testAccComputeGlobalAddress_internal in the beta provider
### [terraform-beta]
## [ansible]
## [inspec]
