### PR TITLE
removing common copy from the product definitions

### DIFF
--- a/compiler.rb
+++ b/compiler.rb
@@ -147,5 +147,8 @@ product_names.each do |product_name|
   provider.generate output_path, types_to_generate, version
 end
 
-provider.copy_common_files(output_path, version) unless provider.nil?
+# In order to only copy files once per provider this must be called outside of the products loop
+# This will get called with the value from the final iteration of the loop
+provider&.copy_common_files(output_path, version)
+
 # rubocop:enable Metrics/BlockLength

--- a/compiler.rb
+++ b/compiler.rb
@@ -96,6 +96,7 @@ if all_products
   raise "No #{provider_name}.yaml files found. Check provider/engine name." if product_names.empty?
 end
 
+provider = nil
 # rubocop:disable Metrics/BlockLength
 product_names.each do |product_name|
   product_yaml_path = File.join(product_name, 'api.yaml')
@@ -144,6 +145,7 @@ product_names.each do |product_name|
   end
 
   provider.generate output_path, types_to_generate, version
-  provider.copy_common_files output_path, version
 end
+
+provider.copy_common_files(output_path, version) unless provider.nil?
 # rubocop:enable Metrics/BlockLength

--- a/products/bigquery/puppet.yaml
+++ b/products/bigquery/puppet.yaml
@@ -35,8 +35,6 @@ examples: !ruby/object:Api::Resource::HashArray
   Table:
     - table.pp
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= indent(compile('provider/puppet/common~copy.yaml'), 4) %>
   compile:
 <%= indent(include('provider/puppet/common~compile~before.yaml'), 4) %>
 <%= indent(include('provider/puppet/common~compile~after.yaml'), 4) %>

--- a/products/binaryauthorization/terraform.yaml
+++ b/products/binaryauthorization/terraform.yaml
@@ -105,9 +105,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
-  # All of these files will be copied verbatim.
-  copy:
-<%= lines(indent(compile('provider/terraform/common~copy.yaml'), 4)) -%>
   # These files have templating (ERB) code that will be run.
   # This is usually to add licensing info, autogeneration notices, etc.
   compile:

--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -347,8 +347,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
     exclude: true
 examples: !ruby/object:Api::Resource::HashArray
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= lines(indent(compile('provider/ansible/common~copy.yaml'), 4)) -%>
   compile:
 <%= lines(indent(compile('provider/ansible/common~compile.yaml'), 4)) -%>
 tests: !ruby/object:Api::Resource::HashArray

--- a/products/compute/chef.yaml
+++ b/products/compute/chef.yaml
@@ -155,8 +155,6 @@ examples: !ruby/object:Api::Resource::HashArray
   VpnTunnel:
     - vpn_tunnel.rb
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= indent(include('provider/chef/common~copy.yaml'), 4) %>
   compile:
 <%= indent(include('provider/chef/common~compile~before.yaml'), 4) %>
 <%= indent(include('provider/chef/common~compile~after.yaml'), 4) %>

--- a/products/compute/puppet.yaml
+++ b/products/compute/puppet.yaml
@@ -568,7 +568,6 @@ examples: !ruby/object:Api::Resource::HashArray
     - zone.pp
 files: !ruby/object:Provider::Config::Files
   copy:
-<%= indent(compile('provider/puppet/common~copy.yaml'), 4) %>
     # Client-side functions require 'google/authorization'
     spec/stubs/google/authorization.rb: templates/spec_lib_stub.rb.erb
   compile:

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -964,9 +964,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
-  # All of these files will be copied verbatim.
-  copy:
-<%= lines(indent(compile('provider/terraform/common~copy.yaml'), 4)) -%>
   # These files have templating (ERB) code that will be run.
   # This is usually to add licensing info, autogeneration notices, etc.
   compile:

--- a/products/container/ansible.yaml
+++ b/products/container/ansible.yaml
@@ -47,8 +47,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
       - 'products/container/helpers/python/provider_node_pool.py'
 examples: !ruby/object:Api::Resource::HashArray
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= lines(indent(compile('provider/ansible/common~copy.yaml'), 4)) -%>
   compile:
 <%= lines(indent(compile('provider/ansible/common~compile.yaml'), 4)) -%>
 tests: !ruby/object:Api::Resource::HashArray

--- a/products/container/chef.yaml
+++ b/products/container/chef.yaml
@@ -43,8 +43,6 @@ examples: !ruby/object:Api::Resource::HashArray
   KubeConfig:
     - kube_config.rb
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= indent(include('provider/chef/common~copy.yaml'), 4) %>
   compile:
 <%= indent(include('provider/chef/common~compile~before.yaml'), 4) %>
 <%= indent(include('provider/chef/common~compile~after.yaml'), 4) %>

--- a/products/container/puppet.yaml
+++ b/products/container/puppet.yaml
@@ -109,8 +109,6 @@ examples: !ruby/object:Api::Resource::HashArray
   KubeConfig:
     - kube_config.pp
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= indent(compile('provider/puppet/common~copy.yaml'), 4) %>
   compile:
     lib/google/container/api/gcontainer_node_pool.rb:
       products/container/helpers/puppet/bolt/api_gcontainer_node_pool.erb

--- a/products/containeranalysis/terraform.yaml
+++ b/products/containeranalysis/terraform.yaml
@@ -31,9 +31,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
-  # All of these files will be copied verbatim.
-  copy:
-<%= lines(indent(compile('provider/terraform/common~copy.yaml'), 4)) -%>
   # These files have templating (ERB) code that will be run.
   # This is usually to add licensing info, autogeneration notices, etc.
   compile:

--- a/products/dns/ansible.yaml
+++ b/products/dns/ansible.yaml
@@ -93,8 +93,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
     exclude: true
 examples: !ruby/object:Api::Resource::HashArray
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= lines(indent(compile('provider/ansible/common~copy.yaml'), 4)) -%>
   compile:
 <%= lines(indent(compile('provider/ansible/common~compile.yaml'), 4)) -%>
 tests: !ruby/object:Api::Resource::HashArray

--- a/products/dns/chef.yaml
+++ b/products/dns/chef.yaml
@@ -73,8 +73,6 @@ examples: !ruby/object:Api::Resource::HashArray
     - delete_resource_record_set.rb
     - resource_record_set.rb
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= indent(include('provider/chef/common~copy.yaml'), 4) %>
   compile:
 <%= indent(include('provider/chef/common~compile~before.yaml'), 4) %>
 <%= indent(include('provider/chef/common~compile~after.yaml'), 4) %>

--- a/products/dns/puppet.yaml
+++ b/products/dns/puppet.yaml
@@ -71,8 +71,6 @@ examples: !ruby/object:Api::Resource::HashArray
     - delete_resource_record_set.pp
     - resource_record_set.pp
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= indent(compile('provider/puppet/common~copy.yaml'), 4) %>
   compile:
 <%= indent(include('provider/puppet/common~compile~before.yaml'), 4) %>
 <%= indent(include('provider/puppet/common~compile~after.yaml'), 4) %>

--- a/products/filestore/terraform.yaml
+++ b/products/filestore/terraform.yaml
@@ -37,9 +37,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
-  # All of these files will be copied verbatim.
-  copy:
-<%= lines(indent(compile('provider/terraform/common~copy.yaml'), 4)) -%>
   # These files have templating (ERB) code that will be run.
   # This is usually to add licensing info, autogeneration notices, etc.
   compile:

--- a/products/iam/chef.yaml
+++ b/products/iam/chef.yaml
@@ -103,7 +103,6 @@ examples: !ruby/object:Api::Resource::HashArray
     - delete_service_account_key.rb
 files: !ruby/object:Provider::Config::Files
   copy:
-<%= indent(compile('provider/chef/common~copy.yaml'), 4) %>
     # Client-side functions require 'google/authorization'
     spec/stubs/google/authorization.rb: templates/spec_lib_stub.rb.erb
   compile:

--- a/products/iam/puppet.yaml
+++ b/products/iam/puppet.yaml
@@ -109,7 +109,6 @@ examples: !ruby/object:Api::Resource::HashArray
     - delete_service_account_key.pp
 files: !ruby/object:Provider::Config::Files
   copy:
-<%= indent(compile('provider/puppet/common~copy.yaml'), 4) %>
     # Client-side functions require 'google/authorization'
     spec/stubs/google/authorization.rb: templates/spec_lib_stub.rb.erb
   compile:

--- a/products/monitoring/terraform.yaml
+++ b/products/monitoring/terraform.yaml
@@ -85,9 +85,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
       post_create: templates/terraform/post_create/group.erb
 
 files: !ruby/object:Provider::Config::Files
-  # All of these files will be copied verbatim.
-  copy:
-<%= lines(indent(compile('provider/terraform/common~copy.yaml'), 4)) -%>
   # These files have templating (ERB) code that will be run.
   # This is usually to add licensing info, autogeneration notices, etc.
   compile:

--- a/products/pubsub/ansible.yaml
+++ b/products/pubsub/ansible.yaml
@@ -50,8 +50,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
       - 'products/pubsub/helpers/python/provider_subscription.py'
 examples: !ruby/object:Api::Resource::HashArray
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= lines(indent(compile('provider/ansible/common~copy.yaml'), 4)) -%>
   compile:
 <%= lines(indent(compile('provider/ansible/common~compile.yaml'), 4)) -%>
 tests: !ruby/object:Api::Resource::HashArray

--- a/products/pubsub/chef.yaml
+++ b/products/pubsub/chef.yaml
@@ -94,8 +94,6 @@ examples: !ruby/object:Api::Resource::HashArray
     - topic.rb
     - delete_topic.rb
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= indent(include('provider/chef/common~copy.yaml'), 4) %>
   compile:
 <%= indent(include('provider/chef/common~compile~before.yaml'), 4) %>
 <%= indent(include('provider/chef/common~compile~after.yaml'), 4) %>

--- a/products/pubsub/puppet.yaml
+++ b/products/pubsub/puppet.yaml
@@ -146,8 +146,6 @@ bolt_tasks:
         exit 1
       end
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= indent(compile('provider/puppet/common~copy.yaml'), 4) %>
   compile:
     lib/google/pubsub/api/gpubsub_topic.rb:
       products/pubsub/helpers/puppet/bolt/api_gpubsub_topic.erb

--- a/products/redis/terraform.yaml
+++ b/products/redis/terraform.yaml
@@ -56,9 +56,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
-  # All of these files will be copied verbatim.
-  copy:
-<%= lines(indent(compile('provider/terraform/common~copy.yaml'), 4)) -%>
   # These files have templating (ERB) code that will be run.
   # This is usually to add licensing info, autogeneration notices, etc.
   compile:

--- a/products/resourcemanager/chef.yaml
+++ b/products/resourcemanager/chef.yaml
@@ -56,8 +56,6 @@ examples: !ruby/object:Api::Resource::HashArray
     - project.rb
     - delete_project.rb
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= indent(include('provider/chef/common~copy.yaml'), 4) %>
   compile:
 <%= indent(include('provider/chef/common~compile~before.yaml'), 4) %>
 <%= indent(include('provider/chef/common~compile~after.yaml'), 4) %>

--- a/products/resourcemanager/puppet.yaml
+++ b/products/resourcemanager/puppet.yaml
@@ -60,8 +60,6 @@ examples: !ruby/object:Api::Resource::HashArray
     - project.pp
     - delete_project.pp
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= indent(compile('provider/puppet/common~copy.yaml'), 4) %>
   compile:
 <%= indent(include('provider/puppet/common~compile~before.yaml'), 4) %>
 <%= indent(include('provider/puppet/common~compile~after.yaml'), 4) %>

--- a/products/resourcemanager/terraform.yaml
+++ b/products/resourcemanager/terraform.yaml
@@ -37,9 +37,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
       decoder: templates/terraform/decoders/avoid_meaningless_project_update.erb
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
-  # All of these files will be copied verbatim.
-  copy:
-<%= lines(indent(compile('provider/terraform/common~copy.yaml'), 4)) -%>
   # These files have templating (ERB) code that will be run.
   # This is usually to add licensing info, autogeneration notices, etc.
   compile:

--- a/products/spanner/ansible.yaml
+++ b/products/spanner/ansible.yaml
@@ -54,8 +54,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
     exclude: true
 examples: !ruby/object:Api::Resource::HashArray
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= lines(indent(compile('provider/ansible/common~copy.yaml'), 4)) -%>
   compile:
 <%= lines(indent(compile('provider/ansible/common~compile.yaml'), 4)) -%>
 tests: !ruby/object:Api::Resource::HashArray

--- a/products/spanner/chef.yaml
+++ b/products/spanner/chef.yaml
@@ -107,8 +107,6 @@ examples: !ruby/object:Api::Resource::HashArray
     - delete_instance.rb
     - instance.rb
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= indent(compile('provider/chef/common~copy.yaml'), 4) %>
   compile:
 <%= indent(include('provider/chef/common~compile~before.yaml'), 4) %>
 <%= indent(include('provider/chef/common~compile~after.yaml'), 4) %>

--- a/products/spanner/puppet.yaml
+++ b/products/spanner/puppet.yaml
@@ -112,8 +112,6 @@ examples: !ruby/object:Api::Resource::HashArray
     - delete_instance.pp
     - instance.pp
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= indent(compile('provider/puppet/common~copy.yaml'), 4) %>
   compile:
 <%= indent(include('provider/puppet/common~compile~before.yaml'), 4) %>
 <%= indent(include('provider/puppet/common~compile~after.yaml'), 4) %>

--- a/products/sql/chef.yaml
+++ b/products/sql/chef.yaml
@@ -128,8 +128,6 @@ examples: !ruby/object:Api::Resource::HashArray
     - user.rb
     - delete_user.rb
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= indent(include('provider/chef/common~copy.yaml'), 4) %>
   compile:
 <%= indent(include('provider/chef/common~compile~before.yaml'), 4) %>
 <%= indent(include('provider/chef/common~compile~after.yaml'), 4) %>

--- a/products/sql/puppet.yaml
+++ b/products/sql/puppet.yaml
@@ -280,7 +280,6 @@ examples: !ruby/object:Api::Resource::HashArray
     - delete_user.pp
 files: !ruby/object:Provider::Config::Files
   copy:
-<%= indent(compile('provider/puppet/common~copy.yaml'), 4) %>
     # Client-side functions require 'google/authorization'
     spec/stubs/google/authorization.rb: templates/spec_lib_stub.rb.erb
   compile:

--- a/products/storage/ansible.yaml
+++ b/products/storage/ansible.yaml
@@ -44,8 +44,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
     exclude: true
 examples: !ruby/object:Api::Resource::HashArray
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= lines(indent(compile('provider/ansible/common~copy.yaml'), 4)) -%>
   compile:
 <%= lines(indent(compile('provider/ansible/common~compile.yaml'), 4)) -%>
 tests: !ruby/object:Api::Resource::HashArray

--- a/products/storage/chef.yaml
+++ b/products/storage/chef.yaml
@@ -39,8 +39,6 @@ examples: !ruby/object:Api::Resource::HashArray
   DefaultObjectACL:
     - default_object_acl.rb
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= indent(include('provider/chef/common~copy.yaml'), 4) %>
   compile:
 <%= indent(include('provider/chef/common~compile~before.yaml'), 4) %>
 <%= indent(include('provider/chef/common~compile~after.yaml'), 4) %>

--- a/products/storage/puppet.yaml
+++ b/products/storage/puppet.yaml
@@ -97,8 +97,6 @@ examples: !ruby/object:Api::Resource::HashArray
   ObjectAccessControl:
     - object_access_control.pp
 files: !ruby/object:Provider::Config::Files
-  copy:
-<%= indent(compile('provider/puppet/common~copy.yaml'), 4) %>
   compile:
     lib/google/storage/api/gstorage_object.rb:
       products/storage/helpers/puppet/bolt/api_gstorage_object.erb

--- a/products/storage/terraform.yaml
+++ b/products/storage/terraform.yaml
@@ -54,9 +54,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
-  # All of these files will be copied verbatim.
-  copy:
-<%= lines(indent(compile('provider/terraform/common~copy.yaml'), 4)) -%>
   # These files have templating (ERB) code that will be run.
   # This is usually to add licensing info, autogeneration notices, etc.
   compile:


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
The common copy logic was moved into the provider core it's no longer needed in the product definitions 

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
Removing common copy from the product definitions

This should be a no-op
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
