### PR TITLE
Automatically retry client and server errors

### DIFF
--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -13,7 +13,7 @@ resource_types:
       type: docker-image
       source:
           repository: nmckinley/concourse-github-pr-resource
-          tag: v0.1.12
+          tag: v0.1.13
 
 resources:
     - name: magic-modules


### PR DESCRIPTION
Should clear up the 405s in `merge-prs`, if they're truly being caused by transient issues.

-----------------------------------------------------------------
# [all]
CI changes only.
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
