### PR TITLE
Replace NameValues with KeyValuePairs, Map

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -158,7 +158,9 @@ Currently MM supports the following types:
    specified by the `values` property.
 -  `Api::Type::Integer`: An integer number.
 -  `Api::Type::Long`: A long number
--  Api::Type::NameValues
+-  `Api::Type::KeyValuePairs`: A string -> string key -> value pair such as
+   labels
+-  `Api::Type::Map`: A string -> `Api::Type::NestedObject` map.
 -  `Api::Type::NestedObject`: A composite field, composed of inner fields. This
    is used for structures that are nested.
 -  <a id="resource-ref"></a>`Api::Type::ResourceRef`: A reference to another object described in the

--- a/api/object.rb
+++ b/api/object.rb
@@ -43,16 +43,5 @@ module Api
     def out_name
       @name.underscore
     end
-
-    # Utility class for Objects
-    module ObjectUtils
-      module_function
-
-      def string_to_object_map?(property)
-        property.is_a?(Api::Type::NameValues) &&
-          property.key_type == 'Api::Type::String' &&
-          property.value_type.is_a?(Api::Type::NestedObject)
-      end
-    end
   end
 end

--- a/api/type.rb
+++ b/api/type.rb
@@ -508,36 +508,42 @@ module Api
       end
     end
 
-    # Represents an array of name=value pairs, and stores its items' type
-    class NameValues < Composite
-      # The fields which can be overridden in provider.yaml.
+    # An array of string -> string key -> value pairs, such as labels.
+    # While this is technically a map, it's split out because it's a much
+    # simpler property to generate and means we can avoid conditional logic
+    # in Map.
+    class KeyValuePairs < Composite
+    end
+
+    # Map from string keys -> nested object entries
+    class Map < Composite
+      # The list of properties (attr_reader) that can be overridden in
+      # <provider>.yaml.
       module Fields
-        attr_reader :key_type
+        # The type definition of the contents of the map.
         attr_reader :value_type
 
-        # Not all providers support the concept of a String->Object map. In
-        # those cases, treat the map as an Array of NestedObjects, in which each
-        # object has an extra property to act as the map key. This attr
-        # represents the name that key should be called in the downstream
-        # schema.
+        # While the API doesn't give keys an explicit name, we specify one
+        # because in Terraform the key has to be a property of the object.
+        #
+        # The name of the key. Used in the Terraform schema as a field name.
         attr_reader :key_name
+
+        # A description of the key's format. Used in Terraform to describe
+        # the field in documentation.
+        attr_reader :key_description
       end
       include Fields
 
       def validate
         super
-        default_value_property :key_type, Api::Type::String.to_s
-        default_value_property :key_name, 'key'
-        check_property :key_type, ::String
         check_property :key_name, ::String
-        raise "Missing 'value_type' on #{object_display_name}" if @value_type.nil?
-        if @value_type.is_a?(NestedObject)
-          @value_type.set_variable(@name, :__name)
-          @value_type.set_variable(@__resource, :__resource)
-          @value_type.set_variable(self, :__parent)
-          @value_type.validate
-        end
-        raise "Invalid type #{@key_type}" unless type?(@key_type)
+        check_optional_property :key_description, ::String
+
+        @value_type.set_variable(@name, :__name)
+        @value_type.set_variable(@__resource, :__resource)
+        @value_type.set_variable(self, :__parent)
+        check_property :value_type, Api::Type::NestedObject
         raise "Invalid type #{@value_type}" unless type?(@value_type)
       end
     end

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 77.85
+    "covered_percent": 68.89
   }
 }

--- a/products/bigquery/api.yaml
+++ b/products/bigquery/api.yaml
@@ -124,12 +124,11 @@ objects:
           The fully-qualified unique name of the dataset in the format
           projectId:datasetId. The dataset name without the project name is
           given in the datasetId field
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: >
           The labels associated with this dataset. You can use these to
           organize and group your datasets
-        value_type: Api::Type::String
       - !ruby/object:Api::Type::Integer
         name: 'lastModifiedTime'
         description: >
@@ -184,12 +183,11 @@ objects:
         name: 'id'
         description: 'An opaque ID uniquely identifying the table.'
         output: true
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: >
           The labels associated with this dataset. You can use these to
           organize and group your datasets
-        value_type: Api::Type::String
       - !ruby/object:Api::Type::Integer
         name: 'lastModifiedTime'
         description: >

--- a/products/binaryauthorization/api.yaml
+++ b/products/binaryauthorization/api.yaml
@@ -138,7 +138,7 @@ objects:
                 `registry/path/to/image`. This supports a trailing * as a
                 wildcard, but this is allowed only in text after the registry/
                 part.
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::Map
         name: clusterAdmissionRules
         description: |
           Per-cluster admission rules. An admission rule specifies either that
@@ -151,7 +151,6 @@ objects:
           Identifier format: `{{location}}.{{clusterId}}`.
           A location is either a compute zone (e.g. `us-central1-a`) or a region
           (e.g. `us-central1`).
-        key_type: Api::Type::String
         key_name: cluster
         value_type: !ruby/object:Api::Type::NestedObject
           name: clusterAdmissionRule

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -132,12 +132,10 @@ objects:
         description: 'The URLs of the resources that are using this address.'
         item_type: Api::Type::String
         output: true
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: |
           Labels to apply to this address.  A list of key->value pairs.
-        key_type: Api::Type::String
-        value_type: Api::Type::String
         update_verb: :POST
         update_url: 'projects/{{project}}/regions/{{region}}/addresses/{{name}}/setLabels'
         min_version: beta
@@ -987,11 +985,10 @@ objects:
         update_verb: :POST
         update_url:
           'projects/{{project}}/regions/{{region}}/forwardingRules/{{name}}/setTarget'
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: |
           Labels to apply to this forwarding rule.  A list of key->value pairs.
-        value_type: Api::Type::String
         update_verb: :POST
         update_url: 'projects/{{project}}/regions/{{region}}/forwardingRules/{{name}}/setLabels'
         min_version: beta
@@ -1088,12 +1085,10 @@ objects:
           characters must be a dash, lowercase letter, or digit, except the last
           character, which cannot be a dash.
         required: true
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: |
           Labels to apply to this address.  A list of key->value pairs.
-        key_type: Api::Type::String
-        value_type: Api::Type::String
         update_verb: :POST
         update_url: 'projects/{{project}}/global/addresses/{{name}}/setLabels'
         min_version: beta
@@ -4269,11 +4264,9 @@ objects:
           for example `192.168.0.0/16`. The ranges should be disjoint.
           Only IPv4 is supported.
         item_type: Api::Type::String
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: Labels to apply to this VpnTunnel.
-        key_type: Api::Type::String
-        value_type: Api::Type::String
         update_verb: :POST
         update_url: 'projects/{{project}}/regions/{{region}}/vpnTunnels/{{name}}/setLabels'
       - !ruby/object:Api::Type::Fingerprint

--- a/products/compute/disks.yaml
+++ b/products/compute/disks.yaml
@@ -38,11 +38,10 @@
   name: 'lastDetachTimestamp'
   description: 'Last dettach timestamp in RFC3339 text format.'
   output: true
-- !ruby/object:Api::Type::NameValues
+- !ruby/object:Api::Type::KeyValuePairs
   name: 'labels'
   description: |
     Labels to apply to this disk.  A list of key->value pairs.
-  value_type: Api::Type::String
   update_verb: :POST
   update_url: 'projects/{{project}}/<%= ctx[:location] -%>s/{{<%= ctx[:location] -%>}}/disks/{{name}}/setLabels'
 - !ruby/object:Api::Type::Array

--- a/products/compute/instance_metadata.yaml
+++ b/products/compute/instance_metadata.yaml
@@ -31,10 +31,9 @@
 # adding the 'fingerprint' of the last metadata to allow update.
 #
 # To comply with the API please add an encoder: and decoder: to the provider.
-- !ruby/object:Api::Type::NameValues
+- !ruby/object:Api::Type::KeyValuePairs
   name: 'metadata'
   description: |
     The metadata key/value pairs to assign to instances that are
     created from this template. These pairs can consist of custom
     metadata or predefined keys.
-  value_type: Api::Type::String

--- a/products/container/node_config.yaml
+++ b/products/container/node_config.yaml
@@ -54,9 +54,8 @@
     The Google Cloud Platform Service Account to be used by the node
     VMs.  If no Service Account is specified, the "default" service
     account is used.
-- !ruby/object:Api::Type::NameValues
+- !ruby/object:Api::Type::KeyValuePairs
   name: 'metadata'
-  value_type: Api::Type::String
   description: |
     The metadata key/value pairs assigned to instances in the cluster.
 
@@ -81,9 +80,8 @@
   description: |
     The image type to use for this node.  Note that for a given image
     type, the latest version of it will be used.
-- !ruby/object:Api::Type::NameValues
+- !ruby/object:Api::Type::KeyValuePairs
   name: 'labels'
-  value_type: Api::Type::String
   description: |
     The map of Kubernetes labels (key/value pairs) to be applied to
     each node. These will added in addition to any default label(s)

--- a/products/filestore/api.yaml
+++ b/products/filestore/api.yaml
@@ -98,12 +98,10 @@ objects:
           - TIER_UNSPECIFIED
           - STANDARD
           - PREMIUM
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: |
           Resource labels to represent user-provided metadata.
-        key_type: Api::Type::String
-        value_type: Api::Type::String
       - !ruby/object:Api::Type::Array
         name: 'fileShares'
         required: true

--- a/products/redis/api.yaml
+++ b/products/redis/api.yaml
@@ -97,14 +97,12 @@ objects:
           Hostname or IP address of the exposed Redis endpoint used by clients
           to connect to the service.
         output: true
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: Resource labels to represent user provided metadata.
-        value_type: Api::Type::String
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'redisConfigs'
         description: Redis configuration parameters, according to http://redis.io/topics/config.
-        value_type: Api::Type::String
       - !ruby/object:Api::Type::String
         name: locationId
         description: |

--- a/products/resourcemanager/api.yaml
+++ b/products/resourcemanager/api.yaml
@@ -65,9 +65,8 @@ objects:
         name: 'createTime'
         description: 'Time of creation'
         output: true
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
-        value_type: Api::Type::String
         description: |
           The labels associated with this Project.
 

--- a/products/spanner/api.yaml
+++ b/products/spanner/api.yaml
@@ -81,9 +81,8 @@ objects:
         name: 'nodeCount'
         description: 'The number of nodes allocated to this instance.'
       # 'state' not suitable for state convergeance.
-      - !ruby/object:Api::Type::NameValues
+      - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
-        value_type: Api::Type::String
         description: |
           Cloud Labels are a flexible and lightweight mechanism for organizing
           cloud resources into groups that reflect a customer's organizational

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -36,7 +36,7 @@ module Provider
         'Api::Type::Array' => 'list',
         'Api::Type::Boolean' => 'bool',
         'Api::Type::Integer' => 'int',
-        'Api::Type::NameValues' => 'dict',
+        'Api::Type::KeyValuePairs' => 'dict',
         'Provider::Ansible::FilterProp' => 'list'
       }.freeze
 

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -30,7 +30,6 @@ module Provider
   # such as compiling and including files, formatting data, etc.
   class Core
     include Compile::Core
-    include Api::Object::ObjectUtils
 
     attr_reader :test_data
 

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -122,18 +122,21 @@ module Provider
     end
 
     # Figuring out if a property is a primitive ruby type is a hassle. But it is important
-    # Fingerprints are strings, NameValues are hashes, and arrays of primitives are arrays
-    # Arrays of NestedObjects need to have their contents parsed and returned in an array
+    # Fingerprints are strings, KeyValuePairs and Maps are hashes, and arrays of primitives are
+    # arrays. Arrays of NestedObjects need to have their contents parsed and returned in an array
     # ResourceRefs are strings
+    # rubocop:disable Metrics/CyclomaticComplexity
     def primitive?(property)
       array_primitive = (property.is_a?(Api::Type::Array)\
         && !property.item_type.is_a?(::Api::Type::NestedObject))
       property.is_a?(::Api::Type::Primitive)\
         || array_primitive\
-        || property.is_a?(::Api::Type::NameValues)\
+        || property.is_a?(::Api::Type::KeyValuePairs)\
+        || property.is_a?(::Api::Type::Map)\
         || property.is_a?(::Api::Type::Fingerprint)\
         || property.is_a?(::Api::Type::ResourceRef)
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     # Arrays of nested objects need special requires statements
     def typed_array?(property)

--- a/provider/property_override.rb
+++ b/provider/property_override.rb
@@ -33,7 +33,8 @@ module Provider
     include Api::Type::Fields
     # To allow overrides for type-specific fields, include those type's
     # fields with an 'include' directive here.
-    include Api::Type::NameValues::Fields
+    include Api::Type::KeyValuePairs::Fields
+    include Api::Type::Map::Fields
     include Api::Type::ResourceRef::Fields
 
     # Apply this override to property inheriting from Api::Type
@@ -79,7 +80,8 @@ module Provider
     def our_override_modules
       self.class.included_modules.select do |mod|
         [Api::Type::Fields,
-         Api::Type::NameValues::Fields,
+         Api::Type::KeyValuePairs::Fields,
+         Api::Type::Map::Fields,
          Api::Type::ResourceRef::Fields].include?(mod) \
           || mod.name.split(':').last == 'OverrideFields'
       end

--- a/provider/resource_overrides.rb
+++ b/provider/resource_overrides.rb
@@ -148,7 +148,7 @@ module Provider
       elsif api_entity.is_a?(Api::Type::Array) &&
             api_entity.item_type.is_a?(Api::Type::NestedObject)
         api_entity.item_type.all_properties
-      elsif ObjectUtils.string_to_object_map?(api_entity)
+      elsif api_entity.is_a?(Api::Type::Map)
         api_entity.value_type.all_properties
       end
     end

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -37,7 +37,6 @@ module Provider
     end
 
     def tf_type(property)
-      return 'schema.TypeSet' if string_to_object_map?(property)
       tf_types[property.class]
     end
 
@@ -56,7 +55,8 @@ module Provider
         Api::Type::ResourceRef => 'schema.TypeString',
         Api::Type::NestedObject => 'schema.TypeList',
         Api::Type::Array => 'schema.TypeList',
-        Api::Type::NameValues => 'schema.TypeMap',
+        Api::Type::KeyValuePairs => 'schema.TypeMap',
+        Api::Type::Map => 'schema.TypeSet',
         Api::Type::Fingerprint => 'schema.TypeString'
       }
     end
@@ -103,7 +103,7 @@ module Provider
       elsif property.is_a?(Api::Type::Array) &&
             property.item_type.is_a?(Api::Type::NestedObject)
         property.item_type.properties
-      elsif string_to_object_map?(property)
+      elsif property.is_a?(Api::Type::Map)
         property.value_type.properties
       else
         []

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -129,10 +129,10 @@ module Provider
         end
 
         unless api_property.is_a?(Api::Type::Array) ||
-               ObjectUtils.string_to_object_map?(api_property)
+               api_property.is_a?(Api::Type::Map)
           if @is_set
             raise 'Set can only be specified for Api::Type::Array ' \
-                  'or Api::Type::NameValues<String, NestedObject>. ' \
+                  'or Api::Type:Map. ' \
                   "Type is #{api_property.class} for property "\
                   "'#{api_property.name}'"
           end

--- a/templates/terraform/expand_property_method.erb
+++ b/templates/terraform/expand_property_method.erb
@@ -17,7 +17,7 @@
                            prefix: prefix,
                            property: property)) -%>
 <% else -%>
-<%   if string_to_object_map?(property) -%>
+<%   if property.is_a?(Api::Type::Map) -%>
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) (map[string]interface{}, error) {
   if v == nil {
     return map[string]interface{}{}, nil
@@ -46,7 +46,7 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *
 <%     next if prop.name == property.key_name -%>
 <%=      lines(build_expand_method(prefix + titlelize_property(property), prop), 1) -%>
 <%   end -%>
-<%   elsif property.is_a?(Api::Type::NameValues) -%>
+<%   elsif property.is_a?(Api::Type::KeyValuePairs) -%>
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) (map[string]string, error) {
   if v == nil {
     return map[string]string{}, nil

--- a/templates/terraform/flatten_property_method.erb
+++ b/templates/terraform/flatten_property_method.erb
@@ -45,7 +45,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}) in
     })
   }
   return transformed
-<% elsif string_to_object_map?(property) -%>
+<% elsif property.is_a?(Api::Type::Map) -%>
   if v == nil {
     return v
   }

--- a/templates/terraform/nested_property_documentation.erb
+++ b/templates/terraform/nested_property_documentation.erb
@@ -4,7 +4,7 @@
   if !nested_properties.empty?
 -%>
 The `<%= property.name.underscore -%>` block <%= if property.output then "contains" else "supports" end -%>:
-<%- if string_to_object_map?(property) %>
+<%- if property.is_a?(Api::Type::Map) %>
 * `<%= property.key_name.underscore -%>` - (Required) The identifier for this object. Format specified above.
 <% end -%>
 <% nested_properties.each do |prop| -%>

--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -6,6 +6,6 @@
   (Optional)
 <% end -%>
 <%= indent(property.description.strip.gsub("\n\n", "\n"), 2) -%>
-<% if property.is_a?(Api::Type::NestedObject) || string_to_object_map?(property) || (property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::NestedObject)) -%>
+<% if property.is_a?(Api::Type::NestedObject) || property.is_a?(Api::Type::Map) || (property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::NestedObject)) -%>
   Structure is documented below.
 <% end -%>

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -102,32 +102,26 @@
     // Default schema.HashSchema is used.
   <% end -%>
 	<% end -%>
-<% elsif property.is_a?(Api::Type::NameValues) -%>
-  <% if property.key_type == 'Api::Type::String' && property.value_type == 'Api::Type::String' -%>
+<% elsif property.is_a?(Api::Type::KeyValuePairs) -%>
   Elem: &schema.Schema{Type: schema.TypeString},
-  <% elsif string_to_object_map?(property) -%>
-  Elem: &schema.Resource{
-    Schema: map[string]*schema.Schema{
-      "<%= property.key_name -%>": {
-        Type:     schema.TypeString,
-        Required: true,
-        <% if force_new?(property, object) -%>
-        ForceNew: true,
-        <% end -%>
-      },
-      <% order_properties(property.value_type.properties).each do |prop| -%>
-        <%= lines(build_schema_property(prop, object)) -%>
-      <% end -%>
-    },
-  },
-  <% if !property.set_hash_func.nil? -%>
-  Set: <%= property.set_hash_func -%>,
-  <% end -%>
-  <% else -%>
-    // TODO(magic-modules): Handle this map specially - Terraform maps are String->String only,
-    // and support has been added for the String->Object case,
-    // but this map is marked as being <%= property.key_type -%>-><%= property.value_type -%>.
-  <% end -%>
+<% elsif property.is_a?(Api::Type::Map) -%>
+	Elem: &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"<%= property.key_name -%>": {
+				Type:     schema.TypeString,
+				Required: true,
+				<% if force_new?(property, object) -%>
+				ForceNew: true,
+				<% end -%>
+			},
+			<% order_properties(property.value_type.properties).each do |prop| -%>
+				<%= lines(build_schema_property(prop, object)) -%>
+			<% end -%>
+		},
+	},
+	<% if !property.set_hash_func.nil? -%>
+	Set: <%= property.set_hash_func -%>,
+	<% end -%>
 <% end -%>
 <% if property.sensitive -%>
     Sensitive: true,


### PR DESCRIPTION
Supersedes https://github.com/GoogleCloudPlatform/magic-modules/pull/506 in light of big provider changes since opening. See that for previous discussion. 

Remove NameValues, and add
* Map for complex string -> object cases (replacing `string_to_object_map` with a real type)
* KeyValuePairs for arrays/sets of key -> value pairs like `labels`

-----------------------------------------------------------------
# [all]
Rename NameValues to KeyValuePairs, Map
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
