### PR TITLE
[Terraform] Regional Clusters are GA followup

### DIFF
--- a/provider/terraform/data_sources/data_source_google_container_engine_versions.go.erb
+++ b/provider/terraform/data_sources/data_source_google_container_engine_versions.go.erb
@@ -21,9 +21,6 @@ func dataSourceGoogleContainerEngineVersions() *schema.Resource {
 				Optional: true,
 			},
 			"region": {
-<% if version.nil? || version == 'ga' -%>
-				Deprecated:    "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
-<% end -%>
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"zone"},
@@ -71,7 +68,7 @@ func dataSourceGoogleContainerEngineVersionsRead(d *schema.ResourceData, meta in
 	}
 
 	location = fmt.Sprintf("projects/%s/locations/%s", project, location)
-	resp, err := config.clientContainerBeta.Projects.Locations.GetServerConfig(location).Do()
+	resp, err := config.clientContainer.Projects.Locations.GetServerConfig(location).Do()
 	if err != nil {
 		return fmt.Errorf("Error retrieving available container cluster versions: %s", err.Error())
 	}

--- a/provider/terraform/data_sources/data_source_google_container_engine_versions.go.erb
+++ b/provider/terraform/data_sources/data_source_google_container_engine_versions.go.erb
@@ -68,7 +68,7 @@ func dataSourceGoogleContainerEngineVersionsRead(d *schema.ResourceData, meta in
 	}
 
 	location = fmt.Sprintf("projects/%s/locations/%s", project, location)
-	resp, err := config.clientContainer.Projects.Locations.GetServerConfig(location).Do()
+	resp, err := config.clientContainerBeta.Projects.Locations.GetServerConfig(location).Do()
 	if err != nil {
 		return fmt.Errorf("Error retrieving available container cluster versions: %s", err.Error())
 	}

--- a/provider/terraform/resources/resource_container_node_pool.go.erb
+++ b/provider/terraform/resources/resource_container_node_pool.go.erb
@@ -55,9 +55,6 @@ func resourceContainerNodePool() *schema.Resource {
 					ForceNew: true,
 				},
 				"region": &schema.Schema{
-<% if version.nil? || version == 'ga' -%>
-					Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
-<% end -%>
 					Type:       schema.TypeString,
 					Optional:   true,
 					ForceNew:   true,


### PR DESCRIPTION
Add some missed region params from https://github.com/GoogleCloudPlatform/magic-modules/pull/646

sort-of https://github.com/terraform-providers/terraform-provider-google/issues/1203

-----------------------------------------------------------------
# [all]
## [terraform]
Regional Clusters are GA followup
### [terraform-beta]
## [ansible]
## [inspec]
