### PR TITLE
[Terraform]: Start removing beta igm/rigm fields.

### DIFF
--- a/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
+++ b/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
@@ -536,7 +536,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	}
 	d.Set("update_strategy", update_strategy.(string))
 
-	// Terraform _really_ doesn't like removing lists.
+	// When we make a list Removed, we see a permadiff from `0 => ` (nil). Set to nil in Read so we see no diff.
 	d.Set("version" , nil)
 <% else -%>
 	if err = d.Set("auto_healing_policies", flattenAutoHealingPolicies(manager.AutoHealingPolicies)); err != nil {

--- a/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
+++ b/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
@@ -234,6 +234,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 				Computed:   true,
 <% else -%>
 			"update_policy": &schema.Schema{
+				Computed:   true,
 <% end -%>
 				Type:       schema.TypeList,
 				Optional:   true,
@@ -538,6 +539,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 
 	// When we make a list Removed, we see a permadiff from `field_name.#: "" => "<computed>"`. Set to nil in Read so we see no diff.
 	d.Set("version" , nil)
+	d.Set("rolling_update_policy" , nil)
 <% else -%>
 	if err = d.Set("auto_healing_policies", flattenAutoHealingPolicies(manager.AutoHealingPolicies)); err != nil {
 		return fmt.Errorf("Error setting auto_healing_policies in state: %s", err.Error())

--- a/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
+++ b/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
@@ -47,43 +47,56 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 <% end -%>
 
 			"version": &schema.Schema{
-<% if version.nil? || version == 'ga' -%>
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
-<% end -%>
 				Type:       schema.TypeList,
 <% if version.nil? || version == 'ga' -%>
-				Optional:   true,
-				Computed:   true,
+				Optional: true,
+				Computed: true,
+				Removed:  "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 <% else -%>
-				Required:   true,
+				Required: true,
 <% end -%>
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"name": &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
+<% if version.nil? || version == 'ga' -%>
+							Removed:  "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 						},
 
 						"instance_template": &schema.Schema{
 							Type:             schema.TypeString,
 							Required:         true,
+<% if version.nil? || version == 'ga' -%>
+							Removed:          "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 							DiffSuppressFunc: compareSelfLinkRelativePaths,
 						},
 
 						"target_size": &schema.Schema{
 							Type:     schema.TypeList,
 							Optional: true,
+<% if version.nil? || version == 'ga' -%>
+							Removed:  "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"fixed": &schema.Schema{
 										Type:     schema.TypeInt,
 										Optional: true,
+<% if version.nil? || version == 'ga' -%>
+										Removed:  "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 									},
 
 									"percent": &schema.Schema{
 										Type:         schema.TypeInt,
 										Optional:     true,
+<% if version.nil? || version == 'ga' -%>
+										Removed:  "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 										ValidateFunc: validation.IntBetween(0, 100),
 									},
 								},
@@ -123,11 +136,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			},
 
 			"named_port": &schema.Schema{
-<% if version.nil? || version == 'ga' -%>
-				Type:     schema.TypeList,
-<% else -%>
 				Type:     schema.TypeSet,
-<% end -%>
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -190,23 +199,29 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 			},
 
 			"auto_healing_policies": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
 <% if version.nil? || version == 'ga' -%>
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+				Removed:  "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 <% end -%>
-				Type:       schema.TypeList,
-				Optional:   true,
-				MaxItems:   1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"health_check": &schema.Schema{
 							Type:             schema.TypeString,
 							Required:         true,
+<% if version.nil? || version == 'ga' -%>
+							Removed:          "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 							DiffSuppressFunc: compareSelfLinkRelativePaths,
 						},
 
 						"initial_delay_sec": &schema.Schema{
 							Type:         schema.TypeInt,
 							Required:     true,
+<% if version.nil? || version == 'ga' -%>
+							Removed:      "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 							ValidateFunc: validation.IntBetween(0, 3600),
 						},
 					},
@@ -215,7 +230,8 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 
 <% if version.nil? || version == 'ga' -%>
 			"rolling_update_policy": &schema.Schema{
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+				Removed:    "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+				Computed:   true,
 <% else -%>
 			"update_policy": &schema.Schema{
 <% end -%>
@@ -227,23 +243,28 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 						"minimal_action": &schema.Schema{
 							Type:         schema.TypeString,
 							Required:     true,
+<% if version.nil? || version == 'ga' -%>
+							Removed:      "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 							ValidateFunc: validation.StringInSlice([]string{"RESTART", "REPLACE"}, false),
 						},
 
 						"type": &schema.Schema{
 							Type:         schema.TypeString,
 							Required:     true,
+<% if version.nil? || version == 'ga' -%>
+							Removed:      "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 							ValidateFunc: validation.StringInSlice([]string{"OPPORTUNISTIC", "PROACTIVE"}, false),
 						},
 
 						"max_surge_fixed": &schema.Schema{
 							Type:          schema.TypeInt,
 							Optional:      true,
-<% if version.nil? || version == 'ga' -%>
-							Default:       1,
-							ConflictsWith: []string{"rolling_update_policy.0.max_surge_percent"},
-<% else -%>
 							Computed:      true,
+<% if version.nil? || version == 'ga' -%>
+							Removed:       "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% else -%>
 							ConflictsWith: []string{"update_policy.0.max_surge_percent"},
 <% end -%>
 						},
@@ -252,7 +273,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 							Type:          schema.TypeInt,
 							Optional:      true,
 <% if version.nil? || version == 'ga' -%>
-							ConflictsWith: []string{"rolling_update_policy.0.max_surge_fixed"},
+							Removed:       "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 <% else -%>
 							ConflictsWith: []string{"update_policy.0.max_surge_fixed"},
 <% end -%>
@@ -263,8 +284,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 							Type:          schema.TypeInt,
 							Optional:      true,
 <% if version.nil? || version == 'ga' -%>
-							Default:       1,
-							ConflictsWith: []string{"rolling_update_policy.0.max_unavailable_percent"},
+							Removed:       "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 <% else -%>
 							Computed:      true,
 							ConflictsWith: []string{"update_policy.0.max_unavailable_percent"},
@@ -275,7 +295,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 							Type:          schema.TypeInt,
 							Optional:      true,
 <% if version.nil? || version == 'ga' -%>
-							ConflictsWith: []string{"rolling_update_policy.0.max_unavailable_fixed"},
+							Removed:       "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 <% else -%>
 							ConflictsWith: []string{"update_policy.0.max_unavailable_fixed"},
 <% end -%>
@@ -284,6 +304,9 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 
 						"min_ready_sec": &schema.Schema{
 							Type:         schema.TypeInt,
+<% if version.nil? || version == 'ga' -%>
+							Removed:      "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(0, 3600),
 						},
@@ -339,12 +362,6 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 		return err
 	}
 
-<% if version.nil? || version == 'ga' -%>
-	if _, ok := d.GetOk("rolling_update_policy"); d.Get("update_strategy") == "ROLLING_UPDATE" && !ok {
-		return fmt.Errorf("[rolling_update_policy] must be set when 'update_strategy' is set to 'ROLLING_UPDATE'")
-	}
-<% end -%>
-
 	// Build the parameter
 	manager := &computeBeta.InstanceGroupManager{
 		Name:                d.Get("name").(string),
@@ -354,15 +371,11 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 		InstanceTemplate:    d.Get("instance_template").(string),
 <% end -%>
 		TargetSize:          int64(d.Get("target_size").(int)),
-<% if version.nil? || version == 'ga' -%>
-		NamedPorts:          getNamedPortsBeta(d.Get("named_port").([]interface{})),
-<% else -%>
 		NamedPorts:          getNamedPortsBeta(d.Get("named_port").(*schema.Set).List()),
-<% end -%>
 		TargetPools:         convertStringSet(d.Get("target_pools").(*schema.Set)),
+<% unless version.nil? || version == 'ga' -%>
 		AutoHealingPolicies: expandAutoHealingPolicies(d.Get("auto_healing_policies").([]interface{})),
 		Versions:            expandVersions(d.Get("version").([]interface{})),
-<% unless version.nil? || version == 'ga' -%>
 		UpdatePolicy:        expandUpdatePolicy(d.Get("update_policy").([]interface{})),
 <% end -%>
 		// Force send TargetSize to allow a value of 0.
@@ -501,9 +514,6 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 <% if version.nil? || version == 'ga' -%>
 	d.Set("instance_template", ConvertSelfLinkToV1(manager.InstanceTemplate))
 <% end -%>
-	if err := d.Set("version", flattenVersions(manager.Versions)); err != nil {
-		return err
-	}
 	d.Set("name", manager.Name)
 	d.Set("zone", GetResourceNameFromSelfLink(manager.Zone))
 	d.Set("description", manager.Description)
@@ -525,14 +535,21 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 		update_strategy = "REPLACE"
 	}
 	d.Set("update_strategy", update_strategy.(string))
+
+	// Terraform _really_ doesn't like removing lists.
+	d.Set("version" , nil)
 <% else -%>
+	if err = d.Set("auto_healing_policies", flattenAutoHealingPolicies(manager.AutoHealingPolicies)); err != nil {
+		return fmt.Errorf("Error setting auto_healing_policies in state: %s", err.Error())
+	}
+	if err := d.Set("version", flattenVersions(manager.Versions)); err != nil {
+		return err
+	}
 	if err = d.Set("update_policy", flattenUpdatePolicy(manager.UpdatePolicy)); err != nil {
 		return fmt.Errorf("Error setting update_policy in state: %s", err.Error())
 	}
 <% end -%>
-	if err = d.Set("auto_healing_policies", flattenAutoHealingPolicies(manager.AutoHealingPolicies)); err != nil {
-		return fmt.Errorf("Error setting auto_healing_policies in state: %s", err.Error())
-	}
+
 
 	if d.Get("wait_for_instances").(bool) {
 		conf := resource.StateChangeConf{
@@ -555,7 +572,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 // Updates an instance group manager by applying the update strategy (REPLACE, RESTART)
 // and rolling update policy (PROACTIVE, OPPORTUNISTIC). Updates performed by API
 // are OPPORTUNISTIC by default.
-func performZoneUpdate(config *Config, id string, updateStrategy string, rollingUpdatePolicy *computeBeta.InstanceGroupManagerUpdatePolicy, versions []*computeBeta.InstanceGroupManagerVersion, project string, zone string) error {
+func performZoneUpdate(config *Config, id string, updateStrategy string, project string, zone string) error {
 	if updateStrategy == "RESTART" || updateStrategy == "REPLACE" {
 		managedInstances, err := config.clientComputeBeta.InstanceGroupManagers.ListManagedInstances(project, zone, id).Do()
 		if err != nil {
@@ -579,28 +596,6 @@ func performZoneUpdate(config *Config, id string, updateStrategy string, rolling
 
 		// Wait for the operation to complete
 		err = computeSharedOperationWaitTime(config.clientCompute, op, project, managedInstanceCount*4, "Restarting InstanceGroupManagers instances")
-		if err != nil {
-			return err
-		}
-	}
-
-	if updateStrategy == "ROLLING_UPDATE" {
-		// UpdatePolicy is set for InstanceGroupManager on update only, because it is only relevant for `Patch` calls.
-		// Other tools(gcloud and UI) capable of executing the same `ROLLING UPDATE` call
-		// expect those values to be provided by user as part of the call
-		// or provide their own defaults without respecting what was previously set on UpdateManager.
-		// To follow the same logic, we provide policy values on relevant update change only.
-		manager := &computeBeta.InstanceGroupManager{
-			UpdatePolicy: rollingUpdatePolicy,
-			Versions:     versions,
-		}
-
-		op, err := config.clientComputeBeta.InstanceGroupManagers.Patch(project, zone, id, manager).Do()
-		if err != nil {
-			return fmt.Errorf("Error updating managed group instances: %s", err)
-		}
-
-		err = computeSharedOperationWait(config.clientCompute, op, project, "Updating managed group instances")
 		if err != nil {
 			return err
 		}
@@ -630,10 +625,6 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 	}
 
 	d.Partial(true)
-
-	if _, ok := d.GetOk("rolling_update_policy"); d.Get("update_strategy") == "ROLLING_UPDATE" && !ok {
-		return fmt.Errorf("[rolling_update_policy] must be set when 'update_strategy' is set to 'ROLLING_UPDATE'")
-	}
 
 	// If target_pools changes then update
 	if d.HasChange("target_pools") {
@@ -665,7 +656,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 	if d.HasChange("named_port") {
 
 		// Build the parameters for a "SetNamedPorts" request:
-		namedPorts := getNamedPortsBeta(d.Get("named_port").([]interface{}))
+		namedPorts := getNamedPortsBeta(d.Get("named_port").(*schema.Set).List())
 		setNamedPorts := &computeBeta.InstanceGroupsSetNamedPortsRequest{
 			NamedPorts: namedPorts,
 		}
@@ -705,29 +696,6 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		d.SetPartial("target_size")
 	}
 
-	// We will always be in v0beta inside this conditional
-	if d.HasChange("auto_healing_policies") {
-		setAutoHealingPoliciesRequest := &computeBeta.InstanceGroupManagersSetAutoHealingRequest{}
-		if v, ok := d.GetOk("auto_healing_policies"); ok {
-			setAutoHealingPoliciesRequest.AutoHealingPolicies = expandAutoHealingPolicies(v.([]interface{}))
-		}
-
-		op, err := config.clientComputeBeta.InstanceGroupManagers.SetAutoHealingPolicies(
-			zonalID.Project, zonalID.Zone, zonalID.Name, setAutoHealingPoliciesRequest).Do()
-
-		if err != nil {
-			return fmt.Errorf("Error updating AutoHealingPolicies: %s", err)
-		}
-
-		// Wait for the operation to complete
-		err = computeSharedOperationWait(config.clientCompute, op, zonalID.Project, "Updating AutoHealingPolicies")
-		if err != nil {
-			return err
-		}
-
-		d.SetPartial("auto_healing_policies")
-	}
-
 	// If instance_template changes then update
 	if d.HasChange("instance_template") {
 		// Build the parameter
@@ -748,22 +716,8 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		}
 
 		updateStrategy := d.Get("update_strategy").(string)
-		rollingUpdatePolicy := expandUpdatePolicy(d.Get("rolling_update_policy").([]interface{}))
-		err = performZoneUpdate(config, zonalID.Name, updateStrategy, rollingUpdatePolicy, nil, zonalID.Project, zonalID.Zone)
+		err = performZoneUpdate(config, zonalID.Name, updateStrategy, zonalID.Project, zonalID.Zone)
 		d.SetPartial("instance_template")
-	}
-
-	// If version changes then update
-	if d.HasChange("version") {
-		updateStrategy := d.Get("update_strategy").(string)
-		rollingUpdatePolicy := expandUpdatePolicy(d.Get("rolling_update_policy").([]interface{}))
-		versions := expandVersions(d.Get("version").([]interface{}))
-		err = performZoneUpdate(config, zonalID.Name, updateStrategy, rollingUpdatePolicy, versions, zonalID.Project, zonalID.Zone)
-		if err != nil {
-			return err
-		}
-
-		d.SetPartial("version")
 	}
 
 	d.Partial(false)
@@ -933,6 +887,7 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 	return nil
 }
 
+<% unless version.nil? || version == 'ga' -%>
 func expandAutoHealingPolicies(configured []interface{}) []*computeBeta.InstanceGroupManagerAutoHealingPolicy {
 	autoHealingPolicies := make([]*computeBeta.InstanceGroupManagerAutoHealingPolicy, 0, len(configured))
 	for _, raw := range configured {
@@ -946,7 +901,9 @@ func expandAutoHealingPolicies(configured []interface{}) []*computeBeta.Instance
 	}
 	return autoHealingPolicies
 }
+<% end -%>
 
+<% unless version.nil? || version == 'ga' -%>
 func expandVersions(configured []interface{}) []*computeBeta.InstanceGroupManagerVersion {
 	versions := make([]*computeBeta.InstanceGroupManagerVersion, 0, len(configured))
 	for _, raw := range configured {
@@ -962,7 +919,9 @@ func expandVersions(configured []interface{}) []*computeBeta.InstanceGroupManage
 	}
 	return versions
 }
+<% end -%>
 
+<% unless version.nil? || version == 'ga' -%>
 func expandFixedOrPercent(configured []interface{}) *computeBeta.FixedOrPercent {
 	fixedOrPercent := &computeBeta.FixedOrPercent{}
 
@@ -977,7 +936,10 @@ func expandFixedOrPercent(configured []interface{}) *computeBeta.FixedOrPercent 
 	}
 	return fixedOrPercent
 }
+<% end -%>
 
+
+<% unless version.nil? || version == 'ga' -%>
 func expandUpdatePolicy(configured []interface{}) *computeBeta.InstanceGroupManagerUpdatePolicy {
 	updatePolicy := &computeBeta.InstanceGroupManagerUpdatePolicy{}
 
@@ -992,36 +954,28 @@ func expandUpdatePolicy(configured []interface{}) *computeBeta.InstanceGroupMana
 		if v := data["max_surge_percent"]; v.(int) > 0 {
 			updatePolicy.MaxSurge = &computeBeta.FixedOrPercent{
 				Percent: int64(v.(int)),
-<% unless version.nil? || version == 'ga' -%>
 				NullFields: []string{"Fixed"},
-<% end -%>
 			}
 		} else {
 			updatePolicy.MaxSurge = &computeBeta.FixedOrPercent{
 				Fixed: int64(data["max_surge_fixed"].(int)),
 				// allow setting this value to 0
 				ForceSendFields: []string{"Fixed"},
-<% unless version.nil? || version == 'ga' -%>
 				NullFields:      []string{"Percent"},
-<% end -%>
 			}
 		}
 
 		if v := data["max_unavailable_percent"]; v.(int) > 0 {
 			updatePolicy.MaxUnavailable = &computeBeta.FixedOrPercent{
 				Percent: int64(v.(int)),
-<% unless version.nil? || version == 'ga' -%>
 				NullFields: []string{"Fixed"},
-<% end -%>
 			}
 		} else {
 			updatePolicy.MaxUnavailable = &computeBeta.FixedOrPercent{
 				Fixed: int64(data["max_unavailable_fixed"].(int)),
 				// allow setting this value to 0
 				ForceSendFields: []string{"Fixed"},
-<% unless version.nil? || version == 'ga' -%>
 				NullFields:      []string{"Percent"},
-<% end -%>
 			}
 		}
 
@@ -1031,7 +985,9 @@ func expandUpdatePolicy(configured []interface{}) *computeBeta.InstanceGroupMana
 	}
 	return updatePolicy
 }
+<% end -%>
 
+<% unless version.nil? || version == 'ga' -%>
 func flattenAutoHealingPolicies(autoHealingPolicies []*computeBeta.InstanceGroupManagerAutoHealingPolicy) []map[string]interface{} {
 	autoHealingPoliciesSchema := make([]map[string]interface{}, 0, len(autoHealingPolicies))
 	for _, autoHealingPolicy := range autoHealingPolicies {
@@ -1044,6 +1000,7 @@ func flattenAutoHealingPolicies(autoHealingPolicies []*computeBeta.InstanceGroup
 	}
 	return autoHealingPoliciesSchema
 }
+<% end -%>
 
 <% unless version.nil? || version == 'ga' -%>
 func flattenUpdatePolicy(updatePolicy *computeBeta.InstanceGroupManagerUpdatePolicy) []map[string]interface{} {

--- a/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
+++ b/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
@@ -536,7 +536,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	}
 	d.Set("update_strategy", update_strategy.(string))
 
-	// When we make a list Removed, we see a permadiff from `0 => ` (nil). Set to nil in Read so we see no diff.
+	// When we make a list Removed, we see a permadiff from `field_name.#: "" => "<computed>"`. Set to nil in Read so we see no diff.
 	d.Set("version" , nil)
 <% else -%>
 	if err = d.Set("auto_healing_policies", flattenAutoHealingPolicies(manager.AutoHealingPolicies)); err != nil {

--- a/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
+++ b/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
@@ -250,6 +250,7 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 				Computed:   true,
 <% else -%>
 			"update_policy": &schema.Schema{
+				Computed:   true,
 <% end -%>
 				Type:       schema.TypeList,
 				Optional:   true,
@@ -477,6 +478,7 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 <% if version.nil? || version == 'ga' -%>
 	// When we make a list Removed, we see a permadiff from `field_name.#: "" => "<computed>"`. Set to nil in Read so we see no diff.
 	d.Set("version" , nil)
+	d.Set("rolling_update_policy" , nil)
 <% else -%>
 	if err := d.Set("auto_healing_policies", flattenAutoHealingPolicies(manager.AutoHealingPolicies)); err != nil {
 		return fmt.Errorf("Error setting auto_healing_policies in state: %s", err.Error())

--- a/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
+++ b/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
@@ -480,7 +480,7 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 	}
 	d.Set("update_strategy", update_strategy.(string))
 
-	// When we make a list Removed, we see a permadiff from `0 => ` (nil). Set to nil in Read so we see no diff.
+	// When we make a list Removed, we see a permadiff from `field_name.#: "" => "<computed>"`. Set to nil in Read so we see no diff.
 	d.Set("version" , nil)
 <% else -%>
 	if err := d.Set("auto_healing_policies", flattenAutoHealingPolicies(manager.AutoHealingPolicies)); err != nil {

--- a/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
+++ b/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
@@ -172,8 +172,9 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 <% if version.nil? || version == 'ga' -%>
 			"update_strategy": &schema.Schema{
 				Type:         schema.TypeString,
+				Deprecated:   "This field is deprecated as it has no functionality anymore. It will be removed in 3.0.0.",
 				Optional:     true,
-				Default:      "NONE",
+				Computed:     true,
 				ValidateFunc: validation.StringInSlice([]string{"NONE", "ROLLING_UPDATE"}, false),
 			},
 <% end -%>
@@ -474,12 +475,6 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 	}
 	d.Set("self_link", ConvertSelfLinkToV1(manager.SelfLink))
 <% if version.nil? || version == 'ga' -%>
-	update_strategy, ok := d.GetOk("update_strategy")
-	if !ok {
-		update_strategy = "NONE"
-	}
-	d.Set("update_strategy", update_strategy.(string))
-
 	// When we make a list Removed, we see a permadiff from `field_name.#: "" => "<computed>"`. Set to nil in Read so we see no diff.
 	d.Set("version" , nil)
 <% else -%>

--- a/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
+++ b/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
@@ -54,9 +54,9 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 			"version": &schema.Schema{
 				Type:       schema.TypeList,
 <% if version.nil? || version == 'ga' -%>
-				Optional:   true,
-				Computed:   true,
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+				Optional: true,
+				Computed: true,
+				Removed:  "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 <% else -%>
 				Required: true,
 <% end -%>
@@ -65,28 +65,43 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 						"name": &schema.Schema{
 							Type:     schema.TypeString,
 							Required: true,
+<% if version.nil? || version == 'ga' -%>
+							Removed:  "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 						},
 
 						"instance_template": &schema.Schema{
 							Type:             schema.TypeString,
 							Required:         true,
+<% if version.nil? || version == 'ga' -%>
+							Removed:          "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 							DiffSuppressFunc: compareSelfLinkRelativePaths,
 						},
 
 						"target_size": &schema.Schema{
 							Type:     schema.TypeList,
 							Optional: true,
+<% if version.nil? || version == 'ga' -%>
+							Removed:  "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"fixed": &schema.Schema{
 										Type:     schema.TypeInt,
 										Optional: true,
+<% if version.nil? || version == 'ga' -%>
+										Removed:  "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 									},
 
 									"percent": &schema.Schema{
 										Type:         schema.TypeInt,
 										Optional:     true,
+<% if version.nil? || version == 'ga' -%>
+										Removed:  "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 										ValidateFunc: validation.IntBetween(0, 100),
 									},
 								},
@@ -125,11 +140,7 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 			},
 
 			"named_port": &schema.Schema{
-<% if version.nil? || version == 'ga' -%>
-				Type:     schema.TypeList,
-<% else -%>
 				Type:     schema.TypeSet,
-<% end -%>
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -191,23 +202,29 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 			},
 
 			"auto_healing_policies": &schema.Schema{
-				Type:       schema.TypeList,
-				Optional:   true,
-				MaxItems:   1,
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
 <% if version.nil? || version == 'ga' -%>
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+				Removed:  "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 <% end -%>
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"health_check": &schema.Schema{
 							Type:             schema.TypeString,
 							Required:         true,
+<% if version.nil? || version == 'ga' -%>
+							Removed:          "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 							DiffSuppressFunc: compareSelfLinkRelativePaths,
 						},
 
 						"initial_delay_sec": &schema.Schema{
 							Type:         schema.TypeInt,
 							Required:     true,
+<% if version.nil? || version == 'ga' -%>
+							Removed:      "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 							ValidateFunc: validation.IntBetween(0, 3600),
 						},
 					},
@@ -228,10 +245,10 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 
 <% if version.nil? || version == 'ga' -%>
 			"rolling_update_policy": &schema.Schema{
-				Deprecated: "This field is in beta and will be removed from this provider. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+				Removed:    "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+				Computed:   true,
 <% else -%>
 			"update_policy": &schema.Schema{
-				Computed:   true,
 <% end -%>
 				Type:       schema.TypeList,
 				Optional:   true,
@@ -241,23 +258,28 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 						"minimal_action": &schema.Schema{
 							Type:         schema.TypeString,
 							Required:     true,
+<% if version.nil? || version == 'ga' -%>
+							Removed:      "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 							ValidateFunc: validation.StringInSlice([]string{"RESTART", "REPLACE"}, false),
 						},
 
 						"type": &schema.Schema{
 							Type:         schema.TypeString,
 							Required:     true,
+<% if version.nil? || version == 'ga' -%>
+							Removed:      "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 							ValidateFunc: validation.StringInSlice([]string{"OPPORTUNISTIC", "PROACTIVE"}, false),
 						},
 
 						"max_surge_fixed": &schema.Schema{
 							Type:          schema.TypeInt,
 							Optional:      true,
-<% if version.nil? || version == 'ga' -%>
-							Default:       0,
-							ConflictsWith: []string{"rolling_update_policy.0.max_surge_percent"},
-<% else -%>
 							Computed:      true,
+<% if version.nil? || version == 'ga' -%>
+							Removed:       "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% else -%>
 							ConflictsWith: []string{"update_policy.0.max_surge_percent"},
 <% end -%>
 						},
@@ -266,7 +288,7 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 							Type:          schema.TypeInt,
 							Optional:      true,
 <% if version.nil? || version == 'ga' -%>
-							ConflictsWith: []string{"rolling_update_policy.0.max_surge_fixed"},
+							Removed:       "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 <% else -%>
 							ConflictsWith: []string{"update_policy.0.max_surge_fixed"},
 <% end -%>
@@ -277,8 +299,7 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 							Type:          schema.TypeInt,
 							Optional:      true,
 <% if version.nil? || version == 'ga' -%>
-							Default:       0,
-							ConflictsWith: []string{"rolling_update_policy.0.max_unavailable_percent"},
+							Removed:       "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 <% else -%>
 							Computed:      true,
 							ConflictsWith: []string{"update_policy.0.max_unavailable_percent"},
@@ -289,7 +310,7 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 							Type:          schema.TypeInt,
 							Optional:      true,
 <% if version.nil? || version == 'ga' -%>
-							ConflictsWith: []string{"rolling_update_policy.0.max_unavailable_fixed"},
+							Removed:       "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
 <% else -%>
 							ConflictsWith: []string{"update_policy.0.max_unavailable_fixed"},
 <% end -%>
@@ -298,6 +319,9 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 
 						"min_ready_sec": &schema.Schema{
 							Type:         schema.TypeInt,
+<% if version.nil? || version == 'ga' -%>
+							Removed:      "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
+<% end -%>
 							Optional:     true,
 							ValidateFunc: validation.IntBetween(0, 3600),
 						},
@@ -321,12 +345,6 @@ func resourceComputeRegionInstanceGroupManagerCreate(d *schema.ResourceData, met
 		return err
 	}
 
-<% if version.nil? || version == 'ga' -%>
-	if _, ok := d.GetOk("rolling_update_policy"); d.Get("update_strategy") == "ROLLING_UPDATE" && !ok {
-		return fmt.Errorf("[rolling_update_policy] must be set when 'update_strategy' is set to 'ROLLING_UPDATE'")
-	}
-<% end -%>
-
 	manager := &computeBeta.InstanceGroupManager{
 		Name:                d.Get("name").(string),
 		Description:         d.Get("description").(string),
@@ -335,15 +353,11 @@ func resourceComputeRegionInstanceGroupManagerCreate(d *schema.ResourceData, met
 		InstanceTemplate:    d.Get("instance_template").(string),
 <% end -%>
 		TargetSize:          int64(d.Get("target_size").(int)),
-<% if version.nil? || version == 'ga' -%>
-		NamedPorts:          getNamedPortsBeta(d.Get("named_port").([]interface{})),
-<% else -%>
 		NamedPorts:          getNamedPortsBeta(d.Get("named_port").(*schema.Set).List()),
-<% end -%>
 		TargetPools:         convertStringSet(d.Get("target_pools").(*schema.Set)),
+<% unless version.nil? || version == 'ga' -%>
 		AutoHealingPolicies: expandAutoHealingPolicies(d.Get("auto_healing_policies").([]interface{})),
 		Versions:            expandVersions(d.Get("version").([]interface{})),
-<% unless version.nil? || version == 'ga' -%>
 		UpdatePolicy:        expandUpdatePolicy(d.Get("update_policy").([]interface{})),
 <% end -%>
 		DistributionPolicy:  expandDistributionPolicy(d.Get("distribution_policy_zones").(*schema.Set)),
@@ -441,9 +455,7 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 <% if version.nil? || version == 'ga' -%>
 	d.Set("instance_template", ConvertSelfLinkToV1(manager.InstanceTemplate))
 <% end -%>
-	if err := d.Set("version", flattenVersions(manager.Versions)); err != nil {
-		return err
-	}
+
 	d.Set("name", manager.Name)
 	d.Set("region", GetResourceNameFromSelfLink(manager.Region))
 	d.Set("description", manager.Description)
@@ -457,9 +469,6 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 	}
 	d.Set("fingerprint", manager.Fingerprint)
 	d.Set("instance_group", ConvertSelfLinkToV1(manager.InstanceGroup))
-	if err := d.Set("auto_healing_policies", flattenAutoHealingPolicies(manager.AutoHealingPolicies)); err != nil {
-		return fmt.Errorf("Error setting auto_healing_policies in state: %s", err.Error())
-	}
 	if err := d.Set("distribution_policy_zones", flattenDistributionPolicy(manager.DistributionPolicy)); err != nil {
 		return err
 	}
@@ -470,7 +479,16 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 		update_strategy = "NONE"
 	}
 	d.Set("update_strategy", update_strategy.(string))
+
+	// Terraform _really_ doesn't like removing lists.
+	d.Set("version" , nil)
 <% else -%>
+	if err := d.Set("auto_healing_policies", flattenAutoHealingPolicies(manager.AutoHealingPolicies)); err != nil {
+		return fmt.Errorf("Error setting auto_healing_policies in state: %s", err.Error())
+	}
+	if err := d.Set("version", flattenVersions(manager.Versions)); err != nil {
+		return err
+	}
 	if err := d.Set("update_policy", flattenUpdatePolicy(manager.UpdatePolicy)); err != nil {
 		return fmt.Errorf("Error setting update_policy in state: %s", err.Error())
 	}
@@ -493,63 +511,6 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 }
 
 <% if version.nil? || version == 'ga' -%>
-// Updates an instance group manager by applying the update strategy (REPLACE, RESTART)
-// and rolling update policy (PROACTIVE, OPPORTUNISTIC). Updates performed by API
-// are OPPORTUNISTIC by default.
-func performRegionUpdate(config *Config, id string, updateStrategy string, rollingUpdatePolicy *computeBeta.InstanceGroupManagerUpdatePolicy, versions []*computeBeta.InstanceGroupManagerVersion, project string, region string) error {
-	if updateStrategy == "RESTART" {
-		managedInstances, err := config.clientComputeBeta.RegionInstanceGroupManagers.ListManagedInstances(project, region, id).Do()
-		if err != nil {
-			return fmt.Errorf("Error getting region instance group managers instances: %s", err)
-		}
-
-		managedInstanceCount := len(managedInstances.ManagedInstances)
-		instances := make([]string, managedInstanceCount)
-		for i, v := range managedInstances.ManagedInstances {
-			instances[i] = v.Instance
-		}
-
-		recreateInstances := &computeBeta.RegionInstanceGroupManagersRecreateRequest{
-			Instances: instances,
-		}
-
-		op, err := config.clientComputeBeta.RegionInstanceGroupManagers.RecreateInstances(project, region, id, recreateInstances).Do()
-		if err != nil {
-			return fmt.Errorf("Error restarting region instance group managers instances: %s", err)
-		}
-
-		// Wait for the operation to complete
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, managedInstanceCount*4, "Restarting RegionInstanceGroupManagers instances")
-		if err != nil {
-			return err
-		}
-	}
-
-	if updateStrategy == "ROLLING_UPDATE" {
-		// UpdatePolicy is set for InstanceGroupManager on update only, because it is only relevant for `Patch` calls.
-		// Other tools(gcloud and UI) capable of executing the same `ROLLING UPDATE` call
-		// expect those values to be provided by user as part of the call
-		// or provide their own defaults without respecting what was previously set on UpdateManager.
-		// To follow the same logic, we provide policy values on relevant update change only.
-		manager := &computeBeta.InstanceGroupManager{
-			UpdatePolicy: rollingUpdatePolicy,
-			Versions:     versions,
-		}
-
-		op, err := config.clientComputeBeta.RegionInstanceGroupManagers.Patch(project, region, id, manager).Do()
-		if err != nil {
-			return fmt.Errorf("Error updating region managed group instances: %s", err)
-		}
-
-		err = computeSharedOperationWait(config.clientCompute, op, project, "Updating region managed group instances")
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
@@ -564,10 +525,6 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 	}
 
 	d.Partial(true)
-
-	if _, ok := d.GetOk("rolling_update_policy"); d.Get("update_strategy") == "ROLLING_UPDATE" && !ok {
-		return fmt.Errorf("[rolling_update_policy] must be set when 'update_strategy' is set to 'ROLLING_UPDATE'")
-	}
 
 	if d.HasChange("target_pools") {
 		targetPools := convertStringSet(d.Get("target_pools").(*schema.Set))
@@ -613,28 +570,12 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 			return err
 		}
 
-		updateStrategy := d.Get("update_strategy").(string)
-		rollingUpdatePolicy := expandUpdatePolicy(d.Get("rolling_update_policy").([]interface{}))
-		err = performRegionUpdate(config, d.Id(), updateStrategy, rollingUpdatePolicy, nil, project, region)
 		d.SetPartial("instance_template")
-	}
-
-	// If version changes then update
-	if d.HasChange("version") {
-		updateStrategy := d.Get("update_strategy").(string)
-		rollingUpdatePolicy := expandUpdatePolicy(d.Get("rolling_update_policy").([]interface{}))
-		versions := expandVersions(d.Get("version").([]interface{}))
-		err = performRegionUpdate(config, d.Get("name").(string), updateStrategy, rollingUpdatePolicy, versions, project, region)
-		if err != nil {
-			return err
-		}
-
-		d.SetPartial("version")
 	}
 
 	if d.HasChange("named_port") {
 		// Build the parameters for a "SetNamedPorts" request:
-		namedPorts := getNamedPortsBeta(d.Get("named_port").([]interface{}))
+		namedPorts := getNamedPortsBeta(d.Get("named_port").(*schema.Set).List())
 		setNamedPorts := &computeBeta.RegionInstanceGroupsSetNamedPortsRequest{
 			NamedPorts: namedPorts,
 		}
@@ -672,28 +613,6 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 		}
 
 		d.SetPartial("target_size")
-	}
-
-	if d.HasChange("auto_healing_policies") {
-		setAutoHealingPoliciesRequest := &computeBeta.RegionInstanceGroupManagersSetAutoHealingRequest{}
-		if v, ok := d.GetOk("auto_healing_policies"); ok {
-			setAutoHealingPoliciesRequest.AutoHealingPolicies = expandAutoHealingPolicies(v.([]interface{}))
-		}
-
-		op, err := config.clientComputeBeta.RegionInstanceGroupManagers.SetAutoHealingPolicies(
-			project, region, d.Get("name").(string), setAutoHealingPoliciesRequest).Do()
-
-		if err != nil {
-			return fmt.Errorf("Error updating AutoHealingPolicies: %s", err)
-		}
-
-		// Wait for the operation to complete
-		err = computeSharedOperationWait(config.clientCompute, op, project, "Updating AutoHealingPolicies")
-		if err != nil {
-			return err
-		}
-
-		d.SetPartial("auto_healing_policies")
 	}
 
 	d.Partial(false)

--- a/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
+++ b/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
@@ -480,7 +480,7 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 	}
 	d.Set("update_strategy", update_strategy.(string))
 
-	// Terraform _really_ doesn't like removing lists.
+	// When we make a list Removed, we see a permadiff from `0 => ` (nil). Set to nil in Read so we see no diff.
 	d.Set("version" , nil)
 <% else -%>
 	if err := d.Set("auto_healing_policies", flattenAutoHealingPolicies(manager.AutoHealingPolicies)); err != nil {

--- a/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -153,7 +153,8 @@ func TestAccInstanceGroupManager_updateStrategy(t *testing.T) {
 }
 <% end -%>
 
-func TestAccInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
+<% unless version.nil? || version == 'ga' -%>
+func TestAccInstanceGroupManager_updatePolicy(t *testing.T) {
 	t.Parallel()
 
 	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
@@ -166,20 +167,15 @@ func TestAccInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 			{
 				Config: testAccInstanceGroupManager_rollingUpdatePolicy(igm),
 			},
-<% if version.nil? || version == 'ga' -%>
-			// No import step because rolling updates are broken and the field will be removed in 2.0.0.
-			// TODO(danawillow): Remove this test once we've removed the field.
-<% else -%>
 			{
 				ResourceName:      "google_compute_instance_group_manager.igm-rolling-update-policy",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-<% end -%>
 			{
 				Config: testAccInstanceGroupManager_rollingUpdatePolicy2(igm),
 			},
-<% unless version.nil? || version == 'ga' -%>
+
 			{
 				ResourceName:      "google_compute_instance_group_manager.igm-rolling-update-policy",
 				ImportState:       true,
@@ -201,10 +197,10 @@ func TestAccInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-<% end -%>
 		},
 	})
 }
+<% end -%>
 
 func TestAccInstanceGroupManager_separateRegions(t *testing.T) {
 	t.Parallel()
@@ -234,6 +230,7 @@ func TestAccInstanceGroupManager_separateRegions(t *testing.T) {
 	})
 }
 
+<% unless version.nil? || version == 'ga' -%>
 func TestAccInstanceGroupManager_versions(t *testing.T) {
 	t.Parallel()
 
@@ -257,7 +254,9 @@ func TestAccInstanceGroupManager_versions(t *testing.T) {
 		},
 	})
 }
+<% end -%>
 
+<% unless version.nil? || version == 'ga' -%>
 func TestAccInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 	t.Parallel()
 
@@ -279,7 +278,6 @@ func TestAccInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-<% unless version.nil? || version == 'ga' -%>
 			{
 				Config: testAccInstanceGroupManager_autoHealingPoliciesRemoved(template, target, igm, hck),
 			},
@@ -288,40 +286,10 @@ func TestAccInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+		},
+	})
+}
 <% end -%>
-		},
-	})
-}
-
-// This test is to make sure that a single version resource can link to a versioned resource
-// without perpetual diffs because the self links mismatch.
-// Once auto_healing_policies is no longer beta, we will need to use a new field or resource
-// with Beta fields.
-func TestAccInstanceGroupManager_selfLinkStability(t *testing.T) {
-	t.Parallel()
-
-	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
-	target := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
-	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
-	hck := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
-	autoscaler := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceGroupManagerDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccInstanceGroupManager_selfLinkStability(template, target, igm, hck, autoscaler),
-			},
-			{
-				ResourceName:      "google_compute_instance_group_manager.igm-basic",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
 
 func testAccCheckInstanceGroupManagerDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
@@ -731,6 +699,7 @@ func testAccInstanceGroupManager_updateStrategy(igm string) string {
 }
 <% end -%>
 
+<% unless version.nil? || version == 'ga' -%>
 func testAccInstanceGroupManager_rollingUpdatePolicy(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -765,23 +734,14 @@ resource "google_compute_instance_template" "igm-rolling-update-policy" {
 resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 	description = "Terraform test instance group manager"
 	name = "%s"
-<% if version.nil? || version == 'ga' -%>
-	instance_template = "${google_compute_instance_template.igm-rolling-update-policy.self_link}"
-<% else -%>
 	version {
 		name = "prod"
 		instance_template = "${google_compute_instance_template.igm-rolling-update-policy.self_link}"
 	}
-<% end -%>
 	base_instance_name = "igm-rolling-update-policy"
 	zone = "us-central1-c"
 	target_size = 3
-<% if version.nil? || version == 'ga' -%>
-	update_strategy = "ROLLING_UPDATE"
-	rolling_update_policy {
-<% else -%>
 	update_policy {
-<% end -%>
 		type = "PROACTIVE"
 		minimal_action = "REPLACE"
 		max_surge_percent = 50
@@ -794,7 +754,9 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 	}
 }`, igm)
 }
+<% end -%>
 
+<% unless version.nil? || version == 'ga' -%>
 func testAccInstanceGroupManager_rollingUpdatePolicy2(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -825,23 +787,14 @@ resource "google_compute_instance_template" "igm-rolling-update-policy" {
 resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 	description = "Terraform test instance group manager"
 	name = "%s"
-<% if version.nil? || version == 'ga' -%>
-	instance_template = "${google_compute_instance_template.igm-rolling-update-policy.self_link}"
-<% else -%>
 	version {
 		name = "prod2"
 		instance_template = "${google_compute_instance_template.igm-rolling-update-policy.self_link}"
 	}
-<% end -%>
 	base_instance_name = "igm-rolling-update-policy"
 	zone = "us-central1-c"
 	target_size = 3
-<% if version.nil? || version == 'ga' -%>
-	update_strategy = "ROLLING_UPDATE"
-	rolling_update_policy {
-<% else -%>
 	update_policy {
-<% end -%>
 		type = "PROACTIVE"
 		minimal_action = "REPLACE"
 		max_surge_fixed = 2
@@ -854,6 +807,7 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 	}
 }`, igm)
 }
+<% end -%>
 
 <% unless version.nil? || version == 'ga' -%>
 func testAccInstanceGroupManager_rollingUpdatePolicy3(igm string) string {
@@ -901,7 +855,9 @@ resource "google_compute_instance_group_manager" "igm-rolling-update-policy" {
 	}
 }`, igm)
 }
+<% end -%>
 
+<% unless version.nil? || version == 'ga' -%>
 func testAccInstanceGroupManager_rollingUpdatePolicy4(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -1014,6 +970,7 @@ func testAccInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 	`, igm1, igm2)
 }
 
+<% unless version.nil? || version == 'ga' -%>
 func testAccInstanceGroupManager_autoHealingPolicies(template, target, igm, hck string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -1051,14 +1008,10 @@ resource "google_compute_target_pool" "igm-basic" {
 resource "google_compute_instance_group_manager" "igm-basic" {
 	description = "Terraform test instance group manager"
 	name = "%s"
-<% if version.nil? || version == 'ga' -%>
-	instance_template = "${google_compute_instance_template.igm-basic.self_link}"
-<% else -%>
 	version {
 		instance_template = "${google_compute_instance_template.igm-basic.self_link}"
 		name = "prod"
 	}
-<% end -%>
 	target_pools = ["${google_compute_target_pool.igm-basic.self_link}"]
 	base_instance_name = "igm-basic"
 	zone = "us-central1-c"
@@ -1077,6 +1030,7 @@ resource "google_compute_http_health_check" "zero" {
 }
 	`, template, target, igm, hck)
 }
+<% end -%>
 
 <% unless version.nil? || version == 'ga' -%>
 func testAccInstanceGroupManager_autoHealingPoliciesRemoved(template, target, igm, hck string) string {
@@ -1132,6 +1086,7 @@ resource "google_compute_http_health_check" "zero" {
 }
 <% end -%>
 
+<% unless version.nil? || version == 'ga' -%>
 func testAccInstanceGroupManager_versions(primaryTemplate string, canaryTemplate string, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -1203,85 +1158,4 @@ resource "google_compute_instance_group_manager" "igm-basic" {
 }
 	`, primaryTemplate, canaryTemplate, igm)
 }
-
-// This test is to make sure that a single version resource can link to a versioned resource
-// without perpetual diffs because the self links mismatch.
-// Once auto_healing_policies is no longer beta, we will need to use a new field or resource
-// with Beta fields.
-func testAccInstanceGroupManager_selfLinkStability(template, target, igm, hck, autoscaler string) string {
-	return fmt.Sprintf(`
-data "google_compute_image" "my_image" {
-	family  = "debian-9"
-	project = "debian-cloud"
-}
-
-resource "google_compute_instance_template" "igm-basic" {
-	name = "%s"
-	machine_type = "n1-standard-1"
-	can_ip_forward = false
-	tags = ["foo", "bar"]
-	disk {
-		source_image = "${data.google_compute_image.my_image.self_link}"
-		auto_delete = true
-		boot = true
-	}
-	network_interface {
-		network = "default"
-	}
-	metadata {
-		foo = "bar"
-	}
-	service_account {
-		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
-	}
-}
-
-resource "google_compute_target_pool" "igm-basic" {
-	description = "Resource created for Terraform acceptance testing"
-	name = "%s"
-	session_affinity = "CLIENT_IP_PROTO"
-}
-
-resource "google_compute_instance_group_manager" "igm-basic" {
-	description = "Terraform test instance group manager"
-	name = "%s"
-<% if version.nil? || version == 'ga' -%>
-	instance_template = "${google_compute_instance_template.igm-basic.self_link}"
-<% else -%>
-	version {
-		instance_template = "${google_compute_instance_template.igm-basic.self_link}"
-		name = "primary"
-	}
 <% end -%>
-	target_pools = ["${google_compute_target_pool.igm-basic.self_link}"]
-	base_instance_name = "igm-basic"
-	zone = "us-central1-c"
-	target_size = 2
-	auto_healing_policies {
-		health_check = "${google_compute_http_health_check.zero.self_link}"
-		initial_delay_sec = "10"
-	}
-}
-
-resource "google_compute_http_health_check" "zero" {
-	name               = "%s"
-	request_path       = "/"
-	check_interval_sec = 1
-	timeout_sec        = 1
-}
-
-resource "google_compute_autoscaler" "foobar" {
-	name = "%s"
-	zone = "us-central1-c"
-	target = "${google_compute_instance_group_manager.igm-basic.self_link}"
-	autoscaling_policy = {
-		max_replicas = 10
-		min_replicas = 1
-		cooldown_period = 60
-		cpu_utilization = {
-			target = 0.5
-		}
-	}
-}
-`, template, target, igm, hck, autoscaler)
-}

--- a/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
@@ -154,6 +154,7 @@ func TestAccRegionInstanceGroupManager_updateStrategy(t *testing.T) {
 }
 <% end -%>
 
+<% unless version.nil? || version == 'ga' -%>
 func TestAccRegionInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 	t.Parallel()
 
@@ -167,29 +168,24 @@ func TestAccRegionInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 			{
 				Config: testAccRegionInstanceGroupManager_rollingUpdatePolicy(igm),
 			},
-<% if version.nil? || version == 'ga' -%>
-			// No import step because rolling updates are broken and the field will be removed in 2.0.0.
-			// TODO(danawillow): Remove this test once we've removed the field.
-<% else -%>
 			{
 				ResourceName:      "google_compute_region_instance_group_manager.igm-rolling-update-policy",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-<% end -%>
 			{
 				Config: testAccRegionInstanceGroupManager_rollingUpdatePolicy2(igm),
 			},
-<% unless version.nil? || version == 'ga' -%>
 			{
 				ResourceName:      "google_compute_region_instance_group_manager.igm-rolling-update-policy",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-<% end -%>
 		},
 	})
 }
+<% end -%>
+
 func TestAccRegionInstanceGroupManager_separateRegions(t *testing.T) {
 	t.Parallel()
 
@@ -218,6 +214,7 @@ func TestAccRegionInstanceGroupManager_separateRegions(t *testing.T) {
 	})
 }
 
+<% unless version.nil? || version == 'ga' -%>
 func TestAccRegionInstanceGroupManager_versions(t *testing.T) {
 	t.Parallel()
 
@@ -241,7 +238,9 @@ func TestAccRegionInstanceGroupManager_versions(t *testing.T) {
 		},
 	})
 }
+<% end -%>
 
+<% unless version.nil? || version == 'ga' -%>
 func TestAccRegionInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 	t.Parallel()
 
@@ -263,7 +262,6 @@ func TestAccRegionInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-<% unless version.nil? || version == 'ga' -%>
 			{
 				Config: testAccRegionInstanceGroupManager_autoHealingPoliciesRemoved(template, target, igm, hck),
 			},
@@ -272,10 +270,10 @@ func TestAccRegionInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-<% end -%>
 		},
 	})
 }
+<% end -%>
 
 func TestAccRegionInstanceGroupManager_distributionPolicy(t *testing.T) {
 	t.Parallel()
@@ -726,6 +724,7 @@ func testAccRegionInstanceGroupManager_separateRegions(igm1, igm2 string) string
 	`, igm1, igm2)
 }
 
+<% unless version.nil? || version == 'ga' -%>
 func testAccRegionInstanceGroupManager_autoHealingPolicies(template, target, igm, hck string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -763,14 +762,10 @@ resource "google_compute_target_pool" "igm-basic" {
 resource "google_compute_region_instance_group_manager" "igm-basic" {
 	description = "Terraform test instance group manager"
 	name = "%s"
-<% if version.nil? || version == 'ga' -%>
-	instance_template = "${google_compute_instance_template.igm-basic.self_link}"
-<% else -%>
 	version {
 		instance_template = "${google_compute_instance_template.igm-basic.self_link}"
 		name = "primary"
 	}
-<% end -%>
 	target_pools = ["${google_compute_target_pool.igm-basic.self_link}"]
 	base_instance_name = "igm-basic"
 	region = "us-central1"
@@ -789,6 +784,7 @@ resource "google_compute_http_health_check" "zero" {
 }
 	`, template, target, igm, hck)
 }
+<% end -%>
 
 <% unless version.nil? || version == 'ga' -%>
 func testAccRegionInstanceGroupManager_autoHealingPoliciesRemoved(template, target, igm, hck string) string {
@@ -844,6 +840,7 @@ resource "google_compute_http_health_check" "zero" {
 }
 <% end -%>
 
+<% unless version.nil? || version == 'ga' -%>
 func testAccRegionInstanceGroupManager_versions(primaryTemplate string, canaryTemplate string, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -915,6 +912,7 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 }
 	`, primaryTemplate, canaryTemplate, igm)
 }
+<% end -%>
 
 func testAccRegionInstanceGroupManager_distributionPolicy(template, igm string, zones []string) string {
 	return fmt.Sprintf(`
@@ -1008,6 +1006,7 @@ resource "google_compute_region_instance_group_manager" "igm-update-strategy" {
 }
 <% end -%>
 
+<% unless version.nil? || version == 'ga' -%>
 func testAccRegionInstanceGroupManager_rollingUpdatePolicy(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -1042,26 +1041,16 @@ resource "google_compute_instance_template" "igm-rolling-update-policy" {
 resource "google_compute_region_instance_group_manager" "igm-rolling-update-policy" {
 	description        = "Terraform test instance group manager"
 	name               = "%s"
-<% if version.nil? || version == 'ga' -%>
-	instance_template  = "${google_compute_instance_template.igm-rolling-update-policy.self_link}"
-<% else -%>
 	version {
 		instance_template  = "${google_compute_instance_template.igm-rolling-update-policy.self_link}"
 		name = "primary"
 	}
-<% end -%>
 	base_instance_name = "igm-rolling-update-policy"
 	region             = "us-central1"
 	target_size        = 4
 	distribution_policy_zones  = ["us-central1-a", "us-central1-f"]
-<% if version.nil? || version == 'ga' -%>
-	update_strategy = "ROLLING_UPDATE"
-
-	rolling_update_policy {
-<% else -%>
 
 	update_policy {
-<% end -%>
 		type                  = "PROACTIVE"
 		minimal_action        = "REPLACE"
 		max_surge_fixed       = 2
@@ -1075,7 +1064,9 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
 	}
 }`, igm)
 }
+<% end -%>
 
+<% unless version.nil? || version == 'ga' -%>
 func testAccRegionInstanceGroupManager_rollingUpdatePolicy2(igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -1106,26 +1097,15 @@ resource "google_compute_instance_template" "igm-rolling-update-policy" {
 resource "google_compute_region_instance_group_manager" "igm-rolling-update-policy" {
 	description                = "Terraform test instance group manager"
 	name                       = "%s"
-<% if version.nil? || version == 'ga' -%>
-	instance_template          = "${google_compute_instance_template.igm-rolling-update-policy.self_link}"
-<% else -%>
 	version {
 		name              = "primary"
 		instance_template = "${google_compute_instance_template.igm-rolling-update-policy.self_link}"
 	}
-<% end -%>
 	base_instance_name         = "igm-rolling-update-policy"
 	region                     = "us-central1"
 	distribution_policy_zones  = ["us-central1-a", "us-central1-f"]
 	target_size                = 3
-<% if version.nil? || version == 'ga' -%>
-	update_strategy            = "ROLLING_UPDATE"
-
-	rolling_update_policy {
-<% else -%>
-
 	update_policy {
-<% end -%>
 		type                  = "PROACTIVE"
 		minimal_action        = "REPLACE"
 		max_surge_fixed       = 2
@@ -1138,3 +1118,4 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
 	}
 }`, igm)
 }
+<% end -%>

--- a/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
@@ -145,9 +145,10 @@ func TestAccRegionInstanceGroupManager_updateStrategy(t *testing.T) {
 				Config: testAccRegionInstanceGroupManager_updateStrategy(igm),
 			},
 			{
-				ResourceName:      "google_compute_region_instance_group_manager.igm-update-strategy",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_region_instance_group_manager.igm-update-strategy",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"update_strategy"},
 			},
 		},
 	})

--- a/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -116,10 +116,9 @@ The following arguments are supported:
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
 
-* `update_strategy` - (Optional, Default `"REPLACE"`) If the `instance_template`
+* `update_strategy` - (Optional, Default `"NONE"`) If the `instance_template`
     resource is modified, a value of `"NONE"` will prevent any of the managed
-    instances from being restarted by Terraform. A value of `"REPLACE"` will
-    restart all of the instances at once. This field is only present in the
+    instances from being restarted by Terraform. This field is only present in the
     `google` provider.
 
 * `target_size` - (Optional) The target number of running instances for this managed

--- a/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -116,10 +116,8 @@ The following arguments are supported:
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
 
-* `update_strategy` - (Optional, Default `"NONE"`) If the `instance_template`
-    resource is modified, a value of `"NONE"` will prevent any of the managed
-    instances from being restarted by Terraform. This field is only present in the
-    `google` provider.
+* `update_strategy` - (Optional, Default `"NONE"`) This field is deprecated as it has no functionality anymore.
+It previously turned update behaviour on and off. This field is only present in the `google` provider.
 
 * `target_size` - (Optional) The target number of running instances for this managed
     instance group. This value should always be explicitly set unless this resource is attached to


### PR DESCRIPTION
Hmm. I started on this resource thinking "I know [r]igm! This should be easy enough!" and I think I mostly got it right but `rigm.update_strategy` has bamboozled me - it doesn't do anything anymore but we forgot to deprecate it.

Not looking for feedback until Monday, just writing this down so I can remember after I context switch. 

Part of https://github.com/terraform-providers/terraform-provider-google/issues/1203

* Change `named_ports` to a `Set`
* Remove `rolling_update_policy`, `versions`, `auto_healing_policies` from GA provider
* Remove old self link stability test

-----------------------------------------------------------------
# [all]
## [terraform]
Start removing beta igm/rigm fields.
### [terraform-beta]
## [ansible]
## [inspec]
