### PR TITLE
Removing less useful rubocop exceptions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,35 +11,28 @@ AllCops:
     - 'vendor/**/*'
 
 Metrics/AbcSize:
-  Max: 20
+  Enabled: false
 
-Metrics/LineLength:
-  Max: 100
-
-# TODO(nelsonjr): Refactor this class and remove Rubocop exemptions below
 Metrics/ClassLength:
-  Exclude:
-    - 'google/yaml_validator.rb'
-    - 'provider/core.rb'
-    - 'provider/puppet.rb'
-    - 'provider/legacy_test_data_formatter.rb'
-    # TODO(alexstephen): Remove this when generate_object is removed
-    - 'provider/chef.rb'
-    - 'tools/end2end/tester_base.rb'
+  Enabled: false
 
-Metrics/ModuleLength:
-  Exclude:
-    - 'compile/core.rb'
+Metrics/CyclomaticComplexity:
+  Enabled: false
 
 Metrics/MethodLength:
-  Max: 25
+  Enabled: false
 
-Security/Eval:
-  Exclude:
-    - 'provider/legacy_test_data_generator.rb'
+Metrics/ModuleLength:
+  Enabled: false
+
+Metrics/PerceivedComplexity:
+  Enabled: false
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Metrics/LineLength:
+  Max: 100
 
 Style/CommandLiteral:
   EnforcedStyle: percent_x

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -16,7 +16,6 @@ require 'google/string_utils'
 
 module Api
   # An object available in the product
-  # rubocop:disable Metrics/ClassLength
   class Resource < Api::Object::Named
     # The list of properties (attr_reader) that can be overridden in
     # <provider>.yaml.
@@ -233,8 +232,6 @@ module Api
     # the number of properties, it is okay to ignore Rubocop warnings about
     # method size and complexity.
     #
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/MethodLength
     def validate
       super
       check_optional_property :async, Api::Async
@@ -447,9 +444,6 @@ module Api
     #   props- a list of props
     #   original_object - the original object containing props. This is to
     #                     avoid self-referencing objects.
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
     def resourcerefs_for_properties(props, original_obj)
       rrefs = []
       props.each do |p|

--- a/api/type.rb
+++ b/api/type.rb
@@ -16,7 +16,6 @@ require 'google/string_utils'
 
 module Api
   # Represents a property type
-  # rubocop:disable Metrics/ClassLength
   class Type < Api::Object::Named
     # The list of properties (attr_reader) that can be overridden in
     # <provider>.yaml.
@@ -253,8 +252,6 @@ module Api
       STRING_ARRAY_TYPE = [Api::Type::Array, Api::Type::String].freeze
       NESTED_ARRAY_TYPE = [Api::Type::Array, Api::Type::NestedObject].freeze
       RREF_ARRAY_TYPE = [Api::Type::Array, Api::Type::ResourceRef].freeze
-
-      # rubocop:disable Metrics/CyclomaticComplexity
       def validate
         super
         if @item_type.is_a?(NestedObject) || @item_type.is_a?(ResourceRef)

--- a/google/golang_utils.rb
+++ b/google/golang_utils.rb
@@ -24,8 +24,6 @@ module Google
     # quotes becomes a ruby string without quotes unless you explicitly set
     # quotes in the string like "\"foo\"" which is not a pattern we want to
     # see in our yaml config files.
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
     def go_literal(value)
       if value.is_a?(String) || value.is_a?(Symbol)
         "\"#{value}\""

--- a/google/ruby_utils.rb
+++ b/google/ruby_utils.rb
@@ -37,8 +37,6 @@ module Google
     def method_decl(name, args)
       ["def #{name}", ("(#{args.compact.join(', ')})" unless args.empty?)].compact.join
     end
-
-    # rubocop:disable Metrics/AbcSize
     def method_call(name, args, indent = 0)
       args = args.compact
       format([

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -30,7 +30,6 @@ module Provider
     # Code generator for Ansible Cookbooks that manage Google Cloud Platform
     # resources.
     # TODO(alexstephen): Split up class into multiple modules.
-    # rubocop:disable Metrics/ClassLength
     class Core < Provider::Core
       PYTHON_TYPE_FROM_MM_TYPE = {
         'Api::Type::NestedObject' => 'dict',
@@ -101,7 +100,6 @@ module Provider
       # * module will always be included.
       # * extra_data is a dict of extra information.
       # * extra_url will have a URL chunk to be appended after the URL.
-      # rubocop:disable Metrics/MethodLength
       def emit_link(name, url, object, has_extra_data = false)
         params = emit_link_var_args(url, has_extra_data)
         if rrefs_in_link(url, object)
@@ -150,8 +148,6 @@ module Provider
             p.is_a?(Api::Type::ResourceRef) && !p.resource_ref.readonly
         end.any?
       end
-
-      # rubocop:disable Metrics/AbcSize
       def resourceref_hash_for_links(link, object)
         props_in_link = link.scan(/{([a-z_]*)}/).flatten
         props = props_in_link.map do |p|

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -18,9 +18,6 @@ require 'provider/ansible/manifest'
 
 # Rubocop doesn't like this file because the hashes are complicated.
 # Humans like this file because the hashes are explicit and easy to read.
-# rubocop:disable Metrics/AbcSize
-# rubocop:disable Metrics/CyclomaticComplexity
-# rubocop:disable Metrics/PerceivedComplexity
 module Provider
   module Ansible
     # Responsible for building out YAML documentation blocks.

--- a/provider/ansible/module.rb
+++ b/provider/ansible/module.rb
@@ -50,8 +50,6 @@ module Provider
       end
 
       # Returns an array of all base options for a given property.
-      # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/AbcSize
       def prop_options(prop, _object, spaces)
         [
           ('required=True' if prop.required && !prop.default_value),
@@ -69,7 +67,6 @@ module Provider
       # rubocop:enable Metrics/AbcSize
 
       # Returns a formatted string represented the choices of an enum
-      # rubocop:disable Metrics/AbcSize
       def choices_enum(prop, spaces)
         name = prop.out_name.underscore
         type = "type=#{quote_string(python_type(prop))}"

--- a/provider/ansible/request.rb
+++ b/provider/ansible/request.rb
@@ -15,7 +15,6 @@ module Provider
   module Ansible
     # Responsible for building out the resource_to_request and
     # request_from_hash methods.
-    # rubocop:disable Metrics/ModuleLength
     module Request
       # Takes in a list of properties and outputs a python hash that takes
       # in a module and outputs a formatted JSON request.
@@ -129,11 +128,6 @@ module Provider
         end
       end
       # rubocop:enable Metrics/MethodLength
-
-      # rubocop:disable Metrics/MethodLength
-      # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/CyclomaticComplexity
-      # rubocop:disable Metrics/PerceivedComplexity
       def request_output(prop, hash_name, module_name)
         return "response.get(#{quote_string(prop.name)})" \
           if prop.is_a? Api::Type::FetchedExternal

--- a/provider/ansible/resource_override.rb
+++ b/provider/ansible/resource_override.rb
@@ -42,8 +42,6 @@ module Provider
     # Product specific overriden properties for Ansible
     class ResourceOverride < Provider::ResourceOverride
       include OverrideProperties
-      # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/MethodLength
       def validate
         super
 

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -46,9 +46,6 @@ module Provider
     # generators, it is okay to ignore Rubocop warnings about method size and
     # complexity.
     #
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
     def generate(output_folder, types, version_name)
       generate_objects(output_folder, types, version_name)
       copy_files(output_folder) \
@@ -158,9 +155,6 @@ module Provider
             Hash[section[o.name].map { |file| mapper.call(o, file) }]
           end
     end
-
-    # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/AbcSize
     def compile_file_list(output_folder, files, data = {})
       files.each do |target, source|
         Google::LOGGER.debug "Compiling #{source} => #{target}"
@@ -193,10 +187,6 @@ module Provider
     end
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/AbcSize
-
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
-    # rubocop:disable Metrics/AbcSize
     def generate_objects(output_folder, types, version_name)
       version = @api.version_obj_or_default(version_name)
       @api.set_properties_based_on_version(version)
@@ -226,10 +216,6 @@ module Provider
       generate_resource data
       generate_resource_tests data
     end
-
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
     def generate_datasources(output_folder, types, version_name)
       # We need to apply overrides for datasources
       @config.datasources.validate

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -22,7 +22,6 @@ require 'active_support/inflector'
 module Provider
   # Code generator for Example Cookbooks that manage Google Cloud Platform
   # resources.
-  # rubocop:disable Metrics/ClassLength
   class Inspec < Provider::Core
     include Google::RubyUtils
     # Settings for the provider

--- a/provider/resource_overrides.rb
+++ b/provider/resource_overrides.rb
@@ -35,7 +35,6 @@ module Provider
   #         !ruby/object:Provider::MyProvider::PropertyOverride
   #         description: 'baz'
   #   ...
-  # rubocop:disable Metrics/ClassLength
   class ResourceOverrides < Api::Object
     def consume_config(api, config)
       @__api = api

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -23,7 +23,6 @@ require 'google/golang_utils'
 module Provider
   # Code generator for Terraform Resources that manage Google Cloud Platform
   # resources.
-  # rubocop:disable Metrics/ClassLength
   class Terraform < Provider::AbstractCore
     include Provider::Terraform::Import
     include Provider::Terraform::SubTemplate
@@ -146,8 +145,6 @@ module Provider
         out_file: filepath
       )
     end
-
-    # rubocop:disable Metrics/AbcSize
     def generate_resource_tests(data)
       return if data[:object].example.reject(&:skip_test).empty?
 

--- a/provider/terraform/import.rb
+++ b/provider/terraform/import.rb
@@ -28,7 +28,6 @@ module Provider
       # c) short id w/o defaults: {{name}}
       #
       # Fields with default values are `project`, `region` and `zone`.
-      # rubocop:disable Metrics/AbcSize
       def import_id_formats(resource)
         if resource.import_format.nil? || resource.import_format.empty?
           underscored_base_url = resource.base_url.gsub(

--- a/provider/terraform_example.rb
+++ b/provider/terraform_example.rb
@@ -24,7 +24,6 @@ module Provider
     end
 
     # Create a directory of examples per resource
-    # rubocop:disable Metrics/AbcSize
     def generate_resource(data)
       return if data[:object].example.reject(&:skip_test).empty?
 

--- a/spec/network_blocker.rb
+++ b/spec/network_blocker.rb
@@ -87,7 +87,6 @@ end
 # ALLOWED_TEST_URI URL.
 module Net
   class HTTP
-    # rubocop:disable Metrics/AbcSize - keep in a single injected method
     define_method(:initialize) do |*args|
       blocker = Google::Codegen::NetworkBlocker.instance
       unless blocker.allowed_test_hosts.map { |h| h[:host] }.include?(args[0])


### PR DESCRIPTION
This removes a whole bunch of less-than-helpful Rubocop rules + the disable/enables.

I tried using the Airbnb + Github Rubocop guides to see what would happen. 634 + 1174 exceptions respectively. Unbelievable amounts of exceptions. I don't know how many of the exceptions I agree with, but it's not worth the PRs + the hassle to move to a new arbitrary style guide.

I think the best step forward is to become more opinionated on what rules we find useful/not and create our own style guide.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
