### PR TITLE
Remove version: every from authorize-single-rev.

### DIFF
--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -79,7 +79,6 @@ jobs:
     - name: authorize-single-rev
       plan:
           - get: magic-modules-external-prs
-            version: every
             trigger: false
           - put: magic-modules-new-prs
             params:


### PR DESCRIPTION
This should make concourse behave more predictably when selecting which rev to authorize.

-----------------------------------------------------------------
# [all]
CI changes only.
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
