### PR TITLE
[Terraform] Copy over resource_service_networking_connection resource+artifacts

### DIFF
--- a/provider/terraform/resources/resource_service_networking_connection.go
+++ b/provider/terraform/resources/resource_service_networking_connection.go
@@ -1,0 +1,235 @@
+package google
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/servicenetworking/v1beta"
+)
+
+func resourceServiceNetworkingConnection() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServiceNetworkingConnectionCreate,
+		Read:   resourceServiceNetworkingConnectionRead,
+		Update: resourceServiceNetworkingConnectionUpdate,
+		Delete: resourceServiceNetworkingConnectionDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceServiceNetworkingConnectionImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"network": &schema.Schema{
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: compareSelfLinkOrResourceName,
+			},
+			// NOTE(craigatgoogle): This field is weird, it's required to make the Insert/List calls as a parameter
+			// named "parent", however it's also defined in the response as an output field called "peering", which
+			// uses "-" as a delimeter instead of ".". To alleviate user confusion I've opted to model the gcloud
+			// CLI's approach, calling the field "service" and accepting the same format as the CLI with the "."
+			// delimiter.
+			// See: https://cloud.google.com/vpc/docs/configure-private-services-access#creating-connection
+			"service": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"reserved_peering_ranges": &schema.Schema{
+				Type:     schema.TypeList,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func resourceServiceNetworkingConnectionCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	network := d.Get("network").(string)
+	serviceNetworkingNetworkName, err := retrieveServiceNetworkingNetworkName(d, config, network)
+	if err != nil {
+		return fmt.Errorf("Failed to find Service Networking Connection, err: %s", err)
+	}
+
+	connection := &servicenetworking.Connection{
+		Network:               serviceNetworkingNetworkName,
+		ReservedPeeringRanges: convertStringArr(d.Get("reserved_peering_ranges").([]interface{})),
+	}
+
+	parentService := formatParentService(d.Get("service").(string))
+	op, err := config.clientServiceNetworking.Services.Connections.Create(parentService, connection).Do()
+	if err != nil {
+		return err
+	}
+
+	if err := serviceNetworkingOperationWait(config, op, "Create Service Networking Connection"); err != nil {
+		return err
+	}
+
+	connectionId := &connectionId{
+		Network: network,
+		Service: d.Get("service").(string),
+	}
+
+	d.SetId(connectionId.Id())
+	return resourceServiceNetworkingConnectionRead(d, meta)
+}
+
+func resourceServiceNetworkingConnectionRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	connectionId, err := parseConnectionId(d.Id())
+	if err != nil {
+		return fmt.Errorf("Failed to find Service Networking Connection, err: %s", err)
+	}
+
+	serviceNetworkingNetworkName, err := retrieveServiceNetworkingNetworkName(d, config, connectionId.Network)
+	if err != nil {
+		return fmt.Errorf("Failed to find Service Networking Connection, err: %s", err)
+	}
+
+	parentService := formatParentService(connectionId.Service)
+	listCall := config.clientServiceNetworking.Services.Connections.List(parentService)
+	listCall.Network(serviceNetworkingNetworkName)
+	response, err := listCall.Do()
+	if err != nil {
+		return err
+	}
+
+	var connection *servicenetworking.Connection
+	for _, c := range response.Connections {
+		if c.Network == serviceNetworkingNetworkName {
+			connection = c
+			break
+		}
+	}
+
+	if connection == nil {
+		return fmt.Errorf("Failed to find Service Networking Connection, network: %s service: %s", connectionId.Network, connectionId.Service)
+	}
+
+	d.Set("network", connectionId.Network)
+	d.Set("service", connectionId.Service)
+	d.Set("reserved_peering_ranges", connection.ReservedPeeringRanges)
+	return nil
+}
+
+// NOTE(craigatgoogle): The API for this resource doesn't define an update, however the behavior
+// of Create serves as a de facto update by overwriting connections with the duplicate
+// tuples: (network/service).
+func resourceServiceNetworkingConnectionUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceServiceNetworkingConnectionCreate(d, meta)
+}
+
+// NOTE(craigatgoogle): This resource doesn't have a defined Delete method, however an un-documented
+// behavior is for the Connection to be deleted when its associated network is deleted. This is
+// helpeful for acctest cleanup.
+func resourceServiceNetworkingConnectionDelete(d *schema.ResourceData, meta interface{}) error {
+	connectionId, err := parseConnectionId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[WARNING] Service Networking Connection resources cannot be deleted from GCP. This Connection (network: %s, service: %s) will be removed from Terraform state, but will still be present on the server.", connectionId.Network, connectionId.Service)
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourceServiceNetworkingConnectionImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	connectionId, err := parseConnectionId(d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	d.Set("network", connectionId.Network)
+	d.Set("service", connectionId.Service)
+	return []*schema.ResourceData{d}, nil
+}
+
+// NOTE(craigatgoogle): The Connection resource in this API doesn't have an Id field, so inorder
+// to support the Read method, we create an Id using the tuple(Network, Service).
+type connectionId struct {
+	Network string
+	Service string
+}
+
+func (id *connectionId) Id() string {
+	return fmt.Sprintf("%s:%s", url.QueryEscape(id.Network), url.QueryEscape(id.Service))
+}
+
+func parseConnectionId(id string) (*connectionId, error) {
+	res := strings.Split(id, ":")
+
+	if len(res) != 2 {
+		return nil, fmt.Errorf("Failed to parse service networking connection id, value: %s", id)
+	}
+
+	network, err := url.QueryUnescape(res[0])
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse service networking connection id, invalid network, err: %s", err)
+	} else if len(network) == 0 {
+		return nil, fmt.Errorf("Failed to parse service networking connection id, empty network")
+	}
+
+	service, err := url.QueryUnescape(res[1])
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse service networking connection id, invalid service, err: %s", err)
+	} else if len(service) == 0 {
+		return nil, fmt.Errorf("Failed to parse service networking connection id, empty service")
+	}
+
+	return &connectionId{
+		Network: network,
+		Service: service,
+	}, nil
+}
+
+// NOTE(craigatgoogle): An out of band aspect of this API is that it uses a unique formatting of network
+// different from the standard self_link URI. It requires a call to the resource manager to get the project
+// number for the current project.
+func retrieveServiceNetworkingNetworkName(d *schema.ResourceData, config *Config, network string) (string, error) {
+	networkFieldValue, err := ParseNetworkFieldValue(network, d, config)
+	if err != nil {
+		return "", fmt.Errorf("Failed to retrieve network field value, err: %s", err)
+	}
+
+	pid := networkFieldValue.Project
+	if pid == "" {
+		return "", fmt.Errorf("Could not determine project")
+	}
+
+	project, err := config.clientResourceManager.Projects.Get(pid).Do()
+	if err != nil {
+		return "", fmt.Errorf("Failed to retrieve project, pid: %s, err: %s", pid, err)
+	}
+
+	networkName := networkFieldValue.Name
+	if networkName == "" {
+		return "", fmt.Errorf("Failed to parse network")
+	}
+
+	// return the network name formatting unique to this API
+	return fmt.Sprintf("projects/%v/global/networks/%v", project.ProjectNumber, networkName), nil
+
+}
+
+const parentServicePattern = "^services/.+$"
+
+// NOTE(craigatgoogle): An out of band aspect of this API is that it requires the service name to be
+// formatted as "services/<serviceName>"
+func formatParentService(service string) string {
+	r := regexp.MustCompile(parentServicePattern)
+	if !r.MatchString(service) {
+		return fmt.Sprintf("services/%s", service)
+	} else {
+		return service
+	}
+}

--- a/provider/terraform/resources/resource_service_networking_connection.go.erb
+++ b/provider/terraform/resources/resource_service_networking_connection.go.erb
@@ -1,3 +1,6 @@
+<% autogen_exception -%>
+package google
+<% unless version.nil? || version == 'ga' -%>
 package google
 
 import (
@@ -233,3 +236,6 @@ func formatParentService(service string) string {
 		return service
 	}
 }
+<% else %>
+// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
+<% end -%>

--- a/provider/terraform/resources/resource_service_networking_connection.go.erb
+++ b/provider/terraform/resources/resource_service_networking_connection.go.erb
@@ -1,7 +1,6 @@
 <% autogen_exception -%>
 package google
 <% unless version.nil? || version == 'ga' -%>
-package google
 
 import (
 	"fmt"

--- a/provider/terraform/tests/resource_service_networking_connection_test.go
+++ b/provider/terraform/tests/resource_service_networking_connection_test.go
@@ -1,0 +1,92 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccServiceNetworkingConnectionCreate(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccServiceNetworkingConnection(
+					fmt.Sprintf("tf-test-%s", acctest.RandString(10)),
+					fmt.Sprintf("tf-test-%s", acctest.RandString(10)),
+					"servicenetworking.googleapis.com",
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "google_service_networking_connection.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+
+}
+
+func TestAccServiceNetworkingConnectionUpdate(t *testing.T) {
+	t.Parallel()
+
+	network := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccServiceNetworkingConnection(
+					network,
+					fmt.Sprintf("tf-test-%s", acctest.RandString(10)),
+					"servicenetworking.googleapis.com",
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "google_service_networking_connection.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			resource.TestStep{
+				Config: testAccServiceNetworkingConnection(
+					network,
+					fmt.Sprintf("tf-test-%s", acctest.RandString(10)),
+					"servicenetworking.googleapis.com",
+				),
+			},
+			resource.TestStep{
+				ResourceName:      "google_service_networking_connection.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+
+}
+
+func testAccServiceNetworkingConnection(networkName, addressRangeName, serviceName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+	name       = "%s"
+}
+
+resource "google_compute_global_address" "foobar" {
+	name          = "%s"
+	purpose       = "VPC_PEERING"
+	address_type = "INTERNAL"
+	prefix_length = 16
+	network       = "${google_compute_network.foobar.self_link}"
+}
+
+resource "google_service_networking_connection" "foobar" {
+	network       = "${google_compute_network.foobar.self_link}"
+	service       = "%s"
+	reserved_peering_ranges = ["${google_compute_global_address.foobar.name}"]
+}
+`, networkName, addressRangeName, serviceName)
+}

--- a/provider/terraform/tests/resource_service_networking_connection_test.go.erb
+++ b/provider/terraform/tests/resource_service_networking_connection_test.go.erb
@@ -1,4 +1,6 @@
+<% autogen_exception -%>
 package google
+<% unless version.nil? || version == 'ga' -%>
 
 import (
 	"fmt"
@@ -90,3 +92,7 @@ resource "google_service_networking_connection" "foobar" {
 }
 `, networkName, addressRangeName, serviceName)
 }
+<% else %>
+// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
+<% end -%>
+

--- a/provider/terraform/utils/config.go.erb
+++ b/provider/terraform/utils/config.go.erb
@@ -44,6 +44,9 @@ import (
 	"google.golang.org/api/redis/v1beta1"
 	"google.golang.org/api/runtimeconfig/v1beta1"
 	"google.golang.org/api/servicemanagement/v1"
+<% unless version.nil? || version == 'ga' -%>
+	"google.golang.org/api/servicenetworking/v1beta"
+<% end -%>
 	"google.golang.org/api/serviceusage/v1beta1"
 	"google.golang.org/api/sourcerepo/v1"
 	"google.golang.org/api/spanner/v1"
@@ -97,6 +100,9 @@ type Config struct {
 	clientCloudFunctions         *cloudfunctions.Service
 	clientCloudIoT               *cloudiot.Service
 	clientAppEngine              *appengine.APIService
+	<% unless version.nil? || version == 'ga' -%>
+	clientServiceNetworking      *servicenetworking.APIService
+	<% end -%>
 
 	bigtableClientFactory *BigtableClientFactory
 }
@@ -392,6 +398,15 @@ func (c *Config) loadAndValidate() error {
 		return err
 	}
 	c.clientComposer.UserAgent = userAgent
+
+	<% unless version.nil? || version == 'ga' -%>
+	log.Printf("[INFO] Instantiating Service Networking Client...")
+	c.clientServiceNetworking, err = servicenetworking.New(client)
+	if err != nil {
+		return err
+	}
+	c.clientServiceNetworking.UserAgent = userAgent
+	<% end -%>
 
 	return nil
 }

--- a/provider/terraform/utils/provider.go.erb
+++ b/provider/terraform/utils/provider.go.erb
@@ -197,6 +197,9 @@ func Provider() terraform.ResourceProvider {
 				"google_kms_crypto_key":                        resourceKmsCryptoKey(),
 				"google_kms_crypto_key_iam_binding":            ResourceIamBindingWithImport(IamKmsCryptoKeySchema, NewKmsCryptoKeyIamUpdater, CryptoIdParseFunc),
 				"google_kms_crypto_key_iam_member":             ResourceIamMemberWithImport(IamKmsCryptoKeySchema, NewKmsCryptoKeyIamUpdater, CryptoIdParseFunc),
+<% unless version.nil? || version == 'ga' -%>
+				"google_service_networking_connection":         resourceServiceNetworkingConnection(),
+<% end -%>
 				"google_sourcerepo_repository":                 resourceSourceRepoRepository(),
 				"google_spanner_instance":                      resourceSpannerInstance(),
 				"google_spanner_instance_iam_binding":          ResourceIamBindingWithImport(IamSpannerInstanceSchema, NewSpannerInstanceIamUpdater, SpannerInstanceIdParseFunc),

--- a/provider/terraform/utils/service_networking_operation.go
+++ b/provider/terraform/utils/service_networking_operation.go
@@ -1,0 +1,82 @@
+package google
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/servicenetworking/v1beta"
+)
+
+type ServiceNetworkingOperationWaiter struct {
+	Service *servicenetworking.APIService
+	Op      *servicenetworking.Operation
+}
+
+func (w *ServiceNetworkingOperationWaiter) RefreshFunc() resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		op, err := w.Service.Operations.Get(w.Op.Name).Do()
+
+		if e, ok := err.(*googleapi.Error); ok && (e.Code == 429 || e.Code == 503) {
+			return w.Op, fmt.Sprintf("%v", op.Done), nil
+		} else if err != nil {
+			return nil, "", err
+		}
+
+		log.Printf("[DEBUG] Got done: %v  when asking for operation %q", op.Done, w.Op.Name)
+
+		return op, fmt.Sprintf("%v", op.Done), nil
+	}
+}
+
+func (w *ServiceNetworkingOperationWaiter) Conf() *resource.StateChangeConf {
+	return &resource.StateChangeConf{
+		Pending: []string{"false"},
+		Target:  []string{"true"},
+		Refresh: w.RefreshFunc(),
+	}
+}
+
+// ServiceNetworkingOperationError wraps servicenetworking.Status and implements
+// the error interface so it can be returned.
+type ServiceNetworkingOperationError servicenetworking.Status
+
+func (e ServiceNetworkingOperationError) Error() string {
+	return e.Message
+}
+
+func serviceNetworkingOperationWait(config *Config, op *servicenetworking.Operation, activity string) error {
+	return serviceNetworkingOperationWaitTime(config, op, activity, 10)
+}
+
+func serviceNetworkingOperationWaitTime(config *Config, op *servicenetworking.Operation, activity string, timeoutMinutes int) error {
+	if op.Done {
+		if op.Error != nil {
+			return ServiceNetworkingOperationError(*op.Error)
+		}
+		return nil
+	}
+
+	w := &ServiceNetworkingOperationWaiter{
+		Service: config.clientServiceNetworking,
+		Op:      op,
+	}
+
+	state := w.Conf()
+	state.Timeout = time.Duration(timeoutMinutes) * time.Minute
+	state.MinTimeout = 2 * time.Second
+	state.Delay = 5 * time.Second
+	opRaw, err := state.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for %s (op %s): %s", activity, op.Name, err)
+	}
+
+	op = opRaw.(*servicenetworking.Operation)
+	if op.Error != nil {
+		return ServiceNetworkingOperationError(*op.Error)
+	}
+
+	return nil
+}

--- a/provider/terraform/utils/service_networking_operation.go.erb
+++ b/provider/terraform/utils/service_networking_operation.go.erb
@@ -1,4 +1,6 @@
+<% autogen_exception -%>
 package google
+<% unless version.nil? || version == 'ga' -%>
 
 import (
 	"fmt"
@@ -80,3 +82,6 @@ func serviceNetworkingOperationWaitTime(config *Config, op *servicenetworking.Op
 
 	return nil
 }
+<% else %>
+// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
+<% end -%>

--- a/provider/terraform/website/docs/r/service_networking_connection.html.markdown
+++ b/provider/terraform/website/docs/r/service_networking_connection.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "google"
+page_title: "Google: google_service_networking_connection"
+sidebar_current: "docs-google-service-networking-connection"
+description: |-
+  Manages creating a private VPC connection to a service provider.
+---
+
+# google\_service\_networking\_connection
+
+Manages a private VPC connection with a GCP service provider. For more information see
+[the official documentation](https://cloud.google.com/vpc/docs/configure-private-services-access#creating-connection)
+and
+[API](https://cloud.google.com/service-infrastructure/docs/service-networking/reference/rest/v1/services.connections).
+
+## Example usage
+
+```hcl
+resource "google_compute_network" "peering_network" {
+  name = "peering_network"
+}
+
+resource "google_compute_global_address" "private_ip_alloc" {
+  name          = "private_ip_alloc"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = "${google_compute_network.peering_network.self_link}"
+}
+
+resource "google_service_networking_connection" "foobar" {
+  network                 = "${google_compute_network.peering_network.self_link}"
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = ["${google_compute_global_address.private_ip_alloc.name}"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `network` - (Required) Name of VPC network connected with service producers using VPC peering.
+
+* `service` - (Required) Provider peering service that is managing peering connectivity for a
+  service provider organization. For Google services that support this functionality it is
+  'servicenetworking.googleapis.com'.
+
+* `reserved_peering_ranges` - (Required) Named IP address range(s) of PEERING type reserved for
+  this service provider. Note that invoking this method with a different range when connection
+  is already established will not reallocate already provisioned service producer subnetworks.

--- a/provider/terraform/website/docs/r/service_networking_connection.html.markdown
+++ b/provider/terraform/website/docs/r/service_networking_connection.html.markdown
@@ -8,6 +8,9 @@ description: |-
 
 # google\_service\_networking\_connection
 
+~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
+
 Manages a private VPC connection with a GCP service provider. For more information see
 [the official documentation](https://cloud.google.com/vpc/docs/configure-private-services-access#creating-connection)
 and

--- a/provider/terraform/website/google.erb
+++ b/provider/terraform/website/google.erb
@@ -626,13 +626,13 @@
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-service-networking") %>>  
-    <a href="#">Google Service Networking Resources</a> 
-    <ul class="nav nav-visible">  
-      <li<%= sidebar_current("docs-google-service-networking-connection") %>> 
-      <a href="/docs/providers/google/r/service_networking_connection.html">google_service_networking_connection</a>  
-      </li> 
-    </ul> 
+    <li<%= sidebar_current("docs-google-service-networking") %>>
+    <a href="#">Google Service Networking Resources</a>
+    <ul class="nav nav-visible">
+      <li<%= sidebar_current("docs-google-service-networking-connection") %>>
+      <a href="/docs/providers/google/r/service_networking_connection.html">google_service_networking_connection</a>
+      </li>
+    </ul>
     </li>
 
     <li<%= sidebar_current("docs-google-sourcerepo") %>>

--- a/provider/terraform/website/google.erb
+++ b/provider/terraform/website/google.erb
@@ -626,6 +626,15 @@
     </ul>
     </li>
 
+    <li<%= sidebar_current("docs-google-service-networking") %>>  
+    <a href="#">Google Service Networking Resources</a> 
+    <ul class="nav nav-visible">  
+      <li<%= sidebar_current("docs-google-service-networking-connection") %>> 
+      <a href="/docs/providers/google/r/service_networking_connection.html">google_service_networking_connection</a>  
+      </li> 
+    </ul> 
+    </li>
+
     <li<%= sidebar_current("docs-google-sourcerepo") %>>
     <a href="#">Google Source Repositories Resources</a>
     <ul class="nav nav-visible">


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Copied over from https://github.com/terraform-providers/terraform-provider-google-beta/pull/84.
<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Add empty files because of copying over beta resources
### [terraform-beta]
Small changes to clean up the resource_service_networking_connection PR from #84.
## [ansible]
## [inspec]
