### PR TITLE
Remove old config.examples field.

### DIFF
--- a/products/pubsub/example.yaml
+++ b/products/pubsub/example.yaml
@@ -15,9 +15,6 @@
 # This is where custom code would be defined eventually.
 objects: !ruby/object:Api::Resource::HashArray
 
-# This is for a list of example files.
-examples: !ruby/object:Api::Resource::HashArray
-
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
   # All of these files will be copied verbatim.

--- a/products/resourcemanager/ansible.yaml
+++ b/products/resourcemanager/ansible.yaml
@@ -35,7 +35,6 @@ overrides: !ruby/object:Provider::ResourceOverrides
   Project: !ruby/object:Provider::Ansible::ResourceOverride
     return_if_object: |
 <%= lines(indent(compile('products/resourcemanager/helpers/ansible/return_if_object.py'), 6)) -%>
-examples: !ruby/object:Api::Resource::HashArray
 files: !ruby/object:Provider::Config::Files
   copy:
 <%= lines(indent(compile('provider/ansible/common~copy.yaml'), 4)) -%>

--- a/provider/config.rb
+++ b/provider/config.rb
@@ -25,7 +25,6 @@ module Provider
     attr_reader :overrides
     # Overrides for datasources
     attr_reader :datasources
-    attr_reader :examples
     attr_reader :properties # TODO(nelsonjr): Remove this once bug 193 is fixed.
     attr_reader :tests
     attr_reader :files

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -45,7 +45,6 @@ module Provider
       generate_objects(output_folder, types, version_name)
       copy_files(output_folder) \
         unless @config.files.nil? || @config.files.copy.nil?
-      compile_examples(output_folder) unless @config.examples.nil?
       compile_changelog(output_folder) unless @config.changelog.nil?
       # Compilation has to be the last step, as some files (e.g.
       # CONTRIBUTING.md) may depend on the list of all files previously copied

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -126,26 +126,6 @@ module Provider
       end
     end
 
-    def compile_file_map(output_folder, section, mapper)
-      create_object_list(section, mapper).each do |o|
-        compile_file_list(
-          output_folder,
-          o
-        )
-      end
-    end
-
-    # Creates an object list by calling a lambda
-    # This can be useful for converting a list of config values to something
-    # less human-centric.
-    def create_object_list(section, mapper)
-      @api.objects
-          .select { |o| section.key?(o.name) }
-          .map do |o|
-            Hash[section[o.name].map { |file| mapper.call(o, file) }]
-          end
-    end
-
     def compile_file_list(output_folder, files, data = {})
       files.each do |target, source|
         Google::LOGGER.debug "Compiling #{source} => #{target}"


### PR DESCRIPTION
So, I don't think anyone uses this anymore. Let's try removing it and see what happens!

Assuming the Magician succeeds, let's just get rid of the dead code.

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
