### PR TITLE
Move website nav bar to magic modules template

### DIFF
--- a/provider/terraform/common~compile.yaml
+++ b/provider/terraform/common~compile.yaml
@@ -13,6 +13,7 @@
 # These files contains code that needs to be compiled before being delivered to
 # the final module tree structure:
 <% dir = version_name == 'beta' ? 'google-beta' : 'google' -%>
+'website/google.erb': 'provider/terraform/website/google.erb'
 <%  Dir["provider/terraform/tests/*.go.erb"].each do |file_path|
     fname = file_path.split('/')[-1]
 -%>

--- a/provider/terraform/website/google.erb
+++ b/provider/terraform/website/google.erb
@@ -1,820 +1,828 @@
-<% wrap_layout :inner do %>
-  <% content_for :sidebar do %>
+<% autogen_exception -%>
+<%#
+ Hashicorp uses erb's to generate their website files. In order to run through the MM
+ generator we need to double escape their code with '<%%' 
+ -%>
+<%% wrap_layout :inner do %>
+  <%% content_for :sidebar do %>
   <div class="docs-sidebar hidden-print affix-top" role="complementary">
   <ul class="nav docs-sidenav">
-    <li<%= sidebar_current("docs-home") %>>
+    <li<%%= sidebar_current("docs-home") %>>
     <a class="back" href="/docs/providers/index.html">All Providers</a>
     </li>
 
-    <li<%= sidebar_current("docs-google-provider") %>>
+    <li<%%= sidebar_current("docs-google-provider") %>>
       <a href="/docs/providers/google/index.html">Google Provider</a>
       <ul class="nav nav-visible">
-        <li<%= sidebar_current("docs-google-provider-x") %>>
+        <li<%%= sidebar_current("docs-google-provider-x") %>>
           <a href="/docs/providers/google/index.html">Provider Info</a>
         </li>
-        <li<%= sidebar_current("docs-google-provider-getting-started") %>>
+        <li<%%= sidebar_current("docs-google-provider-getting-started") %>>
           <a href="/docs/providers/google/getting_started.html">Getting Started</a>
         </li>
-        <li<%= sidebar_current("docs-google-provider-reference") %>>
+        <li<%%= sidebar_current("docs-google-provider-reference") %>>
           <a href="/docs/providers/google/provider_reference.html">google provider reference</a>
         </li>
-        <li<%= sidebar_current("docs-google-provider-versions") %>>
+        <li<%%= sidebar_current("docs-google-provider-versions") %>>
           <a href="/docs/providers/google/provider_versions.html">Google Provider Versions</a>
         </li>
-        <li<%= sidebar_current("docs-google-provider-version-2-upgrade") %>>
+        <li<%%= sidebar_current("docs-google-provider-version-2-upgrade") %>>
           <a href="/docs/providers/google/version_2_upgrade.html">Version 2.0.0 Upgrade Guide</a>
         </li>
       </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-datasource") %>>
+    <li<%%= sidebar_current("docs-google-datasource") %>>
     <a href="#">Google Cloud Platform Data Sources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-datasource-active-folder") %>>
+      <li<%%= sidebar_current("docs-google-datasource-active-folder") %>>
       <a href="/docs/providers/google/d/google_active_folder.html">google_active_folder</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-billing-account") %>>
+      <li<%%= sidebar_current("docs-google-datasource-billing-account") %>>
         <a href="/docs/providers/google/d/google_billing_account.html">google_billing_account</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-client-config") %>>
+      <li<%%= sidebar_current("docs-google-datasource-client-config") %>>
         <a href="/docs/providers/google/d/datasource_client_config.html">google_client_config</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-cloudfunctions-function") %>>
+      <li<%%= sidebar_current("docs-google-datasource-cloudfunctions-function") %>>
         <a href="/docs/providers/google/d/datasource_cloudfunctions_function.html">google_cloudfunctions_function</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-address") %>>
+      <li<%%= sidebar_current("docs-google-datasource-compute-address") %>>
         <a href="/docs/providers/google/d/datasource_compute_address.html">google_compute_address</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-backend-service") %>>
+      <li<%%= sidebar_current("docs-google-datasource-compute-backend-service") %>>
       <a href="/docs/providers/google/d/datasource_google_compute_backend_service.html">google_compute_backend_service</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-default-service-account") %>>
+      <li<%%= sidebar_current("docs-google-datasource-compute-default-service-account") %>>
         <a href="/docs/providers/google/d/google_compute_default_service_account.html">google_compute_default_service_account</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-forwarding-rule") %>>
+      <li<%%= sidebar_current("docs-google-datasource-compute-forwarding-rule") %>>
         <a href="/docs/providers/google/d/datasource_compute_forwarding_rule.html">google_compute_forwarding_rule</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-global-address") %>>
+      <li<%%= sidebar_current("docs-google-datasource-compute-global-address") %>>
         <a href="/docs/providers/google/d/datasource_compute_global_address.html">google_compute_global_address</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-image") %>>
+      <li<%%= sidebar_current("docs-google-datasource-compute-image") %>>
         <a href="/docs/providers/google/d/datasource_compute_image.html">google_compute_image</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-instance-x") %>>
+      <li<%%= sidebar_current("docs-google-datasource-compute-instance-x") %>>
       <a href="/docs/providers/google/d/datasource_compute_instance.html">google_compute_instance</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-instance-group") %>>
+      <li<%%= sidebar_current("docs-google-datasource-compute-instance-group") %>>
       <a href="/docs/providers/google/d/google_compute_instance_group.html">google_compute_instance_group</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-lb-ip-ranges") %>>
+      <li<%%= sidebar_current("docs-google-datasource-compute-lb-ip-ranges") %>>
       <a href="/docs/providers/google/d/datasource_compute_lb_ip_ranges.html">google_compute_lb_ip_ranges</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-network") %>>
+      <li<%%= sidebar_current("docs-google-datasource-compute-network") %>>
         <a href="/docs/providers/google/d/datasource_compute_network.html">google_compute_network</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-region-instance-group") %>>
+      <li<%%= sidebar_current("docs-google-datasource-compute-region-instance-group") %>>
       <a href="/docs/providers/google/d/datasource_compute_region_instance_group.html">google_compute_region_instance_group</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-project-services") %>>
+      <li<%%= sidebar_current("docs-google-datasource-project-services") %>>
         <a href="/docs/providers/google/d/google_project_services.html">google_project_services</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-regions") %>>
+      <li<%%= sidebar_current("docs-google-datasource-compute-regions") %>>
       <a href="/docs/providers/google/d/google_compute_regions.html">google_compute_regions</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-ssl-policy") %>>
+      <li<%%= sidebar_current("docs-google-datasource-compute-ssl-policy") %>>
         <a href="/docs/providers/google/d/datasource_compute_ssl_policy.html">google_compute_ssl_policy</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-subnetwork") %>>
+      <li<%%= sidebar_current("docs-google-datasource-compute-subnetwork") %>>
         <a href="/docs/providers/google/d/datasource_compute_subnetwork.html">google_compute_subnetwork</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-vpn-gateway") %>>
+      <li<%%= sidebar_current("docs-google-datasource-compute-vpn-gateway") %>>
         <a href="/docs/providers/google/d/datasource_compute_vpn_gateway.html">google_compute_vpn_gateway</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-compute-zones") %>>
+      <li<%%= sidebar_current("docs-google-datasource-compute-zones") %>>
       <a href="/docs/providers/google/d/google_compute_zones.html">google_compute_zones</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-container-cluster") %>>
+      <li<%%= sidebar_current("docs-google-datasource-container-cluster") %>>
       <a href="/docs/providers/google/d/google_container_cluster.html">google_container_cluster</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-container-versions") %>>
+      <li<%%= sidebar_current("docs-google-datasource-container-versions") %>>
       <a href="/docs/providers/google/d/google_container_engine_versions.html">google_container_engine_versions</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-container-image") %>>
+      <li<%%= sidebar_current("docs-google-datasource-container-image") %>>
       <a href="/docs/providers/google/d/google_container_registry_image.html">google_container_registry_image</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-container-repo") %>>
+      <li<%%= sidebar_current("docs-google-datasource-container-repo") %>>
       <a href="/docs/providers/google/d/google_container_registry_repository.html">google_container_registry_repository</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-dns-managed-zone") %>>
+      <li<%%= sidebar_current("docs-google-datasource-dns-managed-zone") %>>
       <a href="/docs/providers/google/d/dns_managed_zone.html">google_dns_managed_zone</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-folder") %>>
+      <li<%%= sidebar_current("docs-google-datasource-folder") %>>
       <a href="/docs/providers/google/d/google_folder.html">google_folder</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-iam-policy") %>>
+      <li<%%= sidebar_current("docs-google-datasource-iam-policy") %>>
       <a href="/docs/providers/google/d/google_iam_policy.html">google_iam_policy</a>
       </li>
-      <li<%= sidebar_current("docs-google-kms-secret") %>>
+      <li<%%= sidebar_current("docs-google-kms-secret") %>>
       <a href="/docs/providers/google/d/google_kms_secret.html">google_kms_secret</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-netblock-ip-ranges") %>>
+      <li<%%= sidebar_current("docs-google-datasource-netblock-ip-ranges") %>>
       <a href="/docs/providers/google/d/datasource_google_netblock_ip_ranges.html">google_netblock_ip_ranges</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-organization") %>>
+      <li<%%= sidebar_current("docs-google-datasource-organization") %>>
       <a href="/docs/providers/google/d/google_organization.html">google_organization</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-project") %>>
+      <li<%%= sidebar_current("docs-google-datasource-project") %>>
         <a href="/docs/providers/google/d/google_project.html">google_project</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-service-account") %>>
+      <li<%%= sidebar_current("docs-google-datasource-service-account") %>>
         <a href="/docs/providers/google/d/datasource_google_service_account.html">google_service_account</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-service-account-key") %>>
+      <li<%%= sidebar_current("docs-google-datasource-service-account-key") %>>
         <a href="/docs/providers/google/d/datasource_google_service_account_key.html">google_service_account_key</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-signed_url") %>>
+      <li<%%= sidebar_current("docs-google-datasource-signed_url") %>>
         <a href="/docs/providers/google/d/signed_url.html">google_storage_object_signed_url</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-storage-project-service-account") %>>
+      <li<%%= sidebar_current("docs-google-datasource-storage-project-service-account") %>>
         <a href="/docs/providers/google/d/google_storage_project_service_account.html">google_storage_project_service_account</a>
       </li>
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-app-engine") %>>
+    <li<%%= sidebar_current("docs-google-app-engine") %>>
     <a href="#">Google App Engine Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-app-engine-application") %>>
+      <li<%%= sidebar_current("docs-google-app-engine-application") %>>
       <a href="/docs/providers/google/r/app_engine_application.html">google_app_engine_application</a>
       </li>
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-bigquery") %>>
+    <li<%%= sidebar_current("docs-google-bigquery") %>>
     <a href="#">Google BigQuery Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-bigquery-dataset") %>>
+      <li<%%= sidebar_current("docs-google-bigquery-dataset") %>>
       <a href="/docs/providers/google/r/bigquery_dataset.html">google_bigquery_dataset</a>
-      <li<%= sidebar_current("docs-google-bigquery-table") %>>
+      <li<%%= sidebar_current("docs-google-bigquery-table") %>>
       <a href="/docs/providers/google/r/bigquery_table.html">google_bigquery_table</a>
       </li>
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-bigtable") %>>
+    <li<%%= sidebar_current("docs-google-bigtable") %>>
     <a href="#">Google Bigtable Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-bigtable-instance") %>>
+      <li<%%= sidebar_current("docs-google-bigtable-instance") %>>
       <a href="/docs/providers/google/r/bigtable_instance.html">google_bigtable_instance</a>
-      <li<%= sidebar_current("docs-google-bigtable-table") %>>
+      <li<%%= sidebar_current("docs-google-bigtable-table") %>>
       <a href="/docs/providers/google/r/bigtable_table.html">google_bigtable_table</a>
       </li>
     </ul>
     </li>
-
-    <li<%= sidebar_current("docs-google-binary-authorization") %>>
+<% unless version.nil? || version == 'ga' %>
+    <li<%%= sidebar_current("docs-google-binary-authorization") %>>
     <a href="#">Google Binary Authorization Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-binary-authorization-attestor") %>>
+      <li<%%= sidebar_current("docs-google-binary-authorization-attestor") %>>
       <a href="/docs/providers/google/r/binaryauthorization_attestor.html">google_binary_authorization_attestor</a>
-      <li<%= sidebar_current("docs-google-binary-authorization-policy") %>>
+      <li<%%= sidebar_current("docs-google-binary-authorization-policy") %>>
       <a href="/docs/providers/google/r/binaryauthorization_policy.html">google_binary_authorization_policy</a>
       </li>
     </ul>
     </li>
+<% end -%>
 
-    <li<%= sidebar_current("docs-google-cloudbuild") %>>
+    <li<%%= sidebar_current("docs-google-cloudbuild") %>>
     <a href="#">Google Cloud Build Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-cloudbuild-trigger") %>>
+      <li<%%= sidebar_current("docs-google-cloudbuild-trigger") %>>
       <a href="/docs/providers/google/r/cloudbuild_trigger.html">google_cloudbuild_trigger</a>
       </li>
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-composer") %>>
+    <li<%%= sidebar_current("docs-google-composer") %>>
       <a href="#">Google Cloud Composer Resources</a>
       <ul class="nav nav-visible">
-        <li<%= sidebar_current("docs-google-composer-environment") %>>
+        <li<%%= sidebar_current("docs-google-composer-environment") %>>
           <a href="/docs/providers/google/r/composer_environment.html">google_composer_environment</a>
         </li>
       </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-cloudfunctions") %>>
+    <li<%%= sidebar_current("docs-google-cloudfunctions") %>>
     <a href="#">Google Cloud Functions Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-cloudfunctions-function") %>>
+      <li<%%= sidebar_current("docs-google-cloudfunctions-function") %>>
       <a href="/docs/providers/google/r/cloudfunctions_function.html">google_cloudfunctions_function</a>
       </li>
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-(project|service)") %>>
+    <li<%%= sidebar_current("docs-google-(project|service)") %>>
     <a href="#">Google Cloud Platform Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-folder-x") %>>
+      <li<%%= sidebar_current("docs-google-folder-x") %>>
         <a href="/docs/providers/google/r/google_folder.html">google_folder</a>
       </li>
-      <li<%= sidebar_current("docs-google-folder-iam-binding") %>>
+      <li<%%= sidebar_current("docs-google-folder-iam-binding") %>>
         <a href="/docs/providers/google/r/google_folder_iam_binding.html">google_folder_iam_binding</a>
       </li>
-      <li<%= sidebar_current("docs-google-folder-iam-member") %>>
+      <li<%%= sidebar_current("docs-google-folder-iam-member") %>>
         <a href="/docs/providers/google/r/google_folder_iam_member.html">google_folder_iam_member</a>
       </li>
-      <li<%= sidebar_current("docs-google-folder-iam-policy") %>>
+      <li<%%= sidebar_current("docs-google-folder-iam-policy") %>>
         <a href="/docs/providers/google/r/google_folder_iam_policy.html">google_folder_iam_policy</a>
       </li>
-      <li<%= sidebar_current("docs-google-folder-organization-policy") %>>
+      <li<%%= sidebar_current("docs-google-folder-organization-policy") %>>
         <a href="/docs/providers/google/r/google_folder_organization_policy.html">google_folder_organization_policy</a>
       </li>
-      <li<%= sidebar_current("docs-google-organization-policy") %>>
+      <li<%%= sidebar_current("docs-google-organization-policy") %>>
         <a href="/docs/providers/google/r/google_organization_policy.html">google_organization_policy</a>
       </li>
-      <li<%= sidebar_current("docs-google-organization-iam-binding") %>>
+      <li<%%= sidebar_current("docs-google-organization-iam-binding") %>>
         <a href="/docs/providers/google/r/google_organization_iam_binding.html">google_organization_iam_binding</a>
       </li>
-      <li<%= sidebar_current("docs-google-organization-iam-custom-role") %>>
+      <li<%%= sidebar_current("docs-google-organization-iam-custom-role") %>>
         <a href="/docs/providers/google/r/google_organization_iam_custom_role.html">google_organization_iam_custom_role</a>
       </li>
-      <li<%= sidebar_current("docs-google-organization-iam-member") %>>
+      <li<%%= sidebar_current("docs-google-organization-iam-member") %>>
         <a href="/docs/providers/google/r/google_organization_iam_member.html">google_organization_iam_member</a>
       </li>
-      <li<%= sidebar_current("docs-google-organization-iam-policy") %>>
+      <li<%%= sidebar_current("docs-google-organization-iam-policy") %>>
         <a href="/docs/providers/google/r/google_organization_iam_policy.html">google_organization_iam_policy</a>
       </li>
-      <li<%= sidebar_current("docs-google-project-x") %>>
+      <li<%%= sidebar_current("docs-google-project-x") %>>
         <a href="/docs/providers/google/r/google_project.html">google_project</a>
       </li>
-      <li<%= sidebar_current("docs-google-project-iam-x") %>>
+      <li<%%= sidebar_current("docs-google-project-iam-x") %>>
         <a href="/docs/providers/google/r/google_project_iam.html">google_project_iam_binding</a>
       </li>
-      <li<%= sidebar_current("docs-google-project-iam-x") %>>
+      <li<%%= sidebar_current("docs-google-project-iam-x") %>>
         <a href="/docs/providers/google/r/google_project_iam.html">google_project_iam_member</a>
       </li>
-      <li<%= sidebar_current("docs-google-project-iam-x") %>>
+      <li<%%= sidebar_current("docs-google-project-iam-x") %>>
         <a href="/docs/providers/google/r/google_project_iam.html">google_project_iam_policy</a>
       </li>
-      <li<%= sidebar_current("docs-google-project-iam-custom-role") %>>
+      <li<%%= sidebar_current("docs-google-project-iam-custom-role") %>>
         <a href="/docs/providers/google/r/google_project_iam_custom_role.html">google_project_iam_custom_role</a>
       </li>
-      <li<%= sidebar_current("docs-google-project-organization-policy") %>>
+      <li<%%= sidebar_current("docs-google-project-organization-policy") %>>
         <a href="/docs/providers/google/r/google_project_organization_policy.html">google_project_organization_policy</a>
       </li>
-      <li<%= sidebar_current("docs-google-project-service-x") %>>
+      <li<%%= sidebar_current("docs-google-project-service-x") %>>
         <a href="/docs/providers/google/r/google_project_service.html">google_project_service</a>
       </li>
-      <li<%= sidebar_current("docs-google-project-services") %>>
+      <li<%%= sidebar_current("docs-google-project-services") %>>
         <a href="/docs/providers/google/r/google_project_services.html">google_project_services</a>
       </li>
-      <li<%= sidebar_current("docs-google-project-usage-export-bucket") %>>
+      <li<%%= sidebar_current("docs-google-project-usage-export-bucket") %>>
         <a href="/docs/providers/google/r/usage_export_bucket.html">google_project_usage_export_bucket</a>
       </li>
-      <li<%= sidebar_current("docs-google-resource-manager-lien") %>>
+      <li<%%= sidebar_current("docs-google-resource-manager-lien") %>>
         <a href="/docs/providers/google/r/resourcemanager_lien.html">google_resource_manager_lien</a>
       </li>
-      <li<%= sidebar_current("docs-google-service-account-x") %>>
+      <li<%%= sidebar_current("docs-google-service-account-x") %>>
         <a href="/docs/providers/google/r/google_service_account.html">google_service_account</a>
       </li>
-      <li<%= sidebar_current("docs-google-service-account-iam") %>>
+      <li<%%= sidebar_current("docs-google-service-account-iam") %>>
         <a href="/docs/providers/google/r/google_service_account_iam.html">google_service_account_iam_binding</a>
       </li>
-      <li<%= sidebar_current("docs-google-service-account-iam") %>>
+      <li<%%= sidebar_current("docs-google-service-account-iam") %>>
         <a href="/docs/providers/google/r/google_service_account_iam.html">google_service_account_iam_member</a>
       </li>
-      <li<%= sidebar_current("docs-google-service-account-iam") %>>
+      <li<%%= sidebar_current("docs-google-service-account-iam") %>>
         <a href="/docs/providers/google/r/google_service_account_iam.html">google_service_account_iam_policy</a>
       </li>
-      <li<%= sidebar_current("docs-google-service-account-key") %>>
+      <li<%%= sidebar_current("docs-google-service-account-key") %>>
       <a href="/docs/providers/google/r/google_service_account_key.html">google_service_account_key</a>
       </li>
 
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-compute") %>>
+    <li<%%= sidebar_current("docs-google-compute") %>>
     <a href="#">Google Compute Engine Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-compute-address") %>>
+      <li<%%= sidebar_current("docs-google-compute-address") %>>
       <a href="/docs/providers/google/r/compute_address.html">google_compute_address</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-attached-disk") %>>
+      <li<%%= sidebar_current("docs-google-compute-attached-disk") %>>
       <a href="/docs/providers/google/r/compute_attached_disk.html">google_compute_attached_disk</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-autoscaler") %>>
+      <li<%%= sidebar_current("docs-google-compute-autoscaler") %>>
       <a href="/docs/providers/google/r/compute_autoscaler.html">google_compute_autoscaler</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-backend-bucket") %>>
+      <li<%%= sidebar_current("docs-google-compute-backend-bucket") %>>
       <a href="/docs/providers/google/r/compute_backend_bucket.html">google_compute_backend_bucket</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-backend-service") %>>
+      <li<%%= sidebar_current("docs-google-compute-backend-service") %>>
       <a href="/docs/providers/google/r/compute_backend_service.html">google_compute_backend_service</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-disk") %>>
+      <li<%%= sidebar_current("docs-google-compute-disk") %>>
       <a href="/docs/providers/google/r/compute_disk.html">google_compute_disk</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-firewall") %>>
+      <li<%%= sidebar_current("docs-google-compute-firewall") %>>
       <a href="/docs/providers/google/r/compute_firewall.html">google_compute_firewall</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-forwarding-rule") %>>
+      <li<%%= sidebar_current("docs-google-compute-forwarding-rule") %>>
       <a href="/docs/providers/google/r/compute_forwarding_rule.html">google_compute_forwarding_rule</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-global-address") %>>
+      <li<%%= sidebar_current("docs-google-compute-global-address") %>>
       <a href="/docs/providers/google/r/compute_global_address.html">google_compute_global_address</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-global-forwarding-rule") %>>
+      <li<%%= sidebar_current("docs-google-compute-global-forwarding-rule") %>>
       <a href="/docs/providers/google/r/compute_global_forwarding_rule.html">google_compute_global_forwarding_rule</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-health-check") %>>
+      <li<%%= sidebar_current("docs-google-compute-health-check") %>>
       <a href="/docs/providers/google/r/compute_health_check.html">google_compute_health_check</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-http-health-check") %>>
+      <li<%%= sidebar_current("docs-google-compute-http-health-check") %>>
       <a href="/docs/providers/google/r/compute_http_health_check.html">google_compute_http_health_check</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-https-health-check") %>>
+      <li<%%= sidebar_current("docs-google-compute-https-health-check") %>>
       <a href="/docs/providers/google/r/compute_https_health_check.html">google_compute_https_health_check</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-image") %>>
+      <li<%%= sidebar_current("docs-google-compute-image") %>>
       <a href="/docs/providers/google/r/compute_image.html">google_compute_image</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-instance-x") %>>
+      <li<%%= sidebar_current("docs-google-compute-instance-x") %>>
       <a href="/docs/providers/google/r/compute_instance.html">google_compute_instance</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-instance-from-template") %>>
+      <li<%%= sidebar_current("docs-google-compute-instance-from-template") %>>
       <a href="/docs/providers/google/r/compute_instance_from_template.html">google_compute_instance_from_template</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-instance-group-x") %>>
+      <li<%%= sidebar_current("docs-google-compute-instance-group-x") %>>
       <a href="/docs/providers/google/r/compute_instance_group.html">google_compute_instance_group</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-instance-group-manager") %>>
+      <li<%%= sidebar_current("docs-google-compute-instance-group-manager") %>>
       <a href="/docs/providers/google/r/compute_instance_group_manager.html">google_compute_instance_group_manager</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-instance-template") %>>
+      <li<%%= sidebar_current("docs-google-compute-instance-template") %>>
       <a href="/docs/providers/google/r/compute_instance_template.html">google_compute_instance_template</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-interconnect-attachment") %>>
+      <li<%%= sidebar_current("docs-google-compute-interconnect-attachment") %>>
       <a href="/docs/providers/google/r/compute_interconnect_attachment.html">google_compute_interconnect_attachment</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-network-x") %>>
+      <li<%%= sidebar_current("docs-google-compute-network-x") %>>
       <a href="/docs/providers/google/r/compute_network.html">google_compute_network</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-network-peering") %>>
+      <li<%%= sidebar_current("docs-google-compute-network-peering") %>>
       <a href="/docs/providers/google/r/compute_network_peering.html">google_compute_network_peering</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-project-metadata") %>>
+      <li<%%= sidebar_current("docs-google-compute-project-metadata") %>>
       <a href="/docs/providers/google/r/compute_project_metadata.html">google_compute_project_metadata</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-project-metadata-item") %>>
+      <li<%%= sidebar_current("docs-google-compute-project-metadata-item") %>>
       <a href="/docs/providers/google/r/compute_project_metadata_item.html">google_compute_project_metadata_item</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-region-autoscaler") %>>
+      <li<%%= sidebar_current("docs-google-compute-region-autoscaler") %>>
       <a href="/docs/providers/google/r/compute_region_autoscaler.html">google_compute_region_autoscaler</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-region-backend-service") %>>
+      <li<%%= sidebar_current("docs-google-compute-region-backend-service") %>>
       <a href="/docs/providers/google/r/compute_region_backend_service.html">google_compute_region_backend_service</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-region-disk") %>>
+      <li<%%= sidebar_current("docs-google-compute-region-disk") %>>
       <a href="/docs/providers/google/r/compute_region_disk.html">google_compute_region_disk</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-region-instance-group-manager") %>>
+      <li<%%= sidebar_current("docs-google-compute-region-instance-group-manager") %>>
       <a href="/docs/providers/google/r/compute_region_instance_group_manager.html">google_compute_region_instance_group_manager</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-route-x") %>>
+      <li<%%= sidebar_current("docs-google-compute-route-x") %>>
       <a href="/docs/providers/google/r/compute_route.html">google_compute_route</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-router-x") %>>
+      <li<%%= sidebar_current("docs-google-compute-router-x") %>>
       <a href="/docs/providers/google/r/compute_router.html">google_compute_router</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-router-interface") %>>
+      <li<%%= sidebar_current("docs-google-compute-router-interface") %>>
       <a href="/docs/providers/google/r/compute_router_interface.html">google_compute_router_interface</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-router-peer") %>>
+      <li<%%= sidebar_current("docs-google-compute-router-peer") %>>
       <a href="/docs/providers/google/r/compute_router_peer.html">google_compute_router_peer</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-security-policy") %>>
+      <li<%%= sidebar_current("docs-google-compute-security-policy") %>>
       <a href="/docs/providers/google/r/compute_security_policy.html">google_compute_security_policy</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-shared-vpc-host-project") %>>
+      <li<%%= sidebar_current("docs-google-compute-shared-vpc-host-project") %>>
       <a href="/docs/providers/google/r/compute_shared_vpc_host_project.html">google_compute_shared_vpc_host_project</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-shared-vpc-service-project") %>>
+      <li<%%= sidebar_current("docs-google-compute-shared-vpc-service-project") %>>
       <a href="/docs/providers/google/r/compute_shared_vpc_service_project.html">google_compute_shared_vpc_service_project</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-snapshot") %>>
+      <li<%%= sidebar_current("docs-google-compute-snapshot") %>>
 			<a href="/docs/providers/google/r/compute_snapshot.html">google_compute_snapshot</a>
 			</li>
 
-      <li<%= sidebar_current("docs-google-compute-ssl-certificate") %>>
+      <li<%%= sidebar_current("docs-google-compute-ssl-certificate") %>>
       <a href="/docs/providers/google/r/compute_ssl_certificate.html">google_compute_ssl_certificate</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-ssl-policy") %>>
+      <li<%%= sidebar_current("docs-google-compute-ssl-policy") %>>
       <a href="/docs/providers/google/r/compute_ssl_policy.html">google_compute_ssl_policy</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-subnetwork-x") %>>
+      <li<%%= sidebar_current("docs-google-compute-subnetwork-x") %>>
       <a href="/docs/providers/google/r/compute_subnetwork.html">google_compute_subnetwork</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-subnetwork-iam") %>>
+      <li<%%= sidebar_current("docs-google-compute-subnetwork-iam") %>>
         <a href="/docs/providers/google/r/compute_subnetwork_iam.html">google_compute_subnetwork_iam_binding</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-subnetwork-iam") %>>
+      <li<%%= sidebar_current("docs-google-compute-subnetwork-iam") %>>
         <a href="/docs/providers/google/r/compute_subnetwork_iam.html">google_compute_subnetwork_iam_member</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-subnetwork-iam") %>>
+      <li<%%= sidebar_current("docs-google-compute-subnetwork-iam") %>>
         <a href="/docs/providers/google/r/compute_subnetwork_iam.html">google_compute_subnetwork_iam_policy</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-target-http-proxy") %>>
+      <li<%%= sidebar_current("docs-google-compute-target-http-proxy") %>>
       <a href="/docs/providers/google/r/compute_target_http_proxy.html">google_compute_target_http_proxy</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-target-https-proxy") %>>
+      <li<%%= sidebar_current("docs-google-compute-target-https-proxy") %>>
       <a href="/docs/providers/google/r/compute_target_https_proxy.html">google_compute_target_https_proxy</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-target-ssl-proxy") %>>
+      <li<%%= sidebar_current("docs-google-compute-target-ssl-proxy") %>>
       <a href="/docs/providers/google/r/compute_target_ssl_proxy.html">google_compute_target_ssl_proxy</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-target-tcp-proxy") %>>
+      <li<%%= sidebar_current("docs-google-compute-target-tcp-proxy") %>>
       <a href="/docs/providers/google/r/compute_target_tcp_proxy.html">google_compute_target_tcp_proxy</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-target-pool") %>>
+      <li<%%= sidebar_current("docs-google-compute-target-pool") %>>
       <a href="/docs/providers/google/r/compute_target_pool.html">google_compute_target_pool</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-url-map") %>>
+      <li<%%= sidebar_current("docs-google-compute-url-map") %>>
       <a href="/docs/providers/google/r/compute_url_map.html">google_compute_url_map</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-vpn-gateway") %>>
+      <li<%%= sidebar_current("docs-google-compute-vpn-gateway") %>>
       <a href="/docs/providers/google/r/compute_vpn_gateway.html">google_compute_vpn_gateway</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-compute-vpn-tunnel") %>>
+      <li<%%= sidebar_current("docs-google-compute-vpn-tunnel") %>>
       <a href="/docs/providers/google/r/compute_vpn_tunnel.html">google_compute_vpn_tunnel</a>
       </li>
     </ul>
     </li>
-
-    <li<%= sidebar_current("docs-google-container-analysis") %>>
+<% unless version.nil? || version == 'ga' %>
+    <li<%%= sidebar_current("docs-google-container-analysis") %>>
     <a href="#">Google Container Analysis Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-container-analysis-note") %>>
+      <li<%%= sidebar_current("docs-google-container-analysis-note") %>>
       <a href="/docs/providers/google/r/containeranalysis_note.html">google_container_analysis_note</a>
       </li>
     </ul>
     </li>
+<% end -%>
 
-    <li<%= sidebar_current("docs-google-container") %>>
+    <li<%%= sidebar_current("docs-google-container") %>>
     <a href="#">Google Kubernetes (Container) Engine Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-container-cluster") %>>
+      <li<%%= sidebar_current("docs-google-container-cluster") %>>
       <a href="/docs/providers/google/r/container_cluster.html">google_container_cluster</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-container-node-pool") %>>
+      <li<%%= sidebar_current("docs-google-container-node-pool") %>>
       <a href="/docs/providers/google/r/container_node_pool.html">google_container_node_pool</a>
       </li>
     </ul>
     </li>
 
 
-    <li<%= sidebar_current("docs-google-dataflow") %>>
+    <li<%%= sidebar_current("docs-google-dataflow") %>>
     <a href="#">Google Dataflow Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-dataflow-job") %>>
+      <li<%%= sidebar_current("docs-google-dataflow-job") %>>
           <a href="/docs/providers/google/r/dataflow_job.html">google_dataflow_job</a>
       </li>
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-dataproc") %>>
+    <li<%%= sidebar_current("docs-google-dataproc") %>>
         <a href="#">Google Dataproc Resources</a>
         <ul class="nav nav-visible">
-          <li<%= sidebar_current("docs-google-dataproc-cluster") %>>
+          <li<%%= sidebar_current("docs-google-dataproc-cluster") %>>
           <a href="/docs/providers/google/r/dataproc_cluster.html">google_dataproc_cluster</a>
           </li>
         </ul>
         <ul class="nav nav-visible">
-          <li<%= sidebar_current("docs-google-dataproc-job") %>>
+          <li<%%= sidebar_current("docs-google-dataproc-job") %>>
           <a href="/docs/providers/google/r/dataproc_job.html">google_dataproc_job</a>
           </li>
         </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-dns") %>>
+    <li<%%= sidebar_current("docs-google-dns") %>>
     <a href="#">Google DNS Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-dns-managed-zone") %>>
+      <li<%%= sidebar_current("docs-google-dns-managed-zone") %>>
       <a href="/docs/providers/google/r/dns_managed_zone.html">google_dns_managed_zone</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-dns-record-set") %>>
+      <li<%%= sidebar_current("docs-google-dns-record-set") %>>
       <a href="/docs/providers/google/r/dns_record_set.html">google_dns_record_set</a>
       </li>
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-endpoints") %>>
+    <li<%%= sidebar_current("docs-google-endpoints") %>>
     <a href="#">Google Endpoints Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-endpoints-service") %>>
+      <li<%%= sidebar_current("docs-google-endpoints-service") %>>
           <a href="/docs/providers/google/r/endpoints_service.html">google_endpoints_service</a>
       </li>
     </ul>
     </li>
-
-    <li<%= sidebar_current("docs-google-filestore") %>>
+<% unless version.nil? || version == 'ga' %>
+    <li<%%= sidebar_current("docs-google-filestore") %>>
     <a href="#">Google Filestore Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-filestore-instance") %>>
+      <li<%%= sidebar_current("docs-google-filestore-instance") %>>
           <a href="/docs/providers/google/r/filestore_instance.html">google_filestore_instance</a>
       </li>
     </ul>
     </li>
+<% end -%>
 
-    <li<%= sidebar_current("docs-google-pubsub") %>>
+    <li<%%= sidebar_current("docs-google-pubsub") %>>
     <a href="#">Google PubSub Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-pubsub-subscription-x") %>>
+      <li<%%= sidebar_current("docs-google-pubsub-subscription-x") %>>
       <a href="/docs/providers/google/r/pubsub_subscription.html">google_pubsub_subscription</a>
       </li>
-      <li<%= sidebar_current("docs-google-pubsub-subscription-iam") %>>
+      <li<%%= sidebar_current("docs-google-pubsub-subscription-iam") %>>
         <a href="/docs/providers/google/r/pubsub_subscription_iam.html">google_pubsub_subscription_iam_binding</a>
       </li>
-      <li<%= sidebar_current("docs-google-pubsub-subscription-iam") %>>
+      <li<%%= sidebar_current("docs-google-pubsub-subscription-iam") %>>
         <a href="/docs/providers/google/r/pubsub_subscription_iam.html">google_pubsub_subscription_iam_member</a>
       </li>
-      <li<%= sidebar_current("docs-google-pubsub-subscription-iam") %>>
+      <li<%%= sidebar_current("docs-google-pubsub-subscription-iam") %>>
         <a href="/docs/providers/google/r/pubsub_subscription_iam.html">google_pubsub_subscription_iam_policy</a>
       </li>
-      <li<%= sidebar_current("docs-google-pubsub-topic-x") %>>
+      <li<%%= sidebar_current("docs-google-pubsub-topic-x") %>>
       <a href="/docs/providers/google/r/pubsub_topic.html">google_pubsub_topic</a>
       </li>
-      <li<%= sidebar_current("docs-google-pubsub-topic-iam") %>>
+      <li<%%= sidebar_current("docs-google-pubsub-topic-iam") %>>
         <a href="/docs/providers/google/r/pubsub_topic_iam.html">google_pubsub_topic_iam_binding</a>
       </li>
-      <li<%= sidebar_current("docs-google-pubsub-topic-iam") %>>
+      <li<%%= sidebar_current("docs-google-pubsub-topic-iam") %>>
         <a href="/docs/providers/google/r/pubsub_topic_iam.html">google_pubsub_topic_iam_member</a>
       </li>
-      <li<%= sidebar_current("docs-google-pubsub-topic-iam") %>>
+      <li<%%= sidebar_current("docs-google-pubsub-topic-iam") %>>
         <a href="/docs/providers/google/r/pubsub_topic_iam.html">google_pubsub_topic_iam_policy</a>
       </li>
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-redis") %>>
+    <li<%%= sidebar_current("docs-google-redis") %>>
     <a href="#">Google Redis (Cloud Memorystore) Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-redis-instance") %>>
+      <li<%%= sidebar_current("docs-google-redis-instance") %>>
       <a href="/docs/providers/google/r/redis_instance.html">google_redis_instance</a>
       </li>
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-runtimeconfig") %>>
+    <li<%%= sidebar_current("docs-google-runtimeconfig") %>>
     <a href="#">Google RuntimeConfig Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-runtimeconfig-config") %>>
+      <li<%%= sidebar_current("docs-google-runtimeconfig-config") %>>
       <a href="/docs/providers/google/r/runtimeconfig_config.html">google_runtimeconfig_config</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-runtimeconfig-variable") %>>
+      <li<%%= sidebar_current("docs-google-runtimeconfig-variable") %>>
       <a href="/docs/providers/google/r/runtimeconfig_variable.html">google_runtimeconfig_variable</a>
       </li>
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-service-networking") %>>
+    <li<%%= sidebar_current("docs-google-service-networking") %>>
     <a href="#">Google Service Networking Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-service-networking-connection") %>>
+      <li<%%= sidebar_current("docs-google-service-networking-connection") %>>
       <a href="/docs/providers/google/r/service_networking_connection.html">google_service_networking_connection</a>
       </li>
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-sourcerepo") %>>
+    <li<%%= sidebar_current("docs-google-sourcerepo") %>>
     <a href="#">Google Source Repositories Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-sourcerepo-repository") %>>
+      <li<%%= sidebar_current("docs-google-sourcerepo-repository") %>>
       <a href="/docs/providers/google/r/sourcerepo_repository.html">google_sourcerepo_repository</a>
       </li>
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-spanner") %>>
+    <li<%%= sidebar_current("docs-google-spanner") %>>
     <a href="#">Google Spanner Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-spanner-database") %>>
+      <li<%%= sidebar_current("docs-google-spanner-database") %>>
       <a href="/docs/providers/google/r/spanner_database.html">google_spanner_database</a>
       </li>
-      <li<%= sidebar_current("docs-google-spanner-database-iam") %>>
+      <li<%%= sidebar_current("docs-google-spanner-database-iam") %>>
       <a href="/docs/providers/google/r/spanner_database_iam.html">google_spanner_database_iam_binding</a>
       </li>
-      <li<%= sidebar_current("docs-google-spanner-database-iam") %>>
+      <li<%%= sidebar_current("docs-google-spanner-database-iam") %>>
       <a href="/docs/providers/google/r/spanner_database_iam.html">google_spanner_database_iam_member</a>
       </li>
-      <li<%= sidebar_current("docs-google-spanner-database-iam") %>>
+      <li<%%= sidebar_current("docs-google-spanner-database-iam") %>>
       <a href="/docs/providers/google/r/spanner_database_iam.html">google_spanner_database_iam_policy</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-spanner-instance") %>>
+      <li<%%= sidebar_current("docs-google-spanner-instance") %>>
       <a href="/docs/providers/google/r/spanner_instance.html">google_spanner_instance</a>
       </li>
-      <li<%= sidebar_current("docs-google-spanner-instance-iam") %>>
+      <li<%%= sidebar_current("docs-google-spanner-instance-iam") %>>
       <a href="/docs/providers/google/r/spanner_instance_iam.html">google_spanner_instance_iam_binding</a>
       </li>
-      <li<%= sidebar_current("docs-google-spanner-instance-iam") %>>
+      <li<%%= sidebar_current("docs-google-spanner-instance-iam") %>>
       <a href="/docs/providers/google/r/spanner_instance_iam.html">google_spanner_instance_iam_member</a>
       </li>
-      <li<%= sidebar_current("docs-google-spanner-instance-iam") %>>
+      <li<%%= sidebar_current("docs-google-spanner-instance-iam") %>>
       <a href="/docs/providers/google/r/spanner_instance_iam.html">google_spanner_instance_iam_policy</a>
       </li>
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-sql") %>>
+    <li<%%= sidebar_current("docs-google-sql") %>>
     <a href="#">Google SQL Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-sql-database-x") %>>
+      <li<%%= sidebar_current("docs-google-sql-database-x") %>>
       <a href="/docs/providers/google/r/sql_database.html">google_sql_database</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-sql-database-instance") %>>
+      <li<%%= sidebar_current("docs-google-sql-database-instance") %>>
       <a href="/docs/providers/google/r/sql_database_instance.html">google_sql_database_instance</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-sql-user") %>>
+      <li<%%= sidebar_current("docs-google-sql-user") %>>
       <a href="/docs/providers/google/r/sql_user.html">google_sql_user</a>
       </li>
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-logging") %>>
+    <li<%%= sidebar_current("docs-google-logging") %>>
     <a href="#">Google Stackdriver Logging Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-logging-billing-account-exclusion") %>>
+      <li<%%= sidebar_current("docs-google-logging-billing-account-exclusion") %>>
       <a href="/docs/providers/google/r/logging_billing_account_exclusion.html">google_logging_billing_account_exclusion</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-logging-billing-account-sink") %>>
+      <li<%%= sidebar_current("docs-google-logging-billing-account-sink") %>>
       <a href="/docs/providers/google/r/logging_billing_account_sink.html">google_logging_billing_account_sink</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-logging-folder-exclusion") %>>
+      <li<%%= sidebar_current("docs-google-logging-folder-exclusion") %>>
       <a href="/docs/providers/google/r/logging_folder_exclusion.html">google_logging_folder_exclusion</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-logging-folder-sink") %>>
+      <li<%%= sidebar_current("docs-google-logging-folder-sink") %>>
       <a href="/docs/providers/google/r/logging_folder_sink.html">google_logging_folder_sink</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-logging-organization-exclusion") %>>
+      <li<%%= sidebar_current("docs-google-logging-organization-exclusion") %>>
       <a href="/docs/providers/google/r/logging_organization_exclusion.html">google_logging_organization_exclusion</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-logging-organization-sink") %>>
+      <li<%%= sidebar_current("docs-google-logging-organization-sink") %>>
       <a href="/docs/providers/google/r/logging_organization_sink.html">google_logging_organization_sink</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-logging-project-exclusion") %>>
+      <li<%%= sidebar_current("docs-google-logging-project-exclusion") %>>
       <a href="/docs/providers/google/r/logging_project_exclusion.html">google_logging_project_exclusion</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-logging-project-sink") %>>
+      <li<%%= sidebar_current("docs-google-logging-project-sink") %>>
       <a href="/docs/providers/google/r/logging_project_sink.html">google_logging_project_sink</a>
       </li>
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-monitoring") %>>
+    <li<%%= sidebar_current("docs-google-monitoring") %>>
     <a href="#">Google Stackdriver Monitoring Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-monitoring-alert-policy") %>>
+      <li<%%= sidebar_current("docs-google-monitoring-alert-policy") %>>
       <a href="/docs/providers/google/r/monitoring_alert_policy.html">google_monitoring_alert_policy</a>
       </li>
 
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-storage") %>>
+    <li<%%= sidebar_current("docs-google-storage") %>>
     <a href="#">Google Storage Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-storage-bucket-x") %>>
+      <li<%%= sidebar_current("docs-google-storage-bucket-x") %>>
       <a href="/docs/providers/google/r/storage_bucket.html">google_storage_bucket</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-storage-bucket-acl") %>>
+      <li<%%= sidebar_current("docs-google-storage-bucket-acl") %>>
       <a href="/docs/providers/google/r/storage_bucket_acl.html">google_storage_bucket_acl</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-storage-bucket-iam") %>>
+      <li<%%= sidebar_current("docs-google-storage-bucket-iam") %>>
       <a href="/docs/providers/google/r/storage_bucket_iam.html">google_storage_bucket_iam_binding</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-storage-bucket-iam") %>>
+      <li<%%= sidebar_current("docs-google-storage-bucket-iam") %>>
       <a href="/docs/providers/google/r/storage_bucket_iam.html">google_storage_bucket_iam_member</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-storage-bucket-object") %>>
+      <li<%%= sidebar_current("docs-google-storage-bucket-object") %>>
       <a href="/docs/providers/google/r/storage_bucket_object.html">google_storage_bucket_object</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-storage-default-object-access-control") %>>
+      <li<%%= sidebar_current("docs-google-storage-default-object-access-control") %>>
       <a href="/docs/providers/google/r/storage_default_object_access_control.html">google_storage_default_object_access_control</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-storage-default-object-acl") %>>
+      <li<%%= sidebar_current("docs-google-storage-default-object-acl") %>>
       <a href="/docs/providers/google/r/storage_default_object_acl.html">google_storage_default_object_acl</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-storage-notification") %>>
+      <li<%%= sidebar_current("docs-google-storage-notification") %>>
       <a href="/docs/providers/google/r/storage_notification.html">google_storage_notification</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-storage-object-access-control") %>>
+      <li<%%= sidebar_current("docs-google-storage-object-access-control") %>>
       <a href="/docs/providers/google/r/storage_object_access_control.html">google_storage_object_access_control</a>
       </li>
 
-      <li<%= sidebar_current("docs-google-storage-object-acl") %>>
+      <li<%%= sidebar_current("docs-google-storage-object-acl") %>>
       <a href="/docs/providers/google/r/storage_object_acl.html">google_storage_object_acl</a>
       </li>
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-kms") %>>
+    <li<%%= sidebar_current("docs-google-kms") %>>
     <a href="#">Google Key Management Service Resources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-kms-crypto-key-x") %>>
+      <li<%%= sidebar_current("docs-google-kms-crypto-key-x") %>>
         <a href="/docs/providers/google/r/google_kms_crypto_key.html">google_kms_crypto_key</a>
       </li>
-      <li<%= sidebar_current("docs-google-kms-crypto-key-iam-binding") %>>
+      <li<%%= sidebar_current("docs-google-kms-crypto-key-iam-binding") %>>
         <a href="/docs/providers/google/r/google_kms_crypto_key_iam_binding.html">google_kms_crypto_key_iam_binding</a>
       </li>
-      <li<%= sidebar_current("docs-google-kms-crypto-key-iam-member") %>>
+      <li<%%= sidebar_current("docs-google-kms-crypto-key-iam-member") %>>
         <a href="/docs/providers/google/r/google_kms_crypto_key_iam_member.html">google_kms_crypto_key_iam_member</a>
       </li>
-      <li<%= sidebar_current("docs-google-kms-key-ring-x") %>>
+      <li<%%= sidebar_current("docs-google-kms-key-ring-x") %>>
         <a href="/docs/providers/google/r/google_kms_key_ring.html">google_kms_key_ring</a>
       </li>
-      <li<%= sidebar_current("docs-google-kms-key-ring-iam") %>>
+      <li<%%= sidebar_current("docs-google-kms-key-ring-iam") %>>
         <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_binding</a>
       </li>
-      <li<%= sidebar_current("docs-google-kms-key-ring-iam") %>>
+      <li<%%= sidebar_current("docs-google-kms-key-ring-iam") %>>
         <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_member</a>
       </li>
-      <li<%= sidebar_current("docs-google-kms-key-ring-iam") %>>
+      <li<%%= sidebar_current("docs-google-kms-key-ring-iam") %>>
         <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_policy</a>
       </li>
     </ul>
     </li>
 
-    <li<%= sidebar_current("docs-google-cloudiot") %>>
+    <li<%%= sidebar_current("docs-google-cloudiot") %>>
       <a href="#">Google Cloud IoT Core</a>
       <ul class="nav nav-visible">
-        <li<%= sidebar_current("docs-google-cloudiot-registry-x") %>>
+        <li<%%= sidebar_current("docs-google-cloudiot-registry-x") %>>
           <a href="/docs/providers/google/r/cloudiot_registry.html">google_cloudiot_registry</a>
         </li>
       </ul>
@@ -822,7 +830,7 @@
 
   </ul>
 </div>
-  <% end %>
+  <%% end %>
 
-<%= yield %>
-  <% end %>
+<%%= yield %>
+  <%% end %>


### PR DESCRIPTION
In order to generate website nav bars that exclude beta features the google.erb
needs to be double escaped so that it can run once through MM and a second time
through the Hashi website generator.

<!-- A summary of the changes in this commit goes here -->

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
Move website nav bar to magic modules template
## [terraform]
Remove beta resources from the website
### [terraform-beta]
## [ansible]
## [inspec]
