### PR TITLE
[Terraform]: Fix disk snapshot expand/encode, kmsKeyName decoder.

### DIFF
--- a/templates/terraform/decoders/disk.erb
+++ b/templates/terraform/decoders/disk.erb
@@ -5,9 +5,12 @@ if v, ok := res["diskEncryptionKey"]; ok {
   transformed["rawKey"] = d.Get("disk_encryption_key.0.raw_key")
   transformed["sha256"] = original["sha256"]
   <% unless version.nil? || version == 'ga' %>
-  // The response for crypto keys often includes the version of the key which needs to be removed
-  // format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
-  transformed["kmsKeyName"] = strings.Split(original["kmsKeyName"].(string), "/cryptoKeyVersions")[0]
+  if v, ok := original["kmsKeyName"]; ok {
+    // The response for crypto keys often includes the version of the key which needs to be removed
+    // format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
+    transformed["kmsKeyName"] = strings.Split(v.(string), "/cryptoKeyVersions")[0]
+  }
+
   <% end %>
   res["diskEncryptionKey"] = transformed
 }
@@ -19,9 +22,11 @@ if v, ok := res["sourceImageEncryptionKey"]; ok {
   transformed["rawKey"] = d.Get("source_image_encryption_key.0.raw_key")
   transformed["sha256"] = original["sha256"]
   <% unless version.nil? || version == 'ga' %>
-  // The response for crypto keys often includes the version of the key which needs to be removed
-  // format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
-  transformed["kmsKeyName"] = strings.Split(original["kmsKeyName"].(string), "/cryptoKeyVersions")[0]
+  if v, ok := original["kmsKeyName"]; ok {
+    // The response for crypto keys often includes the version of the key which needs to be removed
+    // format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
+    transformed["kmsKeyName"] = strings.Split(v.(string), "/cryptoKeyVersions")[0]
+  }
   <% end %>
   res["sourceImageEncryptionKey"] = transformed
 }
@@ -33,9 +38,12 @@ if v, ok := res["sourceSnapshotEncryptionKey"]; ok {
   transformed["rawKey"] = d.Get("source_snapshot_encryption_key.0.raw_key")
   transformed["sha256"] = original["sha256"]
   <% unless version.nil? || version == 'ga' %>
-  // The response for crypto keys often includes the version of the key which needs to be removed
-  // format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
-  transformed["kmsKeyName"] = strings.Split(original["kmsKeyName"].(string), "/cryptoKeyVersions")[0]
+  if v, ok := original["kmsKeyName"]; ok {
+    // The response for crypto keys often includes the version of the key which needs to be removed
+    // format: projects/<project>/locations/<region>/keyRings/<keyring>/cryptoKeys/<key>/cryptoKeyVersions/1
+    transformed["kmsKeyName"] = strings.Split(v.(string), "/cryptoKeyVersions")[0]
+  }
+
   <% end %>
   res["sourceSnapshotEncryptionKey"] = transformed
 }

--- a/templates/terraform/encoders/disk.erb
+++ b/templates/terraform/encoders/disk.erb
@@ -67,23 +67,4 @@ if v, ok := d.GetOk("image"); ok {
 	log.Printf("[DEBUG] Image name resolved to: %s", imageUrl)
 }
 
-if v, ok := d.GetOk("snapshot"); ok {
-		snapshotName := v.(string)
-		match, _ := regexp.MatchString("^https://www.googleapis.com/compute", snapshotName)
-		if match {
-			obj["sourceSnapshot"] = snapshotName
-		} else {
-			log.Printf("[DEBUG] Loading snapshot: %s", snapshotName)
-			snapshotData, err := config.clientCompute.Snapshots.Get(
-				project, snapshotName).Do()
-
-			if err != nil {
-				return nil, fmt.Errorf(
-					"Error loading snapshot '%s': %s",
-					snapshotName, err)
-			}
-			obj["sourceSnapshot"] = snapshotData.SelfLink
-		}
-}
-
 return obj, nil


### PR DESCRIPTION
We had some custom code that was wrong for no good reason! The automatic expander for `snapshot` has the correct behaviour anyways, so let's just use that.

I caught a bug with `kmsKeyName` while running beta acc tests, so I fixed that up as well.

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/2448

-----------------------------------------------------------------
# [all]
## [terraform]
Fix disk snapshot, kmsKeyName decoder.
### [terraform-beta]
## [ansible]
## [inspec]
