### PR TITLE
[Terraform]: Add a datasource for interpolating on self links

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_self_link.go
+++ b/third_party/terraform/data_sources/data_source_google_self_link.go
@@ -1,0 +1,41 @@
+package google
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceGoogleSelfLink() *schema.Resource {
+	return &schema.Resource{
+		Read: datasourceGoogleSelfLink,
+		Schema: map[string]*schema.Schema{
+			"self_link": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"relative_uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func datasourceGoogleSelfLink(d *schema.ResourceData, meta interface{}) error {
+	selfLink := d.Get("self_link").(string)
+
+	relativeUri, err := getRelativePath(selfLink)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(selfLink)
+	d.Set("self_link", selfLink)
+	d.Set("relative_uri", relativeUri)
+	d.Set("name", GetResourceNameFromSelfLink(selfLink))
+
+	return nil
+}

--- a/third_party/terraform/tests/data_source_google_self_link_test.go
+++ b/third_party/terraform/tests/data_source_google_self_link_test.go
@@ -1,0 +1,31 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccGoogleSelfLink_basic(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGoogleSelfLink_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.google_self_link.instance", "relative_uri", "projects/my-gcp-project/regions/us-central1/instances/my-instance"),
+					resource.TestCheckResourceAttr("data.google_self_link.instance", "name", "my-instance"),
+				),
+			},
+		},
+	})
+}
+
+var testAccGoogleSelfLink_basic = `
+data "google_self_link" "instance" {
+  self_link = "https://www.googleapis.com/compute/v1/projects/my-gcp-project/regions/us-central1/instances/my-instance"
+}
+`

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -95,6 +95,7 @@ func Provider() terraform.ResourceProvider {
 			"google_organization":                    dataSourceGoogleOrganization(),
 			"google_project":                         dataSourceGoogleProject(),
 			"google_project_services":                dataSourceGoogleProjectServices(),
+			"google_self_link":                       dataSourceGoogleSelfLink(),
 			"google_service_account":                 dataSourceGoogleServiceAccount(),
 			"google_service_account_key":             dataSourceGoogleServiceAccountKey(),
 			"google_storage_object_signed_url":       dataSourceGoogleSignedUrl(),

--- a/third_party/terraform/utils/self_link_helpers.go
+++ b/third_party/terraform/utils/self_link_helpers.go
@@ -84,10 +84,6 @@ func NameFromSelfLinkStateFunc(v interface{}) string {
 	return GetResourceNameFromSelfLink(v.(string))
 }
 
-func StoreResourceName(resourceLink interface{}) string {
-	return GetResourceNameFromSelfLink(resourceLink.(string))
-}
-
 type LocationType int
 
 const (

--- a/third_party/terraform/website/docs/d/google_self_link.html.markdown
+++ b/third_party/terraform/website/docs/d/google_self_link.html.markdown
@@ -1,0 +1,73 @@
+---
+layout: "google"
+page_title: "Google: google_self_link"
+sidebar_current: "docs-google-datasource-self-link"
+description: |-
+  Terraform-native interpolation of a Google Cloud Platform self link
+---
+
+# google\_self\_link
+
+This datasource allows Terraform-native interpolation of a Google Cloud Platform project-level self link's `name` and relative/partial URI (`relative_uri`).
+
+## Example Usage - Basic
+
+```hcl
+data "google_self_link" "instance" {
+  self_link = "https://www.googleapis.com/compute/v1/projects/my-gcp-project/regions/us-central1/instances/my-instance"
+}
+
+output "relative_uri" {
+  value = "${data.google_self_link.instance.relative_uri}"
+}
+```
+
+## Example Usage - with Instance
+
+```hcl
+data "google_self_link" "instance" {
+  self_link = "${google_compute_instance.vm_instance.self_link}"
+}
+
+output "name" {
+  value = "${data.google_self_link.instance.name}"
+}
+
+resource "google_compute_instance" "vm_instance" {
+	name                      = "vm-instance"
+	machine_type              = "f1-micro"
+	zone                      = "us-central1-a"
+	allow_stopping_for_update = true
+
+	boot_disk {
+		initialize_params{
+			image = "${data.google_compute_image.debian_image.self_link}"
+		}
+	}
+
+	network_interface {
+		network = "default"
+		access_config {
+		}
+	}
+}
+
+data "google_compute_image" "debian_image" {
+	family  = "debian-9"
+	project = "debian-cloud"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `self_link` (Required) - The self link you are interpolating.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `relative_uri` - The self link's relative/partial URI (starting from `projects/`)
+
+* `name` - The name of the resource the self link refers to.

--- a/third_party/terraform/website/google.erb
+++ b/third_party/terraform/website/google.erb
@@ -131,6 +131,9 @@
       <li<%%= sidebar_current("docs-google-datasource-project") %>>
         <a href="/docs/providers/google/d/google_project.html">google_project</a>
       </li>
+      <li<%%= sidebar_current("docs-google-datasource-self-link") %>>
+        <a href="/docs/providers/google/d/google_self_link.html">google_self_link</a>
+      </li>
       <li<%%= sidebar_current("docs-google-datasource-service-account") %>>
         <a href="/docs/providers/google/d/datasource_google_service_account.html">google_service_account</a>
       </li>


### PR DESCRIPTION
I wasn't happy with my fix in #894 because it isn't easy to test relative (partial) self links in resources; we had no way of guaranteeing they would continue to work. Recreating the self link in code by drawing from the project, the location, and the name and passing it in is an _option_, but that's boring and means we reinvent the wheel every time.

So let's fix the problem in a reusable, Terraform-native way 🙂 

-----------------------------------------------------------------
# [all]
## [terraform]
Add datasource google_self_link for interpolating on self links
### [terraform-beta]
## [ansible]
## [inspec]
