### PR TITLE
[Terraform]: Add documentation on resource.google_container_cluster

### DIFF
--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -353,6 +353,11 @@ The `node_config` block supports:
 
 * `service_account` - (Optional) The service account to be used by the Node VMs.
     If not specified, the "default" service account is used.
+    In order to use the configured `oauth_scopes` for logging and monitoring, the service account being used needs the
+    [roles/logging.logWriter](https://cloud.google.com/iam/docs/understanding-roles#stackdriver_logging_roles) and
+    [roles/monitoring.metricWriter](https://cloud.google.com/iam/docs/understanding-roles#stackdriver_monitoring_roles) roles.
+
+     -> Projects that enable the [Cloud Compute Engine API](https://cloud.google.com/compute/) with Terraform may need these roles added manually to the service account. Projects that enable the API in the Cloud Console should have them added automatically.
 
 * `tags` - (Optional) The list of instance tags applied to all nodes. Tags are used to identify
     valid sources or targets for network firewalls.


### PR DESCRIPTION
Merge https://github.com/terraform-providers/terraform-provider-google/pull/2419 instead of tpg downstream

-----------------------------------------------------------------
# [all]
## [terraform]
Add documentation on resource.google_container_cluster
### [terraform-beta]
## [ansible]
## [inspec]
