### PR TITLE
Add new resource_compute_router_nat to Terraform provider

### DIFF
--- a/third_party/terraform/resources/resource_compute_router_nat.go
+++ b/third_party/terraform/resources/resource_compute_router_nat.go
@@ -148,7 +148,6 @@ func resourceComputeRouterNatCreate(d *schema.ResourceData, meta interface{}) er
 	router, err := routersService.Get(project, region, routerName).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
-			d.SetId("")
 			return fmt.Errorf("Router %s/%s not found", region, routerName)
 		}
 
@@ -158,7 +157,6 @@ func resourceComputeRouterNatCreate(d *schema.ResourceData, meta interface{}) er
 	nats := router.Nats
 	for _, nat := range nats {
 		if nat.Name == natName {
-			d.SetId("")
 			return fmt.Errorf("Router %s has nat %s already", routerName, natName)
 		}
 	}
@@ -324,8 +322,7 @@ func resourceComputeRouterNatDelete(d *schema.ResourceData, meta interface{}) er
 		return nil
 	}
 
-	log.Printf(
-		"[INFO] Removing nat %s from router %s/%s", natName, region, routerName)
+	log.Printf("[INFO] Removing nat %s from router %s/%s", natName, region, routerName)
 	patchRouter := &computeBeta.Router{
 		Nats: newNats,
 	}

--- a/third_party/terraform/resources/resource_compute_router_nat.go
+++ b/third_party/terraform/resources/resource_compute_router_nat.go
@@ -1,0 +1,294 @@
+package google
+
+import (
+	"fmt"
+	"log"
+
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/googleapi"
+)
+
+func resourceComputeRouterNat() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceComputeRouterNatCreate,
+		Read:   resourceComputeRouterNatRead,
+		Delete: resourceComputeRouterNatDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceComputeRouterNatImportState,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"router": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"interface": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"peer_ip_address": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"peer_asn": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"advertised_route_priority": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"ip_address": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceComputeRouterNatCreate(d *schema.ResourceData, meta interface{}) error {
+
+	config := meta.(*Config)
+
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	routerName := d.Get("router").(string)
+	peerName := d.Get("name").(string)
+
+	routerLock := getRouterLockName(region, routerName)
+	mutexKV.Lock(routerLock)
+	defer mutexKV.Unlock(routerLock)
+
+	routersService := config.clientCompute.Routers
+	router, err := routersService.Get(project, region, routerName).Do()
+	if err != nil {
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing router peer %s because its router %s/%s is gone", peerName, region, routerName)
+			d.SetId("")
+
+			return nil
+		}
+
+		return fmt.Errorf("Error Reading router %s/%s: %s", region, routerName, err)
+	}
+
+	peers := router.BgpPeers
+	for _, peer := range peers {
+		if peer.Name == peerName {
+			d.SetId("")
+			return fmt.Errorf("Router %s has peer %s already", routerName, peerName)
+		}
+	}
+
+	ifaceName := d.Get("interface").(string)
+
+	peer := &compute.RouterBgpPeer{Name: peerName,
+		InterfaceName: ifaceName}
+
+	if v, ok := d.GetOk("peer_ip_address"); ok {
+		peer.PeerIpAddress = v.(string)
+	}
+
+	if v, ok := d.GetOk("peer_asn"); ok {
+		peer.PeerAsn = int64(v.(int))
+	}
+
+	if v, ok := d.GetOk("advertised_route_priority"); ok {
+		peer.AdvertisedRoutePriority = int64(v.(int))
+	}
+
+	log.Printf("[INFO] Adding peer %s", peerName)
+	peers = append(peers, peer)
+	patchRouter := &compute.Router{
+		BgpPeers: peers,
+	}
+
+	log.Printf("[DEBUG] Updating router %s/%s with peers: %+v", region, routerName, peers)
+	op, err := routersService.Patch(project, region, router.Name, patchRouter).Do()
+	if err != nil {
+		return fmt.Errorf("Error patching router %s/%s: %s", region, routerName, err)
+	}
+	d.SetId(fmt.Sprintf("%s/%s/%s", region, routerName, peerName))
+	err = computeOperationWait(config.clientCompute, op, project, "Patching router")
+	if err != nil {
+		d.SetId("")
+		return fmt.Errorf("Error waiting to patch router %s/%s: %s", region, routerName, err)
+	}
+
+	return resourceComputeRouterNatRead(d, meta)
+}
+
+func resourceComputeRouterNatRead(d *schema.ResourceData, meta interface{}) error {
+
+	config := meta.(*Config)
+
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	routerName := d.Get("router").(string)
+	peerName := d.Get("name").(string)
+
+	routersService := config.clientCompute.Routers
+	router, err := routersService.Get(project, region, routerName).Do()
+	if err != nil {
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing router peer %s because its router %s/%s is gone", peerName, region, routerName)
+			d.SetId("")
+
+			return nil
+		}
+
+		return fmt.Errorf("Error Reading router %s/%s: %s", region, routerName, err)
+	}
+
+	for _, peer := range router.BgpPeers {
+
+		if peer.Name == peerName {
+			d.SetId(fmt.Sprintf("%s/%s/%s", region, routerName, peerName))
+			d.Set("interface", peer.InterfaceName)
+			d.Set("peer_ip_address", peer.PeerIpAddress)
+			d.Set("peer_asn", peer.PeerAsn)
+			d.Set("advertised_route_priority", peer.AdvertisedRoutePriority)
+			d.Set("ip_address", peer.IpAddress)
+			d.Set("region", region)
+			d.Set("project", project)
+			return nil
+		}
+	}
+
+	log.Printf("[WARN] Removing router peer %s/%s/%s because it is gone", region, routerName, peerName)
+	d.SetId("")
+	return nil
+}
+
+func resourceComputeRouterNatDelete(d *schema.ResourceData, meta interface{}) error {
+
+	config := meta.(*Config)
+
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	routerName := d.Get("router").(string)
+	peerName := d.Get("name").(string)
+
+	routerLock := getRouterLockName(region, routerName)
+	mutexKV.Lock(routerLock)
+	defer mutexKV.Unlock(routerLock)
+
+	routersService := config.clientCompute.Routers
+	router, err := routersService.Get(project, region, routerName).Do()
+	if err != nil {
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing router peer %s because its router %s/%s is gone", peerName, region, routerName)
+
+			return nil
+		}
+
+		return fmt.Errorf("Error Reading Router %s: %s", routerName, err)
+	}
+
+	var newPeers []*compute.RouterBgpPeer = make([]*compute.RouterBgpPeer, 0, len(router.BgpPeers))
+	for _, peer := range router.BgpPeers {
+		if peer.Name == peerName {
+			continue
+		} else {
+			newPeers = append(newPeers, peer)
+		}
+	}
+
+	if len(newPeers) == len(router.BgpPeers) {
+		log.Printf("[DEBUG] Router %s/%s had no peer %s already", region, routerName, peerName)
+		d.SetId("")
+		return nil
+	}
+
+	log.Printf(
+		"[INFO] Removing peer %s from router %s/%s", peerName, region, routerName)
+	patchRouter := &compute.Router{
+		BgpPeers: newPeers,
+	}
+
+	if len(newPeers) == 0 {
+		patchRouter.ForceSendFields = append(patchRouter.ForceSendFields, "BgpPeers")
+	}
+
+	log.Printf("[DEBUG] Updating router %s/%s with peers: %+v", region, routerName, newPeers)
+	op, err := routersService.Patch(project, region, router.Name, patchRouter).Do()
+	if err != nil {
+		return fmt.Errorf("Error patching router %s/%s: %s", region, routerName, err)
+	}
+
+	err = computeOperationWait(config.clientCompute, op, project, "Patching router")
+	if err != nil {
+		return fmt.Errorf("Error waiting to patch router %s/%s: %s", region, routerName, err)
+	}
+
+	d.SetId("")
+	return nil
+}
+
+func resourceComputeRouterNatImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	parts := strings.Split(d.Id(), "/")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("Invalid router peer specifier. Expecting {region}/{router}/{nat}")
+	}
+
+	d.Set("region", parts[0])
+	d.Set("router", parts[1])
+	d.Set("name", parts[2])
+
+	return []*schema.ResourceData{d}, nil
+}

--- a/third_party/terraform/resources/resource_compute_router_nat.go
+++ b/third_party/terraform/resources/resource_compute_router_nat.go
@@ -39,7 +39,7 @@ var (
 
 func resourceComputeRouterNat() *schema.Resource {
 	return &schema.Resource{
-		// TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/963)
+		// TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/963): Implement Update
 		Create: resourceComputeRouterNatCreate,
 		Read:   resourceComputeRouterNatRead,
 		Delete: resourceComputeRouterNatDelete,

--- a/third_party/terraform/resources/resource_compute_router_nat.go
+++ b/third_party/terraform/resources/resource_compute_router_nat.go
@@ -22,11 +22,10 @@ var (
 				ForceNew: true,
 			},
 			"source_ip_ranges_to_nat": &schema.Schema{
-				Type:         schema.TypeSet,
-				Optional:     true,
-				ForceNew:     true,
-				Elem:         &schema.Schema{Type: schema.TypeString},
-				ValidateFunc: validation.StringInSlice([]string{"ALL_IP_RANGES", "LIST_OF_SECONDARY_IP_RANGES", "PRIMARY_IP_RANGE"}, false),
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"secondary_ip_range_names": &schema.Schema{
 				Type:     schema.TypeSet,
@@ -52,9 +51,8 @@ func resourceComputeRouterNat() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validateRFC1035Name(1, 63),
+				ValidateFunc: validateRFC1035Name(2, 63),
 			},
-
 			"router": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,

--- a/third_party/terraform/resources/resource_compute_router_nat.go.erb
+++ b/third_party/terraform/resources/resource_compute_router_nat.go.erb
@@ -42,7 +42,7 @@ var (
 
 func resourceComputeRouterNat() *schema.Resource {
 	return &schema.Resource{
-		// TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/963)
+		// TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/963): Implement Update
 		Create: resourceComputeRouterNatCreate,
 		Read:   resourceComputeRouterNatRead,
 		Delete: resourceComputeRouterNatDelete,

--- a/third_party/terraform/resources/resource_compute_router_nat.go.erb
+++ b/third_party/terraform/resources/resource_compute_router_nat.go.erb
@@ -1,4 +1,6 @@
+<% autogen_exception -%>
 package google
+<% unless version.nil? || version == 'ga' -%>
 
 import (
 	"fmt"
@@ -385,3 +387,6 @@ func convertSelfLinksToV1(selfLinks []string) []string {
 	}
 	return result
 }
+<% else %>
+// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
+<% end -%>

--- a/third_party/terraform/tests/resource_compute_router_nat_test.go
+++ b/third_party/terraform/tests/resource_compute_router_nat_test.go
@@ -1,0 +1,305 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccComputeRouterNat_basic(t *testing.T) {
+	t.Parallel()
+
+	testId := acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeRouterNatDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeRouterNatBasic(testId),
+				Check: testAccCheckComputeRouterNatExists(
+					"google_compute_router_peer.foobar"),
+			},
+			resource.TestStep{
+				ResourceName:      "google_compute_router_peer.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			resource.TestStep{
+				Config: testAccComputeRouterNatKeepRouter(testId),
+				Check: testAccCheckComputeRouterNatDelete(
+					"google_compute_router_peer.foobar"),
+			},
+		},
+	})
+}
+
+func testAccCheckComputeRouterNatDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+
+	routersService := config.clientCompute.Routers
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "google_compute_router" {
+			continue
+		}
+
+		project, err := getTestProject(rs.Primary, config)
+		if err != nil {
+			return err
+		}
+
+		region, err := getTestRegion(rs.Primary, config)
+		if err != nil {
+			return err
+		}
+
+		routerName := rs.Primary.Attributes["router"]
+
+		_, err = routersService.Get(project, region, routerName).Do()
+
+		if err == nil {
+			return fmt.Errorf("Error, Router %s in region %s still exists",
+				routerName, region)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckComputeRouterNatDelete(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*Config)
+
+		routersService := config.clientCompute.Routers
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "google_compute_router_peer" {
+				continue
+			}
+
+			project, err := getTestProject(rs.Primary, config)
+			if err != nil {
+				return err
+			}
+
+			region, err := getTestRegion(rs.Primary, config)
+			if err != nil {
+				return err
+			}
+
+			name := rs.Primary.Attributes["name"]
+			routerName := rs.Primary.Attributes["router"]
+
+			router, err := routersService.Get(project, region, routerName).Do()
+
+			if err != nil {
+				return fmt.Errorf("Error Reading Router %s: %s", routerName, err)
+			}
+
+			peers := router.BgpPeers
+			for _, peer := range peers {
+
+				if peer.Name == name {
+					return fmt.Errorf("Peer %s still exists on router %s/%s", name, region, router.Name)
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeRouterNatExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		project, err := getTestProject(rs.Primary, config)
+		if err != nil {
+			return err
+		}
+
+		region, err := getTestRegion(rs.Primary, config)
+		if err != nil {
+			return err
+		}
+
+		name := rs.Primary.Attributes["name"]
+		routerName := rs.Primary.Attributes["router"]
+
+		routersService := config.clientCompute.Routers
+		router, err := routersService.Get(project, region, routerName).Do()
+
+		if err != nil {
+			return fmt.Errorf("Error Reading Router %s: %s", routerName, err)
+		}
+
+		for _, peer := range router.BgpPeers {
+
+			if peer.Name == name {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("Peer %s not found for router %s", name, router.Name)
+	}
+}
+
+func testAccComputeRouterNatBasic(testId string) string {
+	return fmt.Sprintf(`
+	        resource "google_compute_network" "foobar" {
+			name = "router-peer-test-%s"
+		}
+		resource "google_compute_subnetwork" "foobar" {
+			name = "router-peer-test-subnetwork-%s"
+			network = "${google_compute_network.foobar.self_link}"
+			ip_cidr_range = "10.0.0.0/16"
+			region = "us-central1"
+		}
+		resource "google_compute_address" "foobar" {
+			name = "router-peer-test-%s"
+			region = "${google_compute_subnetwork.foobar.region}"
+		}
+		resource "google_compute_vpn_gateway" "foobar" {
+			name = "router-peer-test-%s"
+			network = "${google_compute_network.foobar.self_link}"
+			region = "${google_compute_subnetwork.foobar.region}"
+		}
+		resource "google_compute_forwarding_rule" "foobar_esp" {
+			name = "router-peer-test-%s-1"
+			region = "${google_compute_vpn_gateway.foobar.region}"
+			ip_protocol = "ESP"
+			ip_address = "${google_compute_address.foobar.address}"
+			target = "${google_compute_vpn_gateway.foobar.self_link}"
+		}
+		resource "google_compute_forwarding_rule" "foobar_udp500" {
+			name = "router-peer-test-%s-2"
+			region = "${google_compute_forwarding_rule.foobar_esp.region}"
+			ip_protocol = "UDP"
+			port_range = "500-500"
+			ip_address = "${google_compute_address.foobar.address}"
+			target = "${google_compute_vpn_gateway.foobar.self_link}"
+		}
+		resource "google_compute_forwarding_rule" "foobar_udp4500" {
+			name = "router-peer-test-%s-3"
+			region = "${google_compute_forwarding_rule.foobar_udp500.region}"
+			ip_protocol = "UDP"
+			port_range = "4500-4500"
+			ip_address = "${google_compute_address.foobar.address}"
+			target = "${google_compute_vpn_gateway.foobar.self_link}"
+		}
+		resource "google_compute_router" "foobar"{
+			name = "router-peer-test-%s"
+			region = "${google_compute_forwarding_rule.foobar_udp500.region}"
+			network = "${google_compute_network.foobar.self_link}"
+			bgp {
+				asn = 64514
+			}
+		}
+		resource "google_compute_vpn_tunnel" "foobar" {
+			name = "router-peer-test-%s"
+			region = "${google_compute_forwarding_rule.foobar_udp4500.region}"
+			target_vpn_gateway = "${google_compute_vpn_gateway.foobar.self_link}"
+			shared_secret = "unguessable"
+			peer_ip = "8.8.8.8"
+			router = "${google_compute_router.foobar.name}"
+		}
+		resource "google_compute_router_interface" "foobar" {
+			name = "router-peer-test-%s"
+			router = "${google_compute_router.foobar.name}"
+			region = "${google_compute_router.foobar.region}"
+			ip_range = "169.254.3.1/30"
+			vpn_tunnel = "${google_compute_vpn_tunnel.foobar.name}"
+		}
+		resource "google_compute_router_peer" "foobar" {
+			name = "router-peer-test-%s"
+			router = "${google_compute_router.foobar.name}"
+			region = "${google_compute_router.foobar.region}"
+			peer_ip_address = "169.254.3.2"
+			peer_asn = 65515
+			advertised_route_priority = 100
+			interface = "${google_compute_router_interface.foobar.name}"
+		}
+	`, testId, testId, testId, testId, testId, testId, testId, testId, testId, testId, testId)
+}
+
+func testAccComputeRouterNatKeepRouter(testId string) string {
+	return fmt.Sprintf(`
+		resource "google_compute_network" "foobar" {
+			name = "router-peer-test-%s"
+		}
+		resource "google_compute_subnetwork" "foobar" {
+			name = "router-peer-test-subnetwork-%s"
+			network = "${google_compute_network.foobar.self_link}"
+			ip_cidr_range = "10.0.0.0/16"
+			region = "us-central1"
+		}
+		resource "google_compute_address" "foobar" {
+			name = "router-peer-test-%s"
+			region = "${google_compute_subnetwork.foobar.region}"
+		}
+		resource "google_compute_vpn_gateway" "foobar" {
+			name = "router-peer-test-%s"
+			network = "${google_compute_network.foobar.self_link}"
+			region = "${google_compute_subnetwork.foobar.region}"
+		}
+		resource "google_compute_forwarding_rule" "foobar_esp" {
+			name = "router-peer-test-%s-1"
+			region = "${google_compute_vpn_gateway.foobar.region}"
+			ip_protocol = "ESP"
+			ip_address = "${google_compute_address.foobar.address}"
+			target = "${google_compute_vpn_gateway.foobar.self_link}"
+		}
+		resource "google_compute_forwarding_rule" "foobar_udp500" {
+			name = "router-peer-test-%s-2"
+			region = "${google_compute_forwarding_rule.foobar_esp.region}"
+			ip_protocol = "UDP"
+			port_range = "500-500"
+			ip_address = "${google_compute_address.foobar.address}"
+			target = "${google_compute_vpn_gateway.foobar.self_link}"
+		}
+		resource "google_compute_forwarding_rule" "foobar_udp4500" {
+			name = "router-peer-test-%s-3"
+			region = "${google_compute_forwarding_rule.foobar_udp500.region}"
+			ip_protocol = "UDP"
+			port_range = "4500-4500"
+			ip_address = "${google_compute_address.foobar.address}"
+			target = "${google_compute_vpn_gateway.foobar.self_link}"
+		}
+		resource "google_compute_router" "foobar"{
+			name = "router-peer-test-%s"
+			region = "${google_compute_forwarding_rule.foobar_udp500.region}"
+			network = "${google_compute_network.foobar.self_link}"
+			bgp {
+				asn = 64514
+			}
+		}
+		resource "google_compute_vpn_tunnel" "foobar" {
+			name = "router-peer-test-%s"
+			region = "${google_compute_forwarding_rule.foobar_udp4500.region}"
+			target_vpn_gateway = "${google_compute_vpn_gateway.foobar.self_link}"
+			shared_secret = "unguessable"
+			peer_ip = "8.8.8.8"
+			router = "${google_compute_router.foobar.name}"
+		}
+		resource "google_compute_router_interface" "foobar" {
+			name = "router-peer-test-%s"
+			router = "${google_compute_router.foobar.name}"
+			region = "${google_compute_router.foobar.region}"
+			ip_range = "169.254.3.1/30"
+			vpn_tunnel = "${google_compute_vpn_tunnel.foobar.name}"
+		}
+	`, testId, testId, testId, testId, testId, testId, testId, testId, testId, testId)
+}

--- a/third_party/terraform/tests/resource_compute_router_nat_test.go
+++ b/third_party/terraform/tests/resource_compute_router_nat_test.go
@@ -20,8 +20,6 @@ func TestAccComputeRouterNat_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccComputeRouterNatBasic(testId),
-				Check: testAccCheckComputeRouterNatExists(
-					"google_compute_router_nat.foobar"),
 			},
 			resource.TestStep{
 				ResourceName:      "google_compute_router_nat.foobar",
@@ -48,8 +46,11 @@ func TestAccComputeRouterNat_withManualIpAndSubnetConfiguration(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccComputeRouterNatWithManualIpAndSubnetConfiguration(testId),
-				Check: testAccCheckComputeRouterNatExists(
-					"google_compute_router_nat.foobar"),
+			},
+			resource.TestStep{
+				ResourceName:      "google_compute_router_nat.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -128,50 +129,6 @@ func testAccCheckComputeRouterNatDelete(n string) resource.TestCheckFunc {
 		}
 
 		return nil
-	}
-}
-
-func testAccCheckComputeRouterNatExists(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := testAccProvider.Meta().(*Config)
-
-		project, err := getTestProject(rs.Primary, config)
-		if err != nil {
-			return err
-		}
-
-		region, err := getTestRegion(rs.Primary, config)
-		if err != nil {
-			return err
-		}
-
-		name := rs.Primary.Attributes["name"]
-		routerName := rs.Primary.Attributes["router"]
-
-		routersService := config.clientComputeBeta.Routers
-		router, err := routersService.Get(project, region, routerName).Do()
-
-		if err != nil {
-			return fmt.Errorf("Error Reading Router %s: %s", routerName, err)
-		}
-
-		for _, nat := range router.Nats {
-
-			if nat.Name == name {
-				return nil
-			}
-		}
-
-		return fmt.Errorf("Nat %s not found for router %s", name, router.Name)
 	}
 }
 

--- a/third_party/terraform/tests/resource_compute_router_nat_test.go
+++ b/third_party/terraform/tests/resource_compute_router_nat_test.go
@@ -164,7 +164,8 @@ func testAccComputeRouterNatBasic(testId string) string {
 func testAccComputeRouterNatWithManualIpAndSubnetConfiguration(testId string) string {
 	return fmt.Sprintf(`
 	        resource "google_compute_network" "foobar" {
-			name = "router-nat-test-%s"
+			name                    = "router-nat-test-%s"
+			auto_create_subnetworks = "false"
 		}
 		resource "google_compute_subnetwork" "foobar" {
 			name = "router-nat-test-subnetwork-%s"
@@ -173,7 +174,7 @@ func testAccComputeRouterNatWithManualIpAndSubnetConfiguration(testId string) st
 			region = "us-central1"
 		}
 		resource "google_compute_address" "foobar" {
-			name = "router-peer-test-%s"
+			name = "router-nat-test-%s"
 			region = "${google_compute_subnetwork.foobar.region}"
 		}
 		resource "google_compute_router" "foobar"{
@@ -192,7 +193,8 @@ func testAccComputeRouterNatWithManualIpAndSubnetConfiguration(testId string) st
 			nat_ips                            = ["${google_compute_address.foobar.self_link}"]
 			source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
 			subnetwork {
-			  name = "${google_compute_subnetwork.foobar.self_link}"
+			  name                    = "${google_compute_subnetwork.foobar.self_link}"
+			  source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
 			}
 		}
 	`, testId, testId, testId, testId, testId)
@@ -201,7 +203,8 @@ func testAccComputeRouterNatWithManualIpAndSubnetConfiguration(testId string) st
 func testAccComputeRouterNatKeepRouter(testId string) string {
 	return fmt.Sprintf(`
 		resource "google_compute_network" "foobar" {
-			name = "router-nat-test-%s"
+			name                    = "router-nat-test-%s"
+			auto_create_subnetworks = "false"
 		}
 		resource "google_compute_subnetwork" "foobar" {
 			name = "router-nat-test-subnetwork-%s"

--- a/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
@@ -140,14 +140,14 @@ func testAccComputeRouterNatBasic(testId string) string {
 			name = "router-nat-test-%s"
 		}
 		resource "google_compute_subnetwork" "foobar" {
-			name = "router-nat-test-subnetwork-%s"
-			network = "${google_compute_network.foobar.self_link}"
+			name          = "router-nat-test-subnetwork-%s"
+			network       = "${google_compute_network.foobar.self_link}"
 			ip_cidr_range = "10.0.0.0/16"
-			region = "us-central1"
+			region        = "us-central1"
 		}
 		resource "google_compute_router" "foobar"{
-			name = "router-nat-test-%s"
-			region = "${google_compute_subnetwork.foobar.region}"
+			name    = "router-nat-test-%s"
+			region  = "${google_compute_subnetwork.foobar.region}"
 			network = "${google_compute_network.foobar.self_link}"
 			bgp {
 				asn = 64514
@@ -170,18 +170,18 @@ func testAccComputeRouterNatWithManualIpAndSubnetConfiguration(testId string) st
 			auto_create_subnetworks = "false"
 		}
 		resource "google_compute_subnetwork" "foobar" {
-			name = "router-nat-test-subnetwork-%s"
-			network = "${google_compute_network.foobar.self_link}"
+			name          = "router-nat-test-subnetwork-%s"
+			network       = "${google_compute_network.foobar.self_link}"
 			ip_cidr_range = "10.0.0.0/16"
-			region = "us-central1"
+			region        = "us-central1"
 		}
 		resource "google_compute_address" "foobar" {
-			name = "router-nat-test-%s"
+			name   = "router-nat-test-%s"
 			region = "${google_compute_subnetwork.foobar.region}"
 		}
 		resource "google_compute_router" "foobar"{
-			name = "router-nat-test-%s"
-			region = "${google_compute_subnetwork.foobar.region}"
+			name    = "router-nat-test-%s"
+			region  = "${google_compute_subnetwork.foobar.region}"
 			network = "${google_compute_network.foobar.self_link}"
 			bgp {
 				asn = 64514
@@ -209,14 +209,14 @@ func testAccComputeRouterNatKeepRouter(testId string) string {
 			auto_create_subnetworks = "false"
 		}
 		resource "google_compute_subnetwork" "foobar" {
-			name = "router-nat-test-subnetwork-%s"
-			network = "${google_compute_network.foobar.self_link}"
+			name          = "router-nat-test-subnetwork-%s"
+			network       = "${google_compute_network.foobar.self_link}"
 			ip_cidr_range = "10.0.0.0/16"
-			region = "us-central1"
+			region        = "us-central1"
 		}
 		resource "google_compute_router" "foobar"{
-			name = "router-nat-test-%s"
-			region = "${google_compute_subnetwork.foobar.region}"
+			name    = "router-nat-test-%s"
+			region  = "${google_compute_subnetwork.foobar.region}"
 			network = "${google_compute_network.foobar.self_link}"
 			bgp {
 				asn = 64514

--- a/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
@@ -1,4 +1,6 @@
+<% autogen_exception -%>
 package google
+<% unless version.nil? || version == 'ga' -%>
 
 import (
 	"fmt"
@@ -222,3 +224,6 @@ func testAccComputeRouterNatKeepRouter(testId string) string {
 		}
 	`, testId, testId, testId)
 }
+<% else %>
+// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
+<% end -%>

--- a/third_party/terraform/tests/resource_compute_router_test.go
+++ b/third_party/terraform/tests/resource_compute_router_test.go
@@ -6,259 +6,177 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccComputeRouterNat_basic(t *testing.T) {
+func TestAccComputeRouter_basic(t *testing.T) {
+	t.Parallel()
+
+	testId := acctest.RandString(10)
+	resourceRegion := "europe-west1"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeRouterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeRouterBasic(testId, resourceRegion),
+			},
+			resource.TestStep{
+				ResourceName:      "google_compute_router.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRouter_noRegion(t *testing.T) {
+	t.Parallel()
+
+	testId := acctest.RandString(10)
+	providerRegion := "us-central1"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeRouterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeRouterNoRegion(testId, providerRegion),
+			},
+			resource.TestStep{
+				ResourceName:      "google_compute_router.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRouter_full(t *testing.T) {
 	t.Parallel()
 
 	testId := acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeRouterNatDestroy,
+		CheckDestroy: testAccCheckComputeRouterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeRouterNatBasic(testId),
-				Check: testAccCheckComputeRouterNatExists(
-					"google_compute_router_nat.foobar"),
+				Config: testAccComputeRouterFull(testId),
 			},
 			resource.TestStep{
-				ResourceName:      "google_compute_router_nat.foobar",
+				ResourceName:      "google_compute_router.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccComputeRouter_update(t *testing.T) {
+	t.Parallel()
+
+	testId := acctest.RandString(10)
+	region := getTestRegionFromEnv()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeRouterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeRouterBasic(testId, region),
+			},
+			resource.TestStep{
+				ResourceName:      "google_compute_router.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			resource.TestStep{
-				Config: testAccComputeRouterNatKeepRouter(testId),
-				Check: testAccCheckComputeRouterNatDelete(
-					"google_compute_router_nat.foobar"),
+				Config: testAccComputeRouterFull(testId),
 			},
-		},
-	})
-}
-
-func TestAccComputeRouterNat_withManualIpAndSubnetConfiguration(t *testing.T) {
-	t.Parallel()
-
-	testId := acctest.RandString(10)
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeRouterNatDestroy,
-		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeRouterNatWithManualIpAndSubnetConfiguration(testId),
-				Check: testAccCheckComputeRouterNatExists(
-					"google_compute_router_nat.foobar"),
+				ResourceName:      "google_compute_router.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			resource.TestStep{
+				Config: testAccComputeRouterBasic(testId, region),
+			},
+			resource.TestStep{
+				ResourceName:      "google_compute_router.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
 }
 
-func testAccCheckComputeRouterNatDestroy(s *terraform.State) error {
-	config := testAccProvider.Meta().(*Config)
-
-	routersService := config.clientCompute.Routers
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "google_compute_router" {
-			continue
+func testAccComputeRouterBasic(testId, resourceRegion string) string {
+	return fmt.Sprintf(`
+		resource "google_compute_network" "foobar" {
+			name = "router-test-%s"
+			auto_create_subnetworks = false
 		}
-
-		project, err := getTestProject(rs.Primary, config)
-		if err != nil {
-			return err
+		resource "google_compute_subnetwork" "foobar" {
+			name = "router-test-subnetwork-%s"
+			network = "${google_compute_network.foobar.self_link}"
+			ip_cidr_range = "10.0.0.0/16"
+			region = "%s"
 		}
-
-		region, err := getTestRegion(rs.Primary, config)
-		if err != nil {
-			return err
+		resource "google_compute_router" "foobar" {
+			name = "router-test-%s"
+			region = "${google_compute_subnetwork.foobar.region}"
+			network = "${google_compute_network.foobar.name}"
+			bgp {
+				asn = 64514
+			}
 		}
-
-		routerName := rs.Primary.Attributes["router"]
-
-		_, err = routersService.Get(project, region, routerName).Do()
-
-		if err == nil {
-			return fmt.Errorf("Error, Router %s in region %s still exists",
-				routerName, region)
-		}
-	}
-
-	return nil
+	`, testId, testId, resourceRegion, testId)
 }
 
-func testAccCheckComputeRouterNatDelete(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		config := testAccProvider.Meta().(*Config)
-
-		routersService := config.clientComputeBeta.Routers
-
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "google_compute_router_nat" {
-				continue
+func testAccComputeRouterNoRegion(testId, providerRegion string) string {
+	return fmt.Sprintf(`
+		resource "google_compute_network" "foobar" {
+			name = "router-test-%s"
+			auto_create_subnetworks = false
+		}
+		resource "google_compute_subnetwork" "foobar" {
+			name = "router-test-subnetwork-%s"
+			network = "${google_compute_network.foobar.self_link}"
+			ip_cidr_range = "10.0.0.0/16"
+			region = "%s"
+		}
+		resource "google_compute_router" "foobar" {
+			name = "router-test-%s"
+			network = "${google_compute_network.foobar.name}"
+			bgp {
+				asn = 64514
 			}
+		}
+	`, testId, testId, providerRegion, testId)
+}
 
-			project, err := getTestProject(rs.Primary, config)
-			if err != nil {
-				return err
-			}
+func testAccComputeRouterFull(testId string) string {
+	return fmt.Sprintf(`
+		resource "google_compute_network" "foobar" {
+			name = "router-test-%s"
+			auto_create_subnetworks = false
+		}
 
-			region, err := getTestRegion(rs.Primary, config)
-			if err != nil {
-				return err
-			}
-
-			name := rs.Primary.Attributes["name"]
-			routerName := rs.Primary.Attributes["router"]
-
-			router, err := routersService.Get(project, region, routerName).Do()
-
-			if err != nil {
-				return fmt.Errorf("Error Reading Router %s: %s", routerName, err)
-			}
-
-			nats := router.Nats
-			for _, nat := range nats {
-
-				if nat.Name == name {
-					return fmt.Errorf("Nat %s still exists on router %s/%s", name, region, router.Name)
+		resource "google_compute_router" "foobar" {
+			name = "router-test-%s"
+			network = "${google_compute_network.foobar.name}"
+			bgp {
+				asn = 64514
+				advertise_mode = "CUSTOM"
+				advertised_groups = ["ALL_SUBNETS"]
+				advertised_ip_ranges {
+					range = "1.2.3.4"
+				}
+				advertised_ip_ranges {
+					range = "6.7.0.0/16"
 				}
 			}
 		}
-
-		return nil
-	}
-}
-
-func testAccCheckComputeRouterNatExists(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-
-		config := testAccProvider.Meta().(*Config)
-
-		project, err := getTestProject(rs.Primary, config)
-		if err != nil {
-			return err
-		}
-
-		region, err := getTestRegion(rs.Primary, config)
-		if err != nil {
-			return err
-		}
-
-		name := rs.Primary.Attributes["name"]
-		routerName := rs.Primary.Attributes["router"]
-
-		routersService := config.clientComputeBeta.Routers
-		router, err := routersService.Get(project, region, routerName).Do()
-
-		if err != nil {
-			return fmt.Errorf("Error Reading Router %s: %s", routerName, err)
-		}
-
-		for _, nat := range router.Nats {
-
-			if nat.Name == name {
-				return nil
-			}
-		}
-
-		return fmt.Errorf("Nat %s not found for router %s", name, router.Name)
-	}
-}
-
-func testAccComputeRouterNatBasic(testId string) string {
-	return fmt.Sprintf(`
-	        resource "google_compute_network" "foobar" {
-			name = "router-nat-test-%s"
-		}
-		resource "google_compute_subnetwork" "foobar" {
-			name = "router-nat-test-subnetwork-%s"
-			network = "${google_compute_network.foobar.self_link}"
-			ip_cidr_range = "10.0.0.0/16"
-			region = "us-central1"
-		}
-		resource "google_compute_router" "foobar"{
-			name = "router-nat-test-%s"
-			region = "${google_compute_subnetwork.foobar.region}"
-			network = "${google_compute_network.foobar.self_link}"
-			bgp {
-				asn = 64514
-			}
-		}
-		resource "google_compute_router_nat" "foobar" {
-			name                               = "router-nat-test-%s"
-			router                             = "${google_compute_router.foobar.name}"
-			region                             = "${google_compute_router.foobar.region}"
-			nat_ip_allocate_option             = "AUTO_ONLY"
-			source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
-		}
-	`, testId, testId, testId, testId)
-}
-
-func testAccComputeRouterNatWithManualIpAndSubnetConfiguration(testId string) string {
-	return fmt.Sprintf(`
-	        resource "google_compute_network" "foobar" {
-			name = "router-nat-test-%s"
-		}
-		resource "google_compute_subnetwork" "foobar" {
-			name = "router-nat-test-subnetwork-%s"
-			network = "${google_compute_network.foobar.self_link}"
-			ip_cidr_range = "10.0.0.0/16"
-			region = "us-central1"
-		}
-		resource "google_compute_address" "foobar" {
-			name = "router-peer-test-%s"
-			region = "${google_compute_subnetwork.foobar.region}"
-		}
-		resource "google_compute_router" "foobar"{
-			name = "router-nat-test-%s"
-			region = "${google_compute_subnetwork.foobar.region}"
-			network = "${google_compute_network.foobar.self_link}"
-			bgp {
-				asn = 64514
-			}
-		}
-		resource "google_compute_router_nat" "foobar" {
-			name                               = "router-nat-test-%s"
-			router                             = "${google_compute_router.foobar.name}"
-			region                             = "${google_compute_router.foobar.region}"
-			nat_ip_allocate_option             = "MANUAL_ONLY"
-			nat_ips                            = ["${google_compute_address.foobar.self_link}"]
-			source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
-			subnetwork {
-			  name = "${google_compute_subnetwork.foobar.self_link}"
-			}
-		}
-	`, testId, testId, testId, testId, testId)
-}
-
-func testAccComputeRouterNatKeepRouter(testId string) string {
-	return fmt.Sprintf(`
-		resource "google_compute_network" "foobar" {
-			name = "router-nat-test-%s"
-		}
-		resource "google_compute_subnetwork" "foobar" {
-			name = "router-nat-test-subnetwork-%s"
-			network = "${google_compute_network.foobar.self_link}"
-			ip_cidr_range = "10.0.0.0/16"
-			region = "us-central1"
-		}
-		resource "google_compute_router" "foobar"{
-			name = "router-nat-test-%s"
-			region = "${google_compute_subnetwork.foobar.region}"
-			network = "${google_compute_network.foobar.self_link}"
-			bgp {
-				asn = 64514
-			}
-		}
-	`, testId, testId, testId)
+	`, testId, testId)
 }

--- a/third_party/terraform/tests/resource_compute_router_test.go
+++ b/third_party/terraform/tests/resource_compute_router_test.go
@@ -6,177 +6,259 @@ import (
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccComputeRouter_basic(t *testing.T) {
-	t.Parallel()
-
-	testId := acctest.RandString(10)
-	resourceRegion := "europe-west1"
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeRouterDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccComputeRouterBasic(testId, resourceRegion),
-			},
-			resource.TestStep{
-				ResourceName:      "google_compute_router.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccComputeRouter_noRegion(t *testing.T) {
-	t.Parallel()
-
-	testId := acctest.RandString(10)
-	providerRegion := "us-central1"
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeRouterDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccComputeRouterNoRegion(testId, providerRegion),
-			},
-			resource.TestStep{
-				ResourceName:      "google_compute_router.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccComputeRouter_full(t *testing.T) {
+func TestAccComputeRouterNat_basic(t *testing.T) {
 	t.Parallel()
 
 	testId := acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeRouterDestroy,
+		CheckDestroy: testAccCheckComputeRouterNatDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeRouterFull(testId),
+				Config: testAccComputeRouterNatBasic(testId),
+				Check: testAccCheckComputeRouterNatExists(
+					"google_compute_router_nat.foobar"),
 			},
 			resource.TestStep{
-				ResourceName:      "google_compute_router.foobar",
+				ResourceName:      "google_compute_router_nat.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+			resource.TestStep{
+				Config: testAccComputeRouterNatKeepRouter(testId),
+				Check: testAccCheckComputeRouterNatDelete(
+					"google_compute_router_nat.foobar"),
 			},
 		},
 	})
 }
 
-func TestAccComputeRouter_update(t *testing.T) {
+func TestAccComputeRouterNat_withManualIpAndSubnetConfiguration(t *testing.T) {
 	t.Parallel()
 
 	testId := acctest.RandString(10)
-	region := getTestRegionFromEnv()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeRouterDestroy,
+		CheckDestroy: testAccCheckComputeRouterNatDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeRouterBasic(testId, region),
-			},
-			resource.TestStep{
-				ResourceName:      "google_compute_router.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			resource.TestStep{
-				Config: testAccComputeRouterFull(testId),
-			},
-			resource.TestStep{
-				ResourceName:      "google_compute_router.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			resource.TestStep{
-				Config: testAccComputeRouterBasic(testId, region),
-			},
-			resource.TestStep{
-				ResourceName:      "google_compute_router.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				Config: testAccComputeRouterNatWithManualIpAndSubnetConfiguration(testId),
+				Check: testAccCheckComputeRouterNatExists(
+					"google_compute_router_nat.foobar"),
 			},
 		},
 	})
 }
 
-func testAccComputeRouterBasic(testId, resourceRegion string) string {
+func testAccCheckComputeRouterNatDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+
+	routersService := config.clientCompute.Routers
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "google_compute_router" {
+			continue
+		}
+
+		project, err := getTestProject(rs.Primary, config)
+		if err != nil {
+			return err
+		}
+
+		region, err := getTestRegion(rs.Primary, config)
+		if err != nil {
+			return err
+		}
+
+		routerName := rs.Primary.Attributes["router"]
+
+		_, err = routersService.Get(project, region, routerName).Do()
+
+		if err == nil {
+			return fmt.Errorf("Error, Router %s in region %s still exists",
+				routerName, region)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckComputeRouterNatDelete(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*Config)
+
+		routersService := config.clientComputeBeta.Routers
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "google_compute_router_nat" {
+				continue
+			}
+
+			project, err := getTestProject(rs.Primary, config)
+			if err != nil {
+				return err
+			}
+
+			region, err := getTestRegion(rs.Primary, config)
+			if err != nil {
+				return err
+			}
+
+			name := rs.Primary.Attributes["name"]
+			routerName := rs.Primary.Attributes["router"]
+
+			router, err := routersService.Get(project, region, routerName).Do()
+
+			if err != nil {
+				return fmt.Errorf("Error Reading Router %s: %s", routerName, err)
+			}
+
+			nats := router.Nats
+			for _, nat := range nats {
+
+				if nat.Name == name {
+					return fmt.Errorf("Nat %s still exists on router %s/%s", name, region, router.Name)
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeRouterNatExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		project, err := getTestProject(rs.Primary, config)
+		if err != nil {
+			return err
+		}
+
+		region, err := getTestRegion(rs.Primary, config)
+		if err != nil {
+			return err
+		}
+
+		name := rs.Primary.Attributes["name"]
+		routerName := rs.Primary.Attributes["router"]
+
+		routersService := config.clientComputeBeta.Routers
+		router, err := routersService.Get(project, region, routerName).Do()
+
+		if err != nil {
+			return fmt.Errorf("Error Reading Router %s: %s", routerName, err)
+		}
+
+		for _, nat := range router.Nats {
+
+			if nat.Name == name {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("Nat %s not found for router %s", name, router.Name)
+	}
+}
+
+func testAccComputeRouterNatBasic(testId string) string {
 	return fmt.Sprintf(`
-		resource "google_compute_network" "foobar" {
-			name = "router-test-%s"
-			auto_create_subnetworks = false
+	        resource "google_compute_network" "foobar" {
+			name = "router-nat-test-%s"
 		}
 		resource "google_compute_subnetwork" "foobar" {
-			name = "router-test-subnetwork-%s"
+			name = "router-nat-test-subnetwork-%s"
 			network = "${google_compute_network.foobar.self_link}"
 			ip_cidr_range = "10.0.0.0/16"
-			region = "%s"
+			region = "us-central1"
 		}
-		resource "google_compute_router" "foobar" {
-			name = "router-test-%s"
+		resource "google_compute_router" "foobar"{
+			name = "router-nat-test-%s"
 			region = "${google_compute_subnetwork.foobar.region}"
-			network = "${google_compute_network.foobar.name}"
+			network = "${google_compute_network.foobar.self_link}"
 			bgp {
 				asn = 64514
 			}
 		}
-	`, testId, testId, resourceRegion, testId)
+		resource "google_compute_router_nat" "foobar" {
+			name                               = "router-nat-test-%s"
+			router                             = "${google_compute_router.foobar.name}"
+			region                             = "${google_compute_router.foobar.region}"
+			nat_ip_allocate_option             = "AUTO_ONLY"
+			source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+		}
+	`, testId, testId, testId, testId)
 }
 
-func testAccComputeRouterNoRegion(testId, providerRegion string) string {
+func testAccComputeRouterNatWithManualIpAndSubnetConfiguration(testId string) string {
 	return fmt.Sprintf(`
-		resource "google_compute_network" "foobar" {
-			name = "router-test-%s"
-			auto_create_subnetworks = false
+	        resource "google_compute_network" "foobar" {
+			name = "router-nat-test-%s"
 		}
 		resource "google_compute_subnetwork" "foobar" {
-			name = "router-test-subnetwork-%s"
+			name = "router-nat-test-subnetwork-%s"
 			network = "${google_compute_network.foobar.self_link}"
 			ip_cidr_range = "10.0.0.0/16"
-			region = "%s"
+			region = "us-central1"
 		}
-		resource "google_compute_router" "foobar" {
-			name = "router-test-%s"
-			network = "${google_compute_network.foobar.name}"
+		resource "google_compute_address" "foobar" {
+			name = "router-peer-test-%s"
+			region = "${google_compute_subnetwork.foobar.region}"
+		}
+		resource "google_compute_router" "foobar"{
+			name = "router-nat-test-%s"
+			region = "${google_compute_subnetwork.foobar.region}"
+			network = "${google_compute_network.foobar.self_link}"
 			bgp {
 				asn = 64514
 			}
 		}
-	`, testId, testId, providerRegion, testId)
+		resource "google_compute_router_nat" "foobar" {
+			name                               = "router-nat-test-%s"
+			router                             = "${google_compute_router.foobar.name}"
+			region                             = "${google_compute_router.foobar.region}"
+			nat_ip_allocate_option             = "MANUAL_ONLY"
+			nat_ips                            = ["${google_compute_address.foobar.self_link}"]
+			source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+			subnetwork {
+			  name = "${google_compute_subnetwork.foobar.self_link}"
+			}
+		}
+	`, testId, testId, testId, testId, testId)
 }
 
-func testAccComputeRouterFull(testId string) string {
+func testAccComputeRouterNatKeepRouter(testId string) string {
 	return fmt.Sprintf(`
 		resource "google_compute_network" "foobar" {
-			name = "router-test-%s"
-			auto_create_subnetworks = false
+			name = "router-nat-test-%s"
 		}
-
-		resource "google_compute_router" "foobar" {
-			name = "router-test-%s"
-			network = "${google_compute_network.foobar.name}"
+		resource "google_compute_subnetwork" "foobar" {
+			name = "router-nat-test-subnetwork-%s"
+			network = "${google_compute_network.foobar.self_link}"
+			ip_cidr_range = "10.0.0.0/16"
+			region = "us-central1"
+		}
+		resource "google_compute_router" "foobar"{
+			name = "router-nat-test-%s"
+			region = "${google_compute_subnetwork.foobar.region}"
+			network = "${google_compute_network.foobar.self_link}"
 			bgp {
 				asn = 64514
-				advertise_mode = "CUSTOM"
-				advertised_groups = ["ALL_SUBNETS"]
-				advertised_ip_ranges {
-					range = "1.2.3.4"
-				}
-				advertised_ip_ranges {
-					range = "6.7.0.0/16"
-				}
 			}
 		}
-	`, testId, testId)
+	`, testId, testId, testId)
 }

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -156,6 +156,7 @@ func Provider() terraform.ResourceProvider {
 				"google_compute_route":                         resourceComputeRoute(),
 				"google_compute_router":                        resourceComputeRouter(),
 				"google_compute_router_interface":              resourceComputeRouterInterface(),
+				"google_compute_router_nat":                    resourceComputeRouterNat(),
 				"google_compute_router_peer":                   resourceComputeRouterPeer(),
 				"google_compute_security_policy":               resourceComputeSecurityPolicy(),
 				"google_compute_shared_vpc_host_project":       resourceComputeSharedVpcHostProject(),

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -156,7 +156,9 @@ func Provider() terraform.ResourceProvider {
 				"google_compute_route":                         resourceComputeRoute(),
 				"google_compute_router":                        resourceComputeRouter(),
 				"google_compute_router_interface":              resourceComputeRouterInterface(),
+<% unless version.nil? || version == 'ga' -%>
 				"google_compute_router_nat":                    resourceComputeRouterNat(),
+<% end -%>
 				"google_compute_router_peer":                   resourceComputeRouterPeer(),
 				"google_compute_security_policy":               resourceComputeSecurityPolicy(),
 				"google_compute_shared_vpc_host_project":       resourceComputeSharedVpcHostProject(),

--- a/third_party/terraform/website/docs/r/compute_router_nat.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_router_nat.html.markdown
@@ -31,12 +31,12 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 resource "google_compute_router" "router" {
-        name    = "router"
-        region  = "${google_compute_subnetwork.foobar.region}"
-        network = "${google_compute_network.foobar.self_link}"
-        bgp {
-          asn = 64514
-        }
+  name    = "router"
+  region  = "${google_compute_subnetwork.foobar.region}"
+  network = "${google_compute_network.foobar.self_link}"
+  bgp {
+    asn = 64514
+  }
 }
 
 resource "google_compute_router_nat" "simple-nat" {
@@ -64,12 +64,12 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 resource "google_compute_router" "router" {
-        name    = "router"
-        region  = "${google_compute_subnetwork.foobar.region}"
-        network = "${google_compute_network.foobar.self_link}"
-        bgp {
-          asn = 64514
-        }
+  name    = "router"
+  region  = "${google_compute_subnetwork.foobar.region}"
+  network = "${google_compute_network.foobar.self_link}"
+  bgp {
+    asn = 64514
+  }
 }
 
 resource "google_compute_address" "address" {

--- a/third_party/terraform/website/docs/r/compute_router_nat.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_router_nat.html.markdown
@@ -1,0 +1,74 @@
+---
+layout: "google"
+page_title: "Google: google_compute_router_nat"
+sidebar_current: "docs-google-compute-router-nat"
+description: |-
+  Manages a Cloud Router BGP peer.
+---
+
+# google\_compute\_router\_nat
+
+Manages a Cloud Router BGP peer. For more information see
+[the official documentation](https://cloud.google.com/compute/docs/cloudrouter)
+and
+[API](https://cloud.google.com/compute/docs/reference/latest/routers).
+
+## Example Usage
+
+```hcl
+resource "google_compute_router_peer" "foobar" {
+  name                      = "peer-1"
+  router                    = "router-1"
+  region                    = "us-central1"
+  peer_ip_address           = "169.254.1.2"
+  peer_asn                  = 65513
+  advertised_route_priority = 100
+  interface                 = "interface-1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name for BGP peer, required by GCE. Changing
+    this forces a new peer to be created.
+
+* `router` - (Required) The name of the router in which this BGP peer will be configured.
+    Changing this forces a new peer to be created.
+
+* `interface` - (Required) The name of the interface the BGP peer is associated with.
+    Changing this forces a new peer to be created.
+
+* `peer_ip_address` - (Required) IP address of the BGP interface outside Google Cloud.
+    Changing this forces a new peer to be created.
+
+* `peer_asn` - (Required) Peer BGP Autonomous System Number (ASN).
+    Changing this forces a new peer to be created.
+
+- - -
+
+* `advertised_route_priority` - (Optional) The priority of routes advertised to this BGP peer.
+    Changing this forces a new peer to be created.
+
+* `project` - (Optional) The ID of the project in which this peer's router belongs. If it
+    is not provided, the provider project is used. Changing this forces a new peer to be created.
+
+* `region` - (Optional) The region this peer's router sits in. If not specified,
+    the project region will be used. Changing this forces a new peer to be
+    created.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `ip_address` - IP address of the interface inside Google Cloud Platform.
+
+## Import
+
+Router BGP peers can be imported using the `region`, `router`, and `name`, e.g.
+
+```
+$ terraform import google_compute_router_peer.foobar us-central1/router-1/peer-1
+```

--- a/third_party/terraform/website/docs/r/compute_router_nat.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_router_nat.html.markdown
@@ -31,11 +31,11 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 resource "google_compute_router" "router" {
-        name = "router"
-        region = "${google_compute_subnetwork.foobar.region}"
+        name    = "router"
+        region  = "${google_compute_subnetwork.foobar.region}"
         network = "${google_compute_network.foobar.self_link}"
         bgp {
-                asn = 64514
+          asn = 64514
         }
 }
 
@@ -64,11 +64,11 @@ resource "google_compute_subnetwork" "subnetwork" {
 }
 
 resource "google_compute_router" "router" {
-        name = "router"
-        region = "${google_compute_subnetwork.foobar.region}"
+        name    = "router"
+        region  = "${google_compute_subnetwork.foobar.region}"
         network = "${google_compute_network.foobar.self_link}"
         bgp {
-                asn = 64514
+          asn = 64514
         }
 }
 

--- a/third_party/terraform/website/docs/r/compute_router_nat.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_router_nat.html.markdown
@@ -28,6 +28,24 @@ resource "google_compute_router_nat" "simple-nat" {
 }
 ```
 
+A production-like configuration: enable NAT for one Subnetwork and use a list of
+static external IP address.
+
+```hcl
+resource "google_compute_router_nat" "advanced-nat" {
+  name                               = "nat-1"
+  router                             = "router-1"
+  region                             = "us-central1"
+  nat_ip_allocate_option             = "MANUAL_ONLY"
+  nat_ips                            =
+  ["${google_compute_address.addr1.self_link}", "${google_compute_address.addr2.self_link}"]
+  source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
+  subnetwork {
+    name = "${google_compute_subnetwork.subnetwork1.self_link}"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:

--- a/third_party/terraform/website/google.erb
+++ b/third_party/terraform/website/google.erb
@@ -436,6 +436,10 @@
       <a href="/docs/providers/google/r/compute_router_interface.html">google_compute_router_interface</a>
       </li>
 
+      <li<%%= sidebar_current("docs-google-compute-router-nat") %>>
+      <a href="/docs/providers/google/r/compute_router_nat.html">google_compute_router_nat</a>
+      </li>
+
       <li<%%= sidebar_current("docs-google-compute-router-peer") %>>
       <a href="/docs/providers/google/r/compute_router_peer.html">google_compute_router_peer</a>
       </li>


### PR DESCRIPTION
Add new resource_compute_router_nat to beta Terraform provider

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
Add support for Cloud NAT
## [ansible]
## [inspec]
