### PR TITLE
add beta info back into the docs

### DIFF
--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -1,9 +1,17 @@
 
 * `<%= property.name.underscore -%>` -
-<% if property.required -%>
+<% if property.min_version.name == 'beta' && property.__resource.min_version.name != 'beta'-%>
+<%   if property.required -%>
+  (Required, [Beta](https://terraform.io/docs/providers/google/provider_versions.html))
+<%   elsif !property.output -%>
+  (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html))
+<%   end -%>
+<% else -%>
+<%   if property.required -%>
   (Required)
-<% elsif !property.output -%>
+<%   elsif !property.output -%>
   (Optional)
+<%   end -%>
 <% end -%>
 <%= indent(property.description.strip.gsub("\n\n", "\n"), 2) -%>
 <% if property.is_a?(Api::Type::NestedObject) || property.is_a?(Api::Type::Map) || (property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::NestedObject)) -%>

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -51,7 +51,10 @@ description: |-
 # google\_<%= resource_name.gsub("_", "\\_") %>
 
 <%= lines(object.description) -%>
-
+<% if object.min_version.name == 'beta' -%>
+~> **Warning:** This resource is in beta, and should be used with the terraform-provider-google-beta provider.
+See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
+<% end -%>
 
 <% if !object.references.nil? -%>
 To get more information about <%= object.name -%>, see:


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
They were removed in #558 when deprecation notices were removed, but it still makes sense to have info about whether a resource/property is in beta in the docs since we'll only have one docs site.
<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
add info about whether a resource/property is in beta into the docs
## [ansible]
## [inspec]
