### PR TITLE
[Terraform] use shorter beta link in docs instead of long description

### DIFF
--- a/third_party/terraform/website/docs/d/google_container_engine_versions.html.markdown
+++ b/third_party/terraform/website/docs/d/google_container_engine_versions.html.markdown
@@ -41,10 +41,9 @@ The following arguments are supported:
 * `zone` (optional) - Zone to list available cluster versions for. Should match the zone the cluster will be deployed in.
     If not specified, the provider-level zone is used. One of zone or provider-level zone is required.
 
-* `region` (optional) - Region to list available cluster versions for. Should match the region the cluster will be deployed in.
+* `region` (optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) - Region to list available cluster versions for. Should match the region the cluster will be deployed in.
     For regional clusters, this value must be specified and cannot be inferred from provider-level region. One of zone,
-    region, or provider-level zone is required. This property is in beta, and should be used with the terraform-provider-google-beta provider.
-    See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
+    region, or provider-level zone is required.
 
 * `project` (optional) - ID of the project to list available cluster versions for. Should match the project the cluster will be deployed to.
   Defaults to the project that the provider is authenticated with.

--- a/third_party/terraform/website/docs/r/compute_backend_service.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_backend_service.html.markdown
@@ -84,10 +84,8 @@ The following arguments are supported:
 * `connection_draining_timeout_sec` - (Optional) Time for which instance will be drained (not accept new connections,
 but still work to finish started ones). Defaults to `300`.
 
-* `custom_request_headers` - (Optional) Headers that the
+* `custom_request_headers` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) Headers that the
     HTTP/S load balancer should add to proxied requests. See [guide](https://cloud.google.com/compute/docs/load-balancing/http/backend-service#user-defined-request-headers) for details.
-    This property is in beta, and should be used with the terraform-provider-google-beta provider.
-    See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
 
 * `description` - (Optional) The textual description for the backend service.
 

--- a/third_party/terraform/website/docs/r/compute_global_forwarding_rule.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_global_forwarding_rule.html.markdown
@@ -105,9 +105,8 @@ The IP Version that will be used by this resource's address. One of `"IPV4"` or 
 
 - - -
 
-* `labels` - (Optional)
-A set of key/value label pairs to assign to the resource. This property is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
+* `labels` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html))
+A set of key/value label pairs to assign to the resource.
 
 
 ## Attributes Reference
@@ -117,8 +116,7 @@ exported:
 
 * `self_link` - The URI of the created resource.
 
-* `label_fingerprint` - The current label fingerprint. This property is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
+* `label_fingerprint` ([Beta](https://terraform.io/docs/providers/google/provider_versions.html)) - The current label fingerprint.
 
 ## Import
 

--- a/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -93,11 +93,9 @@ The following arguments are supported:
     which all new instances will be created. This field is only present in the
     `google` provider.
 
-* `version` - (Optional) Application versions managed by this instance group. Each
+* `version` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) Application versions managed by this instance group. Each
     version deals with a specific instance template, allowing canary release scenarios.
     Structure is documented below.
-    This property is in beta, and should be used with the terraform-provider-google-beta provider.
-    See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
 
 * `name` - (Required) The name of the instance group manager. Must be 1-63
     characters long and comply with
@@ -138,14 +136,10 @@ The following arguments are supported:
 
 ---
 
-* `auto_healing_policies` - (Optional) The autohealing policies for this managed instance
+* `auto_healing_policies` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) The autohealing policies for this managed instance
 group. You can specify only one value. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/creating-groups-of-managed-instances#monitoring_groups).
-This property is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
 
-* `update_policy` - (Optional) The update policy for this managed instance group. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/updating-managed-instance-groups) and [API](https://cloud.google.com/compute/docs/reference/rest/beta/instanceGroupManagers/patch)
-This property is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
+* `update_policy` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) The update policy for this managed instance group. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/updating-managed-instance-groups) and [API](https://cloud.google.com/compute/docs/reference/rest/beta/instanceGroupManagers/patch)
 - - -
 
 The `update_policy` block supports:

--- a/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -94,11 +94,9 @@ The following arguments are supported:
     which all new instances will be created. This field is only present in the
     `google` provider.
 
-* `version` - (Optional) Application versions managed by this instance group. Each
+* `version` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) Application versions managed by this instance group. Each
     version deals with a specific instance template, allowing canary release scenarios.
     Structure is documented below.
-    This property is in beta, and should be used with the terraform-provider-google-beta provider.
-    See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
 
 * `name` - (Required) The name of the instance group manager. Must be 1-63
     characters long and comply with
@@ -138,15 +136,11 @@ The following arguments are supported:
 
 ---
 
-* `auto_healing_policies` - (Optional) The autohealing policies for this managed instance
+* `auto_healing_policies` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) The autohealing policies for this managed instance
 group. You can specify only one value. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/creating-groups-of-managed-instances#monitoring_groups).
-This property is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
 
 
-* `update_policy` - (Optional) The update policy for this managed instance group. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/updating-managed-instance-groups) and [API](https://cloud.google.com/compute/docs/reference/rest/beta/regionInstanceGroupManagers/patch)
-This property is in beta, and should be used with the terraform-provider-google-beta provider.
-See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
+* `update_policy` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) The update policy for this managed instance group. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/updating-managed-instance-groups) and [API](https://cloud.google.com/compute/docs/reference/rest/beta/regionInstanceGroupManagers/patch)
 
 
 * `distribution_policy_zones` - (Optional) The distribution policy for this managed instance

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -75,13 +75,11 @@ output "cluster_ca_certificate" {
     in `initial_node_count` should be created in. Only one of `zone` and `region`
     may be set. If neither zone nor region are set, the provider zone is used.
 
-* `region` (Optional)
+* `region` (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html))
     The region to create the cluster in, for
     [Regional Clusters](https://cloud.google.com/kubernetes-engine/docs/concepts/multi-zone-and-regional-clusters#regional).
     In a Regional Cluster, the number of nodes specified in `initial_node_count` is 
     created in three zones of the region (this can be changed by setting `additional_zones`).
-    This property is in beta, and should be used with the terraform-provider-google-beta provider.
-    See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
 
 * `additional_zones` - (Optional) The list of additional Google Compute Engine
     locations in which the cluster's nodes should be located. If additional zones are
@@ -96,19 +94,15 @@ output "cluster_ca_certificate" {
 
 * `description` - (Optional) Description of the cluster.
 
-* `enable_binary_authorization` - (Optional) Enable Binary Authorization for this cluster.
+* `enable_binary_authorization` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) Enable Binary Authorization for this cluster.
     If enabled, all container images will be validated by Google Binary Authorization.
-    This property is in beta, and should be used with the terraform-provider-google-beta provider.
-    See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
 
 * `enable_kubernetes_alpha` - (Optional) Whether to enable Kubernetes Alpha features for
     this cluster. Note that when this option is enabled, the cluster cannot be upgraded
     and will be automatically deleted after 30 days.
 
-* `enable_tpu` - (Optional) Whether to enable Cloud TPU resources in this cluster.
+* `enable_tpu` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) Whether to enable Cloud TPU resources in this cluster.
     See the [official documentation](https://cloud.google.com/tpu/docs/kubernetes-engine-setup).
-    This property is in beta, and should be used with the terraform-provider-google-beta provider.
-    See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
 
 * `enable_legacy_abac` - (Optional) Whether the ABAC authorizer is enabled for this cluster.
     When enabled, identities in the system, including service accounts, nodes, and controllers,
@@ -176,16 +170,12 @@ to the datasource. A `region` can have a different set of supported versions tha
     or set to the same value as `min_master_version` on create. Defaults to the default
     version set by GKE which is not necessarily the latest version.
 
-* `pod_security_policy_config` - (Optional) Configuration for the
+* `pod_security_policy_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) Configuration for the
     [PodSecurityPolicy](https://cloud.google.com/kubernetes-engine/docs/how-to/pod-security-policies) feature.
     Structure is documented below.
-    This property is in beta, and should be used with the terraform-provider-google-beta provider.
-    See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
 
-* `private_cluster_config` - (Optional) A set of options for creating
+* `private_cluster_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) A set of options for creating
     a private cluster. Structure is documented below.
-    This property is in beta, and should be used with the terraform-provider-google-beta provider.
-    See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
 
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
@@ -370,15 +360,12 @@ The `node_config` block supports:
 * `tags` - (Optional) The list of instance tags applied to all nodes. Tags are used to identify
     valid sources or targets for network firewalls.
 
-* `taint` - (Optional) List of
+* `taint` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) List of
     [kubernetes taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
-    to apply to each node. Structure is documented below. This property is in beta, and should be
-    used with the terraform-provider-google-beta provider. See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html)
-    for more details on beta fields.
+    to apply to each node. Structure is documented below.
 
-* `workload_metadata_config` - (Optional) Metadata configuration to expose to workloads on the node pool.
-    Structure is documented below. This property is in beta, and should be used with the terraform-provider-google-beta provider.
-    See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
+* `workload_metadata_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) Metadata configuration to expose to workloads on the node pool.
+    Structure is documented below.
 
 The `guest_accelerator` block supports:
 

--- a/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -112,9 +112,7 @@ resource "google_container_node_pool" "regional-np" {
 
 * `zone` - (Optional) The zone in which the cluster resides.
 
-* `region` - (Optional) The region in which the cluster resides (for regional clusters).
-    This property is in beta, and should be used with the terraform-provider-google-beta provider.
-    See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
+* `region` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) The region in which the cluster resides (for regional clusters).
 
 * `cluster` - (Required) The cluster to create the node pool for.  Cluster must be present in `zone` provided for zonal clusters.
 
@@ -131,11 +129,9 @@ Note: You must be provide region for regional clusters and zone for zonal cluste
 * `management` - (Optional) Node management configuration, wherein auto-repair and
     auto-upgrade is configured. Structure is documented below.
 
-* `max_pods_per_node` - (Optional) The maximum number of pods per node in this node pool.
+* `max_pods_per_node` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) The maximum number of pods per node in this node pool.
     Note that this does not work on node pools which are "route-based" - that is, node
     pools belonging to clusters that do not have IP Aliasing enabled.
-    This property is in beta, and should be used with the terraform-provider-google-beta provider.
-    See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta fields.
 
 * `name` - (Optional) The name of the node pool. If left blank, Terraform will
     auto-generate a unique name.


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
IMO this improves readability by keeping the resource descriptions a bit shorter and providing this link up front.
<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
use shorter beta link in docs instead of long description
### [terraform-beta]
## [ansible]
## [inspec]
