### PR TITLE
Potential fix for container cluster autoscaling test failures in GA.

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -844,6 +844,10 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	if err := d.Set("cluster_autoscaling", flattenClusterAutoscaling(cluster.Autoscaling)); err != nil {
 		return err
 	}
+<% else -%>
+	if err := d.Set("cluster_autoscaling", nil); err != nil {
+		return err
+	}
 <% end -%>
 	if err := d.Set("node_config", flattenNodeConfig(cluster.NodeConfig)); err != nil {
 		return err

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1563,6 +1563,7 @@ func expandMaintenancePolicy(configured interface{}) *containerBeta.MaintenanceP
 	}
 }
 
+<% unless version.nil? || version == 'ga' -%>
 func expandClusterAutoscaling(configured interface{}, d *schema.ResourceData) *containerBeta.ClusterAutoscaling {
 	l, ok := configured.([]interface{})
 	if !ok || l == nil || len(l) == 0 || l[0] == nil {
@@ -1619,6 +1620,7 @@ func expandClusterAutoscaling(configured interface{}, d *schema.ResourceData) *c
 	}
 	return r
 }
+<% end -%>
 
 func expandMasterAuth(configured interface{}) *containerBeta.MasterAuth {
 	l := configured.([]interface{})
@@ -1855,6 +1857,7 @@ func flattenMasterAuth(ma *containerBeta.MasterAuth) []map[string]interface{} {
 	return masterAuth
 }
 
+<% unless version.nil? || version == 'ga' -%>
 func flattenClusterAutoscaling(a *containerBeta.ClusterAutoscaling) []map[string]interface{} {
 	r := make(map[string]interface{})
 	if a == nil || !a.EnableNodeAutoprovisioning {
@@ -1873,6 +1876,7 @@ func flattenClusterAutoscaling(a *containerBeta.ClusterAutoscaling) []map[string
 	}
 	return []map[string]interface{}{r}
 }
+<% end -%>
 
 func flattenMasterAuthorizedNetworksConfig(c *containerBeta.MasterAuthorizedNetworksConfig) []map[string]interface{} {
 	if c == nil {

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2193,6 +2193,7 @@ resource "google_container_cluster" "with_node_pool" {
 }`, cluster, nodePool)
 }
 
+<% unless version.nil? || version == 'ga' -%>
 func testAccContainerCluster_autoprovisioning(cluster string, autoprovisioning bool) string {
 	config := fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
@@ -2229,6 +2230,7 @@ resource "google_container_cluster" "with_autoprovisioning" {
 }`
 	return config
 }
+<% end -%>
 
 func testAccContainerCluster_withNodePoolAutoscaling(cluster, np string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
Always set cluster_autoscaling to nil in read in GA.

-----------------------------------------------------------------
# [all]
## [terraform]
Fix for permadiff in container cluster caused by beta resource.
### [terraform-beta]
## [ansible]
## [inspec]
