### PR TITLE
Ansible - Alter Compute Instance On/Off

### DIFF
--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -266,9 +266,10 @@ overrides: !ruby/object:Provider::ResourceOverrides
   Instance: !ruby/object:Provider::Ansible::ResourceOverride
     post_action: |
       if fetch:
-        instance = InstancePower(module, fetch)
-        instance.run()
-        fetch.update({'status': module.params['status']})
+          instance = InstancePower(module, fetch.get('status'))
+          instance.run()
+          if module.params.get('status'):
+              fetch.update({'status': module.params['status']})
     provider_helpers:
       - 'products/compute/helpers/python/provider_instance.py'
       - 'products/compute/helpers/python/instance_metadata.py'

--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -264,9 +264,15 @@ overrides: !ruby/object:Provider::ResourceOverrides
     provider_helpers:
       - 'products/compute/helpers/python/instancegroup_instances.py'
   Instance: !ruby/object:Provider::Ansible::ResourceOverride
+    post_action: |
+      if fetch:
+        instance = InstancePower(module, fetch)
+        instance.run()
+        fetch.update({'status': module.params['status']})
     provider_helpers:
       - 'products/compute/helpers/python/provider_instance.py'
       - 'products/compute/helpers/python/instance_metadata.py'
+      - 'products/compute/helpers/python/instance_start.py'
   InstanceTemplate: !ruby/object:Provider::Ansible::ResourceOverride
     provider_helpers:
       - 'products/compute/helpers/python/provider_instance.py'

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -1945,13 +1945,23 @@ objects:
 %>
 <%= indent(compile('products/compute/instance_scheduling.yaml'), 6) %>
 <%= indent(compile('products/compute/instance_serviceaccounts.yaml'), 6) %>
-      - !ruby/object:Api::Type::String
+      - !ruby/object:Api::Type::Enum
         name: 'status'
         description: |
           The status of the instance. One of the following values:
           PROVISIONING, STAGING, RUNNING, STOPPING, SUSPENDING, SUSPENDED,
           and TERMINATED.
-        output: true
+
+          As a user, use RUNNING to keep a machine "on" and TERMINATED to
+          turn a machine off
+        values:
+          - :PROVISIONING
+          - :STAGING
+          - :RUNNING
+          - :STOPPING
+          - :SUSPENDING
+          - :SUSPENDED
+          - :TERMINATED
       - !ruby/object:Api::Type::String
         name: 'statusMessage'
         description: An optional, human-readable explanation of the status.

--- a/products/compute/helpers/python/instance_start.py
+++ b/products/compute/helpers/python/instance_start.py
@@ -10,11 +10,12 @@ class InstancePower(object):
         self.desired_status = self.module.params.get('status')
 
     def run(self):
-        if to_text(self.current_status) == to_text(self.desired_status):
+        # GcpRequest handles unicode text handling
+        if GcpRequest({'status': self.current_status}) == GcpRequest({'status': self.desired_status}):
             return
         elif self.desired_status == 'RUNNING':
             self.start()
-        elif self.desired_status == 'TERMINATED' or self.desired_status == 'SUSPENDED'
+        elif self.desired_status == 'TERMINATED' or self.desired_status == 'SUSPENDED':
             self.stop()
 
     def start(self):

--- a/products/compute/helpers/python/instance_start.py
+++ b/products/compute/helpers/python/instance_start.py
@@ -1,0 +1,32 @@
+<%
+# Instance On/Off logic
+# This code handles the turning a machine on/off depending on user input.
+# It should be run after all normal create/update/delete logic.
+-%>
+class InstancePower(object):
+    def __init__(self, module, current_status):
+        self.module = module
+        self.current_status = current_status
+        self.desired_status = self.module.params.get('status')
+
+    def run(self):
+        if to_text(self.current_status) == to_text(self.desired_status):
+            return
+        elif self.desired_status == 'RUNNING':
+            self.start()
+        elif self.desired_status == 'TERMINATED' or self.desired_status == 'SUSPENDED'
+            self.stop()
+
+    def start(self):
+        auth = GcpSession(self.module, 'compute')
+        wait_for_operation(self.module, auth.post(self._start_url()))
+
+    def stop(self):
+        auth = GcpSession(self.module, 'compute')
+        wait_for_operation(self.module, auth.post(self._stop_url()))
+
+    def _start_url(self):
+        return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances/{name}/start".format(**self.module.params)
+
+    def _stop_url(self):
+        return "https://www.googleapis.com/compute/v1/projects/{project}/zones/{zone}/instances/{name}/stop".format(**self.module.params)


### PR DESCRIPTION
Ansible's old modules allow for on/off on instances. New modules should do the same.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
