### PR TITLE
Wrap 404 error so it can be detected later, instead of overwriting.

### DIFF
--- a/third_party/terraform/utils/logging_exclusion_billing_account.go
+++ b/third_party/terraform/utils/logging_exclusion_billing_account.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/logging/v2"
@@ -58,7 +59,7 @@ func (u *BillingAccountLoggingExclusionUpdater) ReadLoggingExclusion(id string) 
 	exclusion, err := u.Config.clientLogging.BillingAccounts.Exclusions.Get(id).Do()
 
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving logging exclusion for %s: %s", u.DescribeResource(), err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving logging exclusion for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	return exclusion, nil

--- a/third_party/terraform/utils/logging_exclusion_folder.go
+++ b/third_party/terraform/utils/logging_exclusion_folder.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/logging/v2"
@@ -59,7 +60,7 @@ func (u *FolderLoggingExclusionUpdater) ReadLoggingExclusion(id string) (*loggin
 	exclusion, err := u.Config.clientLogging.Folders.Exclusions.Get(id).Do()
 
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving logging exclusion for %s: %s", u.DescribeResource(), err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving logging exclusion for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	return exclusion, nil

--- a/third_party/terraform/utils/logging_exclusion_organization.go
+++ b/third_party/terraform/utils/logging_exclusion_organization.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/logging/v2"
@@ -58,7 +59,7 @@ func (u *OrganizationLoggingExclusionUpdater) ReadLoggingExclusion(id string) (*
 	exclusion, err := u.Config.clientLogging.Organizations.Exclusions.Get(id).Do()
 
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving logging exclusion for %s: %s", u.DescribeResource(), err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving logging exclusion for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	return exclusion, nil

--- a/third_party/terraform/utils/logging_exclusion_project.go
+++ b/third_party/terraform/utils/logging_exclusion_project.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/logging/v2"
@@ -65,7 +66,7 @@ func (u *ProjectLoggingExclusionUpdater) ReadLoggingExclusion(id string) (*loggi
 	exclusion, err := u.Config.clientLogging.Projects.Exclusions.Get(id).Do()
 
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving logging exclusion for %s: %s", u.DescribeResource(), err)
+		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving logging exclusion for %s: {{err}}", u.DescribeResource()), err)
 	}
 
 	return exclusion, nil


### PR DESCRIPTION
404 errors are overwritten so they can't be detected with `handleNotFoundError` - fix that, fix https://github.com/terraform-providers/terraform-provider-google/issues/2519.

-----------------------------------------------------------------
# [all]
## [terraform]
Avoid overwriting errors so that they can be detected by handleNotFoundError.
### [terraform-beta]
## [ansible]
## [inspec]
