### PR TITLE
Ansible: Service Account Keys

### DIFF
--- a/products/iam/ansible.yaml
+++ b/products/iam/ansible.yaml
@@ -36,6 +36,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
       - 'products/iam/helpers/python/provider_service_account.py'
   ServiceAccountKey: !ruby/object:Provider::Ansible::ResourceOverride
     template: 'products/iam/helpers/ansible/service_account_key_template.erb'
+    has_tests: false
 files: !ruby/object:Provider::Config::Files
   copy:
 <%= lines(indent(compile('provider/ansible/common~copy.yaml'), 4)) -%>

--- a/products/iam/ansible.yaml
+++ b/products/iam/ansible.yaml
@@ -35,7 +35,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
     provider_helpers:
       - 'products/iam/helpers/python/provider_service_account.py'
   ServiceAccountKey: !ruby/object:Provider::Ansible::ResourceOverride
-    exclude: true
+    template: 'products/iam/helpers/ansible/service_account_key_template.erb'
 files: !ruby/object:Provider::Config::Files
   copy:
 <%= lines(indent(compile('provider/ansible/common~copy.yaml'), 4)) -%>

--- a/products/iam/api.yaml
+++ b/products/iam/api.yaml
@@ -71,7 +71,7 @@ objects:
         resource: ServiceAccount
         imports: name
       # A non-API property to allow writing results to a specific output file.
-      - !ruby/object:Api::Type::String
+      - !ruby/object:Api::Type::Path
         name: path
         description: |
           The full name of the file that will hold the service account private
@@ -79,17 +79,6 @@ objects:
           sync_file parameter.
 
           File path must be absolute.
-      # A non-API property to allow writing results to a specific output file.
-      - !ruby/object:Api::Type::String
-        name: key_id
-        description: |
-          Used to ensure the deletion of the key in the absence of a key file.
-      - !ruby/object:Api::Type::Boolean
-        name: fail_if_mismatch
-        description: |
-          If set to 'true' protects the target file from being rewritten with a
-          new private key. By default the file is always ensured to have a valid
-          private key on final state.
     properties:
       - !ruby/object:Api::Type::String
         name: name

--- a/products/iam/examples/ansible/service_account_key.yaml
+++ b/products/iam/examples/ansible/service_account_key.yaml
@@ -1,0 +1,32 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- !ruby/object:Provider::Ansible::Example
+task: !ruby/object:Provider::Ansible::Task
+    name: gcp_iam_service_account_key
+    code:
+      service_account: "{{ serviceaccount }}"
+      private_key_type: TYPE_GOOGLE_CREDENTIALS_FILE
+      path: ~/test_account.json
+      project: <%= ctx[:project] %>
+      auth_kind: <%= ctx[:auth_kind] %>
+      service_account_file: <%= ctx[:service_account_file] %>
+dependencies:
+  - !ruby/object:Provider::Ansible::Task
+    name: gcp_iam_service_account
+    code:
+      name: 'test-ansible@graphite-playground.google.com.iam.gserviceaccount.com'
+      display_name: 'My Ansible test key'
+      project: <%= ctx[:project] %>
+      auth_kind: <%= ctx[:auth_kind] %>
+      service_account_file: <%= ctx[:service_account_file] %>
+    register: serviceaccount

--- a/products/iam/helpers/ansible/service_account_key_template.erb
+++ b/products/iam/helpers/ansible/service_account_key_template.erb
@@ -1,0 +1,164 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2017 Google
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+<%= lines(autogen_notice :python) -%>
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+<%= lines(compile('templates/ansible/documentation.erb'), 1) -%>
+################################################################################
+# Imports
+################################################################################
+<%
+  readonly_selflink_rrefs = object.all_resourcerefs
+                                  .select { |prop| prop.resource_ref.readonly }
+                                  .select { |prop| prop.imports == 'selfLink' }
+                                  .map(&:resource_ref)
+                                  .uniq
+-%>
+
+<%
+  update_props = properties_by_custom_update(object.all_user_properties)
+  import = 'from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest'
+  import += ', remove_nones_from_dict' unless properties_with_classes(object.all_user_properties).empty?
+  import += ', replace_resource_dict' if nonreadonly_rrefs(object)
+-%>
+<%= lines(import) -%>
+import json
+import os
+import mimetypes
+import hashlib
+import base64
+<%
+  imports = object.imports || []
+  imports << 'time' if object.async
+  imports << 're' unless readonly_selflink_rrefs.empty?
+-%>
+<%= lines(imports.sort.uniq.map { |i| "import #{i}" }) -%>
+
+################################################################################
+# Main
+################################################################################
+
+
+def main():
+    """Main function"""
+
+<%
+  mod_props = object.all_user_properties.reject(&:output).map do |prop|
+    python_dict_for_property(prop, object)
+  end
+-%>
+    module = GcpModule(
+        argument_spec=dict(
+            state=dict(default='present', choices=['present', 'absent'], type='str'),
+<%= lines(indent_list(mod_props, 12)) -%>
+        )
+    )
+
+    if not module.params['scopes']:
+        module.params['scopes'] = <%= python_literal(object.__product.scopes) %>
+
+    state = module.params['state']
+
+    # If file exists, we're doing a no-op or deleting the key.
+    changed = False
+    if os.path.isfile(module.params['path']):
+        fetch = fetch_resource(module)
+        # If file exists and we should delete the file, delete it.
+        if fetch and module.params['state'] == 'absent':
+            delete(module)
+            changed = True
+
+    # Create the file if present state and no current file.
+    elif module.params['state'] == 'present':
+        create(module)
+        changed = True
+
+    # Not returning any information about the key because that information should
+    # end up in logs.
+    module.exit_json(**{'changed': changed, 'file_path': module.params['path']})
+
+
+def create(module):
+    auth = GcpSession(module, 'iam')
+    json_content = return_if_object(module, auth.post(self_link(module), resource_to_request(module)))
+    with open(module.params['path'], 'w') as f:
+        private_key_contents = base64.b64decode(json_content['privateKeyData'])
+        f.write(private_key_contents)
+
+
+def delete(module):
+    auth = GcpSession(module, 'iam')
+    return return_if_object(module, auth.delete(self_link_from_file(module)))
+
+
+def resource_to_request(module):
+    request = {
+        u'privateKeyType': module.params.get('private_key_type'),
+        u'keyAlgorithm': module.params.get('key_algorithm')
+    }
+    return_vals = {}
+    for k, v in request.items():
+        if v:
+            return_vals[k] = v
+
+    return return_vals
+
+
+def fetch_resource(module):
+    auth = GcpSession(module, 'iam')
+    return return_if_object(module, auth.get(self_link_from_file(module)))
+
+
+def key_name_from_file(filename, module):
+    with open(filename, 'r') as f:
+        try:
+            json_data = json.loads(f.read())
+            return "projects/{project_id}/serviceAccounts/{client_email}/keys/{private_key_id}".format(**json_data)
+        except:
+            module.fail_json(msg="File is not a valid GCP JSON service account key")
+
+
+def self_link_from_file(module):
+    key_name = key_name_from_file(module.params['path'], module)
+    return "https://iam.googleapis.com/v1/{key_name}".format(key_name=key_name)
+
+
+def self_link(module):
+    results = {
+        'project': module.params['project'],
+        'service_account': replace_resource_dict(module.params['service_account'], 'name')
+    }
+    return "https://iam.googleapis.com/v1/projects/{project}/serviceAccounts/{service_account}/keys".format(**results)
+
+
+def return_if_object(module, response):
+    # If not found, return nothing.
+    # return_if_object not used in any context where 404 means error.
+    if response.status_code == 404:
+        return None
+
+    # If no content, return nothing.
+    if response.status_code == 204:
+        return None
+
+    try:
+        module.raise_for_status(response)
+        result = response.json()
+    except getattr(json.decoder, 'JSONDecodeError', ValueError) as inst:
+        module.fail_json(msg="Invalid JSON response with error: %s" % inst)
+
+    if navigate_hash(result, ['error', 'errors']):
+        module.fail_json(msg=navigate_hash(result, ['error', 'errors']))
+
+    return result
+
+if __name__ == '__main__':
+    main()
+
+if __name__ == '__main__':
+    main()

--- a/products/iam/helpers/ansible/service_account_key_template.erb
+++ b/products/iam/helpers/ansible/service_account_key_template.erb
@@ -157,8 +157,6 @@ def return_if_object(module, response):
 
     return result
 
-if __name__ == '__main__':
-    main()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Service Account Keys on Ansible. This allows Ansible to create / delete
Service Account Keys.

Note: this will not delete the service_account_key file for deletions.

<!-- A summary of the changes in this commit goes here -->

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
