### PR TITLE
Adding rubocop for generated inspec files

### DIFF
--- a/.ci/magic-modules/generate-inspec.sh
+++ b/.ci/magic-modules/generate-inspec.sh
@@ -15,6 +15,10 @@ do
   bundle exec compiler -p $i -e inspec -o "build/inspec/"
 done
 
+pushd build/inspec
+rubocop -c .rubocop.yml
+popd
+
 # This command can crash - if that happens, the script should not fail.
 set +e
 INSPEC_COMMIT_MSG="$(python .ci/magic-modules/extract_from_pr_description.py --tag inspec < .git/body)"

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,6 @@ group :test do
   gem 'mocha', '~> 1.3.0'
   gem 'parallel_tests'
   gem 'rspec'
-  gem 'rubocop', '~> 0.52.1'
+  gem 'rubocop', '~> 0.60.0'
   gem 'simplecov'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,7 @@ GEM
     docile (1.3.1)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.1-x86_64-darwin-17)
     json (2.1.0)
     metaclass (0.0.4)
     minitest (5.11.3)
@@ -23,7 +24,7 @@ GEM
     parallel (1.12.1)
     parallel_tests (2.23.0)
       parallel
-    parser (2.5.1.2)
+    parser (2.5.3.0)
       ast (~> 2.4.0)
     powerpack (0.1.2)
     rainbow (3.0.0)
@@ -41,13 +42,14 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.52.1)
+    rubocop (0.60.0)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.4.0.2, < 3.0)
+      parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
+      unicode-display_width (~> 1.4.0)
     ruby-progressbar (1.10.0)
     simplecov (0.16.1)
       docile (~> 1.1)
@@ -69,7 +71,7 @@ DEPENDENCIES
   parallel_tests
   rake
   rspec
-  rubocop (~> 0.52.1)
+  rubocop (~> 0.60.0)
   simplecov
 
 BUNDLED WITH

--- a/api/product.rb
+++ b/api/product.rb
@@ -95,8 +95,10 @@ module Api
       # Versions aren't normally going to be empty since products need a
       # base_url. This nil check exists for atypical products, like _bundle.
       return true if @versions.nil?
+
       name ||= Version::ORDER[0]
       return false unless Version::ORDER.include?(name)
+
       (0..Version::ORDER.index(name)).each do |i|
         return true if exists_at_version(Version::ORDER[i])
       end
@@ -107,6 +109,7 @@ module Api
       # Versions aren't normally going to be empty since products need a
       # base_url. This nil check exists for atypical products, like _bundle.
       return true if @versions.nil?
+
       @versions.any? { |v| v.name == name }
     end
 

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -138,6 +138,7 @@ module Api
 
       def validate
         return unless @__objects.nil? # allows idempotency of calling validate
+
         convert_findings_to_hash
         ensure_keys_are_objects unless @__api.nil?
         super
@@ -149,12 +150,14 @@ module Api
 
       def each
         return enum_for(:each) unless block_given?
+
         @__objects.each { |o| yield o }
         self
       end
 
       def select
         return enum_for(:select) unless block_given?
+
         @__objects.select { |k, v| yield k, v }
       end
 
@@ -184,6 +187,7 @@ module Api
         @__objects = {}
         instance_variables.each do |var|
           next if var.id2name.start_with?('@__')
+
           @__objects[var.id2name[1..-1]] = instance_variable_get(var)
           remove_instance_variable(var)
         end
@@ -192,6 +196,7 @@ module Api
       def ensure_keys_are_objects
         @__objects.each_key do |type|
           next unless @__api.objects.select { |o| o.name == type }.empty?
+
           raise [
             "Object #{type} is not a valid type.",
             "Allowed types are: #{@__api.objects.map(&:name)}"
@@ -297,6 +302,7 @@ module Api
 
     def exported_properties
       return [] if @exports.nil?
+
       from_api = @exports.select { |e| e.is_a?(Api::Type::FetchedExternal) }
                          .each { |e| e.resource = self }
       prop_names = @exports - from_api
@@ -383,6 +389,7 @@ module Api
 
     def async_operation_url
       raise 'Not an async resource' if @async.nil?
+
       [@__product.base_url, @async.operation.base_url]
     end
 
@@ -444,6 +451,7 @@ module Api
           # in between it.
           next if p.resource_ref == original_obj
           next if p.resource_ref == p.__resource
+
           rrefs << p
           rrefs.concat(resourcerefs_for_properties(p.resource_ref
                                                     .required_properties,

--- a/api/type.rb
+++ b/api/type.rb
@@ -131,15 +131,18 @@ module Api
       end
     end
 
+    # rubocop:disable Naming/MemoizedInstanceVariableName
     def exclude_if_not_in_version(version)
       @exclude ||= version < min_version
     end
+    # rubocop:enable Naming/MemoizedInstanceVariableName
 
     # Overriding is_a? to enable class overrides.
     # Ruby does not let you natively change types, so this is the next best
     # thing.
     def is_a?(clazz)
       return Module.const_get(@new_type).new.is_a?(clazz) if @new_type
+
       super(clazz)
     end
 
@@ -148,6 +151,7 @@ module Api
     # thing.
     def class
       return Module.const_get(@new_type) if @new_type
+
       super
     end
 
@@ -275,6 +279,7 @@ module Api
       def item_type_class
         return Api::Type::NestedObject if @item_type.is_a? NestedObject
         return Api::Type::ResourceRef if @item_type.is_a? ResourceRef
+
         get_type("Api::Type::#{@item_type}")
       end
 
@@ -307,6 +312,7 @@ module Api
         if @item_type.is_a?(NestedObject) || @item_type.is_a?(ResourceRef)
           return @item_type.requires
         end
+
         [property_file]
       end
 
@@ -417,6 +423,7 @@ module Api
         product = @__resource.__product
         resources = product.objects.select { |obj| obj.name == @resource }
         raise "Unknown item type '#{@resource}'" if resources.empty?
+
         resources[0]
       end
 
@@ -466,6 +473,7 @@ module Api
         super
 
         raise "Properties missing on #{name}" if @properties.nil?
+
         @properties.each do |p|
           p.set_variable(@__resource, :__resource)
           p.set_variable(self, :__parent)

--- a/compile/core.rb
+++ b/compile/core.rb
@@ -185,6 +185,7 @@ module Compile
 
     def indent_array(text, spaces, filler = ' ')
       return [] if text.nil?
+
       lines = text.class <= Array ? text : text.split("\n")
       lines.map do |line|
         if line.class <= Array
@@ -218,6 +219,7 @@ module Compile
 
     def quote_string(value)
       raise 'Invalid value' if value.nil?
+
       if value.include?('#{') || value.include?("'")
         ['"', value, '"'].join
       else
@@ -227,6 +229,7 @@ module Compile
 
     def lines(code, number = 0)
       return if code.nil? || code.empty?
+
       code = code.join("\n") if code.is_a?(Array)
       code[-1] = '' while code[-1] == "\n" || code[-1] == "\r"
       "#{code}#{"\n" * (number + 1)}"
@@ -234,6 +237,7 @@ module Compile
 
     def lines_before(code, number = 0)
       return if code.nil? || code.empty?
+
       code = code.join("\n") if code.is_a?(Array)
       code[0] = '' while code[0] == "\n" || code[0] == "\r"
       "#{"\n" * (number + 1)}#{code}"
@@ -294,6 +298,7 @@ module Compile
     def strip_copyright_notice(content, comment_marker = '#')
       lines = content.split("\n")
       return content unless lines[0].include?('Copyright 20')
+
       lines = lines.drop(1) while lines[0].start_with?(comment_marker)
       lines = lines.drop(1) while lines[0].strip.empty?
       lines.join("\n")

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 68.88
+    "covered_percent": 69.91
   }
 }

--- a/google/hash_utils.rb
+++ b/google/hash_utils.rb
@@ -19,21 +19,17 @@ module Google
     # Converts all keys to symbols
     def self.camelize_keys(source)
       result = source.clone
-      # rubocop:disable Performance/HashEachMethods
       result.keys.each do |k|
         result[Google::StringUtils.camelize(k.to_s)] = result.delete(k)
       end
-      # rubocop:enable Performance/HashEachMethods
       result
     end
 
     def self.symbolize_keys(source)
       result = source.clone
-      # rubocop:disable Performance/HashEachMethods
       result.keys.each do |k|
         result[Google::StringUtils.symbolize(k)] = result.delete(k)
       end
-      # rubocop:enable Performance/HashEachMethods
       result
     end
 
@@ -42,6 +38,7 @@ module Google
       key = path.take(1)[0]
       path = path.drop(1)
       return default unless source.key?(key)
+
       result = source.fetch(key)
       return HashUtils.navigate(result, path, default) unless path.empty?
       return result if path.empty?

--- a/google/integer_utils.rb
+++ b/google/integer_utils.rb
@@ -16,6 +16,7 @@ module Google
   class IntegerUtils
     def self.underscore(value)
       return '0' if value.zero?
+
       result = []
       while value.positive?
         value, part = value.divmod(1000)

--- a/google/string_utils.rb
+++ b/google/string_utils.rb
@@ -54,6 +54,7 @@ module Google
     def self.first_sentence(text)
       period_pos = text.index(/[\.\?!]/)
       return text if period_pos.nil?
+
       text[0, period_pos + 1]
     end
   end

--- a/google/yaml_validator.rb
+++ b/google/yaml_validator.rb
@@ -47,6 +47,7 @@ module Google
 
     def check_types(objects, type)
       return if objects.nil?
+
       objects.each do |object|
         log_check_type object
         check_type object, type
@@ -79,12 +80,14 @@ module Google
     def check_optional_property(property, type = nil)
       value = instance_variable_get("@#{property}")
       return if value.nil?
+
       check_property_value property, value, type
     end
 
     def check_property_value(property, prop_value, type)
       Google::LOGGER.debug "Checking '#{property}' on #{object_display_name}"
       raise "Missing '#{property}' on #{object_display_name}" if prop_value.nil?
+
       check_type property, prop_value, type unless type.nil?
       prop_value.validate if prop_value.is_a?(Api::Object)
     end
@@ -98,6 +101,7 @@ module Google
       instance_variables.each do |variable|
         var_name = variable.id2name[1..-1]
         next if var_name.start_with?('__')
+
         Google::LOGGER.debug "Validating '#{var_name}' on #{object_display_name}"
         raise "Extraneous variable '#{var_name}' in #{object_display_name}" \
           unless methods.include?(var_name.intern)
@@ -118,6 +122,7 @@ module Google
     def check_optional_property_list(name, type = nil)
       obj_list = instance_variable_get("@#{name}")
       return if obj_list.nil?
+
       check_property_list(name, type)
     end
 
@@ -147,11 +152,13 @@ module Google
                                               type = nil)
       prop_value = instance_variable_get("@#{prop}")
       return if prop_value.nil? && default.nil?
+
       check_property_oneof_default(prop, valid_values, default, type)
     end
 
     def set_variables(objects, property)
       return if objects.nil?
+
       objects.each do |object|
         object.set_variable(self, property) if object.respond_to?(:set_variable)
       end

--- a/products/monitoring/terraform.yaml
+++ b/products/monitoring/terraform.yaml
@@ -89,13 +89,13 @@ overrides: !ruby/object:Provider::ResourceOverrides
     import_format: ["{{name}}"]
     example:
       - !ruby/object:Provider::Terraform::Examples
-        version: <%= _version_name %>
+        version: <%= version_name %>
         name: "uptime_check_config_http"
         primary_resource_id: "http"
         vars:
           display_name: "http-uptime-check"
       - !ruby/object:Provider::Terraform::Examples
-        version: <%= _version_name %>
+        version: <%= version_name %>
         name: "uptime_check_tcp"
         primary_resource_id: "tcp_group"
         vars:

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -57,6 +57,7 @@ module Provider
         # All ResourceRefs are dicts with properties.
         if prop.is_a? Api::Type::ResourceRef
           return 'str' if prop.resource_ref.readonly
+
           return 'dict'
         end
         PYTHON_TYPE_FROM_MM_TYPE.fetch(prop.class.to_s, 'str')
@@ -209,6 +210,7 @@ module Provider
         ex = Google::YamlValidator.parse(File.read(cfg_file))
         raise "#{cfg_file}(#{ex.class}) is not a Provider::Ansible::Example" \
           unless ex.is_a?(Provider::Ansible::Example)
+
         ex.validate
         ex
       end

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -42,10 +42,10 @@ module Provider
                if prop.is_a?(Api::Type::ResourceRef) && !prop.resource_ref.readonly)
             ].flatten.compact,
             'required' => required,
-            'default' => (prop.default_value.to_s if prop.default_value),
+            'default' => (prop.default_value&.to_s),
             'type' => ('bool' if prop.is_a? Api::Type::Boolean),
-            'aliases' => (prop.aliases if prop.aliases),
-            'version_added' => (prop.version_added.to_f if prop.version_added),
+            'aliases' => prop.aliases,
+            'version_added' => (prop.version_added&.to_f),
             'choices' => (prop.values.map(&:to_s) if prop.is_a? Api::Type::Enum),
             'suboptions' => (
               if prop.is_a?(Api::Type::NestedObject)

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -198,6 +198,56 @@ module Provider
       end
     end
 
+    # Holds all information necessary to run a facts module and verify the
+    # creation / deletion of a resource.
+    # FactsVerifiers are verifiers in the sense that they verify GCP status.
+    # They do not do this with bash commands, but with a Ansible facts module.
+    # This verifier will look + an act a lot like a Task.
+    class FactsVerifier < Verifier
+      # Ruby YAML requires at least one value to create the object.
+      attr_reader :noop
+
+      attr_reader :__example
+      include Compile::Core
+      include Provider::Ansible::HandwrittenValuesFromExample
+
+      def validate
+        true
+      end
+
+      def build_task(_state, object)
+        @parameters = build_parameters(object)
+        compile 'templates/ansible/verifiers/facts.yaml.erb'
+      end
+
+      private
+
+      def verbs
+        {
+          present: 'created',
+          absent: 'deleted'
+        }
+      end
+
+      def build_parameters(object)
+        sample_code = @__example.task.code
+        ignored_props = %w[project name]
+
+        # Grab all code values for parameters
+        parameters = handwritten_vals_for_properties(object,
+                                                     uri_properties(object, ignored_props))
+
+        # Grab values for filters.
+        underscore_name = object.facts.filter.name.underscore
+        parameters[underscore_name] = sample_code[underscore_name] if sample_code[underscore_name]
+        parameters.compact
+      end
+
+      def name_parameter
+        compile_string(INTEGRATION_TEST_DEFAULTS, @__example.task.code['name']).join
+      end
+    end
+
     # A gcloud command failing is not enough to verify that a resource does not
     # exist
     # Stderr should be checked to verify that the resource actually does not

--- a/provider/ansible/facts_override.rb
+++ b/provider/ansible/facts_override.rb
@@ -52,6 +52,7 @@ module Provider
                 Each additional filter in the list will act be added as an AND condition
                 (filter1 and filter2)
         STRING
+        true
       end
 
       def gce?

--- a/provider/ansible/manifest.rb
+++ b/provider/ansible/manifest.rb
@@ -39,6 +39,7 @@ module Provider
       def get(value, object)
         return object.instance_variable_get("@#{value}".to_sym) \
           unless object.instance_variable_get("@#{value}".to_sym).nil?
+
         instance_variable_get("@#{value}".to_sym)
       end
     end

--- a/provider/ansible/request.rb
+++ b/provider/ansible/request.rb
@@ -110,6 +110,7 @@ module Provider
         # If input true, treat like request, but use module names.
         return request_output(prop, "#{module_name}.params", module_name) \
           if prop.input
+
         if prop.is_a? Api::Type::NestedObject
           [
             "#{prop.property_class[-1]}(",

--- a/provider/ansible/resourceref.rb
+++ b/provider/ansible/resourceref.rb
@@ -28,6 +28,7 @@ module Provider
       def resourceref_handlers(object)
         rrefs = nonreadonly_rrefs(object)
         return unless rrefs.any?
+
         comments = [
           '# Converts data from:',
           '# foo:',

--- a/provider/config.rb
+++ b/provider/config.rb
@@ -22,7 +22,6 @@ module Provider
     include Compile::Core
     extend Compile::Core
 
-    attr_reader :overrides
     # Overrides for datasources
     attr_reader :datasources
     attr_reader :properties # TODO(nelsonjr): Remove this once bug 193 is fixed.
@@ -91,7 +90,7 @@ module Provider
       # class features
       source = config.compile(cfg_file)
       config = Google::YamlValidator.parse(source)
-      config.default_overrides
+      config.overrides
       config.spread_api config, api, [], '' unless api.nil?
       config.validate
       config
@@ -108,7 +107,7 @@ module Provider
     def validate
       super
 
-      default_overrides
+      overrides
 
       check_optional_property :files, Provider::Config::Files
       check_property :overrides, Provider::ResourceOverrides
@@ -133,8 +132,8 @@ module Provider
     end
 
     # TODO(nelsonjr): Investigate why we need to call default_overrides twice.
-    def default_overrides
-      @default_overrides ||= Provider::ResourceOverrides.new
+    def overrides
+      @overrides ||= Provider::ResourceOverrides.new
     end
   end
 end

--- a/provider/config.rb
+++ b/provider/config.rb
@@ -84,6 +84,7 @@ module Provider
       config = Google::YamlValidator.parse(source)
       raise "Config #{cfg_file}(#{config.class}) is not a Provider::Config" \
         unless config.class <= Provider::Config
+
       # Config must be validated so items are properly setup for next compile
       config.validate
       # Compile step #2: Now that we have the target class, compile with that
@@ -122,6 +123,7 @@ module Provider
       object.instance_variables.each do |var|
         var_value = object.instance_variable_get(var)
         next if visited.include?(var_value)
+
         visited << var_value
         var_value.consume_api api if var_value.respond_to?(:consume_api)
         var_value.consume_config api, self \
@@ -132,7 +134,7 @@ module Provider
 
     # TODO(nelsonjr): Investigate why we need to call default_overrides twice.
     def default_overrides
-      @overrides ||= Provider::ResourceOverrides.new
+      @default_overrides ||= Provider::ResourceOverrides.new
     end
   end
 end

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -254,6 +254,7 @@ module Provider
     def unquote_string(value)
       return value.gsub(/"(.*)"/, '\1') if value.start_with?('"')
       return value.gsub(/'(.*)'/, '\1') if value.start_with?("'")
+
       value
     end
 
@@ -337,6 +338,7 @@ module Provider
 
     def update_url(resource, url_part)
       return build_url(resource.self_link_url) if url_part.nil?
+
       [resource.__product.base_url, url_part].flatten.join
     end
 
@@ -407,6 +409,7 @@ module Provider
     def format_section_ruler(size)
       size_pad = (size - size.to_s.length - 4) # < + > + 2 spaces around number.
       return unless size_pad.positive?
+
       ['<',
        '-' * (size_pad / 2), ' ', size.to_s, ' ', '-' * (size_pad / 2),
        (size_pad.even? ? '' : '-'),

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -126,6 +126,7 @@ module Provider
     # Format a url that may be include newlines into a single line
     def format_url(url)
       return url.join('') if url.is_a?(Array)
+
       url.split("\n").join('')
     end
 

--- a/provider/overrides/validator.rb
+++ b/provider/overrides/validator.rb
@@ -38,17 +38,19 @@ module Provider
         @overrides.instance_variables.reject { |i| i == :@product }.each do |var|
           obj_array = objects.select { |o| o.name == var[1..-1] }
           raise "#{var[1..-1]} not found" if obj_array.empty?
+
           verify_resource(obj_array.first, @overrides[var])
         end
       end
 
       # Verify top-level fields exist on resource
       def verify_resource(res, overrides)
-        overrides.instance_variables.reject { |i| i == :@properties || i == :@parameters }
+        overrides.instance_variables.reject { |i| %i[@properties @parameters].include?(i) }
                  .each do |field_name|
           # Check override object.
           field_symbol = field_name[1..-1].to_sym
           next if check_if_exists(res, field_symbol)
+
           raise "#{field_name} does not exist on #{res.name}"
         end
         # Use instance_variable_get to get excluded properties
@@ -102,11 +104,12 @@ module Provider
 
       def verify_property(property, overrides)
         overrides.instance_variables
-                 .reject { |i| i == :@properties || i == :@item_type || i == :@type }
+                 .reject { |i| %i[@properties @item_type @type].include?(i) }
                  .each do |field_name|
           # Check override object.
           field_symbol = field_name[1..-1].to_sym
           next if check_if_exists(property, field_symbol, overrides['@type'])
+
           raise "#{field_name} does not exist on #{property.name}"
         end
       end

--- a/provider/resource_overrides.rb
+++ b/provider/resource_overrides.rb
@@ -44,6 +44,7 @@ module Provider
     def validate
       return unless @__objects.nil? # allows idempotency of calling validate
       return if @__api.nil?
+
       populate_nonoverridden_objects
       convert_findings_to_hash
       override_objects
@@ -56,12 +57,14 @@ module Provider
 
     def each
       return enum_for(:each) unless block_given?
+
       @__objects.each { |o| yield o }
       self
     end
 
     def select
       return enum_for(:select) unless block_given?
+
       @__objects.select { |o| yield o }
       self
     end
@@ -88,6 +91,7 @@ module Provider
       @__objects = {}
       instance_variables.each do |var|
         next if var.id2name.start_with?('@__')
+
         @__objects[var.id2name[1..-1]] = instance_variable_get(var)
         remove_instance_variable(var)
       end
@@ -98,6 +102,7 @@ module Provider
       @__objects.each do |name, override|
         api_object = @__api.objects.find { |o| o.name == name }
         raise "The resource to override must exist #{name}" if api_object.nil?
+
         check_property_value 'overrides', override, Provider::ResourceOverride
         override.apply api_object
         populate_nonoverridden_properties api_object, override

--- a/provider/terraform/custom_code.rb
+++ b/provider/terraform/custom_code.rb
@@ -87,11 +87,11 @@ module Provider
                          version: version
                        },
                        "templates/terraform/examples/#{name}.tf.erb"
-        ))
+                     ))
         lines(compile_file(
                 { content: body },
                 'templates/terraform/examples/base_configs/documentation.tf.erb'
-        ))
+              ))
       end
 
       def config_test
@@ -103,7 +103,7 @@ module Provider
                          version: version
                        },
                        "templates/terraform/examples/#{name}.tf.erb"
-        ))
+                     ))
 
         body = substitute_test_paths body
 
@@ -113,7 +113,7 @@ module Provider
                   count: vars.length
                 },
                 'templates/terraform/examples/base_configs/test_body.go.erb'
-        ))
+              ))
       end
 
       def config_example
@@ -125,7 +125,7 @@ module Provider
                          version: version
                        },
                        "templates/terraform/examples/#{name}.tf.erb"
-        ))
+                     ))
 
         substitute_example_paths body
       end

--- a/spec/copyright.rb
+++ b/spec/copyright.rb
@@ -39,12 +39,14 @@ module Google
     def exist?(files)
       not_found = files.reject { |f| File.exist?(f) }
       raise "Some files were not found: #{not_found}" unless not_found.empty?
+
       files
     end
 
     def file?(files)
       not_files = files.reject { |f| File.file?(f) }
       raise "Some inputs were not files: #{not_files}" unless not_files.empty?
+
       files
     end
 

--- a/spec/network_blocker.rb
+++ b/spec/network_blocker.rb
@@ -110,6 +110,7 @@ module Net
                 send_request start trace unlock].include?(m)
         next
       end
+
       define_method(m) do |*args|
         request_allowed = true
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,6 +54,7 @@ RSpec::Matchers.define :contain_array do |expected|
       start = actual.index(expected[0])
       actual = actual.drop(start) unless start.nil?
       return true if actual[0, expected.size] == expected
+
       actual = actual.drop(1)
     end
     false

--- a/templates/inspec/nested_object.erb
+++ b/templates/inspec/nested_object.erb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -%>
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 <%= compile('templates/license.erb') -%>
 

--- a/templates/inspec/nested_object.erb
+++ b/templates/inspec/nested_object.erb
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -%>
+# frozen_string_literal: true
+
 <%= compile('templates/license.erb') -%>
 
 <%= lines(autogen_notice :ruby) -%>
-
 <%
   requires = generate_requires(nested_properties)
 -%>
@@ -24,20 +25,19 @@ module Google
   module <%= product_ns %>
     module Property
       class <%= class_name -%>
-
 <% if !nested_properties.empty? -%>
 <% nested_properties.each do |prop| -%>
+
         attr_reader :<%= prop.out_name %>
 <% end # nested_properties.each -%>
 
 <% end # if !nested_properties.empty? -%>
-
         def initialize(args = nil)
-          return nil if args.nil?
+          return if args.nil?
 <% nested_properties.each do |prop| -%>
 <%
   if time?(prop)
-      init = "DateTime.parse(args['#{prop.api_name}'])"
+      init = "Time.parse(args['#{prop.api_name}'])"
   elsif primitive?(prop)
     init = "args['#{prop.api_name}']"
   elsif typed_array?(prop)

--- a/templates/inspec/plural_resource.erb
+++ b/templates/inspec/plural_resource.erb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -%>
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 <%= compile 'templates/license.erb' -%>
 

--- a/templates/inspec/plural_resource.erb
+++ b/templates/inspec/plural_resource.erb
@@ -12,19 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -%>
+# frozen_string_literal: true
+
 <%= compile 'templates/license.erb' -%>
 
 <%= lines(autogen_notice :ruby) -%>
-
 require 'gcp_backend'
 class <%= object.name -%>s < GcpResourceBase
-
 <%
 name = "google_#{product_ns.downcase}_#{object.name.underscore}"
 -%>
   name '<%= name.pluralize -%>'
   desc '<%= object.name -%> plural resource'
   supports platform: 'gcp'
+
+  attr_reader :table
 
   filter_table_config = FilterTable.create
 <% object.all_user_properties.each do |prop| -%>
@@ -50,16 +52,12 @@ base = "'#{object.self_link_url[0].join}'"
 link_query = object.self_link_query || object.collection_url_response
 -%>
   def initialize(params = {})
-    super(params.merge({:use_http_transport => true}))
+    super(params.merge({ use_http_transport: true }))
     @params = params
-    @table = fetch_wrapped_resource(<%= "'#{link_query.kind}'" -%>, <%= "'#{link_query.items}'" -%>)
+    @table = fetch_wrapped_resource(<%= "'#{link_query.items}'" -%>)
   end
 
-  def table
-    @table
-  end
-
-  def fetch_wrapped_resource(wrap_kind, wrap_path)
+  def fetch_wrapped_resource(wrap_path)
     # fetch_resource returns an array of responses (to handle pagination)
     result = @connection.fetch_all(base, url, @params)
     return if result.nil?
@@ -67,7 +65,7 @@ link_query = object.self_link_query || object.collection_url_response
     # Conversion of string -> object hash to symbol -> object hash that InSpec needs
     converted = []
     result.each do |response|
-      return if response.nil? || !response.key?(wrap_path)
+      next if response.nil? || !response.key?(wrap_path)
       response[wrap_path].each do |hash|
         hash_with_symbols = {}
         hash.each_pair { |k, v| hash_with_symbols[k.to_sym] = v }
@@ -77,5 +75,4 @@ link_query = object.self_link_query || object.collection_url_response
 
     converted
   end
-
 end

--- a/templates/inspec/singular_resource.erb
+++ b/templates/inspec/singular_resource.erb
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -%>
+# frozen_string_literal: true
+
 <%= compile 'templates/license.erb' -%>
 
 <%= lines(autogen_notice :ruby) -%>
-
 <%
   require 'google/string_utils'
 
@@ -26,10 +27,8 @@
 -%>
 <%= lines(emit_requires(requires)) -%>
 
-
 # A provider to manage <%= @api.name -%> resources.
 class <%= object.name -%> < GcpResourceBase
-
   name '<%= resource_name(object, product_ns) -%>'
   desc '<%= object.name -%>'
   supports platform: 'gcp'
@@ -48,7 +47,7 @@ class <%= object.name -%> < GcpResourceBase
 
 <% if object.self_link_query.nil? -%>
   def initialize(params)
-    super(params.merge({:use_http_transport => true}))
+    super(params.merge({ use_http_transport: true }))
     @fetched = @connection.fetch(base, url, params)
     parse unless @fetched.nil?
   end
@@ -65,7 +64,7 @@ class <%= object.name -%> < GcpResourceBase
     name = prop.out_name
 
     if time?(prop)
-      init = "DateTime.parse(@fetched['#{prop.api_name}'])"
+      init = "Time.parse(@fetched['#{prop.api_name}'])"
     elsif primitive?(prop)
       init = "@fetched['#{prop.api_name}']"
     elsif typed_array?(prop)

--- a/templates/inspec/singular_resource.erb
+++ b/templates/inspec/singular_resource.erb
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -%>
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 <%= compile 'templates/license.erb' -%>
 


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Run rubocop on generated InSpec files as part of the generation step. Fix simple rubocop errors
<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
