### PR TITLE
Retry all fetches of github PR resource.

### DIFF
--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -109,6 +109,7 @@ jobs:
             resource: magic-modules-new-prs
             version: every
             trigger: true
+            attempts: 2
             params:
               fetch_merge: true
           - aggregate:
@@ -300,6 +301,7 @@ jobs:
               - ansible-test
               - inspec-test
           - get: mm-initial-pr
+            attempts: 2
             resource: magic-modules-new-prs
             passed: [mm-generate]
             version: every
@@ -390,6 +392,7 @@ jobs:
     - name: merge-prs
       plan:
           - get: mm-approved-prs
+            attempts: 2
           - put: mark-automerged
             resource: mm-approved-prs
             params:


### PR DESCRIPTION
Concourse can catch failed clones and retry them.  This will cause some minor annoyances when it retries unretryable errors like "there are merge conflicts", and probably some other annoyances when it retries errors that have already been retried repeatedly, but it fixes a serious problem with this symptom:
`error: RPC failed; curl 56 LibreSSL SSL_read: SSL_ERROR_SYSCALL, errno 104`.

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
