### PR TITLE
Fixing firewall issues on Ansible

### DIFF
--- a/google/python_utils.rb
+++ b/google/python_utils.rb
@@ -29,6 +29,8 @@ module Google
         "'#{value}'"
       elsif value.is_a?(Numeric)
         value.to_s
+      elsif value.is_a?(Hash) and value.keys.length == 1
+        "{#{quote_string(value.keys.first) }: #{python_literal(value[value.keys.first]) }}"
       elsif value.is_a?(Array)
         "[#{value.map { |x| python_literal(x) }.join(' ,')}]"
       elsif value == true

--- a/google/python_utils.rb
+++ b/google/python_utils.rb
@@ -29,8 +29,8 @@ module Google
         "'#{value}'"
       elsif value.is_a?(Numeric)
         value.to_s
-      elsif value.is_a?(Hash) and value.keys.length == 1
-        "{#{quote_string(value.keys.first) }: #{python_literal(value[value.keys.first]) }}"
+      elsif value.is_a?(Hash) && (value.keys.length == 1)
+        "{#{quote_string(value.keys.first)}: #{python_literal(value[value.keys.first])}}"
       elsif value.is_a?(Array)
         "[#{value.map { |x| python_literal(x) }.join(' ,')}]"
       elsif value == true

--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -140,7 +140,16 @@ overrides: !ruby/object:Provider::ResourceOverrides
       type: !ruby/object:Provider::Ansible::PropertyOverride
         version_added: '2.7'
   Firewall: !ruby/object:Provider::Ansible::ResourceOverride
+    imports:
+      - re
+    provider_helpers:
+      - 'products/compute/helpers/python/provider_firewall.py'
+    transport: !ruby/object:Api::Resource::Transport
+      encoder: encode_request
     properties:
+      network: !ruby/object:Provider::Ansible::PropertyOverride
+        default_value:
+          selfLink: global/networks/default
       denied: !ruby/object:Provider::Ansible::PropertyOverride
         version_added: '2.8'
       destinationRanges: !ruby/object:Provider::Ansible::PropertyOverride

--- a/products/compute/helpers/python/provider_firewall.py
+++ b/products/compute/helpers/python/provider_firewall.py
@@ -17,5 +17,5 @@ def encode_request(request, module):
         if not re.match(r"https://www.googleapis.com/compute/v1/projects/.*", request['network']):
             request['network'] = "https://www.googleapis.com/compute/v1/projects/{project}/{network}".format(project=module.params['project'],
                                                                                                              network=request['network'])
-                                    
+
     return request

--- a/products/compute/helpers/python/provider_firewall.py
+++ b/products/compute/helpers/python/provider_firewall.py
@@ -14,8 +14,8 @@
 
 def encode_request(request, module):
     if 'network' in request and request['network'] is not None:
-        if not re.match(r"https://www.googleapis.com/compute/v1/projects/.*", request['network']):
-            request['network'] = "https://www.googleapis.com/compute/v1/projects/{project}/{network}".format(project=module.params['project'],
+        if not re.match(r'https://www.googleapis.com/compute/v1/projects/.*', request['network']):
+            request['network'] = 'https://www.googleapis.com/compute/v1/projects/{project}/{network}'.format(project=module.params['project'],
                                                                                                              network=request['network'])
 
     return request

--- a/products/compute/helpers/python/provider_firewall.py
+++ b/products/compute/helpers/python/provider_firewall.py
@@ -1,0 +1,21 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# Verify that firewall network names match what the API returns
+
+def encode_request(request, module):
+    if 'network' in request and request['network'] is not None:
+        if not re.match(r"https://www.googleapis.com/compute/v1/projects/.*", request['network']):
+            request['network'] = "https://www.googleapis.com/compute/v1/projects/{project}/{network}".format(project=module.params['project'],
+                                                                                                             network=request['network'])
+                                    
+    return request

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -42,7 +42,12 @@ module Provider
                if prop.is_a?(Api::Type::ResourceRef) && !prop.resource_ref.readonly)
             ].flatten.compact,
             'required' => required,
-            'default' => (prop.default_value&.to_s),
+            'default' => (
+              if prop.default_value&.is_a?(::Hash)
+                prop.default_value
+              else
+                prop.default_value&.to_s
+              end),
             'type' => ('bool' if prop.is_a? Api::Type::Boolean),
             'aliases' => prop.aliases,
             'version_added' => (prop.version_added&.to_f),


### PR DESCRIPTION
Firewalls on Ansible had two issues:

1) Default values for networks were different than GCP expected.
2) GCP returns long self_links but Firewall takes in short values (in addition to long). This means that idempotency can fail.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
