### PR TITLE
fixing rubocop break because of linter

### DIFF
--- a/tools/linter/discovery.rb
+++ b/tools/linter/discovery.rb
@@ -93,6 +93,7 @@ module Discovery
 
     def get_methods_for_resource(resource)
       return unless @results['resources'][resource.pluralize.camelize(:lower)]
+
       @results['resources'][resource.pluralize.camelize(:lower)]['methods']
     end
 

--- a/tools/linter/fetcher.rb
+++ b/tools/linter/fetcher.rb
@@ -30,6 +30,7 @@ class PropertyFetcher
       discovery_properties.each do |disc_prop|
         api_props = api_properties.select { |p| p.name == disc_prop.name }
         raise 'Multiple properties with name' if api_props.length > 1
+
         api_prop = api_props.first
         yield(disc_prop, api_prop, "#{prefix}#{disc_prop.name}")
         if disc_prop.nested_properties?

--- a/tools/linter/run.rb
+++ b/tools/linter/run.rb
@@ -39,6 +39,7 @@ docs = YAML.safe_load(File.read(doc_file))
 
 docs.each do |doc|
   raise "#{doc.keys} not in #{VALID_KEYS}" unless doc.keys.sort == %w[filename url]
+
   api = ApiFetcher.api_from_file(doc['filename'])
   builder = Discovery::Builder.new(doc['url'], api.objects.map(&:name))
 


### PR DESCRIPTION
Somehow, linter broke build on Rubocop (not sure how it was allowed to merge, but whatever).

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
