### PR TITLE
We need to pull external revs because the push requires the real git repo.

### DIFF
--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -94,8 +94,6 @@ jobs:
       plan:
           - get: magic-modules-external-prs
             trigger: false
-            params:
-              skip_clone: true
           - put: magic-modules-new-prs
             params:
                 status: pending


### PR DESCRIPTION
This fixes a bug I introduced but which we didn't notice because testing concourse isn't really supported.  :(

-----------------------------------------------------------------
# [all]
CI changes only.
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
