### PR TITLE
Plural doc generation

### DIFF
--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -55,7 +55,8 @@ module Provider
         out_file: \
           File.join(target_folder, "google_#{data[:product_name]}_#{name}".pluralize + '.rb')
       )
-      generate_documentation(data)
+      generate_documentation(data, name, false)
+      generate_documentation(data, name, true)
       generate_properties(data)
     end
 
@@ -113,10 +114,13 @@ module Provider
     end
 
     # Generates InSpec markdown documents for the resource
-    def generate_documentation(data)
-      name = data[:object].name.underscore
+    def generate_documentation(data, base_name, plural)
       docs_folder = File.join(data[:output_folder], 'docs', 'resources')
+
+      name = plural ? base_name.pluralize : base_name
       generate_resource_file data.clone.merge(
+        name: name,
+        plural: plural,
         doc_generation: true,
         default_template: 'templates/inspec/doc_template.md.erb',
         out_file: File.join(docs_folder, "google_#{data[:product_name]}_#{name}.md")

--- a/templates/inspec/doc_template.md.erb
+++ b/templates/inspec/doc_template.md.erb
@@ -20,7 +20,7 @@ title: About the <%= object.name -%> resource
 platform: gcp
 ---
 
-<% resource_underscored_name = resource_name(object, product_ns) %>
+<% resource_underscored_name = plural ? resource_name(object, product_ns).pluralize : resource_name(object, product_ns) %>
 ## Syntax
 A `<%= resource_underscored_name -%>` is used to test a Google <%= object.name -%> resource
 
@@ -33,9 +33,22 @@ A `<%= resource_underscored_name -%>` is used to test a Google <%= object.name -
 ## Properties
 Properties that can be accessed from the `<%= resource_underscored_name -%>` resource:
 
+<% if plural -%>
+See <%= "[#{resource_name(object, product_ns)}.md](#{resource_name(object, product_ns)}.md)" -%> for more detailed information
+<% object.properties.each do |prop| -%>
+  * `<%= "#{prop.out_name.pluralize}" -%>`: an array of `<%= resource_name(object, product_ns) -%>` <%= "#{prop.out_name}" -%>
+
+<% end -%>
+
+## Filter Criteria
+This resource supports all of the above properties as filter criteria, which can be used
+with `where` as a block or a method.
+<% else # if plural -%>
 <% object.properties.each do |prop| -%>
   * `<%= "#{prop.out_name}" -%>`: <%= "#{prop.description.split("\n").join(' ')}" -%>
 
 
 <%= sub_property_descriptions(prop) -%>
 <% end -%>
+
+<% end # if plural -%>

--- a/templates/inspec/doc_template.md.erb
+++ b/templates/inspec/doc_template.md.erb
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -%>
-
 <% autogen_exception -%>
-
 ---
 title: About the <%= object.name -%> resource
 platform: gcp

--- a/templates/inspec/examples/google_compute_ssl_policies.erb
+++ b/templates/inspec/examples/google_compute_ssl_policies.erb
@@ -5,4 +5,11 @@ describe resource do
   it { should exist }
   its('names') { should include <%= doc_generation ? "'#{ssl_policy['name']}'" : "ssl_policy['name']" -%> }
   its('profiles') { should include <%= doc_generation ? "'#{ssl_policy['profile']}'" : "ssl_policy['profile']" -%> }
+  its('count') { should eq 1 }
+end
+
+resource.names.each do |policy_name|
+  describe google_compute_ssl_policy({project: <%= doc_generation ? "'#{project_name}'" : "project_name" -%>, name: policy_name}) do
+    its('min_tls_version') { should cmp <%= doc_generation ? "'#{ssl_policy['min_tls_version']}'" : "ssl_policy['min_tls_version']" -%> }
+  end
 end

--- a/templates/inspec/integration_test_template.erb
+++ b/templates/inspec/integration_test_template.erb
@@ -1,4 +1,3 @@
-<%= compile 'templates/license.erb' -%>
 <%= lines(autogen_notice :ruby) -%>
 
 require 'vcr_config'

--- a/templates/inspec/plural_resource.erb
+++ b/templates/inspec/plural_resource.erb
@@ -14,8 +14,6 @@
 -%>
 # frozen_string_literal: false
 
-<%= compile 'templates/license.erb' -%>
-
 <%= lines(autogen_notice :ruby) -%>
 require 'gcp_backend'
 class <%= object.name -%>s < GcpResourceBase

--- a/templates/inspec/singular_resource.erb
+++ b/templates/inspec/singular_resource.erb
@@ -14,8 +14,6 @@
 -%>
 # frozen_string_literal: false
 
-<%= compile 'templates/license.erb' -%>
-
 <%= lines(autogen_notice :ruby) -%>
 <%
   require 'google/string_utils'


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Generate a markdown doc for InSpec plural resources as well as singular resources
Also remove license headers from files
<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
