### PR TITLE
Set x not e

### DIFF
--- a/.ci/acceptance-tests/inspec-integration.sh
+++ b/.ci/acceptance-tests/inspec-integration.sh
@@ -15,9 +15,9 @@ export GOPATH=${PWD}/go
 
 # CI sets the contents of our json account secret in our environment; dump it
 # to disk for use in tests.
-set +e
+set +x
 echo "${TERRAFORM_KEY}" > /tmp/google-account.json
-set -e
+set -x
 
 gcloud auth activate-service-account terraform@graphite-test-sam-chef.iam.gserviceaccount.com --key-file=$GOOGLE_CLOUD_KEYFILE_JSON
 

--- a/.ci/unit-tests/inspec.sh
+++ b/.ci/unit-tests/inspec.sh
@@ -8,9 +8,9 @@ export GOOGLE_CLOUD_KEYFILE_JSON="/tmp/google-account.json"
 
 # CI sets the contents of our json account secret in our environment; dump it
 # to disk for use in tests.
-set +e
+set +x
 echo "${TERRAFORM_KEY}" > /tmp/google-account.json
-set -e
+set -x
 
 export CLOUD_SDK_REPO="cloud-sdk-stretch"
 echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Set e doesn't help with logging.... set x may
<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
