### PR TITLE
CSV Formatter

### DIFF
--- a/tools/linter/README.md
+++ b/tools/linter/README.md
@@ -12,6 +12,28 @@ The linter is powered by RSpec.
   rspec tools/linter/run.rb
 ```
 
+Tests are divided into two parts: property tests and resource tests. Each is
+tagged with :property or :resource To run only property tests, do the
+following:
+
+```
+  rspec tools/linter/run.rb --tag property
+```
+
+## Getting Results as a CSV
+RSpec uses formatters to create the output.
+We have a custom formatter that works only with property tests to show which tests do/do not exist.
+The formatter is located at `tools/linter/formatter.rb`
+
+To get the property tests as a CSV, do the following:
+
+```
+  rspec tools/linter/run.rb --require ./tools/linter/formatter.rb -f
+  CsvFormatterForMM --tag property > <output_file>
+```
+
+NOTE: The first line of this CSV will be RSpec formatting info and should be deleted.
+
 ## Adding new tests
 All new tests should be added in `tools/linter/tests.rb`
 New tests for properties should be added in `property_tests`.

--- a/tools/linter/formatter.rb
+++ b/tools/linter/formatter.rb
@@ -17,6 +17,8 @@ require 'csv'
 # This is an Rspec Formatter that's responsible for outputting the
 # linter 'tests' out to a CSV format.
 #
+# This formatter only works on tests tagged with `property`
+#
 # Format:
 # product | resource | property | api.yaml (y/n)
 class CsvFormatterForMM
@@ -28,23 +30,22 @@ class CsvFormatterForMM
 
   # Places in the CSV header
   def start(_start_notification)
-    @output << ["Product", "Resource", "Property", "api.yaml"].to_csv
+    @output << ['Product', 'Resource', 'Property', 'api.yaml'].to_csv
   end
 
   # This property exists in api.yaml
   def example_passed(notification)
-    @output << info_to_csv(test_information(notification).merge({ api_yaml: true }))
+    @output << info_to_csv(test_information(notification).merge(api_yaml: true))
   end
 
   # This property does not exist in api.yaml
   def example_failed(notification)
-    @output << info_to_csv(test_information(notification).merge({ api_yaml: false }))
+    @output << info_to_csv(test_information(notification).merge(api_yaml: false))
   end
 
   # This test isn't being run.
   # Don't do anything.
-  def example_pending
-  end
+  def example_pending; end
 
   private
 

--- a/tools/linter/formatter.rb
+++ b/tools/linter/formatter.rb
@@ -1,0 +1,65 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'rspec'
+require 'csv'
+
+# This is an Rspec Formatter that's responsible for outputting the
+# linter 'tests' out to a CSV format.
+#
+# Format:
+# product | resource | property | api.yaml (y/n)
+class CsvFormatterForMM
+  RSpec::Core::Formatters.register self, :start, :example_passed, :example_failed, :example_pending
+
+  def initialize(output)
+    @output = output
+  end
+
+  # Places in the CSV header
+  def start(_start_notification)
+    @output << ["Product", "Resource", "Property", "api.yaml"].to_csv
+  end
+
+  # This property exists in api.yaml
+  def example_passed(notification)
+    @output << info_to_csv(test_information(notification).merge({ api_yaml: true }))
+  end
+
+  # This property does not exist in api.yaml
+  def example_failed(notification)
+    @output << info_to_csv(test_information(notification).merge({ api_yaml: false }))
+  end
+
+  # This test isn't being run.
+  # Don't do anything.
+  def example_pending
+  end
+
+  private
+
+  def test_information(notification)
+    example_group = notification.example.metadata[:example_group]
+    {
+      product: example_group[:parent_example_group][:parent_example_group][:description],
+      resource: example_group[:parent_example_group][:description],
+      property: example_group[:description]
+    }
+  end
+
+  def info_to_csv(test_info)
+    [
+      test_info[:product], test_info[:resource], test_info[:property], test_info[:api_yaml]
+    ].to_csv
+  end
+end

--- a/tools/linter/tests.rb
+++ b/tools/linter/tests.rb
@@ -22,7 +22,7 @@ end
 RSpec.shared_examples 'resource_tests' do |disc_res, api_res|
   # This test will be skipped if the Discovery Doc doesn't have a kind listed.
   it 'should have kind', skip: !disc_res.schema.dig('properties', 'kind', 'default'),
-    resource: true do
+                         resource: true do
     expect(disc_res.schema.dig('properties', 'kind', 'default')).to eq(api_res.kind)
   end
 end

--- a/tools/linter/tests.rb
+++ b/tools/linter/tests.rb
@@ -14,14 +14,15 @@
 require 'rspec'
 
 RSpec.shared_examples 'property_tests' do |_disc_prop, api_prop|
-  it 'should exist' do
+  it 'should exist', property: true do
     expect(api_prop).to be_truthy
   end
 end
 
 RSpec.shared_examples 'resource_tests' do |disc_res, api_res|
   # This test will be skipped if the Discovery Doc doesn't have a kind listed.
-  it 'should have kind', skip: !disc_res.schema.dig('properties', 'kind', 'default') do
+  it 'should have kind', skip: !disc_res.schema.dig('properties', 'kind', 'default'),
+    resource: true do
     expect(disc_res.schema.dig('properties', 'kind', 'default')).to eq(api_res.kind)
   end
 end


### PR DESCRIPTION
@erjohnso suggested that the API Linter should give out CSV results so that we can do Sheets magic with the results.

Since the linter is written as a set of RSpec tests, we get the whole RSpec ecosystem for free! RSpec has a Formatter API that allows you to write out code that formats test results.

I've built out a formatter that formats the linter results and returns a CSV of the format:

```
product | resource | property | api.yaml (y/n)
``` 

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
