### PR TITLE
Temporarily disable SQL sweepers in Terraform.

### DIFF
--- a/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -30,10 +30,12 @@ var ignoredReplicaConfigurationFields = []string{
 }
 
 func init() {
+	/*
 	resource.AddTestSweepers("gcp_sql_db_instance", &resource.Sweeper{
 		Name: "gcp_sql_db_instance",
 		F:    testSweepDatabases,
 	})
+	*/
 }
 
 func testSweepDatabases(region string) error {


### PR DESCRIPTION
Terraform's test sweepers run before every CI run, and fail the CI run
if there's an error deleting things. Right now, we have an SQL instance
that stubbornly refuses to be deleted, and it's breaking CI. As we work
with support to resolve that situation, let's disable the sweeper so we
can run the CI again.

<!-- A summary of the changes in this commit goes here -->

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Disable SQL instance sweepers

### [terraform-beta]
Disable SQL instance sweepers

## [ansible]
## [inspec]
