### PR TITLE
[Terraform] router nat is in ga now

### DIFF
--- a/third_party/terraform/resources/resource_compute_router_nat.go.erb
+++ b/third_party/terraform/resources/resource_compute_router_nat.go.erb
@@ -1,6 +1,5 @@
 <% autogen_exception -%>
 package google
-<% unless version.nil? || version == 'ga' -%>
 
 import (
 	"fmt"
@@ -387,6 +386,3 @@ func convertSelfLinksToV1(selfLinks []string) []string {
 	}
 	return result
 }
-<% else %>
-// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
-<% end -%>

--- a/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
@@ -1,6 +1,5 @@
 <% autogen_exception -%>
 package google
-<% unless version.nil? || version == 'ga' -%>
 
 import (
 	"fmt"
@@ -224,6 +223,3 @@ func testAccComputeRouterNatKeepRouter(testId string) string {
 		}
 	`, testId, testId, testId)
 }
-<% else %>
-// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
-<% end -%>

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -156,9 +156,7 @@ func Provider() terraform.ResourceProvider {
 				"google_compute_route":                         resourceComputeRoute(),
 				"google_compute_router":                        resourceComputeRouter(),
 				"google_compute_router_interface":              resourceComputeRouterInterface(),
-<% unless version.nil? || version == 'ga' -%>
 				"google_compute_router_nat":                    resourceComputeRouterNat(),
-<% end -%>
 				"google_compute_router_peer":                   resourceComputeRouterPeer(),
 				"google_compute_security_policy":               resourceComputeSecurityPolicy(),
 				"google_compute_shared_vpc_host_project":       resourceComputeSharedVpcHostProject(),


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Add router nat resource. For TPG #2249.
### [terraform-beta]
expecting no-op
## [ansible]
## [inspec]
