### PR TITLE
[Terraform] Make shared VPC test beta-only.

### DIFF
--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1249,7 +1249,6 @@ func TestAccContainerCluster_autoprovisioning(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccContainerCluster_sharedVpc(t *testing.T) {
 	t.Parallel()
@@ -1276,6 +1275,7 @@ func TestAccContainerCluster_sharedVpc(t *testing.T) {
 		},
 	})
 }
+<% end -%>
 
 func TestAccContainerCluster_withResourceLabels(t *testing.T) {
 	t.Parallel()
@@ -2506,6 +2506,7 @@ resource "google_container_cluster" "with_private_cluster" {
 	}
 }`, clusterName, clusterName)
 }
+<% unless version.nil? || version == 'ga' -%>
 func testAccContainerCluster_sharedVpc(org, billingId, projectName, name string) string {
 	return fmt.Sprintf(`
 resource "google_project" "host_project" {
@@ -2609,6 +2610,7 @@ resource "google_container_cluster" "shared_vpc_cluster" {
 	]
 }`, projectName, org, billingId, projectName, org, billingId, acctest.RandString(10), acctest.RandString(10), name)
 }
+<% end -%>
 
 func testAccContainerCluster_withoutResourceLabels(clusterName string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
The subnetwork IAM resources needed in this test are only available in
beta, so the test should only be run against the beta provider._

It looks like there were no changes to the resource that would be
exercised only by this test (as far as I can tell?) so I'm ok wtih the
test only running against the beta provider.

<!-- A summary of the changes in this commit goes here -->

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Remove the ContainerCluster_sharedVpc test

### [terraform-beta]
## [ansible]
## [inspec]
