### PR TITLE
[Terraform] Account for new iamcredentials service.

### DIFF
--- a/third_party/terraform/tests/resource_google_project_services_test.go
+++ b/third_party/terraform/tests/resource_google_project_services_test.go
@@ -19,9 +19,9 @@ func TestAccProjectServices_basic(t *testing.T) {
 
 	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
-	services1 := []string{"iam.googleapis.com", "cloudresourcemanager.googleapis.com"}
+	services1 := []string{"cloudbuild.googleapis.com", "cloudresourcemanager.googleapis.com"}
 	services2 := []string{"cloudresourcemanager.googleapis.com"}
-	oobService := "iam.googleapis.com"
+	oobService := "cloudbuild.googleapis.com"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -70,7 +70,7 @@ func TestAccProjectServices_authoritative(t *testing.T) {
 	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
 	services := []string{"cloudresourcemanager.googleapis.com"}
-	oobService := "iam.googleapis.com"
+	oobService := "cloudbuild.googleapis.com"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -106,8 +106,8 @@ func TestAccProjectServices_authoritative2(t *testing.T) {
 
 	org := getTestOrgFromEnv(t)
 	pid := "terraform-" + acctest.RandString(10)
-	oobServices := []string{"iam.googleapis.com", "cloudresourcemanager.googleapis.com"}
-	services := []string{"iam.googleapis.com"}
+	oobServices := []string{"cloudbuild.googleapis.com", "cloudresourcemanager.googleapis.com"}
+	services := []string{"cloudbuild.googleapis.com"}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -217,6 +217,7 @@ func TestAccProjectServices_pagination(t *testing.T) {
 		"firestore.googleapis.com",
 		"genomics.googleapis.com",
 		"iam.googleapis.com",
+		"iamcredentials.googleapis.com",
 		"language.googleapis.com",
 		"logging.googleapis.com",
 		"ml.googleapis.com",

--- a/third_party/terraform/tests/resource_kms_crypto_key_iam_test.go
+++ b/third_party/terraform/tests/resource_kms_crypto_key_iam_test.go
@@ -187,6 +187,7 @@ resource "google_project_services" "test_project" {
   services = [
      "cloudkms.googleapis.com",
      "iam.googleapis.com",
+     "iamcredentials.googleapis.com",
   ]
 }
 
@@ -230,6 +231,7 @@ resource "google_project_services" "test_project" {
   services = [
      "cloudkms.googleapis.com",
      "iam.googleapis.com",
+     "iamcredentials.googleapis.com",
   ]
 }
 
@@ -282,6 +284,7 @@ resource "google_project_services" "test_project" {
   services = [
      "cloudkms.googleapis.com",
      "iam.googleapis.com",
+     "iamcredentials.googleapis.com",
   ]
 }
 

--- a/third_party/terraform/tests/resource_kms_key_ring_iam_test.go
+++ b/third_party/terraform/tests/resource_kms_key_ring_iam_test.go
@@ -179,6 +179,7 @@ resource "google_project_services" "test_project" {
   services = [
      "cloudkms.googleapis.com",
      "iam.googleapis.com",
+     "iamcredentials.googleapis.com",
   ]
 }
 
@@ -217,6 +218,7 @@ resource "google_project_services" "test_project" {
   services = [
      "cloudkms.googleapis.com",
      "iam.googleapis.com",
+     "iamcredentials.googleapis.com",
   ]
 }
 
@@ -264,6 +266,7 @@ resource "google_project_services" "test_project" {
   services = [
      "cloudkms.googleapis.com",
      "iam.googleapis.com",
+     "iamcredentials.googleapis.com",
   ]
 }
 
@@ -302,6 +305,7 @@ resource "google_project_services" "test_project" {
   services = [
      "cloudkms.googleapis.com",
      "iam.googleapis.com",
+     "iamcredentials.googleapis.com",
   ]
 }
 


### PR DESCRIPTION
It looks like the iam.googleapis.com service got a new sidecar service
that gets enabled when it does, iamcredentials.googleapis.com, and that
broke a few of our tests that were enabling iam.googleapis.com.

This updates those tests, either to expect the new sidecar service, or
to use a different service when appropriate.

<!-- A summary of the changes in this commit goes here -->

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Accommodate the new iamcredentials service in tests
### [terraform-beta]
Accommodate the new iamcredentials service in tests
## [ansible]
## [inspec]
