### PR TITLE
Pull cassettes from repo rather than gs bucket

### DIFF
--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -271,8 +271,6 @@ jobs:
           passed: [mm-generate]
         - task: test
           file: magic-modules/.ci/unit-tests/inspec.yml
-          params:
-            TERRAFORM_KEY: ((terraform-key))
           timeout: 30m
           on_failure:
               do:

--- a/templates/inspec/tests/integration/verify-mm/vcr_config.rb
+++ b/templates/inspec/tests/integration/verify-mm/vcr_config.rb
@@ -15,7 +15,7 @@ require 'vcr'
 
 VCR.configure do |c|
   c.hook_into :webmock
-  c.cassette_library_dir = 'inspec-cassettes'
+  c.cassette_library_dir = 'inspec-gcp-cassettes'
   c.allow_http_connections_when_no_cassette = true
 
   c.before_record do |i|


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
InSpec unit test pulls cassettes from git repo rather than storage bucket
<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
