### PR TITLE
Split up Generation logic from Providers

### DIFF
--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -45,7 +45,7 @@ module Provider
       include Provider::Ansible::Module
       include Provider::Ansible::Request
 
-      generation_steps([:generate_objects, :copy_files, :compile_files, :generate_datasources])
+      generation_steps :generate_objects, :copy_files, :compile_files, :generate_datasources
 
       def initialize(config, api)
         super(config, api)

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -301,10 +301,9 @@ module Provider
         data[:object].instance_variable_set(:@facts, facts_info)
       end
 
-      private
-
       def generate_datasources(output_folder, types, version_name)
         return if @config.datasources.nil?
+
         # We need to apply overrides for datasources
         @config.datasources.validate
 

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -304,6 +304,7 @@ module Provider
       private
 
       def generate_datasources(output_folder, types, version_name)
+        return if @config.datasources.nil?
         # We need to apply overrides for datasources
         @config.datasources.validate
 

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'provider/generator'
+require 'provider/generation'
 require 'compile/core'
 require 'fileutils'
 require 'google/extensions'
@@ -31,7 +31,7 @@ module Provider
   # such as compiling and including files, formatting data, etc.
   class Core
     include Compile::Core
-    include Provider::Generator
+    include Provider::Generation
 
     def self.generation_steps(*steps)
       @steps = steps

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -33,7 +33,7 @@ module Provider
     include Compile::Core
     include Provider::Generator
 
-    def self.generation_steps(steps)
+    def self.generation_steps(*steps)
       @steps = steps
     end
 

--- a/provider/generation.rb
+++ b/provider/generation.rb
@@ -65,21 +65,33 @@ module Provider
     # way so it needs to be named consistently
     # rubocop:disable Lint/UnusedMethodArgument
     def copy_common_files(output_folder, version_name = 'ga')
-      provider_name = self.class.name.split('::').last.downcase
-      return unless File.exist?("provider/#{provider_name}/common~copy.yaml")
+      # The provider name may be a module name or a class name.
+      # We need to try both
+      possible_provider_names = self.class.name.split('::')[1..-1].map(&:downcase)
+      filename = possible_provider_names.map do |provider_name|
+        name = "provider/#{provider_name}/common~copy.yaml"
+        name if File.exist?(name)
+      end.compact.first
+      return unless filename
 
-      Google::LOGGER.info "Copying common files for #{provider_name}"
-      files = YAML.safe_load(compile("provider/#{provider_name}/common~copy.yaml"))
+      Google::LOGGER.info "Copying common files at #{filename}"
+      files = YAML.safe_load(compile(filename))
       copy_file_list(output_folder, files)
     end
     # rubocop:enable Lint/UnusedMethodArgument
 
     def compile_common_files(output_folder, _types, version_name = nil)
-      provider_name = self.class.name.split('::').last.downcase
-      return unless File.exist?("provider/#{provider_name}/common~compile.yaml")
+      # The provider name may be a module name or a class name.
+      # We need to try both
+      possible_provider_names = self.class.name.split('::')[1..-1].map(&:downcase)
+      filename = possible_provider_names.map do |provider_name|
+        name = "provider/#{provider_name}/common~compile.yaml"
+        name if File.exist?(name)
+      end.compact.first
+      return unless filename
 
-      Google::LOGGER.info "Compiling common files for #{provider_name}"
-      files = YAML.safe_load(compile("provider/#{provider_name}/common~compile.yaml"))
+      Google::LOGGER.info "Compiling common files at #{filename}"
+      files = YAML.safe_load(compile(filename))
       compile_file_list(output_folder, files, version: version_name)
     end
 

--- a/provider/generation.rb
+++ b/provider/generation.rb
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 module Provider
-  module Generator
+  module Generation
     # Main entry point for the compiler. As this method is simply invoking other
     # generators, it is okay to ignore Rubocop warnings about method size and
     # complexity.

--- a/provider/generator.rb
+++ b/provider/generator.rb
@@ -33,17 +33,6 @@ module Provider
       copy_file_list(output_folder, @config.files.copy)
     end
 
-    # Generate the CHANGELOG.md file with the history of the module.
-    def compile_changelog(output_folder)
-      FileUtils.mkpath output_folder
-      generate_file(
-        changes: @config.changelog,
-        template: 'templates/CHANGELOG.md.erb',
-        output_folder: output_folder,
-        out_file: File.join(output_folder, 'CHANGELOG.md')
-      )
-    end
-
     def compile_files(output_folder, _types, version_name)
       return if @config.files.nil? || @config.files.compile.nil?
       compile_file_list(output_folder, @config.files.compile, version: version_name)

--- a/provider/generator.rb
+++ b/provider/generator.rb
@@ -28,31 +28,6 @@ module Provider
       end
     end
 
-    def generate_datasources(output_folder, types, version_name)
-      # We need to apply overrides for datasources
-      @config.datasources.validate
-
-      version = @api.version_obj_or_default(version_name)
-      @api.set_properties_based_on_version(version)
-      @api.objects.each do |object|
-        if !types.empty? && !types.include?(object.name)
-          Google::LOGGER.info(
-            "Excluding #{object.name} datasource per user request"
-          )
-        elsif types.empty? && object.exclude
-          Google::LOGGER.info(
-            "Excluding #{object.name} datasource per API catalog"
-          )
-        elsif types.empty? && object.exclude_if_not_in_version(version)
-          Google::LOGGER.info(
-            "Excluding #{object.name} datasource per API version"
-          )
-        else
-          generate_datasource object, output_folder, version_name
-        end
-      end
-    end
-
     def copy_files(output_folder, _types, _version_name)
       return if @config.files.nil? || @config.files.copy.nil?
       copy_file_list(output_folder, @config.files.copy)
@@ -155,12 +130,6 @@ module Provider
 
       generate_resource data
       generate_resource_tests data
-    end
-
-    def generate_datasource(object, output_folder, version_name)
-      data = build_object_data(object, output_folder, version_name)
-
-      compile_datasource data
     end
 
     def build_object_data(object, output_folder, version)

--- a/provider/generator.rb
+++ b/provider/generator.rb
@@ -1,0 +1,191 @@
+module Provider
+  module Generator
+    # Main entry point for the compiler. As this method is simply invoking other
+    # generators, it is okay to ignore Rubocop warnings about method size and
+    # complexity.
+    def generate(output_folder, types, version_name)
+      raise "Use `generation_steps` to specify which steps and ordering" unless self.class.instance_variable_get(:@steps)
+      self.class.instance_variable_get(:@steps).each { |s| method(s).call(output_folder, types, version_name) }
+    end
+
+    def generate_objects(output_folder, types, version_name)
+      version = @api.version_obj_or_default(version_name)
+      @api.set_properties_based_on_version(version)
+      (@api.objects || []).each do |object|
+        if !types.empty? && !types.include?(object.name)
+          Google::LOGGER.info "Excluding #{object.name} per user request"
+        elsif types.empty? && object.exclude
+          Google::LOGGER.info "Excluding #{object.name} per API catalog"
+        elsif types.empty? && object.exclude_if_not_in_version(version)
+          Google::LOGGER.info "Excluding #{object.name} per API version"
+        else
+          # version_name will differ from version.name if the resource is being
+          # generated at its default version instead of the one that was passed
+          # in to the compiler. Terraform needs to know which version was passed
+          # in so it can name its output directories correctly.
+          generate_object object, output_folder, version_name
+        end
+      end
+    end
+
+    def generate_datasources(output_folder, types, version_name)
+      # We need to apply overrides for datasources
+      @config.datasources.validate
+
+      version = @api.version_obj_or_default(version_name)
+      @api.set_properties_based_on_version(version)
+      @api.objects.each do |object|
+        if !types.empty? && !types.include?(object.name)
+          Google::LOGGER.info(
+            "Excluding #{object.name} datasource per user request"
+          )
+        elsif types.empty? && object.exclude
+          Google::LOGGER.info(
+            "Excluding #{object.name} datasource per API catalog"
+          )
+        elsif types.empty? && object.exclude_if_not_in_version(version)
+          Google::LOGGER.info(
+            "Excluding #{object.name} datasource per API version"
+          )
+        else
+          generate_datasource object, output_folder, version_name
+        end
+      end
+    end
+
+    def copy_files(output_folder, _types, _version_name)
+      return if @config.files.nil? || @config.files.copy.nil?
+      copy_file_list(output_folder, @config.files.copy)
+    end
+
+    # Generate the CHANGELOG.md file with the history of the module.
+    def compile_changelog(output_folder)
+      FileUtils.mkpath output_folder
+      generate_file(
+        changes: @config.changelog,
+        template: 'templates/CHANGELOG.md.erb',
+        output_folder: output_folder,
+        out_file: File.join(output_folder, 'CHANGELOG.md')
+      )
+    end
+
+    def compile_files(output_folder, _types, version_name)
+      return if @config.files.nil? || @config.files.compile.nil?
+      compile_file_list(output_folder, @config.files.compile, version: version_name)
+    end
+
+    # version_name is actually used because all of the variables in scope in this method
+    # are made available within the templates by the compile call. This means that version_name
+    # is exposed to the templating logic and version_name is used in other places in the same
+    # way so it needs to be named consistently
+    # rubocop:disable Lint/UnusedMethodArgument
+    def copy_common_files(output_folder, version_name = 'ga')
+      provider_name = self.class.name.split('::').last.downcase
+      return unless File.exist?("provider/#{provider_name}/common~copy.yaml")
+
+      Google::LOGGER.info "Copying common files for #{provider_name}"
+      files = YAML.safe_load(compile("provider/#{provider_name}/common~copy.yaml"))
+      copy_file_list(output_folder, files)
+    end
+    # rubocop:enable Lint/UnusedMethodArgument
+
+    def compile_common_files(output_folder, _types, version_name = nil)
+      provider_name = self.class.name.split('::').last.downcase
+      return unless File.exist?("provider/#{provider_name}/common~compile.yaml")
+
+      Google::LOGGER.info "Compiling common files for #{provider_name}"
+      files = YAML.safe_load(compile("provider/#{provider_name}/common~compile.yaml"))
+      compile_file_list(output_folder, files, version: version_name)
+    end
+
+    private
+
+    def copy_file_list(output_folder, files)
+      files.each do |target, source|
+        target_file = File.join(output_folder, target)
+        target_dir = File.dirname(target_file)
+        Google::LOGGER.debug "Copying #{source} => #{target}"
+        FileUtils.mkpath target_dir unless Dir.exist?(target_dir)
+        FileUtils.copy_entry source, target_file
+      end
+    end
+
+    def compile_examples(output_folder)
+      compile_file_map(
+        output_folder,
+        @config.examples,
+        lambda do |_object, file|
+          ["examples/#{file}",
+           "products/#{@api.prefix[1..-1]}/files/examples~#{file}"]
+        end
+      )
+    end
+
+    def compile_file_list(output_folder, files, data = {})
+      files.each do |target, source|
+        Google::LOGGER.debug "Compiling #{source} => #{target}"
+        target_file = File.join(output_folder, target)
+                          .gsub('{{product_name}}', @api.prefix[1..-1])
+
+        manifest = @config.respond_to?(:manifest) ? @config.manifest : {}
+        generate_file(
+          data.clone.merge(
+            name: target,
+            product: @api,
+            object: {},
+            config: {},
+            scopes: @api.scopes,
+            manifest: manifest,
+            tests: '',
+            template: source,
+            compiler: compiler,
+            output_folder: output_folder,
+            out_file: target_file,
+            prop_ns_dir: @api.prefix[1..-1].downcase,
+            product_ns: @api.prefix[1..-1].camelize(:upper)
+          )
+        )
+
+        %x(goimports -w #{target_file}) if File.extname(target_file) == '.go'
+      end
+    end
+
+    def generate_object(object, output_folder, version_name)
+      data = build_object_data(object, output_folder, version_name)
+
+      generate_resource data
+      generate_resource_tests data
+    end
+
+    def generate_datasource(object, output_folder, version_name)
+      data = build_object_data(object, output_folder, version_name)
+
+      compile_datasource data
+    end
+
+    def build_object_data(object, output_folder, version)
+      {
+        name: object.out_name,
+        object: object,
+        tests: (@config.tests || {}).select { |o, _v| o == object.name }
+                                    .fetch(object.name, {}),
+        output_folder: output_folder,
+        product_name: object.__product.prefix[1..-1],
+        version: version
+      }
+    end
+
+    def generate_resource_file(data)
+      product_ns = if @config.name.nil?
+                     data[:object].__product.prefix[1..-1].camelize(:upper)
+                   else
+                     @config.name
+                   end
+      generate_file(data.clone.merge(
+        # Override with provider specific template for this object, if needed
+        template: data[:default_template],
+        product_ns: product_ns
+      ))
+    end
+  end
+end

--- a/provider/generator.rb
+++ b/provider/generator.rb
@@ -1,3 +1,16 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 module Provider
   module Generator
     # Main entry point for the compiler. As this method is simply invoking other

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -40,7 +40,7 @@ module Provider
       end
     end
 
-    generation_steps([:generate_objects, :copy_files, :compile_changelog, :compile_files])
+    generation_steps :generate_objects, :copy_files, :compile_changelog, :compile_files
 
     # This function uses the resource templates to create singular and plural
     # resources that can be used by InSpec

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -132,6 +132,7 @@ module Provider
     # Generate the CHANGELOG.md file with the history of the module.
     def compile_changelog(output_folder, _types, _version_name)
       return if @config.changelog.nil?
+
       FileUtils.mkpath output_folder
       generate_file(
         changes: @config.changelog,

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -40,6 +40,8 @@ module Provider
       end
     end
 
+    generation_steps([:generate_objects, :copy_files, :compile_changelog, :compile_files])
+
     # This function uses the resource templates to create singular and plural
     # resources that can be used by InSpec
     def generate_resource(data)
@@ -124,6 +126,18 @@ module Provider
         doc_generation: true,
         default_template: 'templates/inspec/doc_template.md.erb',
         out_file: File.join(docs_folder, "google_#{data[:product_name]}_#{name}.md")
+      )
+    end
+
+    # Generate the CHANGELOG.md file with the history of the module.
+    def compile_changelog(output_folder, _types, _version_name)
+      return if @config.changelog.nil?
+      FileUtils.mkpath output_folder
+      generate_file(
+        changes: @config.changelog,
+        template: 'templates/CHANGELOG.md.erb',
+        output_folder: output_folder,
+        out_file: File.join(output_folder, 'CHANGELOG.md')
       )
     end
 

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -29,7 +29,7 @@ module Provider
       include Provider::Terraform::SubTemplate
       include Google::GolangUtils
 
-      generation_steps([:generate_objects, :copy_files, :compile_files])
+      generation_steps :generate_objects, :copy_files, :compile_files
 
       # Sorts properties in the order they should appear in the TF schema:
       # Required, Optional, Computed

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'provider/abstract_core'
+require 'provider/core'
 require 'provider/terraform/config'
 require 'provider/terraform/import'
 require 'provider/terraform/custom_code'
@@ -24,10 +24,12 @@ module Provider
   # Code generator for Terraform Resources that manage Google Cloud Platform
   # resources.
   module Terraform
-    class Core
+    class Core < Provider::Core
       include Provider::Terraform::Import
       include Provider::Terraform::SubTemplate
       include Google::GolangUtils
+
+      generation_steps([:generate_objects, :copy_files, :compile_files])
 
       # Sorts properties in the order they should appear in the TF schema:
       # Required, Optional, Computed
@@ -110,8 +112,9 @@ module Provider
           []
         end
       end
-    end
-    class Generator < Provider::Generator
+
+      private
+
       # This function uses the resource.erb template to create one file
       # per resource. The resource.erb template forms the basis of a single
       # GCP Resource on Terraform.

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -24,6 +24,7 @@ module Provider
   # Code generator for Terraform Resources that manage Google Cloud Platform
   # resources.
   module Terraform
+    # Functions used in Terraform templates
     class Core < Provider::Core
       include Provider::Terraform::Import
       include Provider::Terraform::SubTemplate

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -23,151 +23,152 @@ require 'google/golang_utils'
 module Provider
   # Code generator for Terraform Resources that manage Google Cloud Platform
   # resources.
-  class Terraform < Provider::AbstractCore
-    include Provider::Terraform::Import
-    include Provider::Terraform::SubTemplate
-    include Google::GolangUtils
+  module Terraform
+    class Core
+      include Provider::Terraform::Import
+      include Provider::Terraform::SubTemplate
+      include Google::GolangUtils
 
-    # Sorts properties in the order they should appear in the TF schema:
-    # Required, Optional, Computed
-    def order_properties(properties)
-      properties.select(&:required).sort_by(&:name) +
-        properties.reject(&:required).reject(&:output).sort_by(&:name) +
-        properties.select(&:output).sort_by(&:name)
-    end
+      # Sorts properties in the order they should appear in the TF schema:
+      # Required, Optional, Computed
+      def order_properties(properties)
+        properties.select(&:required).sort_by(&:name) +
+          properties.reject(&:required).reject(&:output).sort_by(&:name) +
+          properties.select(&:output).sort_by(&:name)
+      end
 
-    def tf_type(property)
-      tf_types[property.class]
-    end
+      def tf_type(property)
+        tf_types[property.class]
+      end
 
-    # Converts between the Magic Modules type of an object and its type in the
-    # TF schema
-    def tf_types
-      {
-        Api::Type::Boolean => 'schema.TypeBool',
-        Api::Type::Double => 'schema.TypeFloat',
-        Api::Type::Integer => 'schema.TypeInt',
-        Api::Type::String => 'schema.TypeString',
-        # Anonymous string property used in array of strings.
-        'Api::Type::String' => 'schema.TypeString',
-        Api::Type::Time => 'schema.TypeString',
-        Api::Type::Enum => 'schema.TypeString',
-        Api::Type::ResourceRef => 'schema.TypeString',
-        Api::Type::NestedObject => 'schema.TypeList',
-        Api::Type::Array => 'schema.TypeList',
-        Api::Type::KeyValuePairs => 'schema.TypeMap',
-        Api::Type::Map => 'schema.TypeSet',
-        Api::Type::Fingerprint => 'schema.TypeString'
-      }
-    end
+      # Converts between the Magic Modules type of an object and its type in the
+      # TF schema
+      def tf_types
+        {
+          Api::Type::Boolean => 'schema.TypeBool',
+          Api::Type::Double => 'schema.TypeFloat',
+          Api::Type::Integer => 'schema.TypeInt',
+          Api::Type::String => 'schema.TypeString',
+          # Anonymous string property used in array of strings.
+          'Api::Type::String' => 'schema.TypeString',
+          Api::Type::Time => 'schema.TypeString',
+          Api::Type::Enum => 'schema.TypeString',
+          Api::Type::ResourceRef => 'schema.TypeString',
+          Api::Type::NestedObject => 'schema.TypeList',
+          Api::Type::Array => 'schema.TypeList',
+          Api::Type::KeyValuePairs => 'schema.TypeMap',
+          Api::Type::Map => 'schema.TypeSet',
+          Api::Type::Fingerprint => 'schema.TypeString'
+        }
+      end
 
-    def updatable?(resource, properties)
-      !resource.input || !properties.reject { |p| p.update_url.nil? }.empty?
-    end
+      def updatable?(resource, properties)
+        !resource.input || !properties.reject { |p| p.update_url.nil? }.empty?
+      end
 
-    def force_new?(property, resource)
-      !property.output &&
-        (property.input || (resource.input && property.update_url.nil? &&
-                            (property.parent.nil? ||
-                             force_new?(property.parent, resource))))
-    end
+      def force_new?(property, resource)
+        !property.output &&
+          (property.input || (resource.input && property.update_url.nil? &&
+                              (property.parent.nil? ||
+                               force_new?(property.parent, resource))))
+      end
 
-    def build_url(url_parts, _extra = false)
-      url_parts.flatten.join
-    end
+      def build_url(url_parts, _extra = false)
+        url_parts.flatten.join
+      end
 
-    # Transforms a format string with field markers to a regex string with
-    # capture groups.
-    #
-    # For instance,
-    #   projects/{{project}}/global/networks/{{name}}
-    # is transformed to
-    #   projects/(?P<project>[^/]+)/global/networks/(?P<name>[^/]+)
-    def format2regex(format)
-      format.gsub(/{{([[:word:]]+)}}/, '(?P<\1>[^/]+)')
-    end
+      # Transforms a format string with field markers to a regex string with
+      # capture groups.
+      #
+      # For instance,
+      #   projects/{{project}}/global/networks/{{name}}
+      # is transformed to
+      #   projects/(?P<project>[^/]+)/global/networks/(?P<name>[^/]+)
+      def format2regex(format)
+        format.gsub(/{{([[:word:]]+)}}/, '(?P<\1>[^/]+)')
+      end
 
-    # Capitalize the first letter of a property name.
-    # E.g. "creationTimestamp" becomes "CreationTimestamp".
-    def titlelize_property(property)
-      p = property.name.clone
-      p[0] = p[0].capitalize
-      p
-    end
+      # Capitalize the first letter of a property name.
+      # E.g. "creationTimestamp" becomes "CreationTimestamp".
+      def titlelize_property(property)
+        p = property.name.clone
+        p[0] = p[0].capitalize
+        p
+      end
 
-    # Returns the nested properties. An empty list is returned if the property
-    # is not a NestedObject or an Array of NestedObjects.
-    def nested_properties(property)
-      if property.is_a?(Api::Type::NestedObject)
-        property.properties
-      elsif property.is_a?(Api::Type::Array) &&
-            property.item_type.is_a?(Api::Type::NestedObject)
-        property.item_type.properties
-      elsif property.is_a?(Api::Type::Map)
-        property.value_type.properties
-      else
-        []
+      # Returns the nested properties. An empty list is returned if the property
+      # is not a NestedObject or an Array of NestedObjects.
+      def nested_properties(property)
+        if property.is_a?(Api::Type::NestedObject)
+          property.properties
+        elsif property.is_a?(Api::Type::Array) &&
+              property.item_type.is_a?(Api::Type::NestedObject)
+          property.item_type.properties
+        elsif property.is_a?(Api::Type::Map)
+          property.value_type.properties
+        else
+          []
+        end
       end
     end
-
-    private
-
-    # This function uses the resource.erb template to create one file
-    # per resource. The resource.erb template forms the basis of a single
-    # GCP Resource on Terraform.
-    def generate_resource(data)
-      dir = data[:version] == 'beta' ? 'google-beta' : 'google'
-      target_folder = File.join(data[:output_folder], dir)
-      FileUtils.mkpath target_folder
-      name = data[:object].name.underscore
-      product_name = data[:product_name].underscore
-      filepath = File.join(target_folder, "resource_#{product_name}_#{name}.go")
-      generate_resource_file data.clone.merge(
-        default_template: 'templates/terraform/resource.erb',
-        out_file: filepath
-      )
-      # TODO: error check goimports
-      %x(goimports -w #{filepath})
-      generate_documentation(data)
-    end
-
-    def generate_documentation(data)
-      target_folder = data[:output_folder]
-      target_folder = File.join(target_folder, 'website', 'docs', 'r')
-      FileUtils.mkpath target_folder
-      name = data[:object].name.underscore
-      product_name = data[:product_name].underscore
-
-      filepath =
-        File.join(target_folder, "#{product_name}_#{name}.html.markdown")
-      generate_resource_file data.clone.merge(
-        default_template: 'templates/terraform/resource.html.markdown.erb',
-        out_file: filepath
-      )
-    end
-
-    def generate_resource_tests(data)
-      return if data[:object].example.reject(&:skip_test).empty?
-
-      dir = data[:version] == 'beta' ? 'google-beta' : 'google'
-      target_folder = File.join(data[:output_folder], dir)
-      FileUtils.mkpath target_folder
-      name = data[:object].name.underscore
-      product_name = data[:product_name].underscore
-      filepath =
-        File.join(
-          target_folder,
-          "resource_#{product_name}_#{name}_generated_test.go"
+    class Generator < Provider::Generator
+      # This function uses the resource.erb template to create one file
+      # per resource. The resource.erb template forms the basis of a single
+      # GCP Resource on Terraform.
+      def generate_resource(data)
+        dir = data[:version] == 'beta' ? 'google-beta' : 'google'
+        target_folder = File.join(data[:output_folder], dir)
+        FileUtils.mkpath target_folder
+        name = data[:object].name.underscore
+        product_name = data[:product_name].underscore
+        filepath = File.join(target_folder, "resource_#{product_name}_#{name}.go")
+        generate_resource_file data.clone.merge(
+          default_template: 'templates/terraform/resource.erb',
+          out_file: filepath
         )
-      generate_resource_file data.clone.merge(
-        product: data[:product_name].camelize(:upper),
-        resource_name: data[:object].name.camelize(:upper),
-        default_template: 'templates/terraform/examples/base_configs/test_file.go.erb',
-        out_file: filepath
-      )
+        # TODO: error check goimports
+        %x(goimports -w #{filepath})
+        generate_documentation(data)
+      end
 
-      # TODO: error check goimports
-      %x(goimports -w #{filepath})
+      def generate_documentation(data)
+        target_folder = data[:output_folder]
+        target_folder = File.join(target_folder, 'website', 'docs', 'r')
+        FileUtils.mkpath target_folder
+        name = data[:object].name.underscore
+        product_name = data[:product_name].underscore
+
+        filepath =
+          File.join(target_folder, "#{product_name}_#{name}.html.markdown")
+        generate_resource_file data.clone.merge(
+          default_template: 'templates/terraform/resource.html.markdown.erb',
+          out_file: filepath
+        )
+      end
+
+      def generate_resource_tests(data)
+        return if data[:object].example.reject(&:skip_test).empty?
+
+        dir = data[:version] == 'beta' ? 'google-beta' : 'google'
+        target_folder = File.join(data[:output_folder], dir)
+        FileUtils.mkpath target_folder
+        name = data[:object].name.underscore
+        product_name = data[:product_name].underscore
+        filepath =
+          File.join(
+            target_folder,
+            "resource_#{product_name}_#{name}_generated_test.go"
+          )
+        generate_resource_file data.clone.merge(
+          product: data[:product_name].camelize(:upper),
+          resource_name: data[:object].name.camelize(:upper),
+          default_template: 'templates/terraform/examples/base_configs/test_file.go.erb',
+          out_file: filepath
+        )
+
+        # TODO: error check goimports
+        %x(goimports -w #{filepath})
+      end
     end
   end
 end

--- a/provider/terraform/config.rb
+++ b/provider/terraform/config.rb
@@ -11,15 +11,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'provider/abstract_core'
 require 'provider/config'
 
 module Provider
-  class Terraform < Provider::AbstractCore
+  module Terraform
     # Settings for the provider
     class Config < Provider::Config
       def provider
-        Provider::Terraform
+        Provider::Terraform::Core
       end
 
       def resource_override
@@ -28,6 +27,10 @@ module Provider
 
       def property_override
         Provider::Terraform::PropertyOverride
+      end
+
+      def generator
+        Provider::Terraform::Generator
       end
     end
   end

--- a/provider/terraform/config.rb
+++ b/provider/terraform/config.rb
@@ -28,10 +28,6 @@ module Provider
       def property_override
         Provider::Terraform::PropertyOverride
       end
-
-      def generator
-        Provider::Terraform::Generator
-      end
     end
   end
 end

--- a/provider/terraform/custom_code.rb
+++ b/provider/terraform/custom_code.rb
@@ -19,7 +19,7 @@ require 'provider/abstract_core'
 require 'provider/property_override'
 
 module Provider
-  class Terraform < Provider::AbstractCore
+  module Terraform
     # Inserts custom strings into terraform resource docs.
     class Docs < Api::Object
       # All these values should be strings, which will be inserted

--- a/provider/terraform/import.rb
+++ b/provider/terraform/import.rb
@@ -11,10 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'provider/abstract_core'
-
 module Provider
-  class Terraform < Provider::AbstractCore
+  module Terraform
     # Functions to support 'terraform import'.
     module Import
       # Returns a list of acceptable import id formats for a given resource.

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -12,11 +12,10 @@
 # limitations under the License.
 
 require 'api/object'
-require 'provider/abstract_core'
 require 'provider/property_override'
 
 module Provider
-  class Terraform < Provider::AbstractCore
+  module Terraform
     # Collection of fields allowed in the PropertyOverride section for
     # Terraform. All fields should be `attr_reader :<property>`
     module OverrideFields

--- a/provider/terraform/resource_override.rb
+++ b/provider/terraform/resource_override.rb
@@ -11,12 +11,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'provider/abstract_core'
 require 'provider/resource_override'
 require 'provider/terraform/custom_code'
 
 module Provider
-  class Terraform < Provider::AbstractCore
+  module Terraform
     # Collection of properties allowed in the ResourceOverride section for
     # Terraform. All properties should be `attr_reader :<property>`
     module OverrideProperties

--- a/provider/terraform/sub_template.rb
+++ b/provider/terraform/sub_template.rb
@@ -11,10 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'provider/abstract_core'
-
 module Provider
-  class Terraform < Provider::AbstractCore
+  module Terraform
     # Functions to compile sub-templates.
     module SubTemplate
       def build_schema_property(property, object)

--- a/provider/terraform_example.rb
+++ b/provider/terraform_example.rb
@@ -15,7 +15,7 @@ require 'provider/terraform'
 
 module Provider
   # Code generator for runnable Terraform Examples
-  class TerraformExample < Provider::Terraform
+  class TerraformExample < Provider::Terraform::Core
     # We don't want *any* static generation, so we override generate to only
     # generate objects.
     def generate(output_folder, types, version_name)

--- a/spec/provider_terraform_import_spec.rb
+++ b/spec/provider_terraform_import_spec.rb
@@ -27,7 +27,7 @@ describe Provider::Terraform do
     let(:config) do
       Provider::Config.parse('spec/data/terraform-config.yaml', product)
     end
-    let(:provider) { Provider::Terraform.new(config, product) }
+    let(:provider) { Provider::Terraform::Core.new(config, product) }
 
     before do
       allow_open 'spec/data/good-file.yaml'

--- a/spec/provider_terraform_spec.rb
+++ b/spec/provider_terraform_spec.rb
@@ -26,7 +26,7 @@ describe Provider::Terraform do
     let(:config) do
       Provider::Config.parse('spec/data/terraform-config.yaml', product)
     end
-    let(:provider) { Provider::Terraform.new(config, product) }
+    let(:provider) { Provider::Terraform::Core.new(config, product) }
     let(:resource) { product.objects[0] }
 
     before do


### PR DESCRIPTION
This isn't perfect, but it's a good start.

The idea is to split up the generation logic from the providers (Provider::Core) in particular. Each provider calls `generation_steps` and specifies exactly which generation steps it requires.

There's still intermingling in the individual providers, but this makes Provider::Core much easier to parse.

I also changed `Provider::Terraform` to a module instead of a class, because that was desperately needed for my own sanity 😀

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
