### PR TITLE
[Terraform]: Add docs about using lifecycle when recreating instance groups

### DIFF
--- a/third_party/terraform/website/docs/r/compute_instance_group.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance_group.html.markdown
@@ -12,9 +12,11 @@ Creates a group of dissimilar Compute Engine virtual machine instances.
 For more information, see [the official documentation](https://cloud.google.com/compute/docs/instance-groups/#unmanaged_instance_groups)
 and [API](https://cloud.google.com/compute/docs/reference/latest/instanceGroups)
 
-## Example Usage
+-> Recreating an instance group that's in use by another resource will give a
+`resourceInUseByAnotherResource` error. You can avoid this error with a
+Terraform `lifecycle` block as outlined in the example below.
 
-### Empty instance group
+## Example Usage - Empty instance group
 
 ```hcl
 resource "google_compute_instance_group" "test" {
@@ -25,7 +27,7 @@ resource "google_compute_instance_group" "test" {
 }
 ```
 
-### With instances and named ports
+### Example Usage - With instances and named ports
 
 ```hcl
 resource "google_compute_instance_group" "webservers" {
@@ -48,6 +50,71 @@ resource "google_compute_instance_group" "webservers" {
   }
 
   zone = "us-central1-a"
+}
+```
+
+### Example Usage - Recreating an instance group in use
+Recreating an instance group that's in use by another resource will give a
+`resourceInUseByAnotherResource` error. Use `lifecycle.create_before_destroy`
+as shown in this example to avoid this type of error.
+
+```hcl
+resource "google_compute_instance_group" "staging_group" {
+  name = "staging-instance-group"
+  zone = "us-central1-c"
+  instances = [ "${google_compute_instance.staging_vm.self_link}" ]
+  named_port {
+    name = "http"
+    port = "8080"
+  }
+
+  named_port {
+    name = "https"
+    port = "8443"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+data "google_compute_image" "debian_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "staging_vm" {
+  name = "staging-vm"
+  machine_type = "n1-standard-1"
+  zone = "us-central1-c"
+  boot_disk {
+    initialize_params {
+      image = "${data.google_compute_image.debian_image.self_link}"
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+
+resource "google_compute_backend_service" "staging_service" {
+  name      = "staging-service"
+  port_name = "https"
+  protocol  = "HTTPS"
+
+  backend {
+    group = "${google_compute_instance_group.staging_group.self_link}"
+  }
+
+  health_checks = [
+    "${google_compute_https_health_check.staging_health.self_link}",
+  ]
+}
+
+resource "google_compute_https_health_check" "staging_health" {
+  name         = "staging-health"
+  request_path = "/health_check"
 }
 ```
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/1853

Users can avoid the error with `lifecycle.create_before_destroy'; it isn't feasible to copy the Disk behaviour because an InstanceGroup doesn't list its users. We would need to list every BackendService / other users (are there any?) in the zone and `GET` each of them for a similar approach to be feasible.

-----------------------------------------------------------------
# [all]
## [terraform]
Add docs about using lifecycle when recreating instance groups
### [terraform-beta]
## [ansible]
## [inspec]
