### PR TITLE
[Terraform] allow cross-project imports for sql user

### DIFF
--- a/third_party/terraform/resources/resource_sql_user.go
+++ b/third_party/terraform/resources/resource_sql_user.go
@@ -227,15 +227,17 @@ func resourceSqlUserDelete(d *schema.ResourceData, meta interface{}) error {
 func resourceSqlUserImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 
-	if len(parts) == 2 {
-		d.Set("instance", parts[0])
-		d.Set("name", parts[1])
-	} else if len(parts) == 3 {
-		d.Set("instance", parts[0])
-		d.Set("host", parts[1])
+	if len(parts) == 3 {
+		d.Set("project", parts[0])
+		d.Set("instance", parts[1])
 		d.Set("name", parts[2])
+	} else if len(parts) == 4 {
+		d.Set("project", parts[0])
+		d.Set("instance", parts[1])
+		d.Set("host", parts[2])
+		d.Set("name", parts[3])
 	} else {
-		return nil, fmt.Errorf("Invalid specifier. Expecting {instance}/{name} for postgres instance and {instance}/{host}/{name} for MySQL instance")
+		return nil, fmt.Errorf("Invalid specifier. Expecting {project}/{instance}/{name} for postgres instance and {project}/{instance}/{host}/{name} for MySQL instance")
 	}
 
 	return []*schema.ResourceData{d}, nil

--- a/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -62,14 +62,14 @@ Only the arguments listed above are exposed as attributes.
 
 ## Import
 
-SQL users for MySQL databases can be imported using the `instance`, `host` and `name`, e.g.
+SQL users for MySQL databases can be imported using the `project`, `instance`, `host` and `name`, e.g.
 
 ```
-$ terraform import google_sql_user.users master-instance/my-domain.com/me
+$ terraform import google_sql_user.users my-project/master-instance/my-domain.com/me
 ```
 
-SQL users for PostgreSQL databases can be imported using the `instance` and `name`, e.g.
+SQL users for PostgreSQL databases can be imported using the `project`, `instance` and `name`, e.g.
 
 ```
-$ terraform import google_sql_user.users master-instance/me
+$ terraform import google_sql_user.users my-project/master-instance/me
 ```


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/2563.

Since we already have multiple options for sql user imports, I made project mandatory in the import. I don't think this is a big deal.
<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
allow cross-project imports for sql user
### [terraform-beta]
## [ansible]
## [inspec]
