### PR TITLE
Better resourceref flexibility

### DIFF
--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -58,7 +58,7 @@ module Provider
         if prop.is_a? Api::Type::ResourceRef
           return 'str' if prop.resource_ref.readonly
 
-          return 'dict'
+          return ''
         end
         PYTHON_TYPE_FROM_MM_TYPE.fetch(prop.class.to_s, 'str')
       end

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -57,8 +57,7 @@ module Provider
         # All ResourceRefs are dicts with properties.
         if prop.is_a? Api::Type::ResourceRef
           return 'str' if prop.resource_ref.readonly
-
-          return ''
+          return nil
         end
         PYTHON_TYPE_FROM_MM_TYPE.fetch(prop.class.to_s, 'str')
       end

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -57,6 +57,7 @@ module Provider
         # All ResourceRefs are dicts with properties.
         if prop.is_a? Api::Type::ResourceRef
           return 'str' if prop.resource_ref.readonly
+
           return nil
         end
         PYTHON_TYPE_FROM_MM_TYPE.fetch(prop.class.to_s, 'str')

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -103,9 +103,9 @@ module Provider
           "This field represents a link to a #{prop.resource_ref.name} resource in GCP.",
           'It can be specified in two ways.',
           "First, you can place in the #{prop.imports} of the resource here as a string",
-          "Alternatively, you can add `register: name-of-resource` to a",
+          'Alternatively, you can add `register: name-of-resource` to a',
           "#{module_name(prop.resource_ref)} task",
-          "and then set this #{prop.name.underscore} field to \"{{ name-of-resource }}\"",
+          "and then set this #{prop.name.underscore} field to \"{{ name-of-resource }}\""
         ].join(' ')
       end
 

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -102,11 +102,10 @@ module Provider
         [
           "This field represents a link to a #{prop.resource_ref.name} resource in GCP.",
           'It can be specified in two ways.',
-          "You can add `register: name-of-resource` to a #{module_name(prop.resource_ref)} task",
+          "First, you can place in the #{prop.imports} of the resource here as a string",
+          "Alternatively, you can add `register: name-of-resource` to a",
+          "#{module_name(prop.resource_ref)} task",
           "and then set this #{prop.name.underscore} field to \"{{ name-of-resource }}\"",
-          "Alternatively, you can set this #{prop.name.underscore} to a dictionary",
-          "with the #{prop.imports} key",
-          "where the value is the #{prop.imports} of your #{prop.resource_ref.name}"
         ].join(' ')
       end
 

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -68,7 +68,7 @@ module Provider
       # Builds out the RETURNS for a property.
       # This will eventually be converted to YAML
       def returns_for_property(prop)
-        type = python_type(prop)
+        type = python_type(prop) || 'str'
         # Type is a valid AnsibleModule type, but not a valid return type
         type = 'str' if type == 'path'
         # Complex types only mentioned in reference to RETURNS YAML block

--- a/provider/ansible/gcp_utils.py
+++ b/provider/ansible/gcp_utils.py
@@ -19,6 +19,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule, env_fallback
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_text
+import ast
 import os
 
 
@@ -60,8 +61,15 @@ def replace_resource_dict(item, value):
     else:
         if not item:
             return item
-        return item.get(value)
+        if isinstance(item, dict):
+            return item.get(value)
 
+        # Item could be a string or a string representing a dictionary.
+        try:
+            new_item = ast.literal_eval(item)
+            return replace_resource_dict(new_item, value)
+        except ValueError:
+            return new_item
 
 # Handles all authentation and HTTP sessions for GCP API calls.
 class GcpSession(object):

--- a/provider/ansible/module.rb
+++ b/provider/ansible/module.rb
@@ -55,10 +55,10 @@ module Provider
           ('required=True' if prop.required && !prop.default_value),
           ("default=#{python_literal(prop.default_value)}" \
            if prop.default_value),
-          "type=#{quote_string(python_type(prop))}",
+          ("type=#{quote_string(python_type(prop))}" if python_type(prop)),
           (choices_enum(prop, spaces) if prop.is_a? Api::Type::Enum),
           ("elements=#{quote_string(python_type(prop.item_type))}" \
-            if prop.is_a? Api::Type::Array),
+            if prop.is_a?(Api::Type::Array) && python_type(prop.item_type)),
           ("aliases=[#{prop.aliases.map { |x| quote_string(x) }.join(', ')}]" \
             if prop.aliases)
         ].compact


### PR DESCRIPTION
ResourceRefs on Ansible are the only MM downstream that follow the classical view of ResourceRefs. You build a dependency in a task, assign it to a variable (it's a dict) and then reference that variable in the resourceref field. The ResourceRef logic grabs the proper information from the dict.

This is less than ideal for users. Even with better documentation, it's just not intuitive enough for them. I've had multiple users mention this and using this system just makes the examples look opaque.

The new system allows users to input a dict (as before) or just a string of the proper value. The documentation mentions both of these systems.
<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
