### PR TITLE
Remove code coverage stats as they aren't being consumed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,15 +16,11 @@
 *#
 *.swp
 
-coverage/*
 *.pyc
 
 # IDEA files
 .idea/*
 *.iml
-
-# Keep project coverage statistics under source control
-!coverage/.last_run.json
 
 # OS generated files
 .DS_Store

--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,4 @@ group :test do
   gem 'parallel_tests'
   gem 'rspec'
   gem 'rubocop', '~> 0.60.0'
-  gem 'simplecov'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,11 +51,6 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.4.0)
     ruby-progressbar (1.10.0)
-    simplecov (0.16.1)
-      docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -72,7 +67,6 @@ DEPENDENCIES
   rake
   rspec
   rubocop (~> 0.60.0)
-  simplecov
 
 BUNDLED WITH
    1.16.5

--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,0 @@
-{
-  "result": {
-    "covered_percent": 69.55
-  }
-}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,9 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'simplecov'
-SimpleCov.start unless ENV['DISABLE_COVERAGE']
-
 RSpec.configure do |config|
   config.mock_with :mocha
 end


### PR DESCRIPTION
`rake test` will be able to be ran w/o side effects!

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
