### PR TITLE
Add docs about how to import with google-beta

### DIFF
--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -165,6 +165,9 @@ This resource provides the following
 
 ```
 <% import_id_formats(object).each do |id_format| -%>
-$ terraform import google_<%= resource_name -%>.default <%= id_format %>
+$ terraform import <% if object.min_version.name == 'beta' %>-provider=google-beta <% end -%>google_<%= resource_name -%>.default <%= id_format %>
 <% end -%>
 ```
+
+-> If you're importing a resource with beta features, make sure to include `provider=google-beta"
+as an argument so that Terraform uses the correct provider to import your resource.

--- a/third_party/terraform/website/docs/provider_versions.html.markdown
+++ b/third_party/terraform/website/docs/provider_versions.html.markdown
@@ -85,6 +85,16 @@ resource "google_compute_instance" "beta-instance" {
 }
 ```
 
+## Importing resources with `google-beta`
+By default, Terraform will always import resources using the `google` provider.
+To import resources with `google-beta`, you need to explicitly specify a provider
+with the `-provider` flag, similarly to if you were using a provider alias.
+
+
+```bash
+terraform import -provider=google-beta google_compute_instance.beta-instance my-instance
+```
+
 ## Converting resources between versions
 
 Resources can safely be converted from one version to the other without needing to rebuild infrastructure.


### PR DESCRIPTION
So far just target generated resources, and add a note to Api Versions. I can add the note to some handwritten resources, but coverage is *probably* good enough as-is? Let me know your thoughts.

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/2705

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
