### PR TITLE
Migrate TF over to new Overrides

### DIFF
--- a/api/type.rb
+++ b/api/type.rb
@@ -88,6 +88,8 @@ module Api
         clazz = ::Symbol
       when Api::Type::Boolean
         clazz = :boolean
+      when Api::Type::ResourceRef
+        clazz = ::String
       else
         raise "Update 'check_default_value_property' method to support " \
               "default value for type #{self.class}"
@@ -477,8 +479,7 @@ module Api
       def check_resource_ref_exists
         product = @__resource.__product
         resources = product.objects.select { |obj| obj.name == @resource }
-        raise "Missing '#{@resource}'" \
-          if resources.empty? || resources[0].exclude
+        raise "Missing '#{@resource}'" if resources.empty?
       end
 
       def check_resource_ref_property_exists

--- a/api/type.rb
+++ b/api/type.rb
@@ -105,7 +105,8 @@ module Api
 
       return if @conflicts.empty?
 
-      names = @__resource.all_user_properties.map(&:api_name) + @__resource.all_user_properties.map(&:name)
+      names = @__resource.all_user_properties.map(&:api_name) +
+              @__resource.all_user_properties.map(&:name)
       @conflicts.each do |p|
         raise "#{p} does not exist" unless names.include?(p)
       end

--- a/api/type.rb
+++ b/api/type.rb
@@ -105,7 +105,7 @@ module Api
 
       return if @conflicts.empty?
 
-      names = @__resource.all_user_properties.map(&:name)
+      names = @__resource.all_user_properties.map(&:api_name) + @__resource.all_user_properties.map(&:name)
       @conflicts.each do |p|
         raise "#{p} does not exist" unless names.include?(p)
       end

--- a/products/accesscontextmanager/terraform.yaml
+++ b/products/accesscontextmanager/terraform.yaml
@@ -13,8 +13,8 @@
 
 --- !ruby/object:Provider::Terraform::Config
 name: AccessContextManager
-overrides: !ruby/object:Provider::ResourceOverrides
-  AccessPolicy: !ruby/object:Provider::Terraform::ResourceOverride
+overrides: !ruby/object:Provider::Overrides::ResourceOverrides
+  AccessPolicy: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     import_format: ["{{name}}"]
     example:
       - !ruby/object:Provider::Terraform::Examples
@@ -23,14 +23,14 @@ overrides: !ruby/object:Provider::ResourceOverrides
         primary_resource_id: "access-policy"
         version: <%= version_name %>
     properties:
-      name: !ruby/object:Provider::Terraform::PropertyOverride
+      name: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
         description: |
           Resource name of the AccessPolicy. Format: {policy_id}
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_update: templates/terraform/pre_update/update_mask.erb
       post_create: templates/terraform/post_create/accesspolicy.erb
-  AccessLevel: !ruby/object:Provider::Terraform::ResourceOverride
+  AccessLevel: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     id_format: "{{name}}"
     import_format: ["{{name}}"]
     example:
@@ -42,15 +42,15 @@ overrides: !ruby/object:Provider::ResourceOverrides
       vars:
         access_level_name: "ios_no_lock"
     properties:
-      parent: !ruby/object:Provider::Terraform::PropertyOverride
+      parent: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         ignore_read: true
-      basic.combiningFunction: !ruby/object:Provider::Terraform::PropertyOverride
+      basic.combiningFunction: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/default_if_empty.erb
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_update: templates/terraform/pre_update/update_mask.erb
       encoder: templates/terraform/encoders/access_level_never_send_parent.go.erb
       custom_import: templates/terraform/custom_import/access_level_self_link_as_name_and_set_parent.go.erb
-  ServicePerimeter: !ruby/object:Provider::Terraform::ResourceOverride
+  ServicePerimeter: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     id_format: "{{name}}"
     import_format: ["{{name}}"]
     example:
@@ -63,9 +63,9 @@ overrides: !ruby/object:Provider::ResourceOverrides
           access_level_name: "ios_no_lock"
           service_perimeter_name: "restrict_all"
     properties:
-      parent: !ruby/object:Provider::Terraform::PropertyOverride
+      parent: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         ignore_read: true
-      perimeterType: !ruby/object:Provider::Terraform::PropertyOverride
+      perimeterType: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/default_if_empty.erb
         input: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode

--- a/products/binaryauthorization/terraform.yaml
+++ b/products/binaryauthorization/terraform.yaml
@@ -13,8 +13,8 @@
 
 --- !ruby/object:Provider::Terraform::Config
 name: BinaryAuthorization
-overrides: !ruby/object:Provider::ResourceOverrides
-  Attestor: !ruby/object:Provider::Terraform::ResourceOverride
+overrides: !ruby/object:Provider::Overrides::ResourceOverrides
+  Attestor: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     import_format: ["projects/{{project}}/attestors/{{name}}"]
     example:
      - !ruby/object:Provider::Terraform::Examples
@@ -25,9 +25,9 @@ overrides: !ruby/object:Provider::ResourceOverrides
         attestor_name: "test-attestor"
         note_name: "test-attestor-note"
     properties:
-      name: !ruby/object:Provider::Terraform::PropertyOverride
+      name: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
-      attestationAuthorityNote.noteReference: !ruby/object:Provider::Terraform::PropertyOverride
+      attestationAuthorityNote.noteReference: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/container_analysis_note.erb'
         diff_suppress_func: 'compareSelfLinkOrResourceName'
         description: |
@@ -38,7 +38,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
           An attestation by this attestor is stored as a Container Analysis
           ATTESTATION_AUTHORITY Occurrence that names a container image
           and that links to this Note.
-  Policy: !ruby/object:Provider::Terraform::ResourceOverride
+  Policy: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     id_format: "{{project}}"
     import_format: ["projects/{{project}}"]
     custom_code: !ruby/object:Provider::Terraform::CustomCode
@@ -53,7 +53,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
         attestor_name: "test-attestor"
         note_name: "test-attestor-note"
     properties:
-      clusterAdmissionRules: !ruby/object:Provider::Terraform::PropertyOverride
+      clusterAdmissionRules: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         is_set: true
         set_hash_func: |-
           func(v interface{}) int {
@@ -72,7 +72,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
             schema.SerializeResourceForHash(&buf, raw, resourceBinaryAuthorizationPolicy().Schema["cluster_admission_rules"].Elem.(*schema.Resource))
             return hashcode.String(buf.String())
           }
-      clusterAdmissionRules.requireAttestationsBy: !ruby/object:Provider::Terraform::PropertyOverride
+      clusterAdmissionRules.requireAttestationsBy: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         is_set: true
         set_hash_func: selfLinkNameHash
         custom_expand: 'templates/terraform/custom_expand/binaryauthorization_attestors.erb'
@@ -87,7 +87,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
 
           Note: this field must be non-empty when the evaluation_mode field
           specifies REQUIRE_ATTESTATION, otherwise it must be empty.
-      defaultAdmissionRule.requireAttestationsBy: !ruby/object:Provider::Terraform::PropertyOverride
+      defaultAdmissionRule.requireAttestationsBy: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         is_set: true
         set_hash_func: selfLinkNameHash
         custom_expand: 'templates/terraform/custom_expand/binaryauthorization_attestors.erb'

--- a/products/compute/helpers/terraform/autoscaler_overrides.yaml
+++ b/products/compute/helpers/terraform/autoscaler_overrides.yaml
@@ -11,12 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-id: !ruby/object:Provider::Terraform::PropertyOverride
+id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   exclude: true
-name: !ruby/object:Provider::Terraform::PropertyOverride
+name: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   validation: !ruby/object:Provider::Terraform::Validation
     function: 'validateGCPName'
-autoscalingPolicy.minNumReplicas: !ruby/object:Provider::Terraform::PropertyOverride
+autoscalingPolicy.minNumReplicas: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   name: minReplicas
   # Even though this field isn't actually required by the API, it makes our
   # lives easier if we treat it as a required field. It has a default that is
@@ -26,23 +26,23 @@ autoscalingPolicy.minNumReplicas: !ruby/object:Provider::Terraform::PropertyOver
   # when our users aren't expecting us to. For more info, see
   # https://github.com/GoogleCloudPlatform/magic-modules/issues/305.
   required: true
-autoscalingPolicy.maxNumReplicas: !ruby/object:Provider::Terraform::PropertyOverride
+autoscalingPolicy.maxNumReplicas: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   name: maxReplicas
-autoscalingPolicy.coolDownPeriodSec: !ruby/object:Provider::Terraform::PropertyOverride
+autoscalingPolicy.coolDownPeriodSec: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   name: cooldownPeriod
-autoscalingPolicy.cpuUtilization: !ruby/object:Provider::Terraform::PropertyOverride
+autoscalingPolicy.cpuUtilization: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   default_from_api: true
-autoscalingPolicy.cpuUtilization.utilizationTarget: !ruby/object:Provider::Terraform::PropertyOverride
+autoscalingPolicy.cpuUtilization.utilizationTarget: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   name: target
   required: true # See comment for minReplicas
-autoscalingPolicy.customMetricUtilizations: !ruby/object:Provider::Terraform::PropertyOverride
+autoscalingPolicy.customMetricUtilizations: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   name: metric
-autoscalingPolicy.customMetricUtilizations.metric: !ruby/object:Provider::Terraform::PropertyOverride
+autoscalingPolicy.customMetricUtilizations.metric: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   name: name
-autoscalingPolicy.customMetricUtilizations.utilizationTarget: !ruby/object:Provider::Terraform::PropertyOverride
+autoscalingPolicy.customMetricUtilizations.utilizationTarget: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   name: target
-autoscalingPolicy.customMetricUtilizations.utilizationTargetType: !ruby/object:Provider::Terraform::PropertyOverride
+autoscalingPolicy.customMetricUtilizations.utilizationTargetType: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   name: type
-autoscalingPolicy.loadBalancingUtilization.utilizationTarget: !ruby/object:Provider::Terraform::PropertyOverride
+autoscalingPolicy.loadBalancingUtilization.utilizationTarget: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   name: target
   required: true # See comment for minReplicas

--- a/products/compute/helpers/terraform/disk_overrides.yaml
+++ b/products/compute/helpers/terraform/disk_overrides.yaml
@@ -10,21 +10,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-id: !ruby/object:Provider::Terraform::PropertyOverride
+id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   exclude: true
-sizeGb: !ruby/object:Provider::Terraform::PropertyOverride
+sizeGb: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   name: size
   default_from_api: true
-sourceSnapshot: !ruby/object:Provider::Terraform::PropertyOverride
+sourceSnapshot: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   name: snapshot
   description: |
     {{description}}* `snapshot`
-type: !ruby/object:Provider::Terraform::PropertyOverride
+type: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
   default_value: 'pd-standard'
-name: !ruby/object:Provider::Terraform::PropertyOverride
+name: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   input: true
-licenses: !ruby/object:Provider::Terraform::PropertyOverride
+licenses: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   exclude: true
-labelFingerprint: !ruby/object:Provider::Terraform::PropertyOverride
+labelFingerprint: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
   exclude: false

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -12,8 +12,8 @@
 # limitations under the License.
 
 --- !ruby/object:Provider::Terraform::Config
-overrides: !ruby/object:Provider::ResourceOverrides
-  Address: !ruby/object:Provider::Terraform::ResourceOverride
+overrides: !ruby/object:Provider::Overrides::ResourceOverrides
+  Address: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     id_format: "{{project}}/{{region}}/{{name}}"
     example:
       - !ruby/object:Provider::Terraform::Examples
@@ -39,34 +39,34 @@ overrides: !ruby/object:Provider::ResourceOverrides
          address_name: "ipv4-address"
          instance_name: "vm-instance"
     properties:
-      address: !ruby/object:Provider::Terraform::PropertyOverride
+      address: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_from_api: true
-      addressType: !ruby/object:Provider::Terraform::PropertyOverride
+      addressType: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      labelFingerprint: !ruby/object:Provider::Terraform::PropertyOverride
+      labelFingerprint: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: false
-      name: !ruby/object:Provider::Terraform::PropertyOverride
+      name: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           regex: '^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$'
-      networkTier: !ruby/object:Provider::Terraform::PropertyOverride
+      networkTier: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_from_api: true
-      region: !ruby/object:Provider::Terraform::PropertyOverride
+      region: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         required: false
         default_from_api: true
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
         description: |
           The Region in which the created address should reside.
           If it is not provided, the provider region is used.
-      subnetwork: !ruby/object:Provider::Terraform::PropertyOverride
+      subnetwork: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_from_api: true
     docs: !ruby/object:Provider::Terraform::Docs
       attributes: |
           * `address` - The IP of the created resource.
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       post_create: templates/terraform/post_create/labels.erb
-  Autoscaler: !ruby/object:Provider::Terraform::ResourceOverride
+  Autoscaler: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     id_format: "{{zone}}/{{name}}"
     example:
       - !ruby/object:Provider::Terraform::Examples
@@ -80,12 +80,12 @@ overrides: !ruby/object:Provider::ResourceOverrides
           igm_name: "my-igm"
     properties:
 <%= indent(compile_file({}, 'products/compute/helpers/terraform/autoscaler_overrides.yaml'), 6) %>
-      target: !ruby/object:Provider::Terraform::PropertyOverride
+      target: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/compute_full_url.erb'
-      zone: !ruby/object:Provider::Terraform::PropertyOverride
+      zone: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         required: false
         default_from_api: true
-  BackendBucket: !ruby/object:Provider::Terraform::ResourceOverride
+  BackendBucket: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     example:
       - !ruby/object:Provider::Terraform::Examples
         name: "backend_bucket_basic"
@@ -95,51 +95,24 @@ overrides: !ruby/object:Provider::ResourceOverrides
           backend_bucket_name: "image-backend-bucket"
           bucket_name: "image-store-bucket"
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      name: !ruby/object:Provider::Terraform::PropertyOverride
+      name: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           regex: '^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$'
-  BackendService: !ruby/object:Provider::Terraform::ResourceOverride
+  BackendService: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
-  Disk: !ruby/object:Provider::Terraform::ResourceOverride
+  Disk: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     properties:
 <%= indent(compile_file({}, 'products/compute/helpers/terraform/disk_overrides.yaml'), 6) %>
-      zone: !ruby/object:Provider::Terraform::PropertyOverride
+      zone: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         required: false
         default_from_api: true
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
-      sourceImage: !ruby/object:Provider::Terraform::PropertyOverride
+      sourceImage: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         # sourceImage must be overridden first because it creates the 'image' property
-        override_order: -1
         name: image
         diff_suppress_func: 'diskImageDiffSuppress'
-      diskEncryptionKey.kmsKeyName: !ruby/object:Provider::Terraform::PropertyOverride
-        diff_suppress_func: 'compareSelfLinkRelativePaths'
-        name: "kmsKeySelfLink"
-        description: |
-          The self link of the encryption key used to encrypt the disk. Also called KmsKeyName
-          in the cloud console. In order to use this additional
-          IAM permissions need to be set on the Compute Engine Service Agent. See
-          https://cloud.google.com/compute/docs/disks/customer-managed-encryption#encrypt_a_new_persistent_disk_with_your_own_keys
-      sourceSnapshotEncryptionKey.kmsKeyName: !ruby/object:Provider::Terraform::PropertyOverride
-        diff_suppress_func: 'compareSelfLinkRelativePaths'
-        name: "kmsKeySelfLink"
-        description: |
-          The self link of the encryption key used to encrypt the disk. Also called KmsKeyName
-          in the cloud console. In order to use this additional
-          IAM permissions need to be set on the Compute Engine Service Agent. See
-          https://cloud.google.com/compute/docs/disks/customer-managed-encryption#encrypt_a_new_persistent_disk_with_your_own_keys
-      sourceImageEncryptionKey.kmsKeyName: !ruby/object:Provider::Terraform::PropertyOverride
-        diff_suppress_func: 'compareSelfLinkRelativePaths'
-        name: "kmsKeySelfLink"
-        description: |
-          The self link of the encryption key used to encrypt the disk. Also called KmsKeyName
-          in the cloud console. In order to use this additional
-          IAM permissions need to be set on the Compute Engine Service Agent. See
-          https://cloud.google.com/compute/docs/disks/customer-managed-encryption#encrypt_a_new_persistent_disk_with_your_own_keys
-      image: !ruby/object:Provider::Terraform::PropertyOverride
-        override_order: 5
         description: |
           The image from which to initialize this disk. This can be
           one of: the image's `self_link`, `projects/{project}/global/images/{image}`,
@@ -150,6 +123,30 @@ overrides: !ruby/object:Provider::ResourceOverrides
           [google_compute_image data source](/docs/providers/google/d/datasource_compute_image.html).
           For instance, the image `centos-6-v20180104` includes its family name `centos-6`.
           These images can be referred by family name here.
+      diskEncryptionKey.kmsKeyName: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
+        diff_suppress_func: 'compareSelfLinkRelativePaths'
+        name: "kmsKeySelfLink"
+        description: |
+          The self link of the encryption key used to encrypt the disk. Also called KmsKeyName
+          in the cloud console. In order to use this additional
+          IAM permissions need to be set on the Compute Engine Service Agent. See
+          https://cloud.google.com/compute/docs/disks/customer-managed-encryption#encrypt_a_new_persistent_disk_with_your_own_keys
+      sourceSnapshotEncryptionKey.kmsKeyName: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
+        diff_suppress_func: 'compareSelfLinkRelativePaths'
+        name: "kmsKeySelfLink"
+        description: |
+          The self link of the encryption key used to encrypt the disk. Also called KmsKeyName
+          in the cloud console. In order to use this additional
+          IAM permissions need to be set on the Compute Engine Service Agent. See
+          https://cloud.google.com/compute/docs/disks/customer-managed-encryption#encrypt_a_new_persistent_disk_with_your_own_keys
+      sourceImageEncryptionKey.kmsKeyName: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
+        diff_suppress_func: 'compareSelfLinkRelativePaths'
+        name: "kmsKeySelfLink"
+        description: |
+          The self link of the encryption key used to encrypt the disk. Also called KmsKeyName
+          in the cloud console. In order to use this additional
+          IAM permissions need to be set on the Compute Engine Service Agent. See
+          https://cloud.google.com/compute/docs/disks/customer-managed-encryption#encrypt_a_new_persistent_disk_with_your_own_keys
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_delete: templates/terraform/pre_delete/detach_disk.erb
       constants: templates/terraform/constants/disk.erb
@@ -169,9 +166,9 @@ overrides: !ruby/object:Provider::ResourceOverrides
         version: <%= version_name %>
         vars:
           disk_name: "test-disk"
-  DiskType: !ruby/object:Provider::Terraform::ResourceOverride
+  DiskType: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
-  Firewall: !ruby/object:Provider::Terraform::ResourceOverride
+  Firewall: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     example:
       - !ruby/object:Provider::Terraform::Examples
         name: "firewall_basic"
@@ -184,46 +181,50 @@ overrides: !ruby/object:Provider::ResourceOverrides
       constants: templates/terraform/constants/firewall.erb
       resource_definition: templates/terraform/resource_definition/firewall.erb
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      allowed: !ruby/object:Provider::Terraform::PropertyOverride     
+      allowed: !ruby/object:Provider::Overrides::Terraform::PropertyOverride     
         name: 'allow'
+        conflicts:
+          - deny
         is_set: true
         set_hash_func: 'resourceComputeFirewallRuleHash'
-      allowed.ip_protocol: !ruby/object:Provider::Terraform::PropertyOverride
+      allowed.ip_protocol: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: 'protocol'
-      denied: !ruby/object:Provider::Terraform::PropertyOverride     
+      denied: !ruby/object:Provider::Overrides::Terraform::PropertyOverride     
         name: 'deny'
+        conflicts:
+          - allow
         is_set: true
         set_hash_func: 'resourceComputeFirewallRuleHash'
-      denied.ip_protocol: !ruby/object:Provider::Terraform::PropertyOverride
+      denied.ip_protocol: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: 'protocol'
-      destinationRanges: !ruby/object:Provider::Terraform::PropertyOverride
+      destinationRanges: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         is_set: true 
         default_from_api: true
-      direction: !ruby/object:Provider::Terraform::PropertyOverride
+      direction: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_from_api: true
-      name: !ruby/object:Provider::Terraform::PropertyOverride
+      name: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateGCPName'
-      network: !ruby/object:Provider::Terraform::PropertyOverride
+      network: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         description: |
           The name or self_link of the network to attach this firewall to.
-      priority: !ruby/object:Provider::Terraform::PropertyOverride
+      priority: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validation.IntBetween(0, 65535)'
-      sourceRanges: !ruby/object:Provider::Terraform::PropertyOverride
+      sourceRanges: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         is_set: true 
         default_from_api: true
-      sourceTags: !ruby/object:Provider::Terraform::PropertyOverride
+      sourceTags: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         is_set: true 
-      sourceServiceAccounts: !ruby/object:Provider::Terraform::PropertyOverride
+      sourceServiceAccounts: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         is_set: true 
-      targetServiceAccounts: !ruby/object:Provider::Terraform::PropertyOverride
+      targetServiceAccounts: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         is_set: true 
-      targetTags: !ruby/object:Provider::Terraform::PropertyOverride
+      targetTags: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         is_set: true
-  ForwardingRule: !ruby/object:Provider::Terraform::ResourceOverride
+  ForwardingRule: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     example:
       - !ruby/object:Provider::Terraform::Examples
         name: "forwarding_rule_basic"
@@ -235,44 +236,44 @@ overrides: !ruby/object:Provider::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       post_create: templates/terraform/post_create/labels.erb
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      portRange: !ruby/object:Provider::Terraform::PropertyOverride
+      portRange: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'portRangeDiffSuppress'
-      region: !ruby/object:Provider::Terraform::PropertyOverride
+      region: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         required: false
         default_from_api: true
-      IPAddress: !ruby/object:Provider::Terraform::PropertyOverride
+      IPAddress: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_from_api: true
-      IPProtocol: !ruby/object:Provider::Terraform::PropertyOverride
+      IPProtocol: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'caseDiffSuppress'
         default_from_api: true
-      loadBalancingScheme: !ruby/object:Provider::Terraform::PropertyOverride
+      loadBalancingScheme: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: :EXTERNAL
-      network: !ruby/object:Provider::Terraform::PropertyOverride
+      network: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_from_api: true
-      subnetwork: !ruby/object:Provider::Terraform::PropertyOverride
+      subnetwork: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_from_api: true
-      region: !ruby/object:Provider::Terraform::PropertyOverride
+      region: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         required: false
         default_from_api: true
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
-      backendService: !ruby/object:Provider::Terraform::PropertyOverride
+      backendService: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/self_link_from_name.erb'
-      networkTier: !ruby/object:Provider::Terraform::PropertyOverride
+      networkTier: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_from_api: true
-      target: !ruby/object:Provider::Terraform::PropertyOverride
+      target: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'compareSelfLinkRelativePaths'
         custom_expand: 'templates/terraform/custom_expand/self_link_from_name.erb'
-      ports: !ruby/object:Provider::Terraform::PropertyOverride
+      ports: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         is_set: true
         custom_expand: 'templates/terraform/custom_expand/set_to_list.erb'
-      labelFingerprint: !ruby/object:Provider::Terraform::PropertyOverride
+      labelFingerprint: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: false
-      serviceLabel: !ruby/object:Provider::Terraform::PropertyOverride
+      serviceLabel: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateGCPName'
-  GlobalAddress: !ruby/object:Provider::Terraform::ResourceOverride
+  GlobalAddress: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     example:
       - !ruby/object:Provider::Terraform::Examples
         name: "global_address_basic"
@@ -281,23 +282,23 @@ overrides: !ruby/object:Provider::ResourceOverrides
         vars:
           global_address_name: "global-appserver-ip"
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      address: !ruby/object:Provider::Terraform::PropertyOverride
+      address: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_from_api: true
-      ipVersion: !ruby/object:Provider::Terraform::PropertyOverride
+      ipVersion: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'emptyOrDefaultStringSuppress("IPV4")'
-      labelFingerprint: !ruby/object:Provider::Terraform::PropertyOverride
+      labelFingerprint: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: false
-      region: !ruby/object:Provider::Terraform::PropertyOverride
+      region: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      addressType: !ruby/object:Provider::Terraform::PropertyOverride
+      addressType: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'emptyOrDefaultStringSuppress("EXTERNAL")'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       post_create: templates/terraform/post_create/labels.erb
-  GlobalForwardingRule: !ruby/object:Provider::Terraform::ResourceOverride
+  GlobalForwardingRule: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
-  HttpHealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
+  HttpHealthCheck: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     description: |
       {{description}}
 
@@ -314,21 +315,21 @@ overrides: !ruby/object:Provider::ResourceOverrides
         vars:
           http_health_check_name: "authentication-health-check"
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      checkIntervalSec: !ruby/object:Provider::Terraform::PropertyOverride
+      checkIntervalSec: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: 5
-      healthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
+      healthyThreshold: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: 2
-      port: !ruby/object:Provider::Terraform::PropertyOverride
+      port: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: 80
-      requestPath: !ruby/object:Provider::Terraform::PropertyOverride
+      requestPath: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: "/"
-      timeoutSec: !ruby/object:Provider::Terraform::PropertyOverride
+      timeoutSec: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: 5
-      unhealthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
+      unhealthyThreshold: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: 2
-  HttpsHealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
+  HttpsHealthCheck: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     description: |
       {{description}}
 
@@ -345,21 +346,21 @@ overrides: !ruby/object:Provider::ResourceOverrides
         vars:
           https_health_check_name: "authentication-health-check"
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      checkIntervalSec: !ruby/object:Provider::Terraform::PropertyOverride
+      checkIntervalSec: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: 5
-      healthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
+      healthyThreshold: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: 2
-      port: !ruby/object:Provider::Terraform::PropertyOverride
+      port: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: 443
-      requestPath: !ruby/object:Provider::Terraform::PropertyOverride
+      requestPath: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: "/"
-      timeoutSec: !ruby/object:Provider::Terraform::PropertyOverride
+      timeoutSec: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: 5
-      unhealthyThreshold: !ruby/object:Provider::Terraform::PropertyOverride
+      unhealthyThreshold: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: 2
-  HealthCheck: !ruby/object:Provider::Terraform::ResourceOverride
+  HealthCheck: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     example:
       - !ruby/object:Provider::Terraform::Examples
         name: "health_check_basic"
@@ -370,28 +371,28 @@ overrides: !ruby/object:Provider::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       encoder: templates/terraform/encoders/health_check_type.erb
     properties:
-     id: !ruby/object:Provider::Terraform::PropertyOverride
+     id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
        exclude: true
-     type: !ruby/object:Provider::Terraform::PropertyOverride
+     type: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
        output: true
        description: The type of the health check. One of HTTP, HTTPS, TCP, or SSL.
-     httpHealthCheck.portName: !ruby/object:Provider::Terraform::PropertyOverride
+     httpHealthCheck.portName: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
        exclude: true
-     httpHealthCheck.port: !ruby/object:Provider::Terraform::PropertyOverride
+     httpHealthCheck.port: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
        default_value: 80
-     httpsHealthCheck.portName: !ruby/object:Provider::Terraform::PropertyOverride
+     httpsHealthCheck.portName: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
        exclude: true
-     httpsHealthCheck.port: !ruby/object:Provider::Terraform::PropertyOverride
+     httpsHealthCheck.port: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
        default_value: 443
-     tcpHealthCheck.portName: !ruby/object:Provider::Terraform::PropertyOverride
+     tcpHealthCheck.portName: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
        exclude: true
-     tcpHealthCheck.port: !ruby/object:Provider::Terraform::PropertyOverride
+     tcpHealthCheck.port: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
        default_value: 80
-     sslHealthCheck.portName: !ruby/object:Provider::Terraform::PropertyOverride
+     sslHealthCheck.portName: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
        exclude: true
-     sslHealthCheck.port: !ruby/object:Provider::Terraform::PropertyOverride
+     sslHealthCheck.port: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
        default_value: 443
-  Image: !ruby/object:Provider::Terraform::ResourceOverride
+  Image: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     example:
       - !ruby/object:Provider::Terraform::Examples
         name: "image_basic"
@@ -400,51 +401,51 @@ overrides: !ruby/object:Provider::ResourceOverrides
         vars:
           image_name: "example-image"
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      diskSizeGb: !ruby/object:Provider::Terraform::PropertyOverride
+      diskSizeGb: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_from_api: true
-      deprecated: !ruby/object:Provider::Terraform::PropertyOverride
+      deprecated: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      guestOsFeatures: !ruby/object:Provider::Terraform::PropertyOverride
+      guestOsFeatures: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      imageEncryptionKey: !ruby/object:Provider::Terraform::PropertyOverride
+      imageEncryptionKey: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      licenses: !ruby/object:Provider::Terraform::PropertyOverride
+      licenses: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_from_api: true
-      rawDisk.sha1Checksum: !ruby/object:Provider::Terraform::PropertyOverride
+      rawDisk.sha1Checksum: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: 'sha1'
-      rawDisk.containerType: !ruby/object:Provider::Terraform::PropertyOverride
+      rawDisk.containerType: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: "TAR"
-      rawDisk: !ruby/object:Provider::Terraform::PropertyOverride
+      rawDisk: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         ignore_read: true
-      sourceDiskEncryptionKey: !ruby/object:Provider::Terraform::PropertyOverride
+      sourceDiskEncryptionKey: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      sourceDiskId: !ruby/object:Provider::Terraform::PropertyOverride
+      sourceDiskId: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      sourceType: !ruby/object:Provider::Terraform::PropertyOverride
+      sourceType: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-  Instance: !ruby/object:Provider::Terraform::ResourceOverride
+  Instance: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
-  InstanceGroup: !ruby/object:Provider::Terraform::ResourceOverride
+  InstanceGroup: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
-  InstanceGroupManager: !ruby/object:Provider::Terraform::ResourceOverride
+  InstanceGroupManager: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
-  InstanceTemplate: !ruby/object:Provider::Terraform::ResourceOverride
+  InstanceTemplate: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
-  InterconnectAttachment: !ruby/object:Provider::Terraform::ResourceOverride
+  InterconnectAttachment: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      name: !ruby/object:Provider::Terraform::PropertyOverride
+      name: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           regex: '^[a-z]([-a-z0-9]*[a-z0-9])?$'
-      region: !ruby/object:Provider::Terraform::PropertyOverride
+      region: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         required: false
         default_from_api: true
-      router: !ruby/object:Provider::Terraform::PropertyOverride
+      router: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'compareSelfLinkOrResourceName'
-      interconnect: !ruby/object:Provider::Terraform::PropertyOverride
+      interconnect: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'compareSelfLinkOrResourceName'
     examples: |
       ```hcl
@@ -459,15 +460,15 @@ overrides: !ruby/object:Provider::ResourceOverrides
         router       = "${google_compute_router.foobar.self_link}"
       }
       ```
-  License: !ruby/object:Provider::Terraform::ResourceOverride
+  License: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
-  MachineType: !ruby/object:Provider::Terraform::ResourceOverride
+  MachineType: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
-  Network: !ruby/object:Provider::Terraform::ResourceOverride
+  Network: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
-  Region: !ruby/object:Provider::Terraform::ResourceOverride
+  Region: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
-  RegionAutoscaler: !ruby/object:Provider::Terraform::ResourceOverride
+  RegionAutoscaler: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     id_format: "{{region}}/{{name}}"
     example:
       - !ruby/object:Provider::Terraform::Examples
@@ -481,15 +482,15 @@ overrides: !ruby/object:Provider::ResourceOverrides
           rigm_name: "my-region-igm"
     properties:
 <%= indent(compile_file({}, 'products/compute/helpers/terraform/autoscaler_overrides.yaml'), 6) %>
-      target: !ruby/object:Provider::Terraform::PropertyOverride
+      target: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'compareSelfLinkOrResourceName'
-      region: !ruby/object:Provider::Terraform::PropertyOverride
+      region: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         required: false
         default_from_api: true
-  RegionDisk: !ruby/object:Provider::Terraform::ResourceOverride
+  RegionDisk: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     properties:
 <%= indent(compile_file({}, 'products/compute/helpers/terraform/disk_overrides.yaml'), 6) %>
-      region: !ruby/object:Provider::Terraform::PropertyOverride
+      region: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         required: false
         default_from_api: true
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
@@ -512,9 +513,9 @@ overrides: !ruby/object:Provider::ResourceOverrides
           region_disk_name: "my-region-disk"
           disk_name: "my-disk"
           snapshot_name: "my-snapshot"
-  RegionDiskType: !ruby/object:Provider::Terraform::ResourceOverride
+  RegionDiskType: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
-  Route: !ruby/object:Provider::Terraform::ResourceOverride
+  Route: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     example:
       - !ruby/object:Provider::Terraform::Examples
         name: "route_basic"
@@ -524,14 +525,14 @@ overrides: !ruby/object:Provider::ResourceOverrides
           route_name: "network-route"
           network_name: "compute-network"
     properties:
-      name: !ruby/object:Provider::Terraform::PropertyOverride
+      name: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           regex: '^[a-z]([-a-z0-9]*[a-z0-9])?$'
-      network: !ruby/object:Provider::Terraform::PropertyOverride
+      network: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'compareSelfLinkOrResourceName'
-      priority: !ruby/object:Provider::Terraform::PropertyOverride
+      priority: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: 1000
-      nextHopGateway: !ruby/object:Provider::Terraform::PropertyOverride
+      nextHopGateway: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'compareSelfLinkOrResourceName'
         custom_expand: templates/terraform/custom_expand/route_gateway.erb
         # Description here is overridden because puppet won't compile if you ask
@@ -544,7 +545,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
           * `projects/project/global/gateways/default-internet-gateway`
           * `global/gateways/default-internet-gateway`
           * The string `default-internet-gateway`.
-      nextHopInstance: !ruby/object:Provider::Terraform::PropertyOverride
+      nextHopInstance: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'compareSelfLinkOrResourceName'
         custom_expand: templates/terraform/custom_expand/route_instance.erb
         # Description here is overridden because puppet won't compile if you ask
@@ -557,7 +558,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
           * `zones/zone/instances/instance`
           * Just the instance name, with the zone in `next_hop_instance_zone`.
           
-      tags: !ruby/object:Provider::Terraform::PropertyOverride
+      tags: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_expand: templates/terraform/custom_expand/set_to_list.erb
         is_set: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
@@ -569,7 +570,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
             specified)  The zone of the instance specified in
             `next_hop_instance`.  Omit if `next_hop_instance` is specified as
             a URL.
-  Router: !ruby/object:Provider::Terraform::ResourceOverride
+  Router: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     id_format: "{{region}}/{{name}}"
     mutex: router/{{region}}/{{name}}
     example:
@@ -581,16 +582,16 @@ overrides: !ruby/object:Provider::ResourceOverrides
           router_name: "my-router"
           network_name: "my-network"
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      name: !ruby/object:Provider::Terraform::PropertyOverride
+      name: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateGCPName'
-      region: !ruby/object:Provider::Terraform::PropertyOverride
+      region: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         required: false
         default_from_api: true
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
-  Snapshot: !ruby/object:Provider::Terraform::ResourceOverride
+  Snapshot: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     create_url: projects/{{project}}/zones/{{zone}}/disks/{{source_disk}}/createSnapshot
     example:
       - !ruby/object:Provider::Terraform::Examples
@@ -601,35 +602,35 @@ overrides: !ruby/object:Provider::ResourceOverrides
           snapshot_name: "my-snapshot"
           disk_name: "debian-disk"
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: 'snapshot_id'
-      zone: !ruby/object:Provider::Terraform::PropertyOverride
+      zone: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         ignore_read: true
         default_from_api: true
         required: false
-      snapshotEncryptionKey.rawKey: !ruby/object:Provider::Terraform::PropertyOverride
+      snapshotEncryptionKey.rawKey: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         # This is _correct_, but we don't support ignore_read on nested fields
         # so we use a custom_flatten for now.
         # https://github.com/GoogleCloudPlatform/magic-modules/issues/1019
         ignore_read: true
         sensitive: true
         custom_flatten: templates/terraform/custom_flatten/compute_snapshot_snapshot_encryption_raw_key.go.erb
-      snapshotEncryptionKey.kmsKeyName: !ruby/object:Provider::Terraform::PropertyOverride
+      snapshotEncryptionKey.kmsKeyName: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         # This is a beta field that showed up in GA. Removed from both.
         exclude: true
-      sourceDisk: !ruby/object:Provider::Terraform::PropertyOverride
+      sourceDisk: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
-      sourceDiskEncryptionKey: !ruby/object:Provider::Terraform::PropertyOverride
+      sourceDiskEncryptionKey: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         ignore_read: true
-      sourceDiskEncryptionKey.rawKey: !ruby/object:Provider::Terraform::PropertyOverride
+      sourceDiskEncryptionKey.rawKey: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         sensitive: true
-      sourceDiskEncryptionKey.kmsKeyName: !ruby/object:Provider::Terraform::PropertyOverride
+      sourceDiskEncryptionKey.kmsKeyName: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         # This is a beta field that showed up in GA. Removed from both.
         exclude: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       decoder: templates/terraform/decoders/snapshot.go.erb
       extra_schema_entry: templates/terraform/extra_schema_entry/snapshot.erb
-  SslCertificate: !ruby/object:Provider::Terraform::ResourceOverride
+  SslCertificate: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     docs: !ruby/object:Provider::Terraform::Docs
       optional_properties: |
         * `name_prefix` - (Optional) Creates a unique name beginning with the
@@ -659,19 +660,19 @@ overrides: !ruby/object:Provider::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       extra_schema_entry: templates/terraform/extra_schema_entry/ssl_certificate.erb
     properties:
-      name: !ruby/object:Provider::Terraform::PropertyOverride
+      name: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_from_api: true
         custom_expand: 'templates/terraform/custom_expand/name_or_name_prefix.go.erb'
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateGCPName'
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: 'certificate_id'
-      certificate: !ruby/object:Provider::Terraform::PropertyOverride
+      certificate: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         sensitive: true
-      privateKey: !ruby/object:Provider::Terraform::PropertyOverride
+      privateKey: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         sensitive: true
         ignore_read: true
-  SslPolicy: !ruby/object:Provider::Terraform::ResourceOverride
+  SslPolicy: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     example:
       - !ruby/object:Provider::Terraform::Examples
         name: "ssl_policy_basic"
@@ -686,9 +687,9 @@ overrides: !ruby/object:Provider::ResourceOverrides
       resource_definition: 'templates/terraform/resource_definition/ssl_policy.erb'
       update_encoder: 'templates/terraform/update_encoder/ssl_policy.erb'
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      customFeatures: !ruby/object:Provider::Terraform::PropertyOverride
+      customFeatures: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         is_set: true
         # TODO(https://github.com/GoogleCloudPlatform/magic-modules/issues/187) replace references automatically
         # Overriding the whole description because original has references to
@@ -704,9 +705,9 @@ overrides: !ruby/object:Provider::ResourceOverrides
           for which ciphers are available to use. **Note**: this argument
           *must* be present when using the `CUSTOM` profile. This argument
           *must not* be present when using any other profile.
-      enabledFeatures: !ruby/object:Provider::Terraform::PropertyOverride
+      enabledFeatures: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         is_set: true
-      profile: !ruby/object:Provider::Terraform::PropertyOverride
+      profile: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: :COMPATIBLE
         description: |
           {{description}}
@@ -714,35 +715,35 @@ overrides: !ruby/object:Provider::ResourceOverrides
           for information on what cipher suites each profile provides. If
           `CUSTOM` is used, the `custom_features` attribute **must be set**.
           Default is `COMPATIBLE`.
-      minTlsVersion: !ruby/object:Provider::Terraform::PropertyOverride
+      minTlsVersion: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: :TLS_1_0
         description : '{{description}} Default is `TLS_1_0`.'
-      warnings: !ruby/object:Provider::Terraform::PropertyOverride
+      warnings: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-  Subnetwork: !ruby/object:Provider::Terraform::ResourceOverride
+  Subnetwork: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     id_format: "{{region}}/{{name}}"
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      name: !ruby/object:Provider::Terraform::PropertyOverride
+      name: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateGCPName'
-      secondaryIpRanges: !ruby/object:Provider::Terraform::PropertyOverride
+      secondaryIpRanges: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: secondaryIpRange
         unordered_list: true
         default_from_api: true
-      secondaryIpRanges.rangeName: !ruby/object:Provider::Terraform::PropertyOverride
+      secondaryIpRanges.rangeName: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateGCPName'
-      secondaryIpRanges.ipCidrRange: !ruby/object:Provider::Terraform::PropertyOverride
+      secondaryIpRanges.ipCidrRange: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateIpCidrRange'
-      fingerprint: !ruby/object:Provider::Terraform::PropertyOverride
+      fingerprint: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: false
-      ipCidrRange: !ruby/object:Provider::Terraform::PropertyOverride
+      ipCidrRange: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateIpCidrRange'
-      region: !ruby/object:Provider::Terraform::PropertyOverride
+      region: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         required: false
         input: false
         default_from_api: true
@@ -758,7 +759,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
         vars:
           subnetwork_name: "test-subnetwork"
           network_name: "test-network"
-  TargetHttpProxy: !ruby/object:Provider::Terraform::ResourceOverride
+  TargetHttpProxy: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     example:
       - !ruby/object:Provider::Terraform::Examples
         name: "target_http_proxy_basic"
@@ -770,9 +771,9 @@ overrides: !ruby/object:Provider::ResourceOverrides
           backend_service_name: "backend-service"
           http_health_check_name: "http-health-check"
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: proxyId
-  TargetHttpsProxy: !ruby/object:Provider::Terraform::ResourceOverride
+  TargetHttpsProxy: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     example:
       - !ruby/object:Provider::Terraform::Examples
         name: "target_https_proxy_basic"
@@ -785,9 +786,9 @@ overrides: !ruby/object:Provider::ResourceOverrides
           backend_service_name: "backend-service"
           http_health_check_name: "http-health-check"
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: proxyId
-  TargetPool: !ruby/object:Provider::Terraform::ResourceOverride
+  TargetPool: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
     examples: |
       ```hcl
@@ -812,15 +813,15 @@ overrides: !ruby/object:Provider::ResourceOverrides
       }
       ```
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      region: !ruby/object:Provider::Terraform::PropertyOverride
+      region: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         required: false # the provider-default value will be used if not specified
-      sessionAffinity: !ruby/object:Provider::Terraform::PropertyOverride
+      sessionAffinity: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: :NONE
       # TODO: Custom code needed for updating `instances` and `healthCheck`.
       #       Update methods are (add|remove)Instance, (add/remove)HealthCheck
-  TargetSslProxy: !ruby/object:Provider::Terraform::ResourceOverride
+  TargetSslProxy: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     example:
       - !ruby/object:Provider::Terraform::Examples
         name: "target_ssl_proxy_basic"
@@ -832,13 +833,13 @@ overrides: !ruby/object:Provider::ResourceOverrides
           backend_service_name: "backend-service"
           health_check_name: "health-check"
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: proxyId
-      proxyHeader: !ruby/object:Provider::Terraform::PropertyOverride
+      proxyHeader: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: :NONE
-      service: !ruby/object:Provider::Terraform::PropertyOverride
+      service: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: backendService
-  TargetTcpProxy: !ruby/object:Provider::Terraform::ResourceOverride
+  TargetTcpProxy: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     example:
       - !ruby/object:Provider::Terraform::Examples
         name: "target_tcp_proxy_basic"
@@ -849,13 +850,13 @@ overrides: !ruby/object:Provider::ResourceOverrides
           backend_service_name: "backend-service"
           health_check_name: "health-check"
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: proxyId
-      service: !ruby/object:Provider::Terraform::PropertyOverride
+      service: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: backendService
-      proxyHeader: !ruby/object:Provider::Terraform::PropertyOverride
+      proxyHeader: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_value: :NONE
-  TargetVpnGateway: !ruby/object:Provider::Terraform::ResourceOverride
+  TargetVpnGateway: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     name: 'VpnGateway'
     example:
       - !ruby/object:Provider::Terraform::Examples
@@ -872,17 +873,17 @@ overrides: !ruby/object:Provider::ResourceOverrides
           vpn_tunnel_name: "tunnel1"
           route_name: "route1"
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      region: !ruby/object:Provider::Terraform::PropertyOverride
+      region: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         required: false # the provider-default value will be used if not specified
         default_from_api: true
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
-      forwardingRules: !ruby/object:Provider::Terraform::PropertyOverride
+      forwardingRules: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      tunnels: !ruby/object:Provider::Terraform::PropertyOverride
+      tunnels: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-  UrlMap: !ruby/object:Provider::Terraform::ResourceOverride
+  UrlMap: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     example:
       - !ruby/object:Provider::Terraform::Examples
         name: "url_map_basic"
@@ -896,34 +897,34 @@ overrides: !ruby/object:Provider::ResourceOverrides
           backend_bucket_name: "static-asset-backend-bucket"
           storage_bucket_name: "static-asset-bucket"
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: "map_id"
-      defaultService: !ruby/object:Provider::Terraform::PropertyOverride
+      defaultService: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/url_map_only_set_string.go.erb'
         description: The backend service or backend bucket to use when none of the given rules match.
-      hostRules: !ruby/object:Provider::Terraform::PropertyOverride
+      hostRules: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: "host_rule"
         is_set: true
-      hostRules.hosts: !ruby/object:Provider::Terraform::PropertyOverride
+      hostRules.hosts: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         is_set: true
-      pathMatchers: !ruby/object:Provider::Terraform::PropertyOverride
+      pathMatchers: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: "path_matcher"
-      pathMatchers.defaultService: !ruby/object:Provider::Terraform::PropertyOverride
+      pathMatchers.defaultService: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/url_map_only_set_string.go.erb'
         description: The backend service or backend bucket to use when none of the given paths match.
-      pathMatchers.pathRules: !ruby/object:Provider::Terraform::PropertyOverride
+      pathMatchers.pathRules: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: "path_rule"
-      pathMatchers.pathRules.paths: !ruby/object:Provider::Terraform::PropertyOverride
+      pathMatchers.pathRules.paths: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         is_set: true
-      pathMatchers.pathRules.service: !ruby/object:Provider::Terraform::PropertyOverride
+      pathMatchers.pathRules.service: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/url_map_only_set_string.go.erb'
         description: The backend service or backend bucket to use if any of the given paths match.
-      tests.service: !ruby/object:Provider::Terraform::PropertyOverride
+      tests.service: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/url_map_only_set_string.go.erb'
         description: The backend service or backend bucket link that should be matched by this test.
-      tests: !ruby/object:Provider::Terraform::PropertyOverride
+      tests: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: "test"
-  VpnTunnel: !ruby/object:Provider::Terraform::ResourceOverride
+  VpnTunnel: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     example:
       - !ruby/object:Provider::Terraform::Examples
         name: "vpn_tunnel_basic"
@@ -944,35 +945,35 @@ overrides: !ruby/object:Provider::ResourceOverrides
         state as plain-text.
         [Read more about sensitive data in state](/docs/state/sensitive-data.html).
     properties:
-      targetVpnGateway: !ruby/object:Provider::Terraform::PropertyOverride
+      targetVpnGateway: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         resource: 'VpnGateway'
-      peerIp: !ruby/object:Provider::Terraform::PropertyOverride
+      peerIp: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validatePeerAddr'
-      sharedSecret: !ruby/object:Provider::Terraform::PropertyOverride
+      sharedSecret: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         sensitive: true
         ignore_read: true
-      region: !ruby/object:Provider::Terraform::PropertyOverride
+      region: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         required: false
         default_from_api: true
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
         description: '{{description}} If unset, is set to the region of `target_vpn_gateway`.'
-      localTrafficSelector: !ruby/object:Provider::Terraform::PropertyOverride
+      localTrafficSelector: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         is_set: true
         default_from_api: true
-      remoteTrafficSelector: !ruby/object:Provider::Terraform::PropertyOverride
+      remoteTrafficSelector: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         is_set: true
         default_from_api: true
-      detailedStatus: !ruby/object:Provider::Terraform::PropertyOverride
+      detailedStatus: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: false
-      labelFingerprint: !ruby/object:Provider::Terraform::PropertyOverride
+      labelFingerprint: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: false
-      router: !ruby/object:Provider::Terraform::PropertyOverride
+      router: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/compute_full_url.erb'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/vpn_tunnel.erb
       encoder: templates/terraform/encoders/vpn_tunnel.go.erb
-  Zone: !ruby/object:Provider::Terraform::ResourceOverride
+  Zone: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
 
 # This is for copying files over

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -411,7 +411,7 @@ overrides: !ruby/object:Provider::Overrides::ResourceOverrides
       rawDisk.sha1Checksum: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: 'sha1'
       rawDisk.containerType: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
-        default_value: "TAR"
+        default_value: :TAR
       rawDisk: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         ignore_read: true
       sourceDiskEncryptionKey: !ruby/object:Provider::Overrides::Terraform::PropertyOverride

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -110,7 +110,6 @@ overrides: !ruby/object:Provider::Overrides::ResourceOverrides
         default_from_api: true
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
       sourceImage: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
-        # sourceImage must be overridden first because it creates the 'image' property
         name: image
         diff_suppress_func: 'diskImageDiffSuppress'
         description: |

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -185,16 +185,12 @@ overrides: !ruby/object:Provider::Overrides::ResourceOverrides
         exclude: true
       allowed: !ruby/object:Provider::Overrides::Terraform::PropertyOverride     
         name: 'allow'
-        conflicts:
-          - deny
         is_set: true
         set_hash_func: 'resourceComputeFirewallRuleHash'
       allowed.ip_protocol: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         name: 'protocol'
       denied: !ruby/object:Provider::Overrides::Terraform::PropertyOverride     
         name: 'deny'
-        conflicts:
-          - allow
         is_set: true
         set_hash_func: 'resourceComputeFirewallRuleHash'
       denied.ip_protocol: !ruby/object:Provider::Overrides::Terraform::PropertyOverride

--- a/products/containeranalysis/terraform.yaml
+++ b/products/containeranalysis/terraform.yaml
@@ -13,8 +13,8 @@
 
 --- !ruby/object:Provider::Terraform::Config
 name: ContainerAnalysis
-overrides: !ruby/object:Provider::ResourceOverrides
-  Note: !ruby/object:Provider::Terraform::ResourceOverride
+overrides: !ruby/object:Provider::Overrides::ResourceOverrides
+  Note: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     import_format: ["projects/{{project}}/notes/{{name}}"]
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_update: 'templates/terraform/pre_update/containeranalysis_note.erb'
@@ -26,7 +26,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
         vars:
           note_name: "test-attestor-note"
     properties:
-      name: !ruby/object:Provider::Terraform::PropertyOverride
+      name: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
 
 # This is for copying files over

--- a/products/dns/terraform.yaml
+++ b/products/dns/terraform.yaml
@@ -12,28 +12,28 @@
 # limitations under the License.
 
 --- !ruby/object:Provider::Terraform::Config
-overrides: !ruby/object:Provider::ResourceOverrides
-  ManagedZone: !ruby/object:Provider::Terraform::ResourceOverride
+overrides: !ruby/object:Provider::Overrides::ResourceOverrides
+  ManagedZone: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     example:
       - !ruby/object:Provider::Terraform::Examples
         name: "dns_managed_zone_basic"
         primary_resource_id: "example-zone"
         version: <%= version_name %>
     properties:
-      creationTime: !ruby/object:Provider::Terraform::PropertyOverride
+      creationTime: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      description: !ruby/object:Provider::Terraform::PropertyOverride
+      description: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         description: |
           A textual description field. Defaults to 'Managed by Terraform'.
         default_value: 'Managed by Terraform'
         required: false
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      nameServerSet: !ruby/object:Provider::Terraform::PropertyOverride
+      nameServerSet: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-  ResourceRecordSet: !ruby/object:Provider::Terraform::ResourceOverride
+  ResourceRecordSet: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
-  Project: !ruby/object:Provider::Terraform::ResourceOverride
+  Project: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
 
 # This is for copying files over

--- a/products/filestore/terraform.yaml
+++ b/products/filestore/terraform.yaml
@@ -12,8 +12,8 @@
 # limitations under the License.
 
 --- !ruby/object:Provider::Terraform::Config
-overrides: !ruby/object:Provider::ResourceOverrides
-  Instance: !ruby/object:Provider::Terraform::ResourceOverride
+overrides: !ruby/object:Provider::Overrides::ResourceOverrides
+  Instance: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     id_format: "{{project}}/{{zone}}/{{name}}"
     import_format: ["projects/{{project}}/locations/{{zone}}/instances/{{name}}"]
     example:
@@ -24,11 +24,11 @@ overrides: !ruby/object:Provider::ResourceOverrides
         vars:
           instance_name: "test-instance"
     properties:
-      name: !ruby/object:Provider::Terraform::PropertyOverride
+      name: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
-      zone: !ruby/object:Provider::Terraform::PropertyOverride
+      zone: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         ignore_read: true
-      networks.reservedIpRange: !ruby/object:Provider::Terraform::PropertyOverride
+      networks.reservedIpRange: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_from_api: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_update: templates/terraform/pre_update/update_mask.erb

--- a/products/redis/terraform.yaml
+++ b/products/redis/terraform.yaml
@@ -12,8 +12,8 @@
 # limitations under the License.
 
 --- !ruby/object:Provider::Terraform::Config
-overrides: !ruby/object:Provider::ResourceOverrides
-  Instance: !ruby/object:Provider::Terraform::ResourceOverride
+overrides: !ruby/object:Provider::Overrides::ResourceOverrides
+  Instance: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     id_format: "{{project}}/{{region}}/{{name}}"
     import_format: ["projects/{{project}}/locations/{{region}}/instances/{{name}}"]
     custom_code: !ruby/object:Provider::Terraform::CustomCode
@@ -33,24 +33,24 @@ overrides: !ruby/object:Provider::ResourceOverrides
           instance_name: "ha-memory-cache"
           network_name: "authorized-network"
     properties:
-      alternativeLocationId: !ruby/object:Provider::Terraform::PropertyOverride
+      alternativeLocationId: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_from_api: true
-      authorizedNetwork: !ruby/object:Provider::Terraform::PropertyOverride
+      authorizedNetwork: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_from_api: true
         custom_expand: 'templates/terraform/custom_expand/redis_instance_authorized_network.erb'
         diff_suppress_func: 'compareSelfLinkOrResourceName'
-      locationId: !ruby/object:Provider::Terraform::PropertyOverride
+      locationId: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_from_api: true
-      name: !ruby/object:Provider::Terraform::PropertyOverride
+      name: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/redis_instance_name.erb'
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
-      redisVersion: !ruby/object:Provider::Terraform::PropertyOverride
+      redisVersion: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_from_api: true
-      region: !ruby/object:Provider::Terraform::PropertyOverride
+      region: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         ignore_read: true
         required: false
         default_from_api: true
-      reservedIpRange: !ruby/object:Provider::Terraform::PropertyOverride
+      reservedIpRange: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         default_from_api: true
 
 # This is for copying files over

--- a/products/resourcemanager/terraform.yaml
+++ b/products/resourcemanager/terraform.yaml
@@ -13,10 +13,10 @@
 
 --- !ruby/object:Provider::Terraform::Config
 name: ResourceManager
-overrides: !ruby/object:Provider::ResourceOverrides
-  Project: !ruby/object:Provider::Terraform::ResourceOverride
+overrides: !ruby/object:Provider::Overrides::ResourceOverrides
+  Project: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
-  Lien: !ruby/object:Provider::Terraform::ResourceOverride
+  Lien: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     import_format: ["{{parent}}/{{name}}"]
     example:
       - !ruby/object:Provider::Terraform::Examples
@@ -27,7 +27,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
         vars:
           project_id: "staging-project"
     properties:
-      name: !ruby/object:Provider::Terraform::PropertyOverride
+      name: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       post_create: templates/terraform/post_create/lien.erb

--- a/products/storage/terraform.yaml
+++ b/products/storage/terraform.yaml
@@ -12,12 +12,12 @@
 # limitations under the License.
 
 --- !ruby/object:Provider::Terraform::Config
-overrides: !ruby/object:Provider::ResourceOverrides
-  Bucket: !ruby/object:Provider::Terraform::ResourceOverride
+overrides: !ruby/object:Provider::Overrides::ResourceOverrides
+  Bucket: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
-  BucketAccessControl: !ruby/object:Provider::Terraform::ResourceOverride
+  BucketAccessControl: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
-  ObjectAccessControl: !ruby/object:Provider::Terraform::ResourceOverride
+  ObjectAccessControl: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     example:
     - !ruby/object:Provider::Terraform::Examples
       name: "storage_object_access_control_public_object"
@@ -28,13 +28,13 @@ overrides: !ruby/object:Provider::ResourceOverrides
     id_format: "{{bucket}}/{{object}}/{{entity}}"
     import_format: ["{{bucket}}/{{object}}/{{entity}}"]
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      bucket: !ruby/object:Provider::Terraform::PropertyOverride
+      bucket: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/resourceref_as_string.go.erb'
-      object: !ruby/object:Provider::Terraform::PropertyOverride
+      object: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         description: The name of the object to apply the access control to.
-  DefaultObjectACL: !ruby/object:Provider::Terraform::ResourceOverride
+  DefaultObjectACL: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     name: "DefaultObjectAccessControl"
     example:
     - !ruby/object:Provider::Terraform::Examples
@@ -45,13 +45,13 @@ overrides: !ruby/object:Provider::ResourceOverrides
     id_format: "{{bucket}}/{{entity}}"
     import_format: ["{{bucket}}/{{entity}}"]
     properties:
-      id: !ruby/object:Provider::Terraform::PropertyOverride
+      id: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         exclude: true
-      bucket: !ruby/object:Provider::Terraform::PropertyOverride
+      bucket: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/resourceref_as_string.go.erb'
         # This field is (unexpectedly) not returned from the API
         ignore_read: true
-  Object: !ruby/object:Provider::Terraform::ResourceOverride
+  Object: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true
 
 # This is for copying files over

--- a/provider/overrides/runner.rb
+++ b/provider/overrides/runner.rb
@@ -102,8 +102,8 @@ module Provider
 
           # Using instance_variable_get('properties') to make sure we get `exclude: true` properties
           ['@properties', '@parameters'].each do |val|
-            new_props = (old_resource.instance_variable_get(val) || []).map do |p|
-              build_property(p, res_override[val], override_classes)
+            new_props = ((old_resource.instance_variable_get(val) || [])).map do |p|
+              build_property(p, res_override['properties'], override_classes)
             end
             res.instance_variable_set(val, new_props)
           end
@@ -136,7 +136,7 @@ module Provider
             new_prop.instance_variable_set('@item_type', Api::Type::NestedObject.new)
             new_props = old_property.item_type.properties.map do |p|
               build_property(p, property_overrides, override_classes,
-                             "#{prefix}#{old_property.name}[].")
+                             "#{prefix}#{old_property.name}.")
             end
             new_prop.item_type.instance_variable_set('@properties', new_props)
           end

--- a/provider/overrides/runner.rb
+++ b/provider/overrides/runner.rb
@@ -163,7 +163,7 @@ module Provider
           variables = (old_property.instance_variables + prop_override.instance_variables).uniq
 
           # Set api_name with old property so that a potential new name doesn't override it.
-          prop.instance_variable_set('@api_name', old_property.name)
+          prop.instance_variable_set('@api_name', old_property.api_name || old_property.name)
 
           variables.reject { |o| o == :@properties }
                    .each do |var_name|

--- a/provider/overrides/validator.rb
+++ b/provider/overrides/validator.rb
@@ -85,9 +85,8 @@ module Provider
                          []
                        end
         end
-        unless prop
-          raise "#{path.join('.')} does not exist on #{res_name}"
-        end
+        raise "#{path.join('.')} does not exist on #{res_name}" unless prop
+
         prop
       end
 

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -122,7 +122,7 @@ module Provider
         check_optional_property :custom_expand, String
 
         raise "'default_value' and 'default_from_api' cannot be both set"  \
-          if default_from_api && !default_value.nil?
+          if @default_from_api && !@default_value.nil?
       end
 
       def apply(api_property)

--- a/spec/override_runner_spec.rb
+++ b/spec/override_runner_spec.rb
@@ -128,7 +128,7 @@ describe Provider::Overrides::Runner do
         Provider::Overrides::ResourceOverrides.new(
           'AnotherResource' => Provider::Overrides::ResourceOverride.new(
             'properties' => {
-              'array-property[].property1' => Provider::Overrides::PropertyOverride.new(
+              'array-property.property1' => Provider::Overrides::PropertyOverride.new(
                 'type' => 'Api::Type::Integer'
               )
             }

--- a/spec/override_validator_spec.rb
+++ b/spec/override_validator_spec.rb
@@ -54,8 +54,7 @@ describe Provider::Overrides::Validator do
       it {
         runner = Provider::Overrides::Validator.new(api, overrides)
         expect { runner.run }.to raise_error(RuntimeError,
-                                             ['blahbad does not exist on AnotherResource (is it ',
-                                              'mislabeled as a property, not a parameter?)'].join)
+                                             'blahbad does not exist on AnotherResource')
       }
     end
 


### PR DESCRIPTION
This migrates all of the TF overrides over to the new system.

It also removes the "prop1.prop2[]." notation for arrays of nested objects and the "property vs parameter" distinction. Those just make for messier override configuration and I was being too pedantic with forcing that originally.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
