### PR TITLE
[Terraform] Make all test project names match.

### DIFF
--- a/third_party/terraform/tests/data_source_google_project_services_test.go
+++ b/third_party/terraform/tests/data_source_google_project_services_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccDataSourceGoogleProjectServices_basic(t *testing.T) {
 	t.Parallel()
 	org := getTestOrgFromEnv(t)
-	project := "terraform-" + acctest.RandString(10)
+	project := "tf-acctest-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -78,5 +78,5 @@ resource "google_project_services" "project_services" {
 
 data "google_project_services" "project_services" {
 	project = "${google_project.project.id}"
-}`, project, project, org)
+}`, project, pname, org)
 }

--- a/third_party/terraform/tests/data_source_google_project_test.go
+++ b/third_party/terraform/tests/data_source_google_project_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccDataSourceGoogleProject_basic(t *testing.T) {
 	t.Parallel()
 	org := getTestOrgFromEnv(t)
-	project := "terraform-" + acctest.RandString(10)
+	project := "tf-acctest-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -77,5 +77,5 @@ resource "google_project" "project" {
 	
 data "google_project" "project" {
 	project_id = "${google_project.project.project_id}"
-}`, project, project, org)
+}`, pname, project, org)
 }

--- a/third_party/terraform/tests/resource_app_engine_application_test.go
+++ b/third_party/terraform/tests/resource_app_engine_application_test.go
@@ -12,7 +12,7 @@ func TestAccAppEngineApplication_basic(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := acctest.RandomWithPrefix("tf-test")
+	pid := acctest.RandomWithPrefix("tf-acctest")
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -57,7 +57,7 @@ resource "google_app_engine_application" "acceptance" {
   auth_domain     = "hashicorptest.com"
   location_id     = "us-central"
   serving_status  = "SERVING"
-}`, pid, pid, org)
+}`, pid, pname, org)
 }
 
 func testAccAppEngineApplication_update(pid, org string) string {
@@ -73,5 +73,5 @@ resource "google_app_engine_application" "acceptance" {
   auth_domain     = "tf-test.club"
   location_id     = "us-central"
   serving_status  = "USER_DISABLED"
-}`, pid, pid, org)
+}`, pid, pname, org)
 }

--- a/third_party/terraform/tests/resource_binaryauthorization_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_binaryauthorization_policy_test.go.erb
@@ -16,7 +16,7 @@ func TestAccBinaryAuthorizationPolicy_basic(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "tf-test-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -43,7 +43,7 @@ func TestAccBinaryAuthorizationPolicy_full(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "tf-test-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	note := acctest.RandString(10)
 	attestor := acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
@@ -72,7 +72,7 @@ func TestAccBinaryAuthorizationPolicy_update(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "tf-test-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	note := acctest.RandString(10)
 	attestor := acctest.RandString(10)
 	resource.Test(t, resource.TestCase{

--- a/third_party/terraform/tests/resource_cloudbuild_build_trigger_test.go
+++ b/third_party/terraform/tests/resource_cloudbuild_build_trigger_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccCloudBuildTrigger_basic(t *testing.T) {
 	t.Parallel()
 
-	projectID := "terraform-" + acctest.RandString(10)
+	projectID := "tf-acctest-" + acctest.RandString(10)
 	projectOrg := getTestOrgFromEnv(t)
 	projectBillingAccount := getTestBillingAccountFromEnv(t)
 
@@ -56,7 +56,7 @@ func TestAccCloudBuildTrigger_basic(t *testing.T) {
 func TestAccCloudBuildTrigger_filename(t *testing.T) {
 	t.Parallel()
 
-	projectID := "terraform-" + acctest.RandString(10)
+	projectID := "tf-acctest-" + acctest.RandString(10)
 	projectOrg := getTestOrgFromEnv(t)
 	projectBillingAccount := getTestBillingAccountFromEnv(t)
 
@@ -216,7 +216,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
     }
   }
 }
-  `, projectID, projectID, projectOrg, projectBillingAccount)
+  `, pname, projectID, projectOrg, projectBillingAccount)
 }
 
 func testGoogleCloudBuildTrigger_updated(projectID, projectOrg, projectBillingAccount string) string {
@@ -269,7 +269,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
     }
   }
 }
-  `, projectID, projectID, projectOrg, projectBillingAccount)
+  `, pname, projectID, projectOrg, projectBillingAccount)
 }
 
 func testGoogleCloudBuildTrigger_filename(projectID, projectOrg, projectBillingAccount string) string {
@@ -306,7 +306,7 @@ resource "google_cloudbuild_trigger" "filename_build_trigger" {
   }
   filename = "cloudbuild.yaml"
 }
-  `, projectID, projectID, projectOrg, projectBillingAccount)
+  `, pname, projectID, projectOrg, projectBillingAccount)
 }
 
 func testGoogleCloudBuildTrigger_removed(projectID, projectOrg, projectBillingAccount string) string {
@@ -329,5 +329,5 @@ resource "google_project_services" "acceptance" {
     "storage-api.googleapis.com",
   ]
 }
-  `, projectID, projectID, projectOrg, projectBillingAccount)
+  `, pname, projectID, projectOrg, projectBillingAccount)
 }

--- a/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -348,7 +348,7 @@ func TestAccComputeDisk_encryptionKMS(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "tf-test-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	billingAccount := getTestBillingAccountFromEnv(t)
 	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))

--- a/third_party/terraform/tests/resource_compute_instance_template_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_template_test.go
@@ -304,7 +304,7 @@ func TestAccComputeInstanceTemplate_subnet_xpn(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 	org := getTestOrgFromEnv(t)
 	billingId := getTestBillingAccountFromEnv(t)
-	projectName := fmt.Sprintf("tf-xpntest-%d", time.Now().Unix())
+	projectId := fmt.Sprintf("tf-acctest-%d", time.Now().Unix())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -312,7 +312,7 @@ func TestAccComputeInstanceTemplate_subnet_xpn(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceTemplateDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeInstanceTemplate_subnet_xpn(org, billingId, projectName),
+				Config: testAccComputeInstanceTemplate_subnet_xpn(org, billingId, projectId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExistsInProject(
 						"google_compute_instance_template.foobar", fmt.Sprintf("%s-service", projectName),
@@ -478,7 +478,7 @@ func TestAccComputeInstanceTemplate_EncryptKMS(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 
 	org := getTestOrgFromEnv(t)
-	pid := "tf-test-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	billingAccount := getTestBillingAccountFromEnv(t)
 	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -1169,10 +1169,10 @@ resource "google_compute_instance_template" "foobar" {
 }`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
 }
 
-func testAccComputeInstanceTemplate_subnet_xpn(org, billingId, projectName string) string {
+func testAccComputeInstanceTemplate_subnet_xpn(org, billingId, projectId string) string {
 	return fmt.Sprintf(`
 	resource "google_project" "host_project" {
-		name = "Test Project XPN Host"
+		name = "%s"
 		project_id = "%s-host"
 		org_id = "%s"
 		billing_account = "%s"
@@ -1188,7 +1188,7 @@ func testAccComputeInstanceTemplate_subnet_xpn(org, billingId, projectName strin
 	}
 	
 	resource "google_project" "service_project" {
-		name = "Test Project XPN Service"
+		name = "%s"
 		project_id = "%s-service"
 		org_id = "%s"
 		billing_account = "%s"
@@ -1244,7 +1244,7 @@ func testAccComputeInstanceTemplate_subnet_xpn(org, billingId, projectName strin
 			foo = "bar"
 		}
 		project = "${google_compute_shared_vpc_service_project.service_project.service_project}"
-	}`, projectName, org, billingId, projectName, org, billingId, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
+	}`, pname, projectId, org, billingId, pname, projectId, org, billingId, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
 }
 
 func testAccComputeInstanceTemplate_startup_script() string {

--- a/third_party/terraform/tests/resource_compute_instance_template_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_template_test.go
@@ -315,7 +315,7 @@ func TestAccComputeInstanceTemplate_subnet_xpn(t *testing.T) {
 				Config: testAccComputeInstanceTemplate_subnet_xpn(org, billingId, projectId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExistsInProject(
-						"google_compute_instance_template.foobar", fmt.Sprintf("%s-service", projectName),
+						"google_compute_instance_template.foobar", fmt.Sprintf("%s-service", projectId),
 						&instanceTemplate),
 					testAccCheckComputeInstanceTemplateSubnetwork(&instanceTemplate),
 				),

--- a/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_test.go
@@ -722,7 +722,7 @@ func TestAccComputeInstance_subnet_xpn(t *testing.T) {
 	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
 	org := getTestOrgFromEnv(t)
 	billingId := getTestBillingAccountFromEnv(t)
-	projectName := fmt.Sprintf("tf-xpntest-%d", time.Now().Unix())
+	projectId := fmt.Sprintf("tf-acctest-%d", time.Now().Unix())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -730,7 +730,7 @@ func TestAccComputeInstance_subnet_xpn(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeInstance_subnet_xpn(org, billingId, projectName, instanceName),
+				Config: testAccComputeInstance_subnet_xpn(org, billingId, projectId, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExistsInProject(
 						"google_compute_instance.foobar", fmt.Sprintf("%s-service", projectName),
@@ -2496,7 +2496,7 @@ resource "google_compute_instance" "foobar" {
 `, acctest.RandString(10), acctest.RandString(10), instance)
 }
 
-func testAccComputeInstance_subnet_xpn(org, billingId, projectName, instance string) string {
+func testAccComputeInstance_subnet_xpn(org, billingId, projectId, instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
 	family  = "debian-9"
@@ -2504,7 +2504,7 @@ data "google_compute_image" "my_image" {
 }
 
 resource "google_project" "host_project" {
-	name = "Test Project XPN Host"
+	name = "%s"
 	project_id = "%s-host"
 	org_id = "%s"
 	billing_account = "%s"
@@ -2520,7 +2520,7 @@ resource "google_compute_shared_vpc_host_project" "host_project" {
 }
 
 resource "google_project" "service_project" {
-	name = "Test Project XPN Service"
+	name = "%s"
 	project_id = "%s-service"
 	org_id = "%s"
 	billing_account = "%s"
@@ -2571,7 +2571,7 @@ resource "google_compute_instance" "foobar" {
 	}
 
 }
-`, projectName, org, billingId, projectName, org, billingId, acctest.RandString(10), acctest.RandString(10), instance)
+`, pname, projectId, org, billingId, pname, projectId, org, billingId, acctest.RandString(10), acctest.RandString(10), instance)
 }
 
 func testAccComputeInstance_networkIPAuto(instance string) string {

--- a/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_test.go
@@ -733,7 +733,7 @@ func TestAccComputeInstance_subnet_xpn(t *testing.T) {
 				Config: testAccComputeInstance_subnet_xpn(org, billingId, projectId, instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceExistsInProject(
-						"google_compute_instance.foobar", fmt.Sprintf("%s-service", projectName),
+						"google_compute_instance.foobar", fmt.Sprintf("%s-service", projectId),
 						&instance),
 					testAccCheckComputeInstanceHasSubnet(&instance),
 				),

--- a/third_party/terraform/tests/resource_compute_project_metadata_test.go
+++ b/third_party/terraform/tests/resource_compute_project_metadata_test.go
@@ -15,7 +15,7 @@ func TestAccComputeProjectMetadata_basic(t *testing.T) {
 
 	org := getTestOrgFromEnv(t)
 	billingId := getTestBillingAccountFromEnv(t)
-	projectID := "terrafom-test-" + acctest.RandString(10)
+	projectID := "tf-acctest-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -40,7 +40,7 @@ func TestAccComputeProjectMetadata_modify_1(t *testing.T) {
 
 	org := getTestOrgFromEnv(t)
 	billingId := getTestBillingAccountFromEnv(t)
-	projectID := "terrafom-test-" + acctest.RandString(10)
+	projectID := "tf-acctest-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -74,7 +74,7 @@ func TestAccComputeProjectMetadata_modify_2(t *testing.T) {
 
 	org := getTestOrgFromEnv(t)
 	billingId := getTestBillingAccountFromEnv(t)
-	projectID := "terraform-test-" + acctest.RandString(10)
+	projectID := "tf-acctest-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/third_party/terraform/tests/resource_compute_shared_vpc_test.go
+++ b/third_party/terraform/tests/resource_compute_shared_vpc_test.go
@@ -13,8 +13,8 @@ func TestAccComputeSharedVpc_basic(t *testing.T) {
 	org := getTestOrgFromEnv(t)
 	billingId := getTestBillingAccountFromEnv(t)
 
-	hostProject := "xpn-host-" + acctest.RandString(10)
-	serviceProject := "xpn-service-" + acctest.RandString(10)
+	hostProject := "tf-acctest-" + acctest.RandString(10)
+	serviceProject := "tf-acctest-" + acctest.RandString(10)
 
 	hostProjectResourceName := "google_compute_shared_vpc_host_project.host"
 	serviceProjectResourceName := "google_compute_shared_vpc_service_project.service"
@@ -128,7 +128,7 @@ resource "google_compute_shared_vpc_service_project" "service" {
 	host_project    = "${google_project.host.project_id}"
 	service_project = "${google_project.service.project_id}"
 	depends_on      = ["google_compute_shared_vpc_host_project.host", "google_project_service.service"]
-}`, hostProject, hostProject, org, billing, serviceProject, serviceProject, org, billing)
+}`, hostProject, pname, org, billing, serviceProject, pname, org, billing)
 }
 
 func testAccComputeSharedVpc_disabled(hostProject, serviceProject, org, billing string) string {
@@ -156,5 +156,5 @@ resource "google_project_service" "service" {
 	project  = "${google_project.service.project_id}"
 	service = "compute.googleapis.com"
 }
-`, hostProject, hostProject, org, billing, serviceProject, serviceProject, org, billing)
+`, hostProject, pname, org, billing, serviceProject, pname, org, billing)
 }

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1299,7 +1299,7 @@ func TestAccContainerCluster_sharedVpc(t *testing.T) {
 	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
 	org := getTestOrgFromEnv(t)
 	billingId := getTestBillingAccountFromEnv(t)
-	projectName := fmt.Sprintf("tf-xpntest-%s", acctest.RandString(10))
+	projectId := acctest.RandomWithPrefix("tf-acctest")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1307,7 +1307,7 @@ func TestAccContainerCluster_sharedVpc(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_sharedVpc(org, billingId, projectName, clusterName),
+				Config: testAccContainerCluster_sharedVpc(org, billingId, projectId, clusterName),
 			},
 			{
 				ResourceName:        "google_container_cluster.shared_vpc_cluster",
@@ -2551,10 +2551,10 @@ resource "google_container_cluster" "with_private_cluster" {
 }`, clusterName, clusterName)
 }
 <% unless version.nil? || version == 'ga' -%>
-func testAccContainerCluster_sharedVpc(org, billingId, projectName, name string) string {
+func testAccContainerCluster_sharedVpc(org, billingId, projectId, name string) string {
 	return fmt.Sprintf(`
 resource "google_project" "host_project" {
-	name            = "Test Project XPN Host"
+	name            = "%s"
 	project_id      = "%s-host"
 	org_id          = "%s"
 	billing_account = "%s"
@@ -2570,7 +2570,7 @@ resource "google_compute_shared_vpc_host_project" "host_project" {
 }
 
 resource "google_project" "service_project" {
-	name            = "Test Project XPN Service"
+	name            = "%s"
 	project_id      = "%s-service"
 	org_id          = "%s"
 	billing_account = "%s"
@@ -2652,7 +2652,7 @@ resource "google_container_cluster" "shared_vpc_cluster" {
 		"google_compute_subnetwork_iam_member.service_network_cloud_services",
 		"google_compute_subnetwork_iam_member.service_network_gke_user"
 	]
-}`, projectName, org, billingId, projectName, org, billingId, acctest.RandString(10), acctest.RandString(10), name)
+}`, pname, projectId, org, billingId, pname, projectId, org, billingId, acctest.RandString(10), acctest.RandString(10), name)
 }
 <% end -%>
 

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1311,7 +1311,7 @@ func TestAccContainerCluster_sharedVpc(t *testing.T) {
 			},
 			{
 				ResourceName:        "google_container_cluster.shared_vpc_cluster",
-				ImportStateIdPrefix: fmt.Sprintf("%s-service/us-central1-a/", projectName),
+				ImportStateIdPrefix: fmt.Sprintf("%s-service/us-central1-a/", projectId),
 				ImportState:         true,
 				ImportStateVerify:   true,
 			},

--- a/third_party/terraform/tests/resource_google_project_iam_binding_test.go
+++ b/third_party/terraform/tests/resource_google_project_iam_binding_test.go
@@ -22,7 +22,7 @@ func TestAccProjectIamBinding_basic(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	role := "roles/compute.instanceAdmin"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -49,7 +49,7 @@ func TestAccProjectIamBinding_multiple(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	role := "roles/compute.instanceAdmin"
 	role2 := "roles/viewer"
 
@@ -83,7 +83,7 @@ func TestAccProjectIamBinding_multipleAtOnce(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	role := "roles/compute.instanceAdmin"
 	role2 := "roles/viewer"
 
@@ -113,7 +113,7 @@ func TestAccProjectIamBinding_update(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	role := "roles/compute.instanceAdmin"
 
 	resource.Test(t, resource.TestCase{
@@ -153,7 +153,7 @@ func TestAccProjectIamBinding_remove(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	role := "roles/compute.instanceAdmin"
 	role2 := "roles/viewer"
 

--- a/third_party/terraform/tests/resource_google_project_iam_member_test.go
+++ b/third_party/terraform/tests/resource_google_project_iam_member_test.go
@@ -22,7 +22,7 @@ func TestAccProjectIamMember_basic(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	resourceName := "google_project_iam_member.acceptance"
 	role := "roles/compute.instanceAdmin"
 	member := "user:admin@hashicorptest.com"
@@ -53,7 +53,7 @@ func TestAccProjectIamMember_multiple(t *testing.T) {
 	org := getTestOrgFromEnv(t)
 	skipIfEnvNotSet(t, "GOOGLE_ORG")
 
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	resourceName := "google_project_iam_member.acceptance"
 	resourceName2 := "google_project_iam_member.multiple"
 	role := "roles/compute.instanceAdmin"
@@ -94,7 +94,7 @@ func TestAccProjectIamMember_remove(t *testing.T) {
 	org := getTestOrgFromEnv(t)
 	skipIfEnvNotSet(t, "GOOGLE_ORG")
 
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	resourceName := "google_project_iam_member.acceptance"
 	role := "roles/compute.instanceAdmin"
 	member := "user:admin@hashicorptest.com"

--- a/third_party/terraform/tests/resource_google_project_iam_policy_test.go
+++ b/third_party/terraform/tests/resource_google_project_iam_policy_test.go
@@ -18,7 +18,7 @@ func TestAccProjectIamPolicy_basic(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -48,7 +48,7 @@ func TestAccProjectIamPolicy_expanded(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/third_party/terraform/tests/resource_google_project_service_test.go
+++ b/third_party/terraform/tests/resource_google_project_service_test.go
@@ -14,7 +14,7 @@ func TestAccProjectService_basic(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	services := []string{"iam.googleapis.com", "cloudresourcemanager.googleapis.com"}
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -67,7 +67,7 @@ func TestAccProjectService_handleNotFound(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	service := "iam.googleapis.com"
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/third_party/terraform/tests/resource_google_project_services_test.go
+++ b/third_party/terraform/tests/resource_google_project_services_test.go
@@ -18,7 +18,7 @@ func TestAccProjectServices_basic(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	services1 := []string{"logging.googleapis.com", "cloudresourcemanager.googleapis.com"}
 	services2 := []string{"cloudresourcemanager.googleapis.com"}
 	oobService := "logging.googleapis.com"
@@ -68,7 +68,7 @@ func TestAccProjectServices_authoritative(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	services := []string{"cloudresourcemanager.googleapis.com"}
 	oobService := "logging.googleapis.com"
 	resource.Test(t, resource.TestCase{
@@ -105,7 +105,7 @@ func TestAccProjectServices_authoritative2(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	oobServices := []string{"logging.googleapis.com", "cloudresourcemanager.googleapis.com"}
 	services := []string{"logging.googleapis.com"}
 
@@ -146,7 +146,7 @@ func TestAccProjectServices_ignoreUnenablableServices(t *testing.T) {
 
 	org := getTestOrgFromEnv(t)
 	billingId := getTestBillingAccountFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	services := []string{
 		"dataproc.googleapis.com",
 		// The following services are enabled as a side-effect of dataproc's enablement
@@ -183,7 +183,7 @@ func TestAccProjectServices_pagination(t *testing.T) {
 
 	org := getTestOrgFromEnv(t)
 	billingId := getTestBillingAccountFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 
 	// we need at least 50 services (doesn't matter what they are) to exercise the
 	// pagination handling code.

--- a/third_party/terraform/tests/resource_google_project_test.go
+++ b/third_party/terraform/tests/resource_google_project_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	pname          = "Terraform Acceptance Tests"
+	pname          = "Test Project for TPG"
 	originalPolicy *cloudresourcemanager.Policy
 )
 
@@ -29,7 +29,7 @@ func TestAccProject_createWithoutOrg(t *testing.T) {
 		t.Skip("Service accounts cannot create projects without a parent. Requires user credentials.")
 	}
 
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -51,7 +51,7 @@ func TestAccProject_create(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -75,7 +75,7 @@ func TestAccProject_billing(t *testing.T) {
 	skipIfEnvNotSet(t, "GOOGLE_BILLING_ACCOUNT_2")
 	billingId2 := os.Getenv("GOOGLE_BILLING_ACCOUNT_2")
 	billingId := getTestBillingAccountFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -116,7 +116,7 @@ func TestAccProject_labels(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
@@ -157,7 +157,7 @@ func TestAccProject_deleteDefaultNetwork(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	billingId := getTestBillingAccountFromEnv(t)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -174,7 +174,7 @@ func TestAccProject_parentFolder(t *testing.T) {
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
-	pid := "terraform-" + acctest.RandString(10)
+	pid := "tf-acctest-" + acctest.RandString(10)
 	folderDisplayName := "tf-test-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/third_party/terraform/tests/resource_kms_crypto_key_iam_test.go
+++ b/third_party/terraform/tests/resource_kms_crypto_key_iam_test.go
@@ -15,7 +15,7 @@ func TestAccKmsCryptoKeyIamBinding(t *testing.T) {
 	t.Parallel()
 
 	orgId := getTestOrgFromEnv(t)
-	projectId := acctest.RandomWithPrefix("tf-test")
+	projectId := acctest.RandomWithPrefix("tf-acctest")
 	billingAccount := getTestBillingAccountFromEnv(t)
 	account := acctest.RandomWithPrefix("tf-test")
 	roleId := "roles/cloudkms.cryptoKeyDecrypter"
@@ -66,7 +66,7 @@ func TestAccKmsCryptoKeyIamMember(t *testing.T) {
 	t.Parallel()
 
 	orgId := getTestOrgFromEnv(t)
-	projectId := acctest.RandomWithPrefix("tf-test")
+	projectId := acctest.RandomWithPrefix("tf-acctest")
 	billingAccount := getTestBillingAccountFromEnv(t)
 	account := acctest.RandomWithPrefix("tf-test")
 	roleId := "roles/cloudkms.cryptoKeyEncrypter"
@@ -175,7 +175,7 @@ func testAccCheckGoogleKmsCryptoKeyIamMemberExists(n, role, member string) resou
 func testAccKmsCryptoKeyIamBinding_basic(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId string) string {
 	return fmt.Sprintf(`
 resource "google_project" "test_project" {
-  name            = "Test project"
+  name            = "%s"
   project_id      = "%s"
   org_id          = "%s"
   billing_account = "%s"
@@ -213,13 +213,13 @@ resource "google_kms_crypto_key_iam_binding" "foo" {
   role          = "%s"
   members       = ["serviceAccount:${google_service_account.test_account.email}"]
 }
-`, projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId)
+`, pname, projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId)
 }
 
 func testAccKmsCryptoKeyIamBinding_update(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId string) string {
 	return fmt.Sprintf(`
 resource "google_project" "test_project" {
-  name            = "Test project"
+  name            = "%s"
   project_id      = "%s"
   org_id          = "%s"
   billing_account = "%s"
@@ -266,13 +266,13 @@ resource "google_kms_crypto_key_iam_binding" "foo" {
     "serviceAccount:${google_service_account.test_account_2.email}"
   ]
 }
-`, projectId, orgId, billingAccount, account, account, keyRingName, cryptoKeyName, roleId)
+`, pname, projectId, orgId, billingAccount, account, account, keyRingName, cryptoKeyName, roleId)
 }
 
 func testAccKmsCryptoKeyIamMember_basic(projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId string) string {
 	return fmt.Sprintf(`
 resource "google_project" "test_project" {
-  name            = "Test project"
+  name            = "%s"
   project_id      = "%s"
   org_id          = "%s"
   billing_account = "%s"
@@ -309,5 +309,5 @@ resource "google_kms_crypto_key_iam_member" "foo" {
   role          = "%s"
   member        = "serviceAccount:${google_service_account.test_account.email}"
 }
-`, projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId)
+`, pname, projectId, orgId, billingAccount, account, keyRingName, cryptoKeyName, roleId)
 }

--- a/third_party/terraform/tests/resource_kms_crypto_key_test.go
+++ b/third_party/terraform/tests/resource_kms_crypto_key_test.go
@@ -112,7 +112,7 @@ func TestCryptoKeyNextRotationCalculation_validation(t *testing.T) {
 func TestAccKmsCryptoKey_basic(t *testing.T) {
 	t.Parallel()
 
-	projectId := "terraform-" + acctest.RandString(10)
+	projectId := "tf-acctest-" + acctest.RandString(10)
 	projectOrg := getTestOrgFromEnv(t)
 	location := getTestRegionFromEnv()
 	projectBillingAccount := getTestBillingAccountFromEnv(t)
@@ -146,7 +146,7 @@ func TestAccKmsCryptoKey_basic(t *testing.T) {
 func TestAccKmsCryptoKey_rotation(t *testing.T) {
 	t.Parallel()
 
-	projectId := "terraform-" + acctest.RandString(10)
+	projectId := "tf-acctest-" + acctest.RandString(10)
 	projectOrg := getTestOrgFromEnv(t)
 	location := getTestRegionFromEnv()
 	projectBillingAccount := getTestBillingAccountFromEnv(t)
@@ -271,7 +271,7 @@ resource "google_kms_crypto_key" "crypto_key" {
 	key_ring        = "${google_kms_key_ring.key_ring.self_link}"
 	rotation_period = "1000000s"
 }
-	`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
+	`, pname, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }
 
 func testGoogleKmsCryptoKey_rotation(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, rotationPeriod string) string {
@@ -302,7 +302,7 @@ resource "google_kms_crypto_key" "crypto_key" {
 	key_ring        = "${google_kms_key_ring.key_ring.self_link}"
 	rotation_period = "%s"
 }
-	`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, rotationPeriod)
+	`, pname, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, rotationPeriod)
 }
 
 func testGoogleKmsCryptoKey_rotationRemoved(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
@@ -332,7 +332,7 @@ resource "google_kms_crypto_key" "crypto_key" {
 	name            = "%s"
 	key_ring        = "${google_kms_key_ring.key_ring.self_link}"
 }
-	`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
+	`, pname, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }
 
 func testGoogleKmsCryptoKey_removed(projectId, projectOrg, projectBillingAccount, keyRingName string) string {
@@ -357,5 +357,5 @@ resource "google_kms_key_ring" "key_ring" {
 	name     = "%s"
 	location = "us-central1"
 }
-	`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName)
+	`, pname, projectId, projectOrg, projectBillingAccount, keyRingName)
 }

--- a/third_party/terraform/tests/resource_kms_key_ring_iam_test.go
+++ b/third_party/terraform/tests/resource_kms_key_ring_iam_test.go
@@ -17,9 +17,9 @@ func TestAccKmsKeyRingIamBinding(t *testing.T) {
 	t.Parallel()
 
 	orgId := getTestOrgFromEnv(t)
-	projectId := acctest.RandomWithPrefix("tf-test")
+	projectId := acctest.RandomWithPrefix("tf-acctest")
 	billingAccount := getTestBillingAccountFromEnv(t)
-	account := acctest.RandomWithPrefix("tf-test")
+	account := acctest.RandomWithPrefix("tf-acctest")
 	roleId := "roles/cloudkms.cryptoKeyDecrypter"
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -68,9 +68,9 @@ func TestAccKmsKeyRingIamMember(t *testing.T) {
 	t.Parallel()
 
 	orgId := getTestOrgFromEnv(t)
-	projectId := acctest.RandomWithPrefix("tf-test")
+	projectId := acctest.RandomWithPrefix("tf-acctest")
 	billingAccount := getTestBillingAccountFromEnv(t)
-	account := acctest.RandomWithPrefix("tf-test")
+	account := acctest.RandomWithPrefix("tf-acctest")
 	roleId := "roles/cloudkms.cryptoKeyEncrypter"
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -105,9 +105,9 @@ func TestAccKmsKeyRingIamPolicy(t *testing.T) {
 	t.Parallel()
 
 	orgId := getTestOrgFromEnv(t)
-	projectId := acctest.RandomWithPrefix("tf-test")
+	projectId := acctest.RandomWithPrefix("tf-acctest")
 	billingAccount := getTestBillingAccountFromEnv(t)
-	account := acctest.RandomWithPrefix("tf-test")
+	account := acctest.RandomWithPrefix("tf-acctest")
 	roleId := "roles/cloudkms.cryptoKeyEncrypter"
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
@@ -167,7 +167,7 @@ func testAccCheckGoogleKmsKeyRingIam(keyRingId, role string, members []string) r
 func testAccKmsKeyRingIamBinding_basic(projectId, orgId, billingAccount, account, keyRingName, roleId string) string {
 	return fmt.Sprintf(`
 resource "google_project" "test_project" {
-  name            = "Test project"
+  name            = "Test Project for TPG"
   project_id      = "%s"
   org_id          = "%s"
   billing_account = "%s"
@@ -206,7 +206,7 @@ resource "google_kms_key_ring_iam_binding" "foo" {
 func testAccKmsKeyRingIamBinding_update(projectId, orgId, billingAccount, account, keyRingName, roleId string) string {
 	return fmt.Sprintf(`
 resource "google_project" "test_project" {
-  name            = "Test project"
+  name            = "Test Project for TPG"
   project_id      = "%s"
   org_id          = "%s"
   billing_account = "%s"
@@ -254,7 +254,7 @@ resource "google_kms_key_ring_iam_binding" "foo" {
 func testAccKmsKeyRingIamMember_basic(projectId, orgId, billingAccount, account, keyRingName, roleId string) string {
 	return fmt.Sprintf(`
 resource "google_project" "test_project" {
-  name            = "Test project"
+  name            = "Test Project for TPG"
   project_id      = "%s"
   org_id          = "%s"
   billing_account = "%s"
@@ -293,7 +293,7 @@ resource "google_kms_key_ring_iam_member" "foo" {
 func testAccKmsKeyRingIamPolicy_basic(projectId, orgId, billingAccount, account, keyRingName, roleId string) string {
 	return fmt.Sprintf(`
 resource "google_project" "test_project" {
-  name            = "Test project"
+  name            = "Test Project for TPG"
   project_id      = "%s"
   org_id          = "%s"
   billing_account = "%s"

--- a/third_party/terraform/tests/resource_kms_key_ring_test.go
+++ b/third_party/terraform/tests/resource_kms_key_ring_test.go
@@ -72,7 +72,7 @@ func TestKeyRingIdParsing(t *testing.T) {
 }
 
 func TestAccKmsKeyRing_basic(t *testing.T) {
-	projectId := "terraform-" + acctest.RandString(10)
+	projectId := "tf-acctest-" + acctest.RandString(10)
 	projectOrg := getTestOrgFromEnv(t)
 	projectBillingAccount := getTestBillingAccountFromEnv(t)
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -141,7 +141,7 @@ resource "google_kms_key_ring" "key_ring" {
 	name     = "%s"
 	location = "us-central1"
 }
-	`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName)
+	`, pname, projectId, projectOrg, projectBillingAccount, keyRingName)
 }
 
 func testGoogleKmsKeyRing_removed(projectId, projectOrg, projectBillingAccount string) string {
@@ -159,5 +159,5 @@ resource "google_project_services" "acceptance" {
 		"cloudkms.googleapis.com"
 	]
 }
-	`, projectId, projectId, projectOrg, projectBillingAccount)
+	`, pname, projectId, projectOrg, projectBillingAccount)
 }

--- a/third_party/terraform/tests/resource_resourcemanager_lien_test.go
+++ b/third_party/terraform/tests/resource_resourcemanager_lien_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccResourceManagerLien_basic(t *testing.T) {
 	t.Parallel()
 
-	projectName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	projectId := fmt.Sprintf("tf-acctest-%s", acctest.RandString(10))
 	org := getTestOrgFromEnv(t)
 	var lien resourceManager.Lien
 
@@ -24,10 +24,10 @@ func TestAccResourceManagerLien_basic(t *testing.T) {
 		CheckDestroy: testAccCheckResourceManagerLienDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceManagerLien_basic(projectName, org),
+				Config: testAccResourceManagerLien_basic(projectId, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckResourceManagerLienExists(
-						"google_resource_manager_lien.lien", projectName, &lien),
+						"google_resource_manager_lien.lien", projectId, &lien),
 				),
 			},
 			{
@@ -38,7 +38,7 @@ func TestAccResourceManagerLien_basic(t *testing.T) {
 					// This has to be a function to close over lien.Name, which is necessary
 					// because Name is a Computed attribute.
 					return fmt.Sprintf("%s/%s",
-						projectName,
+						projectId,
 						strings.Split(lien.Name, "/")[1]), nil
 				},
 			},
@@ -46,7 +46,7 @@ func TestAccResourceManagerLien_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckResourceManagerLienExists(n, projectName string, lien *resourceManager.Lien) resource.TestCheckFunc {
+func testAccCheckResourceManagerLienExists(n, projectId string, lien *resourceManager.Lien) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -59,7 +59,7 @@ func testAccCheckResourceManagerLienExists(n, projectName string, lien *resource
 
 		config := testAccProvider.Meta().(*Config)
 
-		found, err := config.clientResourceManager.Liens.List().Parent(fmt.Sprintf("projects/%s", projectName)).Do()
+		found, err := config.clientResourceManager.Liens.List().Parent(fmt.Sprintf("projects/%s", projectId)).Do()
 		if err != nil {
 			return err
 		}
@@ -90,11 +90,11 @@ func testAccCheckResourceManagerLienDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccResourceManagerLien_basic(projectName, org string) string {
+func testAccResourceManagerLien_basic(projectId, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "project" {
   project_id = "%s"
-  name = "some test project"
+  name = "%s"
   org_id = "%s"
 }
 
@@ -104,5 +104,5 @@ resource "google_resource_manager_lien" "lien" {
   origin = "something"
   reason = "something else"
 }
-`, projectName, org)
+`, projectId, pname, org)
 }

--- a/third_party/terraform/tests/resource_storage_bucket_test.go
+++ b/third_party/terraform/tests/resource_storage_bucket_test.go
@@ -611,7 +611,7 @@ func TestAccStorageBucket_cors(t *testing.T) {
 func TestAccStorageBucket_encryption(t *testing.T) {
 	t.Parallel()
 
-	projectId := "terraform-" + acctest.RandString(10)
+	projectId := "tf-acctest-" + acctest.RandString(10)
 	projectOrg := getTestOrgFromEnv(t)
 	projectBillingAccount := getTestBillingAccountFromEnv(t)
 	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -1033,7 +1033,7 @@ resource "google_storage_bucket" "bucket" {
 		default_kms_key_name = "${google_kms_crypto_key.crypto_key.self_link}"
 	}
 }
-	`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, bucketName)
+	`, pname, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, bucketName)
 }
 
 func testAccStorageBucket_updateLabels(bucketName string) string {

--- a/third_party/terraform/tests/resource_usage_export_bucket_test.go
+++ b/third_party/terraform/tests/resource_usage_export_bucket_test.go
@@ -12,7 +12,7 @@ func TestAccComputeResourceUsageExportBucket(t *testing.T) {
 	org := getTestOrgFromEnv(t)
 	billingId := getTestBillingAccountFromEnv(t)
 
-	baseProject := "ub-" + acctest.RandString(10)
+	baseProject := "tf-acctest-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -35,7 +35,7 @@ func testAccResourceUsageExportBucket(baseProject, org, billingId string) string
 	return fmt.Sprintf(`
 resource "google_project" "base" {
 	project_id      = "%s"
-	name            = "Export Bucket Base"
+	name            = "Test Project for TPG"
 	org_id          = "%s"
 	billing_account = "%s"
 }


### PR DESCRIPTION
Use the global constant `pname` for all test project names, and use the
unified prefix `tf-acctest-` for all project IDs, to facillitate
sweeping and automatically deleting projects that may be left dangling.

This is largely prompted by us running out of quota for projects, and me
realising that tracking down the patterns I should match on to delete
with a script was harder than it needed to be.

<!-- A summary of the changes in this commit goes here -->

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Make all test project names and IDs match
### [terraform-beta]
## [ansible]
## [inspec]
