### PR TITLE
[Terraform] ip_address.0.time_to_retire it's not optional

### DIFF
--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -281,7 +281,6 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 						},
 						"time_to_retire": &schema.Schema{
 							Type:     schema.TypeString,
-							Optional: true,
 							Computed: true,
 						},
 					},


### PR DESCRIPTION
ip_address.0.time_to_retire and all ip_address it's Attributes Reference for export

# [all]
## [terraform]
removed "optional" flag(set to false) from time_to_retire
### [terraform-beta]
## [ansible]
## [inspec]
