### PR TITLE
Add pre-commit hook to run rubocop

### DIFF
--- a/.github/pre-commit
+++ b/.github/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+FILES=`git diff --cached --name-status | awk '$1 != "D" { print $2 }'`
+RUBO=""
+
+for FILE in $FILES ; do
+  if [[ $FILE == *.rb ]]; then
+    RUBO=1
+  fi
+done
+
+if [ $RUBO ]
+then
+  echo "ruby file changed, running rubocop"
+  bundle exec rake rubocop
+fi

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -209,3 +209,7 @@ The following exports are allowed:
 [chef-yaml]: docs/chef.yaml.md
 [governance]: GOVERNANCE.md
 [template-sdk]: TEMPLATE_SDK.md
+
+## Misc Help
+
+The ruby files in this project are linted by rubocop as part of the build process. If you want to run rubocop automatically but only when there have been changes to applicable files then run `cp .github/pre-commit .git/hooks` to enable a pre-commit hook that runs rubocop when there are changed .rb files.


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
