### PR TITLE
[Terraform]: Add = to map declarations in examples/tests

### DIFF
--- a/templates/terraform/examples/autoscaler_basic.tf.erb
+++ b/templates/terraform/examples/autoscaler_basic.tf.erb
@@ -29,7 +29,7 @@ resource "google_compute_instance_template" "foobar" {
     network = "default"
   }
 
-  metadata {
+  metadata = {
     foo = "bar"
   }
 

--- a/templates/terraform/examples/disk_basic.tf.erb
+++ b/templates/terraform/examples/disk_basic.tf.erb
@@ -3,7 +3,7 @@ resource "google_compute_disk" "default" {
   type  = "pd-ssd"
   zone  = "us-central1-a"
   image = "debian-8-jessie-v20170523"
-  labels {
+  labels = {
     environment = "dev"
   }
 }

--- a/templates/terraform/examples/redis_instance_full.tf.erb
+++ b/templates/terraform/examples/redis_instance_full.tf.erb
@@ -12,7 +12,7 @@ resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
   display_name      = "Terraform Test Instance"
   reserved_ip_range = "192.168.0.0/29"
 
-  labels {
+  labels = {
     my_key    = "my_val"
     other_key = "other_val"
   }

--- a/templates/terraform/examples/region_autoscaler_basic.tf.erb
+++ b/templates/terraform/examples/region_autoscaler_basic.tf.erb
@@ -29,7 +29,7 @@ resource "google_compute_instance_template" "foobar" {
     network = "default"
   }
 
-  metadata {
+  metadata = {
     foo = "bar"
   }
 

--- a/third_party/terraform/tests/data_source_google_compute_instance_test.go
+++ b/third_party/terraform/tests/data_source_google_compute_instance_test.go
@@ -110,16 +110,16 @@ resource "google_compute_instance" "foo" {
     	}
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 		baz = "qux"
 	}
 
-	metadata {
+	metadata = {
 		startup-script = "echo Hello"
 	}
 
-	labels {
+	labels = {
 		my_key       = "my_value"
 		my_other_key = "my_other_value"
     }

--- a/third_party/terraform/tests/data_source_storage_object_signed_url_test.go
+++ b/third_party/terraform/tests/data_source_storage_object_signed_url_test.go
@@ -245,7 +245,7 @@ data "google_storage_object_signed_url" "story_url" {
 data "google_storage_object_signed_url" "story_url_w_headers" {
   bucket = "${google_storage_bucket.bucket.name}"
   path   = "${google_storage_bucket_object.story.name}"
-  extension_headers {
+  extension_headers = {
   	x-goog-test = "foo"
   	x-goog-if-generation-match = 1
   }

--- a/third_party/terraform/tests/resource_bigquery_dataset_test.go
+++ b/third_party/terraform/tests/resource_bigquery_dataset_test.go
@@ -190,7 +190,7 @@ resource "google_bigquery_dataset" "test" {
   default_partition_expiration_ms = 3600000
   default_table_expiration_ms = 3600000
 
-  labels {
+  labels = {
     env                         = "foo"
     default_table_expiration_ms = 3600000
   }
@@ -207,7 +207,7 @@ resource "google_bigquery_dataset" "test" {
   default_partition_expiration_ms = 7200000
   default_table_expiration_ms = 7200000
 
-  labels {
+  labels = {
     env                         = "bar"
     default_table_expiration_ms = 7200000
   }
@@ -223,7 +223,7 @@ resource "google_bigquery_dataset" "test" {
   location                    = "%s"
   default_table_expiration_ms = 3600000
 
-  labels {
+  labels = {
     env                         = "foo"
     default_table_expiration_ms = 3600000
   }
@@ -240,7 +240,7 @@ resource "google_bigquery_dataset" "access_test" {
     user_by_email = "Joe@example.com"
   }
 
-  labels {
+  labels = {
     env                         = "foo"
     default_table_expiration_ms = 3600000
   }
@@ -261,7 +261,7 @@ resource "google_bigquery_dataset" "access_test" {
     domain = "example.com"
   }
 
-  labels {
+  labels = {
     env                         = "foo"
     default_table_expiration_ms = 3600000
   }
@@ -305,7 +305,7 @@ resource "google_bigquery_dataset" "access_test" {
     }
   }
 
-  labels {
+  labels = {
     env                         = "foo"
     default_table_expiration_ms = 3600000
   }

--- a/third_party/terraform/tests/resource_cloudbuild_build_trigger_test.go
+++ b/third_party/terraform/tests/resource_cloudbuild_build_trigger_test.go
@@ -300,7 +300,7 @@ resource "google_cloudbuild_trigger" "filename_build_trigger" {
     branch_name = "master"
     repo_name   = "some-repo"
   }
-  substitutions {
+  substitutions = {
     _FOO = "bar"
     _BAZ = "qux"
   }

--- a/third_party/terraform/tests/resource_cloudfunctions_function_test.go
+++ b/third_party/terraform/tests/resource_cloudfunctions_function_test.go
@@ -427,10 +427,10 @@ resource "google_cloudfunctions_function" "function" {
   trigger_http          = true
   timeout               = 61
   entry_point           = "helloGET"
-  labels {
+  labels = {
 	my-label = "my-label-value"
   }
-  environment_variables {
+  environment_variables = {
 	TEST_ENV_VARIABLE = "test-env-variable-value"
   }
 }
@@ -459,11 +459,11 @@ resource "google_cloudfunctions_function" "function" {
   runtime               = "nodejs8"
   timeout               = 91
   entry_point           = "helloGET"
-  labels {
+  labels = {
 	my-label = "my-updated-label-value"
 	a-new-label = "a-new-label-value"
   }
-  environment_variables {
+  environment_variables = {
 	TEST_ENV_VARIABLE = "test-env-variable-value"
 	NEW_ENV_VARIABLE = "new-env-variable-value"
   }

--- a/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -269,21 +269,21 @@ resource "google_composer_environment" "test" {
 		node_count = 4
 
 		software_config {
-			airflow_config_overrides {
+			airflow_config_overrides = {
 			  core-load_example = "True"
 			}
 
-			pypi_packages {
+			pypi_packages = {
 			  numpy = ""
 			}
 
-			env_variables {
+			env_variables = {
 			   FOO = "bar"
 			}
 		}
  	}
 
-	labels {
+	labels = {
  		foo = "bar"
 		anotherlabel = "boo"
  	}
@@ -357,7 +357,7 @@ resource "google_composer_environment" "test" {
 	region = "us-central1"
 	config {
 		software_config {
-			pypi_packages {
+			pypi_packages = {
 			  scipy = "==1.1.0"
 			}
 		}

--- a/third_party/terraform/tests/resource_compute_autoscaler_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_autoscaler_test.go.erb
@@ -223,10 +223,6 @@ resource "google_compute_instance_template" "foobar" {
 		network = "default"
 	}
 
-	metadata {
-		foo = "bar"
-	}
-
 	service_account {
 		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 	}

--- a/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -617,7 +617,7 @@ resource "google_compute_disk" "foobar" {
 	size = 50
 	type = "pd-ssd"
 	zone = "us-central1-a"
-	labels {
+	labels = {
 		my-label = "my-label-value"
 	}
 }`, diskName)
@@ -655,7 +655,7 @@ resource "google_compute_disk" "foobar" {
 	size = 100
 	type = "pd-ssd"
 	zone = "us-central1-a"
-	labels {
+	labels = {
 		my-label = "my-updated-label-value"
 		a-new-label = "a-new-label-value"
 	}

--- a/third_party/terraform/tests/resource_compute_global_forwarding_rule_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_global_forwarding_rule_test.go.erb
@@ -355,7 +355,7 @@ func testAccComputeGlobalForwardingRule_labels(fr, proxy1, proxy2, backend, hc, 
 		port_range = "80"
 		target = "${google_compute_target_http_proxy.foobar1.self_link}"
 
-	    labels {
+	    labels = {
 	        my-label = "my-label-value"
 	        my-second-label = "my-second-label-value"
 	    }
@@ -419,7 +419,7 @@ func testAccComputeGlobalForwardingRule_labelsUpdated(fr, proxy1, proxy2, backen
 		port_range = "80"
 		target = "${google_compute_target_http_proxy.foobar1.self_link}"
 
-	    labels {
+	    labels = {
 	        my-label = "my-label-value"
 	        my-third-label = "my-third-label-value"
 	    }

--- a/third_party/terraform/tests/resource_compute_instance_from_template_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_from_template_test.go
@@ -179,7 +179,7 @@ resource "google_compute_instance_template" "foobar" {
 		network = "default"
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 
@@ -194,7 +194,7 @@ resource "google_compute_instance_from_template" "foobar" {
 
 	// Overrides
 	can_ip_forward = false
-	labels {
+	labels = {
 		my_key       = "my_value"
 	}
 }
@@ -245,7 +245,7 @@ resource "google_compute_instance_template" "template" {
 		network = "default"
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 

--- a/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -341,10 +341,6 @@ func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) stri
 			network = "default"
 		}
 
-		metadata {
-			foo = "bar"
-		}
-
 		service_account {
 			scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 		}
@@ -414,10 +410,6 @@ func testAccInstanceGroupManager_targetSizeZero(template, igm string) string {
 			network = "default"
 		}
 
-		metadata {
-			foo = "bar"
-		}
-
 		service_account {
 			scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 		}
@@ -461,10 +453,6 @@ func testAccInstanceGroupManager_update(template, target, igm string) string {
 
 		network_interface {
 			network = "default"
-		}
-
-		metadata {
-			foo = "bar"
 		}
 
 		service_account {
@@ -524,10 +512,6 @@ func testAccInstanceGroupManager_update2(template1, target1, target2, template2,
 			network = "default"
 		}
 
-		metadata {
-			foo = "bar"
-		}
-
 		service_account {
 			scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 		}
@@ -559,10 +543,6 @@ func testAccInstanceGroupManager_update2(template1, target1, target2, template2,
 
 		network_interface {
 			network = "default"
-		}
-
-		metadata {
-			foo = "bar"
 		}
 
 		service_account {
@@ -927,10 +907,6 @@ func testAccInstanceGroupManager_separateRegions(igm1, igm2 string) string {
 			network = "default"
 		}
 
-		metadata {
-			foo = "bar"
-		}
-
 		service_account {
 			scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 		}
@@ -991,9 +967,7 @@ resource "google_compute_instance_template" "igm-basic" {
 	network_interface {
 		network = "default"
 	}
-	metadata {
-		foo = "bar"
-	}
+
 	service_account {
 		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 	}
@@ -1052,9 +1026,7 @@ resource "google_compute_instance_template" "igm-basic" {
 	network_interface {
 		network = "default"
 	}
-	metadata {
-		foo = "bar"
-	}
+
 	service_account {
 		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 	}
@@ -1107,9 +1079,7 @@ resource "google_compute_instance_template" "igm-primary" {
 	network_interface {
 		network = "default"
 	}
-	metadata {
-		foo = "bar"
-	}
+
 	service_account {
 		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 	}
@@ -1128,9 +1098,7 @@ resource "google_compute_instance_template" "igm-canary" {
 	network_interface {
 		network = "default"
 	}
-	metadata {
-		foo = "bar"
-	}
+
 	service_account {
 		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 	}

--- a/third_party/terraform/tests/resource_compute_instance_template_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_template_test.go
@@ -795,7 +795,7 @@ resource "google_compute_instance_template" "foobar" {
 		automatic_restart = true
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 
@@ -803,7 +803,7 @@ resource "google_compute_instance_template" "foobar" {
 		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 	}
 
-    labels {
+    labels = {
         my_label = "foobar"
     }
 }`, acctest.RandString(10))
@@ -848,7 +848,7 @@ resource "google_compute_instance_template" "foobar" {
 		automatic_restart = true
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 
@@ -856,7 +856,7 @@ resource "google_compute_instance_template" "foobar" {
 		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 	}
 
-    labels {
+    labels = {
         my_label = "foobar"
     }
 }`, acctest.RandString(10), acctest.RandString(10))
@@ -890,7 +890,7 @@ resource "google_compute_instance_template" "foobar" {
 		automatic_restart = false
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 
@@ -927,7 +927,7 @@ resource "google_compute_instance_template" "foobar" {
 		}
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 }`, acctest.RandString(10), acctest.RandString(10))
@@ -978,7 +978,7 @@ resource "google_compute_instance_template" "foobar" {
 		network_ip = "%s"
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 }`, acctest.RandString(10), networkIP)
@@ -1005,7 +1005,7 @@ resource "google_compute_instance_template" "foobar" {
 		network_ip    = "%s"
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 }`, acctest.RandString(10), ipAddress)
@@ -1047,7 +1047,7 @@ resource "google_compute_instance_template" "foobar" {
 		network = "default"
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 }`, acctest.RandString(10), acctest.RandString(10))
@@ -1089,7 +1089,7 @@ resource "google_compute_instance_template" "foobar" {
 		network = "default"
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 }`, acctest.RandString(10), acctest.RandString(10))
@@ -1122,7 +1122,7 @@ func testAccComputeInstanceTemplate_subnet_auto(network string) string {
 			network = "${google_compute_network.auto-network.name}"
 		}
 
-		metadata {
+		metadata = {
 			foo = "bar"
 		}
 	}`, network, acctest.RandString(10))
@@ -1163,7 +1163,7 @@ resource "google_compute_instance_template" "foobar" {
 		subnetwork = "${google_compute_subnetwork.subnetwork.name}"
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 }`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
@@ -1240,7 +1240,7 @@ func testAccComputeInstanceTemplate_subnet_xpn(org, billingId, projectName strin
 			subnetwork_project = "${google_compute_subnetwork.subnetwork.project}"
 		}
 
-		metadata {
+		metadata = {
 			foo = "bar"
 		}
 		project = "${google_compute_shared_vpc_service_project.service_project.service_project}"
@@ -1265,7 +1265,7 @@ resource "google_compute_instance_template" "foobar" {
 		boot = true
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 
@@ -1295,7 +1295,7 @@ resource "google_compute_instance_template" "foobar" {
 		boot = true
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 
@@ -1338,7 +1338,7 @@ resource "google_compute_instance_template" "foobar" {
 		boot = true
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 
@@ -1501,7 +1501,7 @@ resource "google_compute_instance_template" "foobar" {
 		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 	}
 
-    labels {
+    labels = {
         my_label = "foobar"
     }
 }`, pid, pname, org, billing, keyRingName, keyName, acctest.RandString(10))

--- a/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_test.go
@@ -1539,16 +1539,13 @@ resource "google_compute_instance" "foobar" {
 		network = "default"
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 		baz = "qux"
-	}
-
-	metadata {
 		startup-script = "echo Hello"
 	}
 
-	labels {
+	labels = {
 		my_key       = "my_value"
 		my_other_key = "my_other_value"
 	}
@@ -1580,7 +1577,7 @@ resource "google_compute_instance" "foobar" {
 		network = "default"
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 }
@@ -1611,7 +1608,7 @@ resource "google_compute_instance" "foobar" {
 		network = "default"
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 }
@@ -1643,7 +1640,7 @@ resource "google_compute_instance" "foobar" {
 	}
 
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 }
@@ -1674,7 +1671,7 @@ resource "google_compute_instance" "foobar" {
 		network = "default"
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 }
@@ -1763,7 +1760,7 @@ resource "google_compute_instance" "foobar" {
 		access_config { }
 	}
 
-	metadata {
+	metadata = {
 		qux = "true"
 	}
 }
@@ -1796,12 +1793,12 @@ resource "google_compute_instance" "foobar" {
 		access_config { }
 	}
 
-	metadata {
+	metadata = {
 		bar            = "baz"
 		startup-script = "echo Hello"
 	}
 
-	labels {
+	labels = {
 		only_me = "nothing_else"
 	}
 }
@@ -1838,7 +1835,7 @@ resource "google_compute_instance" "foobar" {
 		}
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 }
@@ -1871,7 +1868,7 @@ resource "google_compute_instance" "foobar" {
 		}
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 }
@@ -1992,7 +1989,7 @@ resource "google_compute_instance" "foobar" {
 		network = "default"
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 }
@@ -2681,7 +2678,7 @@ resource "google_compute_instance" "foobar" {
 		network = "default"
 	}
 
-	metadata {
+	metadata = {
 		foo = "bar"
 	}
 }

--- a/third_party/terraform/tests/resource_compute_project_metadata_test.go
+++ b/third_party/terraform/tests/resource_compute_project_metadata_test.go
@@ -135,7 +135,7 @@ resource "google_project_service" "compute" {
 
 resource "google_compute_project_metadata" "fizzbuzz" {
   project = "${google_project.project.project_id}"
-  metadata {
+  metadata = {
     banana = "orange"
     sofa = "darwinism"
   }
@@ -159,7 +159,7 @@ resource "google_project_service" "compute" {
 
 resource "google_compute_project_metadata" "fizzbuzz" {
   project = "${google_project.project.project_id}"
-  metadata {
+  metadata = {
     kiwi = "papaya"
     finches = "darwinism"
   }
@@ -183,7 +183,7 @@ resource "google_project_service" "compute" {
 
 resource "google_compute_project_metadata" "fizzbuzz" {
   project = "${google_project.project.project_id}"
-  metadata {
+  metadata = {
     paper = "pen"
     genghis_khan = "french bread"
     happy = "smiling"
@@ -208,7 +208,7 @@ resource "google_project_service" "compute" {
 
 resource "google_compute_project_metadata" "fizzbuzz" {
   project = "${google_project.project.project_id}"
-  metadata {
+  metadata = {
     paper = "pen"
     paris = "french bread"
     happy = "laughing"

--- a/third_party/terraform/tests/resource_compute_region_autoscaler_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_autoscaler_test.go.erb
@@ -155,10 +155,6 @@ resource "google_compute_instance_template" "foobar" {
 		network = "default"
 	}
 
-	metadata {
-		foo = "bar"
-	}
-
 	service_account {
 		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 	}
@@ -225,10 +221,6 @@ resource "google_compute_instance_template" "foobar" {
 
 	network_interface {
 		network = "default"
-	}
-
-	metadata {
-		foo = "bar"
 	}
 
 	service_account {

--- a/third_party/terraform/tests/resource_compute_region_disk_test.go
+++ b/third_party/terraform/tests/resource_compute_region_disk_test.go
@@ -327,7 +327,7 @@ resource "google_compute_region_disk" "regiondisk" {
 	replica_zones = ["us-central1-a", "us-central1-f"]
 
 	size = 100
-	labels {
+	labels = {
 		my-label = "my-updated-label-value"
 		a-new-label = "a-new-label-value"
 	}

--- a/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
@@ -349,10 +349,6 @@ func testAccRegionInstanceGroupManager_basic(template, target, igm1, igm2 string
 			network = "default"
 		}
 
-		metadata {
-			foo = "bar"
-		}
-
 		service_account {
 			scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 		}
@@ -422,10 +418,6 @@ func testAccRegionInstanceGroupManager_targetSizeZero(template, igm string) stri
 			network = "default"
 		}
 
-		metadata {
-			foo = "bar"
-		}
-
 		service_account {
 			scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 		}
@@ -469,10 +461,6 @@ func testAccRegionInstanceGroupManager_update(template, target, igm string) stri
 
 		network_interface {
 			network = "default"
-		}
-
-		metadata {
-			foo = "bar"
 		}
 
 		service_account {
@@ -532,10 +520,6 @@ func testAccRegionInstanceGroupManager_update2(template1, target1, target2, temp
 			network = "default"
 		}
 
-		metadata {
-			foo = "bar"
-		}
-
 		service_account {
 			scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 		}
@@ -567,10 +551,6 @@ func testAccRegionInstanceGroupManager_update2(template1, target1, target2, temp
 
 		network_interface {
 			network = "default"
-		}
-
-		metadata {
-			foo = "bar"
 		}
 
 		service_account {
@@ -681,10 +661,6 @@ func testAccRegionInstanceGroupManager_separateRegions(igm1, igm2 string) string
 			network = "default"
 		}
 
-		metadata {
-			foo = "bar"
-		}
-
 		service_account {
 			scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 		}
@@ -745,9 +721,7 @@ resource "google_compute_instance_template" "igm-basic" {
 	network_interface {
 		network = "default"
 	}
-	metadata {
-		foo = "bar"
-	}
+
 	service_account {
 		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 	}
@@ -806,9 +780,7 @@ resource "google_compute_instance_template" "igm-basic" {
 	network_interface {
 		network = "default"
 	}
-	metadata {
-		foo = "bar"
-	}
+
 	service_account {
 		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 	}
@@ -861,9 +833,7 @@ resource "google_compute_instance_template" "igm-primary" {
 	network_interface {
 		network = "default"
 	}
-	metadata {
-		foo = "bar"
-	}
+
 	service_account {
 		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 	}
@@ -882,9 +852,7 @@ resource "google_compute_instance_template" "igm-canary" {
 	network_interface {
 		network = "default"
 	}
-	metadata {
-		foo = "bar"
-	}
+
 	service_account {
 		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
 	}
@@ -933,9 +901,6 @@ resource "google_compute_instance_template" "igm-basic" {
 	}
 	network_interface {
 		network = "default"
-	}
-	metadata {
-		foo = "bar"
 	}
 }
 

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2059,10 +2059,10 @@ resource "google_container_cluster" "with_node_config" {
 			"https://www.googleapis.com/auth/logging.write"
 		]
 		service_account = "default"
-		metadata {
+		metadata = {
 			foo = "bar"
 		}
-		labels {
+		labels = {
 			foo = "bar"
 		}
 		tags = ["foo", "bar"]
@@ -2094,10 +2094,10 @@ resource "google_container_cluster" "with_node_config" {
 			"https://www.googleapis.com/auth/logging.write"
 		]
 		service_account = "default"
-		metadata {
+		metadata = {
 			foo = "bar"
 		}
-		labels {
+		labels = {
 			foo = "bar"
 		}
 		tags = ["foo", "bar"]
@@ -2463,11 +2463,11 @@ resource "google_container_cluster" "with_node_pool_node_config" {
 				"https://www.googleapis.com/auth/monitoring"
 			]
 			service_account = "default"
-			metadata {
+			metadata = {
 				foo = "bar"
 			}
 			image_type = "COS"
-			labels {
+			labels = {
 				foo = "bar"
 			}
 			tags = ["foo", "bar"]
@@ -2788,7 +2788,7 @@ resource "google_container_cluster" "with_resource_labels" {
 	zone = "us-central1-a"
 	initial_node_count = 1
 
-	resource_labels {
+	resource_labels = {
 		created-by = "terraform"
 	}
 }

--- a/third_party/terraform/tests/resource_dataflow_job_test.go
+++ b/third_party/terraform/tests/resource_dataflow_job_test.go
@@ -138,7 +138,7 @@ resource "google_dataflow_job" "big_data" {
 	template_gcs_path = "gs://dataflow-templates/wordcount/template_file"
 	temp_gcs_location = "${google_storage_bucket.temp.url}"
 
-	parameters {
+	parameters = {
 		inputFile = "gs://dataflow-samples/shakespeare/kinglear.txt"
 		output    = "${google_storage_bucket.temp.url}/output"
 	}
@@ -161,7 +161,7 @@ resource "google_dataflow_job" "big_data" {
 	template_gcs_path = "gs://dataflow-templates/wordcount/template_file"
 	temp_gcs_location = "${google_storage_bucket.temp.url}"
 
-	parameters {
+	parameters = {
 		inputFile = "gs://dataflow-samples/shakespeare/kinglear.txt"
 		output    = "${google_storage_bucket.temp.url}/output"
 	}

--- a/third_party/terraform/tests/resource_dataproc_cluster_test.go
+++ b/third_party/terraform/tests/resource_dataproc_cluster_test.go
@@ -796,7 +796,7 @@ resource "google_dataproc_cluster" "basic" {
 
 	cluster_config {
 		gce_cluster_config {
-			metadata {
+			metadata = {
 				foo = "bar"
 				baz = "qux"
 			}
@@ -989,7 +989,7 @@ resource "google_dataproc_cluster" "with_labels" {
 	name   = "dproc-cluster-test-%s"
 	region = "us-central1"
 
-	labels {
+	labels = {
 		key1 = "value1"
 	}
 

--- a/third_party/terraform/tests/resource_dataproc_job_test.go
+++ b/third_party/terraform/tests/resource_dataproc_job_test.go
@@ -549,7 +549,7 @@ resource "google_dataproc_job" "pyspark" {
 			"spark.logConf" = "true"
 		}
 		logging_config {
-			driver_log_levels {
+			driver_log_levels = {
 				"root" = "INFO"
 			}
 		}
@@ -559,7 +559,7 @@ resource "google_dataproc_job" "pyspark" {
 		max_failures_per_hour = 1
 	}
 
-	labels {
+	labels = {
 		one = "1"
 	}
 }

--- a/third_party/terraform/tests/resource_filestore_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_filestore_instance_test.go.erb
@@ -77,7 +77,7 @@ resource "google_filestore_instance" "instance" {
     network = "default"
     modes = ["MODE_IPV4"]
   }
-	labels {
+	labels = {
 		foo = "bar"
 	}
   tier = "PREMIUM"
@@ -98,7 +98,7 @@ resource "google_filestore_instance" "instance" {
     network = "default"
     modes = ["MODE_IPV4"]
   }
-	labels {
+	labels = {
 		baz = "qux"
 	}
   tier = "PREMIUM"

--- a/third_party/terraform/tests/resource_google_project_test.go
+++ b/third_party/terraform/tests/resource_google_project_test.go
@@ -327,7 +327,7 @@ resource "google_project" "acceptance" {
     project_id = "%s"
     name       = "%s"
     org_id     = "%s"
-	labels {`, pid, name, org)
+	labels = {`, pid, name, org)
 
 	l := ""
 	for key, value := range labels {

--- a/third_party/terraform/tests/resource_redis_instance_test.go
+++ b/third_party/terraform/tests/resource_redis_instance_test.go
@@ -100,7 +100,7 @@ resource "google_redis_instance" "test" {
 	memory_size_gb = 1
 	region         = "us-central1"
 
-	labels {
+	labels = {
 		my_key    = "my_val"
 		other_key = "other_val"
 	}
@@ -119,7 +119,7 @@ resource "google_redis_instance" "test" {
 	display_name   = "post-update"
 	memory_size_gb = 1
 
-	labels {
+	labels = {
 		my_key    = "my_val"
 		other_key = "new_val"
 	}
@@ -152,7 +152,7 @@ resource "google_redis_instance" "test" {
 	display_name      = "Terraform Test Instance"
 	reserved_ip_range = "192.168.0.0/29"
 
-	labels {
+	labels = {
 		my_key    = "my_val"
 		other_key = "other_val"
 	}

--- a/third_party/terraform/tests/resource_spanner_instance_test.go
+++ b/third_party/terraform/tests/resource_spanner_instance_test.go
@@ -292,7 +292,7 @@ resource "google_spanner_instance" "updater" {
   display_name  = "%s"
   num_nodes     = %d
 
-  labels {
+  labels = {
      "key1" = "value1"
      %s
   }

--- a/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -1012,7 +1012,7 @@ resource "google_sql_database_instance" "instance" {
 	region = "us-central1"
 	settings {
 		tier = "db-f1-micro"
-		user_labels {
+		user_labels = {
 		    track = "production"
 		    location = "western-division"
 		}
@@ -1025,7 +1025,7 @@ resource "google_sql_database_instance" "instance" {
 	region = "us-central1"
 	settings {
 		tier = "db-f1-micro"
-		user_labels {
+		user_labels = {
 		    track = "production"
 		}
 	}

--- a/third_party/terraform/tests/resource_storage_bucket_test.go
+++ b/third_party/terraform/tests/resource_storage_bucket_test.go
@@ -991,7 +991,7 @@ func testAccStorageBucket_labels(bucketName string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
-	labels {
+	labels = {
 		my-label = "my-label-value"
 	}
 }
@@ -1040,7 +1040,7 @@ func testAccStorageBucket_updateLabels(bucketName string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
-	labels {
+	labels = {
 		my-label    = "my-updated-label-value"
 		a-new-label = "a-new-label-value"
 	}

--- a/third_party/terraform/tests/resource_storage_notification_test.go
+++ b/third_party/terraform/tests/resource_storage_notification_test.go
@@ -242,7 +242,7 @@ resource "google_storage_notification" "notification" {
 	payload_format    = "JSON_API_V1"
 	topic             = "${google_pubsub_topic.topic.id}"
 	event_types       = ["%s","%s"]
-	custom_attributes {
+	custom_attributes = {
 		new-attribute = "new-attribute-value"
 	}
 	depends_on        = ["google_pubsub_topic_iam_binding.binding"]

--- a/third_party/terraform/website/docs/d/datasource_google_service_account.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_service_account.html.markdown
@@ -30,7 +30,7 @@ resource "google_service_account_key" "mykey" {
 }
 
 resource "kubernetes_secret" "google-application-credentials" {
-  metadata {
+  metadata = {
     name = "google-application-credentials"
   }
   data {

--- a/third_party/terraform/website/docs/d/signed_url.html.markdown
+++ b/third_party/terraform/website/docs/d/signed_url.html.markdown
@@ -46,7 +46,7 @@ data "google_storage_object_signed_url" "get_url" {
   duration     = "2d"
   credentials  = "${file("path/to/credentials.json")}"
   
-  extension_headers {
+  extension_headers = {
     x-goog-if-generation-match = 1
   }
 }

--- a/third_party/terraform/website/docs/r/bigquery_dataset.html.markdown
+++ b/third_party/terraform/website/docs/r/bigquery_dataset.html.markdown
@@ -23,7 +23,7 @@ resource "google_bigquery_dataset" "default" {
   location                    = "EU"
   default_table_expiration_ms = 3600000
 
-  labels {
+  labels = {
     env = "default"
   }
 

--- a/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -23,7 +23,7 @@ resource "google_bigquery_dataset" "default" {
   location                    = "EU"
   default_table_expiration_ms = 3600000
 
-  labels {
+  labels = {
     env = "default"
   }
 }
@@ -36,7 +36,7 @@ resource "google_bigquery_table" "default" {
     type = "DAY"
   }
 
-  labels {
+  labels = {
     env = "default"
   }
 

--- a/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
+++ b/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
@@ -35,10 +35,11 @@ resource "google_cloudfunctions_function" "function" {
   trigger_http          = true
   timeout               = 60
   entry_point           = "helloGET"
-  labels {
+  labels = {
     my-label = "my-label-value"
   }
-  environment_variables {
+  
+  environment_variables = { {
     MY_ENV_VAR = "my-env-var-value"
   }
 }

--- a/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
+++ b/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
@@ -39,7 +39,7 @@ resource "google_cloudfunctions_function" "function" {
     my-label = "my-label-value"
   }
   
-  environment_variables = { {
+  environment_variables = {
     MY_ENV_VAR = "my-env-var-value"
   }
 }

--- a/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -99,16 +99,16 @@ resource "google_composer_environment" "test" {
 
   config {
     software_config {
-      airflow_config_overrides {
+      airflow_config_overrides = {
         core-load_example = "True"
       }
 
-      pypi_packages {
+      pypi_packages = {
         numpy = ""
         scipy = "==1.1.0"
       }
 
-      env_variables {
+      env_variables = {
          FOO = "bar"
       }
     }

--- a/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -42,7 +42,7 @@ resource "google_compute_instance" "default" {
     }
   }
 
-  metadata {
+  metadata = {
     foo = "bar"
   }
 

--- a/third_party/terraform/website/docs/r/compute_instance_from_template.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance_from_template.html.markdown
@@ -36,7 +36,7 @@ resource "google_compute_instance_template" "tpl" {
     network = "default"
   }
 
-  metadata {
+  metadata = {
     foo = "bar"
   }
 
@@ -51,7 +51,7 @@ resource "google_compute_instance_from_template" "tpl" {
 
   // Override fields from instance template
   can_ip_forward = false
-  labels {
+  labels = {
     my_key       = "my_value"
   }
 }

--- a/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -55,7 +55,7 @@ resource "google_compute_instance_template" "default" {
     network = "default"
   }
 
-  metadata {
+  metadata = {
     foo = "bar"
   }
 

--- a/third_party/terraform/website/docs/r/compute_project_metadata.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_project_metadata.html.markdown
@@ -22,7 +22,7 @@ key/value pairs within the project metadata rather than the entire set, then use
 
 ```hcl
 resource "google_compute_project_metadata" "default" {
-  metadata {
+  metadata = {
     foo  = "bar"
     fizz = "buzz"
     "13" = "42"

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -42,7 +42,7 @@ resource "google_container_cluster" "primary" {
       "https://www.googleapis.com/auth/monitoring",
     ]
 
-    labels {
+    labels = {
       foo = "bar"
     }
 

--- a/third_party/terraform/website/docs/r/dataflow_job.html.markdown
+++ b/third_party/terraform/website/docs/r/dataflow_job.html.markdown
@@ -20,7 +20,7 @@ resource "google_dataflow_job" "big_data_job" {
     name = "dataflow-job"
     template_gcs_path = "gs://my-bucket/templates/template_file"
     temp_gcs_location = "gs://my-bucket/tmp_dir"
-    parameters {
+    parameters = {
         foo = "bar"
         baz = "qux"
     }

--- a/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -31,7 +31,7 @@ resource "google_dataproc_cluster" "simplecluster" {
 resource "google_dataproc_cluster" "mycluster" {
     name       = "mycluster"
     region     = "us-central1"
-    labels {
+    labels = {
         foo = "bar"
     }
 

--- a/third_party/terraform/website/docs/r/dataproc_job.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_job.html.markdown
@@ -39,7 +39,7 @@ resource "google_dataproc_job" "spark" {
         }
         
         logging_config {
-            driver_log_levels {
+            driver_log_levels = {
                 "root" = "INFO"
             }
         }
@@ -166,7 +166,7 @@ resource "google_dataproc_job" "spark" {
         }
         
         logging_config {
-            driver_log_levels {
+            driver_log_levels = {
                 "root" = "INFO"
             }
         }

--- a/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
+++ b/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
@@ -38,7 +38,7 @@ resource "google_service_account_key" "mykey" {
 }
 
 resource "kubernetes_secret" "google-application-credentials" {
-  metadata {
+  metadata = {
     name = "google-application-credentials"
   }
   data {

--- a/third_party/terraform/website/docs/r/pubsub_subscription.html.markdown
+++ b/third_party/terraform/website/docs/r/pubsub_subscription.html.markdown
@@ -29,7 +29,7 @@ resource "google_pubsub_subscription" "default" {
   push_config {
     push_endpoint = "https://example.com/push"
 
-    attributes {
+    attributes = {
       x-goog-version = "v1"
     }
   }

--- a/third_party/terraform/website/docs/r/storage_notification.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_notification.html.markdown
@@ -28,7 +28,7 @@ resource "google_storage_notification" "notification" {
 	payload_format    = "JSON_API_V1"
 	topic             = "${google_pubsub_topic.topic.id}"
 	event_types       = ["OBJECT_FINALIZE", "OBJECT_METADATA_UPDATE"]
-	custom_attributes {
+	custom_attributes = {
 		new-attribute = "new-attribute-value"
 	}
 	depends_on        = ["google_pubsub_topic_iam_binding.binding"]


### PR DESCRIPTION
This should get all metadata/labels, and all `TypeMap`s in handwritten code. I'll clean up others based on CI runs. This is a formatting change / test-only error, so it isn't the highest priority that we catch them all but they could be hiding other issues.

Also collapses some metadata fields in instance that were broken in 2.

-----------------------------------------------------------------
# [all]
## [terraform]
Add = to map declarations in examples/tests
### [terraform-beta]
## [ansible]
## [inspec]
