### PR TITLE
[Terraform] add diffsuppress for composer image version

### DIFF
--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -182,7 +182,7 @@ func resourceComposerEnvironment() *schema.Resource {
 									"image_version": {
 										Type:     schema.TypeString,
 										Computed: true,
-<% unless version.nil? || version == 'ga' -%>
+<% unless version == 'ga' -%>
 										Optional: true,
 										ForceNew: true,
 										ValidateFunc: validateRegexp(composerEnvironmentVersionRegexp),
@@ -555,7 +555,7 @@ func flattenComposerEnvironmentConfigSoftwareConfig(softwareCfg *composer.Softwa
 	}
 	transformed := make(map[string]interface{})
 	transformed["image_version"] = softwareCfg.ImageVersion
-<% unless version.nil? || version == 'ga' -%>
+<% unless version == 'ga' -%>
 	transformed["python_version"] = softwareCfg.PythonVersion
 <% end -%>
 	transformed["airflow_config_overrides"] = softwareCfg.AirflowConfigOverrides
@@ -760,7 +760,7 @@ func expandComposerEnvironmentConfigSoftwareConfig(v interface{}, d *schema.Reso
 	transformed := &composer.SoftwareConfig{}
 
 	transformed.ImageVersion = original["image_version"].(string)
-<% unless version.nil? || version == 'ga' -%>
+<% unless version == 'ga' -%>
 	transformed.PythonVersion = original["python_version"].(string)
 <% end -%>
 	transformed.AirflowConfigOverrides = expandComposerEnvironmentConfigSoftwareConfigStringMap(original, "airflow_config_overrides")
@@ -928,7 +928,7 @@ func validateServiceAccountRelativeNameOrEmail(v interface{}, k string) (ws []st
 	return
 }
 
-<% unless version.nil? || version == 'ga' -%>
+<% unless version == 'ga' -%>
 func composerImageVersionDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 	versionRe := regexp.MustCompile(composerEnvironmentVersionRegexp)
 	oldVersions := versionRe.FindStringSubmatch(old)

--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"google.golang.org/api/composer/v1beta1"
@@ -16,6 +17,7 @@ import (
 const (
 	composerEnvironmentEnvVariablesRegexp          = "[a-zA-Z_][a-zA-Z0-9_]*."
 	composerEnvironmentReservedAirflowEnvVarRegexp = "AIRFLOW__[A-Z0-9_]+__[A-Z0-9_]+"
+	composerEnvironmentVersionRegexp               = `composer-([0-9]+\.[0-9]+\.[0-9]+|latest)-airflow-([0-9]+\.[0-9]+(\.[0-9]+.*)?)`
 )
 
 var composerEnvironmentReservedEnvVar = map[string]struct{}{
@@ -183,6 +185,8 @@ func resourceComposerEnvironment() *schema.Resource {
 <% unless version.nil? || version == 'ga' -%>
 										Optional: true,
 										ForceNew: true,
+										ValidateFunc: validateRegexp(composerEnvironmentVersionRegexp),
+										DiffSuppressFunc: composerImageVersionDiffSuppress,
 									},
 									"python_version": {
 										Type:     schema.TypeString,
@@ -923,3 +927,61 @@ func validateServiceAccountRelativeNameOrEmail(v interface{}, k string) (ws []st
 
 	return
 }
+
+<% unless version.nil? || version == 'ga' -%>
+func composerImageVersionDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
+	versionRe := regexp.MustCompile(composerEnvironmentVersionRegexp)
+	oldVersions := versionRe.FindStringSubmatch(old)
+	newVersions := versionRe.FindStringSubmatch(new)
+	if oldVersions == nil || len(oldVersions) < 3 {
+		// Somehow one of the versions didn't match the regexp or didn't
+		// have values in the capturing groups. In that case, fall back to
+		// an equality check.
+		log.Printf("[WARN] Composer version didn't match regexp: %s", old)
+		return old == new
+	}
+	if newVersions == nil || len(newVersions) < 3 {
+		// Somehow one of the versions didn't match the regexp or didn't
+		// have values in the capturing groups. In that case, fall back to
+		// an equality check.
+		log.Printf("[WARN] Composer version didn't match regexp: %s", new)
+		return old == new
+	}
+
+	// Check airflow version using the version package to account for
+	// diffs like 1.10 and 1.10.0
+	eq, err := versionsEqual(oldVersions[2], newVersions[2])
+	if err != nil {
+		log.Printf("[WARN] Could not parse airflow version, %s", err)
+	}
+	if !eq {
+		return false
+	}
+
+	// Check composer version. Assume that "latest" means we should
+	// suppress the diff, because we don't have any other way of
+	// knowing what the latest version actually is.
+	if oldVersions[1] == "latest" || newVersions[1] == "latest" {
+		return true
+	}
+	// If neither version is "latest", check them using the version
+	// package like we did for airflow.
+	eq, err = versionsEqual(oldVersions[1], newVersions[1])
+	if err != nil {
+		log.Printf("[WARN] Could not parse composer version, %s", err)
+	}
+	return eq
+}
+
+func versionsEqual(old, new string) (bool, error) {
+	o, err := version.NewVersion(old)
+	if err != nil {
+		return false, err
+	}
+	n, err := version.NewVersion(new)
+	if err != nil {
+		return false, err
+	}
+	return o.Equal(n), nil
+}
+<% end -%>

--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -17,7 +17,9 @@ import (
 const (
 	composerEnvironmentEnvVariablesRegexp          = "[a-zA-Z_][a-zA-Z0-9_]*."
 	composerEnvironmentReservedAirflowEnvVarRegexp = "AIRFLOW__[A-Z0-9_]+__[A-Z0-9_]+"
+<% unless version == 'ga' -%>
 	composerEnvironmentVersionRegexp               = `composer-([0-9]+\.[0-9]+\.[0-9]+|latest)-airflow-([0-9]+\.[0-9]+(\.[0-9]+.*)?)`
+<% end -%>
 )
 
 var composerEnvironmentReservedEnvVar = map[string]struct{}{

--- a/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -27,6 +27,32 @@ func init() {
 	})
 }
 
+<% unless version.nil? || version == 'ga' -%>
+func TestComposerImageVersionDiffSuppress(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		old string
+		new string
+		expected bool
+	}{
+		{"matches", "composer-1.4.0-airflow-1.10.0", "composer-1.4.0-airflow-1.10.0", true},
+		{"old latest", "composer-latest-airflow-1.10.0", "composer-1.4.1-airflow-1.10.0", true},
+		{"new latest", "composer-1.4.1-airflow-1.10.0", "composer-latest-airflow-1.10.0", true},
+		{"airflow equivalent", "composer-1.4.0-airflow-1.10.0", "composer-1.4.0-airflow-1.10", true},
+		{"airflow different", "composer-1.4.0-airflow-1.10.0", "composer-1.4-airflow-1.9.0", false},
+		{"airflow different composer latest", "composer-1.4.0-airflow-1.10.0", "composer-latest-airflow-1.9.0", false},
+	}
+
+	for _, tc := range cases {
+		if actual := composerImageVersionDiffSuppress("", tc.old, tc.new, nil); actual != tc.expected {
+			t.Fatalf("'%s' failed, expected %v but got %v", tc.name, tc.expected, actual)
+		}
+	}
+}
+<% end -%>
+
 // Checks environment creation with minimum required information.
 func TestAccComposerEnvironment_basic(t *testing.T) {
 	t.Parallel()

--- a/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -27,7 +27,7 @@ func init() {
 	})
 }
 
-<% unless version.nil? || version == 'ga' -%>
+<% unless version == 'ga' -%>
 func TestComposerImageVersionDiffSuppress(t *testing.T) {
 	t.Parallel()
 
@@ -159,7 +159,7 @@ func TestAccComposerEnvironment_withNodeConfig(t *testing.T) {
 	})
 }
 
-<% unless version.nil? || version == 'ga' -%>
+<% unless version == 'ga' -%>
 func TestAccComposerEnvironment_withSoftwareConfig(t *testing.T) {
 	t.Parallel()
  	envName := acctest.RandomWithPrefix(testComposerEnvironmentPrefix)
@@ -359,7 +359,7 @@ resource "google_project_iam_member" "composer-worker" {
 `, environment, network, subnetwork, serviceAccount)
 }
 
-<% unless version.nil? || version == 'ga' -%>
+<% unless version == 'ga' -%>
 func testAccComposerEnvironment_softwareCfg(name string) string {
 	return fmt.Sprintf(`
 resource "google_composer_environment" "test" {


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Fixes TestAccComposerEnvironment_withSoftwareConfig, which was failing with
```
DESTROY/CREATE: google_composer_environment.test
		  config.#:                                  "1" => "1"
		  config.0.airflow_uri:                      "https://tb58739e00c0f9074-tp.appspot.com" => "<computed>"
		  config.0.dag_gcs_prefix:                   "gs://us-central1-tf-cc-testenv-3-f8d09212-bucket/dags" => "<computed>"
		  config.0.gke_cluster:                      "projects/hc-terraform-testing/zones/us-central1-b/clusters/us-central1-tf-cc-testenv-3-f8d09212-gke" => "<computed>"
		  config.0.node_config.#:                    "1" => "<computed>"
		  config.0.node_count:                       "3" => "<computed>"
		  config.0.software_config.#:                "1" => "1"
		  config.0.software_config.0.image_version:  "composer-1.4.1-airflow-1.10.0" => "composer-latest-airflow-1.10" (forces new resource)
		  config.0.software_config.0.python_version: "3" => "3"
		  name:                                      "tf-cc-testenv-3075622059433350670" => "tf-cc-testenv-3075622059433350670"
		  project:                                   "hc-terraform-testing" => "<computed>"
		  region:                                    "us-central1" => "us-central1"
```
<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
add diffsuppress for composer image version
### [terraform-beta]
## [ansible]
## [inspec]
