### PR TITLE
Export data.google_compute_default_service_account.name

### DIFF
--- a/third_party/terraform/tests/data_source_google_compute_default_service_account_test.go
+++ b/third_party/terraform/tests/data_source_google_compute_default_service_account_test.go
@@ -20,6 +20,9 @@ func TestAccDataSourceGoogleComputeDefaultServiceAccount_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet(resourceName, "id"),
 					resource.TestCheckResourceAttrSet(resourceName, "email"),
+					resource.TestCheckResourceAttrSet(resourceName, "unique_id"),
+					resource.TestCheckResourceAttrSet(resourceName, "name"),
+					resource.TestCheckResourceAttrSet(resourceName, "display_name"),
 				),
 			},
 		},

--- a/third_party/terraform/website/docs/d/google_compute_default_service_account.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_default_service_account.html.markdown
@@ -32,3 +32,9 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `email` - Email address of the default service account used by VMs running in this project
+
+* `unique_id` - The unique id of the service account.
+
+* `name` - The fully-qualified name of the service account.
+
+* `display_name` - The display name for the service account.

--- a/third_party/terraform/website/docs/r/google_service_account_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/google_service_account_iam.html.markdown
@@ -39,8 +39,8 @@ resource "google_service_account" "sa" {
 }
 
 resource "google_service_account_iam_policy" "admin-account-iam" {
-	service_account_id = "${google_service_account.sa.name}"
-	policy_data = "${data.google_iam_policy.admin.policy_data}"
+  service_account_id = "${google_service_account.sa.name}"
+  policy_data        = "${data.google_iam_policy.admin.policy_data}"
 }
 ```
 
@@ -66,6 +66,8 @@ resource "google_service_account_iam_binding" "admin-account-iam" {
 ## google\_service\_account\_iam\_member
 
 ```hcl
+data "google_compute_default_service_account" "default" { }
+
 resource "google_service_account" "sa" {
   account_id   = "my-service-account"
   display_name = "A service account that Jane can use"
@@ -75,6 +77,13 @@ resource "google_service_account_iam_member" "admin-account-iam" {
   service_account_id = "${google_service_account.sa.name}"
   role               = "roles/iam.serviceAccountUser"
   member             = "user:jane@example.com"
+}
+
+# Allow SA service account use the default GCE account
+resource "google_service_account_iam_member" "gce-default-account-iam" {
+  service_account_id = "${data.google_compute_default_service_account.default.name}"
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.sa.email}"
 }
 ```
 


### PR DESCRIPTION
Fixes terraform-providers/terraform-provider-google#2611

<!-- A summary of the changes in this commit goes here -->

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]

The following additional attributes are exported from `data.google_compute_default_service_account`:
* `name`
* `display_name`
* `unique_id`

Some code has been taken from data_source_google_service_account,
so that both data sources behave similarly.

Documentation has been updated with additional use cases.

### [terraform-beta]
## [ansible]
## [inspec]
