### PR TITLE
fixing module utils

### DIFF
--- a/.ci/unit-tests/ansible.sh
+++ b/.ci/unit-tests/ansible.sh
@@ -10,4 +10,4 @@ pip install tox
 
 
 source hacking/env-setup
-ansible-test sanity -v --tox --python 2.7 --base-branch origin/devel lib/ansible/modules/cloud/google/
+ansible-test sanity -v --tox --python 2.7 --base-branch origin/devel lib/ansible/modules/cloud/google/ lib/ansible/module_utils/gcp_utils.py

--- a/provider/ansible/gcp_utils.py
+++ b/provider/ansible/gcp_utils.py
@@ -71,6 +71,7 @@ def replace_resource_dict(item, value):
         except ValueError:
             return new_item
 
+
 # Handles all authentation and HTTP sessions for GCP API calls.
 class GcpSession(object):
     def __init__(self, module, product):
@@ -85,16 +86,25 @@ class GcpSession(object):
         except getattr(requests.exceptions, 'RequestException') as inst:
             self.module.fail_json(msg=inst.message)
 
-    def post(self, url, body=None, headers={}, **kwargs):
-        kwargs.update({'json': body, 'headers': self._merge_dictionaries(headers, self._headers())})
+    def post(self, url, body=None, headers=None, **kwargs):
+        if headers:
+            headers = self.merge_dictionaries(headers, self._headers())
+        else:
+            headers = self._headers()
+
         try:
-            return self.session().post(url, json=body, headers=self._headers())
+            return self.session().post(url, json=body, headers=headers)
         except getattr(requests.exceptions, 'RequestException') as inst:
             self.module.fail_json(msg=inst.message)
 
-    def post_contents(self, url, file_contents=None, headers={}, **kwargs):
+    def post_contents(self, url, file_contents=None, headers=None, **kwargs):
+        if headers:
+            headers = self.merge_dictionaries(headers, self._headers())
+        else:
+            headers = self._headers()
+
         try:
-            return self.session().post(url, data=file_contents, headers=self._headers())
+            return self.session().post(url, data=file_contents, headers=headers)
         except getattr(requests.exceptions, 'RequestException') as inst:
             self.module.fail_json(msg=inst.message)
 


### PR DESCRIPTION
Ansible isn't currently testing fixes against the module_utils file. There was an issue and this will fix it.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
