### PR TITLE
Add update mask support to uptimeChecks

### DIFF
--- a/products/monitoring/terraform.yaml
+++ b/products/monitoring/terraform.yaml
@@ -104,6 +104,7 @@ overrides: !ruby/object:Provider::Overrides::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/self_link_as_name.erb
       post_create: templates/terraform/post_create/set_computed_name.erb
+      pre_update: "templates/terraform/pre_update/update_mask.erb"
     properties:
       httpCheck.authInfo.password: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         sensitive: true


### PR DESCRIPTION
Add update mask support for uptimeChecks

Fixes the regression bug introduced in https://github.com/GoogleCloudPlatform/magic-modules/pull/1129

<!-- A summary of the changes in this commit goes here -->

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
