### PR TITLE
Adding labels based on downstreams created

### DIFF
--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -365,6 +365,7 @@ jobs:
                 label: downstream-generated
                 path: mm-initial-pr
                 comment: magic-modules-with-comment/pr_comment
+                label_file: magic-modules-with-comment/label_file
             get_params:
                 skip_clone: true
 

--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -20,7 +20,7 @@ resource_types:
       type: docker-image
       source:
           repository: gcr.io/magic-modules/concourse-github-pr-resource
-          tag: '1.0'
+          tag: '1.1'
 
 resources:
     - name: magic-modules

--- a/.ci/magic-modules/create-pr.sh
+++ b/.ci/magic-modules/create-pr.sh
@@ -119,9 +119,9 @@ EOF
 
   # Create Labels list with the comma-separated list of labels for this PR
   if [ -z "$LABELS" ]; then
-    echo $LABELS > ./label_file
+    printf "%s" "$LABELS" > ./label_file
   else
-    echo "no-op" > ./label_file
+    printf "%s" "no-op" > ./label_file
   fi
 
 else

--- a/.ci/magic-modules/create-pr.sh
+++ b/.ci/magic-modules/create-pr.sh
@@ -73,7 +73,7 @@ if [ "$BRANCH_NAME" = "$ORIGINAL_PR_BRANCH" ]; then
     git checkout -b "$BRANCH_NAME"
     if ANSIBLE_PR=$(hub pull-request -b "$ANSIBLE_REPO_USER/ansible:devel" -F ./downstream_body); then
       DEPENDENCIES="${DEPENDENCIES}depends: $ANSIBLE_PR ${NEWLINE}"
-        LABELS="${LABELS}ansible,"
+      LABELS="${LABELS}ansible,"
     else
       echo "Ansible - did not generate a PR."
     fi
@@ -119,9 +119,9 @@ EOF
 
   # Create Labels list with the comma-separated list of labels for this PR
   if [ -z "$LABELS" ]; then
-    printf "%s" "$LABELS" > ./label_file
-  else
     printf "%s" "no-op" > ./label_file
+  else
+    printf "%s" "$LABELS" > ./label_file
   fi
 
 else


### PR DESCRIPTION
This fixes #124 and will help us build great changelogs for Ansible 

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
