### PR TITLE
Add ResourceRefs for Compute Route.

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2943,9 +2943,9 @@ objects:
         description: 'A list of instance tags to which this route applies.'
         item_type: Api::Type::String
         input: true
-      # TODO(nelsonjr): Make this a ResourceRef when Gateway is submitted.
       - !ruby/object:Api::Type::String
         name: 'nextHopGateway'
+        input: true
         description: |
           URL to a gateway that should handle matching packets.
 
@@ -2956,10 +2956,11 @@ objects:
           global/gateways/default-internet-gateway
           * projects/project/global/gateways/default-internet-gateway
           * global/gateways/default-internet-gateway
-        input: true
-      # TODO(nelsonjr): Make this a ResourceRef when Instance is submitted.
-      - !ruby/object:Api::Type::String
+      - !ruby/object:Api::Type::ResourceRef
         name: 'nextHopInstance'
+        resource: 'Instance'
+        imports: 'selfLink'
+        input: true
         description: |
           URL to an instance that should handle matching packets.
           You can specify this as a full or partial URL. For example:
@@ -2968,7 +2969,6 @@ objects:
           instances/instance
           * projects/project/zones/zone/instances/instance
           * zones/zone/instances/instance
-        input: true
       - !ruby/object:Api::Type::String
         name: 'nextHopIp'
         description: |
@@ -2978,9 +2978,9 @@ objects:
         name: 'nextHopVpnTunnel'
         resource: 'VpnTunnel'
         imports: 'selfLink'
+        input: true
         description: |
           URL to a VpnTunnel that should handle matching packets.
-        input: true
       - !ruby/object:Api::Type::String
         name: 'nextHopNetwork'
         output: true

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -541,8 +541,6 @@ overrides: !ruby/object:Provider::Overrides::ResourceOverrides
           * `global/gateways/default-internet-gateway`
           * The string `default-internet-gateway`.
       nextHopInstance: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
-        diff_suppress_func: 'compareSelfLinkOrResourceName'
-        custom_expand: templates/terraform/custom_expand/route_instance.erb
         # Description here is overridden because puppet won't compile if you ask
         # it to include docs greater than 80 characters.
         description: |+
@@ -552,7 +550,6 @@ overrides: !ruby/object:Provider::Overrides::ResourceOverrides
           * `projects/project/zones/zone/instances/instance`
           * `zones/zone/instances/instance`
           * Just the instance name, with the zone in `next_hop_instance_zone`.
-          
       tags: !ruby/object:Provider::Overrides::Terraform::PropertyOverride
         custom_expand: templates/terraform/custom_expand/set_to_list.erb
         is_set: true


### PR DESCRIPTION
We were failing some tests due to self link stability, turns out the resources weren't ResourceRefs because some old TODOs weren't completed.

Remove the reference to `Gateway` being added to MM because to my best knowledge that is not a GCP resource- only `default-internet-gateway` can be configured.

-----------------------------------------------------------------
# [all]
## [terraform]
Fix self link stability issues in google_compute_route
### [terraform-beta]
## [ansible]
## [inspec]
