### PR TITLE
Add signoff for inspec repo commits

### DIFF
--- a/.ci/magic-modules/generate-inspec.sh
+++ b/.ci/magic-modules/generate-inspec.sh
@@ -36,7 +36,7 @@ git config --global user.name "Modular Magician"
 
 git add -A
 # Set the "author" to the commit's real author.
-git commit -m "$INSPEC_COMMIT_MSG" --author="$LAST_COMMIT_AUTHOR" || true  # don't crash if no changes
+git commit -m "$INSPEC_COMMIT_MSG" --author="$LAST_COMMIT_AUTHOR" --signoff || true  # don't crash if no changes
 git checkout -B "$(cat ../../branchname)"
 
 apply_patches "$PATCH_DIR/modular-magician/inspec-gcp" "$INSPEC_COMMIT_MSG" "$LAST_COMMIT_AUTHOR" "master"


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Magician will sign commits made on InSpec branches
<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
