### PR TITLE
[Terraform-Beta] Enable flexible pod CIDR for GKE clusters.

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -656,6 +656,13 @@ func resourceContainerCluster() *schema.Resource {
 				Computed: true,
 				Type: schema.TypeString,
 			},
+
+			"default_max_pods_per_node": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
 <% end -%>
 		},
 	}
@@ -711,6 +718,12 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		MasterAuth:     expandMasterAuth(d.Get("master_auth")),
 		ResourceLabels: expandStringMap(d, "resource_labels"),
 	}
+
+<% unless version == 'ga' -%>
+	if v, ok := d.GetOk("default_max_pods_per_node"); ok {
+		cluster.DefaultMaxPodsConstraint = expandDefaultMaxPodsConstraint(v)
+	}
+<% end -%>
 
 	// Only allow setting node_version on create if it's set to the equivalent master version,
 	// since `InitialClusterVersion` only accepts valid master-style versions.
@@ -889,6 +902,9 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("tpu_ipv4_cidr_block", cluster.TpuIpv4CidrBlock)
 	if err := d.Set("cluster_autoscaling", flattenClusterAutoscaling(cluster.Autoscaling)); err != nil {
 		return err
+	}
+	if cluster.DefaultMaxPodsConstraint != nil {
+		d.Set("default_max_pods_per_node", cluster.DefaultMaxPodsConstraint.MaxPodsPerNode)
 	}
 <% else -%>
 	if err := d.Set("cluster_autoscaling", nil); err != nil {

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1833,6 +1833,16 @@ func expandPodSecurityPolicyConfig(configured interface{}) *containerBeta.PodSec
 <% end -%>
 }
 
+func expandDefaultMaxPodsConstraint(v interface{}) *containerBeta.MaxPodsConstraint {
+	if v == nil {
+		return nil
+	}
+
+	return &containerBeta.MaxPodsConstraint{
+		MaxPodsPerNode: int64(v.(int)),
+	}
+}
+
 func flattenNetworkPolicy(c *containerBeta.NetworkPolicy) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	if c != nil {

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1465,6 +1465,29 @@ func TestAccContainerCluster_withBinaryAuthorization(t *testing.T) {
 		},
 	})
 }
+
+func TestAccContainerCluster_withFlexiblePodCIDR(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withFlexiblePodCIDR(cluster),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_flexible_cidr",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
 <% end -%>
 
 func testAccCheckContainerClusterDestroy(s *terraform.State) error {
@@ -2806,5 +2829,56 @@ resource "google_container_cluster" "with_binary_authorization" {
 	enable_binary_authorization = %v
 }
 `, clusterName, enabled)
+}
+
+func testAccContainerCluster_withFlexiblePodCIDR(cluster string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "container_network" {
+	name = "container-net-%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "container_subnetwork" {
+	name                     = "${google_compute_network.container_network.name}"
+	network                  = "${google_compute_network.container_network.name}"
+	ip_cidr_range            = "10.0.35.0/24"
+	region                   = "us-central1"
+	private_ip_google_access = true
+
+	secondary_ip_range {
+		range_name    = "pod"
+		ip_cidr_range = "10.1.0.0/19"
+	}
+
+	secondary_ip_range {
+		range_name    = "svc"
+		ip_cidr_range = "10.2.0.0/22"
+	}
+}
+
+resource "google_container_cluster" "with_flexible_cidr" {
+	name = "%s"
+	zone = "us-central1-a"
+	initial_node_count = 3
+
+	network = "${google_compute_network.container_network.name}"
+	subnetwork = "${google_compute_subnetwork.container_subnetwork.name}"
+
+	private_cluster_config {
+		enable_private_endpoint = true
+		enable_private_nodes = true
+		master_ipv4_cidr_block = "10.42.0.0/28"
+	}
+
+	master_authorized_networks_config { cidr_blocks = [] }
+	
+	ip_allocation_policy {
+		cluster_secondary_range_name  = "${google_compute_subnetwork.container_subnetwork.secondary_ip_range.0.range_name}"
+		services_secondary_range_name = "${google_compute_subnetwork.container_subnetwork.secondary_ip_range.1.range_name}"
+	}
+
+	default_max_pods_per_node = 100
+}
+`, cluster, cluster)
 }
 <% end -%>


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Adds default_max_pods_per_node to google_container_cluster schema.

<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
Adds default_max_pods_per_node to google_container_cluster schema. 
## [ansible]
## [inspec]
