### PR TITLE
add magician step to run affected terraform tests

### DIFF
--- a/.ci/acceptance-tests/terraform-acceptance.sh
+++ b/.ci/acceptance-tests/terraform-acceptance.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -e
+set -x
+
+export GOOGLE_CREDENTIALS_FILE="/tmp/google-account.json"
+export GOOGLE_REGION="us-central1"
+export GOOGLE_ZONE="us-central1-a"
+# Setup GOPATH
+export GOPATH=${PWD}/go
+
+# CI sets the contents of our json account secret in our environment; dump it
+# to disk for use in tests.
+set +x
+echo "${GOOGLE_JSON_ACCOUNT}" > $GOOGLE_CREDENTIALS_FILE
+set -x
+
+# Create GOPATH structure
+mkdir -p "${GOPATH}/src/github.com/terraform-providers"
+ln -s "${PWD}/magic-modules/build/$SHORT_NAME" "${GOPATH}/src/github.com/terraform-providers/$PROVIDER_NAME"
+
+cd "${GOPATH}/src/github.com/terraform-providers/$PROVIDER_NAME"
+
+git diff HEAD~ > tmp.diff
+OUTPUT=( $(go run scripts/affectedtests/affectedtests.go -diff tmp.diff) )
+rm tmp.diff
+
+if [ ${#OUTPUT[@]} -eq 0 ]; then
+	echo "No tests to run"
+else
+	make testacc TEST=./$TEST_DIR TESTARGS="-run=\"$( IFS=$'|'; echo "${OUTPUT[*]}" )\""
+fi

--- a/.ci/acceptance-tests/terraform-acceptance.yml
+++ b/.ci/acceptance-tests/terraform-acceptance.yml
@@ -1,0 +1,22 @@
+platform: linux
+params:
+  # Params are set as environment variables when the run part is executed.
+  # Here we use (()) notation to indicate that we're using a credhub secret.
+  GOOGLE_JSON_ACCOUNT: ((terraform-integration-key))
+  GOOGLE_PROJECT: ((terraform-integration-project))
+  GOOGLE_ORG: ((terraform-integration-org))
+  GOOGLE_BILLING_ACCOUNT: ((terraform-integration-billing-account))
+  GOOGLE_PROJECT_NUMBER: ((terraform-integration-project-number))
+  TEST_DIR: ""
+  PROVIDER_NAME: ""
+  SHORT_NAME: ""
+  # TODO: GOOGLE_BILLING_ACCOUNT_2
+inputs:
+  - name: magic-modules
+image_resource:
+  type: docker-image
+  source:
+    repository: golang
+    tag: '1.11'
+run:
+  path: magic-modules/.ci/acceptance-tests/terraform-acceptance.sh

--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -368,6 +368,24 @@ jobs:
                 label_file: magic-modules-with-comment/label_file
             get_params:
                 skip_clone: true
+    - name: terraform-acceptance-tests
+      plan:
+        - get: magic-modules
+          version: every
+          trigger: true
+          params:
+              submodules: [{{','.join(vars.terraform_submodules)}}]
+          passed: [create-prs]
+        - aggregate:
+          {% for v in vars.terraform_v.itervalues() %}
+          - task: test-{{v.short_name}}
+            file: magic-modules/.ci/acceptance-tests/terraform-acceptance.yml
+            params:
+              PROVIDER_NAME: {{v.provider_name}}
+              SHORT_NAME: {{v.short_name}}
+              TEST_DIR: {{v.test_dir}}
+          {% endfor %}
+
 
     - name: merge-prs
       plan:


### PR DESCRIPTION
<!-- A summary of the changes in this commit goes here -->
Should be merged after https://github.com/GoogleCloudPlatform/magic-modules/pull/1151 so TPGB has the script we're running.

For now I just put it in a step by itself (after the PR is created so it doesn't prevent PR creation), but I think it would be neat if in the future it would post to the PR what the output from running the tests was.

I still don't consider myself a concourse or bash expert, so happy to have any suggestions on how to make this better.
<!--
Changes per downstream repository.  For each repository that you
expect to have changed, find the [tag] and write your commit
message beneath it.  More-specific tags replace less-specific tags.
For example, if you provide a message under [all], a message under
[puppet], and a message under [puppet-dns], the Terraform repository
will have the resulting commit made using the [all] message, the
Puppet Compute repository will have its commit made using [puppet],
and the Puppet DNS repository will have its commit made using
[puppet-dns].  You can delete unused tags, but you don't need to.

The structure of the PR body is important to our CI system!
The comments can be deleted, but if you want to make the downstream
commits sensible, you'll need to leave the dashed line separating
this PR's changes from the commit messages for downstream commits.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
ci only, no changes expected
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
