### PR TITLE
[Terraform]: Add timePartitioning.requirePartitionFilter to bigquery table

### DIFF
--- a/third_party/terraform/resources/resource_bigquery_table.go
+++ b/third_party/terraform/resources/resource_bigquery_table.go
@@ -142,13 +142,21 @@ func resourceBigQueryTable() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"DAY"}, false),
 						},
 
-						// Type: [Optional] The field used to determine how to create a time-based
+						// Field: [Optional] The field used to determine how to create a time-based
 						// partition. If time-based partitioning is enabled without this value, the
 						// table is partitioned based on the load time.
 						"field": {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
+						},
+
+						// RequirePartitionFilter: [Optional] If set to true, queries over this table
+						// require a partition filter that can be used for partition elimination to be
+						// specified.
+						"require_partition_filter": {
+							Type:     schema.TypeBool,
+							Optional: true,
 						},
 					},
 				},
@@ -436,6 +444,10 @@ func expandTimePartitioning(configured interface{}) *bigquery.TimePartitioning {
 		tp.ExpirationMs = int64(v.(int))
 	}
 
+	if v, ok := raw["require_partition_filter"]; ok {
+		tp.RequirePartitionFilter = v.(bool)
+	}
+
 	return tp
 }
 
@@ -448,6 +460,10 @@ func flattenTimePartitioning(tp *bigquery.TimePartitioning) []map[string]interfa
 
 	if tp.ExpirationMs != 0 {
 		result["expiration_ms"] = tp.ExpirationMs
+	}
+
+	if tp.RequirePartitionFilter == true {
+		result["require_partition_filter"] = tp.RequirePartitionFilter
 	}
 
 	return []map[string]interface{}{result}

--- a/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -122,7 +122,8 @@ resource "google_bigquery_table" "test" {
 
   time_partitioning {
     type = "DAY"
-    field = "ts"	
+    field = "ts"
+    require_partition_filter = true
   }
 
   schema = <<EOH

--- a/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -88,6 +88,10 @@ The `time_partitioning` block supports:
 * `type` - (Required) The only type supported is DAY, which will generate
     one partition per day based on data loading time.
 
+* `require_partition_filter` - (Optional) If set to true, queries over this table
+    require a partition filter that can be used for partition elimination to be
+    specified.
+
 The `view` block supports:
 
 * `query` - (Required) A query that BigQuery executes when the view is referenced.


### PR DESCRIPTION
Replacing https://github.com/terraform-providers/terraform-provider-google/pull/2288 because the primary branch changes make using that PR infeasible.

-----------------------------------------------------------------
# [all]
## [terraform]
Add timePartitioning.requirePartitionFilter to bigquery table
### [terraform-beta]
## [ansible]
## [inspec]
