### PR TITLE
Start refactoring product/resource names in MM

### DIFF
--- a/api/product.rb
+++ b/api/product.rb
@@ -19,13 +19,37 @@ module Api
   # Repesents a product to be managed
   class Product < Api::Object::Named
     # Inherited:
-    # The full name of the product: `Google Compute Engine`
+    # The name of the product's API capitalised in the appropriate places.
+    # This isn't just the API name because it doesn't meaningfully separate
+    # words in the api name - "accesscontextmanager" vs "AccessContextManager"
+    # Example inputs: "Compute", "AccessContextManager"
     # attr_reader :name
 
-    attr_reader :objects
+    # The full name of the GCP product; eg "Google Cloud Bigtable"
+    attr_reader :display_name
 
-    # The prefix to uniquely identify the types
-    attr_reader :prefix
+    # The name of the product's API; "compute", "accesscontextmanager"
+    def api_name
+      name.delete(' ').downcase
+    end
+
+    # The prefix to uniquely identify the types. This is mostly a legacy thing.
+    # It will output the name in all lowercase and no spaces, prefix with a g
+    def prefix
+      'g' + name.delete(' ').downcase
+    end
+
+    # The product full name is the "display name" in string form intended for
+    # users to read in documentation; "Google Compute Engine", "Cloud Bigtable"
+    def product_full_name
+      if !display_name.nil?
+        display_name
+      else
+        name.underscore.humanize
+      end
+    end
+
+    attr_reader :objects
 
     # The list of permission scopes available for the service
     # For example: `https://www.googleapis.com/auth/compute`
@@ -43,9 +67,9 @@ module Api
     def validate
       super
       set_variables @objects, :__product
+      check_optional_property :display_name, String
       check_property :objects, Array
       check_property_list :objects, Api::Resource
-      check_property :prefix, String
       check_property :scopes, ::Array
       check_property_list :scopes, String
 

--- a/api/type.rb
+++ b/api/type.rb
@@ -422,10 +422,6 @@ module Api
       end
       include Fields
 
-      def out_type
-        resource_ref.out_name
-      end
-
       def validate
         super
         @name = @resource if @name.nil?

--- a/products/accesscontextmanager/api.yaml
+++ b/products/accesscontextmanager/api.yaml
@@ -12,8 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Access Context Manager
-prefix: gaccesscontextmanager
+name: AccessContextManager
 versions:
   - !ruby/object:Api::Product::Version
     name: beta

--- a/products/accesscontextmanager/terraform.yaml
+++ b/products/accesscontextmanager/terraform.yaml
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 --- !ruby/object:Provider::Terraform::Config
-name: AccessContextManager
 overrides: !ruby/object:Provider::Overrides::ResourceOverrides
   AccessPolicy: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     import_format: ["{{name}}"]

--- a/products/appengine/api.yaml
+++ b/products/appengine/api.yaml
@@ -12,8 +12,8 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Google App Engine
-prefix: gappengine
+name: AppEngine
+display_name: Google App Engine
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/appengine/terraform.yaml
+++ b/products/appengine/terraform.yaml
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Provider::Terraform::Config
+legacy_name: "appengine"
 overrides: !ruby/object:Provider::ResourceOverrides
   FirewallRule: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{project}}/{{priority}}"

--- a/products/auth/api.yaml
+++ b/products/auth/api.yaml
@@ -12,8 +12,8 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Bundle
-name: Google Cloud Auth
-prefix: gauth
+name: Auth
+display_name: Google Cloud Auth
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/bigquery/api.yaml
+++ b/products/bigquery/api.yaml
@@ -12,8 +12,8 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Google Cloud BigQuery
-prefix: gbigquery
+name: BigQuery
+display_name: Google Cloud BigQuery
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/binaryauthorization/api.yaml
+++ b/products/binaryauthorization/api.yaml
@@ -12,8 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Binary Authorization
-prefix: gbinaryauthorization
+name: BinaryAuthorization
 versions:
   - !ruby/object:Api::Product::Version
     name: beta

--- a/products/binaryauthorization/terraform.yaml
+++ b/products/binaryauthorization/terraform.yaml
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 --- !ruby/object:Provider::Terraform::Config
-name: BinaryAuthorization
 overrides: !ruby/object:Provider::Overrides::ResourceOverrides
   Attestor: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     import_format: ["projects/{{project}}/attestors/{{name}}"]

--- a/products/cloudbuild/api.yaml
+++ b/products/cloudbuild/api.yaml
@@ -12,8 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Cloud Build
-prefix: gcloudbuild
+name: CloudBuild
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/cloudbuild/terraform.yaml
+++ b/products/cloudbuild/terraform.yaml
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Provider::Terraform::Config
+legacy_name: 'cloudbuild'
 overrides: !ruby/object:Provider::ResourceOverrides
   Trigger: !ruby/object:Provider::Terraform::ResourceOverride
     # import by default only works with old-style self links ending in a name

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -14,8 +14,8 @@
 # TODO(nelsonjr): Make all Zone and Region resource ref
 
 --- !ruby/object:Api::Product
-name: Google Compute Engine
-prefix: gcompute
+name: Compute
+display_name: Google Compute Engine
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -12,8 +12,8 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Google Container Engine
-prefix: gcontainer
+name: Container
+display_name: Google Kubernetes Engine
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/containeranalysis/api.yaml
+++ b/products/containeranalysis/api.yaml
@@ -12,8 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Container Analysis
-prefix: gcontaineranalysis
+name: ContainerAnalysis
 versions:
   - !ruby/object:Api::Product::Version
     name: beta

--- a/products/containeranalysis/terraform.yaml
+++ b/products/containeranalysis/terraform.yaml
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 --- !ruby/object:Provider::Terraform::Config
-name: ContainerAnalysis
 overrides: !ruby/object:Provider::Overrides::ResourceOverrides
   Note: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     import_format: ["projects/{{project}}/notes/{{name}}"]

--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -12,8 +12,8 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Google Cloud DNS
-prefix: gdns
+name: Dns
+display_name: Google Cloud DNS
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/filestore/api.yaml
+++ b/products/filestore/api.yaml
@@ -12,14 +12,14 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Google Cloud Filestore
 # There is a problem here - the generated api is called 'file', and that's
-# a bad name for the library.  So we set the name to gfilestore, and
+# a bad name for the library.  So we set the name to Filestore, and
 # that means that Terraform in particular is going to try to import
 # 'filestore'.  But the library is called 'file', so instead we need to
 # include a small hack to rename the library - see
 # templates/terraform/constants/filestore.erb.
-prefix: gfilestore
+name: Filestore
+display_name: Google Cloud Filestore
 versions:
   - !ruby/object:Api::Product::Version
     name: beta

--- a/products/iam/api.yaml
+++ b/products/iam/api.yaml
@@ -14,7 +14,7 @@
 # TODO(nelsonjr): Make all Zone and Region resource ref
 
 --- !ruby/object:Api::Product
-name: IAM
+name: Iam
 display_name: Google Cloud IAM
 versions:
   - !ruby/object:Api::Product::Version

--- a/products/iam/api.yaml
+++ b/products/iam/api.yaml
@@ -14,8 +14,8 @@
 # TODO(nelsonjr): Make all Zone and Region resource ref
 
 --- !ruby/object:Api::Product
-name: Google Cloud IAM
-prefix: giam
+name: IAM
+display_name: Google Cloud IAM
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/monitoring/api.yaml
+++ b/products/monitoring/api.yaml
@@ -11,7 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 --- !ruby/object:Api::Product
-name: Stackdriver Monitoring and Alerting
+name: Monitoring
+display_name: Stackdriver Monitoring and Alerting
 prefix: gmonitoring
 versions:
   - !ruby/object:Api::Product::Version

--- a/products/pubsub/api.yaml
+++ b/products/pubsub/api.yaml
@@ -12,8 +12,8 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Google Cloud Pub/Sub
-prefix: gpubsub
+name: Pubsub
+display_name: Google Cloud Pub/Sub
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/redis/api.yaml
+++ b/products/redis/api.yaml
@@ -12,8 +12,8 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Google Cloud Memorystore for Redis
-prefix: gredis
+name: Redis
+display_name: Google Cloud Memorystore for Redis
 versions:
   - !ruby/object:Api::Product::Version
     name: beta

--- a/products/resourcemanager/api.yaml
+++ b/products/resourcemanager/api.yaml
@@ -12,8 +12,8 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Google Cloud Resource Manager
-prefix: gresourcemanager
+name: ResourceManager
+display_name: Google Cloud Resource Manager
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/resourcemanager/terraform.yaml
+++ b/products/resourcemanager/terraform.yaml
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 --- !ruby/object:Provider::Terraform::Config
-name: ResourceManager
 overrides: !ruby/object:Provider::Overrides::ResourceOverrides
   Project: !ruby/object:Provider::Overrides::Terraform::ResourceOverride
     exclude: true

--- a/products/sourcerepo/api.yaml
+++ b/products/sourcerepo/api.yaml
@@ -12,8 +12,8 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Cloud Source Repositories
-prefix: gsourcerepo
+name: SourceRepo
+display_name: Cloud Source Repositories
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/sourcerepo/terraform.yaml
+++ b/products/sourcerepo/terraform.yaml
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Provider::Terraform::Config
+legacy_name: 'sourcerepo'
 overrides: !ruby/object:Provider::ResourceOverrides
   Repository: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: '{{project}}/{{name}}'

--- a/products/spanner/api.yaml
+++ b/products/spanner/api.yaml
@@ -12,8 +12,8 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Google Spanner
-prefix: gspanner
+name: Spanner
+display_name: Cloud Spanner
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/sql/api.yaml
+++ b/products/sql/api.yaml
@@ -12,8 +12,8 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Google Cloud SQL
-prefix: gsql
+name: SQL
+display_name: Google Cloud SQL
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/sql/api.yaml
+++ b/products/sql/api.yaml
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: SQL
+name: Sql
 display_name: Google Cloud SQL
 versions:
   - !ruby/object:Api::Product::Version

--- a/products/storage/api.yaml
+++ b/products/storage/api.yaml
@@ -12,8 +12,8 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Google Cloud Storage
-prefix: gstorage
+name: Storage
+display_name: Google Cloud Storage
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/provider/config.rb
+++ b/provider/config.rb
@@ -26,6 +26,8 @@ module Provider
     # Overrides for datasources
     attr_reader :datasources
     attr_reader :files
+
+    # TODO(rileykarson): update this
     # Product names are complicated in MagicModules.  They are given by
     # product.prefix, which is in the format 'g<nameofproduct>', e.g.
     # gcompute or gresourcemanager.  This is munged in many places.
@@ -39,6 +41,11 @@ module Provider
     # instead is passed directly to the template as `product_ns` if
     # set.  Otherwise, the normal logic applies.
     attr_reader :name
+
+    # Some tool-specific names may be in use, and they won't all match;
+    # For Terraform, some products use the API client name w/o spaces and
+    # others use spaces. Eg: "app_engine" vs "appengine".
+    attr_reader :legacy_name
 
     # List of files to copy or compile into target module
     class Files < Api::Object

--- a/provider/config.rb
+++ b/provider/config.rb
@@ -27,21 +27,6 @@ module Provider
     attr_reader :datasources
     attr_reader :files
 
-    # TODO(rileykarson): update this
-    # Product names are complicated in MagicModules.  They are given by
-    # product.prefix, which is in the format 'g<nameofproduct>', e.g.
-    # gcompute or gresourcemanager.  This is munged in many places.
-    # Some examples:
-    #   - prefix[1:-1] ('compute' / 'resourcemanager') for the
-    #     directory to fetch chef / puppet examples.
-    #   - camelCase(prefix[1:-1]) for resource namespaces.
-    #   - TitleCase(prefix[1:-1]) for resource names in terraform.
-    #   - prefix[1:-1] again, for working with libraries directly.
-    # This override does not change any of those inner workings, but
-    # instead is passed directly to the template as `product_ns` if
-    # set.  Otherwise, the normal logic applies.
-    attr_reader :name
-
     # Some tool-specific names may be in use, and they won't all match;
     # For Terraform, some products use the API client name w/o spaces and
     # others use spaces. Eg: "app_engine" vs "appengine".

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -148,8 +148,7 @@ module Provider
             compiler: compiler,
             output_folder: output_folder,
             out_file: target_file,
-            prop_ns_dir: @api.prefix[1..-1].downcase,
-            product_ns: @api.prefix[1..-1].camelize(:upper)
+            product_ns: @api.name
           )
         )
 
@@ -227,11 +226,7 @@ module Provider
     end
 
     def generate_resource_file(data)
-      product_ns = if @config.name.nil?
-                     data[:object].__product.prefix[1..-1].camelize(:upper)
-                   else
-                     @config.name
-                   end
+      product_ns = data[:object].__product.name.delete(' ')
       generate_file(data.clone.merge(
         # Override with provider specific template for this object, if needed
         template: data[:default_template],

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -107,8 +107,7 @@ module Provider
           data[:output_folder],
           { prop[:target] => prop[:source] },
           {
-            product_ns: data[:product_name].camelize(:upper),
-            prop_ns_dir: data[:product_name].downcase
+            product_ns: data[:product_name].camelize(:upper)
           }.merge((prop[:overrides] || {}))
         )
       end

--- a/spec/product_spec.rb
+++ b/spec/product_spec.rb
@@ -19,29 +19,6 @@ describe Api::Product do
     it { is_expected.to raise_error(StandardError, /Missing 'name'/) }
   end
 
-  context 'requires prefix' do
-    subject do
-      lambda do
-        product('name: "foo"',
-                'versions:',
-                '  - !ruby/object:Api::Product::Version',
-                '    name: ga',
-                '    base_url: "http://foo/var/"',
-                'objects:',
-                '  - !ruby/object:Api::Resource',
-                '    kind: foo#resource',
-                '    base_url: myres/',
-                '    description: foo',
-                '    name: "res1"',
-                '    properties:',
-                '      - !ruby/object:Api::Type',
-                '        description: foo',
-                '        name: var').validate
-      end
-    end
-    it { is_expected.to raise_error(StandardError, /Missing 'prefix'/) }
-  end
-
   context 'requires versions' do
     subject do
       lambda do

--- a/spec/type_spec.rb
+++ b/spec/type_spec.rb
@@ -243,23 +243,4 @@ describe Api::Type::ResourceRef do
 
     it { is_expected.to raise_error(StandardError, error) }
   end
-
-  context 'returns referenced type' do
-    let(:product) { Api::Compiler.new('spec/data/good-file.yaml').run }
-
-    before { product.validate }
-
-    subject do
-      product.objects.collect(&:parameters)
-             .flatten
-             .select { |p| p.class <= Api::Type::ResourceRef }
-    end
-
-    it { is_expected.to have_attributes(length: 1) }
-    it 'matches reference type' do
-      is_expected.to satisfy do |value|
-        value[0].out_type == 'myproduct_referenced_resource'
-      end
-    end
-  end
 end

--- a/templates/inspec/singular_resource.erb
+++ b/templates/inspec/singular_resource.erb
@@ -25,7 +25,7 @@
 -%>
 <%= lines(emit_requires(requires)) -%>
 
-# A provider to manage <%= @api.name -%> resources.
+# A provider to manage <%= @api.product_full_name -%> resources.
 class <%= object.name -%> < GcpResourceBase
   name '<%= resource_name(object, product_ns) -%>'
   desc '<%= object.name -%>'

--- a/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/templates/terraform/examples/base_configs/test_file.go.erb
@@ -10,9 +10,12 @@ import (
   "github.com/hashicorp/terraform/helper/resource"
 )
 <%
-  api_name = @config.name || product_ns
-	resource_name = api_name + object.name
-  terraform_name = "google_" + resource_name.underscore
+resource_name = product_ns + object.name
+if @config.legacy_name.nil?
+	terraform_name = "google_" + (product_ns + object.name).underscore
+else
+	terraform_name = "google_" + @config.legacy_name + '_' + object.name.underscore
+end
 %>
 <% object.example.reject(&:skip_test).each do |example| -%>
 <%

--- a/templates/terraform/provider_gen.erb
+++ b/templates/terraform/provider_gen.erb
@@ -18,11 +18,15 @@ package google
 
 import "github.com/hashicorp/terraform/helper/schema"
 
-<% api_name = @config.name || product_ns -%>
-
-var Generated<%= api_name -%>ResourcesMap = map[string]*schema.Resource{
+var Generated<%= product_ns -%>ResourcesMap = map[string]*schema.Resource{
 <% product.objects.reject { |r| r.exclude }.each do |object| -%>
-<% resource_name = api_name + object.name -%>
-	"google_<%= resource_name.underscore -%>": resource<%= resource_name -%>(),
+<%
+if @config.legacy_name.nil?
+	terraform_name = "google_" + (product_ns + object.name).underscore
+else
+	terraform_name = "google_" + @config.legacy_name + '_' + object.name.underscore
+end
+-%>
+	"<%= terraform_name -%>": resource<%= product_ns + object.name -%>(),
 <% end -%>
 }

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -36,20 +36,24 @@
     directly inserted from YAML.
 -%>
 <%
-  resource_name = product_ns.underscore.downcase + '_' + object.name.underscore
+  if @config.legacy_name.nil?
+    terraform_name = "google_" + (product_ns + object.name).underscore
+  else
+    terraform_name = "google_" + @config.legacy_name + '_' + object.name.underscore
+  end
   properties = object.all_user_properties
   timeouts = object.async.nil? ? Api::Timeouts.new : object.async.operation.timeouts
 -%>
 ---
 <%= lines(autogen_notice :yaml) -%>
 layout: "google"
-page_title: "Google: google_<%= resource_name -%>"
-sidebar_current: "docs-google-<%= resource_name.gsub("_", "-") -%>"
+page_title: "Google: <%= terraform_name -%>"
+sidebar_current: "docs-<%= terraform_name.gsub("_", "-") -%>"
 description: |-
 <%= indent(object.description.first_sentence, 2) %>
 ---
 
-# google\_<%= resource_name.gsub("_", "\\_") %>
+# <%= terraform_name.gsub("_", "\\_") %>
 
 <%= lines(object.description) -%>
 
@@ -165,7 +169,7 @@ This resource provides the following
 
 ```
 <% import_id_formats(object).each do |id_format| -%>
-$ terraform import <% if object.min_version.name == 'beta' %>-provider=google-beta <% end -%>google_<%= resource_name -%>.default <%= id_format %>
+$ terraform import <% if object.min_version.name == 'beta' %>-provider=google-beta <% end -%><%= terraform_name -%>.default <%= id_format %>
 <% end -%>
 ```
 

--- a/third_party/terraform/tests/resource_cloudbuild_trigger_test.go
+++ b/third_party/terraform/tests/resource_cloudbuild_trigger_test.go
@@ -13,7 +13,7 @@ func TestAccCloudBuildTrigger_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudbuildTriggerDestroy,
+		CheckDestroy: testAccCheckCloudBuildTriggerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testGoogleCloudBuildTrigger_basic(),

--- a/third_party/terraform/tests/resource_sourcerepo_repository_test.go
+++ b/third_party/terraform/tests/resource_sourcerepo_repository_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccSourcerepoRepository_basic(t *testing.T) {
+func TestAccSourceRepoRepository_basic(t *testing.T) {
 	t.Parallel()
 
 	repositoryName := fmt.Sprintf("source-repo-repository-test-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckSourcerepoRepositoryDestroy,
+		CheckDestroy: testAccCheckSourceRepoRepositoryDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccSourceRepoRepository_basic(repositoryName),

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -126,13 +126,13 @@ func ResourceMapWithErrors() (map[string]*schema.Resource, error) {
 			GeneratedAccessContextManagerResourcesMap,
 			// end beta-only products
 			<% end -%>
-			GeneratedAppengineResourcesMap,
+			GeneratedAppEngineResourcesMap,
 			GeneratedComputeResourcesMap,
-			GeneratedCloudbuildResourcesMap,
+			GeneratedCloudBuildResourcesMap,
 			GeneratedDnsResourcesMap,
 			GeneratedRedisResourcesMap,
 			GeneratedResourceManagerResourcesMap,
-			GeneratedSourcerepoResourcesMap,
+			GeneratedSourceRepoResourcesMap,
 			GeneratedStorageResourcesMap,
 			GeneratedMonitoringResourcesMap,
 			map[string]*schema.Resource{


### PR DESCRIPTION
Part of https://github.com/GoogleCloudPlatform/magic-modules/issues/1055

This [whole refactor] isn't done yet, but this seemed like a generally sensible stopping point for a first PR; Terraform generates with only capitalization changes, and MM will generate Terraform resource names that make general sense. Also the Magician will make Inspec, Ansible changes that I'll fix if needed before review.

Basically, my goal with this PR is; 
* change name from the display name of the product to ~roughly~ the API name (filestore 😠), and generate prefix from that.
* Begin to remove `prefix` usages and use `api_name` instead.
* Introduce `product_full_name` for the single case that a similar string was in use in InSpec; Terraform will probably eventually use this to when I follow up after all this. Also `product_short_name` may exist by the end of these PRs - full would be "Google Cloud Shell", short would be "Cloud Shell".

-----------------------------------------------------------------
# [all]
## [terraform]
Capitalization changes in generated resources
### [terraform-beta]
## [ansible]
## [inspec]
