### PR TITLE
Creating label_file on second generation runs for the Magician

### DIFF
--- a/.ci/magic-modules/create-pr.sh
+++ b/.ci/magic-modules/create-pr.sh
@@ -149,4 +149,8 @@ I am (still) a robot that works on MagicModules PRs!
 I just wanted to let you know that your changes (as of commit $(git rev-parse --short HEAD~1)) have been included in your existing downstream PRs.
 EOF
 
+  # Create blank label file
+  printf "%s" "$LABELS" > ./label_file
+
+
 fi


### PR DESCRIPTION
Creating label_file on second generation runs for the Magician

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
Creating label_file on second generation runs for the Magician
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
