### PR TITLE
add only_third_party label to any PR with only third_party changes

### DIFF
--- a/.ci/magic-modules/create-pr.sh
+++ b/.ci/magic-modules/create-pr.sh
@@ -34,6 +34,14 @@ if [ "$BRANCH_NAME" = "$ORIGINAL_PR_BRANCH" ]; then
   NEWLINE=$'\n'
   # There is no existing PR - this is the first pass through the pipeline and
   # we will need to create a PR using 'hub'.
+
+  # Check the files between this commit and HEAD
+  # If they're only contained in third_party, add the third_party label.
+  if ! git diff --name-only HEAD^1 | grep -v "third_party"; then
+    LABELS="${LABELS}only_third_party,"
+  fi
+
+  # Terraform
   if [ -n "$TERRAFORM_REPO_USER" ]; then
     for VERSION in "${TERRAFORM_VERSIONS[@]}"; do
       IFS=":" read -ra TERRAFORM_DATA <<< "$VERSION"


### PR DESCRIPTION
There's a bunch of Terraform handwritten PRs that only concern TF people. It would be nice to tag those, so that non-TF folks can ignore them.

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
