### PR TITLE
Remove unnecessary branch manipulation

### DIFF
--- a/.ci/magic-modules/create-pr.sh
+++ b/.ci/magic-modules/create-pr.sh
@@ -133,22 +133,7 @@ EOF
   fi
 
 else
-  # This is the second-or-more pass through the pipeline - we need to overwrite
-  # the codegen-pr-* branch with the new updated code to update the existing
-  # PR, rather than create a new one.
-  git branch -f "$ORIGINAL_PR_BRANCH"
-
-  if [ -n "$TERRAFORM_REPO_USER" ]; then
-    for VERSION in "${TERRAFORM_VERSIONS[@]}"; do
-      IFS=":" read -ra TERRAFORM_DATA <<< "$VERSION"
-      PROVIDER_NAME="${TERRAFORM_DATA[0]}"
-      SUBMODULE_DIR="${TERRAFORM_DATA[1]}"
-      pushd "build/$SUBMODULE_DIR"
-      git branch -f "$ORIGINAL_PR_BRANCH"
-      popd
-    done
-  fi
-
+  # Just create the comment stating that existing PRs have been updated.
   # Note - we're interested in HEAD~1 here, not HEAD, because HEAD is the
   # generated code commit.  :)
   cat << EOF > ./pr_comment


### PR DESCRIPTION
@rambleraptor and I discovered that the branch manipulation here is unnecessary - the git resource pushes from HEAD at https://github.com/concourse/git-resource/blob/master/assets/out#L101, so the actual branch state of your repo is unimportant - this simplifies this code a little.

-----------------------------------------------------------------
# [all]
CI changes only.
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
