### PR TITLE
Fix AppEngine FirewallRule naming

### DIFF
--- a/products/appengine/terraform.yaml
+++ b/products/appengine/terraform.yaml
@@ -12,7 +12,6 @@
 # limitations under the License.
 
 --- !ruby/object:Provider::Terraform::Config
-legacy_name: "appengine"
 overrides: !ruby/object:Provider::ResourceOverrides
   FirewallRule: !ruby/object:Provider::Terraform::ResourceOverride
     id_format: "{{project}}/{{priority}}"
@@ -21,7 +20,7 @@ overrides: !ruby/object:Provider::ResourceOverrides
       pre_update: templates/terraform/pre_update/update_mask.erb
     example:
       - !ruby/object:Provider::Terraform::Examples
-        name: "appengine_firewall_rule_basic"
+        name: "app_engine_firewall_rule_basic"
         primary_resource_id: "rule"
         version: <%= version_name %>
         vars:

--- a/templates/terraform/examples/app_engine_firewall_rule_basic.tf.erb
+++ b/templates/terraform/examples/app_engine_firewall_rule_basic.tf.erb
@@ -9,7 +9,7 @@ resource "google_app_engine_application" "app" {
   location_id = "us-central"
 }
 
-resource "google_appengine_firewall_rule" "rule" {
+resource "google_app_engine_firewall_rule" "rule" {
   project = "${google_app_engine_application.app.project}"
   priority = 1000
   action = "ALLOW"

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -158,6 +158,9 @@
       <li<%%= sidebar_current("docs-google-app-engine-application") %>>
       <a href="/docs/providers/google/r/app_engine_application.html">google_app_engine_application</a>
       </li>
+      <li<%%= sidebar_current("docs-google-app-engine-firewall-rule") %>>
+      <a href="/docs/providers/google/r/appengine_firewall_rule.html">google_app_engine_firewall_rule</a>
+      </li>
     </ul>
     </li>
 


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/magic-modules/issues/1210

The generated html still has the wrong name- that will be fixed as part of https://github.com/GoogleCloudPlatform/magic-modules/issues/1055

-----------------------------------------------------------------
# [all]
## [terraform]
Rename (unreleased) google_appengine_firewall_rule to google_app_engine_firewall_rule
### [terraform-beta]
## [ansible]
## [inspec]
