### PR TITLE
Remove `prefix` from Api::Product

### DIFF
--- a/api/product.rb
+++ b/api/product.rb
@@ -33,12 +33,6 @@ module Api
       name.delete(' ').downcase
     end
 
-    # The prefix to uniquely identify the types. This is mostly a legacy thing.
-    # It will output the name in all lowercase and no spaces, prefix with a g
-    def prefix
-      'g' + name.delete(' ').downcase
-    end
-
     # The product full name is the "display name" in string form intended for
     # users to read in documentation; "Google Compute Engine", "Cloud Bigtable"
     def product_full_name

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -138,10 +138,6 @@ module Api
       end
     end
 
-    def out_name
-      [@__product.prefix, @name.underscore].join('_')
-    end
-
     def identity
       props = all_user_properties
       if @identity.nil?

--- a/api/type.rb
+++ b/api/type.rb
@@ -141,7 +141,7 @@ module Api
     def requires
       File.join(
         'google',
-        @__resource.__product.prefix[1..-1],
+        @__resource.__product.api_name,
         'property',
         type
       ).downcase
@@ -245,7 +245,7 @@ module Api
       def requires
         File.join(
           'google',
-          @__resource.__product.prefix[1..-1],
+          @__resource.__product.api_name,
           'property',
           'string'
         ).downcase
@@ -254,7 +254,7 @@ module Api
       def property_type
         [
           'Google',
-          @__resource.__product.prefix[1..-1].camelize(:upper),
+          @__resource.__product.api_name.camelize(:upper),
           'Property',
           'String'
         ].join('::')
@@ -330,7 +330,7 @@ module Api
 
       def property_file
         File.join(
-          'google', @__resource.__product.prefix[1..-1], 'property',
+          'google', @__resource.__product.api_name, 'property',
           [get_type(@item_type).new(@name).type, 'array'].join('_')
         ).downcase
       end
@@ -384,7 +384,7 @@ module Api
           super
         else
           File.join(
-            'google', @__resource.__product.prefix[1..-1], 'property',
+            'google', @__resource.__product.api_name, 'property',
             "#{@__resource.name}_#{@name}".underscore
           ).downcase
         end
@@ -463,7 +463,7 @@ module Api
       end
 
       def property_file
-        File.join('google', @__resource.__product.prefix[1..-1], 'property',
+        File.join('google', @__resource.__product.api_name, 'property',
                   "#{resource}_#{@imports}").downcase
       end
 
@@ -517,7 +517,7 @@ module Api
 
       def property_file
         File.join(
-          'google', @__resource.__product.prefix[1..-1], 'property',
+          'google', @__resource.__product.api_name, 'property',
           [@__resource.name, @name.underscore].join('_')
         ).downcase
       end
@@ -593,7 +593,7 @@ module Api
     def property_ns_prefix
       [
         'Google',
-        @__resource.__product.prefix[1..-1].camelize(:upper),
+        @__resource.__product.api_name.camelize(:upper),
         'Property'
       ]
     end

--- a/compile/core.rb
+++ b/compile/core.rb
@@ -203,7 +203,7 @@ module Compile
     # Includes a require clause and schedules library to be copied, potentially
     # with its dependencies & tests.
     def emit_google_lib(ctx, lib, file)
-      product_ns = ctx.local_variable_get(:object).__product.prefix[1..-1]
+      product_ns = ctx.local_variable_get(:object).__product.api_name
 
       files = case lib
               when Libraries::NETWORK

--- a/products/_bundle/api.yaml
+++ b/products/_bundle/api.yaml
@@ -12,5 +12,4 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Bundle
-name: Google Cloud Platform
-prefix: cloud
+name: GoogleCloudPlatform

--- a/products/monitoring/api.yaml
+++ b/products/monitoring/api.yaml
@@ -13,7 +13,6 @@
 --- !ruby/object:Api::Product
 name: Monitoring
 display_name: Stackdriver Monitoring and Alerting
-prefix: gmonitoring
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -84,7 +84,7 @@ module Provider
       # Returns the name of the module according to Ansible naming standards.
       # Example: gcp_dns_managed_zone
       def module_name(object)
-        ["gcp_#{object.__product.prefix[1..-1]}",
+        ["gcp_#{object.__product.api_name}",
          object.name.underscore].join('_')
       end
 

--- a/provider/ansible/bundle.rb
+++ b/provider/ansible/bundle.rb
@@ -64,7 +64,7 @@ module Provider
 
                      [product, config]
                    end
-        Hash[prod_map.sort_by { |p| p[0].prefix }]
+        Hash[prod_map.sort_by { |p| p[0].api_name }]
       end
     end
   end

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -325,7 +325,7 @@ module Provider
 
       def build_test(state, object, noop = false)
         @code = build_code(object, INTEGRATION_TEST_DEFAULTS)
-        @name = ["gcp_#{object.__product.prefix[1..-1]}",
+        @name = ["gcp_#{object.__product.api_name}",
                  object.name.underscore,
                  'facts'].join('_')
         super(state, object, noop)
@@ -333,7 +333,7 @@ module Provider
 
       def build_example(state, object)
         @code = build_code(object, EXAMPLE_DEFAULTS)
-        @name = ["gcp_#{object.__product.prefix[1..-1]}",
+        @name = ["gcp_#{object.__product.api_name}",
                  object.name.underscore,
                  'facts'].join('_')
         super(state, object)

--- a/provider/ansible/product~compile.yaml
+++ b/provider/ansible/product~compile.yaml
@@ -26,7 +26,7 @@
                     .select { |o| !excludes.include?(o.name) }
                     .select { |o| !o.exclude_if_not_in_version(version) }
                     .map do |object|
-                      ["gcp_#{object.__product.prefix[1..-1]}",
+                      ["gcp_#{object.__product.api_name}",
                        object.name.underscore].join('_')
                     end
 -%>

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -124,7 +124,7 @@ module Provider
         @config.examples,
         lambda do |_object, file|
           ["examples/#{file}",
-           "products/#{@api.prefix[1..-1]}/files/examples~#{file}"]
+           "products/#{@api.api_name}/files/examples~#{file}"]
         end
       )
     end
@@ -133,7 +133,7 @@ module Provider
       files.each do |target, source|
         Google::LOGGER.debug "Compiling #{source} => #{target}"
         target_file = File.join(output_folder, target)
-                          .gsub('{{product_name}}', @api.prefix[1..-1])
+                          .gsub('{{product_name}}', @api.api_name)
 
         manifest = @config.respond_to?(:manifest) ? @config.manifest : {}
         generate_file(
@@ -224,7 +224,7 @@ module Provider
         name: object.out_name,
         object: object,
         output_folder: output_folder,
-        product_name: object.__product.prefix[1..-1],
+        product_name: object.__product.api_name,
         version: version
       }
     end

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -245,7 +245,7 @@ module Provider
     def array_requires(type)
       File.join(
         'google',
-        type.__resource.__product.prefix[1..-1],
+        type.__resource.__product.api_name,
         'property',
         [type.__resource.name.downcase, type.item_type.name.underscore].join('_')
       )
@@ -254,7 +254,7 @@ module Provider
     def nested_object_requires(nested_object_type)
       File.join(
         'google',
-        nested_object_type.__resource.__product.prefix[1..-1],
+        nested_object_type.__resource.__product.api_name,
         'property',
         [nested_object_type.__resource.name, nested_object_type.name.underscore].join('_')
       ).downcase

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -51,7 +51,7 @@ module Provider
         name = property.name.camelize + name
       end
 
-      "#{property.__resource.__product.prefix[1..-1].camelize(:lower)}#{object.name}#{name}"
+      "#{property.__resource.__product.api_name.camelize(:lower)}#{object.name}#{name}"
     end
 
     # Converts between the Magic Modules type of an object and its type in the

--- a/provider/terraform/product~compile.yaml
+++ b/provider/terraform/product~compile.yaml
@@ -13,4 +13,4 @@
 # These files contains code that needs to be compiled before being delivered to
 # the final module tree structure:
 <% dir = version_name == 'beta' ? 'google-beta' : 'google' -%>
-'<%= dir -%>/provider_<%= api.prefix[1..-1] -%>_gen.go': 'templates/terraform/provider_gen.erb'
+'<%= dir -%>/provider_<%= api.api_name -%>_gen.go': 'templates/terraform/provider_gen.erb'

--- a/spec/compiler_spec.rb
+++ b/spec/compiler_spec.rb
@@ -43,7 +43,7 @@ describe Api::Compiler do
     end
 
     it { is_expected.to be_instance_of Api::Product }
-    it { is_expected.to have_attributes(name: 'My Product') }
+    it { is_expected.to have_attributes(api_name: 'myproduct') }
     it { is_expected.to have_attribute_of_length(objects: 4) }
   end
 

--- a/spec/data/good-export-file.yaml
+++ b/spec/data/good-export-file.yaml
@@ -12,8 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: My Product
-prefix: myproduct
+name: MyProduct
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/spec/data/good-file.yaml
+++ b/spec/data/good-file.yaml
@@ -12,8 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: My Product
-prefix: myproduct
+name: MyProduct
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/spec/data/good-longuri.yaml
+++ b/spec/data/good-longuri.yaml
@@ -12,8 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: My Product
-prefix: myproduct
+name: MyProduct
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/spec/data/good-multi-file.yaml
+++ b/spec/data/good-multi-file.yaml
@@ -12,8 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: My Product
-prefix: multiproduct
+name: MyProduct
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/spec/data/good-multi2-file.yaml
+++ b/spec/data/good-multi2-file.yaml
@@ -12,8 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: My Product
-prefix: multiproduct
+name: MyProduct
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/spec/data/good-single-file.yaml
+++ b/spec/data/good-single-file.yaml
@@ -12,8 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: My Product
-prefix: myproduct
+name: MyProduct
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/spec/data/good-single-readonly-file.yaml
+++ b/spec/data/good-single-readonly-file.yaml
@@ -12,8 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: My Product
-prefix: myproduct
+name: MyProduct
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/spec/data/resourceref-missingimports.yaml
+++ b/spec/data/resourceref-missingimports.yaml
@@ -12,8 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: My Product
-prefix: myproduct
+name: MyProduct
 versions:
   - name: ga
     base_url: http://myproduct.google.com/api

--- a/spec/data/resourceref-missingresource.yaml
+++ b/spec/data/resourceref-missingresource.yaml
@@ -12,8 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: My Product
-prefix: myproduct
+name: MyProduct
 versions:
   - name: ga
     base_url: http://myproduct.google.com/api

--- a/spec/product_spec.rb
+++ b/spec/product_spec.rb
@@ -15,7 +15,7 @@ require 'spec_helper'
 
 describe Api::Product do
   context 'requires name' do
-    subject { -> { product('prefix: "bar"').validate } }
+    subject { -> { product('display_name: "Bar"').validate } }
     it { is_expected.to raise_error(StandardError, /Missing 'name'/) }
   end
 
@@ -25,7 +25,7 @@ describe Api::Product do
         product('name: "foo"',
                 'scopes:',
                 '  - link/to/scope',
-                'prefix: "bar"',
+                'name: "Bar"',
                 'objects:',
                 '  - !ruby/object:Api::Resource',
                 '    kind: foo#resource',
@@ -48,7 +48,7 @@ describe Api::Product do
         product('name: "foo"',
                 'scopes:',
                 '  - link/to/scope',
-                'prefix: "bar"',
+                'name: "Bar"',
                 'versions:',
                 '  - !ruby/object:Api::Product::Version',
                 '    name: ga',
@@ -83,7 +83,7 @@ describe Api::Product do
         product('name: "foo"',
                 'scopes:',
                 '  - link/to/scope',
-                'prefix: "bar"',
+                'name: "Bar"',
                 'versions:',
                 '  - !ruby/object:Api::Product::Version',
                 '    name: ga',
@@ -114,7 +114,7 @@ describe Api::Product do
     subject do
       lambda do
         product('name: "foo"',
-                'prefix: "bar"',
+                'name: "Bar"',
                 'versions:',
                 '  - !ruby/object:Api::Product::Version',
                 '    name: ga',
@@ -128,7 +128,7 @@ describe Api::Product do
     subject do
       lambda do
         product('name: "foo"',
-                'prefix: "bar"',
+                'name: "Bar"',
                 'versions:',
                 '  - !ruby/object:Api::Product::Version',
                 '    name: ga',

--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -121,7 +121,7 @@ def main():
 
 
 <%= method_decl('fetch_list', ['module', 'link', ('query' if object.facts.has_filters)]) %>
-<% prod_name = object.__product.prefix[1..-1] -%>
+<% prod_name = object.__product.api_name -%>
     auth = GcpSession(module, <%= quote_string(prod_name) -%>)
     response = <%= method_call('auth.get', ['link', ("params={'#{object.facts.filter_api_param}': query}" if object.facts.has_filters)]) %>
     return return_if_object(module, response)

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -154,7 +154,7 @@ def main():
     module.exit_json(**fetch)
 
 
-<% prod_name = object.__product.prefix[1..-1] -%>
+<% prod_name = object.__product.api_name -%>
 <% unless object.readonly -%>
 <%# TODO: kind param not always needed.
   # https://github.com/GoogleCloudPlatform/magic-modules/issues/45

--- a/templates/ansible/verifiers/facts.yaml.erb
+++ b/templates/ansible/verifiers/facts.yaml.erb
@@ -1,5 +1,5 @@
 <%
-  module_name = ["gcp_#{object.__product.prefix[1..-1]}",
+  module_name = ["gcp_#{object.__product.api_name}",
                  object.name.underscore,
                  'facts'].join('_')
 -%>

--- a/tools/linter/spreadsheet.rb
+++ b/tools/linter/spreadsheet.rb
@@ -49,16 +49,16 @@ docs.each do |doc|
   # Run tests on regular API
   api = ApiFetcher.api_from_file(doc['filename'])
   # Need value in case TF or Ansible file does not exist.
-  prefix = api.prefix
+  api_name = api.api_name
 
   builder = Discovery::Builder.new(doc['url'], api.objects.map(&:name))
-  run_tests(builder, api, { property: true }, { provider: :api }, prefix: prefix)
+  run_tests(builder, api, { property: true }, { provider: :api }, api_name: api_name)
 
   # Run tests on TF API
   api = ApiFetcher.provider_from_file(doc['filename'], 'terraform')
-  run_tests(builder, api, { property: true }, { provider: :terraform }, prefix: prefix)
+  run_tests(builder, api, { property: true }, { provider: :terraform }, api_name: api_name)
 
   # Run tests on Ansible API
   api = ApiFetcher.provider_from_file(doc['filename'], 'ansible')
-  run_tests(builder, api, { property: true }, { provider: :ansible }, prefix: prefix)
+  run_tests(builder, api, { property: true }, { provider: :ansible }, api_name: api_name)
 end

--- a/tools/linter/tests/test_runner.rb
+++ b/tools/linter/tests/test_runner.rb
@@ -15,7 +15,7 @@ require 'tools/linter/tests/tests'
 
 def run_tests(discovery_doc, api, filters, tags = {}, **kwargs)
   # First context: product name
-  RSpec.describe(kwargs[:prefix] || api.prefix) do
+  RSpec.describe(kwargs[:api_name] || api.api_name) do
     discovery_doc.resources.each do |disc_resource|
       api_obj = api&.objects&.select { |p| p.name == disc_resource.name }&.first
       # Second context: resource name


### PR DESCRIPTION
Followup to https://github.com/GoogleCloudPlatform/magic-modules/pull/1195, remove `prefix`.

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
