### PR TITLE
Add back a CONTRIBUTING markdown file.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributor License Agreements
+
+We have a few legal steps to accept most community changes. If you're submitting
+a pull request to this repo, please fill out either the individual or corporate
+Contributor License Agreement (CLA).
+
+  * If you are an individual writing original source code and you're sure you
+    own the intellectual property, then you'll need to sign an [individual CLA](http://code.google.com/legal/individual-cla-v1.0.html).
+  * If you work for a company that wants to allow you to contribute your work,
+    then you'll need to sign a [corporate CLA](http://code.google.com/legal/corporate-cla-v1.0.html).
+
+Follow either of the two links above to access the appropriate CLA and
+instructions for how to sign and return it. Once we receive it, we'll be able to
+review/accept your PR.

--- a/README.md
+++ b/README.md
@@ -231,17 +231,3 @@ that maintainer with no changes needing to be made.
 
 Once you've gotten approvals from the primary reviewer and the reviewers for
 any affected tools, the primary reviewer will merge your changes.
-
-#### Contributor License Agreements
-
-We have a few legal steps to accept most community changes. Please fill out
-either the individual or corporate Contributor License Agreement (CLA).
-
-  * If you are an individual writing original source code and you're sure you
-    own the intellectual property, then you'll need to sign an [individual CLA](http://code.google.com/legal/individual-cla-v1.0.html).
-  * If you work for a company that wants to allow you to contribute your work,
-    then you'll need to sign a [corporate CLA](http://code.google.com/legal/corporate-cla-v1.0.html).
-
-Follow either of the two links above to access the appropriate CLA and
-instructions for how to sign and return it. Once we receive it, we'll be able to
-review/accept your PR.


### PR DESCRIPTION
The old CONTRIBUTING file was mostly a style guide for templates, and included docs about how to submit a patch- but users who saw it were likely already submitting one, because CONTRIBUTING is the special GitHub file that appears while creating PRs.

The CLA section may be worth duplicating into both locations so it's clear to readers before they begin contributing that they'll need to sign one, but the bot on every existing PR + the CONTRIBUTING message is pretty comprehensive too. I'm leaning towards not including the message in the README, let me know if you disagree.

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
