### PR TITLE
Data Sources for KMS Key Ring and Key

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_kms_crypto_key.go
+++ b/third_party/terraform/data_sources/data_source_google_kms_crypto_key.go
@@ -24,16 +24,12 @@ func dataSourceGoogleKmsCryptoKeyRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	cryptoKeyId := &kmsCryptoKeyId{
+	cryptoKeyId := kmsCryptoKeyId{
 		KeyRingId: *keyRingId,
 		Name:      d.Get("name").(string),
 	}
 
 	d.SetId(cryptoKeyId.cryptoKeyId())
 
-	err = resourceKmsCryptoKeyRead(d, meta)
-	if err != nil {
-		return err
-	}
-	return nil
+	return resourceKmsCryptoKeyRead(d, meta)
 }

--- a/third_party/terraform/data_sources/data_source_google_kms_crypto_key.go
+++ b/third_party/terraform/data_sources/data_source_google_kms_crypto_key.go
@@ -1,0 +1,89 @@
+package google
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/validation"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceGoogleKmsCryptoKey() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleKmsCryptoKeyRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"key_ring": {
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: kmsCryptoKeyRingsEquivalent,
+			},
+			"rotation_period": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"version_template": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"algorithm": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"protection_level": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							Default:      "SOFTWARE",
+							ValidateFunc: validation.StringInSlice([]string{"SOFTWARE", "HSM", ""}, false),
+						},
+					},
+				},
+			},
+			"self_link": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+
+}
+
+func dataSourceGoogleKmsCryptoKeyRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	keyRingId, err := parseKmsKeyRingId(d.Get("key_ring").(string), config)
+	if err != nil {
+		return err
+	}
+
+	cryptoKeyId := &kmsCryptoKeyId{
+		KeyRingId: *keyRingId,
+		Name:      d.Get("name").(string),
+	}
+	log.Printf("[DEBUG] Executing read for KMS CryptoKey %s", cryptoKeyId.cryptoKeyId())
+
+	cryptoKey, err := config.clientKms.Projects.Locations.KeyRings.CryptoKeys.Get(cryptoKeyId.cryptoKeyId()).Do()
+	if err != nil {
+		return fmt.Errorf("Error reading CryptoKey: %s", err)
+	}
+	d.Set("key_ring", cryptoKeyId.KeyRingId.terraformId())
+	d.Set("name", cryptoKeyId.Name)
+	d.Set("rotation_period", cryptoKey.RotationPeriod)
+	d.Set("self_link", cryptoKey.Name)
+
+	if err = d.Set("version_template", flattenVersionTemplate(cryptoKey.VersionTemplate)); err != nil {
+		return fmt.Errorf("Error setting version_template in state: %s", err.Error())
+	}
+
+	d.SetId(cryptoKeyId.cryptoKeyId())
+
+	return nil
+}

--- a/third_party/terraform/data_sources/data_source_google_kms_crypto_key.go
+++ b/third_party/terraform/data_sources/data_source_google_kms_crypto_key.go
@@ -1,55 +1,17 @@
 package google
 
 import (
-	"fmt"
-	"log"
-
-	"github.com/hashicorp/terraform/helper/validation"
-
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func dataSourceGoogleKmsCryptoKey() *schema.Resource {
+	dsSchema := datasourceSchemaFromResourceSchema(resourceKmsCryptoKey().Schema)
+	addRequiredFieldsToSchema(dsSchema, "name")
+	addRequiredFieldsToSchema(dsSchema, "key_ring")
+
 	return &schema.Resource{
-		Read: dataSourceGoogleKmsCryptoKeyRead,
-		Schema: map[string]*schema.Schema{
-			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-			},
-			"key_ring": {
-				Type:             schema.TypeString,
-				Required:         true,
-				DiffSuppressFunc: kmsCryptoKeyRingsEquivalent,
-			},
-			"rotation_period": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"version_template": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"algorithm": {
-							Type:    schema.TypeString,
-							Compute: true,
-						},
-						"protection_level": {
-							Type:         schema.TypeString,
-							Commpute:     true,
-							Default:      "SOFTWARE",
-							ValidateFunc: validation.StringInSlice([]string{"SOFTWARE", "HSM", ""}, false),
-						},
-					},
-				},
-			},
-			"self_link": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-		},
+		Read:   dataSourceGoogleKmsCryptoKeyRead,
+		Schema: dsSchema,
 	}
 
 }
@@ -66,22 +28,12 @@ func dataSourceGoogleKmsCryptoKeyRead(d *schema.ResourceData, meta interface{}) 
 		KeyRingId: *keyRingId,
 		Name:      d.Get("name").(string),
 	}
-	log.Printf("[DEBUG] Executing read for KMS CryptoKey %s", cryptoKeyId.cryptoKeyId())
-
-	cryptoKey, err := config.clientKms.Projects.Locations.KeyRings.CryptoKeys.Get(cryptoKeyId.cryptoKeyId()).Do()
-	if err != nil {
-		return fmt.Errorf("Error reading CryptoKey: %s", err)
-	}
-	d.Set("key_ring", cryptoKeyId.KeyRingId.terraformId())
-	d.Set("name", cryptoKeyId.Name)
-	d.Set("rotation_period", cryptoKey.RotationPeriod)
-	d.Set("self_link", cryptoKey.Name)
-
-	if err = d.Set("version_template", flattenVersionTemplate(cryptoKey.VersionTemplate)); err != nil {
-		return fmt.Errorf("Error setting version_template in state: %s", err.Error())
-	}
 
 	d.SetId(cryptoKeyId.cryptoKeyId())
 
+	err = resourceKmsCryptoKeyRead(d, meta)
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/third_party/terraform/data_sources/data_source_google_kms_crypto_key.go
+++ b/third_party/terraform/data_sources/data_source_google_kms_crypto_key.go
@@ -16,7 +16,6 @@ func dataSourceGoogleKmsCryptoKey() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"key_ring": {
 				Type:             schema.TypeString,
@@ -34,13 +33,12 @@ func dataSourceGoogleKmsCryptoKey() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"algorithm": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:    schema.TypeString,
+							Compute: true,
 						},
 						"protection_level": {
 							Type:         schema.TypeString,
-							Optional:     true,
-							ForceNew:     true,
+							Commpute:     true,
 							Default:      "SOFTWARE",
 							ValidateFunc: validation.StringInSlice([]string{"SOFTWARE", "HSM", ""}, false),
 						},

--- a/third_party/terraform/data_sources/data_source_google_kms_key_ring.go
+++ b/third_party/terraform/data_sources/data_source_google_kms_key_ring.go
@@ -1,0 +1,55 @@
+package google
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceGoogleKmsKeyRing() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleKmsKeyRingRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"location": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceGoogleKmsKeyRingRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	keyRingId := &kmsKeyRingId{
+		Name:     d.Get("name").(string),
+		Location: d.Get("location").(string),
+		Project:  project,
+	}
+	log.Printf("[DEBUG] Executing read for KMS KeyRing %s", keyRingId.keyRingId())
+
+	keyRing, err := config.clientKms.Projects.Locations.KeyRings.Get(keyRingId.keyRingId()).Do()
+
+	if err != nil {
+		return fmt.Errorf("Error reading KeyRing: %s", err)
+	}
+
+	d.Set("project", project)
+	d.Set("self_link", keyRing.Name)
+
+	return nil
+}

--- a/third_party/terraform/data_sources/data_source_google_kms_key_ring.go
+++ b/third_party/terraform/data_sources/data_source_google_kms_key_ring.go
@@ -23,6 +23,10 @@ func dataSourceGoogleKmsKeyRing() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"self_link": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -48,6 +52,7 @@ func dataSourceGoogleKmsKeyRingRead(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error reading KeyRing: %s", err)
 	}
 
+	d.SetId(keyRingId.keyRingId())
 	d.Set("project", project)
 	d.Set("self_link", keyRing.Name)
 

--- a/third_party/terraform/data_sources/data_source_google_kms_key_ring.go
+++ b/third_party/terraform/data_sources/data_source_google_kms_key_ring.go
@@ -24,17 +24,12 @@ func dataSourceGoogleKmsKeyRingRead(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	keyRingId := &kmsKeyRingId{
+	keyRingId := kmsKeyRingId{
 		Name:     d.Get("name").(string),
 		Location: d.Get("location").(string),
 		Project:  project,
 	}
 	d.SetId(keyRingId.terraformId())
 
-	err = resourceKmsKeyRingRead(d, meta)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return resourceKmsKeyRingRead(d, meta)
 }

--- a/third_party/terraform/tests/data_source_google_kms_crypto_key_test.go
+++ b/third_party/terraform/tests/data_source_google_kms_crypto_key_test.go
@@ -5,24 +5,22 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccDataSourceGoogleKmsCryptoKey_basic(t *testing.T) {
-	projectId := "terraform-" + acctest.RandString(10)
+	kms := BootstrapKMSKey(t)
+	projectId := getTestProjectFromEnv()
 	projectOrg := getTestOrgFromEnv(t)
 	projectBillingAccount := getTestBillingAccountFromEnv(t)
-	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
-	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceGoogleKmsCryptoKey_basic(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
-				Check:  resource.TestMatchResourceAttr("data.google_kms_crypto_key", "name", regexp.MustCompile(cryptoKeyName)),
+				Config: testAccDataSourceGoogleKmsCryptoKey_basic(projectId, projectOrg, projectBillingAccount, kms.KeyRing.Name, kms.CryptoKey.Name),
+				Check:  resource.TestMatchResourceAttr("data.google_kms_crypto_key", "name", regexp.MustCompile(kms.CryptoKey.Name)),
 			},
 		},
 	})

--- a/third_party/terraform/tests/data_source_google_kms_crypto_key_test.go
+++ b/third_party/terraform/tests/data_source_google_kms_crypto_key_test.go
@@ -1,0 +1,72 @@
+package google
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceGoogleKmsCryptoKey_basic(t *testing.T) {
+	projectId := "terraform-" + acctest.RandString(10)
+	projectOrg := getTestOrgFromEnv(t)
+	projectBillingAccount := getTestBillingAccountFromEnv(t)
+	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleKmsCryptoKey_basic(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+				Check:  resource.TestMatchResourceAttr("data.google_kms_crypto_key", "name", regexp.MustCompile(cryptoKeyName)),
+			},
+		},
+	})
+}
+
+/*
+	This test should run in its own project, because KMS key rings and crypto keys are not deletable
+*/
+func testAccDataSourceGoogleKmsCryptoKey_basic(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+	name            = "%s"
+	project_id      = "%s"
+	org_id          = "%s"
+	billing_account = "%s"
+}
+
+resource "google_project_services" "acceptance" {
+	project = "${google_project.acceptance.project_id}"
+
+	services = [
+	  "cloudkms.googleapis.com",
+	]
+}
+
+resource "google_kms_key_ring" "key_ring" {
+	project  = "${google_project_services.acceptance.project}"
+	name     = "%s"
+	location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+	name            = "%s"
+	key_ring        = "${google_kms_key_ring.key_ring.self_link}"
+	rotation_period = "1000000s"
+	version_template {
+		algorithm =        "GOOGLE_SYMMETRIC_ENCRYPTION"
+		protection_level = "SOFTWARE"
+	}
+}
+
+data "google_kms_crypto_key" "kms_crypto_key" {
+	name     = "%s"
+	key_ring = "${google_kms_key_ring.key_ring.self_link}"
+}
+	`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, cryptoKeyName)
+}

--- a/third_party/terraform/tests/data_source_google_kms_crypto_key_test.go
+++ b/third_party/terraform/tests/data_source_google_kms_crypto_key_test.go
@@ -3,6 +3,7 @@ package google
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -10,17 +11,20 @@ import (
 
 func TestAccDataSourceGoogleKmsCryptoKey_basic(t *testing.T) {
 	kms := BootstrapKMSKey(t)
-	projectId := getTestProjectFromEnv()
-	projectOrg := getTestOrgFromEnv(t)
-	projectBillingAccount := getTestBillingAccountFromEnv(t)
+
+	// Name in the KMS client is in the format projects/<project>/locations/<location>/keyRings/<keyRingName>/cryptoKeys/<keyId>
+	keyParts := strings.Split(kms.CryptoKey.Name, "/")
+	cryptoKeyId := keyParts[len(keyParts)-1]
+
+	fmt.Println(testAccDataSourceGoogleKmsCryptoKey_basic(kms.KeyRing.Name, cryptoKeyId))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceGoogleKmsCryptoKey_basic(projectId, projectOrg, projectBillingAccount, kms.KeyRing.Name, kms.CryptoKey.Name),
-				Check:  resource.TestMatchResourceAttr("data.google_kms_crypto_key", "name", regexp.MustCompile(kms.CryptoKey.Name)),
+				Config: testAccDataSourceGoogleKmsCryptoKey_basic(kms.KeyRing.Name, cryptoKeyId),
+				Check:  resource.TestMatchResourceAttr("data.google_kms_crypto_key.kms_crypto_key", "self_link", regexp.MustCompile(kms.CryptoKey.Name)),
 			},
 		},
 	})
@@ -29,42 +33,11 @@ func TestAccDataSourceGoogleKmsCryptoKey_basic(t *testing.T) {
 /*
 	This test should run in its own project, because KMS key rings and crypto keys are not deletable
 */
-func testAccDataSourceGoogleKmsCryptoKey_basic(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
+func testAccDataSourceGoogleKmsCryptoKey_basic(keyRingName, cryptoKeyName string) string {
 	return fmt.Sprintf(`
-resource "google_project" "acceptance" {
-	name            = "%s"
-	project_id      = "%s"
-	org_id          = "%s"
-	billing_account = "%s"
-}
-
-resource "google_project_services" "acceptance" {
-	project = "${google_project.acceptance.project_id}"
-
-	services = [
-	  "cloudkms.googleapis.com",
-	]
-}
-
-resource "google_kms_key_ring" "key_ring" {
-	project  = "${google_project_services.acceptance.project}"
-	name     = "%s"
-	location = "us-central1"
-}
-
-resource "google_kms_crypto_key" "crypto_key" {
-	name            = "%s"
-	key_ring        = "${google_kms_key_ring.key_ring.self_link}"
-	rotation_period = "1000000s"
-	version_template {
-		algorithm =        "GOOGLE_SYMMETRIC_ENCRYPTION"
-		protection_level = "SOFTWARE"
-	}
-}
-
 data "google_kms_crypto_key" "kms_crypto_key" {
+	key_ring = "%s"
 	name     = "%s"
-	key_ring = "${google_kms_key_ring.key_ring.self_link}"
 }
-	`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName, cryptoKeyName)
+	`, keyRingName, cryptoKeyName)
 }

--- a/third_party/terraform/tests/data_source_google_kms_key_ring_test.go
+++ b/third_party/terraform/tests/data_source_google_kms_key_ring_test.go
@@ -5,23 +5,22 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccDataSourceGoogleKmsKeyRing_basic(t *testing.T) {
-	projectId := "terraform-" + acctest.RandString(10)
+	kms := BootstrapKMSKey(t)
+	projectId := getTestProjectFromEnv()
 	projectOrg := getTestOrgFromEnv(t)
 	projectBillingAccount := getTestBillingAccountFromEnv(t)
-	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceGoogleKmsKeyRing_basic(projectId, projectOrg, projectBillingAccount, keyRingName),
-				Check:  resource.TestMatchResourceAttr("data.google_kms_key_ring.kms_key_ring", "name", regexp.MustCompile(keyRingName)),
+				Config: testAccDataSourceGoogleKmsKeyRing_basic(projectId, projectOrg, projectBillingAccount, kms.KeyRing.Name),
+				Check:  resource.TestMatchResourceAttr("data.google_kms_key_ring.kms_key_ring", "name", regexp.MustCompile(kms.KeyRing.Name)),
 			},
 		},
 	})

--- a/third_party/terraform/tests/data_source_google_kms_key_ring_test.go
+++ b/third_party/terraform/tests/data_source_google_kms_key_ring_test.go
@@ -1,0 +1,60 @@
+package google
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceKmsKeyRing_basic(t *testing.T) {
+	projectId := "terraform-" + acctest.RandString(10)
+	projectOrg := getTestOrgFromEnv(t)
+	projectBillingAccount := getTestBillingAccountFromEnv(t)
+	keyRingName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceKmsKeyRing_basic(projectId, projectOrg, projectBillingAccount, keyRingName),
+				Check:  resource.TestMatchResourceAttr("data.google_kms_key_ring.kms_key_ring", "name", regexp.MustCompile(keyRingName)),
+			},
+		},
+	})
+}
+
+/*
+	This test should run in its own project, because keys and key rings are not deletable
+*/
+func testAccDataSourceKmsKeyRing_basic(projectId, projectOrg, projectBillingAccount, keyRingName string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+	name			= "%s"
+	project_id		= "%s"
+	org_id			= "%s"
+	billing_account	= "%s"
+}
+
+resource "google_project_services" "acceptance" {
+	project  = "${google_project.acceptance.project_id}"
+	services = [
+		"cloudkms.googleapis.com"
+	]
+}
+
+resource "google_kms_key_ring" "key_ring" {
+	project  = "${google_project_services.acceptance.project}"
+	name     = "%s"
+	location = "us-central1"
+}
+
+data "google_kms_key_ring" "kms_key_ring" {
+	name     = "%s"
+	location = "us-central1"
+}
+	`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, keyRingName)
+}

--- a/third_party/terraform/tests/data_source_google_kms_key_ring_test.go
+++ b/third_party/terraform/tests/data_source_google_kms_key_ring_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccDataSourceKmsKeyRing_basic(t *testing.T) {
+func TestAccDataSourceGoogleKmsKeyRing_basic(t *testing.T) {
 	projectId := "terraform-" + acctest.RandString(10)
 	projectOrg := getTestOrgFromEnv(t)
 	projectBillingAccount := getTestBillingAccountFromEnv(t)
@@ -20,7 +20,7 @@ func TestAccDataSourceKmsKeyRing_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceKmsKeyRing_basic(projectId, projectOrg, projectBillingAccount, keyRingName),
+				Config: testAccDataSourceGoogleKmsKeyRing_basic(projectId, projectOrg, projectBillingAccount, keyRingName),
 				Check:  resource.TestMatchResourceAttr("data.google_kms_key_ring.kms_key_ring", "name", regexp.MustCompile(keyRingName)),
 			},
 		},
@@ -30,7 +30,7 @@ func TestAccDataSourceKmsKeyRing_basic(t *testing.T) {
 /*
 	This test should run in its own project, because keys and key rings are not deletable
 */
-func testAccDataSourceKmsKeyRing_basic(projectId, projectOrg, projectBillingAccount, keyRingName string) string {
+func testAccDataSourceGoogleKmsKeyRing_basic(projectId, projectOrg, projectBillingAccount, keyRingName string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
 	name			= "%s"

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -103,6 +103,7 @@ func Provider() terraform.ResourceProvider {
 			"google_iam_policy":                                dataSourceGoogleIamPolicy(),
 			"google_iam_role":                                  dataSourceGoogleIamRole(),
 			"google_kms_secret":                                dataSourceGoogleKmsSecret(),
+			"google_kms_key_ring":                              dataSourceGoogleKmsKeyRing(),
 			"google_folder":                                    dataSourceGoogleFolder(),
 			"google_netblock_ip_ranges":                        dataSourceGoogleNetblockIpRanges(),
 			"google_organization":                              dataSourceGoogleOrganization(),

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -104,6 +104,7 @@ func Provider() terraform.ResourceProvider {
 			"google_iam_role":                                  dataSourceGoogleIamRole(),
 			"google_kms_secret":                                dataSourceGoogleKmsSecret(),
 			"google_kms_key_ring":                              dataSourceGoogleKmsKeyRing(),
+			"google_kms_crypto_key":                            dataSourceGoogleKmsCryptoKey(),
 			"google_folder":                                    dataSourceGoogleFolder(),
 			"google_netblock_ip_ranges":                        dataSourceGoogleNetblockIpRanges(),
 			"google_organization":                              dataSourceGoogleOrganization(),

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -1,7 +1,7 @@
 <% autogen_exception -%>
 <%#
  Hashicorp uses erb's to generate their website files. In order to run through the MM
- generator we need to double escape their code with '<%%' 
+ generator we need to double escape their code with '<%%'
  -%>
 <%% wrap_layout :inner do %>
   <%% content_for :sidebar do %>
@@ -117,13 +117,19 @@
       <a href="/docs/providers/google/d/google_folder.html">google_folder</a>
       </li>
       <li<%%= sidebar_current("docs-google-datasource-iam-policy") %>>
-      <a href="/docs/providers/google/d/google_iam_policy.html">google_iam_policy</a>
+        <a href="/docs/providers/google/d/google_iam_policy.html">google_iam_policy</a>
       </li>
       <li<%%= sidebar_current("docs-google-datasource-iam-role") %>>
       <a href="/docs/providers/google/d/datasource_google_iam_role.html">google_iam_role</a>
       </li>
+      <li<%%= sidebar_current("docs-google-datasource-kms-key-ring") %>>
+        <a href="/docs/providers/google/d/google_kms_key_ring.html">google_kms_key_ring</a>
+      </li>
+      <li<%%= sidebar_current("docs-google-datasource-kms-crypto-key") %>>
+        <a href="/docs/providers/google/d/google_kms_crypto_key.html">google_kms_crypto_key</a>
+      </li>
       <li<%%= sidebar_current("docs-google-kms-secret") %>>
-      <a href="/docs/providers/google/d/google_kms_secret.html">google_kms_secret</a>
+        <a href="/docs/providers/google/d/google_kms_secret.html">google_kms_secret</a>
       </li>
       <li<%%= sidebar_current("docs-google-datasource-netblock-ip-ranges") %>>
       <a href="/docs/providers/google/d/datasource_google_netblock_ip_ranges.html">google_netblock_ip_ranges</a>
@@ -132,10 +138,10 @@
       <a href="/docs/providers/google/d/google_organization.html">google_organization</a>
       </li>
       <li<%%= sidebar_current("docs-google-datasource-project") %>>
-        <a href="/docs/providers/google/d/google_project.html">google_project</a>
+      <a href="/docs/providers/google/d/google_project.html">google_project</a>
       </li>
       <li<%%= sidebar_current("docs-google-datasource-service-account") %>>
-        <a href="/docs/providers/google/d/datasource_google_service_account.html">google_service_account</a>
+      <a href="/docs/providers/google/d/datasource_google_service_account.html">google_service_account</a>
       </li>
       <li<%%= sidebar_current("docs-google-datasource-service-account-key") %>>
         <a href="/docs/providers/google/d/datasource_google_service_account_key.html">google_service_account_key</a>

--- a/third_party/terraform/website/docs/d/google_kms_crypto_key.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_crypto_key.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "google"
 page_title: "Google: google_kms_crypto_key"
-sidebar_current: "docs-google-kms-crypto-key-x"
+sidebar_current: "docs-google-datasource-kms-crypto-key"
 description: |-
  Provides access to KMS key data with Google Cloud KMS.
 ---
@@ -9,7 +9,7 @@ description: |-
 # google\_kms\_crypto\_key
 
 Provides access to a Google Cloud Platform KMS CryptoKey. For more information see
-[the official documentation](https://cloud.google.com/kms/docs/object-hierarchy#cryptokey)
+[the official documentation](https://cloud.google.com/kms/docs/object-hierarchy#key)
 and
 [API](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys).
 
@@ -37,7 +37,7 @@ The following arguments are supported:
 * `name` - (Required) The CryptoKey's name.
     A CryptoKey’s name belonging to the specified Google Cloud Platform KeyRing and match the regular expression `[a-zA-Z0-9_-]{1,63}`
 
-* `key_ring` - (Required) The id of the Google Cloud Platform KeyRing to which the key shall belong.
+* `key_ring` - (Required) The `self_link` of the Google Cloud Platform KeyRing to which the key shall belong.
 
 ## Attributes Reference
 

--- a/third_party/terraform/website/docs/d/google_kms_crypto_key.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_crypto_key.html.markdown
@@ -1,0 +1,54 @@
+---
+layout: "google"
+page_title: "Google: google_kms_crypto_key"
+sidebar_current: "docs-google-kms-crypto-key-x"
+description: |-
+ Provides access to KMS key data with Google Cloud KMS.
+---
+
+# google\_kms\_crypto\_key
+
+Provides access to a Google Cloud Platform KMS CryptoKey. For more information see
+[the official documentation](https://cloud.google.com/kms/docs/object-hierarchy#cryptokey)
+and
+[API](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys).
+
+A CryptoKey is an interface to key material which can be used to encrypt and decrypt data. A CryptoKey belongs to a
+Google Cloud KMS KeyRing.
+
+## Example Usage
+
+```hcl
+data "google_kms_key_ring" "my_key_ring" {
+  name     = "my-key-ring"
+  location = "us-central1"
+}
+
+data "google_kms_crypto_key" "my_crypto_key" {
+  name            = "my-crypto-key"
+  key_ring        = "${data.google_kms_key_ring.my_key_ring.self_link}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The CryptoKey's name.
+    A CryptoKey’s name belonging to the specified Google Cloud Platform KeyRing and match the regular expression `[a-zA-Z0-9_-]{1,63}`
+
+* `key_ring` - (Required) The id of the Google Cloud Platform KeyRing to which the key shall belong.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `rotation_period` - Every time this period passes, generate a new CryptoKeyVersion and set it as
+    the primary. The first rotation will take place after the specified period. The rotation period has the format
+    of a decimal number with up to 9 fractional digits, followed by the letter s (seconds).
+
+* `version_template` - A template describing settings for new crypto key versions. See [google_kms_crypto_key](https://www.terraform.io/docs/providres/google/r/google_kms_crypto_key.html) resource for more information.
+
+* `self_link` - The self link of the created CryptoKey. Its format is `projects/{projectId}/locations/{location}/keyRings/{keyRingName}/cryptoKeys/{cryptoKeyName}`.
+

--- a/third_party/terraform/website/docs/d/google_kms_crypto_key.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_crypto_key.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 * `name` - (Required) The CryptoKey's name.
     A CryptoKey’s name belonging to the specified Google Cloud Platform KeyRing and match the regular expression `[a-zA-Z0-9_-]{1,63}`
 
-* `key_ring` - (Required) The `self_link` of the Google Cloud Platform KeyRing to which the key shall belong.
+* `key_ring` - (Required) The `self_link` of the Google Cloud Platform KeyRing to which the key belongs.
 
 ## Attributes Reference
 
@@ -47,8 +47,6 @@ exported:
 * `rotation_period` - Every time this period passes, generate a new CryptoKeyVersion and set it as
     the primary. The first rotation will take place after the specified period. The rotation period has the format
     of a decimal number with up to 9 fractional digits, followed by the letter s (seconds).
-
-* `version_template` - A template describing settings for new crypto key versions. See [google_kms_crypto_key](https://www.terraform.io/docs/providres/google/r/google_kms_crypto_key.html) resource for more information.
 
 * `self_link` - The self link of the created CryptoKey. Its format is `projects/{projectId}/locations/{location}/keyRings/{keyRingName}/cryptoKeys/{cryptoKeyName}`.
 

--- a/third_party/terraform/website/docs/d/google_kms_key_ring.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_key_ring.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "google"
+page_title: "Google: google_kms_key_ring"
+sidebar_current: "docs-google-kms-key-ring-x"
+description: |-
+ Provides access to KMS key ring data with Google Cloud KMS.
+---
+
+# google\_kms\_key\_ring
+
+Provides access to Google Cloud Platform KMS KeyRing. For more information see
+[the official documentation](https://cloud.google.com/kms/docs/object-hierarchy#keyring)
+and
+[API](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings).
+
+A KeyRing is a grouping of CryptoKeys for organizational purposes. A KeyRing belongs to a Google Cloud Platform Project
+and resides in a specific location.
+
+## Example Usage
+
+```hcl
+data "google_kms_key_ring" "my_key_ring" {
+  name     = "my-key-ring"
+  location = "us-central1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The KeyRing's name.
+    A KeyRing name must exist within the provided location and match the regular expression `[a-zA-Z0-9_-]{1,63}`
+
+* `location` - (Required) The Google Cloud Platform location for the KeyRing.
+    A full list of valid locations can be found by running `gcloud kms locations list`.
+
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `self_link` - The self link of the created KeyRing. Its format is `projects/{projectId}/locations/{location}/keyRings/{keyRingName}`.

--- a/third_party/terraform/website/docs/d/google_kms_key_ring.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_key_ring.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "google"
 page_title: "Google: google_kms_key_ring"
-sidebar_current: "docs-google-kms-key-ring-x"
+sidebar_current: "docs-google-datasource-kms-key-ring"
 description: |-
  Provides access to KMS key ring data with Google Cloud KMS.
 ---
@@ -9,7 +9,7 @@ description: |-
 # google\_kms\_key\_ring
 
 Provides access to Google Cloud Platform KMS KeyRing. For more information see
-[the official documentation](https://cloud.google.com/kms/docs/object-hierarchy#keyring)
+[the official documentation](https://cloud.google.com/kms/docs/object-hierarchy#key_ring)
 and
 [API](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings).
 

--- a/third_party/terraform/website/docs/r/google_kms_crypto_key.html.markdown
+++ b/third_party/terraform/website/docs/r/google_kms_crypto_key.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # google\_kms\_crypto\_key
 
 Allows creation of a Google Cloud Platform KMS CryptoKey. For more information see
-[the official documentation](https://cloud.google.com/kms/docs/object-hierarchy#cryptokey)
+[the official documentation](https://cloud.google.com/kms/docs/object-hierarchy#key)
 and
 [API](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys).
 
@@ -59,7 +59,7 @@ The following arguments are supported:
     the primary. The first rotation will take place after the specified period. The rotation period has the format
     of a decimal number with up to 9 fractional digits, followed by the letter s (seconds). It must be greater than
     a day (ie, 86400).
-    
+
 * `version_template` - (Optional) A template describing settings for new crypto key versions. Structure is documented below.
 
 ---

--- a/third_party/terraform/website/docs/r/google_kms_key_ring.html.markdown
+++ b/third_party/terraform/website/docs/r/google_kms_key_ring.html.markdown
@@ -9,8 +9,8 @@ description: |-
 # google\_kms\_key\_ring
 
 Allows creation of a Google Cloud Platform KMS KeyRing. For more information see
-[the official documentation](https://cloud.google.com/kms/docs/object-hierarchy#keyring)
-and 
+[the official documentation](https://cloud.google.com/kms/docs/object-hierarchy#key_ring)
+and
 [API](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings).
 
 A KeyRing is a grouping of CryptoKeys for organizational purposes. A KeyRing belongs to a Google Cloud Platform Project


### PR DESCRIPTION
<!-- Your regular pull request body goes here -->

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]

Adding `datasource`s to KMS key ring and crypto key for the sake of not having to import them once they've been created and making it easier to manage them in case the state needs to be rolled back after initial create.

This is a bit tricky because tests require creating non-destructible resources.
There's no `yaml`-based template for these yet so I just added plain go code.

The tests expect specific environment variables to run, so I was only able to verify by hardcoding my own account/etc.

* I verified this by building my own copy of `terraform-provider` and running against my own project:
```
An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
 <= read (data resources)

Terraform will perform the following actions:

 <= data.google_kms_key_ring.kms-key-ring
      id:       <computed>
      location: "us-west1"
      name:     "tf-state-key-ring"


Plan: 0 to add, 0 to change, 0 to destroy.
```
* Outputs of data:

```
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

2019-01-11T18:15:17.040-0700 [DEBUG] plugin.terraform-provider-google:                                                  
test-key = projects/my-project/locations/us-west1/keyRings/tf-state-key-ring/cryptoKeys/tf-state-key
test-ring = projects/my-project/locations/us-west1/keyRings/tf-state-key-ring
```

Related issue: https://github.com/terraform-providers/terraform-provider-google/issues/2847
## [terraform]
### [terraform-beta]
