### PR TITLE
Better validation

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,9 @@
+c
+quit
+opts
+value
+up 1
+c
+quit
+value
+up 1

--- a/api/async.rb
+++ b/api/async.rb
@@ -25,10 +25,10 @@ module Api
     def validate
       super
 
-      check_property :operation, Operation
-      check_property :result, Result
-      check_property :status, Status
-      check_property :error, Error
+      check :operation, type: Operation
+      check :result, type: Result
+      check :status, type: Status
+      check :error, type: Error
     end
 
     # Represents the operations (requests) issues to watch for completion
@@ -42,13 +42,11 @@ module Api
       def validate
         super
 
-        @timeouts ||= Api::Timeouts.new
-
-        check_property :kind, String
-        check_property :path, String
-        check_property :base_url, String
-        check_property :wait_ms, Integer
-        check_property :timeouts, Timeouts
+        check :kind, type: String
+        check :path, type: String
+        check :base_url, type: String
+        check :wait_ms, type: Integer
+        check :timeouts, type: Timeouts, default: Api::Timeouts.new
       end
     end
 
@@ -59,10 +57,8 @@ module Api
 
       def validate
         super
-        default_value_property :resource_inside_response, false
-
-        check_optional_property :path, String
-        check_optional_property :resource_inside_response, :boolean
+        check :resource_inside_response, type: :boolean, default: false
+        check :path, type: String, required: false
       end
     end
 
@@ -75,8 +71,8 @@ module Api
 
       def validate
         super
-        check_property :path, String
-        check_property :allowed, Array
+        check :path, type: String
+        check :allowed, type: Array
       end
     end
 
@@ -87,8 +83,8 @@ module Api
 
       def validate
         super
-        check_property :path, String
-        check_property :message, String
+        check :path, type: String
+        check :message, type: String
       end
     end
   end

--- a/api/object.rb
+++ b/api/object.rb
@@ -33,10 +33,9 @@ module Api
       attr_reader :api_name
 
       def validate
-        @api_name ||= name
-
         super
-        check_property :name, String
+        check :name, type: String
+        check :api_name, type: String, default: @name
       end
     end
 

--- a/api/product.rb
+++ b/api/product.rb
@@ -62,8 +62,8 @@ module Api
       super
       set_variables @objects, :__product
       check :display_name, required: false, type: String
-      check :objects, type: Array, list_type: Api::Resource
-      check :scopes, type: Array, list_type: String
+      check :objects, type: Array, item_type: Api::Resource
+      check :scopes, type: Array, item_type: String
 
       check_versions
     end
@@ -141,7 +141,7 @@ module Api
     private
 
     def check_versions
-      check :versions, type: Array, list_type: Api::Product::Version
+      check :versions, type: Array, item_type: Api::Product::Version
 
       # Confirm that at most one version is the default
       defaults = 0

--- a/api/product.rb
+++ b/api/product.rb
@@ -61,11 +61,9 @@ module Api
     def validate
       super
       set_variables @objects, :__product
-      check_optional_property :display_name, String
-      check_property :objects, Array
-      check_property_list :objects, Api::Resource
-      check_property :scopes, ::Array
-      check_property_list :scopes, String
+      check :display_name, required: false, type: String
+      check :objects, type: Array, list_type: Api::Resource
+      check :scopes, type: Array, list_type: String
 
       check_versions
     end
@@ -81,14 +79,9 @@ module Api
 
       def validate
         super
-        @default ||= false
-
-        check_property :base_url, String
-        check_property :name, String
-        check_property :default, :boolean
-
-        raise "API Version must be one of #{ORDER}" \
-          unless ORDER.include?(@name)
+        check :default, type: :boolean, default: false
+        check :base_url, type: String
+        check :name, type: String, allowed: ORDER
       end
 
       def <=>(other)
@@ -148,8 +141,7 @@ module Api
     private
 
     def check_versions
-      check_property :versions, Array
-      check_property_list :versions, Api::Product::Version
+      check :versions, type: Array, list_type: Api::Product::Version
 
       # Confirm that at most one version is the default
       defaults = 0

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -84,8 +84,8 @@ module Api
 
       def validate
         super
-        check_optional_property :encoder, ::String
-        check_optional_property :decoder, ::String
+        check :encoder, required: false, type: ::String
+        check :decoder, required: false, type: ::String
       end
     end
 
@@ -95,7 +95,7 @@ module Api
 
       def validate
         super
-        check_property :create, ::String
+        check :create, type: ::String
       end
     end
 
@@ -106,10 +106,9 @@ module Api
 
       def validate
         super
-        default_value_property :items, 'items'
 
-        check_optional_property :kind, String
-        check_property :items, String
+        check :item, default: 'items', type: ::String
+        check :kind, type: ::String, required: false
       end
 
       def kind?
@@ -130,11 +129,8 @@ module Api
       def validate
         super
 
-        @guides ||= {}
-
-        check_property :guides, Hash
-
-        check_optional_property :api, String
+        check :guides, type: Hash, default: {}
+        check :api, required: false, type: String
       end
     end
 
@@ -158,43 +154,36 @@ module Api
     #
     def validate
       super
-      check_optional_property :async, Api::Async
-      check_optional_property :base_url, String
-      check_optional_property :create_url, String
-      check_optional_property :delete_url, String
-      check_optional_property :update_url, String
-      check_property :description, String
-      check_optional_property :exclude, :boolean
-      check_optional_property :kind, String
-      check_optional_property :parameters, Array
-      check_optional_property :exports, Array
-      check_optional_property :self_link, String
-      check_optional_property :self_link_query, Api::Resource::ResponseList
-      check_optional_property :readonly, :boolean
-      check_optional_property :transport, Transport
-      check_optional_property :references, ReferenceLinks
+      check :async, required: false, type: Api::Async
+      check :base_url, type: String
+      check :create_url, type: String, required: false
+      check :delete_url, type: String, required: false
+      check :update_url, type: String, required: false
+      check :description, type: String
+      check :exclude, required: false, type: :boolean
+      check :kind, required: false, type: String
+      check :parameters, required: false, type: Array, list_type: Api::Type
 
-      default_value_property :collection_url_response,
-                             Api::Resource::ResponseList.new
-      check_property :collection_url_response, Api::Resource::ResponseList
-      default_value_property :collection_url_response,
-                             Api::Resource::ResponseList.new
+      check :exports, required: false, type: Array
+      check :self_link, type: String, required: false
+      check :self_link_query, required: false, type: Api::Resource::ResponseList
+      check :readonly, required: false, type: :boolean
+      check :transport, required: false, type: :Transport
+      check :references, required: false, type: ReferenceLinks
 
-      check_property_oneof_default :create_verb, %i[POST PUT], :POST, Symbol
-      check_property_oneof_default \
-        :delete_verb, %i[POST PUT PATCH DELETE], :DELETE, Symbol
-      check_property_oneof_default \
-        :update_verb, %i[POST PUT PATCH], :PUT, Symbol
-      check_optional_property :input, :boolean
-      check_optional_property :min_version, String
+      check :collection_url_response, default: Api::Resource::ResponseList.new, type: Api::Resource::ResponseList
+
+      check :create_verb, type: Symbol, default: :POST, allowed: %i[POST PUT]
+      check :delete_verb, type: Symbol, default: :DELETE, allowed: %i[POST PUT PATCH DELETE]
+      check :update_verb, type: Symbol, default: :PUT, allowed: %i[POST PUT PATCH]
+
+      check :input, required: false, type: :boolean
+      check :min_version, required: false, type: String
 
       set_variables(@parameters, :__resource)
       set_variables(@properties, :__resource)
 
-      check_property_list :parameters, Api::Type
-
-      check_property :properties, Array unless @exclude
-      check_property_list :properties, Api::Type
+      check :properties, type: Array, list_type: Api::Type unless @exclude
 
       check_identity unless @identity.nil?
     end
@@ -253,8 +242,7 @@ module Api
     end
 
     def check_identity
-      check_property :identity, Array
-      check_property_list :identity, String
+      check :identity, type: Array, list_type: String
 
       # Ensures we have all properties defined
       @identity.each do |i|

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -107,7 +107,7 @@ module Api
       def validate
         super
 
-        check :item, default: 'items', type: ::String
+        check :items, default: 'items', type: ::String
         check :kind, type: ::String, required: false
       end
 
@@ -168,7 +168,7 @@ module Api
       check :self_link, type: String, required: false
       check :self_link_query, required: false, type: Api::Resource::ResponseList
       check :readonly, required: false, type: :boolean
-      check :transport, required: false, type: :Transport
+      check :transport, required: false, type: Transport
       check :references, required: false, type: ReferenceLinks
 
       check :collection_url_response, default: Api::Resource::ResponseList.new, type: Api::Resource::ResponseList

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -162,7 +162,7 @@ module Api
       check :description, type: String
       check :exclude, required: false, type: :boolean
       check :kind, required: false, type: String
-      check :parameters, required: false, type: Array, list_type: Api::Type
+      check :parameters, required: false, type: Array, item_type: Api::Type
 
       check :exports, required: false, type: Array
       check :self_link, type: String, required: false
@@ -183,7 +183,7 @@ module Api
       set_variables(@parameters, :__resource)
       set_variables(@properties, :__resource)
 
-      check :properties, type: Array, list_type: Api::Type unless @exclude
+      check :properties, type: Array, item_type: Api::Type unless @exclude
 
       check_identity unless @identity.nil?
     end
@@ -242,7 +242,7 @@ module Api
     end
 
     def check_identity
-      check :identity, type: Array, list_type: String
+      check :identity, type: Array, item_type: String
 
       # Ensures we have all properties defined
       @identity.each do |i|

--- a/api/timeout.rb
+++ b/api/timeout.rb
@@ -33,13 +33,9 @@ module  Api
     def validate
       super
 
-      @insert_sec ||= DEFAULT_INSERT_TIMEOUT_SEC
-      @update_sec ||= DEFAULT_UPDATE_TIMEOUT_SEC
-      @delete_sec ||= DEFAULT_DELETE_TIMEOUT_SEC
-
-      check_property :insert_sec, Integer
-      check_property :update_sec, Integer
-      check_property :delete_sec, Integer
+      check :insert_sec, type: Integer, default: DEFAULT_INSERT_TIMEOUT_SEC
+      check :update_sec, type: Integer, default: DEFAULT_UPDATE_TIMEOUT_SEC
+      check :delete_sec, type: Integer, default: DEFAULT_DELETE_TIMEOUT_SEC
     end
   end
 end

--- a/api/type.rb
+++ b/api/type.rb
@@ -56,21 +56,19 @@ module Api
     def validate
       super
       @exclude ||= false
-
-      check_property :description, ::String
-      check_property :exclude, :boolean
-      check_optional_property :min_version, ::String
-
-      check_optional_property :output, :boolean
-      check_optional_property :required, :boolean
-      check_optional_property :url_param_only, :boolean
+      check :description, type: ::String
+      check :min_version, required: false, type: ::String
+      check :output, type: :boolean, required: false
+      check :required, type: :boolean, required: false
+      check :url_param_only, type: :boolean, required: false
 
       raise 'Property cannot be output and required at the same time.' \
         if @output && @required
 
       check_optional_property_oneof_default \
         :update_verb, %i[POST PUT PATCH NONE], @__resource&.update_verb, Symbol
-      check_optional_property :update_url, ::String
+
+      check :update_url, type: ::String, required: false
 
       check_default_value_property
       check_conflicts
@@ -95,13 +93,12 @@ module Api
               "default value for type #{self.class}"
       end
 
-      check_optional_property :default_value, clazz
+      check :default_value, type: clazz, required: false
     end
 
     # Checks that all conflicting properties actually exist.
     def check_conflicts
-      default_value_property :conflicts, []
-      check_property :conflicts, ::Array
+      check :conflicts, type: ::Array, default: []
 
       return if @conflicts.empty?
 
@@ -294,14 +291,15 @@ module Api
           @item_type.set_variable(@__resource, :__resource)
           @item_type.set_variable(self, :__parent)
         end
-        check_property :item_type, [::String, NestedObject, ResourceRef, Enum]
+        check :item_type, type: [::String, NestedObject, ResourceRef, Enum]
+
         unless @item_type.is_a?(NestedObject) || @item_type.is_a?(ResourceRef) \
             || @item_type.is_a?(Enum) || type?(@item_type)
           raise "Invalid type #{@item_type}"
         end
 
-        check_optional_property :min_size, ::Integer
-        check_optional_property :max_size, ::Integer
+        check :min_size, type: ::Integer, required: false
+        check :max_size, type: ::Integer, required: false
       end
 
       def item_type_class
@@ -392,7 +390,7 @@ module Api
 
       def validate
         super
-        check_property :values, ::Array
+        check :values, type: ::Array
       end
     end
 
@@ -430,8 +428,8 @@ module Api
 
         return if @__resource.nil? || @__resource.exclude || @exclude
 
-        check_property :resource, ::String
-        check_property :imports, ::String
+        check :resource, type: ::String
+        check :imports, type: ::String
         check_resource_ref_exists
         check_resource_ref_property_exists
       end
@@ -501,7 +499,7 @@ module Api
           p.set_variable(@__resource, :__resource)
           p.set_variable(self, :__parent)
         end
-        check_property_list :properties, Api::Type
+        check :properties, type: ::Array, list_type: Api::Type
       end
 
       def property_class
@@ -571,13 +569,13 @@ module Api
 
       def validate
         super
-        check_property :key_name, ::String
-        check_optional_property :key_description, ::String
+        check :key_name, type: ::String
+        check :key_description, type::String, required: false
 
         @value_type.set_variable(@name, :__name)
         @value_type.set_variable(@__resource, :__resource)
         @value_type.set_variable(self, :__parent)
-        check_property :value_type, Api::Type::NestedObject
+        check :value_type, type: Api::Type::NestedObject
         raise "Invalid type #{@value_type}" unless type?(@value_type)
       end
     end

--- a/api/type.rb
+++ b/api/type.rb
@@ -65,8 +65,7 @@ module Api
       raise 'Property cannot be output and required at the same time.' \
         if @output && @required
 
-      check_optional_property_oneof_default \
-        :update_verb, %i[POST PUT PATCH NONE], @__resource&.update_verb, Symbol
+      check :update_verb, type: Symbol, allowed: %i[POST PUT PATCH NONE], default: @__resource&.update_verb, required: false
 
       check :update_url, type: ::String, required: false
 

--- a/api/type.rb
+++ b/api/type.rb
@@ -55,8 +55,8 @@ module Api
 
     def validate
       super
-      @exclude ||= false
       check :description, type: ::String
+      check :exclude, type: :boolean, default: false
       check :min_version, required: false, type: ::String
       check :output, type: :boolean, required: false
       check :required, type: :boolean, required: false
@@ -221,6 +221,10 @@ module Api
     # Properties that are fetched externally
     class FetchedExternal < Type
       attr_writer :resource
+
+      def validate
+        @conflicts ||= []
+      end
 
       def api_name
         name

--- a/api/type.rb
+++ b/api/type.rb
@@ -573,7 +573,7 @@ module Api
       def validate
         super
         check :key_name, type: ::String
-        check :key_description, type::String, required: false
+        check :key_description, type: ::String, required: false
 
         @value_type.set_variable(@name, :__name)
         @value_type.set_variable(@__resource, :__resource)

--- a/api/type.rb
+++ b/api/type.rb
@@ -502,7 +502,7 @@ module Api
           p.set_variable(@__resource, :__resource)
           p.set_variable(self, :__parent)
         end
-        check :properties, type: ::Array, list_type: Api::Type
+        check :properties, type: ::Array, item_type: Api::Type
       end
 
       def property_class

--- a/google/yaml_validator.rb
+++ b/google/yaml_validator.rb
@@ -46,7 +46,7 @@ module Google
     # options:
     # :default - the default value for this variable if its nil
     # :type - the allowed types (single or array) that this value can be
-    # :list_type - the allowed types that all values in this array should be (impllied that type == array)
+    # :item_type - the allowed types that all values in this array should be (impllied that type == array)
     # :allowed - the allowed values that this non-array variable should be.
     # :required - is the variable required? (defaults: true)
     def check(variable, **opts)
@@ -62,7 +62,7 @@ module Google
 
       check_property_value(variable, value, opts[:type]) if opts[:type]
 
-      value.each_with_index { |o, index| check_property_value("#{variable}[#{index}]", o, opts[:list_type]) } if value.is_a?(Array)
+      value.each_with_index { |o, index| check_property_value("#{variable}[#{index}]", o, opts[:item_type]) } if value.is_a?(Array)
 
       if opts[:allowed]
         raise "#{value} on #{variable} should be one of #{opts[:allowed]}" unless opts[:allowed].include?(value)

--- a/google/yaml_validator.rb
+++ b/google/yaml_validator.rb
@@ -42,6 +42,27 @@ module Google
       instance_variable_set("@#{property}", value)
     end
 
+    # Does all validation checking for a particular variable.
+    # options:
+    # :default - the default value for this variable if its nil
+    # :type - the allowed types (single or array) that this value can be
+    # :list_type - the allowed types that all values in this array should be (impllied that type == array)
+    # :allowed - the allowed values that this non-array variable should be.
+    # :required - is the variable required? (defaults: true)
+    def check(variable, **opts)
+      value = instance_variable_get("@#{variable}")
+      instance_variable_set(variable, opts[:default]) if opts[:default] && value.nil?
+
+      return if value.nil? && opts[:required] == false
+
+      check_property_type(variable, value, opts[:type]) if opts[:type]
+      value.each_with_index { |o, index| check_property_type("#{variable}[#{index}]", o, opts[:list_type]) } if opts[:list_type]
+
+      if opts[:allowed]
+        raise "#{value} on #{variable} should be one of #{opts[:allowed]}" unless opts[:allowed].include?(value)
+      end
+    end
+
     private
 
     def check_types(objects, type)

--- a/google/yaml_validator.rb
+++ b/google/yaml_validator.rb
@@ -51,14 +51,18 @@ module Google
     # :required - is the variable required? (defaults: true)
     def check(variable, **opts)
       value = instance_variable_get("@#{variable}")
-      instance_variable_set(variable, opts[:default]) if opts[:default] && value.nil?
+
+      # Set default value.
+      if !opts[:default].nil? && value.nil?
+        instance_variable_set("@#{variable}", opts[:default])
+        value = instance_variable_get("@#{variable}")
+      end
 
       return if value.nil? && opts[:required] == false
 
-      check_property_type(variable, value, opts[:type]) if opts[:type]
+      check_property_value(variable, value, opts[:type]) if opts[:type]
 
-      raise "Arrays must have a type" if opts[:type] == Array && !opts[:list_type]
-      value.each_with_index { |o, index| check_property_type("#{variable}[#{index}]", o, opts[:list_type]) } if opts[:list_type]
+      value.each_with_index { |o, index| check_property_value("#{variable}[#{index}]", o, opts[:list_type]) } if value.is_a?(Array)
 
       if opts[:allowed]
         raise "#{value} on #{variable} should be one of #{opts[:allowed]}" unless opts[:allowed].include?(value)

--- a/google/yaml_validator.rb
+++ b/google/yaml_validator.rb
@@ -56,6 +56,8 @@ module Google
       return if value.nil? && opts[:required] == false
 
       check_property_type(variable, value, opts[:type]) if opts[:type]
+
+      raise "Arrays must have a type" if opts[:type] == Array && !opts[:list_type]
       value.each_with_index { |o, index| check_property_type("#{variable}[#{index}]", o, opts[:list_type]) } if opts[:list_type]
 
       if opts[:allowed]

--- a/products/dns/ansible.yaml
+++ b/products/dns/ansible.yaml
@@ -25,8 +25,6 @@ manifest: !ruby/object:Provider::Ansible::Manifest
   author: Google Inc. (@googlecloudplatform)
 # This is where custom code would be defined eventually.
 datasources: !ruby/object:Provider::Overrides::ResourceOverrides
-  Change: !ruby/object:Provider::Overrides::Ansible::ResourceOverride
-    exclude: true
   Project: !ruby/object:Provider::Overrides::Ansible::ResourceOverride
     exclude: true
   ResourceRecordSet: !ruby/object:Provider::Overrides::Ansible::ResourceOverride

--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -22,12 +22,6 @@ scopes:
   - https://www.googleapis.com/auth/ndev.clouddns.readwrite
 objects:
   - !ruby/object:Api::Resource
-    # We are not exposing Change directly to the customer, as we cannot
-    # guarantee idempotency of it given its transactional nature.
-    name: 'Change'
-    description: 'An atomic update to a collection of ResourceRecordSets.'
-    exclude: true
-  - !ruby/object:Api::Resource
     name: 'ManagedZone'
     kind: 'dns#managedZone'
     base_url: 'projects/{{project}}/managedZones'

--- a/provider/ansible/bundle.rb
+++ b/provider/ansible/bundle.rb
@@ -30,7 +30,7 @@ module Provider
       end
 
       def validate
-        check_property :manifest, Provider::AnsibleBundle::Manifest
+        check :manifest, type: Provider::AnsibleBundle::Manifest
       end
     end
 

--- a/provider/ansible/config.rb
+++ b/provider/ansible/config.rb
@@ -45,7 +45,7 @@ module Provider
 
       def validate
         super
-        check_optional_property :manifest, Provider::Ansible::Manifest
+        check :manifest, type: Provider::Ansible::Manifest, required: false
       end
     end
   end

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -74,13 +74,11 @@ module Provider
 
       def validate
         super
-        default_value_property :facts, FactsTask.new
-        default_value_property :verifier, FactsVerifier.new
 
-        check_property :task, Task
-        check_optional_property :verifier, Verifier
-        check_optional_property_list :dependencies, Task
-        check_optional_property :facts, Task
+        check :task, type: Task
+        check :verifier, type: Verifier, default: FactsVerifier.new
+        check :dependencies, list_type: Task, type: Array
+        check :facts, type: Task, default: FactsTask.new
 
         @facts&.set_variable(self, :__example)
         @verifier.set_variable(self, :__example) if @verifier.respond_to?(:__example)
@@ -98,9 +96,9 @@ module Provider
 
       def validate
         super
-        check_property :name, String
-        check_property :code, Hash
-        check_optional_property_list :scopes, ::String
+        check :name, type: String
+        check :code, type: Hash
+        check :scopes, type: Array, list_type: ::String, required: false
       end
 
       def build_test(state, object, noop = false)
@@ -152,8 +150,8 @@ module Provider
       def validate
         @failure ||= FailureCondition.new
 
-        check_property :command, String
-        check_property :failure, FailureCondition
+        check :command, type: String
+        check :failure, type: FailureCondition, default: FailureCondition.new
       end
 
       # All of the arguments are used inside the ERB file, so we need
@@ -261,15 +259,10 @@ module Provider
       attr_reader :test
 
       def validate
-        check_optional_property :name, ::String
-        check_optional_property :enabled, [TrueClass, FalseClass]
-        check_optional_property :test, ::String
-
-        @enabled ||= true
-        @name ||= '{{ resource_name }}'
+        check :name, type: ::String, default: '{{ resource_name }}'
         @error ||= "#{@name} was not found."
-        @test ||= "\"\\\"#{@error.strip}\\\" in results.stderr\""
-        true
+        check :enabled, type: [TrueClass, FalseClass], default: true
+        check :test, type: ::String, default: "\"\\\"#{@error.strip}\\\" in results.stderr\""
       end
     end
 
@@ -282,7 +275,7 @@ module Provider
         raise 'Region must be slash delineated (e.g. regions/us-west1)' \
           unless @region == 'global' || @region.match?(%r{.*\/.*})
 
-        check_optional_property :type, ::String
+        check :type, type: ::String, required: false
 
         @name ||= '{{ resource_name }}'
         @error = [
@@ -299,8 +292,8 @@ module Provider
       attr_reader :plural
 
       def validate
-        check_optional_property :single, ::String
-        check_optional_property :plural, ::String
+        check :single, type: ::String, required: false
+        check :plural, type: ::String, required: false
 
         @name ||= '{{ resource_name }}'
         @error = [

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -77,7 +77,7 @@ module Provider
 
         check :task, type: Task
         check :verifier, type: Verifier, default: FactsVerifier.new
-        check :dependencies, list_type: Task, type: Array
+        check :dependencies, list_type: Task, type: Array, required: false
         check :facts, type: Task, default: FactsTask.new
 
         @facts&.set_variable(self, :__example)

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -77,7 +77,7 @@ module Provider
 
         check :task, type: Task
         check :verifier, type: Verifier, default: FactsVerifier.new
-        check :dependencies, list_type: Task, type: Array, required: false
+        check :dependencies, item_type: Task, type: Array, required: false
         check :facts, type: Task, default: FactsTask.new
 
         @facts&.set_variable(self, :__example)
@@ -98,7 +98,7 @@ module Provider
         super
         check :name, type: String
         check :code, type: Hash
-        check :scopes, type: Array, list_type: ::String, required: false
+        check :scopes, type: Array, item_type: ::String, required: false
       end
 
       def build_test(state, object, noop = false)

--- a/provider/ansible/facts_override.rb
+++ b/provider/ansible/facts_override.rb
@@ -25,8 +25,8 @@ module Provider
       attr_reader :does_not_exist
       def validate
         super
-        check_optional_property :exists, ::String
-        check_optional_property :does_not_exist, ::String
+        check :exists, type: ::String, required: false
+        check :does_not_exist, type: ::String, required: false
       end
     end
 

--- a/provider/ansible/facts_override.rb
+++ b/provider/ansible/facts_override.rb
@@ -40,16 +40,11 @@ module Provider
 
       def validate
         super
-        default_value_property :has_filters, true
-        default_value_property :filter, FilterProp.new
-        default_value_property :query_options, true
-        default_value_property :filter_api_param, 'filter'
-
-        check_property :has_filters, :boolean
-        check_property :filter, Api::Object
-        check_property :query_options, :boolean
-        check_property :filter_api_param, ::String
-        check_optional_property :test, AnsibleFactsTestInformation
+        check :has_filters, type: :boolean, default: true
+        check :filter, type: Api::Object, default: FilterProp.new
+        check :query_options, type: :boolean, default: true
+        check :filter_api_param, type: ::String, default: 'filter'
+        check :test, type: AnsibleFactsTestInformation, required: false
 
         # We have to apply the property overrides and validate
         # the filtering property

--- a/provider/ansible/manifest.rb
+++ b/provider/ansible/manifest.rb
@@ -26,9 +26,9 @@ module Provider
 
       def validate
         check :metadata_version, type: String
-        check :status, type: Array, list_type: String
+        check :status, type: Array, item_type: String
         check :supported_by, type: String
-        check :requirements, type: Array, list_type: String
+        check :requirements, type: Array, item_type: String
         check :version_added, type: String
         check :author, type: String
       end

--- a/provider/ansible/manifest.rb
+++ b/provider/ansible/manifest.rb
@@ -25,14 +25,12 @@ module Provider
       attr_reader :author
 
       def validate
-        check_property :metadata_version, String
-        check_property :status, Array
-        check_property_list :status, String
-        check_property :supported_by, String
-        check_property :requirements, Array
-        check_property_list :requirements, String
-        check_property :version_added, String
-        check_property :author, String
+        check :metadata_version, type: String
+        check :status, type: Array, list_type: String
+        check :supported_by, type: String
+        check :requirements, type: Array, list_type: String
+        check :version_added, type: String
+        check :author, type: String
       end
 
       # Get value from config and fallback to manifest.

--- a/provider/ansible/property_override.rb
+++ b/provider/ansible/property_override.rb
@@ -35,8 +35,8 @@ module Provider
       def validate
         super
 
-        check_optional_property :aliases, ::Array
-        check_optional_property :version_added, ::String
+        check :aliases, type: ::Array, required: false
+        check :version_added, type: ::String, required: false
       end
     end
 

--- a/provider/ansible/resource_override.rb
+++ b/provider/ansible/resource_override.rb
@@ -50,35 +50,27 @@ module Provider
       def validate
         super
 
-        default_value_property :access_api_results, false
-        default_value_property :custom_create_resource, false
-        default_value_property :custom_update_resource, false
-        default_value_property :exclude, false
-        default_value_property :has_tests, true
-        default_value_property :imports, []
-        default_value_property :provider_helpers, []
-        default_value_property :unwrap_resource, false
+        @exclude ||= false
 
-        check_property :access_api_results, :boolean
-        check_optional_property :collection, ::String
-        check_property :custom_create_resource, :boolean
-        check_property :custom_update_resource, :boolean
-        check_optional_property :create, ::String
-        check_optional_property :delete, ::String
-        check_property :has_tests, :boolean
-        check_optional_property :hidden, ::Array
-        check_property :imports, ::Array
-        check_optional_property :post_create, ::String
-        check_optional_property :post_action, ::String
-        check_property :provider_helpers, ::Array
-        check_optional_property :return_if_object, ::String
-        check_optional_property :template, ::String
-        check_optional_property :update, ::String
-        check_optional_property :unwrap_resource, :boolean
-        check_optional_property :version_added, ::String
+        check :access_api_results, type: :boolean, default: false
+        check :collection, required: false, type: ::String
+        check :custom_create_resource, type: :boolean, default: false
+        check :custom_update_resource, type: :boolean, default: false
+        check :create, type: ::String, required: false
+        check :delete, type: ::String, required: false
+        check :has_tests, type: :boolean, default: true
+        check :hidden, type: ::Array, required: false
+        check :imports, type: ::Array, default: []
+        check :post_create, type: ::String, required: true
+        check :post_action, type: ::String, required: true
+        check :provider_helpers, type: ::Array, default: []
+        check :return_if_object, type: ::String, required: false
+        check :template, type: ::String, required: false
+        check :update, type: ::String, required: false
+        check :unwrap_resource, type: :boolean, default: false
+        check :version_added, type: ::String, required: false
 
-        @facts ||= FactsOverride.new
-        check_property :facts, FactsOverride
+        check :facts, type: FactsOverride, default: FactsOverride.new
       end
     end
 

--- a/provider/ansible/resource_override.rb
+++ b/provider/ansible/resource_override.rb
@@ -61,8 +61,8 @@ module Provider
         check :has_tests, type: :boolean, default: true
         check :hidden, type: ::Array, required: false
         check :imports, type: ::Array, default: []
-        check :post_create, type: ::String, required: true
-        check :post_action, type: ::String, required: true
+        check :post_create, type: ::String, required: false
+        check :post_action, type: ::String, required: false
         check :provider_helpers, type: ::Array, default: []
         check :return_if_object, type: ::String, required: false
         check :template, type: ::String, required: false

--- a/provider/config.rb
+++ b/provider/config.rb
@@ -39,8 +39,8 @@ module Provider
 
       def validate
         super
-        check_optional_property :compile, Hash
-        check_optional_property :copy, Hash
+        check :compile, type: Hash, required: false
+        check :copy, type: Hash, required: false
       end
     end
 
@@ -88,9 +88,9 @@ module Provider
 
       overrides
 
-      check_optional_property :files, Provider::Config::Files
-      check_property :overrides, [Provider::ResourceOverrides,
-                                  Provider::Overrides::ResourceOverrides]
+      check :files, type: Provider::Config::Files, required: false
+      check :overrides, type: [Provider::ResourceOverrides,
+                               Provider::Overrides::ResourceOverrides]
     end
 
     # Provides the API object to any type that requires, e.g. for validation

--- a/provider/inspec/resource_override.rb
+++ b/provider/inspec/resource_override.rb
@@ -31,16 +31,11 @@ module Provider
     # Shared code between new resource overrides and old overrides
     module ResourceOverrideSharedCode
       def validate
-        assign_defaults
-
+        check :manual, type: :boolean, default: false
         super
-        check_property :manual, :boolean
-        check_optional_property :additional_functions, String
+        check :additional_functions, type: String, required: false
       end
 
-      def assign_defaults
-        default_value_property :manual, false
-      end
     end
 
     # Product specific overriden properties for inspec

--- a/provider/resource_override.rb
+++ b/provider/resource_override.rb
@@ -39,9 +39,7 @@ module Provider
     def validate
       super
 
-      @properties ||= {}
-
-      check_property :properties, Hash
+      check :properties, type: Hash, default: {}
     end
 
     private

--- a/provider/terraform/custom_code.rb
+++ b/provider/terraform/custom_code.rb
@@ -198,7 +198,7 @@ module Provider
         check :name, type: String
         check :primary_resource_id, type: String, required: false
         check :vars, type: Hash, required: false
-        check :ignore_read_extra, type: Array, list_type: String
+        check :ignore_read_extra, type: Array, item_type: String
         check :skip_test, type: TrueClass, required: false
       end
     end

--- a/provider/terraform/custom_code.rb
+++ b/provider/terraform/custom_code.rb
@@ -38,10 +38,10 @@ module Provider
 
       def validate
         super
-        check_optional_property :warning, String
-        check_optional_property :required_properties, String
-        check_optional_property :optional_properties, String
-        check_optional_property :attributes, String
+        check :warning, type: String, required: false
+        check :required_properties, required: false, type: String
+        check :optional_properties, required: false, type: String
+        check :attributes, required: false, type: String
       end
     end
 
@@ -195,11 +195,11 @@ module Provider
         super
         @ignore_read_extra ||= []
 
-        check_property :name, String
-        check_property :primary_resource_id, String
-        check_optional_property :vars, Hash
-        check_optional_property_list :ignore_read_extra, String
-        check_optional_property :skip_test, TrueClass
+        check :name, type: String
+        check :primary_resource_id, type: String, required: false
+        check :vars, type: Hash, required: false
+        check :ignore_read_extra, type: Array, list_type: String
+        check :skip_test, type: TrueClass, required: false
       end
     end
 
@@ -288,18 +288,18 @@ module Provider
       def validate
         super
 
-        check_optional_property :extra_schema_entry, String
-        check_optional_property :resource_definition, String
-        check_optional_property :encoder, String
-        check_optional_property :update_encoder, String
-        check_optional_property :decoder, String
-        check_optional_property :constants, String
-        check_optional_property :post_create, String
-        check_optional_property :pre_update, String
-        check_optional_property :post_update, String
-        check_optional_property :pre_delete, String
-        check_optional_property :custom_import, String
-        check_optional_property :post_import, String
+        check :extra_schema_entry, type: String, required: false
+        check :resource_definition, type: String, required: false
+        check :encoder, type: String, required: false
+        check :update_encoder, type: String, required: false
+        check :decoder, type: String, required: false
+        check :constants, type: String, required: false
+        check :post_create, type: String, required: false
+        check :pre_update, type: String, required: false
+        check :post_update, type: String, required: false
+        check :pre_delete, type: String, required: false
+        check :custom_import, type: String, required: false
+        check :post_import, type: String, required: false
       end
     end
   end

--- a/provider/terraform/property_override.rb
+++ b/provider/terraform/property_override.rb
@@ -92,8 +92,8 @@ module Provider
       def validate
         super
 
-        check_optional_property :regex, String
-        check_optional_property :function, String
+        check :regex, required: false, type: String
+        check :function, required: false, type: String
       end
     end
 
@@ -102,24 +102,19 @@ module Provider
       def validate
         super
 
-        # Ensures boolean values are set to false if nil
-        @sensitive ||= false
-        @is_set ||= false
-        @unordered_list ||= false
-        @default_from_api ||= false
+        check :sensitive, type: :boolean, default: false
+        check :is_set, type: :boolean, default: false
+        check :default_from_api, type: :boolean, default: false
+        check :unordered_list, type: :boolean, default: false
 
-        check_property :sensitive, :boolean
-        check_property :is_set, :boolean
-        check_property :default_from_api, :boolean
+        check :diff_suppress_func, type: String, required: false
+        check :state_func, type: String, required: false
+        check :validation, type: Provider::Terraform::Validation, required: false
+        check :set_hash_func, type: String, required: false
 
-        check_optional_property :diff_suppress_func, String
-        check_optional_property :state_func, String
-        check_optional_property :validation, Provider::Terraform::Validation
-        check_optional_property :set_hash_func, String
-
-        check_optional_property :update_statement, String
-        check_optional_property :custom_flatten, String
-        check_optional_property :custom_expand, String
+        check :update_statement, type: String, required: false
+        check :custom_flatten, type: String, required: false
+        check :custom_expand, type: String, required: false
 
         raise "'default_value' and 'default_from_api' cannot be both set"  \
           if @default_from_api && !@default_value.nil?

--- a/provider/terraform/resource_override.rb
+++ b/provider/terraform/resource_override.rb
@@ -47,19 +47,15 @@ module Provider
       def validate
         super
 
-        @id_format ||= '{{name}}'
-        @import_format ||= []
-        @custom_code ||= Provider::Terraform::CustomCode.new
-        @docs ||= Provider::Terraform::Docs.new
         @examples ||= []
 
-        check_property :id_format, String
-        check_optional_property_list :examples, Provider::Terraform::Examples
+        check :id_format, type: String, default: '{{name}}'
+        check :examples, Provider::Terraform::Examples, type: Array, default: []
 
-        check_optional_property :custom_code, Provider::Terraform::CustomCode
-        check_optional_property :docs, Provider::Terraform::Docs
-        check_property :import_format, Array
-        check_property_list :import_format, String
+        check :custom_code, type: Provider::Terraform::CustomCode, default: Provider::Terraform::CustomCode.new
+        check :docs, type: Provider::Terraform::Docs, default: Provider::Terraform::Docs.new
+        check :import_format, type: Array, default: []
+        check :import_format, type: Array, list_type: String
       end
 
       def apply(resource)

--- a/provider/terraform/resource_override.rb
+++ b/provider/terraform/resource_override.rb
@@ -50,12 +50,12 @@ module Provider
         @examples ||= []
 
         check :id_format, type: String, default: '{{name}}'
-        check :examples, list_type: Provider::Terraform::Examples, type: Array, default: []
+        check :examples, item_type: Provider::Terraform::Examples, type: Array, default: []
 
         check :custom_code, type: Provider::Terraform::CustomCode, default: Provider::Terraform::CustomCode.new
         check :docs, type: Provider::Terraform::Docs, default: Provider::Terraform::Docs.new
         check :import_format, type: Array, default: []
-        check :import_format, type: Array, list_type: String
+        check :import_format, type: Array, item_type: String
       end
 
       def apply(resource)

--- a/provider/terraform/resource_override.rb
+++ b/provider/terraform/resource_override.rb
@@ -50,7 +50,7 @@ module Provider
         @examples ||= []
 
         check :id_format, type: String, default: '{{name}}'
-        check :examples, Provider::Terraform::Examples, type: Array, default: []
+        check :examples, list_type: Provider::Terraform::Examples, type: Array, default: []
 
         check :custom_code, type: Provider::Terraform::CustomCode, default: Provider::Terraform::CustomCode.new
         check :docs, type: Provider::Terraform::Docs, default: Provider::Terraform::Docs.new


### PR DESCRIPTION
Our validation has been bugging me for a while now.

* We have so many functions (one for every combination of default values, enums, arrays, etc).
* It's so verbose. `default_value_property` is a whole thing to type out for default values and it has led us to not use the validation logic at times.
* It doesn't work all the time! I removed Change from DNS because it was a perfect example of validation not working. Change is missing many attributes and the validation logic should be giving off errors. Not all arrays of objects were being checked, etc.

I replaced all of the validation logic with one function `check`. This function takes in multiple parameters, meaning we can use one function for everything.

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
