### PR TITLE
Using Native Ruby Types on AnsibleModule

### DIFF
--- a/google/python_utils.rb
+++ b/google/python_utils.rb
@@ -56,7 +56,7 @@ module Google
         value
       elsif value.is_a?(Numeric)
         value.to_s
-      elsif value.is_a?(Hash) and opts[:use_hash_brackets]
+      elsif value.is_a?(Hash) && opts[:use_hash_brackets]
         hash_format(value)
       elsif value.is_a?(Hash)
         "dict(#{value.map { |k, v| "#{k}=#{python_literal(v)}" if v }.compact.join(', ')})"
@@ -93,6 +93,7 @@ module Google
     def hash_format(value)
       hash_vals = value.map do |k, v|
         next if v.nil?
+
         if k.is_a?(UnicodeString)
           "u'#{k}': #{python_literal(v)}"
         else

--- a/google/python_utils.rb
+++ b/google/python_utils.rb
@@ -29,8 +29,8 @@ module Google
         "'#{value}'"
       elsif value.is_a?(Numeric)
         value.to_s
-      elsif value.is_a?(Hash) && (value.keys.length == 1)
-        "{#{quote_string(value.keys.first)}: #{python_literal(value[value.keys.first])}}"
+      elsif value.is_a?(Hash)
+        "dict(#{value.map { |k, v| "#{k}=#{python_literal(v)}" if v }.compact.join(', ')})"
       elsif value.is_a?(Array)
         values = value.map { |x| python_literal(x) }
         array_format(values)

--- a/products/iam/helpers/ansible/service_account_key_template.erb
+++ b/products/iam/helpers/ansible/service_account_key_template.erb
@@ -47,22 +47,7 @@ import base64
 def main():
     """Main function"""
 
-<% conflicting = conflicting_property_batches(object) -%>
-    module = GcpModule(
-<%=
-  indent(remove_outside_dict(python_literal({
-    'argument_spec'=> {
-      'state' => {
-        'default' => 'present',
-        'choices' => ['present', 'absent'],
-        'type' => 'str'
-      }
-    }.merge(ansible_module(object.all_user_properties)),
-    'mutually_exclusive' => (conflicting_property_batches(object) \
-      unless conflicting_property_batches(object).empty?)
-  })), 12)
--%>
-    )
+<%= lines(indent(compile('templates/ansible/module.erb'), 4)) -%>
 
     if not module.params['scopes']:
         module.params['scopes'] = <%= python_literal(object.__product.scopes) %>

--- a/products/iam/helpers/ansible/service_account_key_template.erb
+++ b/products/iam/helpers/ansible/service_account_key_template.erb
@@ -47,16 +47,21 @@ import base64
 def main():
     """Main function"""
 
-<%
-  mod_props = object.all_user_properties.reject(&:output).map do |prop|
-    python_dict_for_property(prop, object)
-  end
--%>
+<% conflicting = conflicting_property_batches(object) -%>
     module = GcpModule(
-        argument_spec=dict(
-            state=dict(default='present', choices=['present', 'absent'], type='str'),
-<%= lines(indent_list(mod_props, 12)) -%>
-        )
+<%=
+  indent(remove_outside_dict(python_literal({
+    'argument_spec'=> {
+      'state' => {
+        'default' => 'present',
+        'choices' => ['present', 'absent'],
+        'type' => 'str'
+      }
+    }.merge(ansible_module(object.all_user_properties)),
+    'mutually_exclusive' => (conflicting_property_batches(object) \
+      unless conflicting_property_batches(object).empty?)
+  })), 12)
+-%>
     )
 
     if not module.params['scopes']:

--- a/products/storage/helpers/ansible/object_template.erb
+++ b/products/storage/helpers/ansible/object_template.erb
@@ -47,22 +47,7 @@ import base64
 def main():
     """Main function"""
 
-<% conflicting = conflicting_property_batches(object) -%>
-    module = GcpModule(
-<%=
-  indent(remove_outside_dict(python_literal({
-    'argument_spec'=> {
-      'state' => {
-        'default' => 'present',
-        'choices' => ['present', 'absent'],
-        'type' => 'str'
-      }
-    }.merge(ansible_module(object.all_user_properties)),
-    'mutually_exclusive' => (conflicting_property_batches(object) \
-      unless conflicting_property_batches(object).empty?)
-  })), 12)
--%>
-    )
+<%= lines(indent(compile('templates/ansible/module.erb'), 4)) -%>
 
     if not module.params['scopes']:
         module.params['scopes'] = <%= python_literal(object.__product.scopes) %>

--- a/products/storage/helpers/ansible/object_template.erb
+++ b/products/storage/helpers/ansible/object_template.erb
@@ -47,16 +47,21 @@ import base64
 def main():
     """Main function"""
 
-<%
-  mod_props = object.all_user_properties.reject(&:output).map do |prop|
-    python_dict_for_property(prop, object)
-  end
--%>
+<% conflicting = conflicting_property_batches(object) -%>
     module = GcpModule(
-        argument_spec=dict(
-            state=dict(default='present', choices=['present', 'absent'], type='str'),
-<%= lines(indent_list(mod_props, 12)) -%>
-        )
+<%=
+  indent(remove_outside_dict(python_literal({
+    'argument_spec'=> {
+      'state' => {
+        'default' => 'present',
+        'choices' => ['present', 'absent'],
+        'type' => 'str'
+      }
+    }.merge(ansible_module(object.all_user_properties)),
+    'mutually_exclusive' => (conflicting_property_batches(object) \
+      unless conflicting_property_batches(object).empty?)
+  })), 12)
+-%>
     )
 
     if not module.params['scopes']:

--- a/provider/ansible/module.rb
+++ b/provider/ansible/module.rb
@@ -30,16 +30,20 @@ module Provider
         {
           prop.name.underscore => {
             'required' => (true if prop.required && !prop.default_value),
-            'default' => (prop.default_value if prop.default_value),
-            'type' => (python_type(prop) if python_type(prop)),
+            'default' => prop.default_value,
+            'type' => python_type(prop),
             'choices' => (prop.values if prop.is_a?(Api::Type::Enum)),
             'elements' => (python_type(prop.item_type) \
               if prop.is_a?(Api::Type::Array) && python_type(prop.item_type)),
-            'aliases' => (prop.aliases if prop.aliases),
-            'options' => (if prop.is_a?(Api::Type::Array) && prop.item_type.is_a?(Api::Type::NestedObject)
-                            prop.item_type.properties.map { |x| python_dict_for_property(x) }.reduce({}, :merge)
+            'aliases' => prop.aliases,
+            'options' => (if prop.is_a?(Api::Type::Array) && \
+                          prop.item_type.is_a?(Api::Type::NestedObject)
+                            prop.item_type.properties
+                                          .map { |x| python_dict_for_property(x) }
+                                          .reduce({}, :merge)
                           elsif prop.is_a?(Api::Type::NestedObject)
-                            prop.properties.map { |x| python_dict_for_property(x) }.reduce({}, :merge)
+                            prop.properties.map { |x| python_dict_for_property(x) }
+                                           .reduce({}, :merge)
                           end)
           }.reject { |_, v| v.nil? }
         }

--- a/provider/ansible/request.rb
+++ b/provider/ansible/request.rb
@@ -18,16 +18,16 @@ module Provider
     module Request
       # Takes in a list of properties and outputs a python hash that takes
       # in a module and outputs a formatted JSON request.
-      def request_properties(properties, hash_name='module.params', module_name='module')
-          properties.map do |prop|
-            {
-              Google::PythonUtils::UnicodeString.new(prop.api_name) =>
-              Google::PythonUtils::PythonCode.new(request_output(prop, hash_name, module_name))
-            }
-          end.reduce({}, :merge)
+      def request_properties(properties, hash_name = 'module.params', module_name = 'module')
+        properties.map do |prop|
+          {
+            Google::PythonUtils::UnicodeString.new(prop.api_name) =>
+            Google::PythonUtils::PythonCode.new(request_output(prop, hash_name, module_name))
+          }
+        end.reduce({}, :merge)
       end
 
-      def response_properties(properties, hash_name='response', module_name='module')
+      def response_properties(properties, hash_name = 'response', module_name = 'module')
         properties.map do |prop|
           {
             Google::PythonUtils::UnicodeString.new(prop.api_name) =>

--- a/provider/ansible/request.rb
+++ b/provider/ansible/request.rb
@@ -18,44 +18,22 @@ module Provider
     module Request
       # Takes in a list of properties and outputs a python hash that takes
       # in a module and outputs a formatted JSON request.
-      def request_properties(properties, indent)
-        indent_list(
+      def request_properties(properties, hash_name='module.params', module_name='module')
           properties.map do |prop|
-            request_property(prop, 'module.params', 'module', indent)
-          end,
-          indent
-        )
+            {
+              Google::PythonUtils::UnicodeString.new(prop.api_name) =>
+              Google::PythonUtils::PythonCode.new(request_output(prop, hash_name, module_name))
+            }
+          end.reduce({}, :merge)
       end
 
-      def response_properties(properties, indent)
-        indent_list(
-          properties.map do |prop|
-            response_property(prop, 'response', 'module', indent)
-          end,
-          indent
-        )
-      end
-
-      def request_properties_in_classes(properties, indent,
-                                        hash_name = 'self.request',
-                                        module_name = 'self.module')
-        indent_list(
-          properties.map do |prop|
-            request_property(prop, hash_name, module_name, indent)
-          end,
-          indent
-        )
-      end
-
-      def response_properties_in_classes(properties, indent,
-                                         hash_name = 'self.request',
-                                         module_name = 'self.module')
-        indent_list(
-          properties.map do |prop|
-            response_property(prop, hash_name, module_name, indent)
-          end,
-          indent
-        )
+      def response_properties(properties, hash_name='response', module_name='module')
+        properties.map do |prop|
+          {
+            Google::PythonUtils::UnicodeString.new(prop.api_name) =>
+            Google::PythonUtils::PythonCode.new(response_output(prop, hash_name, module_name))
+          }
+        end.reduce({}, :merge)
       end
 
       # This returns a list of properties that require classes being built out.
@@ -71,20 +49,6 @@ module Provider
       end
 
       private
-
-      def request_property(prop, hash_name, module_name, indent_width)
-        indent(
-          ["#{unicode_string(prop.api_name)}: #{request_output(prop, hash_name, module_name)}"],
-          indent_width
-        )
-      end
-
-      def response_property(prop, hash_name, module_name, indent_width)
-        indent(
-          ["#{unicode_string(prop.api_name)}: #{response_output(prop, hash_name, module_name)}"],
-          indent_width
-        )
-      end
 
       def response_output(prop, hash_name, module_name)
         # If input true, treat like request, but use module names.

--- a/provider/ansible/request.rb
+++ b/provider/ansible/request.rb
@@ -50,24 +50,18 @@ module Provider
 
       private
 
+      # This is outputting code and code is easier to read on one line.
+      # rubocop:disable Metrics/LineLength
       def response_output(prop, hash_name, module_name)
         # If input true, treat like request, but use module names.
         return request_output(prop, "#{module_name}.params", module_name) \
           if prop.input
 
         if prop.is_a? Api::Type::NestedObject
-          [
-            "#{prop.property_class[-1]}(",
-            "#{hash_name}.get(#{unicode_string(prop.name)}, {})",
-            ", #{module_name}).from_response()"
-          ].join
+          "#{prop.property_class[-1]}(#{hash_name}.get(#{unicode_string(prop.name)}, {}), #{module_name}).from_response()"
         elsif prop.is_a?(Api::Type::Array) && \
               prop.item_type.is_a?(Api::Type::NestedObject)
-          [
-            "#{prop.property_class[-1]}(",
-            "#{hash_name}.get(#{unicode_string(prop.name)}, [])",
-            ", #{module_name}).from_response()"
-          ].join
+          "#{prop.property_class[-1]}(#{hash_name}.get(#{unicode_string(prop.name)}, []), #{module_name}).from_response()"
         else
           "#{hash_name}.get(#{unicode_string(prop.name)})"
         end
@@ -78,45 +72,24 @@ module Provider
           if prop.is_a? Api::Type::FetchedExternal
 
         if prop.is_a? Api::Type::NestedObject
-          [
-            "#{prop.property_class[-1]}(",
-            "#{hash_name}.get(#{quote_string(prop.out_name)}, {})",
-            ", #{module_name}).to_request()"
-          ].join
+          "#{prop.property_class[-1]}(#{hash_name}.get(#{quote_string(prop.out_name)}, {}), #{module_name}).to_request()"
         elsif prop.is_a?(Api::Type::Array) && \
               prop.item_type.is_a?(Api::Type::NestedObject)
-          [
-            "#{prop.property_class[-1]}(",
-            "#{hash_name}.get(#{quote_string(prop.out_name)}, [])",
-            ", #{module_name}).to_request()"
-          ].join
+          "#{prop.property_class[-1]}(#{hash_name}.get(#{quote_string(prop.out_name)}, []), #{module_name}).to_request()"
         elsif prop.is_a?(Api::Type::ResourceRef) && !prop.resource_ref.readonly
-          prop_name = prop.name.underscore
-          [
-            "replace_resource_dict(#{hash_name}",
-            ".get(#{unicode_string(prop_name)}, {}), ",
-            "#{quote_string(prop.imports)})"
-          ].join
+          "replace_resource_dict(#{hash_name}.get(#{unicode_string(prop.name.underscore)}, {}), #{quote_string(prop.imports)})"
         elsif prop.is_a?(Api::Type::ResourceRef) && \
               prop.resource_ref.readonly && prop.imports == 'selfLink'
-          func = "#{prop.resource.underscore}_selflink"
-          [
-            "#{func}(#{hash_name}.get(#{quote_string(prop.out_name)}),",
-            "#{module_name}.params)"
-          ].join(' ')
+          "#{prop.resource.underscore}_selflink(#{hash_name}.get(#{quote_string(prop.out_name)}), #{module_name}.params)"
         elsif prop.is_a?(Api::Type::Array) && \
               prop.item_type.is_a?(Api::Type::ResourceRef) && \
               !prop.item_type.resource_ref.readonly
-          prop_name = prop.name.underscore
-          [
-            "replace_resource_dict(#{hash_name}",
-            ".get(#{quote_string(prop_name)}, []), ",
-            "#{quote_string(prop.item_type.imports)})"
-          ].join
+          "replace_resource_dict(#{hash_name}.get(#{quote_string(prop.name.underscore)}, []), #{quote_string(prop.item_type.imports)})"
         else
           "#{hash_name}.get(#{quote_string(prop.out_name)})"
         end
       end
+      # rubocop:enable Metrics/LineLength
     end
   end
 end

--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -78,15 +78,15 @@ import json
 
 def main():
 <%
-  mod_props = object.facts.has_filters ? [python_dict_for_property(object.facts.filter, object)] : []
-  mod_props += uri_props.map do |prop|
-    python_dict_for_property(prop, object)
-  end
+  mod_props = object.facts.has_filters ? [object.facts.filter] : []
+  mod_props += uri_props
 -%>
     module = GcpModule(
-        argument_spec=dict(
-<%= lines(indent_list(mod_props, 12)) -%>
-        )
+<%=
+  indent(remove_outside_dict(python_literal({
+    'argument_spec'=> ansible_module(mod_props),
+  })), 12)
+-%>
     )
 
     if not module.params['scopes']:

--- a/templates/ansible/module.erb
+++ b/templates/ansible/module.erb
@@ -1,0 +1,16 @@
+<% conflicting = conflicting_property_batches(object) -%>
+module = GcpModule(
+<%=
+  indent(remove_outside_dict(python_literal({
+    'argument_spec'=> {
+      'state' => {
+        'default' => 'present',
+        'choices' => ['present', 'absent'],
+        'type' => 'str'
+      }
+    }.merge(ansible_module(object.all_user_properties)),
+    'mutually_exclusive' => (conflicting_property_batches(object) \
+      unless conflicting_property_batches(object).empty?)
+  })), 4)
+-%>
+)

--- a/templates/ansible/properties.erb
+++ b/templates/ansible/properties.erb
@@ -9,14 +9,10 @@ class <%= prop.property_class[-1] -%>(object):
             self.request = {}
 
     def to_request(self):
-        return remove_nones_from_dict({
-<%= lines(request_properties_in_classes(prop.properties, 12)) -%>
-        })
+        return remove_nones_from_dict(<%= lines(python_literal(request_properties(prop.properties, 'self.request', 'self.module'), use_hash_brackets: true)) -%>)
 
     def from_response(self):
-        return remove_nones_from_dict({
-<%= lines(response_properties_in_classes(prop.properties, 12)) -%>
-        })
+        return remove_nones_from_dict(<%= lines(python_literal(response_properties(prop.properties, 'self.request', 'self.module'), use_hash_brackets: true)) -%>)
 <% elsif prop.is_a?(Api::Type::Array) && prop.item_type.is_a?(Api::Type::NestedObject) -%>
     def __init__(self, request, module):
         self.module = module
@@ -38,18 +34,10 @@ class <%= prop.property_class[-1] -%>(object):
         return items
 
     def _request_for_item(self, item):
-        return remove_nones_from_dict({
-<%=
-  lines(request_properties_in_classes(prop.item_type.properties, 12, 'item'))
--%>
-        })
+        return remove_nones_from_dict(<%= lines(python_literal(request_properties(prop.item_type.properties, 'item', 'self.module'), use_hash_brackets: true))-%>)
 
     def _response_from_item(self, item):
-        return remove_nones_from_dict({
-<%=
-  lines(response_properties_in_classes(prop.item_type.properties, 12, 'item'))
--%>
-        })
+        return remove_nones_from_dict(<%= lines(python_literal(response_properties(prop.item_type.properties, 'item', 'self.module'), use_hash_brackets: true))-%>)
 <% end # prop.is_a? NestedObject -%>
 <%=
   unless prop == properties_with_classes(object.all_user_properties).last

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -242,9 +242,7 @@ def <%= props.first.name.underscore -%>_update(module, request, response):
             "<%= object.__product.base_url -%>",
             "<%= key[:update_url].gsub('{{', '{').gsub('}}', '}') -%>"
         ]).format(**module.params),
-        {
-<%= lines(request_properties(props, 12)) -%>
-        }
+<%= lines(python_literal(request_properties(props), use_hash_brackets: true)) -%>
     )
 
 
@@ -281,12 +279,12 @@ def resource_to_request(module):
     object.properties.reject(&:output)
   ].flatten.compact
 -%>
-    request = {
-<% if object.kind? -%>
-        u'kind': <%= quote_string(object.kind) -%>,
-<% end # if object.kind? -%>
-<%= lines(indent(request_properties(properties_in_request, 4), 4)) -%>
-    }
+<%
+  request_hash = {
+    Google::PythonUtils::UnicodeString.new('kind') => object.kind
+}.merge(request_properties(properties_in_request))
+-%>
+    request = <%= lines(python_literal(request_hash, use_hash_brackets: true)) -%>
 <% if object.encoder? -%>
     request = <%= object.transport.encoder -%>(request, module)
 <% end -%>
@@ -394,9 +392,7 @@ def is_different(module, response):
 # Remove unnecessary properties from the response.
 # This is for doing comparisons with Ansible's current parameters.
 def response_to_hash(module, response):
-    return {
-<%= lines(response_properties(object.properties, 8)) -%>
-    }
+    return <%= lines(python_literal(response_properties(object.properties), use_hash_brackets: true)) -%>
 <% readonly_selflink_rrefs.each do |resource| -%>
 
 

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -44,22 +44,7 @@ import json
 def main():
     """Main function"""
 
-<% conflicting = conflicting_property_batches(object) -%>
-    module = GcpModule(
-<%=
-  indent(remove_outside_dict(python_literal({
-    'argument_spec'=> {
-      'state' => {
-        'default' => 'present',
-        'choices' => ['present', 'absent'],
-        'type' => 'str'
-      }
-    }.merge(ansible_module(object.all_user_properties)),
-    'mutually_exclusive' => (conflicting_property_batches(object) \
-      unless conflicting_property_batches(object).empty?)
-  })), 12)
--%>
-    )
+<%= lines(indent(compile('templates/ansible/module.erb'), 4)) -%>
 
     if not module.params['scopes']:
         module.params['scopes'] = <%= python_literal(object.__product.scopes) %>

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -44,22 +44,21 @@ import json
 def main():
     """Main function"""
 
-<%
-  mod_props = object.all_user_properties.reject(&:output).map do |prop|
-    python_dict_for_property(prop, object)
-  end
--%>
 <% conflicting = conflicting_property_batches(object) -%>
     module = GcpModule(
-        argument_spec=dict(
-            state=dict(default='present', choices=['present', 'absent'], type='str'),
-<%= lines(indent_list(mod_props, 12)) -%>
-<% unless conflicting.empty? -%>
-        ),
-        mutually_exclusive=<%= python_literal(conflicting) %>
-<% else -%>
-        )
-<% end -%>
+<%=
+  indent(remove_outside_dict(python_literal({
+    'argument_spec'=> {
+      'state' => {
+        'default' => 'present',
+        'choices' => ['present', 'absent'],
+        'type' => 'str'
+      }
+    }.merge(ansible_module(object.all_user_properties)),
+    'mutually_exclusive' => (conflicting_property_batches(object) \
+      unless conflicting_property_batches(object).empty?)
+  })), 12)
+-%>
     )
 
     if not module.params['scopes']:


### PR DESCRIPTION
The AnsibleModule logic is just a giant dictionary. With the new code formatter, you don't need a lot of fancy logic to output a Python dictionary. This looks a lot cleaner in MM and removes code. Win-win!

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
