### PR TITLE
Add custom JSON generation

### DIFF
--- a/.ci/magic-modules/ensure_downstreams_merged.py
+++ b/.ci/magic-modules/ensure_downstreams_merged.py
@@ -20,7 +20,7 @@ def get_unmerged_prs(g, dependencies):
     for pull in pulls:
       # check whether the PR is merged - if it is, add it to the list.
       pr = repo.get_pull(int(pull[1]))
-      if not pr.is_merged():
+      if not pr.is_merged() and not pr.state == "closed":
         unmerged_dependencies.append(pull)
   return unmerged_dependencies
 

--- a/api/product.rb
+++ b/api/product.rb
@@ -35,6 +35,7 @@ module Api
     end
 
     def to_s
+      # relies on the custom to_json definitions
       JSON.pretty_generate(self)
     end
 

--- a/api/product.rb
+++ b/api/product.rb
@@ -34,6 +34,10 @@ module Api
       name.downcase
     end
 
+    def to_s
+      JSON.pretty_generate(self)
+    end
+
     def to_json(opts = nil)
       json_out = {}
 

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -135,6 +135,21 @@ module Api
       end
     end
 
+    def to_json(opts = nil)
+      # ignore fields that will contain references to parent resources
+      ignored_fields = %i[@__product @__parent @__resource @api_name @collection_url_response]
+      json_out = {}
+
+      instance_variables.each do |v|
+        json_out[v] = instance_variable_get(v) unless ignored_fields.include? v
+      end
+
+      json_out[:@properties] = properties.map { |p| [p.name, p] }.to_h
+      json_out[:@parameters] = parameters.map { |p| [p.name, p] }.to_h
+
+      JSON.generate(json_out, opts)
+    end
+
     def identity
       props = all_user_properties
       if @identity.nil?

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -135,6 +135,10 @@ module Api
       end
     end
 
+    def to_s
+      JSON.pretty_generate(self)
+    end
+
     def to_json(opts = nil)
       # ignore fields that will contain references to parent resources
       ignored_fields = %i[@__product @__parent @__resource @api_name @collection_url_response]

--- a/api/type.rb
+++ b/api/type.rb
@@ -83,7 +83,7 @@ module Api
       instance_variables.each do |v|
         if v == :@conflicts && instance_variable_get(v).empty?
           # ignore empty conflict arrays
-        elsif instance_variable_get(v) == false
+        elsif instance_variable_get(v) == false || instance_variable_get(v).nil?
           # ignore false booleans as non-existence indicates falsey
         elsif !ignored_fields.include? v
           json_out[v] = instance_variable_get(v)

--- a/api/type.rb
+++ b/api/type.rb
@@ -74,6 +74,10 @@ module Api
       check_conflicts
     end
 
+    def to_s
+      JSON.pretty_generate(self)
+    end
+
     def to_json(opts = nil)
       # ignore fields that will contain references to parent resources and
       # those which will be added later

--- a/api/type.rb
+++ b/api/type.rb
@@ -74,6 +74,29 @@ module Api
       check_conflicts
     end
 
+    def to_json(opts = nil)
+      # ignore fields that will contain references to parent resources and
+      # those which will be added later
+      ignored_fields = %i[@resource @__parent @__resource @api_name]
+      json_out = {}
+
+      instance_variables.each do |v|
+        if v == :@conflicts && instance_variable_get(v).empty?
+          # ignore empty conflict arrays
+        elsif instance_variable_get(v) == false
+          # ignore false booleans as non-existence indicates falsey
+        elsif !ignored_fields.include? v
+          json_out[v] = instance_variable_get(v)
+        end
+      end
+
+      # convert properties to a hash based on name for nested readability
+      json_out[:@properties] = properties&.map { |p| [p.name, p] }.to_h \
+        if respond_to? 'properties'
+
+      JSON.generate(json_out, opts)
+    end
+
     def check_default_value_property
       return if @default_value.nil?
 


### PR DESCRIPTION
to_json will print out a more human readable representation of the api
representation. It uses api property names as json key's in order to provide
more useful breadcrumbs and viewing when collapsed.

Example output:
![screen shot 2019-01-15 at 12 34 25 pm](https://user-images.githubusercontent.com/1569002/51208282-149bfd00-18c2-11e9-8628-5ceea0f39ca1.png)


<!-- Your regular pull request body goes here -->

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
no-op
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
