### PR TITLE
Ensure exclude_if_not_in_version is run

### DIFF
--- a/api/resource.rb
+++ b/api/resource.rb
@@ -202,15 +202,15 @@ module Api
       version < min_version
     end
 
-    # Recurses through all nested properties and paramters and changes their
+    # Recurses through all nested properties and parameters and changes their
     # 'exclude' instance variable if the property is at a version below the
     # one that is passed in.
     def exclude_if_not_in_version!(version)
-      @exclude ||= version < min_version
+      @exclude ||= below_version? version
       @properties&.each { |p| p.exclude_if_not_in_version!(version) }
       @parameters&.each { |p| p.exclude_if_not_in_version!(version) }
 
-      @exclude
+      nil
     end
 
     # Returns all properties and parameters including the ones that are

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -198,7 +198,7 @@ module Api
       (@parameters || []).reject(&:exclude)
     end
 
-    def below_version?(version)
+    def not_in_version?(version)
       version < min_version
     end
 
@@ -206,7 +206,7 @@ module Api
     # 'exclude' instance variable if the property is at a version below the
     # one that is passed in.
     def exclude_if_not_in_version!(version)
-      @exclude ||= below_version? version
+      @exclude ||= not_in_version? version
       @properties&.each { |p| p.exclude_if_not_in_version!(version) }
       @parameters&.each { |p| p.exclude_if_not_in_version!(version) }
 

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -198,10 +198,10 @@ module Api
       (@parameters || []).reject(&:exclude)
     end
 
-    def exclude_if_not_in_version(version)
+    def exclude_if_not_in_version!(version)
       @exclude ||= version < min_version
-      @properties&.each { |p| p.exclude_if_not_in_version(version) }
-      @parameters&.each { |p| p.exclude_if_not_in_version(version) }
+      @properties&.each { |p| p.exclude_if_not_in_version!(version) }
+      @parameters&.each { |p| p.exclude_if_not_in_version!(version) }
 
       @exclude
     end

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -198,6 +198,13 @@ module Api
       (@parameters || []).reject(&:exclude)
     end
 
+    def below_version?(version)
+      version < min_version
+    end
+
+    # Recurses through all nested properties and paramters and changes their
+    # 'exclude' instance variable if the property is at a version below the
+    # one that is passed in.
     def exclude_if_not_in_version!(version)
       @exclude ||= version < min_version
       @properties&.each { |p| p.exclude_if_not_in_version!(version) }

--- a/api/type.rb
+++ b/api/type.rb
@@ -156,7 +156,7 @@ module Api
       end
     end
 
-    def exclude_if_not_in_version(version)
+    def exclude_if_not_in_version!(version)
       @exclude ||= version < min_version
     end
 
@@ -344,9 +344,9 @@ module Api
         [property_file]
       end
 
-      def exclude_if_not_in_version(version)
+      def exclude_if_not_in_version!(version)
         super
-        @item_type.exclude_if_not_in_version(version) \
+        @item_type.exclude_if_not_in_version!(version) \
           if @item_type.is_a? NestedObject
       end
     end
@@ -536,9 +536,9 @@ module Api
         @properties.reject(&:exclude)
       end
 
-      def exclude_if_not_in_version(version)
+      def exclude_if_not_in_version!(version)
         super
-        @properties.each { |p| p.exclude_if_not_in_version(version) }
+        @properties.each { |p| p.exclude_if_not_in_version!(version) }
       end
     end
 

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -188,7 +188,7 @@ module Provider
           Google::LOGGER.info "Excluding #{object.name} per user request"
         elsif types.empty? && object.exclude
           Google::LOGGER.info "Excluding #{object.name} per API catalog"
-        elsif types.empty? && object.is_below_version(version)
+        elsif types.empty? && object.below_version?(version)
           Google::LOGGER.info "Excluding #{object.name} per API version"
         else
           Google::LOGGER.info "Generating #{object.name}"
@@ -230,7 +230,7 @@ module Provider
           Google::LOGGER.info(
             "Excluding #{object.name} datasource per API catalog"
           )
-        elsif types.empty? && object.exclude_if_not_in_version(version)
+        elsif types.empty? && object.below_version?(version)
           Google::LOGGER.info(
             "Excluding #{object.name} datasource per API version"
           )

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -184,11 +184,15 @@ module Provider
       version = @api.version_obj_or_default(version_name)
       @api.set_properties_based_on_version(version)
       (@api.objects || []).each do |object|
+        # exclude_if_not_in_version is destructive for 'object' and will remove
+        # properties that are not the required version.
+        excluded = object.exclude_if_not_in_version!(version)
+
         if !types.empty? && !types.include?(object.name)
           Google::LOGGER.info "Excluding #{object.name} per user request"
         elsif types.empty? && object.exclude
           Google::LOGGER.info "Excluding #{object.name} per API catalog"
-        elsif types.empty? && object.exclude_if_not_in_version(version)
+        elsif types.empty? && excluded
           Google::LOGGER.info "Excluding #{object.name} per API version"
         else
           # version_name will differ from version.name if the resource is being

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -184,17 +184,18 @@ module Provider
       version = @api.version_obj_or_default(version_name)
       @api.set_properties_based_on_version(version)
       (@api.objects || []).each do |object|
-        # exclude_if_not_in_version is destructive for 'object' and will remove
-        # properties that are not the required version.
-        excluded = object.exclude_if_not_in_version!(version)
-
         if !types.empty? && !types.include?(object.name)
           Google::LOGGER.info "Excluding #{object.name} per user request"
         elsif types.empty? && object.exclude
           Google::LOGGER.info "Excluding #{object.name} per API catalog"
-        elsif types.empty? && excluded
+        elsif types.empty? && object.is_below_version(version)
           Google::LOGGER.info "Excluding #{object.name} per API version"
         else
+          Google::LOGGER.info "Generating #{object.name}"
+          # exclude_if_not_in_version must be called in order to filter out
+          # beta properties that are nested within GA resrouces
+          object.exclude_if_not_in_version!(version)
+
           # version_name will differ from version.name if the resource is being
           # generated at its default version instead of the one that was passed
           # in to the compiler. Terraform needs to know which version was passed

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -188,7 +188,7 @@ module Provider
           Google::LOGGER.info "Excluding #{object.name} per user request"
         elsif types.empty? && object.exclude
           Google::LOGGER.info "Excluding #{object.name} per API catalog"
-        elsif types.empty? && object.below_version?(version)
+        elsif types.empty? && object.not_in_version?(version)
           Google::LOGGER.info "Excluding #{object.name} per API version"
         else
           Google::LOGGER.info "Generating #{object.name}"
@@ -230,7 +230,7 @@ module Provider
           Google::LOGGER.info(
             "Excluding #{object.name} datasource per API catalog"
           )
-        elsif types.empty? && object.below_version?(version)
+        elsif types.empty? && object.not_in_version?(version)
           Google::LOGGER.info(
             "Excluding #{object.name} datasource per API version"
           )

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -27,7 +27,7 @@ describe Api::Resource do
     context 'ga' do
       it do
         version = product.version_obj('ga')
-        subject.exclude_if_not_in_version(version)
+        subject.exclude_if_not_in_version!(version)
         is_expected.not_to(contain_property_with_name('beta-property'))
         is_expected.to(contain_property_with_name('property1'))
       end
@@ -36,7 +36,7 @@ describe Api::Resource do
     context 'beta' do
       it do
         version = product.version_obj('beta')
-        subject.exclude_if_not_in_version(version)
+        subject.exclude_if_not_in_version!(version)
         is_expected.to(contain_property_with_name('beta-property'))
         is_expected.to(contain_property_with_name('property1'))
       end


### PR DESCRIPTION
Fixes the bug where exclude_if_not_in_version wasn't being run when a 'type'
was passed with the -T flag. This would end up with beta properties leaking
into resources.
Marks exclude_if_not_in_version as destructive.

<!-- Your regular pull request body goes here -->

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
no-op
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
