### PR TITLE
Remove legacy chef/puppet Transport encoders/decoders.

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -1617,9 +1617,6 @@ objects:
       so that leftover disks are not left behind on machine deletion.
 <% type = 'InstanceTemplate' -%>
 <%= indent(compile_file({}, 'templates/global_async.yaml.erb'), 4) %>
-    transport: !ruby/object:Api::Resource::Transport
-      encoder: encode_request
-      decoder: decode_response
     properties:
       - !ruby/object:Api::Type::Time
         name: 'creationTimestamp'
@@ -2003,9 +2000,6 @@ objects:
                       'templates/zonal_async.yaml.erb'), 4)
 
 %>
-    transport: !ruby/object:Api::Resource::Transport
-      encoder: encode_request
-      decoder: decode_response
     parameters:
       - !ruby/object:Api::Type::ResourceRef
         name: 'zone'
@@ -3835,9 +3829,6 @@ objects:
         'Official Documentation':
           'https://cloud.google.com/compute/docs/load-balancing/network/target-pools'
       api: 'https://cloud.google.com/compute/docs/reference/rest/v1/targetPools'
-    transport: !ruby/object:Api::Resource::Transport
-      encoder: encode_request
-      decoder: decode_request
 <%= indent(compile_file({}, 'templates/regional_async.yaml.erb'), 4) %>
     parameters:
       - !ruby/object:Api::Type::ResourceRef

--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -36,8 +36,6 @@ objects:
         name: masterAuth
       - name
     description: 'A Google Container Engine cluster.'
-    transport: !ruby/object:Api::Resource::Transport
-      encoder: encode_request
     collection_url_response: !ruby/object:Api::Resource::ResponseList
       items: 'clusters'
     parameters:
@@ -298,8 +296,6 @@ objects:
       set of Kubernetes labels applied to them, which may be used to reference
       them during pod scheduling. They may also be resized up or down, to
       accommodate the workload.
-    transport: !ruby/object:Api::Resource::Transport
-      encoder: encode_request
     collection_url_response: !ruby/object:Api::Resource::ResponseList
       items: 'nodePools'
     parameters:

--- a/products/iam/api.yaml
+++ b/products/iam/api.yaml
@@ -26,9 +26,6 @@ objects:
   - !ruby/object:Api::Resource
     name: 'ServiceAccount'
     base_url: projects/{{project}}/serviceAccounts
-    transport: !ruby/object:Api::Resource::Transport
-      encoder: encode_request
-      decoder: decode_response
     description: |
       A service account in the Identity and Access Management API.
     exports:
@@ -60,8 +57,6 @@ objects:
   - !ruby/object:Api::Resource
     name: 'ServiceAccountKey'
     base_url: projects/{{project}}/serviceAccounts/{{service_account}}/keys
-    transport: !ruby/object:Api::Resource::Transport
-      decoder: decode_response
     description: |
       A service account in the Identity and Access Management API.
     parameters:

--- a/products/spanner/ansible.yaml
+++ b/products/spanner/ansible.yaml
@@ -52,9 +52,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     provider_helpers:
       - 'products/spanner/helpers/python/instance_helpers.py.erb'
   Database: !ruby/object:Overrides::Ansible::ResourceOverride
-    transport: !ruby/object:Api::Resource::Transport
-      encoder: encode_request
-      decoder: decode_response
     provider_helpers:
       - 'products/spanner/helpers/python/database_helpers.py.erb'
   # Virtual => true objects that don't need dedicated resources.

--- a/products/spanner/api.yaml
+++ b/products/spanner/api.yaml
@@ -31,9 +31,6 @@ objects:
       - !ruby/object:Api::Type::FetchedExternal
         name: name
     readonly: true
-    transport: !ruby/object:Api::Resource::Transport
-      encoder: encode_request
-      decoder: decode_response
     properties:
       - !ruby/object:Api::Type::String
         name: 'name'
@@ -54,8 +51,6 @@ objects:
       hosted.
     exports:
       - name
-    transport: !ruby/object:Api::Resource::Transport
-      decoder: decode_response
     collection_url_response: !ruby/object:Api::Resource::ResponseList
       items: 'instances'
     properties:
@@ -115,8 +110,6 @@ objects:
     description: |
       A Cloud Spanner Database which is hosted on a Spanner instance.
     input: true
-    transport: !ruby/object:Api::Resource::Transport
-      decoder: decode_response
     collection_url_response: !ruby/object:Api::Resource::ResponseList
       items: 'databases'
     references: !ruby/object:Api::Resource::ReferenceLinks


### PR DESCRIPTION
Can't fully remove the `transport`, since Ansible uses it for encoders/decoders as well, but these are legacy puppet/chef annotations.

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
Should be a no-op - any PRs generated will be eliminated before upstream is submitted.
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
