### PR TITLE
Moving Property Type from API -> InSpec

### DIFF
--- a/api/type.rb
+++ b/api/type.rb
@@ -519,13 +519,5 @@ module Api
     def get_type(type)
       Module.const_get(type)
     end
-
-    def property_ns_prefix
-      [
-        'Google',
-        @__resource.__product.api_name.camelize(:upper),
-        'Property'
-      ]
-    end
   end
 end

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -304,13 +304,13 @@ module Provider
       end
 
       def array_class(property)
-        if property.item_type.is_a?(Api::Type::NestedObject)
-          type = nestedobject_class(property.item_type)
-        elsif property.item_type.is_a?(Api::Type::ResourceRef)
-          type = resourceref_class(property.item_type)
-        else
-          type = prefix(property).concat(Module.const_get(property.type).new(property.name).type)
-        end
+        type = if property.item_type.is_a?(Api::Type::NestedObject)
+                 nestedobject_class(property.item_type)
+               elsif property.item_type.is_a?(Api::Type::ResourceRef)
+                 resourceref_class(property.item_type)
+               else
+                 prefix(property).concat(Module.const_get(property.type).new(property.name).type)
+               end
         type[-1] = "#{type[-1].camelize(:upper)}Array"
         type
       end


### PR DESCRIPTION
Property_type is only used by InSpec, so I moved it over to InSpec code.

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
