### PR TITLE
gomodules need to be vendored after the code is in its final state.

### DIFF
--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -60,6 +60,8 @@ git checkout -B "$(cat ../../branchname)"
 
 apply_patches "$PATCH_DIR/terraform-providers/$PROVIDER_NAME" "$TERRAFORM_COMMIT_MSG" "$LAST_COMMIT_AUTHOR" "master"
 
+go mod vendor
+
 popd
 popd
 


### PR DESCRIPTION
This will make it much easier to add new dependencies and update old ones.

-----------------------------------------------------------------
# [all]
No changes expected.
## [terraform]
Changes ancillary to adding a new vendoring step in generation.
### [terraform-beta]
## [ansible]
## [inspec]
