### PR TITLE
Fix map in Random provider in SSLCert OiCS example.

### DIFF
--- a/templates/terraform/examples/ssl_certificate_random_provider.tf.erb
+++ b/templates/terraform/examples/ssl_certificate_random_provider.tf.erb
@@ -16,7 +16,7 @@ resource "random_id" "certificate" {
   prefix      = "my-certificate-"
 
   # For security, do not expose raw certificate values in the output
-  keepers {
+  keepers = {
     private_key = "${base64sha256(file("path/to/private.key"))}"
     certificate = "${base64sha256(file("path/to/certificate.crt"))}"
   }


### PR DESCRIPTION
Didn't catch this one before because we had to remove the random provider.

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
