### PR TITLE
Inline generate_file, comment thoroughly

### DIFF
--- a/api/compiler.rb
+++ b/api/compiler.rb
@@ -40,8 +40,7 @@ module Api
       # Compile step #2: Now that we have the target class, compile with that
       # class features
       source = config.compile(@catalog, 0)
-      config = Google::YamlValidator.parse(source)
-      config
+      Google::YamlValidator.parse(source)
     end
   end
 end


### PR DESCRIPTION
When looking through this file, `generate_file` was intimidating- it shelled out to a bunch of functions (that are only used once!) and had some weird syntax I [the reader] didn't expect like the `yield` used to verify that files have an autogen header.

Essentially, it looked complex but we're serially running a bunch of tasks on a file.By inlining, we make it super clear what's happening and in what order.

Also comment the header + comment the body thoroughly at any point that I was initially confused, or felt the code didn't explain it well enough.

also a couple other refactorings oops. I was "gardening" a little and didn't know this PR would end up focused on `generate_file` when I started. Let me know if you want them broken out.

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
