### PR TITLE
Fix Terraform examples override changes that got lost in merges

### DIFF
--- a/overrides/terraform/resource_override.rb
+++ b/overrides/terraform/resource_override.rb
@@ -32,13 +32,9 @@ module Overrides
           # resource.
           :mutex,
 
-          # Deprecated - examples in documentation
-          # TODO(rileykarson): Remove examples and replace them with new examples
-          :examples,
-
-          # New examples in documentation - will take the "examples" name when
-          # old-style examples are gone.
-          :example
+          # Examples in documentation. Backed by generated tests, and have
+          # corresponding OiCS walkthroughs.
+          :examples
         ]
       end
 


### PR DESCRIPTION
Replay the changes from https://github.com/GoogleCloudPlatform/magic-modules/pull/1214/ that got lost somewhere in the new overrides PRs.

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
