### PR TITLE
Make sure that we don't respond to community PRs more than once.

### DIFF
--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -35,6 +35,15 @@ resources:
           uri: git@github.com:GoogleCloudPlatform/magic-modules.git
           private_key: ((repo-key.private_key))
 
+    - name: magic-modules-new-external-prs
+      type: github-pull-request
+      source:
+          repo: GoogleCloudPlatform/magic-modules
+          private_key: ((repo-key.private_key))
+          access_token: ((github-account.password))
+          community_only: true
+          no_label: community
+
     - name: magic-modules-external-prs
       type: github-pull-request
       source:
@@ -109,7 +118,7 @@ jobs:
           - put: magic-modules-external-prs
             params:
                 status: pending
-                path: magic-modules-external-prs
+                path: magic-modules-new-external-prs
                 label: community
                 comment: comment/pr_comment
                 assignee_file: comment/assignee
@@ -120,7 +129,6 @@ jobs:
       plan:
           - get: magic-modules-external-prs
             trigger: false
-            passed: [respond-to-community-pr]
           - put: magic-modules-new-prs
             params:
                 status: pending

--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -109,7 +109,7 @@ resources:
 jobs:
     - name: respond-to-community-pr
       plan:
-          - get: magic-modules-external-prs
+          - get: magic-modules-new-external-prs
             trigger: true
           - get: magic-modules-gcp
             # NOTE: we do NOT run a script from the external PR!

--- a/.ci/magic-modules/welcome-contributor.sh
+++ b/.ci/magic-modules/welcome-contributor.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-echo > comment/pr_comment << EOF
+cat > comment/pr_comment << EOF
 Hello!  I am a robot who works on Magic Modules PRs.
 
 I have detected that you are a community contributor, so your PR will be assigned to someone with a commit-bit on this repo for initial review.  They will authorize it to run through our CI pipeline, which will generate downstream PRs.


### PR DESCRIPTION
Right now we'll welcome/assign PRs from community folks once per commit - we should do it only once.  Use labels / no_label to make that happen.

-----------------------------------------------------------------
# [all]
CI changes only
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
