### PR TITLE
Changing NodePool from Zone to Location

### DIFF
--- a/products/container/ansible.yaml
+++ b/products/container/ansible.yaml
@@ -41,6 +41,7 @@ datasources: !ruby/object:Overrides::ResourceOverrides
     version_added: '2.8'
     properties:
       location: !ruby/object:Overrides::Ansible::PropertyOverride
+        version_added: '2.8'
         aliases: ["zone", "region"]
     facts: !ruby/object:Provider::Ansible::FactsOverride
       has_filters: false

--- a/products/container/ansible.yaml
+++ b/products/container/ansible.yaml
@@ -39,6 +39,9 @@ datasources: !ruby/object:Overrides::ResourceOverrides
           "'my-cluster' not in \"{{ results['items'] | map(attribute='name') | list }}\""
   NodePool: !ruby/object:Overrides::Ansible::ResourceOverride
     version_added: '2.8'
+    properties:
+      location: !ruby/object:Overrides::Ansible::PropertyOverride
+        aliases: ["zone", "region"]
     facts: !ruby/object:Provider::Ansible::FactsOverride
       has_filters: false
       test: !ruby/object:Provider::Ansible::AnsibleFactsTestInformation

--- a/products/container/ansible.yaml
+++ b/products/container/ansible.yaml
@@ -28,8 +28,8 @@ datasources: !ruby/object:Overrides::ResourceOverrides
     version_added: '2.8'
     properties:
       location: !ruby/object:Overrides::Ansible::PropertyOverride
-        aliases:
-          - zone
+        version_added: '2.8'
+        aliases: ["region", "zone"]
     facts: !ruby/object:Provider::Ansible::FactsOverride
       has_filters: false
       test: !ruby/object:Provider::Ansible::AnsibleFactsTestInformation
@@ -42,7 +42,7 @@ datasources: !ruby/object:Overrides::ResourceOverrides
     properties:
       location: !ruby/object:Overrides::Ansible::PropertyOverride
         version_added: '2.8'
-        aliases: ["zone", "region"]
+        aliases: ["region", "zone"]
     facts: !ruby/object:Provider::Ansible::FactsOverride
       has_filters: false
       test: !ruby/object:Provider::Ansible::AnsibleFactsTestInformation
@@ -54,6 +54,11 @@ datasources: !ruby/object:Overrides::ResourceOverrides
     exclude: true
 overrides: !ruby/object:Overrides::ResourceOverrides
   Cluster: !ruby/object:Overrides::Ansible::ResourceOverride
+    properties:
+      location: !ruby/object:Overrides::Ansible::PropertyOverride
+        version_added: '2.8'
+        aliases:
+          - zone
     provider_helpers:
       - 'products/container/helpers/python/provider_cluster.py'
   KubeConfig: !ruby/object:Overrides::Ansible::ResourceOverride
@@ -61,6 +66,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   NodePool: !ruby/object:Overrides::Ansible::ResourceOverride
     provider_helpers:
       - 'products/container/helpers/python/provider_node_pool.py'
+    properties:
+      location: !ruby/object:Overrides::Ansible::PropertyOverride
+        version_added: '2.8'
+        aliases: ["region", "zone"]
 files: !ruby/object:Provider::Config::Files
   compile:
 <%= lines(indent(compile('provider/ansible/product~compile.yaml'), 4)) -%>

--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -284,7 +284,7 @@ objects:
   - !ruby/object:Api::Resource
     name: 'NodePool'
 <%= indent(compile('products/container/async.yaml'), 4) %>
-    base_url: projects/{{project}}/zones/{{zone}}/clusters/{{cluster}}/nodePools
+    base_url: projects/{{project}}/zones/{{location}}/clusters/{{cluster}}/nodePools
     description: |
       NodePool contains the name and configuration for a cluster's node pool.
       Node pools are a set of nodes (i.e. VM's), with a common configuration and
@@ -304,8 +304,8 @@ objects:
         description: 'The cluster this node pool belongs to.'
         required: true
       - !ruby/object:Api::Type::String
-        name: 'zone'
-        description: 'The zone where the node pool is deployed'
+        name: 'location'
+        description: 'The location where the node pool is deployed'
         required: true
     properties:
       - !ruby/object:Api::Type::String
@@ -405,8 +405,8 @@ objects:
       # TODO(nelsonjr): Make 'zone' a ResourceRef once cross-module references
       # are possible.
       - !ruby/object:Api::Type::String
-        name: 'zone'
-        description: 'The zone where the container is deployed'
+        name: 'location'
+        description: 'The location where the container is deployed'
         required: true
       - !ruby/object:Api::Type::String
         name: 'context'

--- a/products/container/examples/ansible/node_pool.yaml
+++ b/products/container/examples/ansible/node_pool.yaml
@@ -18,7 +18,7 @@ task: !ruby/object:Provider::Ansible::Task
       name: 'my-pool'
       initial_node_count: 4
       cluster: "{{ cluster }}"
-      zone: 'us-central1-a'
+      location: 'us-central1-a'
       project: <%= ctx[:project] %>
       auth_kind: <%= ctx[:auth_kind] %>
       service_account_file: <%= ctx[:service_account_file] %>
@@ -28,7 +28,7 @@ dependencies:
     code:
       name: <%= dependency_name('cluster', 'nodePool') %>
       initial_node_count: 4
-      zone: 'us-central1-a'
+      location: 'us-central1-a'
       project: <%= ctx[:project] %>
       auth_kind: <%= ctx[:auth_kind] %>
       service_account_file: <%= ctx[:service_account_file] %>


### PR DESCRIPTION
This allows for regional node pools as well.

Because of Ansible aliasing, there will be no backwards-compatibility issues with this.

Referencing: https://github.com/ansible/ansible/issues/51447
<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
