### PR TITLE
[Terraform]: Make zone required in google_composer_environment.node_config

### DIFF
--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -96,8 +96,7 @@ func resourceComposerEnvironment() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"zone": {
 										Type:             schema.TypeString,
-										Computed:         true,
-										Optional:         true,
+										Required:         true,
 										ForceNew:         true,
 										DiffSuppressFunc: compareSelfLinkOrResourceName,
 									},

--- a/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -167,7 +167,7 @@ The `config` block supports:
 The `node_config` block supports:
 
 * `zone` -
-  (Optional)
+  (Required)
   The Compute Engine zone in which to deploy the VMs running the
   Apache Airflow software, specified as the zone name or
   relative resource name (e.g. "projects/{project}/zones/{zone}"). Must belong to the enclosing environment's project 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/2966

Our tests already define the field, and have an example where the block isn't defined.

Waiting on CI test run to assign.

-----------------------------------------------------------------
# [all]
## [terraform]
Make zone required in google_composer_environment.node_config
### [terraform-beta]
## [ansible]
## [inspec]
