### PR TITLE
Update GKE examples, docs to recommend fine grained node pools.

### DIFF
--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -16,7 +16,7 @@ and [the API reference](https://cloud.google.com/kubernetes-engine/docs/referenc
 passwords as well as certificate outputs will be stored in the raw state as
 plaintext. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
-## Example Usage - With a fine-grained node pool (recommended)
+## Example Usage - with a separately managed node pool (recommended)
 
 ```hcl
 resource "google_container_cluster" "primary" {
@@ -24,7 +24,7 @@ resource "google_container_cluster" "primary" {
   region = "us-central1"
 
   # We can't create a cluster with no node pool defined, but we want to only use
-  # explicitly defined node pools. So, we create the smallest possible default
+  # separately managed node pools. So we create the smallest possible default
   # node pool and immediately delete it.
   remove_default_node_pool = true
   initial_node_count = 1
@@ -62,10 +62,10 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
     machine_type = "n1-standard-1"
 
     oauth_scopes = [
-      "compute-rw",
-      "storage-ro",
-      "logging-write",
-      "monitoring",
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
     ]
   }
 }
@@ -85,7 +85,7 @@ output "cluster_ca_certificate" {
 }
 ```
 
-## Example Usage - With a default node pool
+## Example Usage - with the default node pool
 
 ```hcl
 resource "google_container_cluster" "primary" {

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -8,15 +8,84 @@ description: |-
 
 # google\_container\_cluster
 
-Creates a Google Kubernetes Engine (GKE) cluster. For more information see
+Manages a Google Kubernetes Engine (GKE) cluster. For more information see
 [the official documentation](https://cloud.google.com/container-engine/docs/clusters)
-and
-[API](https://cloud.google.com/container-engine/reference/rest/v1/projects.zones.clusters).
+and [the API reference](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters).
 
-~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
-[Read more about sensitive data in state](/docs/state/sensitive-data.html).
+~> **Note:** All arguments and attributes, including basic auth username and
+passwords as well as certificate outputs will be stored in the raw state as
+plaintext. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 
-## Example usage
+## Example Usage - With a fine-grained node pool (recommended)
+
+```hcl
+resource "google_container_cluster" "primary" {
+  name   = "my-gke-cluster"
+  region = "us-central1"
+
+  # We can't create a cluster with no node pool defined, but we want to only use
+  # explicitly defined node pools. So, we create the smallest possible default
+  # node pool and immediately delete it.
+  remove_default_node_pool = true
+  initial_node_count = 1
+
+  # Setting an empty username and password explicitly disables basic auth
+  master_auth {
+    username = ""
+    password = ""
+  }
+
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+
+    labels = {
+      foo = "bar"
+    }
+
+    tags = ["foo", "bar"]
+  }
+}
+
+resource "google_container_node_pool" "primary_preemptible_nodes" {
+  name       = "my-node-pool"
+  region     = "us-central1"
+  cluster    = "${google_container_cluster.primary.name}"
+  node_count = 1
+
+  node_config {
+    preemptible  = true
+    machine_type = "n1-standard-1"
+
+    oauth_scopes = [
+      "compute-rw",
+      "storage-ro",
+      "logging-write",
+      "monitoring",
+    ]
+  }
+}
+
+# The following outputs allow authentication and connectivity to the GKE Cluster
+# by using certificate-based authentication.
+output "client_certificate" {
+  value = "${google_container_cluster.primary.master_auth.0.client_certificate}"
+}
+
+output "client_key" {
+  value = "${google_container_cluster.primary.master_auth.0.client_key}"
+}
+
+output "cluster_ca_certificate" {
+  value = "${google_container_cluster.primary.master_auth.0.cluster_ca_certificate}"
+}
+```
+
+## Example Usage - With a default node pool
 
 ```hcl
 resource "google_container_cluster" "primary" {
@@ -24,14 +93,10 @@ resource "google_container_cluster" "primary" {
   zone               = "us-central1-a"
   initial_node_count = 3
 
-  additional_zones = [
-    "us-central1-b",
-    "us-central1-c",
-  ]
-
+  # Setting an empty username and password explicitly disables basic auth
   master_auth {
-    username = "mr.yoda"
-    password = "adoy.rm"
+    username = ""
+    password = ""
   }
 
   node_config {
@@ -55,7 +120,8 @@ resource "google_container_cluster" "primary" {
   }
 }
 
-# The following outputs allow authentication and connectivity to the GKE Cluster.
+# The following outputs allow authentication and connectivity to the GKE Cluster
+# by using certificate-based authentication.
 output "client_certificate" {
   value = "${google_container_cluster.primary.master_auth.0.client_certificate}"
 }
@@ -81,10 +147,11 @@ output "cluster_ca_certificate" {
     may be set. If neither zone nor region are set, the provider zone is used.
 
 * `region` (Optional)
-    The region to create the cluster in, for
+    The region to create the cluster in for
     [Regional Clusters](https://cloud.google.com/kubernetes-engine/docs/concepts/multi-zone-and-regional-clusters#regional).
     In a Regional Cluster, the number of nodes specified in `initial_node_count` is
-    created in three zones of the region (this can be changed by setting `additional_zones`).
+    created in each of three zones of the region (this can be changed by setting
+     `additional_zones`).
 
 * `additional_zones` - (Optional) The list of additional Google Compute Engine
     locations in which the cluster's nodes should be located. If additional zones are
@@ -210,18 +277,23 @@ The `addons_config` block supports:
     It ensures that a Heapster pod is running in the cluster, which is also used by the Cloud Monitoring service.
     It is enabled by default;
     set `disabled = true` to disable.
+    
 * `http_load_balancing` - (Optional) The status of the HTTP (L7) load balancing
     controller addon, which makes it easy to set up HTTP load balancers for services in a
     cluster. It is enabled by default; set `disabled = true` to disable.
+    
 * `kubernetes_dashboard` - (Optional) The status of the Kubernetes Dashboard
     add-on, which controls whether the Kubernetes Dashboard is enabled for this cluster.
     It is enabled by default; set `disabled = true` to disable.
+    
 * `network_policy_config` - (Optional) Whether we should enable the network policy addon
     for the master.  This must be enabled in order to enable network policy for the nodes.
     It can only be disabled if the nodes already do not have network policies enabled.
     Set `disabled = true` to disable.
+    
 * `istio_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)).
     Structure is documented below.
+    
 * `cloudrun_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)).
     The status of the CloudRun addon. It requires `istio_config` enabled. It is disabled by default.
     Set `disabled = false` to enable. This addon can only be enabled at cluster creation time.
@@ -254,9 +326,12 @@ The `cluster_autoscaling` block supports:
     sure to set at least `cpu` and `memory`.  Structure is documented below.
 
 The `resource_limits` block supports:
+
 * `resource_type` - (Required) See [the docs](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning)
     for a list of permitted types - `cpu`, `memory`, and others.
+    
 * `minimum` - (Optional) The minimum value for the resource type specified.
+
 * `maximum` - (Optional) The maximum value for the resource type specified.
 
 The `maintenance_policy` block supports:

--- a/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -67,7 +67,6 @@ resource "google_container_cluster" "primary" {
   initial_node_count = 3
 
   additional_zones = [
-    "us-central1-b",
     "us-central1-c",
   ]
 

--- a/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -8,11 +8,11 @@ description: |-
 
 # google\_container\_node\_pool
 
-Manages a node pool in a Google Kubernetes Engine (GKE) cluster. For more
-information see [the official documentation](https://cloud.google.com/container-engine/docs/node-pools)
+Manages a node pool in a Google Kubernetes Engine (GKE) cluster separately from
+the cluster control plane. For more information see [the official documentation](https://cloud.google.com/container-engine/docs/node-pools)
 and [the API reference](https://cloud.google.com/container-engine/reference/rest/v1/projects.zones.clusters.nodePools).
 
-### Example Usage - Without a default pool (recommended)
+### Example Usage - using a separately managed node pool (recommended)
 
 ```hcl
 resource "google_container_cluster" "primary" {
@@ -20,7 +20,7 @@ resource "google_container_cluster" "primary" {
   region = "us-central1"
   
   # We can't create a cluster with no node pool defined, but we want to only use
-  # explicitly defined node pools. So, we create the smallest possible default
+  # separately managed node pools. So we create the smallest possible default
   # node pool and immediately delete it.
   remove_default_node_pool = true
   initial_node_count = 1
@@ -37,16 +37,16 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
     machine_type = "n1-standard-1"
 
     oauth_scopes = [
-      "compute-rw",
-      "storage-ro",
-      "logging-write",
-      "monitoring",
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
     ]
   }
 }
 ```
 
-### Example Usage - mixed usage with a default pool and split out node pool
+### Example Usage - 2 node pools, 1 separately managed + the default node pool
 
 ```hcl
 resource "google_container_node_pool" "np" {


### PR DESCRIPTION
While making https://github.com/GoogleCloudPlatform/magic-modules/pull/1328 I noticed that a lot of our GKE docs pretty badly needed an update. This is the first pass of several, and definitely doesn't fix everything.

This makes it super explicit that users should use the fine grained node pool resource, so imo this fixes https://github.com/terraform-providers/terraform-provider-google/issues/475.

@chrisst: Assigning you since I had you on my PR a few minutes ago also hitting the GKE docs, but feel free to reassign to someone else if you'd like.

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
