### PR TITLE
Make objects immutable

### DIFF
--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -226,7 +226,6 @@ module Provider
       end
 
       def generate_resource(data)
-        add_datasource_info_to_data(data)
         target_folder = data[:output_folder]
         FileUtils.mkpath target_folder
         name = module_name(data[:object])
@@ -281,18 +280,20 @@ module Provider
         )
       end
 
-      def add_datasource_info_to_data(data)
+      def generate_objects(output_folder, types, version_name)
         # We have two sets of overrides - one for regular modules, one for
         # datasources.
         # When building regular modules, we will potentially need some
         # information from the datasource overrides.
         # This method will give the regular module data access to the
         # datasource module overrides.
-        name = "@#{data[:object].name}".to_sym
-        facts_info = @config&.datasources&.instance_variable_get(name)&.facts
-        facts_info ||= Provider::Ansible::FactsOverride.new
-        facts_info.validate
-        data[:object].instance_variable_set(:@facts, facts_info)
+        @api.objects.each do |o|
+          facts_info = @config&.datasources&.instance_variable_get("@#{o.name}".to_sym)&.facts
+          facts_info ||= Provider::Ansible::FactsOverride.new
+          facts_info.validate
+          o.instance_variable_set(:@facts, facts_info)
+        end
+        super
       end
     end
   end

--- a/provider/ansible/product~compile.yaml
+++ b/provider/ansible/product~compile.yaml
@@ -24,7 +24,6 @@
                       .map { |x| x.to_s.tr(':@', '') }
   object_names = api.objects
                     .select { |o| !excludes.include?(o.name) }
-                    .select { |o| !o.exclude_if_not_in_version!(version) }
                     .map do |object|
                       ["gcp_#{object.__product.api_name}",
                        object.name.underscore].join('_')

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -183,6 +183,10 @@ module Provider
           # beta properties that are nested within GA resrouces
           object.exclude_if_not_in_version!(version)
 
+          # Make object immutable.
+          object.freeze
+          object.all_user_properties.each(&:freeze)
+
           # version_name will differ from version.name if the resource is being
           # generated at its default version instead of the one that was passed
           # in to the compiler. Terraform needs to know which version was passed


### PR DESCRIPTION
MM is broken up into multiple stages: 
- API object creation
- Override application
- Validation (+ default values)
- Templating

Templating shouldn't alter the API object. After step 3, the API object should be completely immutable. Turns out it almost was (but not quite).

Before templating is done, this will use Ruby's `.freeze` notation to force the API to be completely immutable. Any attempts to change the API object during templating will cause a `RuntimeError`

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
