### PR TITLE
Inspec property refactor

### DIFF
--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -61,7 +61,7 @@ module Provider
     end
 
     def generate_properties(data, props)
-      nested_objects = props.select { |prop| prop.nested_properties? }
+      nested_objects = props.select(&:nested_properties?)
       return if nested_objects.empty?
 
       # Create property files for any nested objects.
@@ -139,7 +139,7 @@ module Provider
       )
     end
 
-    def emit_nested_object(data, property)
+    def emit_nested_object(_data, property)
       target = if property.is_a?(Api::Type::Array)
                  property.item_type.property_file
                else

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -72,12 +72,6 @@ module Provider
       nested_objects.each { |prop| generate_properties(data, prop.nested_properties) }
     end
 
-    def nested_object_data(data, nested_object)
-      data.clone.merge(
-        property: nested_object
-      )
-    end
-
     # Generate the files for the properties
     def generate_property_files(prop_map, data)
       prop_map.flatten.compact.each do |prop|
@@ -139,7 +133,7 @@ module Provider
       )
     end
 
-    def emit_nested_object(_data, property)
+    def emit_nested_object(property)
       target = if property.is_a?(Api::Type::Array)
                  property.item_type.property_file
                else

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -62,14 +62,14 @@ module Provider
 
     def generate_properties(data, props)
       nested_objects = props.select { |prop| prop.nested_properties? }
+      return if nested_objects.empty?
 
       # Create property files for any nested objects.
-      prop_map = nested_objects.map\
-        { |nested_object| emit_nested_object(data, nested_object) }
+      prop_map = nested_objects.map { |nested_object| emit_nested_object(data, nested_object) }
       generate_property_files(prop_map, data)
 
       # Create property files for any deeper nested objects.
-      nested_objects.map { |prop| generate_properties(data, prop.nested_properties) }
+      nested_objects.each { |prop| generate_properties(data, prop.nested_properties) }
     end
 
     def nested_object_data(data, nested_object)
@@ -140,7 +140,7 @@ module Provider
     end
 
     def emit_nested_object(data, property)
-      target = if data[:object].is_a?(Api::Type::Array)
+      target = if property.is_a?(Api::Type::Array)
                  property.item_type.property_file
                else
                  property.property_file

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -65,7 +65,7 @@ module Provider
       return if nested_objects.empty?
 
       # Create property files for any nested objects.
-      prop_map = nested_objects.map { |nested_object| emit_nested_object(data, nested_object) }
+      prop_map = nested_objects.map { |nested_object| emit_nested_object(nested_object) }
       generate_property_files(prop_map, data)
 
       # Create property files for any deeper nested objects.

--- a/templates/inspec/nested_object.erb
+++ b/templates/inspec/nested_object.erb
@@ -12,27 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -%>
+<%
+  # This template file generates both NestedObjects + Arrays of NestedObjects.
+  nested_property = if property.is_a?(Api::Type::Array)
+                    property.item_type
+                  else
+                    property
+                  end
+  class_name = nested_property.property_class.last
+  product_ns = nested_property.__resource.__product.api_name.camelize(:upper)
+-%>
 # frozen_string_literal: false
 
 <%= lines(autogen_notice :ruby) -%>
 <%
-  requires = generate_requires(nested_properties)
+  requires = generate_requires(nested_property.nested_properties)
 -%>
 <%= lines(emit_requires(requires)) -%>
 module GoogleInSpec
   module <%= product_ns %>
     module Property
       class <%= class_name -%>
-<% if !nested_properties.empty? -%>
-<% nested_properties.each do |prop| -%>
+<% if property.nested_properties? -%>
+<% property.nested_properties.each do |prop| -%>
 
         attr_reader :<%= prop.out_name %>
-<% end # nested_properties.each -%>
+<% end # property.nested_properties.each -%>
 
 <% end # if !nested_properties.empty? -%>
         def initialize(args = nil)
           return if args.nil?
-<% nested_properties.each do |prop| -%>
+<% property.nested_properties.each do |prop| -%>
 <%
   parse_code = "@#{prop.out_name} = #{parse_code(prop, 'args')}"
 -%>
@@ -40,7 +50,7 @@ module GoogleInSpec
 <% end # nested_properties.each -%>
         end
       end
-<% if emit_array -%>
+<% if property.is_a?(Api::Type::Array) -%>
 
       class <%= class_name %>Array
         def self.parse(value)
@@ -49,7 +59,7 @@ module GoogleInSpec
           value.map { |v| <%= class_name %>.new(v) }
         end
       end
-<% end #if emit_array -%>
+<% end #if property is Array -%>
     end
   end
 end

--- a/templates/inspec/nested_object.erb
+++ b/templates/inspec/nested_object.erb
@@ -39,7 +39,7 @@ module GoogleInSpec
         attr_reader :<%= prop.out_name %>
 <% end # property.nested_properties.each -%>
 
-<% end # if !nested_properties.empty? -%>
+<% end # if property.nested_properties? -%>
         def initialize(args = nil)
           return if args.nil?
 <% property.nested_properties.each do |prop| -%>
@@ -47,7 +47,7 @@ module GoogleInSpec
   parse_code = "@#{prop.out_name} = #{parse_code(prop, 'args')}"
 -%>
 <%= lines(indent(parse_code, 10)) -%>
-<% end # nested_properties.each -%>
+<% end # property.nested_properties.each -%>
         end
       end
 <% if property.is_a?(Api::Type::Array) -%>

--- a/templates/inspec/nested_object.erb
+++ b/templates/inspec/nested_object.erb
@@ -20,7 +20,7 @@
                     property
                   end
   class_name = nested_property.property_class.last
-  product_ns = nested_property.__resource.__product.api_name.camelize(:upper)
+  product_ns = product.name.camelize(:upper)
 -%>
 # frozen_string_literal: false
 


### PR DESCRIPTION
After looking through the nested_properties stuff, I really wanted to try and refactor the way InSpec generates property files. Hopefully, this allows nested properties + arrays of nested properties to be a little more interchangeable.

This change should be a no-op.

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
