### PR TITLE
Fix OiCS generation for 2.0.0 

### DIFF
--- a/provider/terraform/custom_code.rb
+++ b/provider/terraform/custom_code.rb
@@ -150,6 +150,7 @@ module Provider
 
       def config_example
         @vars ||= []
+        # Examples with test_env_vars are skipped elsewhere
         body = lines(compile_file(
                        {
                          vars: vars.map { |k, str| [k, "#{str}-${local.name_suffix}"] }.to_h,
@@ -195,6 +196,7 @@ module Provider
         check :name, type: String, required: true
         check :primary_resource_id, type: String
         check :vars, type: Hash
+        check :test_env_vars, type: Hash
         check :ignore_read_extra, type: Array, item_type: String, default: []
         check :skip_test, type: TrueClass
       end

--- a/provider/terraform_example.rb
+++ b/provider/terraform_example.rb
@@ -18,16 +18,18 @@ module Provider
   class TerraformExample < Provider::Terraform
     # We don't want *any* static generation, so we override generate to only
     # generate objects.
-    def generate(output_folder, types, version_name)
+    def generate(output_folder, types, version_name, _product_path, _dump_yaml)
       version = @api.version_obj_or_default(version_name)
       generate_objects(output_folder, types, version)
     end
 
     # Create a directory of examples per resource
     def generate_resource(data)
-      return if data[:object].example.reject(&:skip_test).empty?
+      examples = data[:object].examples
+                              .reject(&:skip_test)
+                              .reject { |e| !e.test_env_vars.nil? && e.test_env_vars.any? }
 
-      data[:object].example.each do |example|
+      examples.each do |example|
         target_folder = data[:output_folder]
         target_folder = File.join(target_folder, example.name)
         FileUtils.mkpath target_folder


### PR DESCRIPTION
Fix a couple compiler issues for the OiCS provider, and ignore examples with `test_env_vars`. This generates the expected output locally.

This one isn't in the Magician because we haven't been releasing, but I should probably change that when we're able to release consistently again.

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
