### PR TITLE
Fix InSpec pubsub subscription test

### DIFF
--- a/templates/inspec/examples/google_pubsub_subscription/google_pubsub_subscriptions.erb
+++ b/templates/inspec/examples/google_pubsub_subscription/google_pubsub_subscriptions.erb
@@ -1,8 +1,7 @@
 <% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
 <% subscription = grab_attributes['subscription'] -%>
 describe google_pubsub_subscriptions(project: <%= gcp_project_id -%>) do
-  it { should exist }
-  its('count') { should eq 1 }
+  its('count') { should be >= 1 }
 end
 
 google_pubsub_subscriptions(project: <%= gcp_project_id -%>).names.each do |subscription_name|


### PR DESCRIPTION
<!-- Your regular pull request body goes here -->
Some actions (enabling container registry?) add new subscriptions and topics to a GCP project. This accounts for that by asserting at least one subscription exists rather than exactly one.
<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
