### PR TITLE
Ansible: better field names on gcp_compute_instance

### DIFF
--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -289,6 +289,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - 'products/compute/helpers/python/instance_metadata.py'
       - 'products/compute/helpers/python/instance_start.py'
     properties:
+      canIpForward: !ruby/object:Overrides::Ansible::PropertyOverride
+        aliases: ["ip_forward"]
+      image: !ruby/object:Overrides::Ansible::PropertyOverride
+        aliases: ["image_family"]
+
       status: !ruby/object:Overrides::Ansible::PropertyOverride
         version_added: '2.8'
   InstanceTemplate: !ruby/object:Overrides::Ansible::ResourceOverride

--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -291,9 +291,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       canIpForward: !ruby/object:Overrides::Ansible::PropertyOverride
         aliases: ["ip_forward"]
-      image: !ruby/object:Overrides::Ansible::PropertyOverride
-        aliases: ["image_family"]
-
+      disks.initializeParams.sourceImage: !ruby/object:Overrides::Ansible::PropertyOverride
+        aliases: ["image", "image_family"]
       status: !ruby/object:Overrides::Ansible::PropertyOverride
         version_added: '2.8'
   InstanceTemplate: !ruby/object:Overrides::Ansible::ResourceOverride


### PR DESCRIPTION
Adding some new aliases on `gcp_compute_instance` to better match the old `gce` module.

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
