### PR TITLE
Slight Override Refactor + Better Docs

### DIFF
--- a/overrides/runner.rb
+++ b/overrides/runner.rb
@@ -159,7 +159,8 @@ module Overrides
       # This will handle NestedObjects, Arrays of NestedObjects of arbitrary length
       def build_property(old_property, resource_name, overrides, prefix = '')
         # Build a new property, minus any nested properties.
-        new_prop = build_primitive_property(old_property, resource_name, overrides)
+        new_prop = build_primitive_property(old_property, overrides, resource_name,
+                                            "#{prefix}#{old_property.name}")
 
         # Build all nested properties in a recursive manner.
         if old_property.nested_properties?
@@ -185,9 +186,9 @@ module Overrides
       # Given a primitive Api::Type (string, integers, times, etc) and override,
       # return a new Api::Type with overrides applied.
       # This will be called by build_property, which handles nesting.
-      def build_primitive_property(old_property, resource_name, overrides)
+      def build_primitive_property(old_property, overrides, resource_name, property_name)
         # Get the property override setup.
-        prop_override = overrides.property_overrides(resource_name, old_property.name)
+        prop_override = overrides.property_overrides(resource_name, property_name)
 
         prop_override.validate
         prop_override.apply old_property

--- a/provider/ansible/facts_override.rb
+++ b/provider/ansible/facts_override.rb
@@ -49,7 +49,7 @@ module Provider
         # We have to apply the property overrides and validate
         # the filtering property
         @filter = Overrides::Runner.build_single_property(
-          @filter, {}, Overrides::Ansible::PropertyOverride
+          @filter, Overrides::Ansible::PropertyOverride.new, Overrides::Ansible::PropertyOverride
         )
       end
     end


### PR DESCRIPTION
I made some override refactors as I tried to handle Ansible backporting. I'm going a different route for the backporting, but I think the refactors are still useful.

This adds in some documentation explaining what exactly is happening with the overrides and hopefully helps make the code more self-documenting.

This PR is a no-op and passes all tests. The overrides still work in the same fundamental manner.

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
