### PR TITLE
[Terraform] Expose factory function for mapping google_storage_bucket to API resource

### DIFF
--- a/third_party/terraform/utils/test_utils.go
+++ b/third_party/terraform/utils/test_utils.go
@@ -21,6 +21,16 @@ func (d *ResourceDataMock) HasChange(key string) bool {
 	return exists
 }
 
+func (d *ResourceDataMock) Get(key string) interface{} {
+	for k, v := range d.FieldsInSchema {
+		if key == k {
+			return v
+		}
+	}
+
+	return nil
+}
+
 func (d *ResourceDataMock) GetOk(key string) (interface{}, bool) {
 	for k, v := range d.FieldsInSchema {
 		if key == k {

--- a/third_party/terraform/utils/utils.go
+++ b/third_party/terraform/utils/utils.go
@@ -18,6 +18,7 @@ import (
 
 type TerraformResourceData interface {
 	HasChange(string) bool
+	Get(string) interface{}
 	GetOk(string) (interface{}, bool)
 	Set(string, interface{}) error
 	SetId(string)
@@ -211,7 +212,7 @@ func rfc3339TimeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 }
 
 // expandLabels pulls the value of "labels" out of a schema.ResourceData as a map[string]string.
-func expandLabels(d *schema.ResourceData) map[string]string {
+func expandLabels(d TerraformResourceData) map[string]string {
 	return expandStringMap(d, "labels")
 }
 
@@ -221,7 +222,7 @@ func expandEnvironmentVariables(d *schema.ResourceData) map[string]string {
 }
 
 // expandStringMap pulls the value of key out of a schema.ResourceData as a map[string]string.
-func expandStringMap(d *schema.ResourceData, key string) map[string]string {
+func expandStringMap(d TerraformResourceData, key string) map[string]string {
 	v, ok := d.GetOk(key)
 
 	if !ok {


### PR DESCRIPTION
This PR exposes the ability to map a terraform `google_storage_bucket` resource into the Google API representation of that resource. The storage bucket resource was chosen as the first cut... it would be useful to apply this change to additional resources as well.

USE-CASE:

Allow third party tools to parse `.tfplan` files, convert the terraform resources into API representations, and run validations against those representations before applying the configuration.

NOTE:

If this approach is applied to other resources (i.e. VMs), a `*Config` constructor will need to be exposed as well.

-----------------------------------------------------------------
# [all]
## [terraform]
Expose factory function for mapping google_storage_bucket to API resource
### [terraform-beta]
## [ansible]
## [inspec]
