### PR TITLE
Update display names across products based on cloud.google.com

### DIFF
--- a/products/accesscontextmanager/api.yaml
+++ b/products/accesscontextmanager/api.yaml
@@ -13,6 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: AccessContextManager
+display_name: Access Context Manager
 versions:
   - !ruby/object:Api::Product::Version
     name: beta

--- a/products/appengine/api.yaml
+++ b/products/appengine/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: AppEngine
-display_name: Google App Engine
+display_name: App Engine
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/bigquery/api.yaml
+++ b/products/bigquery/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: BigQuery
-display_name: Google Cloud BigQuery
+display_name: BigQuery
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/binaryauthorization/api.yaml
+++ b/products/binaryauthorization/api.yaml
@@ -13,6 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: BinaryAuthorization
+display_name: Binary Authorization
 versions:
   - !ruby/object:Api::Product::Version
     name: beta

--- a/products/cloudbuild/api.yaml
+++ b/products/cloudbuild/api.yaml
@@ -13,6 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: CloudBuild
+display_name: Cloud Build
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -15,7 +15,7 @@
 
 --- !ruby/object:Api::Product
 name: Compute
-display_name: Google Compute Engine
+display_name: Compute Engine
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/containeranalysis/api.yaml
+++ b/products/containeranalysis/api.yaml
@@ -13,6 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: ContainerAnalysis
+display_name: Container Registry
 versions:
   - !ruby/object:Api::Product::Version
     name: beta

--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: Dns
-display_name: Google Cloud DNS
+display_name: Cloud DNS
 versions:
   - !ruby/object:Api::Product::Version
     name: beta

--- a/products/filestore/api.yaml
+++ b/products/filestore/api.yaml
@@ -19,7 +19,7 @@
 # include a small hack to rename the library - see
 # templates/terraform/constants/filestore.erb.
 name: Filestore
-display_name: Google Cloud Filestore
+display_name: Cloud Filestore
 versions:
   - !ruby/object:Api::Product::Version
     name: beta

--- a/products/iam/api.yaml
+++ b/products/iam/api.yaml
@@ -15,7 +15,7 @@
 
 --- !ruby/object:Api::Product
 name: Iam
-display_name: Google Cloud IAM
+display_name: Cloud IAM
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/monitoring/api.yaml
+++ b/products/monitoring/api.yaml
@@ -12,7 +12,7 @@
 # limitations under the License.
 --- !ruby/object:Api::Product
 name: Monitoring
-display_name: Stackdriver Monitoring and Alerting
+display_name: Stackdriver Monitoring
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/pubsub/api.yaml
+++ b/products/pubsub/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: Pubsub
-display_name: Google Cloud Pub/Sub
+display_name: Cloud Pub/Sub
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/redis/api.yaml
+++ b/products/redis/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: Redis
-display_name: Google Cloud Memorystore for Redis
+display_name: Cloud Memorystore
 versions:
   - !ruby/object:Api::Product::Version
     name: beta

--- a/products/resourcemanager/api.yaml
+++ b/products/resourcemanager/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: ResourceManager
-display_name: Google Cloud Resource Manager
+display_name: Resource Manager
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/sql/api.yaml
+++ b/products/sql/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: Sql
-display_name: Google Cloud SQL
+display_name: Cloud SQL
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/storage/api.yaml
+++ b/products/storage/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: Storage
-display_name: Google Cloud Storage
+display_name: Cloud Storage
 versions:
   - !ruby/object:Api::Product::Version
     name: ga


### PR DESCRIPTION
I think InSpec is the only user so far; pull in product names from https://cloud.google.com/products/ so that we can use these in generated docs across providers.

Fixes https://github.com/GoogleCloudPlatform/magic-modules/issues/1209

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
