### PR TITLE
Add TLSA to the list of allowed DNS record types

### DIFF
--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -192,6 +192,7 @@ objects:
           - :SOA
           - :SPF
           - :SRV
+          - :TLSA
           - :TXT
         description: One of valid DNS resource types.
         # TODO(nelsonjr): Enforce required in provider manifest


### PR DESCRIPTION
# [all]
The API definition for DNS does not allow TLSA as a DNS record type. I think there is no reason for this. This pull request adds TLSA to the list of allowed record types.

Some other well-known types are missing in this list:
- DNSKEY
- DS
- IPSECKEY
- SSHFP

I didn't add them in the list because I didn't test them but I think they should be allowed as well.

More generally speaking, I'm not sure it's a good idea to keep a list of allowed record types. There is a lot of other DNS record types (see here https://en.wikipedia.org/wiki/List_of_DNS_record_types) and DNS is a generic dictionary system (new record types may be added anytime).

## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
