### PR TITLE
[Terraform] Fix lint errors under golangci-lint.

### DIFF
--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -29,7 +29,7 @@ pushd "${GOPATH}/src/github.com/terraform-providers/$PROVIDER_NAME"
 # "-wholename": entire relative path - including directory names - matches following wildcard.
 # "-name": filename alone matches following string.  e.g. -name README.md matches ./README.md *and* ./foo/bar/README.md
 # "-exec": for each file found, execute the command following until the literal ';'
-find . -type f -not -wholename "./.git*" -not -wholename "./vendor*" -not -name ".travis.yml" -not -name ".gometalinter.json" -not -name "CHANGELOG.md" -not -name GNUmakefile -not -name LICENSE -not -name README.md -not -wholename "./examples*" -not -name "main.go" -not -name "go.mod" -not -name "go.sum" -not -name "staticcheck.conf" -not -wholename "./version*" -exec git rm {} \;
+find . -type f -not -wholename "./.git*" -not -wholename "./vendor*" -not -name ".travis.yml" -not -name ".golangci.yml" -not -name "CHANGELOG.md" -not -name GNUmakefile -not -name LICENSE -not -name README.md -not -wholename "./examples*" -not -name "main.go" -not -name "go.mod" -not -name "go.sum" -not -name "staticcheck.conf" -not -wholename "./version*" -exec git rm {} \;
 popd
 
 pushd magic-modules-branched

--- a/templates/terraform/custom_import/access_level_self_link_as_name_and_set_parent.go.erb
+++ b/templates/terraform/custom_import/access_level_self_link_as_name_and_set_parent.go.erb
@@ -15,7 +15,9 @@
 	config := meta.(*Config)
 	
 	// current import_formats can't import ids with forward slashes in them.
-	parseImportId([]string{"(?P<name>.+)"}, d, config)
+	if err := parseImportId([]string{"(?P<name>.+)"}, d, config); err != nil {
+		return nil, err
+	}
 	stringParts := strings.Split(d.Get("name").(string), "/")
 	d.Set("parent", fmt.Sprintf("%s/%s", stringParts[0], stringParts[1]))
 	return []*schema.ResourceData{d}, nil

--- a/templates/terraform/custom_import/self_link_as_name.erb
+++ b/templates/terraform/custom_import/self_link_as_name.erb
@@ -2,6 +2,8 @@
 	config := meta.(*Config)
 	
 	// current import_formats can't import id's with forward slashes in them.
-	parseImportId([]string{"(?P<name>.+)"}, d, config)
+	if err := parseImportId([]string{"(?P<name>.+)"}, d, config); err != nil {
+		return nil, err
+	}
 
 	return []*schema.ResourceData{d}, nil

--- a/templates/terraform/post_create/labels.erb
+++ b/templates/terraform/post_create/labels.erb
@@ -9,6 +9,9 @@ if v, ok := d.GetOkExists("labels"); !isEmptyValue(reflect.ValueOf(v)) && (ok ||
     obj := make(map[string]interface{})
     // d.Get("labels") will have been overridden by the Read call.
     labelsProp, err := expand<%= resource_name -%>Labels(v, d, config)
+    if err != nil {
+    	return err
+    }
     obj["labels"] = labelsProp
     labelFingerprintProp := d.Get("label_fingerprint")
     obj["labelFingerprint"] = labelFingerprintProp

--- a/templates/terraform/pre_delete/modify_delete_url.erb
+++ b/templates/terraform/pre_delete/modify_delete_url.erb
@@ -1,3 +1,7 @@
+// log the old URL to make the ineffassign linter happy
+// in theory, we should find a way to disable the default URL and not construct
+// both, but that's a problem for another day. Today, we cheat.
+log.Printf("[DEBUG] replacing URL %q with a custom delete URL", url)
 url, err = replaceVars(d, config, "<%= object.__product.base_url -%><%=object.base_url-%>/{{name}}")
 if err != nil {
 	return err

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -358,8 +358,14 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 <%# We need to decide what encoder to use here - if there's an update encoder, use that! -%>
 <%  if object.custom_code.update_encoder -%>
     obj, err = resource<%= resource_name -%>UpdateEncoder(d, meta, obj)
+    if err != nil {
+    	return err
+    }
 <%  elsif object.custom_code.encoder -%>
     obj, err = resource<%= resource_name -%>Encoder(d, meta, obj)
+    if err != nil {
+    	return err
+    }
 <%  end -%>
 
 <%  if object.mutex -%>

--- a/third_party/terraform/data_sources/data_source_storage_object_signed_url.go
+++ b/third_party/terraform/data_sources/data_source_storage_object_signed_url.go
@@ -348,7 +348,9 @@ func SignString(toSign []byte, cfg *jwt.Config) ([]byte, error) {
 
 	// Hash string
 	hasher := sha256.New()
-	hasher.Write(toSign)
+	if _, err := hasher.Write(toSign); err != nil {
+		return nil, errwrap.Wrapf("failed to calculate sha256: {{err}}", err)
+	}
 
 	// Sign string
 	signed, err := rsa.SignPKCS1v15(rand.Reader, pk, crypto.SHA256, hasher.Sum(nil))

--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -493,7 +493,9 @@ func resourceComposerEnvironmentDelete(d *schema.ResourceData, meta interface{})
 
 func resourceComposerEnvironmentImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
-	parseImportId([]string{"projects/(?P<project>[^/]+)/locations/(?P<region>[^/]+)/environments/(?P<name>[^/]+)", "(?P<project>[^/]+)/(?P<region>[^/]+)/(?P<name>[^/]+)", "(?P<name>[^/]+)"}, d, config)
+	if err := parseImportId([]string{"projects/(?P<project>[^/]+)/locations/(?P<region>[^/]+)/environments/(?P<name>[^/]+)", "(?P<project>[^/]+)/(?P<region>[^/]+)/(?P<name>[^/]+)", "(?P<name>[^/]+)"}, d, config); err != nil {
+		return nil, err
+	}
 
 	// Replace import id for the resource id
 	id, err := replaceVars(d, config, "{{project}}/{{region}}/{{name}}")

--- a/third_party/terraform/resources/resource_compute_backend_service.go.erb
+++ b/third_party/terraform/resources/resource_compute_backend_service.go.erb
@@ -282,6 +282,9 @@ func resourceComputeBackendServiceCreate(d *schema.ResourceData, meta interface{
 
 	if v, ok := d.GetOk("security_policy"); ok {
 		pol, err := ParseSecurityPolicyFieldValue(v.(string), d, config)
+		if err != nil {
+			return errwrap.Wrapf("Error parsing Backend Service security policy: {{err}}", err)
+		}
 		op, err := config.clientComputeBeta.BackendServices.SetSecurityPolicy(
 			project, service.Name, &computeBeta.SecurityPolicyReference{
 				SecurityPolicy: pol.RelativeLink(),

--- a/third_party/terraform/resources/resource_compute_instance.go
+++ b/third_party/terraform/resources/resource_compute_instance.go
@@ -1024,8 +1024,6 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		instNetworkInterface := instance.NetworkInterfaces[i]
 		networkName := d.Get(prefix + ".name").(string)
 
-		// TODO: This sanity check is broken by #929, disabled for now (by forcing the equality)
-		networkName = instNetworkInterface.Name
 		// Sanity check
 		if networkName != instNetworkInterface.Name {
 			return fmt.Errorf("Instance networkInterface had unexpected name: %s", instNetworkInterface.Name)

--- a/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
+++ b/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
@@ -693,6 +693,9 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 
 		updateStrategy := d.Get("update_strategy").(string)
 		err = performZoneUpdate(config, name, updateStrategy, project, zone)
+		if err != nil {
+			return err
+		}
 		d.SetPartial("instance_template")
 	}
 
@@ -834,9 +837,9 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 			return err
 		}
 
-		instanceGroup, err := config.clientComputeBeta.InstanceGroups.Get(
+		instanceGroup, igErr := config.clientComputeBeta.InstanceGroups.Get(
 			project, zone, name).Do()
-		if err != nil {
+		if igErr != nil {
 			return fmt.Errorf("Error getting instance group size: %s", err)
 		}
 

--- a/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
+++ b/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
@@ -738,6 +738,9 @@ func resourceComputeRegionInstanceGroupManagerDelete(d *schema.ResourceData, met
 
 	// Wait for the operation to complete
 	err = computeSharedOperationWaitTime(config.clientCompute, op, regionalID.Project, int(d.Timeout(schema.TimeoutDelete).Minutes()), "Deleting RegionInstanceGroupManager")
+	if err != nil {
+		return fmt.Errorf("Error waiting for delete to complete: %s", err)
+	}
 
 	d.SetId("")
 	return nil

--- a/third_party/terraform/resources/resource_dataproc_job.go
+++ b/third_party/terraform/resources/resource_dataproc_job.go
@@ -323,8 +323,10 @@ func resourceDataprocJobDelete(d *schema.ResourceData, meta interface{}) error {
 	if forceDelete {
 		log.Printf("[DEBUG] Attempting to first cancel Dataproc job %s if it's still running ...", d.Id())
 
-		config.clientDataproc.Projects.Regions.Jobs.Cancel(
-			project, region, d.Id(), &dataproc.CancelJobRequest{}).Do()
+		if _, err := config.clientDataproc.Projects.Regions.Jobs.Cancel(
+			project, region, d.Id(), &dataproc.CancelJobRequest{}).Do(); err != nil {
+			return fmt.Errorf("Error canceling job: %v", err)
+		}
 		// ignore error if we get one - job may be finished already and not need to
 		// be cancelled. We do however wait for the state to be one that is
 		// at least not active

--- a/third_party/terraform/resources/resource_endpoints_service.go
+++ b/third_party/terraform/resources/resource_endpoints_service.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/servicemanagement/v1"
 )
@@ -228,7 +229,9 @@ func resourceEndpointsServiceUpdate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 	var serviceConfig servicemanagement.SubmitConfigSourceResponse
-	json.Unmarshal(s, &serviceConfig)
+	if err := json.Unmarshal(s, &serviceConfig); err != nil {
+		return err
+	}
 
 	// Next, we create a new rollout with the new config value, and wait for it to complete.
 	rolloutService := servicemanagement.NewServicesRolloutsService(config.clientServiceMan)

--- a/third_party/terraform/resources/resource_google_project_services.go
+++ b/third_party/terraform/resources/resource_google_project_services.go
@@ -130,7 +130,9 @@ func resourceGoogleProjectServicesDelete(d *schema.ResourceData, meta interface{
 	config := meta.(*Config)
 	services := resourceServices(d)
 	for _, s := range services {
-		disableService(s, d.Id(), config, true)
+		if err := disableService(s, d.Id(), config, true); err != nil {
+			return err
+		}
 	}
 	d.SetId("")
 	return nil

--- a/third_party/terraform/resources/resource_google_service_account.go
+++ b/third_party/terraform/resources/resource_google_service_account.go
@@ -134,10 +134,12 @@ func resourceGoogleServiceAccountUpdate(d *schema.ResourceData, meta interface{}
 
 func resourceGoogleServiceAccountImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
-	parseImportId([]string{
+	if err := parseImportId([]string{
 		"projects/(?P<project>[^/]+)/serviceAccounts/(?P<email>[^/]+)",
 		"(?P<project>[^/]+)/(?P<email>[^/]+)",
-		"(?P<email>[^/]+)"}, d, config)
+		"(?P<email>[^/]+)"}, d, config); err != nil {
+		return nil, err
+	}
 
 	// Replace import id for the resource id
 	id, err := replaceVars(d, config, "projects/{{project}}/serviceAccounts/{{email}}")

--- a/third_party/terraform/resources/resource_runtimeconfig_config.go
+++ b/third_party/terraform/resources/resource_runtimeconfig_config.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 
 	"github.com/hashicorp/terraform/helper/schema"
-	"google.golang.org/api/runtimeconfig/v1beta1"
+	runtimeconfig "google.golang.org/api/runtimeconfig/v1beta1"
 )
 
 var runtimeConfigFullName *regexp.Regexp = regexp.MustCompile("^projects/([^/]+)/configs/(.+)$")
@@ -137,7 +137,9 @@ func resourceRuntimeconfigConfigDelete(d *schema.ResourceData, meta interface{})
 
 func resourceRuntimeconfigConfigImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
-	parseImportId([]string{"projects/(?P<project>[^/]+)/configs/(?P<name>[^/]+)", "(?P<name>[^/]+)"}, d, config)
+	if err := parseImportId([]string{"projects/(?P<project>[^/]+)/configs/(?P<name>[^/]+)", "(?P<name>[^/]+)"}, d, config); err != nil {
+		return nil, err
+	}
 
 	// Replace import id for the resource id
 	id, err := replaceVars(d, config, "projects/{{project}}/configs/{{name}}")

--- a/third_party/terraform/resources/resource_runtimeconfig_variable.go
+++ b/third_party/terraform/resources/resource_runtimeconfig_variable.go
@@ -2,9 +2,10 @@ package google
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
-	"google.golang.org/api/runtimeconfig/v1beta1"
 	"regexp"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	runtimeconfig "google.golang.org/api/runtimeconfig/v1beta1"
 )
 
 func resourceRuntimeconfigVariable() *schema.Resource {
@@ -130,7 +131,9 @@ func resourceRuntimeconfigVariableDelete(d *schema.ResourceData, meta interface{
 
 func resourceRuntimeconfigVariableImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
-	parseImportId([]string{"projects/(?P<project>[^/]+)/configs/(?P<parent>[^/]+)/variables/(?P<name>[^/]+)", "(?P<parent>[^/]+)/(?P<name>[^/]+)"}, d, config)
+	if err := parseImportId([]string{"projects/(?P<project>[^/]+)/configs/(?P<parent>[^/]+)/variables/(?P<name>[^/]+)", "(?P<parent>[^/]+)/(?P<name>[^/]+)"}, d, config); err != nil {
+		return nil, err
+	}
 
 	// Replace import id for the resource id
 	id, err := replaceVars(d, config, "projects/{{project}}/configs/{{parent}}/variables/{{name}}")

--- a/third_party/terraform/resources/resource_sql_database.go
+++ b/third_party/terraform/resources/resource_sql_database.go
@@ -229,13 +229,15 @@ func resourceSqlDatabaseDelete(d *schema.ResourceData, meta interface{}) error {
 
 func resourceSqlDatabaseImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
-	parseImportId([]string{
+	if err := parseImportId([]string{
 		"projects/(?P<project>[^/]+)/instances/(?P<instance>[^/]+)/databases/(?P<name>[^/]+)",
 		"instances/(?P<instance>[^/]+)/databases/(?P<name>[^/]+)",
 		"(?P<project>[^/]+)/(?P<instance>[^/]+)/(?P<name>[^/]+)",
 		"(?P<instance>[^/]+)/(?P<name>[^/]+)",
 		"(?P<instance>[^/]+):(?P<name>[^/]+)",
-	}, d, config)
+	}, d, config); err != nil {
+		return nil, err
+	}
 
 	// Replace import id for the resource id
 	id, err := replaceVars(d, config, "{{instance}}:{{name}}")

--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -802,10 +802,12 @@ func resourceSqlDatabaseInstanceDelete(d *schema.ResourceData, meta interface{})
 
 func resourceSqlDatabaseInstanceImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)
-	parseImportId([]string{
+	if err := parseImportId([]string{
 		"projects/(?P<project>[^/]+)/instances/(?P<name>[^/]+)",
 		"(?P<project>[^/]+)/(?P<name>[^/]+)",
-		"(?P<name>[^/]+)"}, d, config)
+		"(?P<name>[^/]+)"}, d, config); err != nil {
+			return nil, err
+		}
 
 	// Replace import id for the resource id
 	id, err := replaceVars(d, config, "{{name}}")

--- a/third_party/terraform/resources/resource_storage_bucket_acl.go
+++ b/third_party/terraform/resources/resource_storage_bucket_acl.go
@@ -122,7 +122,7 @@ func resourceStorageBucketAclCreate(d *schema.ResourceData, meta interface{}) er
 			return fmt.Errorf("Error reading bucket %s: %v", bucket, err)
 		}
 
-		res, err = config.clientStorage.Buckets.Update(bucket,
+		_, err = config.clientStorage.Buckets.Update(bucket,
 			res).PredefinedAcl(predefined_acl).Do()
 
 		if err != nil {
@@ -175,7 +175,7 @@ func resourceStorageBucketAclCreate(d *schema.ResourceData, meta interface{}) er
 			return fmt.Errorf("Error reading bucket %s: %v", bucket, err)
 		}
 
-		res, err = config.clientStorage.Buckets.Update(bucket,
+		_, err = config.clientStorage.Buckets.Update(bucket,
 			res).PredefinedDefaultObjectAcl(default_acl).Do()
 
 		if err != nil {
@@ -297,7 +297,7 @@ func resourceStorageBucketAclUpdate(d *schema.ResourceData, meta interface{}) er
 			return fmt.Errorf("Error reading bucket %s: %v", bucket, err)
 		}
 
-		res, err = config.clientStorage.Buckets.Update(bucket,
+		_, err = config.clientStorage.Buckets.Update(bucket,
 			res).PredefinedDefaultObjectAcl(default_acl).Do()
 
 		if err != nil {

--- a/third_party/terraform/resources/resource_storage_bucket_object.go
+++ b/third_party/terraform/resources/resource_storage_bucket_object.go
@@ -171,7 +171,7 @@ func resourceStorageBucketObjectCreate(d *schema.ResourceData, meta interface{})
 	var media io.Reader
 
 	if v, ok := d.GetOk("source"); ok {
-		err := error(nil)
+		var err error
 		media, err = os.Open(v.(string))
 		if err != nil {
 			return err
@@ -292,6 +292,8 @@ func getFileMd5Hash(filename string) string {
 
 func getContentMd5Hash(content []byte) string {
 	h := md5.New()
-	h.Write(content)
+	if _, err := h.Write(content); err != nil {
+		log.Printf("[WARN] Failed to compute md5 hash for content: %v", err)
+	}
 	return base64.StdEncoding.EncodeToString(h.Sum(nil))
 }

--- a/third_party/terraform/resources/resource_storage_object_acl.go
+++ b/third_party/terraform/resources/resource_storage_object_acl.go
@@ -2,10 +2,11 @@ package google
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 	"google.golang.org/api/storage/v1"
-	"strings"
 )
 
 func resourceStorageObjectAcl() *schema.Resource {
@@ -110,7 +111,7 @@ func resourceStorageObjectAclCreate(d *schema.ResourceData, meta interface{}) er
 			return fmt.Errorf("Error reading object %s in %s: %v", object, bucket, err)
 		}
 
-		res, err = config.clientStorage.Objects.Update(bucket, object, res).PredefinedAcl(predefinedAcl.(string)).Do()
+		_, err = config.clientStorage.Objects.Update(bucket, object, res).PredefinedAcl(predefinedAcl.(string)).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating object %s in %s: %v", object, bucket, err)
 		}
@@ -176,7 +177,7 @@ func resourceStorageObjectAclUpdate(d *schema.ResourceData, meta interface{}) er
 			return fmt.Errorf("Error reading object %s in %s: %v", object, bucket, err)
 		}
 
-		res, err = config.clientStorage.Objects.Update(bucket, object, res).PredefinedAcl(d.Get("predefined_acl").(string)).Do()
+		_, err = config.clientStorage.Objects.Update(bucket, object, res).PredefinedAcl(d.Get("predefined_acl").(string)).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating object %s in %s: %v", object, bucket, err)
 		}
@@ -219,7 +220,7 @@ func resourceStorageObjectAclDelete(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error reading object %s in %s: %v", object, bucket, err)
 	}
 
-	res, err = config.clientStorage.Objects.Update(bucket, object, res).PredefinedAcl("private").Do()
+	_, err = config.clientStorage.Objects.Update(bucket, object, res).PredefinedAcl("private").Do()
 	if err != nil {
 		return fmt.Errorf("Error updating object %s in %s: %v", object, bucket, err)
 	}

--- a/third_party/terraform/tests/data_source_google_compute_address_test.go
+++ b/third_party/terraform/tests/data_source_google_compute_address_test.go
@@ -141,6 +141,9 @@ func testAccCheckDataSourceComputeAddressDestroy(resource_name string) resource.
 		}
 
 		addressId, err := parseComputeAddressId(rs.Primary.ID, nil)
+		if err != nil {
+			return err
+		}
 
 		_, err = config.clientCompute.Addresses.Get(
 			config.Project, addressId.Region, addressId.Name).Do()

--- a/third_party/terraform/tests/resource_compute_firewall_migrate_test.go
+++ b/third_party/terraform/tests/resource_compute_firewall_migrate_test.go
@@ -73,7 +73,7 @@ func TestComputeFirewallMigrateState_empty(t *testing.T) {
 
 	// should handle non-nil but empty
 	is = &terraform.InstanceState{}
-	is, err = resourceComputeFirewallMigrateState(0, is, meta)
+	_, err = resourceComputeFirewallMigrateState(0, is, meta)
 
 	if err != nil {
 		t.Fatalf("err: %#v", err)

--- a/third_party/terraform/tests/resource_compute_instance_migrate_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_migrate_test.go
@@ -132,7 +132,7 @@ func TestComputeInstanceMigrateState_empty(t *testing.T) {
 
 	// should handle non-nil but empty
 	is = &terraform.InstanceState{}
-	is, err = resourceComputeInstanceMigrateState(0, is, meta)
+	_, err = resourceComputeInstanceMigrateState(0, is, meta)
 
 	if err != nil {
 		t.Fatalf("err: %#v", err)
@@ -841,7 +841,7 @@ func runInstanceMigrateTest(t *testing.T, id, testName string, version int, attr
 		ID:         id,
 		Attributes: attributes,
 	}
-	is, err := resourceComputeInstanceMigrateState(version, is, meta)
+	_, err := resourceComputeInstanceMigrateState(version, is, meta)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/third_party/terraform/tests/resource_compute_instance_template_migrate_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_template_migrate_test.go
@@ -129,7 +129,7 @@ func TestComputeInstanceTemplateMigrateState_empty(t *testing.T) {
 
 	// should handle non-nil but empty
 	is = &terraform.InstanceState{}
-	is, err = resourceComputeInstanceTemplateMigrateState(0, is, meta)
+	_, err = resourceComputeInstanceTemplateMigrateState(0, is, meta)
 
 	if err != nil {
 		t.Fatalf("err: %#v", err)

--- a/third_party/terraform/tests/resource_container_cluster_migrate_test.go
+++ b/third_party/terraform/tests/resource_container_cluster_migrate_test.go
@@ -67,7 +67,7 @@ func TestContainerClusterMigrateState_empty(t *testing.T) {
 
 	// should handle non-nil but empty
 	is = &terraform.InstanceState{}
-	is, err = resourceContainerClusterMigrateState(0, is, meta)
+	_, err = resourceContainerClusterMigrateState(0, is, meta)
 
 	if err != nil {
 		t.Fatalf("err: %#v", err)

--- a/third_party/terraform/tests/resource_container_node_pool_migrate_test.go
+++ b/third_party/terraform/tests/resource_container_node_pool_migrate_test.go
@@ -1,8 +1,9 @@
 package google
 
 import (
-	"github.com/hashicorp/terraform/terraform"
 	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestContainerNodePoolMigrateState(t *testing.T) {
@@ -57,7 +58,7 @@ func TestContainerNodePoolMigrateState_empty(t *testing.T) {
 
 	// should handle non-nil but empty
 	is = &terraform.InstanceState{}
-	is, err = resourceContainerNodePoolMigrateState(0, is, meta)
+	_, err = resourceContainerNodePoolMigrateState(0, is, meta)
 
 	if err != nil {
 		t.Fatalf("err: %#v", err)

--- a/third_party/terraform/tests/resource_google_project_migrate_test.go
+++ b/third_party/terraform/tests/resource_google_project_migrate_test.go
@@ -62,7 +62,7 @@ func TestGoogleProjectMigrateState_empty(t *testing.T) {
 
 	// should handle non-nil but empty
 	is = &terraform.InstanceState{}
-	is, err = resourceGoogleProjectMigrateState(0, is, meta)
+	_, err = resourceGoogleProjectMigrateState(0, is, meta)
 
 	if err != nil {
 		t.Fatalf("err: %#v", err)

--- a/third_party/terraform/tests/resource_google_project_services_test.go
+++ b/third_party/terraform/tests/resource_google_project_services_test.go
@@ -44,7 +44,9 @@ func TestAccProjectServices_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					config := testAccProvider.Meta().(*Config)
-					enableService(oobService, pid, config)
+					if err := enableService(oobService, pid, config); err != nil {
+						t.Fatalf("Error enabling %q: %v", oobService, err)
+					}
 				},
 				Config: testAccProjectAssociateServicesBasic(services2, pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
@@ -87,7 +89,9 @@ func TestAccProjectServices_authoritative(t *testing.T) {
 			{
 				PreConfig: func() {
 					config := testAccProvider.Meta().(*Config)
-					enableService(oobService, pid, config)
+					if err := enableService(oobService, pid, config); err != nil {
+						t.Fatalf("Error enabling %q: %v", oobService, err)
+					}
 				},
 				Config: testAccProjectAssociateServicesBasic(services, pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
@@ -126,7 +130,9 @@ func TestAccProjectServices_authoritative2(t *testing.T) {
 				PreConfig: func() {
 					config := testAccProvider.Meta().(*Config)
 					for _, s := range oobServices {
-						enableService(s, pid, config)
+						if err := enableService(s, pid, config); err != nil {
+							t.Fatalf("Error enabling %q: %v", s, err)
+						}
 					}
 				},
 				Config: testAccProjectAssociateServicesBasic(services, pid, pname, org),

--- a/third_party/terraform/tests/resource_sql_user_migrate_test.go
+++ b/third_party/terraform/tests/resource_sql_user_migrate_test.go
@@ -73,7 +73,7 @@ func TestSqlUserMigrateState_empty(t *testing.T) {
 
 	// should handle non-nil but empty
 	is = &terraform.InstanceState{}
-	is, err = resourceSqlUserMigrateState(0, is, meta)
+	_, err = resourceSqlUserMigrateState(0, is, meta)
 
 	if err != nil {
 		t.Fatalf("err: %#v", err)

--- a/third_party/terraform/tests/resource_storage_bucket_object_test.go
+++ b/third_party/terraform/tests/resource_storage_bucket_object_test.go
@@ -26,11 +26,15 @@ func TestAccStorageObject_basic(t *testing.T) {
 	bucketName := testBucketName()
 	data := []byte("data data data")
 	h := md5.New()
-	h.Write(data)
+	if _, err := h.Write(data); err != nil {
+		t.Errorf("error calculating md5: %v", err)
+	}
 	data_md5 := base64.StdEncoding.EncodeToString(h.Sum(nil))
 
 	testFile := getNewTmpTestFile(t, "tf-test")
-	ioutil.WriteFile(testFile.Name(), data, 0644)
+	if err := ioutil.WriteFile(testFile.Name(), data, 0644); err != nil {
+		t.Errorf("error writing file: %v", err)
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -51,10 +55,14 @@ func TestAccStorageObject_recreate(t *testing.T) {
 
 	writeFile := func(name string, data []byte) string {
 		h := md5.New()
-		h.Write(data)
+		if _, err := h.Write(data); err != nil {
+			t.Errorf("error calculating md5: %v", err)
+		}
 		data_md5 := base64.StdEncoding.EncodeToString(h.Sum(nil))
 
-		ioutil.WriteFile(name, data, 0644)
+		if err := ioutil.WriteFile(name, data, 0644); err != nil {
+			t.Errorf("error writing file: %v", err)
+		}
 		return data_md5
 	}
 	testFile := getNewTmpTestFile(t, "tf-test")
@@ -91,11 +99,15 @@ func TestAccStorageObject_content(t *testing.T) {
 	bucketName := testBucketName()
 	data := []byte(content)
 	h := md5.New()
-	h.Write(data)
+	if _, err := h.Write(data); err != nil {
+		t.Errorf("error calculating md5: %v", err)
+	}
 	data_md5 := base64.StdEncoding.EncodeToString(h.Sum(nil))
 
 	testFile := getNewTmpTestFile(t, "tf-test")
-	ioutil.WriteFile(testFile.Name(), data, 0644)
+	if err := ioutil.WriteFile(testFile.Name(), data, 0644); err != nil {
+		t.Errorf("error writing file: %v", err)
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -121,10 +133,14 @@ func TestAccStorageObject_withContentCharacteristics(t *testing.T) {
 	bucketName := testBucketName()
 	data := []byte(content)
 	h := md5.New()
-	h.Write(data)
+	if _, err := h.Write(data); err != nil {
+		t.Errorf("error calculating md5: %v", err)
+	}
 	data_md5 := base64.StdEncoding.EncodeToString(h.Sum(nil))
 	testFile := getNewTmpTestFile(t, "tf-test")
-	ioutil.WriteFile(testFile.Name(), data, 0644)
+	if err := ioutil.WriteFile(testFile.Name(), data, 0644); err != nil {
+		t.Errorf("error writing file: %v", err)
+	}
 
 	disposition, encoding, language, content_type := "inline", "compress", "en", "binary/octet-stream"
 	resource.Test(t, resource.TestCase{
@@ -178,10 +194,14 @@ func TestAccStorageObject_cacheControl(t *testing.T) {
 	bucketName := testBucketName()
 	data := []byte(content)
 	h := md5.New()
-	h.Write(data)
+	if _, err := h.Write(data); err != nil {
+		t.Errorf("error calculating md5: %v", err)
+	}
 	data_md5 := base64.StdEncoding.EncodeToString(h.Sum(nil))
 	testFile := getNewTmpTestFile(t, "tf-test")
-	ioutil.WriteFile(testFile.Name(), data, 0644)
+	if err := ioutil.WriteFile(testFile.Name(), data, 0644); err != nil {
+		t.Errorf("error writing file: %v", err)
+	}
 
 	cacheControl := "private"
 	resource.Test(t, resource.TestCase{
@@ -207,10 +227,14 @@ func TestAccStorageObject_storageClass(t *testing.T) {
 	bucketName := testBucketName()
 	data := []byte(content)
 	h := md5.New()
-	h.Write(data)
+	if _, err := h.Write(data); err != nil {
+		t.Errorf("error calculating md5: %v", err)
+	}
 	data_md5 := base64.StdEncoding.EncodeToString(h.Sum(nil))
 	testFile := getNewTmpTestFile(t, "tf-test")
-	ioutil.WriteFile(testFile.Name(), data, 0644)
+	if err := ioutil.WriteFile(testFile.Name(), data, 0644); err != nil {
+		t.Errorf("error writing file: %v", err)
+	}
 
 	storageClass := "MULTI_REGIONAL"
 	resource.Test(t, resource.TestCase{

--- a/third_party/terraform/tests/resource_storage_object_access_control_test.go
+++ b/third_party/terraform/tests/resource_storage_object_access_control_test.go
@@ -14,7 +14,9 @@ func TestAccStorageObjectAccessControl_update(t *testing.T) {
 	bucketName := testBucketName()
 	objectName := testAclObjectName()
 	objectData := []byte("data data data")
-	ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644)
+	if err := ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644); err != nil {
+		t.Errorf("error writing file: %v", err)
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			if errObjectAcl != nil {

--- a/third_party/terraform/tests/resource_storage_object_acl_test.go
+++ b/third_party/terraform/tests/resource_storage_object_acl_test.go
@@ -24,7 +24,9 @@ func TestAccStorageObjectAcl_basic(t *testing.T) {
 	bucketName := testBucketName()
 	objectName := testAclObjectName()
 	objectData := []byte("data data data")
-	ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644)
+	if err := ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644); err != nil {
+		t.Errorf("error writing file: %v", err)
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			if errObjectAcl != nil {
@@ -54,7 +56,9 @@ func TestAccStorageObjectAcl_upgrade(t *testing.T) {
 	bucketName := testBucketName()
 	objectName := testAclObjectName()
 	objectData := []byte("data data data")
-	ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644)
+	if err := ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644); err != nil {
+		t.Errorf("error writing file: %v", err)
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			if errObjectAcl != nil {
@@ -106,7 +110,9 @@ func TestAccStorageObjectAcl_downgrade(t *testing.T) {
 	bucketName := testBucketName()
 	objectName := testAclObjectName()
 	objectData := []byte("data data data")
-	ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644)
+	if err := ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644); err != nil {
+		t.Errorf("error writing file: %v", err)
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			if errObjectAcl != nil {
@@ -158,7 +164,9 @@ func TestAccStorageObjectAcl_predefined(t *testing.T) {
 	bucketName := testBucketName()
 	objectName := testAclObjectName()
 	objectData := []byte("data data data")
-	ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644)
+	if err := ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644); err != nil {
+		t.Errorf("error writing file: %v", err)
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			if errObjectAcl != nil {
@@ -182,7 +190,9 @@ func TestAccStorageObjectAcl_predefinedToExplicit(t *testing.T) {
 	bucketName := testBucketName()
 	objectName := testAclObjectName()
 	objectData := []byte("data data data")
-	ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644)
+	if err := ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644); err != nil {
+		t.Errorf("error writing file: %v", err)
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			if errObjectAcl != nil {
@@ -215,7 +225,9 @@ func TestAccStorageObjectAcl_explicitToPredefined(t *testing.T) {
 	bucketName := testBucketName()
 	objectName := testAclObjectName()
 	objectData := []byte("data data data")
-	ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644)
+	if err := ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644); err != nil {
+		t.Errorf("error writing file: %v", err)
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			if errObjectAcl != nil {
@@ -249,7 +261,9 @@ func TestAccStorageObjectAcl_unordered(t *testing.T) {
 	bucketName := testBucketName()
 	objectName := testAclObjectName()
 	objectData := []byte("data data data")
-	ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644)
+	if err := ioutil.WriteFile(tfObjectAcl.Name(), objectData, 0644); err != nil {
+		t.Errorf("error writing file: %v", err)
+	}
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			if errObjectAcl != nil {

--- a/third_party/terraform/utils/convert_test.go
+++ b/third_party/terraform/utils/convert_test.go
@@ -66,7 +66,9 @@ func TestSetOmittedFields(t *testing.T) {
 		},
 	}
 	output := &OutputOuter{}
-	Convert(input, output)
+	if err := Convert(input, output); err != nil {
+		t.Errorf("Error converting: %v", err)
+	}
 	if input.NotOmitted != output.NotOmitted ||
 		!reflect.DeepEqual(input.Omitted, output.Omitted) ||
 		!reflect.DeepEqual(input.Struct, output.Struct) ||

--- a/third_party/terraform/utils/utils_test.go
+++ b/third_party/terraform/utils/utils_test.go
@@ -488,7 +488,9 @@ func TestRetryTimeDuration(t *testing.T) {
 			Code: 500,
 		}
 	}
-	retryTimeDuration(f, time.Duration(1000)*time.Millisecond)
+	if err := retryTimeDuration(f, time.Duration(1000)*time.Millisecond); err == nil || err.(*googleapi.Error).Code != 500 {
+		t.Errorf("unexpected error retrying: %v", err)
+	}
 	if i < 2 {
 		t.Errorf("expected error function to be called at least twice, but was called %d times", i)
 	}
@@ -503,7 +505,9 @@ func TestRetryTimeDuration_wrapped(t *testing.T) {
 		}
 		return errwrap.Wrapf("nested error: {{err}}", err)
 	}
-	retryTimeDuration(f, time.Duration(1000)*time.Millisecond)
+	if err := retryTimeDuration(f, time.Duration(1000)*time.Millisecond); err == nil || err.(*googleapi.Error).Code != 500 {
+		t.Errorf("unexpected error retrying: %v", err)
+	}
 	if i < 2 {
 		t.Errorf("expected error function to be called at least twice, but was called %d times", i)
 	}
@@ -517,7 +521,9 @@ func TestRetryTimeDuration_noretry(t *testing.T) {
 			Code: 400,
 		}
 	}
-	retryTimeDuration(f, time.Duration(1000)*time.Millisecond)
+	if err := retryTimeDuration(f, time.Duration(1000)*time.Millisecond); err == nil || err.(*googleapi.Error).Code != 400 {
+		t.Errorf("unexpected error retrying: %v", err)
+	}
 	if i != 1 {
 		t.Errorf("expected error function to be called exactly once, but was called %d times", i)
 	}


### PR DESCRIPTION
A whole slew of errors reported by golangci-lint are fixed in this PR.
To whit:

* Unchecked errors are now checked.
* When the DELETE URL is overriden, we have a debug log line to get
  around the ineffassign linter's complaints about it. We shoudl
  eventually just only generate the URL we actually need, but this fixes
  the problem for the moment.
* Removed a TODO sanity check override, because the bog that broke it
  was, I believe, fixed years ago.
* Fixed a subtle error shadowing bug in the delete for instance group
  managers.
* Stopped populating the unused "locations" variable in
  container_cluster's Delete method.
* Ignored unused return values instead of populating them.

The effect of these changes is that our linter should pass (once the
linter is updated in tpg and tpgb, see
terraform-providers/terraform-provider-google#3049 and
terraform-providers/terraform-provider-google-beta#437) and we, as a
bonus, are handling more error cases and fixed a subtle bug.

<!-- Your regular pull request body goes here -->

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
Fix golangci-lint errors
### [terraform-beta]
## [ansible]
## [inspec]
