### PR TITLE
Update generate-terraform.sh to vendor after patches

### DIFF
--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -66,8 +66,9 @@ apply_patches "$PATCH_DIR/terraform-providers/$PROVIDER_NAME" "$TERRAFORM_COMMIT
 # instead of based on the tentative output of MM.
 GO111MODULE=on go mod vendor
 git add -A
+
 # Set the "author" to the commit's real author.
-git commit -m "Update vendored dependencies" --author="$LAST_COMMIT_AUTHOR" || true  # don't crash if no changes
+git commit --amend --no-edit --author="$LAST_COMMIT_AUTHOR" || true  # don't crash if no changes
 
 popd
 popd


### PR DESCRIPTION
I was confused why https://github.com/GoogleCloudPlatform/magic-modules/pull/1393 didn't wipe out the downstream, but I think it makes sense now- we only run `go mod vendor` before applying patches and https://github.com/GoogleCloudPlatform/magic-modules/pull/1366 is/was unmerged.

Let me know if this change does what I think & whether you think it's worth it- it's a small complexity gain but I believe it will better keep the Magician caught up in situations like this.

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
