### PR TITLE
[Terraform] Removing Redis client

### DIFF
--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -38,7 +38,6 @@ import (
 	"google.golang.org/api/iam/v1"
 	cloudlogging "google.golang.org/api/logging/v2"
 	"google.golang.org/api/pubsub/v1"
-	"google.golang.org/api/redis/v1beta1"
 	"google.golang.org/api/runtimeconfig/v1beta1"
 	"google.golang.org/api/servicemanagement/v1"
 <% unless version == 'ga' -%>
@@ -85,7 +84,6 @@ type Config struct {
 	clientKms                    *cloudkms.Service
 	clientLogging                *cloudlogging.Service
 	clientPubsub                 *pubsub.Service
-	clientRedis                  *redis.Service
 	clientResourceManager        *cloudresourcemanager.Service
 	clientResourceManagerV2Beta1 *resourceManagerV2Beta1.Service
 	clientRuntimeconfig          *runtimeconfig.Service
@@ -224,13 +222,6 @@ func (c *Config) loadAndValidate() error {
 		return err
 	}
 	c.clientDataflow.UserAgent = userAgent
-
-	log.Printf("[INFO] Instantiating Google Cloud Redis Client...")
-	c.clientRedis, err = redis.New(client)
-	if err != nil {
-		return err
-	}
-	c.clientRedis.UserAgent = userAgent
 
 	log.Printf("[INFO] Instantiating Google Cloud ResourceManager Client...")
 	c.clientResourceManager, err = cloudresourcemanager.New(client)


### PR DESCRIPTION
Now that operations are being auto-generated for Redis, the client is no longer necessary.

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
