### PR TITLE
Compile/copy files in parallel

### DIFF
--- a/compile/core.rb
+++ b/compile/core.rb
@@ -237,12 +237,12 @@ module Compile
     end
 
     def autogen_notice(lang)
-      @file_expectations[:autogen] = true
+      Thread.current[:autogen] = true
       comment_block(compile('templates/autogen_notice.erb').split("\n"), lang)
     end
 
     def autogen_exception
-      @file_expectations[:autogen] = true
+      Thread.current[:autogen] = true
     end
 
     def comment_block(text, lang)


### PR DESCRIPTION
You know what's fun? Multithreading!

Ruby doesn't have [true multithreading](https://thoughtbot.com/blog/untangling-ruby-threads), but it can do parallel tasks while waiting for blocking I/O (like writing files!)

I made copying + compiling product specific files multithreaded. We could try to thread product/resource generation, but I don't think we'll see a huge performance gain.

Running TF full-run before threading: `3m 16.62s`
Running TF full-run after threading:   `2m 10.71s`

edit: I did some tests on generating objects using threads. Much smaller difference than copying + compiling files (15-20s) and the logs impossible to parse. I don't think it's a change worth making, but threading provider common files is (this PR).
 
<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
