### PR TITLE
removing nightly trigger + changing release pipeline script for Ansible

### DIFF
--- a/.ci/magic-modules/release-ansible.sh
+++ b/.ci/magic-modules/release-ansible.sh
@@ -1,9 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
 set -x
 
 pushd "magic-modules-gcp/build/ansible"
-git remote add origin git@github.com:modular-magician/ansible.git
-
 ../../tools/ansible-pr/run.sh

--- a/.ci/release.yml.tmpl
+++ b/.ci/release.yml.tmpl
@@ -43,6 +43,8 @@ resources:
 jobs:
     - name: ansible-nightly-release
       plan:
+          - get: night-trigger
+            trigger: true
           - get: magic-modules-gcp
           - task: build
             file: magic-modules-gcp/.ci/magic-modules/release-ansible.yml

--- a/.ci/release.yml.tmpl
+++ b/.ci/release.yml.tmpl
@@ -43,8 +43,6 @@ resources:
 jobs:
     - name: ansible-nightly-release
       plan:
-          - get: night-trigger
-            trigger: true
           - get: magic-modules-gcp
           - task: build
             file: magic-modules-gcp/.ci/magic-modules/release-ansible.yml


### PR DESCRIPTION
I'm temporarily removing the nightly trigger. I'm also changing the kickoff script for the Ansible release pipeline because it turns out the origin remote is already properly set.

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
