### PR TITLE
Ordering changes in create-prs.

### DIFF
--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -339,7 +339,7 @@ jobs:
             {% for v in vars.terraform_v.itervalues() %}
             - put: {{v.short_name}}-intermediate
               params:
-                repository: magic-modules-with-comment/build/{{ v.short_name }}
+                repository: magic-modules/build/{{ v.short_name }}
                 branch_file: branchname/original_pr_branch_name
                 # Every time a change runs through this pipeline, it will generate a commit with
                 # a different hash - the hash includes timestamps.  Therefore, even if there's no
@@ -354,7 +354,7 @@ jobs:
             {% endfor %}
             - put: ansible-intermediate
               params:
-                repository: magic-modules-with-comment/build/ansible
+                repository: magic-modules/build/ansible
                 branch_file: branchname/original_pr_branch_name
                 # See comment on terraform-intermediate
                 only_if_diff: true
@@ -363,23 +363,13 @@ jobs:
                   skip_clone: true
             - put: inspec-intermediate
               params:
-                repository: magic-modules-with-comment/build/inspec
+                repository: magic-modules/build/inspec
                 branch_file: branchname/original_pr_branch_name
                 # See comment on terraform-intermediate
                 only_if_diff: true
                 force: true
               get_params:
                   skip_clone: true
-          # This isn't load-bearing - it's just aesthetic.  It will also be a no-op the first
-          # time through, it works the same way as the preceding push.
-          - put: magic-modules
-            params:
-              repository: magic-modules-with-comment/
-              branch_file: branchname/original_pr_branch_name
-              only_if_diff: true
-              force: true
-            get_params:
-                skip_clone: true
           - task: create-or-update-pr
             file: magic-modules/.ci/magic-modules/create-pr.yml
             params:
@@ -398,6 +388,15 @@ jobs:
                   path: mm-initial-pr
               get_params:
                   skip_clone: true
+
+          - put: magic-modules
+            params:
+              repository: magic-modules/
+              branch_file: branchname/original_pr_branch_name
+              only_if_diff: true
+              force: true
+            get_params:
+                skip_clone: true
 
           # Once everything is done and working, post the updated information to the
           # magic-modules PR.

--- a/.ci/magic-modules/create-pr.sh
+++ b/.ci/magic-modules/create-pr.sh
@@ -67,7 +67,7 @@ if [ -n "$TERRAFORM_REPO_USER" ]; then
     fi
 
     git checkout -b "$BRANCH_NAME"
-    if hub pull-request -b "$TERRAFORM_REPO_USER/$PROVIDER_NAME:master" -F ./downstream_body > ./tf_pr 2> ./tf_pr_err ; then
+    if hub pull-request -b "$TERRAFORM_REPO_USER/$PROVIDER_NAME:master" -h "$ORIGINAL_PR_BRANCH" -F ./downstream_body > ./tf_pr 2> ./tf_pr_err ; then
       DEPENDENCIES="${DEPENDENCIES}depends: $(cat ./tf_pr) ${NEWLINE}"
       LABELS="${LABELS}${PROVIDER_NAME},"
     else
@@ -96,7 +96,7 @@ if [ -n "$ANSIBLE_REPO_USER" ]; then
   fi
 
   git checkout -b "$BRANCH_NAME"
-  if hub pull-request -b "$ANSIBLE_REPO_USER/ansible:devel" -F ./downstream_body > ./ansible_pr 2> ./ansible_pr_err ; then
+  if hub pull-request -b "$ANSIBLE_REPO_USER/ansible:devel" -h "$ORIGINAL_PR_BRANCH" -F ./downstream_body > ./ansible_pr 2> ./ansible_pr_err ; then
     DEPENDENCIES="${DEPENDENCIES}depends: $(cat ./ansible_pr) ${NEWLINE}"
     LABELS="${LABELS}ansible,"
   else
@@ -122,7 +122,7 @@ fi
   fi
 
   git checkout -b "$BRANCH_NAME"
-  if hub pull-request -b "$INSPEC_REPO_USER/inspec-gcp:master" -F ./downstream_body > ./inspec_pr 2> ./inspec_pr_err ; then
+  if hub pull-request -b "$INSPEC_REPO_USER/inspec-gcp:master" -h "$ORIGINAL_PR_BRANCH" -F ./downstream_body > ./inspec_pr 2> ./inspec_pr_err ; then
     DEPENDENCIES="${DEPENDENCIES}depends: $(cat ./inspec_pr) ${NEWLINE}"
     LABELS="${LABELS}inspec,"
   else


### PR DESCRIPTION
Ordering is extremely important to the magician.  To save time, we don't
close the repo 'magic-modules' back in - but we need it later on to
run jobs out of.  This crashes the magician.  Also, the 'with-comment'
repo does not exist at the time that we are trying to use it to run
jobs.

<!-- Your regular pull request body goes here -->

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
CI changes only.
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
