### PR TITLE
Ansible Release Pipeline - new version of hub image + set SSH keys

### DIFF
--- a/.ci/containers/hub/Dockerfile
+++ b/.ci/containers/hub/Dockerfile
@@ -1,4 +1,4 @@
-from gcr.io/magic-modules/go-ruby:1.9-2.5
+from gcr.io/magic-modules/go-ruby:1.11.5-2.6.0
 
 RUN apt-get update
 RUN apt-get install -y ca-certificates

--- a/.ci/magic-modules/release-ansible.sh
+++ b/.ci/magic-modules/release-ansible.sh
@@ -2,5 +2,15 @@
 
 set -x
 
+# Install dependencies for Template Generator
+pushd "magic-modules-gcp"
+bundle install
+popd
+
 pushd "magic-modules-gcp/build/ansible"
+# Setup Git config.
+git config --global user.email "alexstephen@google.com"
+git config --global user.name "Alex Stephen"
+
+# Run creation script.
 ../../tools/ansible-pr/run.sh

--- a/.ci/magic-modules/release-ansible.sh
+++ b/.ci/magic-modules/release-ansible.sh
@@ -5,6 +5,18 @@ set -x
 # Install dependencies for Template Generator
 pushd "magic-modules-gcp"
 bundle install
+
+# Setup SSH keys.
+
+# Since these creds are going to be managed externally, we need to pass
+# them into the container as an environment variable.  We'll use
+# ssh-agent to ensure that these are the credentials used to update.
+set +x
+echo "$CREDS" > ~/github_private_key
+set -x
+chmod 400 ~/github_private_key
+
+ssh-agent bash -c "ssh-add ~/github_private_key; git submodule update --force --init"
 popd
 
 pushd "magic-modules-gcp/build/ansible"

--- a/.ci/magic-modules/release-ansible.sh
+++ b/.ci/magic-modules/release-ansible.sh
@@ -21,8 +21,8 @@ popd
 
 pushd "magic-modules-gcp/build/ansible"
 # Setup Git config.
-git config --global user.email "alexstephen@google.com"
-git config --global user.name "Alex Stephen"
+git config --global user.email "magic-modules@google.com"
+git config --global user.name "Modular Magician"
 
 # Run creation script.
 ../../tools/ansible-pr/run.sh

--- a/.ci/magic-modules/release-ansible.yml
+++ b/.ci/magic-modules/release-ansible.yml
@@ -6,8 +6,8 @@ platform: linux
 image_resource:
     type: docker-image
     source:
-        repository: gcr.io/magic-modules/go-ruby-python
-        tag: '1.11.5-2.6.0-2.7'
+        repository: gcr.io/magic-modules/hub
+        tag: '1.1'
 
 inputs:
     - name: magic-modules-gcp

--- a/.ci/release.yml.tmpl
+++ b/.ci/release.yml.tmpl
@@ -50,6 +50,7 @@ jobs:
             file: magic-modules-gcp/.ci/magic-modules/release-ansible.yml
             params:
                 GITHUB_TOKEN: ((github-account.password))
+                CREDS: ((repo-key.private_key))
     - name: nightly-build
       plan:
           - get: night-trigger

--- a/tools/ansible-pr/run.sh
+++ b/tools/ansible-pr/run.sh
@@ -31,13 +31,10 @@ if ! git remote -v | grep "origin"; then
   exit 1
 fi
 
-if ! git remote -v | grep "upstream.*git@github.com:ansible/ansible\.git \(fetch\)" 2&>1 >/dev/null; then
-  git remote add upstream git@github.com:ansible/ansible.git
-fi
+git remote add upstream https://github.com/ansible/ansible.git
 
-set -e
-
-git remote add magician git@github.com:modular-magician/ansible.git
+# Use HTTPS endpoint so we don't have to setup SSH keys.
+git remote add magician https://github.com/modular-magician/ansible.git &>/dev/null
 git fetch magician devel
 git fetch upstream devel
 echo "Remotes setup properly"


### PR DESCRIPTION
More Ansible release pipeline stuff!

- The pipeline requires hub and Ruby 2.6. I created (and pushed up) an image with both of these (hub 1.1)
- Pipeline requires ssh keys for pushing up PRs. The keys have been set in credhub + I put in logic to take the keys and set them up properly.

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
