### PR TITLE
moving ansible release pipeline back to nightly build on HEAD

### DIFF
--- a/.ci/magic-modules/release-ansible.sh
+++ b/.ci/magic-modules/release-ansible.sh
@@ -23,7 +23,7 @@ get_all_modules() {
 }
 
 # Install dependencies for Template Generator
-pushd "magic-modules-new-prs"
+pushd "magic-modules-gcp"
 bundle install
 
 # Setup SSH keys.
@@ -37,7 +37,7 @@ set -x
 chmod 400 ~/github_private_key
 popd
 
-pushd "magic-modules-new-prs/build/ansible"
+pushd "magic-modules-gcp/build/ansible"
 
 # Setup Git config and remotes.
 git config --global user.email "magic-modules@google.com"

--- a/.ci/magic-modules/release-ansible.yml
+++ b/.ci/magic-modules/release-ansible.yml
@@ -10,10 +10,10 @@ image_resource:
         tag: '1.1'
 
 inputs:
-    - name: magic-modules-new-prs
+    - name: magic-modules-gcp
 
 run:
-    path: "magic-modules-new-prs/.ci/magic-modules/release-ansible.sh"
+    path: "magic-modules-gcp/.ci/magic-modules/release-ansible.sh"
 
 params:
   GITHUB_TOKEN: ""

--- a/.ci/release.yml.tmpl
+++ b/.ci/release.yml.tmpl
@@ -26,15 +26,6 @@ resources:
           uri: git@github.com:GoogleCloudPlatform/magic-modules.git
           private_key: ((repo-key.private_key))
 
-    - name: magic-modules-new-prs
-      type: github-pull-request
-      source:
-          repo: GoogleCloudPlatform/magic-modules
-          private_key: ((repo-key.private_key))
-          access_token: ((github-account.password))
-          authorship_restriction: true
-          no_label: automerged
-
     - name: gcp-bucket
       type: gcs-resource
       source:
@@ -60,10 +51,10 @@ jobs:
       plan:
           - get: night-trigger
             trigger: true
-          - get: magic-modules-new-prs
+          - get: magic-modules-gcp
             trigger: false
           - task: build
-            file: magic-modules-new-prs/.ci/magic-modules/release-ansible.yml
+            file: magic-modules-gcp/.ci/magic-modules/release-ansible.yml
             params:
                 GITHUB_TOKEN: ((github-account.password))
                 CREDS: ((repo-key.private_key))


### PR DESCRIPTION
For better debugging, I moved the Ansible release pipeline to build off of PRs. Now that the pipeline works, I'm moving it back to a model of being triggered off of HEAD every night.

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
