### PR TITLE
Simplify expand / API object logic, re-document it.

### DIFF
--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -131,7 +131,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
             should always be sent.
 -%>
 <%      unless prop.send_empty_value -%>
-    } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
+    } else if v := d.Get("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) {
 <%      else -%>
     } else {
 <%      end -%>
@@ -291,7 +291,7 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
             return err
 <%#         See the equivalent block in Create for context on this block.-%>
 <%          unless prop.send_empty_value -%>
-        } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
+        } else if v := d.Get("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) {
 <%          else -%>
         } else {
 <%          end -%>
@@ -371,7 +371,7 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
         return err
 <%#         See the equivalent block in Create for context on this block.-%>
 <%      unless prop.send_empty_value -%>
-    } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
+    } else if v := d.Get("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) {
 <%      else -%>
     } else {
 <%      end -%>

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -110,10 +110,30 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     <%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= prop.name.underscore -%>"), d, config)
     if err != nil {
         return err
+<%#         We (often) only want to send values that are non-zero to the API.
+            Unfortunately though, Some APIs require you to send zero values-
+            `enable_foo: false`, or `password: ""` while others will return an
+            error if you send an empty value. We require this nuance to
+            be annotated in api.yaml with `send_empty_value`, since it is not
+            discoverable automatically.
+
+            When that's not set, we determine whether to send a value based on a
+            few conditions;
+
+            * if the expanded value is non-empty, AND
+              * the value in config/state is set (has ever been non-empty)
+                * so it can be set in config, have a default, or be set in state
+              * the expanded value and state value are not the same
+
+            `send_empty_value` subsumes both `ForceSendFields` and `NullFields`
+            in the go API client - `NullFields` is a special case where the
+            empty value in question is go's literal nil. If it's set, the value
+            should always be sent.
+-%>
 <%      unless prop.send_empty_value -%>
     } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
 <%      else -%>
-    } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop) {
+    } else {
 <%      end -%>
         obj["<%= prop.api_name -%>"] = <%= prop.api_name -%>Prop
     }
@@ -269,27 +289,11 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
         <%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= prop.name.underscore -%>"), d, config)
         if err != nil {
             return err
-<%#         There is some nuance in when we choose to send a value to an update function.
-            This is unfortunate, but it's because of the way that GCP works, so there's
-            no easy way out.  Some APIs require you to send `enable_foo: false`, while
-            others will crash if you send `attribute: ''`.  We require this nuance to
-            be annotated in api.yaml, since it is not discoverable automatically.
-
-            The behavior here, which we believe to be correct, is to send a value if
-            * It is non-empty OR
-            * It is marked send_empty_value in api.yaml.
-            AND
-            * It has been set by the user OR
-            * It has been modified by the expander in any way
-
-            This subsumes both `ForceSendFields` and `NullFields` in the go API client -
-            `NullFields` is a special case of `send_empty_value` where the empty value
-            in question is go's literal nil.
--%>
+<%#         See the equivalent block in Create for context on this block.-%>
 <%          unless prop.send_empty_value -%>
-        } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
+        } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
 <%          else -%>
-        } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop) {
+        } else {
 <%          end -%>
             obj["<%= prop.api_name -%>"] = <%= prop.api_name -%>Prop
         }
@@ -365,10 +369,11 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
     <%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(d.Get("<%= prop.name.underscore -%>"), d, config)
     if err != nil {
         return err
+<%#         See the equivalent block in Create for context on this block.-%>
 <%      unless prop.send_empty_value -%>
-    } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
+    } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
 <%      else -%>
-    } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop) {
+    } else {
 <%      end -%>
         obj["<%= prop.api_name -%>"] = <%= prop.api_name -%>Prop
     }

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -131,7 +131,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
             should always be sent.
 -%>
 <%      unless prop.send_empty_value -%>
-    } else if v := d.Get("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) {
+    } else if !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) {
 <%      else -%>
     } else {
 <%      end -%>
@@ -291,7 +291,7 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
             return err
 <%#         See the equivalent block in Create for context on this block.-%>
 <%          unless prop.send_empty_value -%>
-        } else if v := d.Get("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) {
+        } else if !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) {
 <%          else -%>
         } else {
 <%          end -%>
@@ -371,7 +371,7 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
         return err
 <%#         See the equivalent block in Create for context on this block.-%>
 <%      unless prop.send_empty_value -%>
-    } else if v := d.Get("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) {
+    } else if !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) {
 <%      else -%>
     } else {
 <%      end -%>


### PR DESCRIPTION
Not looking to merge until after `2.1.0`, but I had some more thoughts below, so I wanted to start the review;

Sorry about the docs churn- I wanted to make sure I understood the nuance here, so I partially rewrote it to make sure I understood it.

I'm not convinced this statement below needs to be as complex as it is:

```go
if v, ok := d.GetOkExists("prop"); !isEmptyValue(reflect.ValueOf(vProp)) && (ok || !reflect.DeepEqual(v, vProp))
```

So, we have values `v` and `vProp` (the result from the expander)

First, we can assert that `vProp` is non-zero. That's because if `vProp` is the zero value, we short-circuit the whole expression. As well, if the expander had an error we would have failed already.

Next, we check `(ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop))`;

 * `ok` is only ever false when `v` is the empty value based on my understanding of `d.GetOkExists`. So if `v` is anything but the empty value, we short-circuit (and we also short-circuit in some cases where it _is_ the empty value)

 * `!reflect.DeepEqual(v, <%= prop.api_name -%>Prop))` is only inspected when `vProp` has a non-empty value *and* `v` is the empty value.

Compared to the following, the benefit is clear:

```go
if v, ok := d.GetOkExists("prop"); !isEmptyValue(reflect.ValueOf(vProp)) && ok
```

In a case like `region`, if `v` is `""` and `vProp` is `"us-central1"` the conditional ensures we send the value. `ok` would be false in this case.

But reviewing the cases, where `a` and `b` are any two distinct strings, and `n` is the none value:

v | vProp | outcome | why
---|---|---|---
`a` | `a` | true | `a` is non-zero for `vProp`, `a` being non-zero for `v` means `ok` is `true`
`n` | `a` | true | `a` is non-zero for `vProp`, `a` != `n`
`a` | `b` | true | `a` is non-zero for `vProp`, `a` != `b`
`a` | `n` | false | `vProp` is the empty value

So the _only_ case we ever fail is if an expander sets a value to the empty value when it previously had a value in `v`. But we receive the exact same results with the following statement;

```go
if v := d.Get("prop"); !isEmptyValue(reflect.ValueOf(vProp)) {
```

In effect, `(ok || !reflect.DeepEqual(v, vProp))` is a tautology and I believe we can remove it.

One case of note is a boolean default to true; it's the weirdest case, and the second block being redundant holds.

v | vProp | outcome | why
---|---|---|---
`true` | `true` | true | `vProp` is non-zero, `ok` is true as `v` is non-zero
`false` | `true` | true | `vProp` is non-zero, `v` != `vProp`
`false` | `false` | false | `vProp` is the empty value
`true` | `false` | false | `vProp` is the empty value

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
