### PR TITLE
Add managed SSL cert to beta.

### DIFF
--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -78,6 +78,8 @@ datasources: !ruby/object:Overrides::ResourceOverrides
     version_added: '2.7'
   SslCertificate: !ruby/object:Overrides::Ansible::ResourceOverride
     version_added: '2.7'
+  ManagedSslCertificate: !ruby/object:Overrides::Ansible::ResourceOverride
+    exclude: true
   SslPolicy: !ruby/object:Overrides::Ansible::ResourceOverride
     version_added: '2.7'
   Subnetwork: !ruby/object:Overrides::Ansible::ResourceOverride

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -3493,6 +3493,7 @@ objects:
         required: true
         input: true
   - !ruby/object:Api::Resource
+    # This is intentionally out of alphabetic order.
     name: 'ManagedSslCertificate'
     kind: 'compute#sslCertificate'
     min_version: beta
@@ -3507,9 +3508,9 @@ objects:
     input: true
     has_self_link: true
     description: |
-      An SslCertificate resource, used for HTTPS load balancing. This resource
-      provides a mechanism to upload an SSL key and certificate to
-      the load balancer to serve secure connections from the user.
+      An SslCertificate resource, used for HTTPS load balancing.  This resource
+      represents a certificate for which the certificate secrets are created and
+      managed by Google.
 <%= indent(compile_file({timeouts: {
                         insert_sec: 6 * 60,
                         update_sec: 6 * 60,
@@ -3570,6 +3571,7 @@ objects:
         name: 'expireTime'
         description: |
           Expire time of the certificate.
+        output: true
   - !ruby/object:Api::Resource
     name: 'SslPolicy'
     kind: 'compute#sslPolicy'

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -3493,6 +3493,78 @@ objects:
         required: true
         input: true
   - !ruby/object:Api::Resource
+    name: 'ManagedSslCertificate'
+    kind: 'compute#sslCertificate'
+    min_version: beta
+    base_url: projects/{{project}}/global/sslCertificates
+    collection_url_response: !ruby/object:Api::Resource::ResponseList
+      kind: 'compute#sslCertificateList'
+      items: 'items'
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation': 'https://cloud.google.com/load-balancing/docs/ssl-certificates'
+      api: 'https://cloud.google.com/compute/docs/reference/rest/v1/sslCertificates'
+    input: true
+    description: |
+      An SslCertificate resource, used for HTTPS load balancing. This resource
+      provides a mechanism to upload an SSL key and certificate to
+      the load balancer to serve secure connections from the user.
+<%= indent(compile_file({}, 'templates/global_async.yaml.erb'), 4) %>
+    properties:
+      - !ruby/object:Api::Type::Time
+        name: 'creationTimestamp'
+        description: 'Creation timestamp in RFC3339 text format.'
+        output: true
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: 'An optional description of this resource.'
+      - !ruby/object:Api::Type::Integer
+        name: 'id'
+        description: 'The unique identifier for the resource.'
+        output: true
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          Name of the resource. Provided by the client when the resource is
+          created. The name must be 1-63 characters long, and comply with
+          RFC1035. Specifically, the name must be 1-63 characters long and match
+          the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the
+          first character must be a lowercase letter, and all following
+          characters must be a dash, lowercase letter, or digit, except the last
+          character, which cannot be a dash.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'managed'
+        description: |
+          Properties relevant to a managed certificate.  These will be used if the
+          certificate is managed (as indicated by a value of `MANAGED` in `type`).
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: 'domains'
+            description: |
+              Domains for which a managed SSL certificate will be valid.  Currently,
+              there can only be one domain in this list.
+            max_size: 1
+            item_type: Api::Type::String
+            required: true
+      - !ruby/object:Api::Type::Enum
+        name: 'type'
+        description: |
+          Specifies the type of SSL certificate, either `SELF_MANAGED` or `MANAGED`.
+          If not specified, the certificate is self-managed.
+        values:
+          - :MANAGED
+        default_value: :MANAGED
+      - !ruby/object:Api::Type::Array
+        name: 'subjectAlternativeNames'
+        description: |
+          Domains associated with the certificate via Subject Alternative Name.
+        item_type: Api::Type::String
+        output: true
+      - !ruby/object:Api::Type::Time
+        name: 'expireTime'
+        description: |
+          Expire time of the certificate.
+  - !ruby/object:Api::Resource
     name: 'SslPolicy'
     kind: 'compute#sslPolicy'
     base_url: projects/{{project}}/global/sslPolicies

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -3505,11 +3505,17 @@ objects:
         'Official Documentation': 'https://cloud.google.com/load-balancing/docs/ssl-certificates'
       api: 'https://cloud.google.com/compute/docs/reference/rest/v1/sslCertificates'
     input: true
+    has_self_link: true
     description: |
       An SslCertificate resource, used for HTTPS load balancing. This resource
       provides a mechanism to upload an SSL key and certificate to
       the load balancer to serve secure connections from the user.
-<%= indent(compile_file({}, 'templates/global_async.yaml.erb'), 4) %>
+<%= indent(compile_file({timeouts: {
+                        insert_sec: 6 * 60,
+                        update_sec: 6 * 60,
+                        # Deletes can take up to 30 minutes to complete, since they depend
+                        # on the provisioning process either succeeding or failing completely.
+                        delete_sec: 30 * 60}}, 'templates/global_async.yaml.erb'), 4) %>
     properties:
       - !ruby/object:Api::Type::Time
         name: 'creationTimestamp'

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -3457,6 +3457,8 @@ objects:
       An SslCertificate resource, used for HTTPS load balancing. This resource
       provides a mechanism to upload an SSL key and certificate to
       the load balancer to serve secure connections from the user.
+      For a certificate managed by Google, see the ManagedSslCertificate
+      resource.
 <%= indent(compile_file({}, 'templates/global_async.yaml.erb'), 4) %>
     properties:
       - !ruby/object:Api::Type::String
@@ -3487,13 +3489,16 @@ objects:
           first character must be a lowercase letter, and all following
           characters must be a dash, lowercase letter, or digit, except the last
           character, which cannot be a dash.
+
+          These are in the same namespace as the managed SSL certificates.
       - !ruby/object:Api::Type::String
         name: 'privateKey'
         description: 'The write-only private key in PEM format.'
         required: true
         input: true
   - !ruby/object:Api::Resource
-    # This is intentionally out of alphabetic order.
+    # This is intentionally out of alphabetic order because it represents the same
+    # GCP resource as the preceeding certificate object.
     name: 'ManagedSslCertificate'
     kind: 'compute#sslCertificate'
     min_version: beta
@@ -3510,11 +3515,12 @@ objects:
     description: |
       An SslCertificate resource, used for HTTPS load balancing.  This resource
       represents a certificate for which the certificate secrets are created and
-      managed by Google.
+      managed by Google.  For a resource where you provide the key, see the
+      SSL Certificate resource.
 <%= indent(compile_file({timeouts: {
                         insert_sec: 6 * 60,
                         update_sec: 6 * 60,
-                        # Deletes can take up to 30 minutes to complete, since they depend
+                        # Deletes can take 20-30 minutes to complete, since they depend
                         # on the provisioning process either succeeding or failing completely.
                         delete_sec: 30 * 60}}, 'templates/global_async.yaml.erb'), 4) %>
     properties:
@@ -3539,6 +3545,8 @@ objects:
           first character must be a lowercase letter, and all following
           characters must be a dash, lowercase letter, or digit, except the last
           character, which cannot be a dash.
+
+          These are in the same namespace as the unmanaged SSL certificates.
       - !ruby/object:Api::Type::NestedObject
         name: 'managed'
         description: |

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -3457,8 +3457,6 @@ objects:
       An SslCertificate resource, used for HTTPS load balancing. This resource
       provides a mechanism to upload an SSL key and certificate to
       the load balancer to serve secure connections from the user.
-      For a certificate managed by Google, see the ManagedSslCertificate
-      resource.
 <%= indent(compile_file({}, 'templates/global_async.yaml.erb'), 4) %>
     properties:
       - !ruby/object:Api::Type::String
@@ -3489,8 +3487,6 @@ objects:
           first character must be a lowercase letter, and all following
           characters must be a dash, lowercase letter, or digit, except the last
           character, which cannot be a dash.
-
-          These are in the same namespace as the managed SSL certificates.
       - !ruby/object:Api::Type::String
         name: 'privateKey'
         description: 'The write-only private key in PEM format.'
@@ -3515,8 +3511,7 @@ objects:
     description: |
       An SslCertificate resource, used for HTTPS load balancing.  This resource
       represents a certificate for which the certificate secrets are created and
-      managed by Google.  For a resource where you provide the key, see the
-      SSL Certificate resource.
+      managed by Google.
 <%= indent(compile_file({timeouts: {
                         insert_sec: 6 * 60,
                         update_sec: 6 * 60,
@@ -3545,8 +3540,6 @@ objects:
           first character must be a lowercase letter, and all following
           characters must be a dash, lowercase letter, or digit, except the last
           character, which cannot be a dash.
-
-          These are in the same namespace as the unmanaged SSL certificates.
       - !ruby/object:Api::Type::NestedObject
         name: 'managed'
         description: |

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -728,6 +728,26 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       decoder: templates/terraform/decoders/snapshot.go.erb
       extra_schema_entry: templates/terraform/extra_schema_entry/snapshot.erb
+  ManagedSslCertificate: !ruby/object:Overrides::Terraform::ResourceOverride
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "managed_ssl_certificate_basic"
+        primary_resource_id: "default"
+        version: <%= version_name %>
+        vars:
+          cert_name: "test-cert"
+          proxy_name: "test-proxy"
+          url_map_name: "url-map"
+          backend_service_name: "backend-service"
+          dns_zone_name: "dnszone"
+          forwarding_rule_name: "forwarding-rule"
+          http_health_check_name: "http-health-check"
+    properties:
+      id: !ruby/object:Overrides::Terraform::PropertyOverride
+        name: 'certificate_id'
+        default_from_api: true
+      expireTime: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
   SslCertificate: !ruby/object:Overrides::Terraform::ResourceOverride
     docs: !ruby/object:Provider::Terraform::Docs
       optional_properties: |

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -729,6 +729,20 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       decoder: templates/terraform/decoders/snapshot.go.erb
       extra_schema_entry: templates/terraform/extra_schema_entry/snapshot.erb
   ManagedSslCertificate: !ruby/object:Overrides::Terraform::ResourceOverride
+    docs: !ruby/object:Provider::Terraform::Docs
+      warning: |
+        This resource should be used with extreme caution!  Provisioning an SSL
+        certificate is complex.  Ensure that you understand the lifecycle of a
+        certificate before attempting complex tasks like cert rotation automatically.
+        This resource will "return" as soon as the certificate object is created,
+        but post-creation the certificate object will go through a "provisioning"
+        process.  The provisioning process can complete only when the domain name
+        for which the certificate is created points to a target pool which, itself,
+        points at the certificate.  Depending on your DNS provider, this may take
+        some time, and migrating from self-managed certificates to Google-managed
+        certificates may entail some downtime while the certificate provisions.
+
+        In conclusion: Be extremely cautious.
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "managed_ssl_certificate_basic"
@@ -745,8 +759,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         name: 'certificate_id'
-        default_from_api: true
-      expireTime: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
   SslCertificate: !ruby/object:Overrides::Terraform::ResourceOverride
     docs: !ruby/object:Provider::Terraform::Docs

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -756,10 +756,19 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           dns_zone_name: "dnszone"
           forwarding_rule_name: "forwarding-rule"
           http_health_check_name: "http-health-check"
+    description: |
+      {{description}}
+      For a resource where you provide the key, see the
+      SSL Certificate resource.
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         name: 'certificate_id'
         default_from_api: true
+      name: !ruby/object:Overrides::Terraform::PropertyOverride
+        description: |
+          {{description}}
+
+          These are in the same namespace as the managed SSL certificates.
   SslCertificate: !ruby/object:Overrides::Terraform::ResourceOverride
     docs: !ruby/object:Provider::Terraform::Docs
       optional_properties: |
@@ -795,6 +804,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_expand: 'templates/terraform/custom_expand/name_or_name_prefix.go.erb'
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateGCPName'
+        description: |
+          {{description}}
+
+          These are in the same namespace as the managed SSL certificates.
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         name: 'certificate_id'
       certificate: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/templates/terraform/examples/managed_ssl_certificate_basic.tf.erb
+++ b/templates/terraform/examples/managed_ssl_certificate_basic.tf.erb
@@ -1,0 +1,70 @@
+resource "google_compute_managed_ssl_certificate" "default" {
+  name = "<%= ctx[:vars]['cert_name'] %>"
+
+  managed {
+    domains = ["sslcert.tf-test.club"]
+  }
+}
+
+resource "google_compute_target_https_proxy" "default" {
+  name             = "<%= ctx[:vars]['proxy_name'] %>"
+  url_map          = "${google_compute_url_map.default.self_link}"
+  ssl_certificates = ["${google_compute_managed_ssl_certificate.default.self_link}"]
+}
+
+resource "google_compute_url_map" "default" {
+  name        = "<%= ctx[:vars]['url_map_name'] %>"
+  description = "a description"
+
+  default_service = "${google_compute_backend_service.default.self_link}"
+
+  host_rule {
+    hosts        = ["sslcert.tf-test.club"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
+    default_service = "${google_compute_backend_service.default.self_link}"
+
+    path_rule {
+      paths   = ["/*"]
+      service = "${google_compute_backend_service.default.self_link}"
+    }
+  }
+}
+
+resource "google_compute_backend_service" "default" {
+  name        = "<%= ctx[:vars]['backend_service_name'] %>"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = ["${google_compute_http_health_check.default.self_link}"]
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "<%= ctx[:vars]['http_health_check_name'] %>"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_dns_managed_zone" "zone" {
+  name     = "<%= ctx[:vars]['dns_zone_name'] %>"
+  dns_name = "sslcert.tf-test.club."
+}
+
+resource "google_compute_global_forwarding_rule" "default" {
+  name       = "<%= ctx[:vars]['forwarding_rule_name'] %>"
+  target     = "${google_compute_target_https_proxy.default.self_link}"
+  port_range = 443
+}
+
+resource "google_dns_record_set" "set" {
+  name         = "sslcert.tf-test.club."
+  type         = "A"
+  ttl          = 3600
+  managed_zone = "${google_dns_managed_zone.zone.name}"
+  rrdatas      = ["${google_compute_global_forwarding_rule.default.ip_address}"]
+}

--- a/templates/terraform/provider_gen.erb
+++ b/templates/terraform/provider_gen.erb
@@ -19,7 +19,7 @@ package google
 import "github.com/hashicorp/terraform/helper/schema"
 
 var Generated<%= product_ns -%>ResourcesMap = map[string]*schema.Resource{
-<% product.objects.reject { |r| r.exclude }.each do |object| -%>
+<% product.objects.reject { |r| r.exclude || r.not_in_version?(product.version_obj_or_default(version)) }.each do |object| -%>
 <%
 if @config.legacy_name.nil?
 	terraform_name = "google_" + (product_ns + object.name).underscore


### PR DESCRIPTION
All right!

This is an interesting one.  SSL certs and Managed SSL Certs are the same resource type in GCP, so this is the first time that we have had two resources that point to the same endpoints.

We think this is the right move.  Here's the API object for SSL certs in v1:
![image](https://user-images.githubusercontent.com/605324/53134490-3b39fd00-352c-11e9-93df-8911be2464a2.png)

and beta:

![image](https://user-images.githubusercontent.com/605324/53134505-47be5580-352c-11e9-9ebc-127b8237af11.png)

You can see that the beta object contains the v1 object as a subset - and that code which operates with the v1 object is interoperable with the beta object, even though the beta object also contains a separate system for distinguishing managed and unmanaged ssl certificates.

We decided that this is confusing, unnecessarily so, and that the right move here is to treat managed and unmanaged ssl certs as different objects which share an api endpoint.  We believe this is safe, because according to the deprecation policy, as long as compute continues to support v1, the original api will be usable.  This has some side effects - technically, for instance, you could import a managed certificate as a self-managed one, if you wanted to - but they are negligible.

This resource needs to be handled with extreme caution.  The setup steps for this resource are complex - and may include out of band changes to DNS host servers.  I have drafted a cautionary statement for the docs, but would appreciate additional help in conveying the issue.

-----------------------------------------------------------------
# [all]
## [terraform]
Changes ancillary to adding managed SSL certs.
### [terraform-beta]
Add managed SSL certs to beta.
## [ansible]
## [inspec]