### PR TITLE
Only run go mod vendor if git differences

### DIFF
--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -49,7 +49,11 @@ fi
 
 pushd "build/$SHORT_NAME"
 
-GO111MODULE=on go mod vendor
+# go mod vendor is a very expensive operation.
+# If no changes, avoid running.
+if git diff-index --quiet HEAD --; then
+  GO111MODULE=on go mod vendor
+fi
 
 # These config entries will set the "committer".
 git config --global user.email "magic-modules@google.com"


### PR DESCRIPTION
`go mod vendor` is an expensive operation that sometimes crashes due to intermittent network issues.

If there's no difference in the commit, it doesn't look like there's any reason that `go mod vendor` should be run.

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

<!-- Your regular pull request description goes here -->




<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
