### PR TITLE
Improve docs for Cloud Build

### DIFF
--- a/products/cloudbuild/api.yaml
+++ b/products/cloudbuild/api.yaml
@@ -66,7 +66,7 @@ objects:
         conflicts:
           - build
         description: |
-          Path, from the source root, to a file whose contents is used for the template.
+          Path, from the source root, to a file whose contents is used for the template. Either a filename or build template must be provided.
       - !ruby/object:Api::Type::Array
         name: 'ignoredFiles'
         item_type: Api::Type::String
@@ -137,7 +137,7 @@ objects:
       - !ruby/object:Api::Type::NestedObject
         name: 'build'
         description: |
-          Contents of the build template.
+          Contents of the build template. Either a filename or build template must be provided.
         properties:
           - !ruby/object:Api::Type::Array
             name: 'tags'

--- a/products/cloudbuild/api.yaml
+++ b/products/cloudbuild/api.yaml
@@ -125,15 +125,15 @@ objects:
           - !ruby/object:Api::Type::String
             name: 'branchName'
             description: |
-              Name of the branch to build.
+              Name of the branch to build. A branch name, tag, or commit SHA must be provided.
           - !ruby/object:Api::Type::String
             name: 'tagName'
             description: |
-              Name of the tag to build.
+              Name of the tag to build. A branch name, tag, or commit SHA must be provided.
           - !ruby/object:Api::Type::String
             name: 'commitSha'
             description: |
-              Explicit commit SHA to build.
+              Explicit commit SHA to build. A branch name, tag, or commit SHA must be provided.
       - !ruby/object:Api::Type::NestedObject
         name: 'build'
         description: |

--- a/products/cloudbuild/api.yaml
+++ b/products/cloudbuild/api.yaml
@@ -125,15 +125,15 @@ objects:
           - !ruby/object:Api::Type::String
             name: 'branchName'
             description: |
-              Name of the branch to build. A branch name, tag, or commit SHA must be provided.
+              Name of the branch to build. Exactly one a of branch name, tag, or commit SHA must be provided.
           - !ruby/object:Api::Type::String
             name: 'tagName'
             description: |
-              Name of the tag to build. A branch name, tag, or commit SHA must be provided.
+              Name of the tag to build. Exactly one of a branch name, tag, or commit SHA must be provided.
           - !ruby/object:Api::Type::String
             name: 'commitSha'
             description: |
-              Explicit commit SHA to build. A branch name, tag, or commit SHA must be provided.
+              Explicit commit SHA to build. Exactly one of a branch name, tag, or commit SHA must be provided.
       - !ruby/object:Api::Type::NestedObject
         name: 'build'
         description: |


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/3122

In https://cloud.google.com/cloud-build/docs/api/reference/rest/v1/projects.triggers#BuildTrigger, `build` and `filename` are part of a proto `oneof`; let's document that one of them is required. Same w/ triggerTemplate and the Git reference fields.


-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
