### PR TITLE
WIP Adding a "canonical version" of goimports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/GoogleCloudPlatform/magic-modules
+
+require golang.org/x/tools v0.0.0-20190228174337-ac7c11b94d3f // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
+golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190228174337-ac7c11b94d3f h1:wsje7mEpzg68f1D40pX9sS5EM0dFZXUKtE4GrLsEvwY=
+golang.org/x/tools v0.0.0-20190228174337-ac7c11b94d3f/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
+google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=


### PR DESCRIPTION
There have been several issues where develoeprs have been running with
differint versions of go imports that have caused confusion. This is because
recent work on goimports has changed how it works several times and our build
system relies on it to build correct imports. Once we have a version reference
we can change the build system to respect that version and remove the lack
of predictability of this tool by being able to have everybody on a single
version of it.

Changes will still need to be made to the build system to respect this version
Additionally developers will need to be using GO111MODULE=on if magic modules
resides within their build path.

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

<!-- Your regular pull request description goes here -->




<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
