### PR TITLE
Versioned OiCS Examples / Generated tests

### DIFF
--- a/compiler.rb
+++ b/compiler.rb
@@ -111,7 +111,7 @@ product_names.each do |product_name|
   raise "Output path '#{output_path}' does not exist or is not a directory" \
     unless Dir.exist?(output_path)
 
-  Google::LOGGER.info "Compiling '#{product_name}' output to '#{output_path}'"
+  Google::LOGGER.info "Compiling '#{product_name}' (at #{version}) output to '#{output_path}'"
   Google::LOGGER.info \
     "Generating types: #{types_to_generate.empty? ? 'ALL' : types_to_generate}"
 

--- a/products/accesscontextmanager/terraform.yaml
+++ b/products/accesscontextmanager/terraform.yaml
@@ -20,7 +20,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "access_context_manager_access_policy_basic"
         skip_test: true
         primary_resource_id: "access-policy"
-        version: <%= version_name %>
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
@@ -36,7 +35,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       name: "access_context_manager_access_level_basic"
       skip_test: true
       primary_resource_id: "access-level"
-      version: <%= version_name %>
       vars:
         access_level_name: "ios_no_lock"
     properties:
@@ -55,7 +53,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "access_context_manager_service_perimeter_basic"
         skip_test: true
         primary_resource_id: "service-perimeter"
-        version: <%= version_name %>
         vars:
           access_level_name: "ios_no_lock"
           service_perimeter_name: "restrict_all"

--- a/products/appengine/terraform.yaml
+++ b/products/appengine/terraform.yaml
@@ -20,7 +20,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "app_engine_firewall_rule_basic"
         primary_resource_id: "rule"
-        version: <%= version_name %>
         vars:
           project_id: "test-project"
         test_env_vars:

--- a/products/cloudbuild/terraform.yaml
+++ b/products/cloudbuild/terraform.yaml
@@ -23,7 +23,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "cloudbuild_trigger_filename"
         primary_resource_id: "filename-trigger"
-        version: <%= version_name %>
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         name: 'trigger_id'

--- a/products/cloudscheduler/terraform.yaml
+++ b/products/cloudscheduler/terraform.yaml
@@ -18,20 +18,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "scheduler_job_pubsub"
         primary_resource_id: "job"
-        version: <%= version_name %>
         vars:
           job_name: "test-job"
           topic_name: "job-topic"
       - !ruby/object:Provider::Terraform::Examples
         name: "scheduler_job_http"
         primary_resource_id: "job"
-        version: <%= version_name %>
         vars:
           job_name: "test-job"
       - !ruby/object:Provider::Terraform::Examples
         name: "scheduler_job_app_engine"
         primary_resource_id: "job"
-        version: <%= version_name %>
         vars:
           job_name: "test-job"
     properties:

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -746,7 +746,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "managed_ssl_certificate_basic"
         primary_resource_id: "default"
-        version: <%= version_name %>
         vars:
           cert_name: "test-cert"
           proxy_name: "test-proxy"

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -67,9 +67,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     id_format: "{{zone}}/{{name}}"
     examples:
       - !ruby/object:Provider::Terraform::Examples
-        name: "autoscaler_basic"
+        name: "autoscaler_beta"
         primary_resource_id: "foobar"
         min_version: 'beta'
+        vars:
+          autoscaler_name: "my-autoscaler"
+          instance_template_name: "my-instance-template"
+          target_pool_name: "my-target-pool"
+          igm_name: "my-igm"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "autoscaler_basic"
+        primary_resource_id: "foobar"
         vars:
           autoscaler_name: "my-autoscaler"
           instance_template_name: "my-instance-template"
@@ -508,9 +516,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     id_format: "{{region}}/{{name}}"
     examples:
       - !ruby/object:Provider::Terraform::Examples
-        name: "region_autoscaler_basic"
+        name: "region_autoscaler_beta"
         primary_resource_id: "foobar"
         min_version: 'beta'
+        vars:
+          region_autoscaler_name: "my-region-autoscaler"
+          instance_template_name: "my-instance-template"
+          target_pool_name: "my-target-pool"
+          rigm_name: "my-region-igm"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "region_autoscaler_basic"
+        primary_resource_id: "foobar"
         vars:
           region_autoscaler_name: "my-region-autoscaler"
           instance_template_name: "my-instance-template"

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -19,13 +19,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "address_basic"
         primary_resource_id: "ip_address"
-        version: <%= version_name %>
         vars:
           address_name: "my-address"
       - !ruby/object:Provider::Terraform::Examples
         name: "address_with_subnetwork"
         primary_resource_id: "internal_with_subnet_and_address"
-        version: <%= version_name %>
         vars:
           address_name: "my-internal-address"
           network_name: "my-network"
@@ -34,7 +32,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "instance_with_ip"
         primary_resource_id: "static"
-        version: <%= version_name %>
         vars:
          address_name: "ipv4-address"
          instance_name: "vm-instance"
@@ -72,7 +69,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "autoscaler_basic"
         primary_resource_id: "foobar"
-        version: <%= version_name %>
+        min_version: 'beta'
         vars:
           autoscaler_name: "my-autoscaler"
           instance_template_name: "my-instance-template"
@@ -124,7 +121,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "backend_bucket_basic"
         primary_resource_id: "image_backend"
-        version: <%= version_name %>
         vars:
           backend_bucket_name: "image-backend-bucket"
           bucket_name: "image-store-bucket"
@@ -213,7 +209,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "disk_basic"
         primary_resource_id: "default"
-        version: <%= version_name %>
         vars:
           disk_name: "test-disk"
   DiskType: !ruby/object:Overrides::Terraform::ResourceOverride
@@ -223,7 +218,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "firewall_basic"
         primary_resource_id: "default"
-        version: <%= version_name %>
         vars:
           firewall_name: "test-firewall"
           network_name: "test-network"
@@ -280,7 +274,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "forwarding_rule_basic"
         primary_resource_id: "default"
-        version: <%= version_name %>
         vars:
           forwarding_rule_name: "website-forwarding-rule"
           target_pool_name: "website-target-pool"
@@ -329,7 +322,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "global_address_basic"
         primary_resource_id: "default"
-        version: <%= version_name %>
         vars:
           global_address_name: "global-appserver-ip"
     properties:
@@ -362,7 +354,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "http_health_check_basic"
         primary_resource_id: "default"
-        version: <%= version_name %>
         vars:
           http_health_check_name: "authentication-health-check"
     properties:
@@ -393,7 +384,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "https_health_check_basic"
         primary_resource_id: "default"
-        version: <%= version_name %>
         vars:
           https_health_check_name: "authentication-health-check"
     properties:
@@ -416,7 +406,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "health_check_basic"
         primary_resource_id: "internal-health-check"
-        version: <%= version_name %>
         vars:
           health_check_name: "internal-service-health-check"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
@@ -448,7 +437,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "image_basic"
         primary_resource_id: "example"
-        version: <%= version_name %>
         vars:
           image_name: "example-image"
     properties:
@@ -505,7 +493,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "interconnect_attachment_basic"
         primary_resource_id: "on_prem"
         skip_test: true
-        version: <%= version_name %>
         vars:
           interconnect_attachment_name: "on-prem-attachment"
           router_name: "router"
@@ -523,7 +510,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "region_autoscaler_basic"
         primary_resource_id: "foobar"
-        version: <%= version_name %>
+        min_version: 'beta'
         vars:
           region_autoscaler_name: "my-region-autoscaler"
           instance_template_name: "my-instance-template"
@@ -608,7 +595,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "region_disk_basic"
         primary_resource_id: "regiondisk"
-        version: <%= version_name %>
         vars:
           region_disk_name: "my-region-disk"
           disk_name: "my-disk"
@@ -620,7 +606,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "route_basic"
         primary_resource_id: "default"
-        version: <%= version_name %>
         vars:
           route_name: "network-route"
           network_name: "compute-network"
@@ -675,7 +660,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "router_basic"
         primary_resource_id: "foobar"
-        version: <%= version_name %>
         vars:
           router_name: "my-router"
           network_name: "my-network"
@@ -695,7 +679,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "snapshot_basic"
         primary_resource_id: "snapshot"
-        version: <%= version_name %>
         vars:
           snapshot_name: "my-snapshot"
           disk_name: "debian-disk"
@@ -778,17 +761,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "ssl_certificate_basic"
         primary_resource_id: "default"
-        version: <%= version_name %>
         ignore_read_extra:
           - "name_prefix"
       - !ruby/object:Provider::Terraform::Examples
         name: "ssl_certificate_random_provider"
         primary_resource_id: "default"
-        version: <%= version_name %>
       - !ruby/object:Provider::Terraform::Examples
         name: "ssl_certificate_target_https_proxies"
         primary_resource_id: "default"
-        version: <%= version_name %>
         vars:
           target_https_proxy_name: "test-proxy"
           url_map_name: "url-map"
@@ -822,7 +802,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "ssl_policy_basic"
         primary_resource_id: "prod-ssl-policy"
-        version: <%= version_name %>
         vars:
           production_ssl_policy_name: "production-ssl-policy"
           nonprod_ssl_policy_name: "nonprod-ssl-policy"
@@ -900,7 +879,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "subnetwork_basic"
         primary_resource_id: "network-with-private-secondary-ip-ranges"
-        version: <%= version_name %>
         vars:
           subnetwork_name: "test-subnetwork"
           network_name: "test-network"
@@ -909,7 +887,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "target_http_proxy_basic"
         primary_resource_id: "default"
-        version: <%= version_name %>
         vars:
           target_http_proxy_name: "test-proxy"
           url_map_name: "url-map"
@@ -923,7 +900,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "target_https_proxy_basic"
         primary_resource_id: "default"
-        version: <%= version_name %>
         vars:
           target_https_proxy_name: "test-proxy"
           ssl_certificate_name: "my-certificate"
@@ -949,7 +925,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "target_ssl_proxy_basic"
         primary_resource_id: "default"
-        version: <%= version_name %>
         vars:
           target_ssl_proxy_name: "test-proxy"
           ssl_certificate_name: "default-cert"
@@ -967,7 +942,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "target_tcp_proxy_basic"
         primary_resource_id: "default"
-        version: <%= version_name %>
         vars:
           target_tcp_proxy_name: "test-proxy"
           backend_service_name: "backend-service"
@@ -985,7 +959,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "target_vpn_gateway_basic"
         primary_resource_id: "target_gateway"
-        version: <%= version_name %>
         vars:
           target_vpn_gateway_name: "vpn1"
           network_name: "network1"
@@ -1011,7 +984,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "url_map_basic"
         primary_resource_id: "urlmap"
-        version: <%= version_name %>
         vars:
           url_map_name: "urlmap"
           login_backend_service_name: "login"
@@ -1052,7 +1024,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "vpn_tunnel_basic"
         primary_resource_id: "tunnel1"
-        version: <%= version_name %>
         vars:
           vpn_tunnel_name: "tunnel1"
           target_vpn_gateway_name: "vpn1"

--- a/products/containeranalysis/terraform.yaml
+++ b/products/containeranalysis/terraform.yaml
@@ -21,7 +21,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "container_analysis_note_basic"
         primary_resource_id: "note"
-        version: <%= version_name %>
         vars:
           note_name: "test-attestor-note"
     properties:

--- a/products/dns/terraform.yaml
+++ b/products/dns/terraform.yaml
@@ -76,7 +76,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "dns_policy_basic"
         primary_resource_id: "example-policy"
-        version: <%= version_name %>
         vars:
           policy_name: "example-policy"
           network_1_name: "network-1"

--- a/products/dns/terraform.yaml
+++ b/products/dns/terraform.yaml
@@ -18,11 +18,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "dns_managed_zone_basic"
         primary_resource_id: "example-zone"
-        version: <%= version_name %>
       - !ruby/object:Provider::Terraform::Examples
         name: "dns_managed_zone_private"
         primary_resource_id: "private-zone"
-        version: <%= version_name %>
         skip_test: true
         vars:
           zone_name: "private-zone"

--- a/products/filestore/terraform.yaml
+++ b/products/filestore/terraform.yaml
@@ -20,7 +20,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "filestore_instance_basic"
         primary_resource_id: "instance"
-        version: <%= version_name %>
         vars:
           instance_name: "test-instance"
     properties:

--- a/products/monitoring/terraform.yaml
+++ b/products/monitoring/terraform.yaml
@@ -20,7 +20,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "monitoring_alert_policy_basic"
         primary_resource_id: "alert_policy"
-        version: <%= version_name %>
         vars:
           alert_policy_display_name: "My Alert Policy"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
@@ -34,13 +33,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "monitoring_group_basic"
         primary_resource_id: "basic"
-        version: <%= version_name %>
         vars:
           display_name: "New Test Group"
       - !ruby/object:Provider::Terraform::Examples
         name: "monitoring_group_subgroup"
         primary_resource_id: "subgroup"
-        version: <%= version_name %>
         vars:
           display_name: "New Test SubGroup"
           display_name2: "New Test SubGroup"
@@ -57,7 +54,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     mutex: stackdriver/notifications/{{project}}
     examples:
       - !ruby/object:Provider::Terraform::Examples
-        version: <%= version_name %>
         name: "notification_channel_basic"
         primary_resource_id: "basic"
         vars:
@@ -88,13 +84,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     import_format: ["{{name}}"]
     examples:
       - !ruby/object:Provider::Terraform::Examples
-        version: <%= version_name %>
         name: "uptime_check_config_http"
         primary_resource_id: "http"
         vars:
           display_name: "http-uptime-check"
       - !ruby/object:Provider::Terraform::Examples
-        version: <%= version_name %>
         name: "uptime_check_tcp"
         primary_resource_id: "tcp_group"
         vars:

--- a/products/pubsub/terraform.yaml
+++ b/products/pubsub/terraform.yaml
@@ -19,7 +19,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "pubsub_topic_basic"
         primary_resource_id: "example"
-        version: <%= version_name %>
         vars:
           topic_name: "example-topic"
     properties:
@@ -33,7 +32,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "pubsub_subscription_push"
         primary_resource_id: "example"
-        version: <%= version_name %>
         skip_test: true
         vars:
           topic_name: "example-topic"
@@ -41,14 +39,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "pubsub_subscription_pull"
         primary_resource_id: "example"
-        version: <%= version_name %>
         vars:
           topic_name: "example-topic"
           subscription_name: "example-subscription"
       - !ruby/object:Provider::Terraform::Examples
         name: "pubsub_subscription_different_project"
         primary_resource_id: "example"
-        version: <%= version_name %>
         skip_test: true
         vars:
           topic_name: "example-topic"

--- a/products/redis/terraform.yaml
+++ b/products/redis/terraform.yaml
@@ -21,13 +21,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "redis_instance_basic"
         primary_resource_id: "cache"
-        version: <%= version_name %>
         vars:
           instance_name: "memory-cache"
       - !ruby/object:Provider::Terraform::Examples
         name: "redis_instance_full"
         primary_resource_id: "cache"
-        version: <%= version_name %>
         vars:
           instance_name: "ha-memory-cache"
           network_name: "authorized-network"

--- a/products/resourcemanager/terraform.yaml
+++ b/products/resourcemanager/terraform.yaml
@@ -22,7 +22,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "resource_manager_lien"
         skip_test: true
         primary_resource_id: "lien"
-        version: <%= version_name %>
         vars:
           project_id: "staging-project"
     properties:

--- a/products/sourcerepo/terraform.yaml
+++ b/products/sourcerepo/terraform.yaml
@@ -20,7 +20,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "sourcerepo_repository_basic"
         primary_resource_id: "my-repo"
-        version: <%= version_name %>
         vars:
           repository_name: "my-repository"
     properties:

--- a/products/spanner/terraform.yaml
+++ b/products/spanner/terraform.yaml
@@ -25,7 +25,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "spanner_database_basic"
         primary_resource_id: "database"
-        version: <%= version_name %>
         vars:
           database_name: "my-database"
     properties:
@@ -54,7 +53,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "spanner_instance_basic"
         primary_resource_id: "example"
-        version: <%= version_name %>
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         description: |

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -184,7 +184,7 @@ module Provider
         elsif types.empty? && object.exclude
           Google::LOGGER.info "Excluding #{object.name} per API catalog"
         elsif types.empty? && object.not_in_version?(version)
-          Google::LOGGER.info "Excluding #{object.name} per API version (#{object.min_version} required, #{version} given)"
+          Google::LOGGER.info "Excluding #{object.name} per API version"
         else
           Google::LOGGER.info "Generating #{object.name}"
           # exclude_if_not_in_version must be called in order to filter out

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -184,7 +184,7 @@ module Provider
         elsif types.empty? && object.exclude
           Google::LOGGER.info "Excluding #{object.name} per API catalog"
         elsif types.empty? && object.not_in_version?(version)
-          Google::LOGGER.info "Excluding #{object.name} per API version"
+          Google::LOGGER.info "Excluding #{object.name} per API version (#{object.min_version} required, #{version} given)"
         else
           Google::LOGGER.info "Generating #{object.name}"
           # exclude_if_not_in_version must be called in order to filter out

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -144,7 +144,10 @@ module Provider
     def generate_resource_tests(data)
       return if data[:object].examples
                              .reject(&:skip_test)
-                             .reject { |e| @api.version_obj_or_default(data[:version]) < @api.version_obj_or_default(e.min_version) }
+                             .reject do |e|
+                               @api.version_obj_or_default(data[:version]) \
+                                < @api.version_obj_or_default(e.min_version)
+                             end
                              .empty?
 
       dir = data[:version] == 'beta' ? 'google-beta' : 'google'

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -142,7 +142,10 @@ module Provider
     end
 
     def generate_resource_tests(data)
-      return if data[:object].examples.reject(&:skip_test).empty?
+      return if data[:object].examples
+                             .reject(&:skip_test)
+                             .reject { |e| @api.version_obj_or_default(data[:version]) < @api.version_obj_or_default(e.min_version) }
+                             .empty?
 
       dir = data[:version] == 'beta' ? 'google-beta' : 'google'
       target_folder = File.join(data[:output_folder], dir)

--- a/provider/terraform/custom_code.rb
+++ b/provider/terraform/custom_code.rb
@@ -87,8 +87,9 @@ module Provider
       # This list corresponds to the `get*FromEnv` methods in provider_test.go.
       attr_reader :test_env_vars
 
-      # the version (ga, beta, etc.) this example is being generated at
-      attr_reader :version
+      # the version of the example. Note that _all features_ used in an example
+      # must be set to the example min version.
+      attr_reader :min_version
 
       # Extra properties to ignore read on during import.
       # These properties will likely be custom code.
@@ -114,7 +115,6 @@ module Provider
                          vars: vars,
                          test_env_vars: test_env_vars.map { |k, v| [k, docs_defaults[v]] }.to_h,
                          primary_resource_id: primary_resource_id,
-                         version: version
                        },
                        "templates/terraform/examples/#{name}.tf.erb"
                      ))
@@ -132,7 +132,6 @@ module Provider
                          vars: vars.map { |k, str| [k, "#{str}-%{random_suffix}"] }.to_h,
                          test_env_vars: test_env_vars.map { |k, _| [k, "%{#{k}}"] }.to_h,
                          primary_resource_id: primary_resource_id,
-                         version: version
                        },
                        "templates/terraform/examples/#{name}.tf.erb"
                      ))
@@ -155,7 +154,6 @@ module Provider
                        {
                          vars: vars.map { |k, str| [k, "#{str}-${local.name_suffix}"] }.to_h,
                          primary_resource_id: primary_resource_id,
-                         version: version
                        },
                        "templates/terraform/examples/#{name}.tf.erb"
                      ))
@@ -195,6 +193,7 @@ module Provider
         super
         check :name, type: String, required: true
         check :primary_resource_id, type: String
+        check :min_version, type: String
         check :vars, type: Hash
         check :test_env_vars, type: Hash
         check :ignore_read_extra, type: Array, item_type: String, default: []

--- a/provider/terraform/custom_code.rb
+++ b/provider/terraform/custom_code.rb
@@ -114,7 +114,7 @@ module Provider
                        {
                          vars: vars,
                          test_env_vars: test_env_vars.map { |k, v| [k, docs_defaults[v]] }.to_h,
-                         primary_resource_id: primary_resource_id,
+                         primary_resource_id: primary_resource_id
                        },
                        "templates/terraform/examples/#{name}.tf.erb"
                      ))
@@ -131,7 +131,7 @@ module Provider
                        {
                          vars: vars.map { |k, str| [k, "#{str}-%{random_suffix}"] }.to_h,
                          test_env_vars: test_env_vars.map { |k, _| [k, "%{#{k}}"] }.to_h,
-                         primary_resource_id: primary_resource_id,
+                         primary_resource_id: primary_resource_id
                        },
                        "templates/terraform/examples/#{name}.tf.erb"
                      ))
@@ -153,7 +153,7 @@ module Provider
         body = lines(compile_file(
                        {
                          vars: vars.map { |k, str| [k, "#{str}-${local.name_suffix}"] }.to_h,
-                         primary_resource_id: primary_resource_id,
+                         primary_resource_id: primary_resource_id
                        },
                        "templates/terraform/examples/#{name}.tf.erb"
                      ))

--- a/provider/terraform_example.rb
+++ b/provider/terraform_example.rb
@@ -24,10 +24,11 @@ module Provider
 
     # Create a directory of examples per resource
     def generate_resource(data)
+      version = @api.version_obj_or_default(data[:version])
       examples = data[:object].examples
                               .reject(&:skip_test)
                               .reject { |e| !e.test_env_vars.nil? && e.test_env_vars.any? }
-                              .reject
+                              .reject { |e| version < @api.version_obj_or_default(e.min_version) }
 
       examples.each do |example|
         target_folder = data[:output_folder]

--- a/provider/terraform_example.rb
+++ b/provider/terraform_example.rb
@@ -19,8 +19,7 @@ module Provider
     # We don't want *any* static generation, so we override generate to only
     # generate objects.
     def generate(output_folder, types, version_name, _product_path, _dump_yaml)
-      version = @api.version_obj_or_default(version_name)
-      generate_objects(output_folder, types, version)
+      generate_objects(output_folder, types, version_name)
     end
 
     # Create a directory of examples per resource
@@ -28,6 +27,7 @@ module Provider
       examples = data[:object].examples
                               .reject(&:skip_test)
                               .reject { |e| !e.test_env_vars.nil? && e.test_env_vars.any? }
+                              .reject
 
       examples.each do |example|
         target_folder = data[:output_folder]

--- a/templates/terraform/examples/autoscaler_basic.tf.erb
+++ b/templates/terraform/examples/autoscaler_basic.tf.erb
@@ -1,4 +1,8 @@
 resource "google_compute_autoscaler" "foobar" {
+<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
+  provider = "google-beta"
+<% end -%>
+
   name   = "<%= ctx[:vars]['autoscaler_name'] %>"
   zone   = "us-central1-f"
   target = "${google_compute_instance_group_manager.foobar.self_link}"
@@ -15,6 +19,10 @@ resource "google_compute_autoscaler" "foobar" {
 }
 
 resource "google_compute_instance_template" "foobar" {
+<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
+  provider = "google-beta"
+<% end -%>
+
   name           = "<%= ctx[:vars]['instance_template_name'] %>"
   machine_type   = "n1-standard-1"
   can_ip_forward = false
@@ -39,10 +47,18 @@ resource "google_compute_instance_template" "foobar" {
 }
 
 resource "google_compute_target_pool" "foobar" {
+<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
+  provider = "google-beta"
+<% end -%>
+
   name = "<%= ctx[:vars]['target_pool_name'] %>"
 }
 
 resource "google_compute_instance_group_manager" "foobar" {
+<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
+  provider = "google-beta"
+<% end -%>
+
   name = "<%= ctx[:vars]['igm_name'] %>"
   zone = "us-central1-f"
 
@@ -59,6 +75,17 @@ resource "google_compute_instance_group_manager" "foobar" {
 }
 
 data "google_compute_image" "debian_9" {
+<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
+  provider = "google-beta"
+<% end -%>
 	family  = "debian-9"
 	project = "debian-cloud"
 }
+
+<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
+provider "google-beta"{
+  region = "us-central1"
+  zone   = "us-central1-a"
+}
+
+<% end -%>

--- a/templates/terraform/examples/autoscaler_basic.tf.erb
+++ b/templates/terraform/examples/autoscaler_basic.tf.erb
@@ -1,7 +1,5 @@
 resource "google_compute_autoscaler" "foobar" {
-<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
   provider = "google-beta"
-<% end -%>
 
   name   = "<%= ctx[:vars]['autoscaler_name'] %>"
   zone   = "us-central1-f"
@@ -19,9 +17,7 @@ resource "google_compute_autoscaler" "foobar" {
 }
 
 resource "google_compute_instance_template" "foobar" {
-<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
   provider = "google-beta"
-<% end -%>
 
   name           = "<%= ctx[:vars]['instance_template_name'] %>"
   machine_type   = "n1-standard-1"
@@ -47,45 +43,34 @@ resource "google_compute_instance_template" "foobar" {
 }
 
 resource "google_compute_target_pool" "foobar" {
-<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
   provider = "google-beta"
-<% end -%>
 
   name = "<%= ctx[:vars]['target_pool_name'] %>"
 }
 
 resource "google_compute_instance_group_manager" "foobar" {
-<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
   provider = "google-beta"
-<% end -%>
 
   name = "<%= ctx[:vars]['igm_name'] %>"
   zone = "us-central1-f"
 
-<% if ctx[:version].nil? || ctx[:version] == 'ga' -%>
-  instance_template  = "${google_compute_instance_template.foobar.self_link}"
-<% else -%>
   version {
     instance_template  = "${google_compute_instance_template.foobar.self_link}"
     name               = "primary"
   }
-<% end -%>
+
   target_pools       = ["${google_compute_target_pool.foobar.self_link}"]
   base_instance_name = "foobar"
 }
 
 data "google_compute_image" "debian_9" {
-<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
   provider = "google-beta"
-<% end -%>
+
 	family  = "debian-9"
 	project = "debian-cloud"
 }
 
-<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
 provider "google-beta"{
   region = "us-central1"
   zone   = "us-central1-a"
 }
-
-<% end -%>

--- a/templates/terraform/examples/autoscaler_beta.tf.erb
+++ b/templates/terraform/examples/autoscaler_beta.tf.erb
@@ -1,4 +1,6 @@
 resource "google_compute_autoscaler" "foobar" {
+  provider = "google-beta"
+
   name   = "<%= ctx[:vars]['autoscaler_name'] %>"
   zone   = "us-central1-f"
   target = "${google_compute_instance_group_manager.foobar.self_link}"
@@ -15,6 +17,8 @@ resource "google_compute_autoscaler" "foobar" {
 }
 
 resource "google_compute_instance_template" "foobar" {
+  provider = "google-beta"
+
   name           = "<%= ctx[:vars]['instance_template_name'] %>"
   machine_type   = "n1-standard-1"
   can_ip_forward = false
@@ -39,20 +43,34 @@ resource "google_compute_instance_template" "foobar" {
 }
 
 resource "google_compute_target_pool" "foobar" {
+  provider = "google-beta"
+
   name = "<%= ctx[:vars]['target_pool_name'] %>"
 }
 
 resource "google_compute_instance_group_manager" "foobar" {
+  provider = "google-beta"
+
   name = "<%= ctx[:vars]['igm_name'] %>"
   zone = "us-central1-f"
 
-  instance_template  = "${google_compute_instance_template.foobar.self_link}"
+  version {
+    instance_template  = "${google_compute_instance_template.foobar.self_link}"
+    name               = "primary"
+  }
 
   target_pools       = ["${google_compute_target_pool.foobar.self_link}"]
   base_instance_name = "foobar"
 }
 
 data "google_compute_image" "debian_9" {
+  provider = "google-beta"
+
 	family  = "debian-9"
 	project = "debian-cloud"
+}
+
+provider "google-beta"{
+  region = "us-central1"
+  zone   = "us-central1-a"
 }

--- a/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/templates/terraform/examples/base_configs/test_file.go.erb
@@ -53,12 +53,18 @@ func TestAcc<%= test_slug -%>(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
+		<% if object.min_version.name == 'beta' -%>
+		Providers:    testAccProvidersOiCS,
+		<% else -%>
 		Providers:    testAccProviders,
+		<% end -%>
 		CheckDestroy: testAccCheck<%= "#{resource_name}" -%>Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAcc<%= test_slug -%>(context),
 			},
+		<%#- The Terraform test runner doesn't let us import resources with aliased providers (yet) -%>
+		<% unless object.min_version.name == 'beta' -%>
 			{
 				ResourceName:      "<%= terraform_name -%>.<%= example.primary_resource_id -%>",
 				ImportState:       true,
@@ -67,6 +73,7 @@ func TestAcc<%= test_slug -%>(t *testing.T) {
         ImportStateVerifyIgnore: <%= go_literal(ignore_read) %>,
         <%- end -%>
 			},
+		<% end -%>
 		},
 	})
 }

--- a/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/templates/terraform/examples/base_configs/test_file.go.erb
@@ -17,14 +17,30 @@ else
 	terraform_name = "google_" + @config.legacy_name + '_' + object.name.underscore
 end
 %>
-<% object.examples.reject(&:skip_test).each do |example| -%>
 <%
+# @api.version_obj_or_default(version) is slightly wrong; we want the _object_ version or the generation version.
+# Ultimately this won't matter though, since the API default should always be less than the object default.
+object.examples
+         .reject(&:skip_test)
+         .reject { |e| @api.version_obj_or_default(version) < @api.version_obj_or_default(e.min_version) }
+         .each do |example| -
+
+
 	# {Compute}{Address}_{addressBasic}
 	test_slug = "#{resource_name}_#{example.name.camelize(:lower)}Example"
 	  ignore_read = data[:object].all_user_properties
                  .select(&:ignore_read)
                  .map { |p| p.name.underscore }
                  .concat(example.ignore_read_extra)
+
+
+	# If we've set an explicit version for the example use that, otherwise use the
+	# object version.
+  if example.min_version.nil?
+  	example_version = object.min_version.name
+  else
+    example_version = example.min_version
+  end
 -%>
 
 func TestAcc<%= test_slug -%>(t *testing.T) {
@@ -53,10 +69,10 @@ func TestAcc<%= test_slug -%>(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		<% if object.min_version.name == 'beta' -%>
-		Providers:    testAccProvidersOiCS,
-		<% else -%>
+		<% if example_version == 'ga' -%>
 		Providers:    testAccProviders,
+		<% else -%>
+		Providers:    testAccProvidersOiCS,
 		<% end -%>
 		CheckDestroy: testAccCheck<%= "#{resource_name}" -%>Destroy,
 		Steps: []resource.TestStep{
@@ -64,7 +80,7 @@ func TestAcc<%= test_slug -%>(t *testing.T) {
 				Config: testAcc<%= test_slug -%>(context),
 			},
 		<%#- The Terraform test runner doesn't let us import resources with aliased providers (yet) -%>
-		<% unless object.min_version.name == 'beta' -%>
+		<% if example_version == 'ga' -%>
 			{
 				ResourceName:      "<%= terraform_name -%>.<%= example.primary_resource_id -%>",
 				ImportState:       true,

--- a/templates/terraform/examples/container_analysis_note_basic.tf.erb
+++ b/templates/terraform/examples/container_analysis_note_basic.tf.erb
@@ -1,8 +1,15 @@
 resource "google_container_analysis_note" "<%= ctx[:primary_resource_id] %>" {
+  provider = "google-beta"
+
   name = "<%= ctx[:vars]["note_name"] %>"
   attestation_authority {
     hint {
       human_readable_name = "Attestor Note"
     }
   }
+}
+
+provider "google-beta"{
+  region = "us-central1"
+  zone   = "us-central1-a"
 }

--- a/templates/terraform/examples/filestore_instance_basic.tf.erb
+++ b/templates/terraform/examples/filestore_instance_basic.tf.erb
@@ -1,4 +1,6 @@
 resource "google_filestore_instance" "<%= ctx[:primary_resource_id] %>" {
+  provider = "google-beta"
+
   name = "<%= ctx[:vars]["instance_name"] %>"
   zone = "us-central1-b"
   tier = "PREMIUM"
@@ -12,4 +14,9 @@ resource "google_filestore_instance" "<%= ctx[:primary_resource_id] %>" {
     network = "default"
     modes   = ["MODE_IPV4"]
   }
+}
+
+provider "google-beta"{
+  region = "us-central1"
+  zone   = "us-central1-a"
 }

--- a/templates/terraform/examples/managed_ssl_certificate_basic.tf.erb
+++ b/templates/terraform/examples/managed_ssl_certificate_basic.tf.erb
@@ -1,4 +1,6 @@
 resource "google_compute_managed_ssl_certificate" "default" {
+  provider = "google-beta"
+
   name = "<%= ctx[:vars]['cert_name'] %>"
 
   managed {
@@ -7,12 +9,16 @@ resource "google_compute_managed_ssl_certificate" "default" {
 }
 
 resource "google_compute_target_https_proxy" "default" {
+  provider = "google-beta"
+
   name             = "<%= ctx[:vars]['proxy_name'] %>"
   url_map          = "${google_compute_url_map.default.self_link}"
   ssl_certificates = ["${google_compute_managed_ssl_certificate.default.self_link}"]
 }
 
 resource "google_compute_url_map" "default" {
+  provider = "google-beta"
+
   name        = "<%= ctx[:vars]['url_map_name'] %>"
   description = "a description"
 
@@ -35,6 +41,8 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_backend_service" "default" {
+  provider = "google-beta"
+
   name        = "<%= ctx[:vars]['backend_service_name'] %>"
   port_name   = "http"
   protocol    = "HTTP"
@@ -44,6 +52,8 @@ resource "google_compute_backend_service" "default" {
 }
 
 resource "google_compute_http_health_check" "default" {
+  provider = "google-beta"
+
   name               = "<%= ctx[:vars]['http_health_check_name'] %>"
   request_path       = "/"
   check_interval_sec = 1
@@ -51,20 +61,31 @@ resource "google_compute_http_health_check" "default" {
 }
 
 resource "google_dns_managed_zone" "zone" {
+  provider = "google-beta"
+
   name     = "<%= ctx[:vars]['dns_zone_name'] %>"
   dns_name = "sslcert.tf-test.club."
 }
 
 resource "google_compute_global_forwarding_rule" "default" {
+  provider = "google-beta"
+
   name       = "<%= ctx[:vars]['forwarding_rule_name'] %>"
   target     = "${google_compute_target_https_proxy.default.self_link}"
   port_range = 443
 }
 
 resource "google_dns_record_set" "set" {
+  provider = "google-beta"
+
   name         = "sslcert.tf-test.club."
   type         = "A"
   ttl          = 3600
   managed_zone = "${google_dns_managed_zone.zone.name}"
   rrdatas      = ["${google_compute_global_forwarding_rule.default.ip_address}"]
+}
+
+provider "google-beta"{
+  region = "us-central1"
+  zone   = "us-central1-a"
 }

--- a/templates/terraform/examples/region_autoscaler_basic.tf.erb
+++ b/templates/terraform/examples/region_autoscaler_basic.tf.erb
@@ -1,4 +1,8 @@
 resource "google_compute_region_autoscaler" "foobar" {
+<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
+  provider = "google-beta"
+<% end -%>
+
   name   = "<%= ctx[:vars]['region_autoscaler_name'] %>"
   region = "us-central1"
   target = "${google_compute_region_instance_group_manager.foobar.self_link}"
@@ -15,6 +19,10 @@ resource "google_compute_region_autoscaler" "foobar" {
 }
 
 resource "google_compute_instance_template" "foobar" {
+<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
+  provider = "google-beta"
+<% end -%>
+
   name           = "<%= ctx[:vars]['instance_template_name'] %>"
   machine_type   = "n1-standard-1"
   can_ip_forward = false
@@ -39,10 +47,18 @@ resource "google_compute_instance_template" "foobar" {
 }
 
 resource "google_compute_target_pool" "foobar" {
+<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
+  provider = "google-beta"
+<% end -%>
+
   name = "<%= ctx[:vars]['target_pool_name'] %>"
 }
 
 resource "google_compute_region_instance_group_manager" "foobar" {
+<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
+  provider = "google-beta"
+<% end -%>
+
   name   = "<%= ctx[:vars]['rigm_name'] %>"
   region = "us-central1"
 
@@ -59,6 +75,17 @@ resource "google_compute_region_instance_group_manager" "foobar" {
 }
 
 data "google_compute_image" "debian_9" {
+<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
+  provider = "google-beta"
+<% end -%>
 	family  = "debian-9"
 	project = "debian-cloud"
 }
+
+<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
+provider "google-beta"{
+  region = "us-central1"
+  zone   = "us-central1-a"
+}
+
+<% end -%>

--- a/templates/terraform/examples/region_autoscaler_basic.tf.erb
+++ b/templates/terraform/examples/region_autoscaler_basic.tf.erb
@@ -1,7 +1,5 @@
 resource "google_compute_region_autoscaler" "foobar" {
-<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
   provider = "google-beta"
-<% end -%>
 
   name   = "<%= ctx[:vars]['region_autoscaler_name'] %>"
   region = "us-central1"
@@ -19,9 +17,7 @@ resource "google_compute_region_autoscaler" "foobar" {
 }
 
 resource "google_compute_instance_template" "foobar" {
-<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
   provider = "google-beta"
-<% end -%>
 
   name           = "<%= ctx[:vars]['instance_template_name'] %>"
   machine_type   = "n1-standard-1"
@@ -47,45 +43,34 @@ resource "google_compute_instance_template" "foobar" {
 }
 
 resource "google_compute_target_pool" "foobar" {
-<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
   provider = "google-beta"
-<% end -%>
 
   name = "<%= ctx[:vars]['target_pool_name'] %>"
 }
 
 resource "google_compute_region_instance_group_manager" "foobar" {
-<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
   provider = "google-beta"
-<% end -%>
 
   name   = "<%= ctx[:vars]['rigm_name'] %>"
   region = "us-central1"
 
-<% if ctx[:version].nil? || ctx[:version] == 'ga' -%>
-  instance_template  = "${google_compute_instance_template.foobar.self_link}"
-<% else -%>
   version {
     instance_template  = "${google_compute_instance_template.foobar.self_link}"
     name               = "primary"
   }
-<% end -%>
+
   target_pools       = ["${google_compute_target_pool.foobar.self_link}"]
   base_instance_name = "foobar"
 }
 
 data "google_compute_image" "debian_9" {
-<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
   provider = "google-beta"
-<% end -%>
+
 	family  = "debian-9"
 	project = "debian-cloud"
 }
 
-<% unless ctx[:version].nil? || ctx[:version] == 'ga' -%>
 provider "google-beta"{
   region = "us-central1"
   zone   = "us-central1-a"
 }
-
-<% end -%>

--- a/templates/terraform/examples/region_autoscaler_basic.tf.erb
+++ b/templates/terraform/examples/region_autoscaler_basic.tf.erb
@@ -1,6 +1,4 @@
 resource "google_compute_region_autoscaler" "foobar" {
-  provider = "google-beta"
-
   name   = "<%= ctx[:vars]['region_autoscaler_name'] %>"
   region = "us-central1"
   target = "${google_compute_region_instance_group_manager.foobar.self_link}"
@@ -17,8 +15,6 @@ resource "google_compute_region_autoscaler" "foobar" {
 }
 
 resource "google_compute_instance_template" "foobar" {
-  provider = "google-beta"
-
   name           = "<%= ctx[:vars]['instance_template_name'] %>"
   machine_type   = "n1-standard-1"
   can_ip_forward = false
@@ -43,34 +39,20 @@ resource "google_compute_instance_template" "foobar" {
 }
 
 resource "google_compute_target_pool" "foobar" {
-  provider = "google-beta"
-
   name = "<%= ctx[:vars]['target_pool_name'] %>"
 }
 
 resource "google_compute_region_instance_group_manager" "foobar" {
-  provider = "google-beta"
-
   name   = "<%= ctx[:vars]['rigm_name'] %>"
   region = "us-central1"
 
-  version {
-    instance_template  = "${google_compute_instance_template.foobar.self_link}"
-    name               = "primary"
-  }
+  instance_template  = "${google_compute_instance_template.foobar.self_link}"
 
   target_pools       = ["${google_compute_target_pool.foobar.self_link}"]
   base_instance_name = "foobar"
 }
 
 data "google_compute_image" "debian_9" {
-  provider = "google-beta"
-
 	family  = "debian-9"
 	project = "debian-cloud"
-}
-
-provider "google-beta"{
-  region = "us-central1"
-  zone   = "us-central1-a"
 }

--- a/templates/terraform/examples/region_autoscaler_beta.tf.erb
+++ b/templates/terraform/examples/region_autoscaler_beta.tf.erb
@@ -1,7 +1,9 @@
-resource "google_compute_autoscaler" "foobar" {
-  name   = "<%= ctx[:vars]['autoscaler_name'] %>"
-  zone   = "us-central1-f"
-  target = "${google_compute_instance_group_manager.foobar.self_link}"
+resource "google_compute_region_autoscaler" "foobar" {
+  provider = "google-beta"
+
+  name   = "<%= ctx[:vars]['region_autoscaler_name'] %>"
+  region = "us-central1"
+  target = "${google_compute_region_instance_group_manager.foobar.self_link}"
 
   autoscaling_policy {
     max_replicas    = 5
@@ -15,6 +17,8 @@ resource "google_compute_autoscaler" "foobar" {
 }
 
 resource "google_compute_instance_template" "foobar" {
+  provider = "google-beta"
+
   name           = "<%= ctx[:vars]['instance_template_name'] %>"
   machine_type   = "n1-standard-1"
   can_ip_forward = false
@@ -39,20 +43,34 @@ resource "google_compute_instance_template" "foobar" {
 }
 
 resource "google_compute_target_pool" "foobar" {
+  provider = "google-beta"
+
   name = "<%= ctx[:vars]['target_pool_name'] %>"
 }
 
-resource "google_compute_instance_group_manager" "foobar" {
-  name = "<%= ctx[:vars]['igm_name'] %>"
-  zone = "us-central1-f"
+resource "google_compute_region_instance_group_manager" "foobar" {
+  provider = "google-beta"
 
-  instance_template  = "${google_compute_instance_template.foobar.self_link}"
+  name   = "<%= ctx[:vars]['rigm_name'] %>"
+  region = "us-central1"
+
+  version {
+    instance_template  = "${google_compute_instance_template.foobar.self_link}"
+    name               = "primary"
+  }
 
   target_pools       = ["${google_compute_target_pool.foobar.self_link}"]
   base_instance_name = "foobar"
 }
 
 data "google_compute_image" "debian_9" {
+  provider = "google-beta"
+
 	family  = "debian-9"
 	project = "debian-cloud"
+}
+
+provider "google-beta"{
+  region = "us-central1"
+  zone   = "us-central1-a"
 }

--- a/templates/terraform/examples/scheduler_job_app_engine.tf.erb
+++ b/templates/terraform/examples/scheduler_job_app_engine.tf.erb
@@ -1,4 +1,6 @@
 resource "google_cloud_scheduler_job" "job" {
+  provider = "google-beta"
+
   name     = "<%= ctx[:vars]['job_name'] %>"
   schedule = "*/4 * * * *"
   description = "test app engine job"
@@ -15,4 +17,9 @@ resource "google_cloud_scheduler_job" "job" {
 
     relative_uri = "/ping"
   }
+}
+
+provider "google-beta"{
+  region = "us-central1"
+  zone   = "us-central1-a"
 }

--- a/templates/terraform/examples/scheduler_job_http.tf.erb
+++ b/templates/terraform/examples/scheduler_job_http.tf.erb
@@ -1,4 +1,6 @@
 resource "google_cloud_scheduler_job" "job" {
+  provider = "google-beta"
+
   name     = "<%= ctx[:vars]['job_name'] %>"
   description = "test http job"
   schedule = "*/8 * * * *"
@@ -8,4 +10,9 @@ resource "google_cloud_scheduler_job" "job" {
     http_method = "POST"
     uri = "https://example.com/ping"
   }
+}
+
+provider "google-beta"{
+  region = "us-central1"
+  zone   = "us-central1-a"
 }

--- a/templates/terraform/examples/scheduler_job_pubsub.tf.erb
+++ b/templates/terraform/examples/scheduler_job_pubsub.tf.erb
@@ -1,8 +1,12 @@
 resource "google_pubsub_topic" "topic" {
+  provider = "google-beta"
+
   name = "<%= ctx[:vars]['topic_name'] %>"
 }
 
 resource "google_cloud_scheduler_job" "job" {
+  provider = "google-beta"
+
   name     = "<%= ctx[:vars]['job_name'] %>"
   description = "test job"
   schedule = "*/2 * * * *"
@@ -11,4 +15,9 @@ resource "google_cloud_scheduler_job" "job" {
     topic_name = "${google_pubsub_topic.topic.id}"
     data = "${base64encode("test")}"
   }
+}
+
+provider "google-beta"{
+  region = "us-central1"
+  zone   = "us-central1-a"
 }

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -80,6 +80,7 @@ To get more information about <%= object.name -%>, see:
 ~> **Warning:** <%= object.docs.warning -%>
 <%- end -%>
 
+<%#- We over-generate examples/oics buttons here; they'll all be _valid_ just not necessarily for this provider version -%>
 <% unless object.examples.empty? -%>
   <%- object.examples.each do |example| -%>
     <%- unless example.skip_test -%>

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -80,7 +80,8 @@ To get more information about <%= object.name -%>, see:
 ~> **Warning:** <%= object.docs.warning -%>
 <%- end -%>
 
-<%#- We over-generate examples/oics buttons here; they'll all be _valid_ just not necessarily for this provider version -%>
+<%#- We over-generate examples/oics buttons here; they'll all be _valid_ just not necessarily intended for this provider version.
+     Unless/Until we split our docs, this is a non-issue. -%>
 <% unless object.examples.empty? -%>
   <%- object.examples.each do |example| -%>
     <%- unless example.skip_test -%>

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -14,7 +14,7 @@ import (
 )
 
 var testAccProviders map[string]terraform.ResourceProvider
-<% if version == 'ga' -%>
+<% unless version == 'ga' -%>
 var testAccProvidersOiCS map[string]terraform.ResourceProvider
 <% end -%>
 var testAccProvider *schema.Provider

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -14,7 +14,9 @@ import (
 )
 
 var testAccProviders map[string]terraform.ResourceProvider
+<% if version == 'ga' -%>
 var testAccProvidersOiCS map[string]terraform.ResourceProvider
+<% end -%>
 var testAccProvider *schema.Provider
 var testAccRandomProvider *schema.Provider
 
@@ -75,6 +77,7 @@ func init() {
 
 	testAccProvidersOiCS = map[string]terraform.ResourceProvider{
 		"google-beta": testAccProvider,
+		"random": testAccRandomProvider,
 	}
 	<% end -%>
 }

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package google
 
 import (
@@ -13,6 +14,7 @@ import (
 )
 
 var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvidersOiCS map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
 var testAccRandomProvider *schema.Provider
 
@@ -60,10 +62,21 @@ var billingAccountEnvVars = []string{
 func init() {
 	testAccProvider = Provider().(*schema.Provider)
 	testAccRandomProvider = random.Provider().(*schema.Provider)
+	<% if version == 'ga' -%>
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"google": testAccProvider,
 		"random": testAccRandomProvider,
 	}
+	<% else -%>
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"google": testAccProvider,
+		"random": testAccRandomProvider,
+	}
+
+	testAccProvidersOiCS = map[string]terraform.ResourceProvider{
+		"google-beta": testAccProvider,
+	}
+	<% end -%>
 }
 
 func TestProvider(t *testing.T) {

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -75,6 +75,9 @@ func init() {
 		"random": testAccRandomProvider,
 	}
 
+	// The OiCS provider map is used to ensure that OiCS examples use `google-beta`
+	// if the example is versioned as beta; normal beta tests should continue to
+	// use the standard provider map.
 	testAccProvidersOiCS = map[string]terraform.ResourceProvider{
 		"google-beta": testAccProvider,
 		"random": testAccRandomProvider,


### PR DESCRIPTION
Apologies for the size- this touches a lot of files, but is ultimately only doing a few things.

OiCS examples were getting generated w/o beta support, which wasn't a big deal because only a few resources were actually doing anything with beta. This PR fixes that.

The `version` attribute on Example objects was replaced with `min_version`; `version` is an anti-pattern as we don't want examples to switch based on the version being targeted. Instead, we want examples to have a min version similar to resources. Exactly two examples used this feature, autoscaler and regional autoscaler.

Next, we had to make sure our examples were using `google-beta`. So beta-only examples will all use a different set of providers. By using a set that only includes `google-beta` and not `google`, we're forced to specify `google-beta` correctly. Import doesn't work with an alternate provider, so I'll need to file a bug for that.

And finally, plumb through the versions so that we generate the right thing at the right version.

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
