### PR TITLE
Node Pool versioning

### DIFF
--- a/products/container/ansible.yaml
+++ b/products/container/ansible.yaml
@@ -38,6 +38,8 @@ datasources: !ruby/object:Overrides::ResourceOverrides
     properties:
       location: !ruby/object:Overrides::Ansible::PropertyOverride
         aliases: ["region", "zone"]
+      version: !ruby/object:Overrides::Ansible::PropertyOverride
+        aliases: ["node_version"]
     facts: !ruby/object:Provider::Ansible::FactsOverride
       has_filters: false
       test: !ruby/object:Provider::Ansible::AnsibleFactsTestInformation

--- a/products/container/ansible_version_added.yaml
+++ b/products/container/ansible_version_added.yaml
@@ -93,6 +93,8 @@
         :version_added: '2.6'
     :initialNodeCount:
       :version_added: '2.6'
+    :version:
+      :version_added: '2.8'
     :autoscaling:
       :version_added: '2.6'
       :enabled:

--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -353,10 +353,13 @@ objects:
         input: true
       # | 'instanceGroupUrls' not supported as it is dynamically created by the
       # |  server and admin has no way to predict it
+      # NodePool updates use a different name for version for updating.
+      # TODO(alexstephen): Support NodePool updates.
+      # Setting as `input: true` until fixed.
       - !ruby/object:Api::Type::String
         name: 'version'
         description: 'The version of the Kubernetes of this node.'
-        output: true
+        input: true
       # | 'status' is not applicable for state enforcement
       # | 'statusMessage' is not applicable for state enforcement
       - !ruby/object:Api::Type::NestedObject

--- a/provider/ansible/version_added.rb
+++ b/provider/ansible/version_added.rb
@@ -92,7 +92,7 @@ module Provider
         }
 
         # Only properties that aren't output-only + excluded should get versions.
-          # These are the only properties that become module fields.
+        # These are the only properties that become module fields.
         prop.nested_properties.reject(&:exclude).reject(&:output).each do |nested_p|
           property_hash[nested_p.name.to_sym] = property_version(nested_p,
                                                                  path + [prop.name], struct)

--- a/provider/ansible/version_added.rb
+++ b/provider/ansible/version_added.rb
@@ -44,6 +44,7 @@ module Provider
 
           # Add properties.
           # Only properties that aren't output-only + excluded should get versions.
+          # These are the only properties that become module fields.
           obj.all_user_properties.reject(&:exclude).reject(&:output).each do |prop|
             resource[prop.name.to_sym] = property_version(prop, [:regular, obj.name], versions)
           end
@@ -91,6 +92,7 @@ module Provider
         }
 
         # Only properties that aren't output-only + excluded should get versions.
+          # These are the only properties that become module fields.
         prop.nested_properties.reject(&:exclude).reject(&:output).each do |nested_p|
           property_hash[nested_p.name.to_sym] = property_version(nested_p,
                                                                  path + [prop.name], struct)


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

<!-- Your regular pull request description goes here -->
NodePool version can be set. Updates don't work properly on it (yet), so I'm setting it as input: true.

There was also a version_added bug where output: only properties were getting versions. This is wrong because those properties don't get mapped to fields (which require versions) and thus shouldn't get them. This is important for fields like version, where when moved from output: true -> output: false should now get a version.



<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
