### PR TITLE
Nested output: only properties shouldn't be fields

### DIFF
--- a/products/bigquery/ansible_version_added.yaml
+++ b/products/bigquery/ansible_version_added.yaml
@@ -29,8 +29,6 @@
           :version_added: '2.8'
         :tableId:
           :version_added: '2.8'
-    :creationTime:
-      :version_added: '2.8'
     :datasetReference:
       :version_added: '2.8'
       :datasetId:
@@ -43,11 +41,7 @@
       :version_added: '2.8'
     :friendlyName:
       :version_added: '2.8'
-    :id:
-      :version_added: '2.8'
     :labels:
-      :version_added: '2.8'
-    :lastModifiedTime:
       :version_added: '2.8'
     :location:
       :version_added: '2.8'
@@ -61,29 +55,13 @@
         :version_added: '2.8'
       :tableId:
         :version_added: '2.8'
-    :creationTime:
-      :version_added: '2.8'
     :description:
       :version_added: '2.8'
     :friendlyName:
       :version_added: '2.8'
-    :id:
-      :version_added: '2.8'
     :labels:
       :version_added: '2.8'
-    :lastModifiedTime:
-      :version_added: '2.8'
-    :location:
-      :version_added: '2.8'
     :name:
-      :version_added: '2.8'
-    :numBytes:
-      :version_added: '2.8'
-    :numLongTermBytes:
-      :version_added: '2.8'
-    :numRows:
-      :version_added: '2.8'
-    :type:
       :version_added: '2.8'
     :view:
       :version_added: '2.8'
@@ -100,14 +78,6 @@
       :expirationMs:
         :version_added: '2.8'
       :type:
-        :version_added: '2.8'
-    :streamingBuffer:
-      :version_added: '2.8'
-      :estimatedBytes:
-        :version_added: '2.8'
-      :estimatedRows:
-        :version_added: '2.8'
-      :oldestEntryTime:
         :version_added: '2.8'
     :schema:
       :version_added: '2.8'

--- a/products/cloudbuild/ansible_version_added.yaml
+++ b/products/cloudbuild/ansible_version_added.yaml
@@ -11,8 +11,6 @@
       :version_added: '2.8'
     :disabled:
       :version_added: '2.8'
-    :createTime:
-      :version_added: '2.8'
     :substitutions:
       :version_added: '2.8'
     :filename:

--- a/products/compute/ansible_version_added.yaml
+++ b/products/compute/ansible_version_added.yaml
@@ -71,11 +71,7 @@
       :version_added: '2.6'
     :addressType:
       :version_added: '2.7'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :name:
       :version_added: '2.6'
@@ -83,11 +79,7 @@
       :version_added: '2.8'
     :subnetwork:
       :version_added: '2.7'
-    :users:
-      :version_added: '2.6'
     :labels:
-      :version_added: '2.6'
-    :labelFingerprint:
       :version_added: '2.6'
     :region:
       :version_added: '2.6'
@@ -95,13 +87,9 @@
     :version_added: '2.6'
     :bucketName:
       :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
       :version_added: '2.6'
     :enableCdn:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :name:
       :version_added: '2.6'
@@ -147,15 +135,11 @@
       :version_added: '2.6'
       :drainingTimeoutSec:
         :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
       :version_added: '2.6'
     :enableCDN:
       :version_added: '2.6'
     :healthChecks:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :iap:
       :version_added: '2.7'
@@ -164,8 +148,6 @@
       :oauth2ClientId:
         :version_added: '2.7'
       :oauth2ClientSecret:
-        :version_added: '2.7'
-      :oauth2ClientSecretSha256:
         :version_added: '2.7'
     :loadBalancingScheme:
       :version_added: '2.7'
@@ -183,17 +165,7 @@
       :version_added: '2.6'
   :Disk:
     :version_added: '2.6'
-    :labelFingerprint:
-      :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
-      :version_added: '2.6'
-    :id:
-      :version_added: '2.6'
-    :lastAttachTimestamp:
-      :version_added: '2.6'
-    :lastDetachTimestamp:
       :version_added: '2.6'
     :labels:
       :version_added: '2.7'
@@ -202,8 +174,6 @@
     :name:
       :version_added: '2.6'
     :sizeGb:
-      :version_added: '2.6'
-    :users:
       :version_added: '2.6'
     :type:
       :version_added: '2.7'
@@ -215,17 +185,11 @@
       :version_added: '2.6'
       :rawKey:
         :version_added: '2.6'
-      :sha256:
-        :version_added: '2.6'
       :kmsKeyName:
         :version_added: '2.6'
-    :sourceImageId:
-      :version_added: '2.6'
     :diskEncryptionKey:
       :version_added: '2.6'
       :rawKey:
-        :version_added: '2.6'
-      :sha256:
         :version_added: '2.6'
       :kmsKeyName:
         :version_added: '2.6'
@@ -237,10 +201,6 @@
         :version_added: '2.6'
       :kmsKeyName:
         :version_added: '2.6'
-      :sha256:
-        :version_added: '2.6'
-    :sourceSnapshotId:
-      :version_added: '2.6'
   :Firewall:
     :version_added: '2.6'
     :allowed:
@@ -249,8 +209,6 @@
         :version_added: '2.6'
       :ports:
         :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :denied:
       :version_added: '2.8'
       :ip_protocol:
@@ -266,8 +224,6 @@
     :disabled:
       :version_added: '2.8'
     :enableLogging:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :name:
       :version_added: '2.6'
@@ -287,11 +243,7 @@
       :version_added: '2.6'
   :ForwardingRule:
     :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :IPAddress:
       :version_added: '2.6'
@@ -317,15 +269,11 @@
       :version_added: '2.7'
     :labels:
       :version_added: '2.6'
-    :labelFingerprint:
-      :version_added: '2.6'
     :allPorts:
       :version_added: '2.6'
     :networkTier:
       :version_added: '2.8'
     :serviceLabel:
-      :version_added: '2.6'
-    :serviceName:
       :version_added: '2.6'
     :region:
       :version_added: '2.6'
@@ -333,21 +281,13 @@
     :version_added: '2.6'
     :address:
       :version_added: '2.8'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :name:
       :version_added: '2.6'
     :labels:
       :version_added: '2.6'
-    :labelFingerprint:
-      :version_added: '2.6'
     :ipVersion:
-      :version_added: '2.6'
-    :region:
       :version_added: '2.6'
     :prefixLength:
       :version_added: '2.6'
@@ -359,11 +299,7 @@
       :version_added: '2.6'
   :GlobalForwardingRule:
     :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :IPAddress:
       :version_added: '2.6'
@@ -385,23 +321,17 @@
       :version_added: '2.6'
     :subnetwork:
       :version_added: '2.6'
-    :region:
-      :version_added: '2.6'
     :target:
       :version_added: '2.6'
   :HttpHealthCheck:
     :version_added: '2.6'
     :checkIntervalSec:
       :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
       :version_added: '2.6'
     :healthyThreshold:
       :version_added: '2.6'
     :host:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :name:
       :version_added: '2.6'
@@ -417,15 +347,11 @@
     :version_added: '2.6'
     :checkIntervalSec:
       :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
       :version_added: '2.6'
     :healthyThreshold:
       :version_added: '2.6'
     :host:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :name:
       :version_added: '2.6'
@@ -441,13 +367,9 @@
     :version_added: '2.6'
     :checkIntervalSec:
       :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
       :version_added: '2.6'
     :healthyThreshold:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :name:
       :version_added: '2.6'
@@ -511,11 +433,7 @@
         :version_added: '2.6'
   :InstanceTemplate:
     :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :name:
       :version_added: '2.6'
@@ -539,8 +457,6 @@
             :version_added: '2.6'
           :rsaEncryptedKey:
             :version_added: '2.6'
-          :sha256:
-            :version_added: '2.6'
         :index:
           :version_added: '2.6'
         :initializeParams:
@@ -556,8 +472,6 @@
           :sourceImageEncryptionKey:
             :version_added: '2.6'
             :rawKey:
-              :version_added: '2.6'
-            :sha256:
               :version_added: '2.6'
         :interface:
           :version_added: '2.6'
@@ -595,8 +509,6 @@
             :version_added: '2.6'
           :subnetworkRangeName:
             :version_added: '2.6'
-        :name:
-          :version_added: '2.6'
         :network:
           :version_added: '2.6'
         :networkIP:
@@ -625,22 +537,6 @@
           :version_added: '2.6'
   :Image:
     :version_added: '2.6'
-    :archiveSizeBytes:
-      :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
-    :deprecated:
-      :version_added: '2.6'
-      :deleted:
-        :version_added: '2.6'
-      :deprecated:
-        :version_added: '2.6'
-      :obsolete:
-        :version_added: '2.6'
-      :replacement:
-        :version_added: '2.6'
-      :state:
-        :version_added: '2.6'
     :description:
       :version_added: '2.6'
     :diskSizeGb:
@@ -651,20 +547,14 @@
       :version_added: '2.6'
       :type:
         :version_added: '2.6'
-    :id:
-      :version_added: '2.6'
     :imageEncryptionKey:
       :version_added: '2.6'
       :rawKey:
-        :version_added: '2.6'
-      :sha256:
         :version_added: '2.6'
       :kmsKeyName:
         :version_added: '2.6'
     :labels:
       :version_added: '2.8'
-    :labelFingerprint:
-      :version_added: '2.6'
     :licenses:
       :version_added: '2.6'
     :name:
@@ -683,8 +573,6 @@
       :version_added: '2.6'
       :rawKey:
         :version_added: '2.6'
-      :sha256:
-        :version_added: '2.6'
       :kmsKeyName:
         :version_added: '2.6'
     :sourceDiskId:
@@ -694,10 +582,6 @@
   :Instance:
     :version_added: '2.6'
     :canIpForward:
-      :version_added: '2.6'
-    :cpuPlatform:
-      :version_added: '2.6'
-    :creationTimestamp:
       :version_added: '2.6'
     :disks:
       :version_added: '2.6'
@@ -712,8 +596,6 @@
         :rawKey:
           :version_added: '2.6'
         :rsaEncryptedKey:
-          :version_added: '2.6'
-        :sha256:
           :version_added: '2.6'
       :index:
         :version_added: '2.6'
@@ -731,8 +613,6 @@
           :version_added: '2.6'
           :rawKey:
             :version_added: '2.6'
-          :sha256:
-            :version_added: '2.6'
       :interface:
         :version_added: '2.6'
       :mode:
@@ -747,8 +627,6 @@
         :version_added: '2.6'
       :acceleratorType:
         :version_added: '2.6'
-    :id:
-      :version_added: '2.6'
     :labelFingerprint:
       :version_added: '2.6'
     :metadata:
@@ -775,8 +653,6 @@
           :version_added: '2.6'
         :subnetworkRangeName:
           :version_added: '2.6'
-      :name:
-        :version_added: '2.6'
       :network:
         :version_added: '2.6'
       :networkIP:
@@ -799,8 +675,6 @@
         :version_added: '2.6'
     :status:
       :version_added: '2.8'
-    :statusMessage:
-      :version_added: '2.6'
     :tags:
       :version_added: '2.6'
       :fingerprint:
@@ -811,11 +685,7 @@
       :version_added: '2.6'
   :InstanceGroup:
     :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :name:
       :version_added: '2.6'
@@ -839,31 +709,7 @@
     :version_added: '2.6'
     :baseInstanceName:
       :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
-    :currentActions:
-      :version_added: '2.6'
-      :abandoning:
-        :version_added: '2.6'
-      :creating:
-        :version_added: '2.6'
-      :creatingWithoutRetries:
-        :version_added: '2.6'
-      :deleting:
-        :version_added: '2.6'
-      :none:
-        :version_added: '2.6'
-      :recreating:
-        :version_added: '2.6'
-      :refreshing:
-        :version_added: '2.6'
-      :restarting:
-        :version_added: '2.6'
     :description:
-      :version_added: '2.6'
-    :id:
-      :version_added: '2.6'
-    :instanceGroup:
       :version_added: '2.6'
     :instanceTemplate:
       :version_added: '2.6'
@@ -875,8 +721,6 @@
         :version_added: '2.6'
       :port:
         :version_added: '2.6'
-    :region:
-      :version_added: '2.6'
     :targetPools:
       :version_added: '2.6'
     :targetSize:
@@ -885,35 +729,15 @@
       :version_added: '2.6'
   :InterconnectAttachment:
     :version_added: '2.8'
-    :cloudRouterIpAddress:
-      :version_added: '2.8'
-    :customerRouterIpAddress:
-      :version_added: '2.8'
     :interconnect:
       :version_added: '2.8'
     :description:
       :version_added: '2.8'
     :edgeAvailabilityDomain:
       :version_added: '2.8'
-    :pairingKey:
-      :version_added: '2.8'
-    :partnerAsn:
-      :version_added: '2.8'
-    :privateInterconnectInfo:
-      :version_added: '2.8'
-      :tag8021q:
-        :version_added: '2.8'
     :type:
       :version_added: '2.8'
-    :state:
-      :version_added: '2.8'
-    :googleReferenceId:
-      :version_added: '2.8'
     :router:
-      :version_added: '2.8'
-    :creationTimestamp:
-      :version_added: '2.8'
-    :id:
       :version_added: '2.8'
     :name:
       :version_added: '2.8'
@@ -927,19 +751,11 @@
     :version_added: '2.6'
     :description:
       :version_added: '2.6'
-    :gateway_ipv4:
-      :version_added: '2.6'
-    :id:
-      :version_added: '2.6'
     :ipv4_range:
       :version_added: '2.6'
     :name:
       :version_added: '2.6'
-    :subnetworks:
-      :version_added: '2.6'
     :autoCreateSubnetworks:
-      :version_added: '2.6'
-    :creationTimestamp:
       :version_added: '2.6'
     :routingConfig:
       :version_added: '2.8'
@@ -947,17 +763,7 @@
         :version_added: '2.8'
   :RegionDisk:
     :version_added: '2.8'
-    :labelFingerprint:
-      :version_added: '2.8'
-    :creationTimestamp:
-      :version_added: '2.8'
     :description:
-      :version_added: '2.8'
-    :id:
-      :version_added: '2.8'
-    :lastAttachTimestamp:
-      :version_added: '2.8'
-    :lastDetachTimestamp:
       :version_added: '2.8'
     :labels:
       :version_added: '2.8'
@@ -966,8 +772,6 @@
     :name:
       :version_added: '2.8'
     :sizeGb:
-      :version_added: '2.8'
-    :users:
       :version_added: '2.8'
     :replicaZones:
       :version_added: '2.8'
@@ -979,8 +783,6 @@
       :version_added: '2.8'
       :rawKey:
         :version_added: '2.8'
-      :sha256:
-        :version_added: '2.8'
       :kmsKeyName:
         :version_added: '2.8'
     :sourceSnapshot:
@@ -991,10 +793,6 @@
         :version_added: '2.8'
       :kmsKeyName:
         :version_added: '2.8'
-      :sha256:
-        :version_added: '2.8'
-    :sourceSnapshotId:
-      :version_added: '2.8'
   :Route:
     :version_added: '2.6'
     :destRange:
@@ -1017,14 +815,8 @@
       :version_added: '2.6'
     :nextHopVpnTunnel:
       :version_added: '2.6'
-    :nextHopNetwork:
-      :version_added: '2.6'
   :Router:
     :version_added: '2.7'
-    :id:
-      :version_added: '2.7'
-    :creationTimestamp:
-      :version_added: '2.7'
     :name:
       :version_added: '2.7'
     :description:
@@ -1051,11 +843,7 @@
     :version_added: '2.6'
     :certificate:
       :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :name:
       :version_added: '2.6'
@@ -1063,11 +851,7 @@
       :version_added: '2.6'
   :SslPolicy:
     :version_added: '2.7'
-    :creationTimestamp:
-      :version_added: '2.7'
     :description:
-      :version_added: '2.7'
-    :id:
       :version_added: '2.7'
     :name:
       :version_added: '2.7'
@@ -1075,27 +859,11 @@
       :version_added: '2.7'
     :minTlsVersion:
       :version_added: '2.7'
-    :enabledFeatures:
-      :version_added: '2.7'
     :customFeatures:
       :version_added: '2.7'
-    :fingerprint:
-      :version_added: '2.7'
-    :warnings:
-      :version_added: '2.7'
-      :code:
-        :version_added: '2.7'
-      :message:
-        :version_added: '2.7'
   :Subnetwork:
     :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
-      :version_added: '2.6'
-    :gatewayAddress:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :ipCidrRange:
       :version_added: '2.6'
@@ -1105,8 +873,6 @@
       :version_added: '2.6'
     :enableFlowLogs:
       :version_added: '2.8'
-    :fingerprint:
-      :version_added: '2.6'
     :secondaryIpRanges:
       :version_added: '2.8'
       :rangeName:
@@ -1119,11 +885,7 @@
       :version_added: '2.6'
   :TargetHttpProxy:
     :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :name:
       :version_added: '2.6'
@@ -1131,11 +893,7 @@
       :version_added: '2.6'
   :TargetHttpsProxy:
     :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :name:
       :version_added: '2.6'
@@ -1151,15 +909,11 @@
     :version_added: '2.6'
     :backupPool:
       :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
       :version_added: '2.6'
     :failoverRatio:
       :version_added: '2.6'
     :healthCheck:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :instances:
       :version_added: '2.6'
@@ -1171,11 +925,7 @@
       :version_added: '2.6'
   :TargetSslProxy:
     :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :name:
       :version_added: '2.6'
@@ -1189,11 +939,7 @@
       :version_added: '2.8'
   :TargetTcpProxy:
     :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :description:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :name:
       :version_added: '2.6'
@@ -1203,26 +949,16 @@
       :version_added: '2.6'
   :TargetVpnGateway:
     :version_added: '2.7'
-    :creationTimestamp:
-      :version_added: '2.7'
     :description:
       :version_added: '2.7'
     :name:
       :version_added: '2.7'
-    :id:
-      :version_added: '2.7'
     :network:
-      :version_added: '2.7'
-    :tunnels:
-      :version_added: '2.7'
-    :forwardingRules:
       :version_added: '2.7'
     :region:
       :version_added: '2.7'
   :UrlMap:
     :version_added: '2.6'
-    :creationTimestamp:
-      :version_added: '2.6'
     :defaultService:
       :version_added: '2.6'
     :description:
@@ -1235,10 +971,6 @@
         :version_added: '2.6'
       :pathMatcher:
         :version_added: '2.6'
-    :id:
-      :version_added: '2.6'
-    :fingerprint:
-      :version_added: '2.6'
     :name:
       :version_added: '2.6'
     :pathMatchers:
@@ -1267,8 +999,6 @@
         :version_added: '2.6'
   :VpnTunnel:
     :version_added: '2.7'
-    :creationTimestamp:
-      :version_added: '2.7'
     :name:
       :version_added: '2.7'
     :description:
@@ -1281,8 +1011,6 @@
       :version_added: '2.7'
     :sharedSecret:
       :version_added: '2.7'
-    :sharedSecretHash:
-      :version_added: '2.7'
     :ikeVersion:
       :version_added: '2.7'
     :localTrafficSelector:
@@ -1290,8 +1018,6 @@
     :remoteTrafficSelector:
       :version_added: '2.7'
     :labels:
-      :version_added: '2.7'
-    :labelFingerprint:
       :version_added: '2.7'
     :region:
       :version_added: '2.7'

--- a/products/container/ansible_version_added.yaml
+++ b/products/container/ansible_version_added.yaml
@@ -41,12 +41,6 @@
         :version_added: '2.6'
       :password:
         :version_added: '2.6'
-      :clusterCaCertificate:
-        :version_added: '2.6'
-      :clientCertificate:
-        :version_added: '2.6'
-      :clientKey:
-        :version_added: '2.6'
     :loggingService:
       :version_added: '2.6'
     :monitoringService:
@@ -56,8 +50,6 @@
     :clusterIpv4Cidr:
       :version_added: '2.6'
     :enableTpu:
-      :version_added: '2.6'
-    :tpuIpv4CidrBlock:
       :version_added: '2.6'
     :addonsConfig:
       :version_added: '2.6'
@@ -70,24 +62,6 @@
         :disabled:
           :version_added: '2.6'
     :subnetwork:
-      :version_added: '2.6'
-    :endpoint:
-      :version_added: '2.6'
-    :initialClusterVersion:
-      :version_added: '2.6'
-    :currentMasterVersion:
-      :version_added: '2.6'
-    :currentNodeVersion:
-      :version_added: '2.6'
-    :createTime:
-      :version_added: '2.6'
-    :nodeIpv4CidrSize:
-      :version_added: '2.6'
-    :servicesIpv4Cidr:
-      :version_added: '2.6'
-    :currentNodeCount:
-      :version_added: '2.6'
-    :expireTime:
       :version_added: '2.6'
     :location:
       :version_added: '2.8'
@@ -119,8 +93,6 @@
         :version_added: '2.6'
     :initialNodeCount:
       :version_added: '2.6'
-    :version:
-      :version_added: '2.6'
     :autoscaling:
       :version_added: '2.6'
       :enabled:
@@ -137,10 +109,6 @@
         :version_added: '2.6'
       :upgradeOptions:
         :version_added: '2.6'
-        :autoUpgradeStartTime:
-          :version_added: '2.6'
-        :description:
-          :version_added: '2.6'
     :cluster:
       :version_added: '2.6'
     :location:

--- a/products/dns/ansible_version_added.yaml
+++ b/products/dns/ansible_version_added.yaml
@@ -11,15 +11,9 @@
       :version_added: '2.5'
     :dnsName:
       :version_added: '2.5'
-    :id:
-      :version_added: '2.5'
     :name:
       :version_added: '2.5'
-    :nameServers:
-      :version_added: '2.5'
     :nameServerSet:
-      :version_added: '2.5'
-    :creationTime:
       :version_added: '2.5'
     :labels:
       :version_added: '2.8'

--- a/products/iam/ansible_version_added.yaml
+++ b/products/iam/ansible_version_added.yaml
@@ -19,37 +19,17 @@
       :version_added: '2.8'
     :stage:
       :version_added: '2.8'
-    :deleted:
-      :version_added: '2.8'
   :ServiceAccount:
     :version_added: '2.8'
     :name:
       :version_added: '2.8'
-    :projectId:
-      :version_added: '2.8'
-    :uniqueId:
-      :version_added: '2.8'
-    :email:
-      :version_added: '2.8'
     :displayName:
-      :version_added: '2.8'
-    :oauth2ClientId:
       :version_added: '2.8'
   :ServiceAccountKey:
     :version_added: '2.8'
-    :name:
-      :version_added: '2.8'
     :privateKeyType:
       :version_added: '2.8'
     :keyAlgorithm:
-      :version_added: '2.8'
-    :privateKeyData:
-      :version_added: '2.8'
-    :publicKeyData:
-      :version_added: '2.8'
-    :validAfterTime:
-      :version_added: '2.8'
-    :validBeforeTime:
       :version_added: '2.8'
     :serviceAccount:
       :version_added: '2.8'

--- a/products/pubsub/ansible_version_added.yaml
+++ b/products/pubsub/ansible_version_added.yaml
@@ -27,3 +27,7 @@
         :version_added: '2.6'
     :ackDeadlineSeconds:
       :version_added: '2.6'
+    :messageRetentionDuration:
+      :version_added: '2.8'
+    :retainAckedMessages:
+      :version_added: '2.8'

--- a/products/redis/ansible_version_added.yaml
+++ b/products/redis/ansible_version_added.yaml
@@ -9,13 +9,7 @@
       :version_added: '2.8'
     :authorizedNetwork:
       :version_added: '2.8'
-    :createTime:
-      :version_added: '2.8'
-    :currentLocationId:
-      :version_added: '2.8'
     :displayName:
-      :version_added: '2.8'
-    :host:
       :version_added: '2.8'
     :labels:
       :version_added: '2.8'
@@ -26,8 +20,6 @@
     :name:
       :version_added: '2.8'
     :memorySizeGb:
-      :version_added: '2.8'
-    :port:
       :version_added: '2.8'
     :redisVersion:
       :version_added: '2.8'

--- a/products/resourcemanager/ansible_version_added.yaml
+++ b/products/resourcemanager/ansible_version_added.yaml
@@ -5,13 +5,7 @@
 :regular:
   :Project:
     :version_added: '2.8'
-    :number:
-      :version_added: '2.8'
-    :lifecycleState:
-      :version_added: '2.8'
     :name:
-      :version_added: '2.8'
-    :createTime:
       :version_added: '2.8'
     :labels:
       :version_added: '2.8'

--- a/products/sourcerepo/ansible_version_added.yaml
+++ b/products/sourcerepo/ansible_version_added.yaml
@@ -7,7 +7,3 @@
     :version_added: '2.8'
     :name:
       :version_added: '2.8'
-    :url:
-      :version_added: '2.8'
-    :size:
-      :version_added: '2.8'

--- a/products/sql/ansible_version_added.yaml
+++ b/products/sql/ansible_version_added.yaml
@@ -17,20 +17,10 @@
       :version_added: '2.7'
     :failoverReplica:
       :version_added: '2.7'
-      :available:
-        :version_added: '2.7'
       :name:
         :version_added: '2.7'
     :instanceType:
       :version_added: '2.7'
-    :ipAddresses:
-      :version_added: '2.7'
-      :ipAddress:
-        :version_added: '2.7'
-      :timeToRetire:
-        :version_added: '2.7'
-      :type:
-        :version_added: '2.7'
     :ipv6Address:
       :version_added: '2.7'
     :masterInstanceName:
@@ -99,8 +89,6 @@
           :version_added: '2.7'
         :startTime:
           :version_added: '2.7'
-      :settingsVersion:
-        :version_added: '2.7'
   :Database:
     :version_added: '2.7'
     :charset:

--- a/products/storage/ansible_version_added.yaml
+++ b/products/storage/ansible_version_added.yaml
@@ -25,15 +25,9 @@
       :version_added: '2.6'
       :bucket:
         :version_added: '2.6'
-      :domain:
-        :version_added: '2.6'
-      :email:
-        :version_added: '2.6'
       :entity:
         :version_added: '2.6'
       :entityId:
-        :version_added: '2.6'
-      :id:
         :version_added: '2.6'
       :projectTeam:
         :version_added: '2.6'
@@ -57,30 +51,12 @@
       :version_added: '2.7'
       :bucket:
         :version_added: '2.7'
-      :domain:
-        :version_added: '2.7'
-      :email:
-        :version_added: '2.7'
       :entity:
-        :version_added: '2.7'
-      :entityId:
-        :version_added: '2.7'
-      :generation:
-        :version_added: '2.7'
-      :id:
         :version_added: '2.7'
       :object:
         :version_added: '2.7'
-      :projectTeam:
-        :version_added: '2.7'
-        :projectNumber:
-          :version_added: '2.7'
-        :team:
-          :version_added: '2.7'
       :role:
         :version_added: '2.7'
-    :id:
-      :version_added: '2.6'
     :lifecycle:
       :version_added: '2.6'
       :rule:
@@ -119,15 +95,7 @@
       :version_added: '2.6'
       :entity:
         :version_added: '2.6'
-      :entityId:
-        :version_added: '2.6'
-    :projectNumber:
-      :version_added: '2.6'
     :storageClass:
-      :version_added: '2.6'
-    :timeCreated:
-      :version_added: '2.6'
-    :updated:
       :version_added: '2.6'
     :versioning:
       :version_added: '2.6'
@@ -147,15 +115,9 @@
     :version_added: '2.6'
     :bucket:
       :version_added: '2.6'
-    :domain:
-      :version_added: '2.6'
-    :email:
-      :version_added: '2.6'
     :entity:
       :version_added: '2.6'
     :entityId:
-      :version_added: '2.6'
-    :id:
       :version_added: '2.6'
     :projectTeam:
       :version_added: '2.6'

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -73,8 +73,7 @@ module Provider
             'type' => type,
             'contains' => (
               if prop.nested_properties?
-                prop.nested_properties.reject(&:output)
-                                      .map { |p| returns_for_property(p) }
+                prop.nested_properties.map { |p| returns_for_property(p) }
                                       .reduce({}, :merge)
               end
             )

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -46,7 +46,7 @@ module Provider
             'choices' => (prop.values.map(&:to_s) if prop.is_a? Api::Type::Enum),
             'suboptions' => (
                 if prop.nested_properties?
-                  prop.nested_properties.map { |p| documentation_for_property(p) }
+                  prop.nested_properties.reject(&:output).map { |p| documentation_for_property(p) }
                                         .reduce({}, :merge)
                 end
               )
@@ -72,8 +72,11 @@ module Provider
             'returned' => 'success',
             'type' => type,
             'contains' => (
-              prop.nested_properties.map { |p| returns_for_property(p) }.reduce({}, :merge) \
               if prop.nested_properties?
+                prop.nested_properties.reject(&:output)
+                                      .map { |p| returns_for_property(p) }
+                                      .reduce({}, :merge)
+              end
             )
           }.reject { |_, v| v.nil? }
         }

--- a/provider/ansible/module.rb
+++ b/provider/ansible/module.rb
@@ -37,7 +37,8 @@ module Provider
               if prop.is_a?(Api::Type::Array) && python_type(prop.item_type)),
             'aliases' => prop.aliases,
             'options' => (if prop.nested_properties?
-                            prop.nested_properties.map { |x| python_dict_for_property(x) }
+                            prop.nested_properties.reject(&:output)
+                                                  .map { |x| python_dict_for_property(x) }
                                                   .reduce({}, :merge)
                           end
                          )

--- a/provider/ansible/version_added.rb
+++ b/provider/ansible/version_added.rb
@@ -43,7 +43,8 @@ module Provider
           }
 
           # Add properties.
-          obj.all_user_properties.each do |prop|
+          # Only properties that aren't output-only + excluded should get versions.
+          obj.all_user_properties.reject(&:exclude).reject(&:output).each do |prop|
             resource[prop.name.to_sym] = property_version(prop, [:regular, obj.name], versions)
           end
           struct[:regular][obj.name.to_sym] = resource
@@ -89,7 +90,8 @@ module Provider
           version_added: correct_version(path + [prop.name], struct)
         }
 
-        prop.nested_properties.each do |nested_p|
+        # Only properties that aren't output-only + excluded should get versions.
+        prop.nested_properties.reject(&:exclude).reject(&:output).each do |nested_p|
           property_hash[nested_p.name.to_sym] = property_version(nested_p,
                                                                  path + [prop.name], struct)
         end


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

<!-- Your regular pull request description goes here -->
Ansible is listing nested output: true fields as properties. That's incorrect. This also involves not giving those properties an Ansible version (since they aren't Ansible fields + don't have a version).



<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
