### PR TITLE
Fix spurious black error when generating Terraform

### DIFF
--- a/provider/core.rb
+++ b/provider/core.rb
@@ -417,7 +417,7 @@ module Provider
 
     def run_formatter(command)
       output = %x(#{command} 2>&1)
-      Google::LOGGER.error output unless $CHILD_STATUS&.exitstatus&.zero?
+      Google::LOGGER.error output unless $CHILD_STATUS.to_i == 0
     end
 
     def wrap_field(field, spaces)

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -417,7 +417,7 @@ module Provider
 
     def run_formatter(command)
       output = %x(#{command} 2>&1)
-      Google::LOGGER.error output unless $CHILD_STATUS.to_i == 0
+      Google::LOGGER.error output unless $CHILD_STATUS.to_i.zero?
     end
 
     def wrap_field(field, spaces)


### PR DESCRIPTION
An unrelated change to formatters in #1472 started causing spurious errors in Terraform generation per-file because it was considered an error to not have `black` installed.

This stops the false positives, but could suppress false negatives again; not sure how to trigger a `black` error. Taken from https://docs.ruby-lang.org/ja/latest/method/Kernel/v/CHILD_STATUS.html.

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
