### PR TITLE
Add :exclude_import to Terraform resource properties

### DIFF
--- a/overrides/terraform/resource_override.rb
+++ b/overrides/terraform/resource_override.rb
@@ -37,7 +37,10 @@ module Overrides
           :examples,
 
           # TODO(alexstephen): Deprecate once all resources using autogen async.
-          :autogen_async
+          :autogen_async,
+
+          # Flag - if false, resource is not importable
+          :importable
         ]
       end
 
@@ -57,6 +60,7 @@ module Overrides
         check :docs, type: Provider::Terraform::Docs, default: Provider::Terraform::Docs.new
         check :import_format, type: Array, item_type: String, default: []
         check :autogen_async, type: :boolean, default: false
+        check :importable, type: :boolean, default: true
       end
 
       def apply(resource)

--- a/overrides/terraform/resource_override.rb
+++ b/overrides/terraform/resource_override.rb
@@ -40,7 +40,7 @@ module Overrides
           :autogen_async,
 
           # Flag - if false, resource is not importable
-          :importable
+          :exclude_import
         ]
       end
 
@@ -60,7 +60,7 @@ module Overrides
         check :docs, type: Provider::Terraform::Docs, default: Provider::Terraform::Docs.new
         check :import_format, type: Array, item_type: String, default: []
         check :autogen_async, type: :boolean, default: false
-        check :importable, type: :boolean, default: true
+        check :exclude_import, type: :boolean, default: false
       end
 
       def apply(resource)

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -50,7 +50,7 @@ func resource<%= resource_name -%>() *schema.Resource {
         ),
 <%      end -%>
 
-<%      if object.importable -%>
+<%      unless object.exclude_import -%>
         Importer: &schema.ResourceImporter{
             State: resource<%= resource_name -%>Import,
         },
@@ -563,7 +563,7 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
     return nil
 }
 
-<% if object.importable -%>
+<% unless object.exclude_import -%>
 func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 <% if object.custom_code.custom_import -%>
 <%= lines(compile(object.custom_code.custom_import)) -%>

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -50,10 +50,11 @@ func resource<%= resource_name -%>() *schema.Resource {
         ),
 <%      end -%>
 
+<%      if object.importable -%>
         Importer: &schema.ResourceImporter{
             State: resource<%= resource_name -%>Import,
         },
-
+<%      end -%>
 
         Timeouts: &schema.ResourceTimeout {
             Create: schema.DefaultTimeout(<%= timeouts.insert_sec  -%> * time.Second),
@@ -562,6 +563,7 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
     return nil
 }
 
+<% if object.importable -%>
 func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 <% if object.custom_code.custom_import -%>
 <%= lines(compile(object.custom_code.custom_import)) -%>
@@ -582,6 +584,7 @@ func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{
     return []*schema.ResourceData{d}, nil
 <% end -%>
 }
+<% end -%>
 
 <% properties.reject(&:ignore_read).each do |prop| -%>
 <%= lines(build_flatten_method(resource_name, prop), 1) -%>


### PR DESCRIPTION
<!--
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

<!-- Your regular pull request description goes here -->
Add :exclude_import for non-importable resources (signed url key for example only has key name and a sensitive value which is not returned from server, so it seems weird to have an importer)

Precedes https://github.com/GoogleCloudPlatform/magic-modules/pull/1504

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
