### PR TITLE
boolean checks on difference checker

### DIFF
--- a/provider/ansible/gcp_utils.py
+++ b/provider/ansible/gcp_utils.py
@@ -273,19 +273,11 @@ class GcpRequest(object):
     # Takes in two lists and compares them.
     def _compare_lists(self, list1, list2):
         difference = []
-        list1.sort()
-        list2.sort()
         for index in range(len(list1)):
             value1 = list1[index]
-            # If items are dicts or arrays, we're assuming the next value
-            # is the correct one.
-            if isinstance(value1, dict) or isinstance(value1, list):
-                if index < len(list2):
-                    value2 = list2[index]
-                    difference.append(self._compare_value(value1, value2))
-            else:
-                if value1 not in list2:
-                    difference.append(value1)
+            if index < len(list2):
+                value2 = list2[index]
+                difference.append(self._compare_value(value1, value2))
 
         difference2 = []
         for value in difference:
@@ -307,6 +299,8 @@ class GcpRequest(object):
                 diff = self._compare_lists(value1, value2)
             elif isinstance(value2, dict):
                 diff = self._compare_dicts(value1, value2)
+            elif isinstance(value1, bool):
+                diff = self._compare_boolean(value1, value2)
             # Always use to_text values to avoid unicode issues.
             elif to_text(value1) != to_text(value2):
                 diff = value1
@@ -316,3 +310,25 @@ class GcpRequest(object):
             pass
 
         return diff
+
+    def _compare_boolean(self, value1, value2):
+        try:
+            # Both True
+            if value1 and value2:
+                return None
+            # Value1 True, value2 'true'
+            elif value1 and to_text(value2) == 'true':
+                return None
+            # Both False
+            elif not value1 and not value2:
+                return None
+            # Value1 False, value2 'false'
+            elif not value1 and to_text(value2) == 'false':
+                return None
+            else:
+                return value2
+
+        # to_text may throw UnicodeErrors.
+        # These errors shouldn't crash Ansible and should be hidden.
+        except UnicodeError:
+            return None

--- a/provider/ansible/gcp_utils.py
+++ b/provider/ansible/gcp_utils.py
@@ -314,13 +314,13 @@ class GcpRequest(object):
     def _compare_boolean(self, value1, value2):
         try:
             # Both True
-            if value1 and value2 is True:
+            if value1 and isinstance(value2, bool) and value2:
                 return None
             # Value1 True, value2 'true'
             elif value1 and to_text(value2) == 'true':
                 return None
             # Both False
-            elif not value1 and not value2:
+            elif not value1 and isinstance(value2, bool) and not value2:
                 return None
             # Value1 False, value2 'false'
             elif not value1 and to_text(value2) == 'false':

--- a/provider/ansible/gcp_utils.py
+++ b/provider/ansible/gcp_utils.py
@@ -314,7 +314,7 @@ class GcpRequest(object):
     def _compare_boolean(self, value1, value2):
         try:
             # Both True
-            if value1 and value2:
+            if value1 and value2 is True:
                 return None
             # Value1 True, value2 'true'
             elif value1 and to_text(value2) == 'true':


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

The GCP API turns 'true' (string) when you give it a `True` (boolean). This breaks my handwritten difference checker.

After doing some more tests, I ended up reverting a past change I made to the difference checker but didn't backport that change. So, it's showing up now.




<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
