### PR TITLE
removing no-op label

### DIFF
--- a/.ci/magic-modules/create-pr.sh
+++ b/.ci/magic-modules/create-pr.sh
@@ -185,6 +185,8 @@ fi
 echo "$MESSAGE" > ./pr_comment
 
 # Create Labels list with the comma-separated list of labels for this PR
-if [ ! -z "$LABELS" ]; then
+if [ -z "$LABELS" ]; then
+  touch ./label_file
+else
   printf "%s" "$LABELS" > ./label_file
 fi

--- a/.ci/magic-modules/create-pr.sh
+++ b/.ci/magic-modules/create-pr.sh
@@ -185,8 +185,6 @@ fi
 echo "$MESSAGE" > ./pr_comment
 
 # Create Labels list with the comma-separated list of labels for this PR
-if [ -z "$LABELS" ]; then
-  printf "%s" "no-op" > ./label_file
-else
+if [ ! -z "$LABELS" ]; then
   printf "%s" "$LABELS" > ./label_file
 fi


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

The no-op label has been placed on every PR and isn't a signal. A lack of labels (i.e. no downstreams) is more effective.



<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
