### PR TITLE
Add new resource, google_logging_metric

### DIFF
--- a/products/logging/api.yaml
+++ b/products/logging/api.yaml
@@ -1,0 +1,137 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+!ruby/object:Api::Product
+name: Logging
+display_name: Stackdriver Logging
+versions:
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://logging.googleapis.com/v2/
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: Stackdriver Logging API
+    url: https://console.cloud.google.com/apis/library/logging.googleapis.com/
+objects:
+  - !ruby/object:Api::Resource
+    name: "Metric"
+    base_url: projects/{{project}}/metrics
+    self_link: "projects/{{project}}/metrics/{{name}}"
+    update_verb: :PUT
+    description: |
+      A custom metric
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        "Official Documentation": "https://cloud.google.com/logging/docs/reference/v2/rest/v2"
+      api: "https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.metrics/create"
+    properties:
+      - !ruby/object:Api::Type::String
+        name: name
+        description: |
+          The name
+        required: true
+      - !ruby/object:Api::Type::String
+        name: description
+        description: |
+          The description
+        required: false
+      - !ruby/object:Api::Type::String
+        name: filter
+        description: |
+          The filter
+        required: true
+      - !ruby/object:Api::Type::NestedObject
+        name: metricDescriptor
+        description: |
+          The metric descriptor
+        required: true
+        properties:
+          - !ruby/object:Api::Type::Enum
+            name: valueType
+            description: |
+              Value
+            values:
+              - :BOOL
+              - :INT64
+              - :DOUBLE
+              - :STRING
+              - :DISTRIBUTION
+              - :MONEY
+            required: true
+          - !ruby/object:Api::Type::Enum
+            name: metricKind
+            description: |
+              Blah
+            values:
+              - :DELTA
+            required: true
+          - !ruby/object:Api::Type::Array
+            name: labels
+            description: |
+              Blah
+            required: false
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: key
+                  description: |
+                    The key
+                  required: true
+                - !ruby/object:Api::Type::String
+                  name: description
+                  description: |
+                    The description
+                  required: false
+                - !ruby/object:Api::Type::Enum
+                  name: valueType
+                  description: |
+                    How to combine the results of multiple conditions to
+                    determine if an incident should be opened.
+                  values:
+                    - :BOOL
+                    - :INT64
+                    - :STRING
+                  required: false
+                  default_value: :STRING
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: labelExtractors
+        description: |
+          Desc
+      - !ruby/object:Api::Type::String
+        name: valueExtractor
+        description: |
+          Desc
+      - !ruby/object:Api::Type::NestedObject
+        name: bucketOptions
+        description: |
+          Desc
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: exponentialBuckets
+            description: |
+              Desc
+            properties:
+              - !ruby/object:Api::Type::Integer
+                name: numFiniteBuckets
+                description: |
+                  Desc
+              - !ruby/object:Api::Type::Integer
+                name: growthFactor
+                description: |
+                  Desc
+              - !ruby/object:Api::Type::Double
+                name: scale
+                description: |
+                  Desc

--- a/products/logging/api.yaml
+++ b/products/logging/api.yaml
@@ -31,7 +31,7 @@ objects:
     self_link: "projects/{{project}}/metrics/{{name}}"
     update_verb: :PUT
     description: |
-      A custom metric
+      Logs-based metric can also be used to extract values from logs and create a a distribution of the values. The distribution records the statistics of the extracted values along with an optional histogram of the values as specified by the bucket options.
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         "Official Documentation": "https://cloud.google.com/logging/docs/reference/v2/rest/v2"
@@ -40,28 +40,28 @@ objects:
       - !ruby/object:Api::Type::String
         name: name
         description: |
-          The name
+          The client-assigned metric identifier. Examples: "error_count", "nginx/requests".
         required: true
       - !ruby/object:Api::Type::String
         name: description
         description: |
-          The description
+          A description of this metric, which is used in documentation. The maximum length of the description is 8000 characters.
         required: false
       - !ruby/object:Api::Type::String
         name: filter
         description: |
-          The filter
+          An advanced logs filter which is used to match log entries.
         required: true
       - !ruby/object:Api::Type::NestedObject
         name: metricDescriptor
         description: |
-          The metric descriptor
+          The metric descriptor associated with the logs-based metric. If unspecified, it uses a default metric descriptor with a DELTA metric kind, INT64 value type, with no labels and a unit of "1". Such a metric counts the number of log entries matching the filter expression.
         required: true
         properties:
           - !ruby/object:Api::Type::Enum
             name: valueType
             description: |
-              Value
+              Whether the measurement is an integer, a floating-point number, etc. Some combinations of metricKind and valueType might not be supported.Whether the measurement is an integer, a floating-point number, etc. Some combinations of metricKind and valueType might not be supported.
             values:
               - :BOOL
               - :INT64
@@ -73,32 +73,31 @@ objects:
           - !ruby/object:Api::Type::Enum
             name: metricKind
             description: |
-              Blah
+              Whether the metric records instantaneous values, changes to a value, etc. Some combinations of metricKind and valueType might not be supported.
             values:
               - :DELTA
             required: true
           - !ruby/object:Api::Type::Array
             name: labels
             description: |
-              Blah
+              The set of labels that can be used to describe a specific instance of this metric type. For example, the appengine.googleapis.com/http/server/response_latencies metric type has a label for the HTTP response code, response_code, so you can look at latencies for successful responses or just for responses that failed.
             required: false
             item_type: !ruby/object:Api::Type::NestedObject
               properties:
                 - !ruby/object:Api::Type::String
                   name: key
                   description: |
-                    The key
+                    The label key.
                   required: true
                 - !ruby/object:Api::Type::String
                   name: description
                   description: |
-                    The description
+                    A human-readable description for the label.
                   required: false
                 - !ruby/object:Api::Type::Enum
                   name: valueType
                   description: |
-                    How to combine the results of multiple conditions to
-                    determine if an incident should be opened.
+                    The type of data that can be assigned to the label.
                   values:
                     - :BOOL
                     - :INT64
@@ -108,15 +107,15 @@ objects:
       - !ruby/object:Api::Type::KeyValuePairs
         name: labelExtractors
         description: |
-          Desc
+          A map from a label key string to an extractor expression which is used to extract data from a log entry field and assign as the label value. Each label key specified in the LabelDescriptor must have an associated extractor expression in this map. The syntax of the extractor expression is the same as for the valueExtractor field.
       - !ruby/object:Api::Type::String
         name: valueExtractor
         description: |
-          Desc
+          A valueExtractor is required when using a distribution logs-based metric to extract the values to record from a log entry. Two functions are supported for value extraction: EXTRACT(field) or REGEXP_EXTRACT(field, regex). The argument are: 1. field: The name of the log entry field from which the value is to be extracted. 2. regex: A regular expression using the Google RE2 syntax (https://github.com/google/re2/wiki/Syntax) with a single capture group to extract data from the specified log entry field. The value of the field is converted to a string before applying the regex. It is an error to specify a regex that does not include exactly one capture group.
       - !ruby/object:Api::Type::NestedObject
         name: bucketOptions
         description: |
-          Desc
+          The bucketOptions are required when the logs-based metric is using a DISTRIBUTION value type and it describes the bucket boundaries used to create a histogram of the extracted values.
         properties:
           - !ruby/object:Api::Type::NestedObject
             name: exponentialBuckets
@@ -126,12 +125,12 @@ objects:
               - !ruby/object:Api::Type::Integer
                 name: numFiniteBuckets
                 description: |
-                  Desc
+                  Must be greater than 0.
               - !ruby/object:Api::Type::Integer
                 name: growthFactor
                 description: |
-                  Desc
+                  Must be greater than 1.
               - !ruby/object:Api::Type::Double
                 name: scale
                 description: |
-                  Desc
+                  Must be greater than 0.

--- a/products/logging/api.yaml
+++ b/products/logging/api.yaml
@@ -118,9 +118,26 @@ objects:
           The bucketOptions are required when the logs-based metric is using a DISTRIBUTION value type and it describes the bucket boundaries used to create a histogram of the extracted values.
         properties:
           - !ruby/object:Api::Type::NestedObject
+            name: linearBuckets
+            description: |
+              Specifies a linear sequence of buckets that all have the same width (except overflow and underflow). Each bucket represents a constant absolute uncertainty on the specific value in the bucket.
+            properties:
+              - !ruby/object:Api::Type::Integer
+                name: numFiniteBuckets
+                description: |
+                  Must be greater than 0.
+              - !ruby/object:Api::Type::Integer
+                name: width
+                description: |
+                  Must be greater than 0.
+              - !ruby/object:Api::Type::Double
+                name: offset
+                description: |
+                  Lower bound of the first bucket.
+          - !ruby/object:Api::Type::NestedObject
             name: exponentialBuckets
             description: |
-              Desc
+              Specifies an exponential sequence of buckets that have a width that is proportional to the value of the lower bound. Each bucket represents a constant relative uncertainty on a specific value in the bucket.
             properties:
               - !ruby/object:Api::Type::Integer
                 name: numFiniteBuckets
@@ -134,3 +151,13 @@ objects:
                 name: scale
                 description: |
                   Must be greater than 0.
+          - !ruby/object:Api::Type::NestedObject
+            name: explicit
+            description: |
+              Specifies a set of buckets with arbitrary widths.
+            properties:
+              - !ruby/object:Api::Type::Array
+                name: bounds
+                item_type: !ruby/object:Api::Type::Integer
+                description: |
+                  The values must be monotonically increasing.

--- a/products/logging/api.yaml
+++ b/products/logging/api.yaml
@@ -158,6 +158,6 @@ objects:
             properties:
               - !ruby/object:Api::Type::Array
                 name: bounds
-                item_type: !ruby/object:Api::Type::Integer
+                item_type: Api::Type::String
                 description: |
                   The values must be monotonically increasing.

--- a/products/logging/terraform.yaml
+++ b/products/logging/terraform.yaml
@@ -18,16 +18,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     mutex: customMetric/{{project}}
     examples:
       - !ruby/object:Provider::Terraform::Examples
-        name: "monitoring_alert_policy_basic"
-        primary_resource_id: "alert_policy"
+        name: "logging_metric_basic"
+        primary_resource_id: "logging_metric"
         vars:
-          alert_policy_display_name: "My Alert Policy"
+          metric_display_name: "My Custom Metric"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/self_link_as_name.erb
       post_create: templates/terraform/post_create/set_computed_name.erb
     properties:
       metricDescriptor.labels.valueType: !ruby/object:Overrides::Terraform::PropertyOverride
-        # custom_expand: 'templates/terraform/custom_expand/cloudscheduler_job_name.erb'
         custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
 
 files: !ruby/object:Provider::Config::Files

--- a/products/logging/terraform.yaml
+++ b/products/logging/terraform.yaml
@@ -1,0 +1,37 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- !ruby/object:Provider::Terraform::Config
+overrides: !ruby/object:Overrides::ResourceOverrides
+  Metric: !ruby/object:Overrides::Terraform::ResourceOverride
+    id_format: "{{name}}"
+    import_format: ["{{name}}"]
+    mutex: customMetric/{{project}}
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "monitoring_alert_policy_basic"
+        primary_resource_id: "alert_policy"
+        vars:
+          alert_policy_display_name: "My Alert Policy"
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      custom_import: templates/terraform/custom_import/self_link_as_name.erb
+      post_create: templates/terraform/post_create/set_computed_name.erb
+    properties:
+      metricDescriptor.labels.valueType: !ruby/object:Overrides::Terraform::PropertyOverride
+        # custom_expand: 'templates/terraform/custom_expand/cloudscheduler_job_name.erb'
+        custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
+
+files: !ruby/object:Provider::Config::Files
+  # These files have templating (ERB) code that will be run.
+  # This is usually to add licensing info, autogeneration notices, etc.
+  compile:
+<%= lines(indent(compile('provider/terraform/product~compile.yaml'), 4)) -%>

--- a/templates/terraform/examples/logging_metric_basic.tf.erb
+++ b/templates/terraform/examples/logging_metric_basic.tf.erb
@@ -1,0 +1,3 @@
+resource "google_logging_metric" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]["display_name"] %>"
+}


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

Opening this as a draft PR, though I hope it won't kick off the build robot. I wanted to validate my approach early, and will finish over the next couple of days.

**Usage as follows**

```terraform
resource "google_logging_metric" "api_latency" {
  name        = "api-latency"
  filter      = "resource.type=\"k8s_container\" resource.labels.cluster_name=\"cluster\" resource.labels.namespace_name=\"default\" resource.labels.container_name=\"api\" jsonPayload.type=\"request\""
  description = "API latency"

  metric_descriptor = {
    metric_kind = "DELTA"
    value_type  = "DISTRIBUTION"

    labels = [
      {
        key         = "path"
        description = "The request path"
        value_type  = "STRING"
      },
    ]
  }

  value_extractor = "EXTRACT(jsonPayload.event.responseTimeMs)"

  label_extractors = {
    path = "EXTRACT(jsonPayload.event.url)"
  }

  bucket_options = {
    exponential_buckets = {
      num_finite_buckets = 64
      growth_factor      = 2
      scale              = 0.01
    }
  }
}

```


<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
Logs-based metrics support
### [terraform-beta]
## [ansible]
## [inspec]
