### PR TITLE
Third party label isn't showing up

### DIFF
--- a/.ci/magic-modules/create-pr.sh
+++ b/.ci/magic-modules/create-pr.sh
@@ -46,7 +46,7 @@ LABELS=""
 
 # Check the files between this commit and HEAD
 # If they're only contained in third_party, add the third_party label.
-if [ ! git diff --name-only HEAD^1 | grep -v "third_party" ]; then
+if [ ! git diff --name-only HEAD^1 | grep -v "third_party" | grep -v ".gitmodules" | grep -r "build/" ]; then
   LABELS="${LABELS}only_third_party,"
 fi
 

--- a/.ci/magic-modules/create-pr.sh
+++ b/.ci/magic-modules/create-pr.sh
@@ -46,7 +46,7 @@ LABELS=""
 
 # Check the files between this commit and HEAD
 # If they're only contained in third_party, add the third_party label.
-if ! git diff --name-only HEAD^1 | grep -v "third_party"; then
+if [ ! git diff --name-only HEAD^1 | grep -v "third_party" ]; then
   LABELS="${LABELS}only_third_party,"
 fi
 


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->
I forgot about changes in `.gitmodules` and `build/`, which are always occurring. Hence, why the only_third_party label has never shown up.




<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
