### PR TITLE
[terraform-conversions] Add json tags to CAI asset.

### DIFF
--- a/third_party/validator/cai.go
+++ b/third_party/validator/cai.go
@@ -3,34 +3,34 @@ package google
 // Asset is the CAI representation of a resource.
 type Asset struct {
 	// The name, in a peculiar format: `\\<api>.googleapis.com/<self_link>`
-	Name string
+	Name string `json:"name"`
 	// The type name in `google.<api>.<resourcename>` format.
-	Type      string
-	Resource  *AssetResource
-	IAMPolicy *IAMPolicy
+	Type      string         `json:"asset_type"`
+	Resource  *AssetResource `json:"resource,omitempty"`
+	IAMPolicy *IAMPolicy     `json:"iam_policy,omitempty"`
 }
 
 // AssetResource is the Asset's Resource field.
 type AssetResource struct {
 	// Api version
-	Version string
+	Version string `json:"version"`
 	// URI including scheme for the discovery doc - assembled from
 	// product name and version.
-	DiscoveryDocumentURI string
+	DiscoveryDocumentURI string `json:"discovery_document_uri"`
 	// Resource name.
-	DiscoveryName string
+	DiscoveryName string `json:"discovery_name"`
 	// Actual resource state as per Terraform.  Note that this does
 	// not necessarily correspond perfectly with the CAI representation
 	// as there are occasional deviations between CAI and API responses.
 	// This returns the API response values instead.
-	Data map[string]interface{}
+	Data map[string]interface{} `json:"data,omitempty"`
 }
 
 type IAMPolicy struct {
-	Bindings []IAMBinding
+	Bindings []IAMBinding `json:"bindings"`
 }
 
 type IAMBinding struct {
-	Role    string
-	Members []string
+	Role    string   `json:"role"`
+	Members []string `json:"members"`
 }


### PR DESCRIPTION
JSON is the lingua franca of CAI. Adding json tags makes the Asset type
more useful downstream as it can be marshaled directly.