### PR TITLE
[terraform-conversions] Update CAI Asset Type to use v1 format

### DIFF
--- a/templates/terraform/objectlib/base.go.erb
+++ b/templates/terraform/objectlib/base.go.erb
@@ -21,7 +21,7 @@ func Get<%= resource_name -%>CaiObject(d TerraformResourceData, config *Config) 
     if obj, err := Get<%= resource_name -%>ApiObject(d, config); err == nil {
         return Asset{
             Name: name,
-            Type: "google.<%= product_ns.downcase -%>.<%= object.name -%>",
+            Type: "<%= product_ns.downcase -%>.googleapis.com/<%= object.name -%>",
             Resource: &AssetResource{
                 Version: "<%= api_version -%>",
                 DiscoveryDocumentURI: "https://www.googleapis.com/discovery/v1/apis/<%= product_ns.downcase -%>/<%= api_version -%>/rest",

--- a/third_party/validator/compute_instance.go
+++ b/third_party/validator/compute_instance.go
@@ -26,7 +26,7 @@ func GetComputeInstanceCaiObject(d TerraformResourceData, config *Config) (Asset
 	if obj, err := GetComputeInstanceApiObject(d, config); err == nil {
 		return Asset{
 			Name: name,
-			Type: "google.compute.Instance",
+			Type: "compute.googleapis.com/Instance",
 			Resource: &AssetResource{
 				Version:              "v1",
 				DiscoveryDocumentURI: "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",

--- a/third_party/validator/sql_database_instance.go
+++ b/third_party/validator/sql_database_instance.go
@@ -26,7 +26,7 @@ func GetSQLDatabaseInstanceCaiObject(d TerraformResourceData, config *Config) (A
 	if obj, err := GetSQLDatabaseInstanceApiObject(d, config); err == nil {
 		return Asset{
 			Name: name,
-			Type: "google.cloud.sql.Instance",
+			Type: "sqladmin.googleapis.com/Instance",
 			Resource: &AssetResource{
 				Version:              "v1beta4",
 				DiscoveryDocumentURI: "https://www.googleapis.com/discovery/v1/apis/sqladmin/v1beta4/rest",

--- a/third_party/validator/storage_bucket.go
+++ b/third_party/validator/storage_bucket.go
@@ -25,7 +25,7 @@ func GetStorageBucketCaiObject(d TerraformResourceData, config *Config) (Asset, 
 	if obj, err := GetStorageBucketApiObject(d, config); err == nil {
 		return Asset{
 			Name: name,
-			Type: "google.cloud.storage.Bucket",
+			Type: "storage.googleapis.com/Bucket",
 			Resource: &AssetResource{
 				Version:              "v1",
 				DiscoveryDocumentURI: "https://www.googleapis.com/discovery/v1/apis/storage/v1/rest",


### PR DESCRIPTION
Update CAI Asset Type to use v1 format

See:
https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview#supported_resource_types
