### PR TITLE
re-adding force flag

### DIFF
--- a/.ci/magic-modules/release-ansible.sh
+++ b/.ci/magic-modules/release-ansible.sh
@@ -88,7 +88,7 @@ for filename in mm-bug*; do
 
   # Create PR
   ssh-agent bash -c "ssh-add ~/github_private_key; git push origin bug_fixes$filename --force"
-  hub pull-request -b ansible/ansible:devel -F bug_fixes$filename
+  hub pull-request -b ansible/ansible:devel -F bug_fixes$filename -f
   set -e
 
   echo "Bug Fix PR built for $filename"


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

This looks like it was lost during a bad merge or something. Release script doesn't work properly without a force flag (hub doesn't like that the Magician repo + Ansible repo are so many commits apart).

The release script builds a single commit on top of the ansible/ansible branch, so the large difference in commits doesn't matter.




<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
