### PR TITLE
[terraform-conversions] Fix non-generated CAI asset names

### DIFF
--- a/third_party/validator/compute_instance.go
+++ b/third_party/validator/compute_instance.go
@@ -19,9 +19,13 @@ import (
 )
 
 func GetComputeInstanceCaiObject(d TerraformResourceData, config *Config) (Asset, error) {
+	name, err := replaceVars(d, config, "//compute.googleapis.com/projects/{{project}}/zones/{{zone}}/instances/{{name}}")
+	if err != nil {
+		return Asset{}, err
+	}
 	if obj, err := GetComputeInstanceApiObject(d, config); err == nil {
 		return Asset{
-			Name: fmt.Sprintf("//compute.googleapis.com/%s", obj["selfLink"]),
+			Name: name,
 			Type: "google.compute.Instance",
 			Resource: &AssetResource{
 				Version:              "v1",

--- a/third_party/validator/sql_database_instance.go
+++ b/third_party/validator/sql_database_instance.go
@@ -9,7 +9,6 @@
 package google
 
 import (
-	"fmt"
 	"regexp"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -20,9 +19,13 @@ import (
 )
 
 func GetSQLDatabaseInstanceCaiObject(d TerraformResourceData, config *Config) (Asset, error) {
+	name, err := replaceVars(d, config, "//cloudsql.googleapis.com/projects/{{project}}/instances/{{name}}")
+	if err != nil {
+		return Asset{}, err
+	}
 	if obj, err := GetSQLDatabaseInstanceApiObject(d, config); err == nil {
 		return Asset{
-			Name: fmt.Sprintf("//cloudsql.googleapis.com/%s", obj["selfLink"]),
+			Name: name,
 			Type: "google.cloud.sql.Instance",
 			Resource: &AssetResource{
 				Version:              "v1beta4",

--- a/third_party/validator/storage_bucket.go
+++ b/third_party/validator/storage_bucket.go
@@ -18,11 +18,13 @@ import (
 )
 
 func GetStorageBucketCaiObject(d TerraformResourceData, config *Config) (Asset, error) {
+	name, err := replaceVars(d, config, "//storage.googleapis.com/{{name}}")
+	if err != nil {
+		return Asset{}, err
+	}
 	if obj, err := GetStorageBucketApiObject(d, config); err == nil {
 		return Asset{
-			// NOTE: selfLink is currently broken:
-			// https://github.com/GoogleCloudPlatform/terraform-google-conversion/issues/10
-			Name: fmt.Sprintf("//storage.googleapis.com/%s", obj["selfLink"]),
+			Name: name,
 			Type: "google.cloud.storage.Bucket",
 			Resource: &AssetResource{
 				Version:              "v1",


### PR DESCRIPTION
Fix the non-generated CAI asset names to match: https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/resource-name-format