### PR TITLE
Use out_name instead of name for nested properties in markdown doc.

### DIFF
--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -206,7 +206,7 @@ module Provider
     end
 
     def markdown_format(property)
-      "    * `#{property.name}`: #{property.description.split("\n").join(' ')}"
+      "    * `#{property.out_name}`: #{property.description.split("\n").join(' ')}"
     end
 
     def grab_attributes


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

<!-- Your regular pull request description goes here -->
InSpec docs currently incorrectly use camelCase for nested property names. This fixes that by using out_name instead of name



<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
