### PR TITLE
uploading coverage spreadsheet to a bucket

### DIFF
--- a/.ci/magic-modules/coverage-spreadsheet-upload.sh
+++ b/.ci/magic-modules/coverage-spreadsheet-upload.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+set -x
+
+# Service account credentials for GCP to allow terraform to work
+export GOOGLE_CLOUD_KEYFILE_JSON="/tmp/google-account.json"
+export GOOGLE_APPLICATION_CREDENTIALS="/tmp/google-account.json"
+
+# CI sets the contents of our json account secret in our environment; dump it
+# to disk for use in tests.
+set +x
+echo "${SERVICE_ACCOUNT}" > /tmp/google-account.json
+set -x
+
+gcloud auth activate-service-account  magic-modules-spreadsheet@magic-modules.iam.gserviceaccount.com --key-file=$GOOGLE_CLOUD_KEYFILE_JSON
+
+pushd magic-modules-new-prs
+bundle install
+gem install rspec
+
+bundle exec rspec tools/linter/spreadsheet.rb || true
+
+echo "File created"
+date=$(date +'%m%d%Y')
+echo "Date established"
+
+gsutil cp output.csv gs://magic-modules-coverage/$date.csv
+popd

--- a/.ci/magic-modules/coverage-spreadsheet-upload.sh
+++ b/.ci/magic-modules/coverage-spreadsheet-upload.sh
@@ -15,7 +15,7 @@ set -x
 
 gcloud auth activate-service-account  magic-modules-spreadsheet@magic-modules.iam.gserviceaccount.com --key-file=$GOOGLE_CLOUD_KEYFILE_JSON
 
-pushd magic-modules-new-prs
+pushd magic-modules-gcp
 bundle install
 gem install rspec
 

--- a/.ci/magic-modules/coverage-spreadsheet-upload.yml
+++ b/.ci/magic-modules/coverage-spreadsheet-upload.yml
@@ -9,7 +9,7 @@ image_resource:
         tag: '0.11.10-3.0.25'
 
 inputs:
-    - name: magic-modules-new-prs
+    - name: magic-modules-gcp
 
 run:
-    path: magic-modules-new-prs/.ci/magic-modules/coverage-spreadsheet-upload.sh
+    path: magic-modules-gcp/.ci/magic-modules/coverage-spreadsheet-upload.sh

--- a/.ci/magic-modules/coverage-spreadsheet-upload.yml
+++ b/.ci/magic-modules/coverage-spreadsheet-upload.yml
@@ -1,0 +1,15 @@
+---
+platform: linux
+
+image_resource:
+# This image has gcloud, which we need for uploading coverage file to a bucket.
+    type: docker-image
+    source:
+        repository: gcr.io/magic-modules/terraform-gcloud-inspec
+        tag: '0.11.10-3.0.25'
+
+inputs:
+    - name: magic-modules-new-prs
+
+run:
+    path: magic-modules-new-prs/.ci/magic-modules/coverage-spreadsheet-upload.sh

--- a/.ci/release.yml.tmpl
+++ b/.ci/release.yml.tmpl
@@ -46,6 +46,15 @@ resources:
           uri: git@github.com:terraform-providers/terraform-provider-google.git
           private_key: ((repo-key.private_key))
 
+    - name: magic-modules-new-prs
+      type: github-pull-request
+      source:
+          repo: GoogleCloudPlatform/magic-modules
+          private_key: ((repo-key.private_key))
+          access_token: ((github-account.password))
+          authorship_restriction: true
+          no_label: automerged
+
 jobs:
     - name: ansible-nightly-release
       plan:
@@ -58,6 +67,14 @@ jobs:
             params:
                 GITHUB_TOKEN: ((github-account.password))
                 CREDS: ((repo-key.private_key))
+    - name: coverage-spreadsheet-release
+      plan:
+          - get: magic-modules-new-prs
+            trigger: false
+          - task: build
+            file: magic-modules-new-prs/.ci/magic-modules/coverage-spreadsheet-upload.yml
+            params:
+                SERVICE_ACCOUNT: ((magic-modules-service-account))
     - name: nightly-build
       plan:
           - get: night-trigger
@@ -68,13 +85,13 @@ jobs:
           - task: build
             file: magic-modules-gcp/.ci/magic-modules/generate-terraform-all-platforms.yml
 
-          {% for arch in ['darwin_amd64', 'freebsd_386', 'freebsd_amd64', 'freebsd_arm',
-          'linux_386', 'linux_amd64', 'linux_arm', 'openbsd_386', 'openbsd_amd64',
-          'solaris_amd64', 'windows_386.exe', 'windows_amd64.exe'] %}
+{% for arch in ['darwin_amd64', 'freebsd_386', 'freebsd_amd64', 'freebsd_arm',
+'linux_386', 'linux_amd64', 'linux_arm', 'openbsd_386', 'openbsd_amd64',
+'solaris_amd64', 'windows_386.exe', 'windows_amd64.exe'] %}
           - put: gcp-bucket
             params:
               file: dist/terraform-provider-google.{{arch}}
-          {% endfor %}
+{% endfor %}
 
     - name: inspec-integration-test
       serial: true

--- a/.ci/release.yml.tmpl
+++ b/.ci/release.yml.tmpl
@@ -45,16 +45,6 @@ resources:
       source:
           uri: git@github.com:terraform-providers/terraform-provider-google.git
           private_key: ((repo-key.private_key))
-
-    - name: magic-modules-new-prs
-      type: github-pull-request
-      source:
-          repo: GoogleCloudPlatform/magic-modules
-          private_key: ((repo-key.private_key))
-          access_token: ((github-account.password))
-          authorship_restriction: true
-          no_label: automerged
-
 jobs:
     - name: ansible-nightly-release
       plan:
@@ -69,10 +59,12 @@ jobs:
                 CREDS: ((repo-key.private_key))
     - name: coverage-spreadsheet-release
       plan:
-          - get: magic-modules-new-prs
+          - get: night-trigger
+            trigger: true
+          - get: magic-modules-gcp
             trigger: false
           - task: build
-            file: magic-modules-new-prs/.ci/magic-modules/coverage-spreadsheet-upload.yml
+            file: magic-modules-gcp/.ci/magic-modules/coverage-spreadsheet-upload.yml
             params:
                 SERVICE_ACCOUNT: ((magic-modules-service-account))
     - name: nightly-build

--- a/tools/linter/spreadsheet/csv_formatter.rb
+++ b/tools/linter/spreadsheet/csv_formatter.rb
@@ -32,7 +32,8 @@ class CsvFormatterForMM
 
   # Places in the CSV header
   def start(_start_notification)
-    @output << ['Date', 'Product', 'Resource', 'Property', 'api.yaml', 'terraform', 'ansible'].to_csv
+    @output << ['Date',
+                'Product', 'Resource', 'Property', 'api.yaml', 'terraform', 'ansible'].to_csv
   end
 
   # This property exists in api.yaml

--- a/tools/linter/spreadsheet/csv_formatter.rb
+++ b/tools/linter/spreadsheet/csv_formatter.rb
@@ -32,7 +32,7 @@ class CsvFormatterForMM
 
   # Places in the CSV header
   def start(_start_notification)
-    @output << ['Product', 'Resource', 'Property', 'api.yaml', 'terraform', 'ansible'].to_csv
+    @output << ['Date', 'Product', 'Resource', 'Property', 'api.yaml', 'terraform', 'ansible'].to_csv
   end
 
   # This property exists in api.yaml
@@ -59,6 +59,7 @@ class CsvFormatterForMM
   def test_information(notification)
     example_group = notification.example.metadata[:example_group]
     {
+      date: Time.now.strftime('%Y-%m-%d'),
       product: example_group[:parent_example_group][:parent_example_group][:description],
       resource: example_group[:parent_example_group][:description],
       property: example_group[:description],
@@ -68,6 +69,7 @@ class CsvFormatterForMM
 
   def info_to_csv(test_info)
     [
+      test_info[:date],
       test_info[:product], test_info[:resource], test_info[:property], test_info[:api],
       test_info[:terraform], test_info[:ansible]
     ].to_csv


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

<!-- Your regular pull request description goes here -->
I built out a Dashboard on Data Studio that requires putting the coverage spreadsheets in a bucket.

This also adds a date stamp to every row in the spreadsheet (which Data Studio needs)

This will trigger nightly which is probably overkill. We can alter this once we get an idea of how often we want it to trigger.

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
