### PR TITLE
weekly trigger

### DIFF
--- a/.ci/release.yml.tmpl
+++ b/.ci/release.yml.tmpl
@@ -40,6 +40,14 @@ resources:
         stop: 11:59 PM
         location: America/Los_Angeles
 
+    - name: week-trigger
+      type: time
+      source:
+        start: 11:00 PM
+        stop: 11:59 PM
+        days: [Sunday]
+        location: America/Los_Angeles
+
     - name: terraform-head
       type: git-branch
       source:
@@ -59,7 +67,7 @@ jobs:
                 CREDS: ((repo-key.private_key))
     - name: coverage-spreadsheet-release
       plan:
-          - get: night-trigger
+          - get: week-trigger
             trigger: true
           - get: magic-modules-gcp
             trigger: false


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->
New coverage dashboard is triggered nightly. That seems like overkill. I figured out how to make Concourse trigger weekly instead.



<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
