### PR TITLE
Fix .gitmodules to use https for Terraform mapper

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,5 +15,5 @@
 	url = https://github.com/modular-magician/inspec-gcp
 [submodule "build/terraform-mapper"]
 	path = build/terraform-mapper
-	url = git@github.com:GoogleCloudPlatform/terraform-google-conversion.git
+	url = https://github.com/GoogleCloudPlatform/terraform-google-conversion.git
     branch = master


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/magic-modules/issues/1586

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
