### PR TITLE
Migrating self_link_query to nested_query

### DIFF
--- a/api/resource.rb
+++ b/api/resource.rb
@@ -39,10 +39,6 @@ module Api
       # TODO(#302): Add support for the other providers.
       attr_reader :update_url
       attr_reader :self_link
-      # This is useful in case you need to change the query made for
-      # GET/DELETE requests only.  In particular, this is often used
-      # to add query parameters.
-      attr_reader :self_link_query
       # This is the type of response from the collection URL. It contains
       # the name of the list of items within the json, as well as the
       # type that this list should be. This is of type Api::Resource::ResponseList
@@ -200,7 +196,6 @@ module Api
       check :kind, type: String
 
       check :self_link, type: String
-      check :self_link_query, type: Api::Resource::ResponseList
       check :readonly, type: :boolean
       check :references, type: ReferenceLinks
 

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -103,11 +103,16 @@ module Api
       # rather than a list of the actual key objects
       attr_reader :is_list_of_ids
 
+      # This is used by Ansible, but may not be necessary.
+      attr_reader :kind
+
       def validate
         super
 
         check :keys, type: Array, item_type: String, required: true
         check :is_list_of_ids, type: :boolean, default: false
+
+        check :kind, type: String
       end
     end
 

--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -297,9 +297,9 @@ objects:
     self_link: |
       projects/{{project}}/managedZones/{{managed_zone}}/rrsets
       ?name={{name}}&type={{type}}
-    self_link_query: !ruby/object:Api::Resource::ResponseList
+    nested_query: !ruby/object:Api::Resource::NestedQuery
       kind: 'dns#resourceRecordSetsListResponse'
-      items: 'rrsets'
+      keys: ['rrsets']
     collection_url_response: !ruby/object:Api::Resource::ResponseList
       items: 'rrsets'
     identity:

--- a/products/resourcemanager/api.yaml
+++ b/products/resourcemanager/api.yaml
@@ -122,11 +122,8 @@ objects:
     # we might build a more general solution, but this is the only resource I know
     # of where that happens.
     self_link: liens?parent={{parent}}
-    self_link_query: !ruby/object:Api::Resource::ResponseList
-      # This isn't a real 'kind' - this API has some inconsistencies and doesn't return one.
-      kind: 'resourceManager#liensList'
-      items: 'liens'
     nested_query: !ruby/object:Api::Resource::NestedQuery
+      kind: 'resourceManager#liensList'
       keys:
         - liens
     identity:

--- a/products/sql/api.yaml
+++ b/products/sql/api.yaml
@@ -396,9 +396,9 @@ objects:
     self_link: |
       projects/{{project}}/instances/{{instance}}/users
       ?name={{name}}&host={{host}}
-    self_link_query: !ruby/object:Api::Resource::ResponseList
+    nested_query: !ruby/object:Api::Resource::NestedQuery
       kind: 'sql#usersList'
-      items: 'items'
+      keys: ['items']
     identity:
       - name
       - host
@@ -486,9 +486,9 @@ objects:
       'Represents a flag that can be configured for a Cloud SQL instance.'
     base_url: flags
     self_link: flags
-    self_link_query: !ruby/object:Api::Resource::ResponseList
+    nested_query: !ruby/object:Api::Resource::NestedQuery
       kind: 'sql#flagsList'
-      items: 'items'
+      keys: ['items']
     readonly: true
     properties:
       - !ruby/object:Api::Type::Array
@@ -539,9 +539,9 @@ objects:
       Generation, or MySQL First Generation instances.
     base_url: projects/{{project}}/tiers
     self_link: projects/{{project}}/tiers
-    self_link_query: !ruby/object:Api::Resource::ResponseList
+    nested_query: !ruby/object:Api::Resource::NestedQuery
       kind: 'sql#tiersList'
-      items: 'items'
+      keys: ['items']
     identity:
       - tier
     readonly: true

--- a/templates/ansible/async.erb
+++ b/templates/ansible/async.erb
@@ -15,7 +15,7 @@ def wait_for_operation(module, response):
     if op_result is None:
         return {}
     status = navigate_hash(op_result, <%= stat_path -%>)
-<% if object.self_link_query.nil? -%>
+<% if object.nested_query.nil? -%>
     wait_done = wait_for_completion(status, op_result, module)
 <% if object.async.result.resource_inside_response -%>
     raise_if_errors(op_result, <%= err_path -%>, module)
@@ -24,7 +24,7 @@ def wait_for_operation(module, response):
 <% res_path = python_literal(object.async.result.path.split('/')) -%>
     return <%= method_call('fetch_resource', ['module', "navigate_hash(wait_done, #{res_path})", (quote_string(object.kind) if object.kind?)]) %>
 <% end #if object.async.result.resource_inside_response -%>
-<% else # object.self_link_query.nil? -%>
+<% else # object.nested_query.nil? -%>
     wait_for_completion(status, op_result, module)
 <%=
   obj_kind = quote_string(object.kind)
@@ -32,12 +32,12 @@ def wait_for_operation(module, response):
           "return fetch_wrapped_resource(",
           "module,",
           "#{obj_kind},",
-          "'#{object.self_link_query.kind}',",
-          "'#{object.self_link_query.items}')"
+          "'#{object.nested_query.kind}',",
+          "'#{object.nested_query.keys.first}')"
         ].join("\n")
   ), 4)
 -%>
-<% end # object.self_link_query.nil? -%>
+<% end # object.nested_query.nil? -%>
 
 
 def wait_for_completion(status, op_result, module):

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -54,7 +54,7 @@ def main():
     kind = <%= lines(quote_string(object.kind)) -%>
 <% end -%>
 
-<% if object.self_link_query.nil? -%>
+<% if object.nested_query.nil? -%>
 <%
   method = method_call('fetch_resource', ['module', 'self_link(module)',
                                           ('kind' if object.kind?),
@@ -68,11 +68,11 @@ def main():
 <% else #object.identity.empty? -%>
     fetch = <%= method %>
 <% end # object.identity.empty? -%>
-<% else # object.self_link_query.nil? -%>
+<% else # object.nested_query.nil? -%>
     fetch = fetch_wrapped_resource(module, '<%= object.kind -%>',
-                                   '<%= object.self_link_query.kind -%>',
-                                   '<%= object.self_link_query.items -%>')
-<% end # object.self_link_query.nil? -%>
+                                   '<%= object.nested_query.kind -%>',
+                                   '<%= object.nested_query.keys.first -%>')
+<% end # object.nested_query.nil? -%>
     changed = False
 
     if fetch:

--- a/templates/ansible/transport.erb
+++ b/templates/ansible/transport.erb
@@ -21,7 +21,7 @@
                                                 ('kind' if object.kind?),
                                                 'allow_not_found']) %>
 
-<% unless object.self_link_query.nil? -%>
+<% unless object.nested_query.nil? -%>
 
 def fetch_wrapped_resource(module, kind, wrap_kind, wrap_path):
     result = fetch_resource(module, self_link(module), wrap_kind)

--- a/templates/inspec/plural_resource.erb
+++ b/templates/inspec/plural_resource.erb
@@ -36,7 +36,7 @@ name = "google_#{product_ns.downcase}_#{object.name.underscore}"
   filter_table_config.connect(self, :table)
 
 <% 
-link_query_items = object&.self_link_query&.keys&.first || object.collection_url_response.items
+link_query_items = object&.nested_query&.keys&.first || object.collection_url_response.items
 -%>
   def initialize(params = {})
     super(params.merge({ use_http_transport: true }))

--- a/templates/inspec/plural_resource.erb
+++ b/templates/inspec/plural_resource.erb
@@ -36,12 +36,12 @@ name = "google_#{product_ns.downcase}_#{object.name.underscore}"
   filter_table_config.connect(self, :table)
 
 <% 
-link_query = object.self_link_query || object.collection_url_response
+link_query_items = object&.self_link_query&.keys&.first || object.collection_url_response.items
 -%>
   def initialize(params = {})
     super(params.merge({ use_http_transport: true }))
     @params = params
-<%= indent("@table = fetch_wrapped_resource('#{link_query.items}')", 4) %>
+<%= indent("@table = fetch_wrapped_resource('#{link_query_items}')", 4) %>
   end
 
   def fetch_wrapped_resource(wrap_path)

--- a/templates/inspec/singular_resource.erb
+++ b/templates/inspec/singular_resource.erb
@@ -38,19 +38,19 @@ class <%= object.name -%> < GcpResourceBase
 
 <% end -%>
 
-<% if object.self_link_query.nil? -%>
+<% if object.nested_query.nil? -%>
   def initialize(params)
     super(params.merge({ use_http_transport: true }))
     @params = params
-<%= indent('@fetched = @connection.fetch(product_url, resource_base_url, params)', 4) %>
+    @fetched = @connection.fetch(product_url, resource_base_url, params)
     parse unless @fetched.nil?
   end
-<% else # object.self_link_query.nil? -%>
+<% else # object.nested_query.nil? -%>
   def initialize(params)
     super(params.merge({ use_http_transport: true }))
     @params = params
-<%= indent('fetched = @connection.fetch(product_url, resource_base_url, params)', 4) %>
-<%= indent('@fetched = unwrap(fetched, params)', 4) %>
+    fetched = @connection.fetch(product_url, resource_base_url, params)
+    @fetched = unwrap(fetched, params)
     parse unless @fetched.nil?
   end
 
@@ -66,7 +66,7 @@ class <%= object.name -%> < GcpResourceBase
   def unwrap(fetched, params)
     fetched[collection_item].find { |result| identity.all? { |id| result[id.to_sym] == params[id] } }
   end
-<% end # object.self_link_query.nil? -%>
+<% end # object.nested_query.nil? -%>
 
   def parse
 <%


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->
With #1534 merged in, `self_link_query` is now replaced by `nested_query.`

TF has already been migrated. This will migrate InSpec + Ansible.

This PR must be a no-op to be merged.




<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
