### PR TITLE
ERB Linting

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,30 @@
+---
+linters:
+  # TODO: enable this + fix issues.
+  Rubocop:
+    enabled: false
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+  # TODO: enable this + fix issues.
+  SpaceAroundErbTag:
+    enabled: false
+  # TF uses tabs.
+  SpaceIndentation:
+    enabled: false
+  # Newlines at end of files depends greatly on the file.
+  FinalNewline:
+    enabled: false
+  # Not relevant.
+  ErbSafety:
+    enabled: false
+  # It's CSS related and not relevant.
+  DeprecatedClasses:
+    enabled: false
+  # It's HTML related and causes false-positives
+  SpaceInHtmlTag:
+    enabled: false
+  # We add multiple blank lines depending on
+  # templated code should appear.
+  ExtraNewline:
+    enabled: false

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -9,6 +9,16 @@ linters:
   # TODO: enable this + fix issues.
   SpaceAroundErbTag:
     enabled: false
+  # TODO: enable this + fix issues.
+  ClosingErbTagIndent:
+    enabled: false
+  # TODO: enable this + fix issues.
+  TrailingWhitespace:
+    enabled: false
+  # While this tag is HTML, it did pick up
+  # a proper error in the TF markdown files.
+  SelfClosingTag:
+    enabled: false
   # TF uses tabs.
   SpaceIndentation:
     enabled: false
@@ -27,4 +37,10 @@ linters:
   # We add multiple blank lines depending on
   # templated code should appear.
   ExtraNewline:
+    enabled: false
+  # Most parser errors are erb-lint trying
+  # to parse code as HTML
+  # If left on, it will lead to many false negatives.
+  # If turned off, it may lead to some false positives.
+  ParserErrors:
     enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'binding_of_caller'
 gem 'rake'
 
 group :test do
+  gem 'erb_lint'
   gem 'mocha', '~> 1.3.0'
   gem 'parallel_tests'
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    actionview (5.2.1)
+      activesupport (= 5.2.1)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
     activesupport (5.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -9,21 +15,46 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
+    better_html (1.0.13)
+      actionview (>= 4.0)
+      activesupport (>= 4.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      html_tokenizer (~> 0.0.6)
+      parser (>= 2.4)
+      smart_properties
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
+    builder (3.2.3)
     concurrent-ruby (1.0.5)
+    crass (1.0.4)
     debug_inspector (0.0.3)
     diff-lcs (1.3)
+    erb_lint (0.0.28)
+      activesupport
+      better_html (~> 1.0.7)
+      html_tokenizer
+      rainbow
+      rubocop (~> 0.51)
+      smart_properties
+    erubi (1.8.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
+    html_tokenizer (0.0.7)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.2)
+    loofah (2.2.3)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
     metaclass (0.0.4)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
     mocha (1.3.0)
       metaclass (~> 0.0.1)
     multipart-post (2.0.0)
+    nokogiri (1.10.2)
+      mini_portile2 (~> 2.4.0)
     octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.12.1)
@@ -33,6 +64,11 @@ GEM
       ast (~> 2.4.0)
     powerpack (0.1.2)
     public_suffix (3.0.3)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     rainbow (3.0.0)
     rake (12.3.1)
     rspec (3.8.0)
@@ -60,6 +96,7 @@ GEM
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
+    smart_properties (1.13.1)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -71,6 +108,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   binding_of_caller
+  erb_lint
   mocha (~> 1.3.0)
   octokit
   parallel_tests

--- a/Rakefile
+++ b/Rakefile
@@ -81,10 +81,10 @@ desc 'Lints all of the ERB templates'
 task :erblint do
   current_directory = File.dirname(__FILE__)
   ERBLint::CLI.new.run([
-    '--config',
-    current_directory + "/.erb-lint.yml",
-    current_directory + "/templates/**/*.erb"
-  ])
+                         '--config',
+                         current_directory + '/.erb-lint.yml',
+                         current_directory + '/templates/**/*.erb'
+                       ])
 end
 
 # Compiling Tasks

--- a/Rakefile
+++ b/Rakefile
@@ -25,37 +25,10 @@ PROVIDER_FOLDERS = {
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 require 'tempfile'
-
-# Requires for YAML linting.
-require 'api/async'
-require 'api/product'
-require 'api/resource'
-require 'api/type'
-require 'compile/core'
-require 'google/yaml_validator'
+require 'erb_lint/cli'
 
 RSpec::Core::RakeTask.new(:spec)
 RuboCop::RakeTask.new
-
-# YAML Linting
-# This class calls our provider code to get the printed contents of the
-# compiled YAML. We run the linter on this printed version (so, no embedded
-# ERB)
-class YamlLinter
-  include Compile::Core
-
-  def yaml_contents(file)
-    source = compile(file)
-    config = Google::YamlValidator.parse(source)
-    unless config.class <= Api::Product
-      raise StandardError, "#{file} is #{config.class}"\
-        ' instead of Api::Product' \
-    end
-    # Compile step #2: Now that we have the target class, compile with that
-    # class features
-    config.compile(file, 0)
-  end
-end
 
 # Handles finding the list of products for a given provider.
 class Providers
@@ -102,18 +75,16 @@ end
 
 # Test Tasks
 desc 'Run all of the MM tests (rubocop, rspec)'
-multitask test: %w[rubocop spec]
+multitask test: %w[rubocop spec erblint]
 
-desc 'Lints all of the compiled YAML files'
-task :yamllint do
-  Providers.all_products.each do |file|
-    tempfile = Tempfile.new
-    tempfile.write(YamlLinter.new.yaml_contents(file))
-    tempfile.rewind
-    puts %x(yamllint -c #{File.join(File.dirname(__FILE__), '.yamllint')} #{tempfile.path})
-    tempfile.close
-    tempfile.unlink
-  end
+desc 'Lints all of the ERB templates'
+task :erblint do
+  current_directory = File.dirname(__FILE__)
+  ERBLint::CLI.new.run([
+    '--config',
+    current_directory + "/.erb-lint.yml",
+    current_directory + "/templates/**/*.erb"
+  ])
 end
 
 # Compiling Tasks


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->
A while back, I suggested ERB linting and I never took the idea anywhere.

Right now, our templates files are roughly the same size as the rest of the MM codebase. If you look at just Ruby code embedded inside the templates, our template Ruby is roughly 25% the size of the MM codebase. This means that 20% of the Ruby we write has no style checks. Honestly, it shows at times...

I added a ERB linter to `rake test` and turned off all of the linting rules. Some of them are unnecessary and others should be turned on later. As we go forward, we can slowly turn on linting rules and fix the issues.

What does this mean for you right now?

Absolutely nothing. If you run `rake test`, the erb files will be linted (and pass because all of the rules are turned off)

You'll probably have to do a `bundle install` but this doesn't require anything installed locally on your machine.



<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
