### PR TITLE
Turn `go mod vendor` back on in the Magician

### DIFF
--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -58,6 +58,18 @@ fi
 
 pushd "build/$SHORT_NAME"
 
+# Begin building our commit; we need to set the committer details, and add our modified files.
+#
+# Note that we need to perform `go mod vendor` _after_ adding the files because we're skipping
+# the vendor step if Terraform has no changes. Ideally it would happen before, but because we
+# deleted all of the existing files earlier in this script we'll see changes until we've staged
+# our generated changes.
+
+git config --global user.email "magic-modules@google.com"
+git config --global user.name "Modular Magician"
+
+git add -A
+
 # TODO: Remove this, this is just to see what the Magician does
 git status
 
@@ -67,11 +79,6 @@ if [[ ! -z $(git status -s) ]]; then
   GO111MODULE=on go mod vendor
 fi
 
-# These config entries will set the "committer".
-git config --global user.email "magic-modules@google.com"
-git config --global user.name "Modular Magician"
-
-git add -A
 # Set the "author" to the commit's real author.
 git commit -m "$TERRAFORM_COMMIT_MSG" --author="$LAST_COMMIT_AUTHOR" || true  # don't crash if no changes
 git checkout -B "$(cat ../../branchname)"

--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -70,13 +70,13 @@ git config --global user.name "Modular Magician"
 
 git add -A
 
-# TODO: Remove this, this is just to see what the Magician does
+# This is useful for human debugging, but not necessary for the Magician.
 git status
 
-# go mod vendor is a very expensive operation.
-# If no changes, avoid running.
+# Only run `go mod vendor` if we see changes in this downstream repo, since it takes a while to run
 if [[ ! -z $(git status -s) ]]; then
   GO111MODULE=on go mod vendor
+  git add -A
 fi
 
 # Set the "author" to the commit's real author.

--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -58,7 +58,11 @@ fi
 
 pushd "build/$SHORT_NAME"
 
-GO111MODULE=on go mod vendor
+# go mod vendor is a very expensive operation.
+# If no changes, avoid running.
+if git diff-index --quiet master --; then
+  GO111MODULE=on go mod vendor
+fi
 
 # These config entries will set the "committer".
 git config --global user.email "magic-modules@google.com"

--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -58,6 +58,9 @@ fi
 
 pushd "build/$SHORT_NAME"
 
+# TODO: Remove this, this is just to see what the Magician does
+git status
+
 # go mod vendor is a very expensive operation.
 # If no changes, avoid running.
 if [[ ! -z $(git status -s) ]]; then

--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -60,7 +60,7 @@ pushd "build/$SHORT_NAME"
 
 # go mod vendor is a very expensive operation.
 # If no changes, avoid running.
-if git diff-index --quiet master --; then
+if [[ ! -z $(git status -s) ]]; then
   GO111MODULE=on go mod vendor
 fi
 

--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -58,11 +58,7 @@ fi
 
 pushd "build/$SHORT_NAME"
 
-# go mod vendor is a very expensive operation.
-# If no changes, avoid running.
-if git diff-index --quiet HEAD --; then
-  GO111MODULE=on go mod vendor
-fi
+GO111MODULE=on go mod vendor
 
 # These config entries will set the "committer".
 git config --global user.email "magic-modules@google.com"


### PR DESCRIPTION
This doesn't run when there *are* changes, so let's re-enable it for everything.

Reverses #1428

/cc @rambleraptor 

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
