### PR TITLE
Adding proper vars to tests

### DIFF
--- a/products/iam/examples/ansible/service_account.yaml
+++ b/products/iam/examples/ansible/service_account.yaml
@@ -11,11 +11,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 --- !ruby/object:Provider::Ansible::Example
+vars:
+  sa_name: "sa-{{ 100000 | random }}@graphite-playground.google.com.iam.gserviceaccount.com"
 task: !ruby/object:Provider::Ansible::Task
   name: gcp_iam_service_account
   code:
-    name: >
-      "{{resource_name}}@{{gcp_project}}.google.com.iam.gserviceaccount.com"
+    name: "{{ sa_name }}"
     display_name: 'My Ansible test key'
     project: <%= ctx[:project] %>
     auth_kind: <%= ctx[:auth_kind] %>

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -265,9 +265,10 @@ module Provider
         # Generate 'defaults' file that contains variables.
         path = File.join(target_folder,
                          "test/integration/targets/#{name}/defaults/main.yml")
-        generate_resource_file data.clone.merge(
-          default_template: 'templates/ansible/integration_test_variables.erb',
-          out_file: path
+        data.generate(
+          'templates/ansible/integration_test_variables.erb',
+          path,
+          self
         )
       end
 

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -256,11 +256,18 @@ module Provider
         name = module_name(data.object)
         path = File.join(target_folder,
                          "test/integration/targets/#{name}/tasks/main.yml")
-
         data.generate(
           'templates/ansible/integration_test.erb',
           path,
           self
+        )
+
+        # Generate 'defaults' file that contains variables.
+        path = File.join(target_folder,
+                         "test/integration/targets/#{name}/defaults/main.yml")
+        generate_resource_file data.clone.merge(
+          default_template: 'templates/ansible/integration_test_variables.erb',
+          out_file: path
         )
       end
 

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -71,6 +71,7 @@ module Provider
       attr_reader :verifier
       attr_reader :dependencies
       attr_reader :facts
+      attr_reader :vars
 
       def validate
         super
@@ -79,6 +80,7 @@ module Provider
         check :verifier, type: Verifier, default: FactsVerifier.new
         check :dependencies, item_type: Task, type: Array
         check :facts, type: Task, default: FactsTask.new
+        check :vars, type: Hash, default: {}
 
         @facts&.set_variable(self, :__example)
         @verifier.set_variable(self, :__example) if @verifier.respond_to?(:__example)

--- a/provider/ansible/product~compile.yaml
+++ b/provider/ansible/product~compile.yaml
@@ -33,7 +33,6 @@
 -%>
 <% object_names.each do |obj_name| -%>
 'test/integration/targets/<%= obj_name -%>/aliases': 'templates/ansible/aliases'
-'test/integration/targets/<%= obj_name -%>/defaults/main.yml': 'templates/ansible/defaults_main.yaml'
 'test/integration/targets/<%= obj_name -%>/meta/main.yml': 'provider/ansible/blank_file.yaml'
 <% end -%>
 

--- a/templates/ansible/integration_test_variables.erb
+++ b/templates/ansible/integration_test_variables.erb
@@ -14,5 +14,8 @@
 -%>
 <% autogen_exception -%>
 ---
-# defaults file
-resource_name: '{{resource_prefix}}'
+<%=
+  to_yaml({
+    'resource_name' => '{{ resource_prefix }}'
+  }.merge(example.vars))
+-%>


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->
As part of some fixes to Service Account files, I need to build out proper variables in service accounts.

We have a current variable file for each test. That file was static because the contents never changed. Since we can inject variables (see service account), we now need to autogenerate the file.

I'm expecting this to change a lot of files, but only one file will have non-stylistic changes.




<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
