### PR TITLE
Provider Generation Refactor

### DIFF
--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -249,14 +249,6 @@ module Provider
         generate_resource_file data
       end
 
-      def example_defaults(data)
-        obj_name = data.object.name.underscore
-        path = ["products/#{data[:product].api_name}",
-                "examples/ansible/#{obj_name}.yaml"].join('/')
-
-        compile_file(EXAMPLE_DEFAULTS, path) if File.file?(path)
-      end
-
       def generate_resource_tests(data)
         prod_name = data.object.name.underscore
         path = ["products/#{data.product.api_name}",

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -239,14 +239,14 @@ module Provider
 
       def generate_resource(data)
         target_folder = data.output_folder
-        FileUtils.mkpath target_folder
         name = module_name(data.object)
         path = File.join(target_folder,
                          "lib/ansible/modules/cloud/google/#{name}.py")
-        data.default_template = data.object.template || 'templates/ansible/resource.erb'
-        data.out_file = path
-
-        generate_resource_file data
+        data.generate(
+          data.object.template || 'templates/ansible/resource.erb',
+          path,
+          self
+        )
       end
 
       def generate_resource_tests(data)
@@ -262,24 +262,25 @@ module Provider
         return unless File.file?(path)
 
         target_folder = data.output_folder
-        FileUtils.mkpath target_folder
 
         name = module_name(data.object)
         path = File.join(target_folder,
                          "test/integration/targets/#{name}/tasks/main.yml")
-        data.default_template = 'templates/ansible/integration_test.erb'
-        data.out_file = path
-        generate_resource_file data
+
+        data.generate(
+          'templates/ansible/integration_test.erb',
+          path,
+          self
+        )
       end
 
       def compile_datasource(data)
         target_folder = data.output_folder
-        FileUtils.mkpath target_folder
         name = "#{module_name(data.object)}_facts"
-        data.default_template = 'templates/ansible/facts.erb'
-        data.out_file = File.join(target_folder,
-                                  "lib/ansible/modules/cloud/google/#{name}.py")
-        generate_resource_file data
+        data.generate('templates/ansible/facts.erb',
+                      File.join(target_folder,
+                                "lib/ansible/modules/cloud/google/#{name}.py"),
+                      self)
       end
 
       def generate_objects(output_folder, types, version_name)

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -365,6 +365,7 @@ module Provider
         name: object.out_name,
         object: object,
         product: object.__product,
+        product_ns: object.__product.name,
         output_folder: output_folder,
         version: version,
         config: @config,

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -96,7 +96,7 @@ module Provider
         ctx.local_variable_set(name[1..-1], instance_variable_get(name))
       end
 
-      # This variable looks unused, but is used in ansible/resource.erb
+      # This variable is used in ansible/resource.erb
       ctx.local_variable_set('file_relative', relative_path(path, @output_folder).to_s)
 
       Google::LOGGER.debug "Generating #{@name}"

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -39,11 +39,7 @@ module Provider
     attr_accessor :output_folder
     attr_accessor :product_ns
     attr_accessor :config
-    attr_accessor :scopes
     attr_accessor :manifest
-    attr_accessor :tests
-    attr_accessor :compiler
-    attr_accessor :type
     attr_accessor :env
 
     # Ansible stuff.
@@ -270,9 +266,7 @@ module Provider
           FileTemplate.new({
             name: target,
             product: @api,
-            scopes: @api.scopes,
             manifest: manifest,
-            compiler: compiler,
             output_folder: output_folder,
             product_ns: @api.name,
             env: {

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -52,6 +52,13 @@ module Provider
     attr_accessor :out_file
     attr_accessor :output_folder
 
+    # InSpec stuff.
+    attr_accessor :plural
+    attr_accessor :doc_generation
+    attr_accessor :attribute_file_name
+    attr_accessor :privileged
+    attr_accessor :property
+
     def initialize(options)
       @name = options[:name]
       @object = options[:object]
@@ -68,10 +75,7 @@ module Provider
       @example = options[:example]
       @type = options[:type]
       @out_file = options[:out_file]
-    end
-
-    def get_binding
-      binding
+      @property = options[:property]
     end
   end
 
@@ -194,14 +198,14 @@ module Provider
       compile_file_list(output_folder, files, version_name)
     end
 
-    def compile_file_list(output_folder, files, version = nil)
+    def compile_file_list(output_folder, files, data = {})
       files.map do |target, source|
         Thread.new do
           Google::LOGGER.debug "Compiling #{source} => #{target}"
           target_file = File.join(output_folder, target)
           manifest = @config.respond_to?(:manifest) ? @config.manifest : {}
           generate_file(
-            FileTemplate.new(
+            FileTemplate.new({
               name: target,
               product: @api,
               object: {},
@@ -214,8 +218,7 @@ module Provider
               output_folder: output_folder,
               out_file: target_file,
               product_ns: @api.name,
-              version: version
-            )
+            }.merge(data))
           )
 
           format_output_file(target_file)

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -32,27 +32,43 @@ module Provider
   # with a given set of parameters.
   class FileTemplate
     include Compile::Core
+    # The name of the resource
     attr_accessor :name
+    # The resource itself.
     attr_accessor :object
+    # The entire API object.
     attr_accessor :product
+    # The API version
     attr_accessor :version
+    # The root folder we're outputting to.
     attr_accessor :output_folder
+    # The namespace of the product.
     attr_accessor :product_ns
+    # The provider-specific configuration.
     attr_accessor :config
+    # The provider specific high-level configuration fields.
     attr_accessor :manifest
+    # Information about the local environment
+    # (which formatters are enabled, start-time)
     attr_accessor :env
 
     # Ansible stuff.
+    # The Ansible example object.
     attr_accessor :example
 
     # InSpec stuff.
+    # Is this a plural resource?
     attr_accessor :plural
+    # Should we generate documentation?
     attr_accessor :doc_generation
+    # The file name of the attribute
     attr_accessor :attribute_file_name
     attr_accessor :privileged
     attr_accessor :property
 
     # Terraform stuff.
+    # The async object used for making operations.
+    # We assume that all resources share the same async properties.
     attr_accessor :async
     attr_accessor :resource_name
 

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -152,6 +152,7 @@ module Provider
       @go_format_enabled = check_goformat
     end
 
+    # This provides the FileTemplate class with access to a provider.
     def provider_binding
       binding
     end

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -95,13 +95,13 @@ module Provider
       #
       # The templates get access to everything in the provider +
       # all of the variables in this object.
-      ctx = provider.get_binding
+      ctx = provider.provider_binding
       instance_variables.each do |name|
         ctx.local_variable_set(name[1..-1], instance_variable_get(name))
       end
 
       # This variable looks unused, but is used in ansible/resource.erb
-      ctx.local_variable_set("file_relative", relative_path(path, @output_folder).to_s)
+      ctx.local_variable_set('file_relative', relative_path(path, @output_folder).to_s)
 
       Google::LOGGER.debug "Generating #{@name}"
       File.open(path, 'w') { |f| f.puts compile_file(ctx, template) }
@@ -156,7 +156,7 @@ module Provider
       @go_format_enabled = check_goformat
     end
 
-    def get_binding
+    def provider_binding
       binding
     end
 
@@ -267,20 +267,20 @@ module Provider
           Google::LOGGER.debug "Compiling #{source} => #{target}"
           target_file = File.join(output_folder, target)
           manifest = @config.respond_to?(:manifest) ? @config.manifest : {}
-            FileTemplate.new({
-              name: target,
-              product: @api,
-              scopes: @api.scopes,
-              manifest: manifest,
-              compiler: compiler,
-              output_folder: output_folder,
-              product_ns: @api.name,
-              env: {
-                pyformat_enabled: @py_format_enabled,
-                goformat_enabled: @go_format_enabled,
-                start_time: @start_time
-              }
-            }.merge(data)).generate(source, target_file, self)
+          FileTemplate.new({
+            name: target,
+            product: @api,
+            scopes: @api.scopes,
+            manifest: manifest,
+            compiler: compiler,
+            output_folder: output_folder,
+            product_ns: @api.name,
+            env: {
+              pyformat_enabled: @py_format_enabled,
+              goformat_enabled: @go_format_enabled,
+              start_time: @start_time
+            }
+          }.merge(data)).generate(source, target_file, self)
         end
       end.map(&:join)
     end

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -28,12 +28,13 @@ module Provider
     quiet: false
   }.freeze
 
+  # Responsible for generating a file
+  # with a given set of parameters.
   class FileTemplate
     include Compile::Core
     attr_accessor :name
     attr_accessor :object
     attr_accessor :product
-    attr_accessor :output_folder
     attr_accessor :version
     attr_accessor :product_ns
     attr_accessor :config
@@ -221,7 +222,7 @@ module Provider
               compiler: compiler,
               output_folder: output_folder,
               out_file: target_file,
-              product_ns: @api.name,
+              product_ns: @api.name
             }.merge(data))
           )
 
@@ -445,8 +446,9 @@ module Provider
       # through each key:value pair in the common `data` object, and we set them
       # in the scope of the .erb files.
       ctx = binding
-      data.instance_variables.each { |name| ctx.local_variable_set(name[1..-1], data.instance_variable_get(name)) }
-
+      data.instance_variables.each do |name|
+        ctx.local_variable_set(name[1..-1], data.instance_variable_get(name))
+      end
 
       Google::LOGGER.debug "Generating #{data.name}"
       File.open(path, 'w') { |f| f.puts compile_file(ctx, data.template) }

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -59,6 +59,10 @@ module Provider
     attr_accessor :privileged
     attr_accessor :property
 
+    # Terraform stuff.
+    attr_accessor :async
+    attr_accessor :resource_name
+
     def initialize(options)
       @name = options[:name]
       @object = options[:object]
@@ -186,7 +190,7 @@ module Provider
     end
 
     def compile_files(output_folder, version_name)
-      compile_file_list(output_folder, @config.files.compile, version_name)
+      compile_file_list(output_folder, @config.files.compile, version: version_name)
     end
 
     def compile_common_files(output_folder, version_name = nil)
@@ -195,7 +199,7 @@ module Provider
 
       Google::LOGGER.info "Compiling common files for #{provider_name}"
       files = YAML.safe_load(compile("provider/#{provider_name}/common~compile.yaml"))
-      compile_file_list(output_folder, files, version_name)
+      compile_file_list(output_folder, files, version: version_name)
     end
 
     def compile_file_list(output_folder, files, data = {})

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -333,8 +333,8 @@ module Provider
     def generate_object(object, output_folder, version_name)
       data = build_object_data(object, output_folder, version_name)
 
-      generate_resource data
-      generate_resource_tests data
+      generate_resource data.clone
+      generate_resource_tests data.clone
     end
 
     def generate_datasources(output_folder, types, version_name)
@@ -368,7 +368,7 @@ module Provider
     def generate_datasource(object, output_folder, version_name)
       data = build_object_data(object, output_folder, version_name)
 
-      compile_datasource data
+      compile_datasource data.clone
     end
 
     def build_object_data(object, output_folder, version)

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -88,11 +88,15 @@ module Provider
       docs_folder = File.join(data.output_folder, 'docs', 'resources')
 
       name = plural ? base_name.pluralize : base_name
-      data_new = data.clone
-      data_new.name = name
-      data_new.plural = plural
-      data_new.doc_generation = true
-      data_new.generate('templates/inspec/doc_template.md.erb',
+
+      # We need to clone the data object, since we're making temporary alterations
+      # to it for documentation. These alterations shouldn't exist after documentation
+      # creation.
+      copied_data = data.clone
+      copied_data.name = name
+      copied_data.plural = plural
+      copied_data.doc_generation = true
+      copied_data.generate('templates/inspec/doc_template.md.erb',
                         File.join(docs_folder, "google_#{data.product.api_name}_#{name}.md"),
                         self)
     end
@@ -120,13 +124,15 @@ module Provider
     end
 
     def generate_inspec_test(data, name, target_folder, attribute_file_name)
-      data_new = data.clone
-      data_new.name = name
-      data_new.attribute_file_name = attribute_file_name
-      data_new.doc_generation = false
-      data_new.privileged = data.object.privileged
+      # We need to clone the data object, since we're making temporary alterations
+      # to it for test. These alterations shouldn't exist after test creation.
+      copied_data = data.clone
+      copied_data.name = name
+      copied_data.attribute_file_name = attribute_file_name
+      copied_data.doc_generation = false
+      copied_data.privileged = data.object.privileged
 
-      data_new.generate('templates/inspec/integration_test_template.erb',
+      copied_data.generate('templates/inspec/integration_test_template.erb',
                         File.join(
                           target_folder,
                           'integration/verify/controls',

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -44,16 +44,15 @@ module Provider
     # resources that can be used by InSpec
     def generate_resource(data)
       target_folder = File.join(data.output_folder, 'libraries')
-      FileUtils.mkpath target_folder
       name = data.object.name.underscore
-      data.default_template = 'templates/inspec/singular_resource.erb'
-      data.out_file = File.join(target_folder, "google_#{data.product.api_name}_#{name}.rb")
-      generate_resource_file data
 
-      data.default_template = 'templates/inspec/plural_resource.erb'
-      data.out_file =
-        File.join(target_folder, "google_#{data.product.api_name}_#{name}".pluralize + '.rb')
-      generate_resource_file data
+      data.generate('templates/inspec/singular_resource.erb',
+                    File.join(target_folder, "google_#{data.product.api_name}_#{name}.rb"),
+                    self)
+
+      data.generate('templates/inspec/plural_resource.erb',
+                    File.join(target_folder, "google_#{data.product.api_name}_#{name}".pluralize + '.rb'),
+                    self)
 
       generate_documentation(data, name, false)
       generate_documentation(data, name, true)
@@ -78,7 +77,7 @@ module Provider
         compile_file_list(
           data.output_folder,
           { prop[:target] => prop[:source] },
-          prop
+          { property: prop[:property] }
         )
       end
     end
@@ -92,9 +91,9 @@ module Provider
       data_new.name = name
       data_new.plural = plural
       data_new.doc_generation = true
-      data_new.default_template = 'templates/inspec/doc_template.md.erb'
-      data_new.out_file = File.join(docs_folder, "google_#{data.product.api_name}_#{name}.md")
-      generate_resource_file data_new
+      data_new.generate('templates/inspec/doc_template.md.erb',
+                        File.join(docs_folder, "google_#{data.product.api_name}_#{name}.md"),
+                        self)
     end
 
     # Format a url that may be include newlines into a single line
@@ -124,14 +123,15 @@ module Provider
       data_new.name = name
       data_new.attribute_file_name = attribute_file_name
       data_new.doc_generation = false
-      data_new.default_template = 'templates/inspec/integration_test_template.erb'
       data_new.privileged = data.object.privileged
-      data_new.out_file = File.join(
+
+      data_new.generate('templates/inspec/integration_test_template.erb',
+                    File.join(
         target_folder,
         'integration/verify/controls',
         "#{name}.rb"
-      )
-      generate_resource_file data_new
+      ),
+      self)
     end
 
     def emit_nested_object(property)

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -55,9 +55,9 @@ module Provider
                               "google_#{data.product.api_name}_#{name}".pluralize + '.rb'),
                     self)
 
-      generate_documentation(data, name, false)
-      generate_documentation(data, name, true)
-      generate_properties(data, data.object.all_user_properties)
+      generate_documentation(data.clone, name, false)
+      generate_documentation(data.clone, name, true)
+      generate_properties(data.clone, data.object.all_user_properties)
     end
 
     def generate_properties(data, props)
@@ -89,14 +89,10 @@ module Provider
 
       name = plural ? base_name.pluralize : base_name
 
-      # We need to clone the data object, since we're making temporary alterations
-      # to it for documentation. These alterations shouldn't exist after documentation
-      # creation.
-      copied_data = data.clone
-      copied_data.name = name
-      copied_data.plural = plural
-      copied_data.doc_generation = true
-      copied_data.generate('templates/inspec/doc_template.md.erb',
+      data.name = name
+      data.plural = plural
+      data.doc_generation = true
+      data.generate('templates/inspec/doc_template.md.erb',
                            File.join(docs_folder, "google_#{data.product.api_name}_#{name}.md"),
                            self)
     end
@@ -117,22 +113,19 @@ module Provider
 
       name = "google_#{data.product.api_name}_#{data.object.name.underscore}"
 
-      generate_inspec_test(data, name, target_folder, name)
+      generate_inspec_test(data.clone, name, target_folder, name)
 
       # Build test for plural resource
-      generate_inspec_test(data, name.pluralize, target_folder, name)
+      generate_inspec_test(data.clone, name.pluralize, target_folder, name)
     end
 
     def generate_inspec_test(data, name, target_folder, attribute_file_name)
-      # We need to clone the data object, since we're making temporary alterations
-      # to it for test. These alterations shouldn't exist after test creation.
-      copied_data = data.clone
-      copied_data.name = name
-      copied_data.attribute_file_name = attribute_file_name
-      copied_data.doc_generation = false
-      copied_data.privileged = data.object.privileged
+      data.name = name
+      data.attribute_file_name = attribute_file_name
+      data.doc_generation = false
+      data.privileged = data.object.privileged
 
-      copied_data.generate('templates/inspec/integration_test_template.erb',
+      data.generate('templates/inspec/integration_test_template.erb',
                            File.join(
                              target_folder,
                              'integration/verify/controls',

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -127,9 +127,9 @@ module Provider
       data_new.default_template = 'templates/inspec/integration_test_template.erb'
       data_new.privileged = data.object.privileged
       data_new.out_file = File.join(
-          target_folder,
-          'integration/verify/controls',
-          "#{name}.rb"
+        target_folder,
+        'integration/verify/controls',
+        "#{name}.rb"
       )
       generate_resource_file data_new
     end

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -51,7 +51,8 @@ module Provider
                     self)
 
       data.generate('templates/inspec/plural_resource.erb',
-                    File.join(target_folder, "google_#{data.product.api_name}_#{name}".pluralize + '.rb'),
+                    File.join(target_folder,
+                              "google_#{data.product.api_name}_#{name}".pluralize + '.rb'),
                     self)
 
       generate_documentation(data, name, false)
@@ -77,7 +78,7 @@ module Provider
         compile_file_list(
           data.output_folder,
           { prop[:target] => prop[:source] },
-          { property: prop[:property] }
+          property: prop[:property]
         )
       end
     end
@@ -126,12 +127,12 @@ module Provider
       data_new.privileged = data.object.privileged
 
       data_new.generate('templates/inspec/integration_test_template.erb',
-                    File.join(
-        target_folder,
-        'integration/verify/controls',
-        "#{name}.rb"
-      ),
-      self)
+                        File.join(
+                          target_folder,
+                          'integration/verify/controls',
+                          "#{name}.rb"
+                        ),
+                        self)
     end
 
     def emit_nested_object(property)

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -97,8 +97,8 @@ module Provider
       copied_data.plural = plural
       copied_data.doc_generation = true
       copied_data.generate('templates/inspec/doc_template.md.erb',
-                        File.join(docs_folder, "google_#{data.product.api_name}_#{name}.md"),
-                        self)
+                           File.join(docs_folder, "google_#{data.product.api_name}_#{name}.md"),
+                           self)
     end
 
     # Format a url that may be include newlines into a single line
@@ -133,12 +133,12 @@ module Provider
       copied_data.privileged = data.object.privileged
 
       copied_data.generate('templates/inspec/integration_test_template.erb',
-                        File.join(
-                          target_folder,
-                          'integration/verify/controls',
-                          "#{name}.rb"
-                        ),
-                        self)
+                           File.join(
+                             target_folder,
+                             'integration/verify/controls',
+                             "#{name}.rb"
+                           ),
+                           self)
     end
 
     def emit_nested_object(property)

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -93,8 +93,8 @@ module Provider
       data.plural = plural
       data.doc_generation = true
       data.generate('templates/inspec/doc_template.md.erb',
-                           File.join(docs_folder, "google_#{data.product.api_name}_#{name}.md"),
-                           self)
+                    File.join(docs_folder, "google_#{data.product.api_name}_#{name}.md"),
+                    self)
     end
 
     # Format a url that may be include newlines into a single line
@@ -126,12 +126,12 @@ module Provider
       data.privileged = data.object.privileged
 
       data.generate('templates/inspec/integration_test_template.erb',
-                           File.join(
-                             target_folder,
-                             'integration/verify/controls',
-                             "#{name}.rb"
-                           ),
-                           self)
+                    File.join(
+                      target_folder,
+                      'integration/verify/controls',
+                      "#{name}.rb"
+                    ),
+                    self)
     end
 
     def emit_nested_object(property)

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -113,59 +113,57 @@ module Provider
     # per resource. The resource.erb template forms the basis of a single
     # GCP Resource on Terraform.
     def generate_resource(data)
-      dir = data[:version] == 'beta' ? 'google-beta' : 'google'
-      target_folder = File.join(data[:output_folder], dir)
+      dir = data.version == 'beta' ? 'google-beta' : 'google'
+      target_folder = File.join(data.output_folder, dir)
       FileUtils.mkpath target_folder
-      name = data[:object].name.underscore
-      product_name = data[:product].name.underscore
+      name = data.object.name.underscore
+      product_name = data.product.name.underscore
       filepath = File.join(target_folder, "resource_#{product_name}_#{name}.go")
-      generate_resource_file data.clone.merge(
-        default_template: 'templates/terraform/resource.erb',
-        out_file: filepath
-      )
+      data.default_template = 'templates/terraform/resource.erb'
+      data.out_file = filepath
+      generate_resource_file data
       generate_documentation(data)
     end
 
     def generate_documentation(data)
-      target_folder = data[:output_folder]
+      target_folder = data.output_folder
       target_folder = File.join(target_folder, 'website', 'docs', 'r')
       FileUtils.mkpath target_folder
-      name = data[:object].name.underscore
-      product_name = data[:product].name.underscore
+      name = data.object.name.underscore
+      product_name = data.product.name.underscore
 
       filepath =
         File.join(target_folder, "#{product_name}_#{name}.html.markdown")
-      generate_resource_file data.clone.merge(
-        default_template: 'templates/terraform/resource.html.markdown.erb',
-        out_file: filepath
-      )
+      data.default_template = 'templates/terraform/resource.html.markdown.erb'
+      data.out_file = filepath
+      generate_resource_file data
     end
 
     def generate_resource_tests(data)
-      return if data[:object].examples
+      return if data.object.examples
                              .reject(&:skip_test)
                              .reject do |e|
-                               @api.version_obj_or_default(data[:version]) \
+                                  @api.version_obj_or_default(data.version) \
                                 < @api.version_obj_or_default(e.min_version)
                              end
                              .empty?
 
-      dir = data[:version] == 'beta' ? 'google-beta' : 'google'
-      target_folder = File.join(data[:output_folder], dir)
+      dir = data.version == 'beta' ? 'google-beta' : 'google'
+      target_folder = File.join(data.output_folder, dir)
       FileUtils.mkpath target_folder
-      name = data[:object].name.underscore
-      product_name = data[:product].name.underscore
+      name = data.object.name.underscore
+      product_name = data.product.name.underscore
       filepath =
         File.join(
           target_folder,
           "resource_#{product_name}_#{name}_generated_test.go"
         )
-      generate_resource_file data.clone.merge(
-        product: data[:product].name,
-        resource_name: data[:object].name.camelize(:upper),
-        default_template: 'templates/terraform/examples/base_configs/test_file.go.erb',
-        out_file: filepath
-      )
+
+      data.product = data.product.name
+      data.resource_name = data.object.name.camelize(:upper)
+      data.default_template = 'templates/terraform/examples/base_configs/test_file.go.erb'
+      data.out_file = filepath
+      generate_resource_file data
     end
 
     def generate_operation(output_folder, _types, version_name)
@@ -175,16 +173,16 @@ module Provider
       async = @api.objects.map(&:async).compact.first
 
       data = build_object_data(@api.objects.first, output_folder, version_name)
-      dir = data[:version] == 'beta' ? 'google-beta' : 'google'
-      target_folder = File.join(data[:output_folder], dir)
+      dir = data.version == 'beta' ? 'google-beta' : 'google'
+      target_folder = File.join(data.output_folder, dir)
 
-      generate_resource_file(data.clone.merge(
-                               async: async,
-                               object: @api.objects.first,
-                               default_template: 'templates/terraform/operation.go.erb',
-                               out_file: File.join(target_folder,
-                                                   "#{product_name}_operation.go")
-                             ))
+      new_data = data.clone
+      new_data.async = async
+      new_data.object = @api.objects.first
+      new_data.default_template = 'templates/terraform/operation.go.erb'
+      new_data.out_file = File.join(target_folder,
+                                    "#{product_name}_operation.go")
+      generate_resource_file new_data
     end
   end
 end

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -172,10 +172,12 @@ module Provider
       dir = data.version == 'beta' ? 'google-beta' : 'google'
       target_folder = File.join(data.output_folder, dir)
 
-      new_data = data.clone
-      new_data.async = async
-      new_data.object = @api.objects.first
-      new_data.generate('templates/terraform/operation.go.erb',
+      # We need to make alterations to the data just for generating operations.
+      # These changes should not exist after operation generation happens.
+      copied_data = data.clone
+      copied_data.async = async
+      copied_data.object = @api.objects.first
+      copied_data.generate('templates/terraform/operation.go.erb',
                         File.join(target_folder,
                                   "#{product_name}_operation.go"),
                         self)

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -141,12 +141,12 @@ module Provider
 
     def generate_resource_tests(data)
       return if data.object.examples
-                             .reject(&:skip_test)
-                             .reject do |e|
-                                  @api.version_obj_or_default(data.version) \
-                                < @api.version_obj_or_default(e.min_version)
-                             end
-                             .empty?
+                    .reject(&:skip_test)
+                    .reject do |e|
+                  @api.version_obj_or_default(data.version) \
+                < @api.version_obj_or_default(e.min_version)
+                end
+                    .empty?
 
       dir = data.version == 'beta' ? 'google-beta' : 'google'
       target_folder = File.join(data.output_folder, dir)

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -115,13 +115,12 @@ module Provider
     def generate_resource(data)
       dir = data.version == 'beta' ? 'google-beta' : 'google'
       target_folder = File.join(data.output_folder, dir)
-      FileUtils.mkpath target_folder
+
       name = data.object.name.underscore
       product_name = data.product.name.underscore
       filepath = File.join(target_folder, "resource_#{product_name}_#{name}.go")
-      data.default_template = 'templates/terraform/resource.erb'
-      data.out_file = filepath
-      generate_resource_file data
+
+      data.generate('templates/terraform/resource.erb', filepath, self)
       generate_documentation(data)
     end
 
@@ -134,9 +133,7 @@ module Provider
 
       filepath =
         File.join(target_folder, "#{product_name}_#{name}.html.markdown")
-      data.default_template = 'templates/terraform/resource.html.markdown.erb'
-      data.out_file = filepath
-      generate_resource_file data
+      data.generate('templates/terraform/resource.html.markdown.erb', filepath, self)
     end
 
     def generate_resource_tests(data)
@@ -150,7 +147,7 @@ module Provider
 
       dir = data.version == 'beta' ? 'google-beta' : 'google'
       target_folder = File.join(data.output_folder, dir)
-      FileUtils.mkpath target_folder
+
       name = data.object.name.underscore
       product_name = data.product.name.underscore
       filepath =
@@ -161,9 +158,8 @@ module Provider
 
       data.product = data.product.name
       data.resource_name = data.object.name.camelize(:upper)
-      data.default_template = 'templates/terraform/examples/base_configs/test_file.go.erb'
-      data.out_file = filepath
-      generate_resource_file data
+      data.generate('templates/terraform/examples/base_configs/test_file.go.erb',
+                    filepath, self)
     end
 
     def generate_operation(output_folder, _types, version_name)
@@ -179,10 +175,10 @@ module Provider
       new_data = data.clone
       new_data.async = async
       new_data.object = @api.objects.first
-      new_data.default_template = 'templates/terraform/operation.go.erb'
-      new_data.out_file = File.join(target_folder,
-                                    "#{product_name}_operation.go")
-      generate_resource_file new_data
+      new_data.generate('templates/terraform/operation.go.erb',
+                        File.join(target_folder,
+                                    "#{product_name}_operation.go"),
+                        self)
     end
   end
 end

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -175,9 +175,9 @@ module Provider
       data.async = async
       data.object = @api.objects.first
       data.generate('templates/terraform/operation.go.erb',
-                           File.join(target_folder,
-                                     "#{product_name}_operation.go"),
-                           self)
+                    File.join(target_folder,
+                              "#{product_name}_operation.go"),
+                    self)
     end
   end
 end

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -177,7 +177,7 @@ module Provider
       new_data.object = @api.objects.first
       new_data.generate('templates/terraform/operation.go.erb',
                         File.join(target_folder,
-                                    "#{product_name}_operation.go"),
+                                  "#{product_name}_operation.go"),
                         self)
     end
   end

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -172,12 +172,9 @@ module Provider
       dir = data.version == 'beta' ? 'google-beta' : 'google'
       target_folder = File.join(data.output_folder, dir)
 
-      # We need to make alterations to the data just for generating operations.
-      # These changes should not exist after operation generation happens.
-      copied_data = data.clone
-      copied_data.async = async
-      copied_data.object = @api.objects.first
-      copied_data.generate('templates/terraform/operation.go.erb',
+      data.async = async
+      data.object = @api.objects.first
+      data.generate('templates/terraform/operation.go.erb',
                            File.join(target_folder,
                                      "#{product_name}_operation.go"),
                            self)

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -178,9 +178,9 @@ module Provider
       copied_data.async = async
       copied_data.object = @api.objects.first
       copied_data.generate('templates/terraform/operation.go.erb',
-                        File.join(target_folder,
-                                  "#{product_name}_operation.go"),
-                        self)
+                           File.join(target_folder,
+                                     "#{product_name}_operation.go"),
+                           self)
     end
   end
 end

--- a/provider/terraform_example.rb
+++ b/provider/terraform_example.rb
@@ -37,22 +37,29 @@ module Provider
 
         data.example = example
 
-        data.default_template = 'templates/terraform/examples/base_configs/example_file.tf.erb'
-        data.out_file = File.join(target_folder, 'main.tf')
-        generate_resource_file data
+        data.generate(
+          'templates/terraform/examples/base_configs/example_file.tf.erb',
+          File.join(target_folder, 'main.tf'),
+          self
+        )
 
-        data.default_template = 'templates/terraform/examples/base_configs/tutorial.md.erb'
-        data.out_file = File.join(target_folder, 'tutorial.md')
-        generate_resource_file data
+        data.generate(
+          'templates/terraform/examples/base_configs/tutorial.md.erb',
+          File.join(target_folder, 'tutorial.md'),
+          self
+        )
 
-        data.default_template =
-          'templates/terraform/examples/base_configs/example_backing_file.tf.erb'
-        data.out_file = File.join(target_folder, 'backing_file.tf')
-        generate_resource_file data
+        data.generate(
+          'templates/terraform/examples/base_configs/example_backing_file.tf.erb',
+          File.join(target_folder, 'backing_file.tf'),
+          self
+        )
 
-        data.default_template = 'templates/terraform/examples/static/motd'
-        data.out_file = File.join(target_folder, 'motd')
-        generate_resource_file data
+        data.generate(
+          'templates/terraform/examples/static/motd',
+          File.join(target_folder, 'motd'),
+          self
+        )
       end
     end
 

--- a/provider/terraform_example.rb
+++ b/provider/terraform_example.rb
@@ -26,9 +26,9 @@ module Provider
     def generate_resource(data)
       version = @api.version_obj_or_default(data.version)
       examples = data.object.examples
-                            .reject(&:skip_test)
-                            .reject { |e| !e.test_env_vars.nil? && e.test_env_vars.any? }
-                            .reject { |e| version < @api.version_obj_or_default(e.min_version) }
+                     .reject(&:skip_test)
+                     .reject { |e| !e.test_env_vars.nil? && e.test_env_vars.any? }
+                     .reject { |e| version < @api.version_obj_or_default(e.min_version) }
 
       examples.each do |example|
         target_folder = data.output_folder
@@ -45,7 +45,8 @@ module Provider
         data.out_file = File.join(target_folder, 'tutorial.md')
         generate_resource_file data
 
-        data.default_template = 'templates/terraform/examples/base_configs/example_backing_file.tf.erb'
+        data.default_template =
+          'templates/terraform/examples/base_configs/example_backing_file.tf.erb'
         data.out_file = File.join(target_folder, 'backing_file.tf')
         generate_resource_file data
 

--- a/provider/terraform_example.rb
+++ b/provider/terraform_example.rb
@@ -24,38 +24,34 @@ module Provider
 
     # Create a directory of examples per resource
     def generate_resource(data)
-      version = @api.version_obj_or_default(data[:version])
-      examples = data[:object].examples
-                              .reject(&:skip_test)
-                              .reject { |e| !e.test_env_vars.nil? && e.test_env_vars.any? }
-                              .reject { |e| version < @api.version_obj_or_default(e.min_version) }
+      version = @api.version_obj_or_default(data.version)
+      examples = data.object.examples
+                            .reject(&:skip_test)
+                            .reject { |e| !e.test_env_vars.nil? && e.test_env_vars.any? }
+                            .reject { |e| version < @api.version_obj_or_default(e.min_version) }
 
       examples.each do |example|
-        target_folder = data[:output_folder]
+        target_folder = data.output_folder
         target_folder = File.join(target_folder, example.name)
         FileUtils.mkpath target_folder
 
-        generate_resource_file data.clone.merge(
-          example: example,
-          default_template: 'templates/terraform/examples/base_configs/example_file.tf.erb',
-          out_file: File.join(target_folder, 'main.tf')
-        )
+        data.example = example
 
-        generate_resource_file data.clone.merge(
-          example: example,
-          default_template: 'templates/terraform/examples/base_configs/tutorial.md.erb',
-          out_file: File.join(target_folder, 'tutorial.md')
-        )
+        data.default_template = 'templates/terraform/examples/base_configs/example_file.tf.erb'
+        data.out_file = File.join(target_folder, 'main.tf')
+        generate_resource_file data
 
-        generate_resource_file data.clone.merge(
-          default_template: 'templates/terraform/examples/base_configs/example_backing_file.tf.erb',
-          out_file: File.join(target_folder, 'backing_file.tf')
-        )
+        data.default_template = 'templates/terraform/examples/base_configs/tutorial.md.erb'
+        data.out_file = File.join(target_folder, 'tutorial.md')
+        generate_resource_file data
 
-        generate_resource_file data.clone.merge(
-          default_template: 'templates/terraform/examples/static/motd',
-          out_file: File.join(target_folder, 'motd')
-        )
+        data.default_template = 'templates/terraform/examples/base_configs/example_backing_file.tf.erb'
+        data.out_file = File.join(target_folder, 'backing_file.tf')
+        generate_resource_file data
+
+        data.default_template = 'templates/terraform/examples/static/motd'
+        data.out_file = File.join(target_folder, 'motd')
+        generate_resource_file data
       end
     end
 

--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -34,10 +34,10 @@ module Provider
       target_folder = data.output_folder
       product_ns = data.object.__product.name
 
-      data.default_template = 'templates/terraform/objectlib/base.go.erb'
-      data.out_file = File.join(target_folder,
-                                "google/#{product_ns.downcase}_#{data.object.name.underscore}.go")
-      generate_resource_file data
+      data.generate('templates/terraform/objectlib/base.go.erb',
+                    File.join(target_folder,
+                                "google/#{product_ns.downcase}_#{data.object.name.underscore}.go"),
+                    self)
     end
 
     def compile_common_files(output_folder, version_name = 'ga')

--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -36,7 +36,7 @@ module Provider
 
       data.generate('templates/terraform/objectlib/base.go.erb',
                     File.join(target_folder,
-                                "google/#{product_ns.downcase}_#{data.object.name.underscore}.go"),
+                              "google/#{product_ns.downcase}_#{data.object.name.underscore}.go"),
                     self)
     end
 

--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -31,15 +31,13 @@ module Provider
     end
 
     def generate_resource(data)
-      target_folder = data[:output_folder]
-      product_ns = data[:object].__product.name
+      target_folder = data.output_folder
+      product_ns = data.object.__product.name
 
-      generate_resource_file data.clone.merge(
-        object: data[:object],
-        default_template: 'templates/terraform/objectlib/base.go.erb',
-        out_file: File.join(target_folder,
-                            "google/#{product_ns.downcase}_#{data[:object].name.underscore}.go")
-      )
+      data.default_template = 'templates/terraform/objectlib/base.go.erb'
+      data.out_file = File.join(target_folder,
+                                "google/#{product_ns.downcase}_#{data.object.name.underscore}.go")
+      generate_resource_file data
     end
 
     def compile_common_files(output_folder, version_name = 'ga')

--- a/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/templates/terraform/examples/base_configs/test_file.go.erb
@@ -30,7 +30,7 @@ object.examples
 
 	# {Compute}{Address}_{addressBasic}
 	test_slug = "#{resource_name}_#{example.name.camelize(:lower)}Example"
-	  ignore_read = data[:object].all_user_properties
+	  ignore_read = data.object.all_user_properties
                  .select(&:ignore_read)
                  .map { |p| p.name.underscore }
                  .concat(example.ignore_read_extra)

--- a/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/templates/terraform/examples/base_configs/test_file.go.erb
@@ -30,7 +30,7 @@ object.examples
 
 	# {Compute}{Address}_{addressBasic}
 	test_slug = "#{resource_name}_#{example.name.camelize(:lower)}Example"
-	  ignore_read = data.object.all_user_properties
+	  ignore_read = object.all_user_properties
                  .select(&:ignore_read)
                  .map { |p| p.name.underscore }
                  .concat(example.ignore_read_extra)


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->
Generating files involves copying around these `data` hashes and constantly adding fields to them. There isn't a great sense of what's already included or why things aren't working. There's a lot of duplication between providers because we don't realize what core is/isn't doing.

This creates a `FileTemplate` class that's responsible for taking a bunch of information that will be placed inside the template. It means we have a list of parameters that we know templates will have access to and we can be explicit about what functions the templates will have access to as well.

All File Writing logic (writing folders, formatting files) is placed inside this class. The `FileTemplate` object shouldn't have to change much (with few exceptions) and we don't have to copy it around or alter values on it much.



<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
