### PR TITLE
Reverting some ResourceRef changes

### DIFF
--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -68,7 +68,7 @@ module Provider
         if prop.is_a? Api::Type::ResourceRef
           return 'str' if prop.resource_ref.readonly
 
-          return nil
+          return 'dict'
         end
         PYTHON_TYPE_FROM_MM_TYPE.fetch(prop.class.to_s, 'str')
       end

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -90,7 +90,8 @@ module Provider
         [
           "This field represents a link to a #{prop.resource_ref.name} resource in GCP.",
           'It can be specified in two ways.',
-          "First, you can place a dictionary with a key '#{prop.imports}' and a value of your resource's #{prop.imports}",
+          "First, you can place a dictionary with key '#{prop.imports}'",
+          "and value of your resource's #{prop.imports}",
           'Alternatively, you can add `register: name-of-resource` to a',
           "#{module_name(prop.resource_ref)} task",
           "and then set this #{prop.name.underscore} field to \"{{ name-of-resource }}\""

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -90,7 +90,7 @@ module Provider
         [
           "This field represents a link to a #{prop.resource_ref.name} resource in GCP.",
           'It can be specified in two ways.',
-          "First, you can place in the #{prop.imports} of the resource here as a string",
+          "First, you can place a dictionary with a key '#{prop.imports}' and a value of your resource's #{prop.imports}",
           'Alternatively, you can add `register: name-of-resource` to a',
           "#{module_name(prop.resource_ref)} task",
           "and then set this #{prop.name.underscore} field to \"{{ name-of-resource }}\""

--- a/provider/ansible/gcp_utils.py
+++ b/provider/ansible/gcp_utils.py
@@ -62,16 +62,8 @@ def replace_resource_dict(item, value):
     else:
         if not item:
             return item
-        if isinstance(item, dict):
+        else:
             return item.get(value)
-
-        # Item could be a string or a string representing a dictionary.
-        try:
-            new_item = ast.literal_eval(item)
-            return replace_resource_dict(new_item, value)
-        except ValueError:
-            return item
-
 
 # Handles all authentication and HTTP sessions for GCP API calls.
 class GcpSession(object):

--- a/provider/ansible/gcp_utils.py
+++ b/provider/ansible/gcp_utils.py
@@ -65,6 +65,7 @@ def replace_resource_dict(item, value):
         else:
             return item.get(value)
 
+
 # Handles all authentication and HTTP sessions for GCP API calls.
 class GcpSession(object):
     def __init__(self, module, product):


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->
I originally wanted to make ResourceRefs act like strings. There was some Python weirdness that had to happen to make that occur. After seeing some issues in the field, I'm going to revert those changes back.




<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
