### PR TITLE
[terraform-conversions] Add google_project CAI conversion

### DIFF
--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -60,6 +60,8 @@ module Provider
                         'third_party/validator/cai_test.go'],
                        ['google/json_map.go',
                         'third_party/validator/json_map.go'],
+                       ['google/project.go',
+                        'third_party/validator/project.go'],
                        ['google/compute_instance.go',
                         'third_party/validator/compute_instance.go'],
                        ['google/sql_database_instance.go',

--- a/third_party/validator/constants.go
+++ b/third_party/validator/constants.go
@@ -1,10 +1,16 @@
 package google
 
 import (
+	"errors"
+
 	"github.com/hashicorp/terraform/helper/mutexkv"
 )
 
+// ErrNoConversion can be returned if a conversion is unable to be returned
+// because of the current state of the system.
+// Example: The conversion requires that the resource has already been created
+// and is now being updated).
+var ErrNoConversion = errors.New("no conversion")
+
 // Global MutexKV
 var mutexKV = mutexkv.NewMutexKV()
-
-

--- a/third_party/validator/project.go
+++ b/third_party/validator/project.go
@@ -1,0 +1,121 @@
+package google
+
+import (
+	"fmt"
+	"strings"
+
+	"google.golang.org/api/cloudbilling/v1"
+	"google.golang.org/api/cloudresourcemanager/v1"
+)
+
+func GetProjectCaiObject(d TerraformResourceData, config *Config) (Asset, error) {
+	// NOTE: asset.name should use the project number, but we use project_id b/c
+	// the number is computed server-side.
+	name, err := assetName(d, config, "//cloudresourcemanager.googleapis.com/projects/{{project}}")
+	if err != nil {
+		return Asset{}, err
+	}
+	if obj, err := GetProjectApiObject(d, config); err == nil {
+		return Asset{
+			Name: name,
+			Type: "cloudresourcemanager.googleapis.com/Project",
+			Resource: &AssetResource{
+				Version:              "v1",
+				DiscoveryDocumentURI: "https://www.googleapis.com/discovery/v1/apis/compute/v1/rest",
+				DiscoveryName:        "Project",
+				Data:                 obj,
+			},
+		}, nil
+	} else {
+		return Asset{}, err
+	}
+}
+
+func GetProjectApiObject(d TerraformResourceData, config *Config) (map[string]interface{}, error) {
+	pid := d.Get("project_id").(string)
+
+	project := &cloudresourcemanager.Project{
+		ProjectId: pid,
+		Name:      d.Get("name").(string),
+	}
+
+	if err := getParentResourceId(d, project); err != nil {
+		return nil, err
+	}
+
+	if _, ok := d.GetOk("labels"); ok {
+		project.Labels = expandLabels(d)
+	}
+
+	return jsonMap(project)
+}
+
+func getParentResourceId(d TerraformResourceData, p *cloudresourcemanager.Project) error {
+	orgId := d.Get("org_id").(string)
+	folderId := d.Get("folder_id").(string)
+
+	if orgId != "" && folderId != "" {
+		return fmt.Errorf("'org_id' and 'folder_id' cannot be both set.")
+	}
+
+	if orgId != "" {
+		p.Parent = &cloudresourcemanager.ResourceId{
+			Id:   orgId,
+			Type: "organization",
+		}
+	}
+
+	if folderId != "" {
+		p.Parent = &cloudresourcemanager.ResourceId{
+			Id:   parseFolderId(folderId),
+			Type: "folder",
+		}
+	}
+
+	return nil
+}
+
+func parseFolderId(v interface{}) string {
+	folderId := v.(string)
+	if strings.HasPrefix(folderId, "folders/") {
+		return folderId[8:]
+	}
+	return folderId
+}
+
+func GetProjectBillingInfoCaiObject(d TerraformResourceData, config *Config) (Asset, error) {
+	name, err := assetName(d, config, "//cloudbilling.googleapis.com/projects/{{project}}/billingInfo")
+	if err != nil {
+		return Asset{}, err
+	}
+	if obj, err := GetProjectBillingInfoApiObject(d, config); err == nil {
+		return Asset{
+			Name: name,
+			Type: "cloudbilling.googleapis.com/ProjectBillingInfo",
+			Resource: &AssetResource{
+				Version:              "v1",
+				DiscoveryDocumentURI: "https://www.googleapis.com/discovery/v1/apis/cloudbilling/v1/rest",
+				DiscoveryName:        "ProjectBillingInfo",
+				Data:                 obj,
+			},
+		}, nil
+	} else {
+		return Asset{}, err
+	}
+}
+
+func GetProjectBillingInfoApiObject(d TerraformResourceData, config *Config) (map[string]interface{}, error) {
+	if _, ok := d.GetOk("billing_account"); !ok {
+		// TODO: If the project already exists, we could ask the API about it's
+		// billing info here.
+		return nil, ErrNoConversion
+	}
+
+	ba := &cloudbilling.ProjectBillingInfo{
+		BillingAccountName: fmt.Sprintf("billingAccounts/%s", d.Get("billing_account")),
+		Name:               fmt.Sprintf("projects/%s/billingInfo", d.Get("project_id")),
+		ProjectId:          d.Get("project_id").(string),
+	}
+
+	return jsonMap(ba)
+}

--- a/third_party/validator/project.go
+++ b/third_party/validator/project.go
@@ -67,20 +67,12 @@ func getParentResourceId(d TerraformResourceData, p *cloudresourcemanager.Projec
 
 	if folderId != "" {
 		p.Parent = &cloudresourcemanager.ResourceId{
-			Id:   parseFolderId(folderId),
+			Id:   strings.TrimPrefix(folderId, "folders/"),
 			Type: "folder",
 		}
 	}
 
 	return nil
-}
-
-func parseFolderId(v interface{}) string {
-	folderId := v.(string)
-	if strings.HasPrefix(folderId, "folders/") {
-		return folderId[8:]
-	}
-	return folderId
 }
 
 func GetProjectBillingInfoCaiObject(d TerraformResourceData, config *Config) (Asset, error) {


### PR DESCRIPTION
Note:

Terraform resource `google_project` has a 1:N relationship with CAI assets: `cloudresourcemanager.Project` & `cloudbilling.ProjectBillingInfo` so we have two conversion functions in this PR.