### PR TITLE
moving coverage dashboard to nightly

### DIFF
--- a/.ci/release.yml.tmpl
+++ b/.ci/release.yml.tmpl
@@ -40,14 +40,6 @@ resources:
         stop: 11:59 PM
         location: America/Los_Angeles
 
-    - name: week-trigger
-      type: time
-      source:
-        start: 11:00 PM
-        stop: 11:59 PM
-        days: [Sunday]
-        location: America/Los_Angeles
-
     - name: terraform-head
       type: git-branch
       source:
@@ -67,7 +59,7 @@ jobs:
                 CREDS: ((repo-key.private_key))
     - name: coverage-spreadsheet-release
       plan:
-          - get: week-trigger
+          - get: night-trigger
             trigger: true
           - get: magic-modules-gcp
             trigger: false


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->
Grabbing data for the coverage dashboard nightly instead of weekly because @chrisst @rileykarson wanted it




<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
