### PR TITLE
Add support for aliasing resource names.

### DIFF
--- a/tools/linter/README.md
+++ b/tools/linter/README.md
@@ -14,7 +14,7 @@ The linter is powered by RSpec.
   rspec tools/linter/run.rb
 ```
 
-Tests are divided into two parts: property tests and resource tests. The linter uses [rspec tags](https://relishapp.com/rspec/rspec-core/v/3-8/docs/command-line/tag-option) to filter which tests are run. The tests are broken down into `property` and `resource` tests and can be run with `--tag property` or `--tag resource`. It is also possible to filter by product using `--tag product:name`.
+Tests are divided into two parts: property tests and resource tests. The linter uses [rspec tags](https://relishapp.com/rspec/rspec-core/v/3-8/docs/command-line/tag-option) to filter which tests are run. The tests are broken down into `property` and `resource` tests and can be run with `--tag property` or `--tag resource`. It is also possible to filter by product or resource `--tag product:<name>` or `--tag resource:<name>`.
 
 To run only property tests, do the following:
 ```
@@ -24,6 +24,11 @@ To run only property tests, do the following:
 To run only cloudbuild tests, do the following:
 ```
   rspec tools/linter/run.rb --tag product:cloudbuild
+```
+
+To run only cloudbuild Trigger tests, do the following:
+```
+  rspec tools/linter/run.rb --tag resource:Trigger
 ```
 
 ## Getting Results as a CSV

--- a/tools/linter/discovery.rb
+++ b/tools/linter/discovery.rb
@@ -84,6 +84,7 @@ module Discovery
       @product = doc['product']
       @filename = doc['filename']
       @url = doc['url']
+      @aliases = doc['aliases'] || {}
       @resources_in_api_yaml = objects
       @results = fetch_discovery_doc(@url)
     end
@@ -100,13 +101,12 @@ module Discovery
     end
 
     def get_resource(resource)
-      # TODO: (chrisst) add aliases since 'Trigger' is 'BuildTrigger'
-      # in the schema
-
-      # Region, Global should resolve to normal.
       original_resource = resource
+
+      resource = @aliases[resource] if @aliases[resource]
+      # Region, Global should resolve to normal.
       if @results['schemas'][resource]
-        Resource.new(@results['schemas'][resource], resource, self)
+        Resource.new(@results['schemas'][resource], original_resource, self)
       elsif @results['schemas'][resource.sub('Region', '')]
         resource = resource.sub('Region', '')
         Resource.new(@results['schemas'][resource], resource, self)

--- a/tools/linter/docs.yaml
+++ b/tools/linter/docs.yaml
@@ -33,7 +33,7 @@
   version: v1
   filename: products/cloudbuild/api.yaml
   aliases:
-    - Trigger: BuildTrigger
+    Trigger: BuildTrigger
 - url: https://clouddebugger.googleapis.com/$discovery/rest?version=v2
   product: clouddebugger
   version: v2

--- a/tools/linter/tests/test_runner.rb
+++ b/tools/linter/tests/test_runner.rb
@@ -19,7 +19,7 @@ def run_tests(discovery_doc, api, filters, tags = {}, **kwargs)
     discovery_doc.resources.each do |disc_resource|
       api_obj = api&.objects&.select { |p| p.name == disc_resource.name }&.first
       # Second context: resource name
-      describe disc_resource.name do
+      describe disc_resource.name, resource: disc_resource.name do
         # Run all resource tests on this resource
         include_examples 'resource_tests', disc_resource, api_obj, tags if filters[:resource]
 


### PR DESCRIPTION
Some of the newer style disocvery docs don't have a 1 to 1 relationship between
the names of API methods and the names of the resource definition returned
*cough* looking at you cloud build. There doesn't appear to be a way to tie
the two together using the discovery docs so we have to manually build the
aliases so that we can match the API.yaml definition correctly.

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

<!-- Your regular pull request description goes here -->




<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
