### PR TITLE
Fix API Linter Spreadsheet

### DIFF
--- a/.ci/magic-modules/coverage-spreadsheet-upload.sh
+++ b/.ci/magic-modules/coverage-spreadsheet-upload.sh
@@ -19,7 +19,7 @@ pushd magic-modules-gcp
 bundle install
 gem install rspec
 
-bundle exec rspec tools/linter/spreadsheet.rb || true
+bundle exec rspec tools/linter/spreadsheet.rb
 
 echo "File created"
 date=$(date +'%m%d%Y')

--- a/tools/linter/spreadsheet.rb
+++ b/tools/linter/spreadsheet.rb
@@ -39,7 +39,7 @@ RSpec.configure do |c|
   c.inclusion_filter = [:property]
 end
 Google::LOGGER.level = Logger::ERROR
-VALID_KEYS = %w[filename url product version].freeze
+VALID_KEYS = %w[filename url product version aliases].freeze
 
 # Running tests.
 docs = YAML.safe_load(File.read(doc_file))
@@ -52,7 +52,7 @@ docs.each do |doc|
   # Need value in case TF or Ansible file does not exist.
   api_name = api.api_name
 
-  builder = Discovery::Builder.new(doc['url'], api.objects.map(&:name))
+  builder = Discovery::Builder.new(doc, api.objects.map(&:name))
   run_tests(builder, api, { property: true }, { provider: :api }, api_name: api_name)
 
   # Run tests on TF API


### PR DESCRIPTION
#1621 modified one of the api linter entry points, but not the other. Fix that. Also make the pipeline fail if the linter fails (I think).

Do you think it would be worth moving this bucket to the `magic-modules` project we own so it's more discoverable?

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
