### PR TITLE
Add back `|| true` to spreadsheet script

### DIFF
--- a/.ci/magic-modules/coverage-spreadsheet-upload.sh
+++ b/.ci/magic-modules/coverage-spreadsheet-upload.sh
@@ -19,6 +19,8 @@ pushd magic-modules-gcp
 bundle install
 gem install rspec
 
+# || true will suppress errors, but it's necessary for this to run. If unset,
+# Concourse will fail on *any* rspec step failing (eg: any API mismatch)
 bundle exec rspec tools/linter/spreadsheet.rb  || true
 
 echo "File created"

--- a/.ci/magic-modules/coverage-spreadsheet-upload.sh
+++ b/.ci/magic-modules/coverage-spreadsheet-upload.sh
@@ -19,7 +19,7 @@ pushd magic-modules-gcp
 bundle install
 gem install rspec
 
-bundle exec rspec tools/linter/spreadsheet.rb
+bundle exec rspec tools/linter/spreadsheet.rb  || true
 
 echo "File created"
 date=$(date +'%m%d%Y')


### PR DESCRIPTION
Any individual rspec test failing cancels the build, so even though the command returns a `0` as a whole since it ran successfully, it doesn't work. Fix it by adding back the `|| true` and sadly also the silent failure.

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
