### PR TITLE
fixes for 012 integration

### DIFF
--- a/third_party/terraform/tests/resource_compute_instance_from_template_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_from_template_test.go
@@ -159,7 +159,6 @@ func TestAccComputeInstanceFromTemplate_012_removableFields(t *testing.T) {
 					testAccCheckComputeInstanceExists(resourceName, &instance),
 
 					// Check that fields were able to be removed
-					resource.TestCheckResourceAttr(resourceName, "service_account.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "scratch_disk.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "attached_disk.#", "0"),
 					resource.TestCheckResourceAttr(resourceName, "network_interface.0.alias_ip_range.#", "0"),

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -551,6 +551,37 @@ func TestAccContainerNodePool_regionalClusters(t *testing.T) {
 	})
 }
 
+func TestAccContainerNodePool_012_ConfigModeAttr(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-nodepool-test-%s", acctest.RandString(10))
+	np := fmt.Sprintf("tf-nodepool-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerNodePoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_012_ConfigModeAttr1(cluster, np),
+			},
+			{
+				ResourceName:      "google_container_node_pool.np",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContainerNodePool_012_ConfigModeAttr2(cluster, np),
+			},
+			{
+				ResourceName:      "google_container_node_pool.np",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccContainerNodePool_basic(cluster, np string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
@@ -947,11 +978,11 @@ resource "google_container_node_pool" "np_with_gpu" {
 		disk_size_gb = 10
 
 		oauth_scopes = [
-			"https://www.googleapis.com/auth/devstorage.read_only", 
-			"https://www.googleapis.com/auth/logging.write", 
-			"https://www.googleapis.com/auth/monitoring", 
+			"https://www.googleapis.com/auth/devstorage.read_only",
+			"https://www.googleapis.com/auth/logging.write",
+			"https://www.googleapis.com/auth/monitoring",
 			"https://www.googleapis.com/auth/service.management.readonly",
-			"https://www.googleapis.com/auth/servicecontrol", 
+			"https://www.googleapis.com/auth/servicecontrol",
 			"https://www.googleapis.com/auth/trace.append"
 		]
 
@@ -1030,5 +1061,48 @@ resource "google_container_node_pool" "np" {
 	initial_node_count = 1
 
 	version = "${data.google_container_engine_versions.central1a.valid_node_versions.0}"
+}`, cluster, np)
+}
+
+func testAccContainerNodePool_012_ConfigModeAttr1(cluster, np string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+	name               = "%s"
+	zone = "us-central1-f"
+	initial_node_count = 3
+}
+
+resource "google_container_node_pool" "np" {
+	name               = "%s"
+	zone = "us-central1-f"
+	cluster            = "${google_container_cluster.cluster.name}"
+	initial_node_count = 1
+
+	node_config {
+		guest_accelerator {
+			count = 1
+			type  = "nvidia-tesla-p100"
+		}
+	}
+}`, cluster, np)
+}
+
+func testAccContainerNodePool_012_ConfigModeAttr2(cluster, np string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "cluster" {
+	name               = "%s"
+	zone               = "us-central1-f"
+	initial_node_count = 3
+}
+
+resource "google_container_node_pool" "np" {
+	name               = "%s"
+	zone               = "us-central1-f"
+	cluster            = "${google_container_cluster.cluster.name}"
+	initial_node_count = 1
+
+	node_config {
+		guest_accelerator = []
+	}
 }`, cluster, np)
 }

--- a/third_party/terraform/utils/node_config.go.erb
+++ b/third_party/terraform/utils/node_config.go.erb
@@ -49,6 +49,9 @@ var schemaNodeConfig = &schema.Schema{
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
+				// Legacy config mode allows removing GPU's from an existing resource
+				// See https://www.terraform.io/docs/configuration/attr-as-blocks.html
+				ConfigMode: schema.SchemaConfigModeAttr,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"count": &schema.Schema{

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -169,8 +169,8 @@ should be located. These must be in the same region as the cluster zone for
 zonal clusters, or in the region of a regional cluster. In a multi-zonal cluster,
 the number of nodes specified in `initial_node_count` is created in
 all specified zones as well as the primary zone. If specified for a regional
-cluster, nodes will only be created in these zones. `additional_zones` has been 
-deprecated in favour of `node_locations`. 
+cluster, nodes will only be created in these zones. `additional_zones` has been
+deprecated in favour of `node_locations`.
 
 * `addons_config` - (Optional) The configuration for addons supported by GKE.
     Structure is documented below.
@@ -471,6 +471,8 @@ The `node_config` block supports:
 
 * `guest_accelerator` - (Optional) List of the type and count of accelerator cards attached to the instance.
     Structure documented below.
+    To support removal of guest_accelerators in Terraform 0.12 this field is an
+    [Attribute as Block](/docs/configuration/attr-as-blocks.html)
 
 * `image_type` - (Optional) The image type to use for this node. Note that changing the image type
     will delete and recreate all nodes in the node pool.


### PR DESCRIPTION
1. Stop checking service account for emptiness. Our projects add back a default account.
2. Mark guest_accelerators as ConfigModeAttr for 012 so they can be removed.


<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

<!-- Your regular pull request description goes here -->




<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
