### PR TITLE
Handle null iap block in BackendService

### DIFF
--- a/templates/terraform/decoders/backend_service.go.erb
+++ b/templates/terraform/decoders/backend_service.go.erb
@@ -15,9 +15,12 @@
 // We need to pretend IAP isn't there if it's disabled for Terraform to maintain
 // BC behaviour with the handwritten resource.
 v, ok :=  res["iap"]
-m := v.(map[string]interface{})
-if ok && m["enabled"] == false {
-	delete(res, "iap")
+if ok {
+	m := v.(map[string]interface{})
+
+	if m["enabled"] == false {
+		delete(res, "iap")
+	}
 }
 
 return res, nil


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/3441

This isn't feasible to test in an acc test, but I verified this worked locally by creating a service with the API explorer that didn't have the block present.

Annoyingly, the block is a case where it defaults to disabled so we ran into this error when a user had used an old resource; users could also encounter it when importing though. We've sent a default block since version 1.2 of the provider, so on any resources created since this was a non-issue.


-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
