### PR TITLE
Removing ability to use compilation logic in api.yaml

### DIFF
--- a/api/compiler.rb
+++ b/api/compiler.rb
@@ -31,16 +31,12 @@ module Api
 
     def run
       # Compile step #1: compile with generic class to instantiate target class
-      source = compile(@catalog)
-      config = Google::YamlValidator.parse(source)
+      config = Google::YamlValidator.parse(File.read(@catalog))
       unless config.class <= Api::Product
         raise StandardError, "#{@catalog} is #{config.class}"\
           ' instead of Api::Product' \
       end
-      # Compile step #2: Now that we have the target class, compile with that
-      # class features
-      source = config.compile(@catalog, 0)
-      Google::YamlValidator.parse(source)
+      config
     end
   end
 end

--- a/spec/compiler_spec.rb
+++ b/spec/compiler_spec.rb
@@ -26,10 +26,14 @@ describe Api::Compiler do
     subject { -> { Api::Compiler.new('my-file-to-parse.yaml').run } }
 
     before do
+      # File will only be read once because there's no
+      # compilation occurring.
+      # (Compilation means file will be read twice - once
+      # to determine class + once to compile)
       IO.expects(:read).with('my-file-to-parse.yaml')
         .returns('--- !ruby/object:Api::Product
                       name: "foo"')
-        .twice
+        .once
     end
 
     it { is_expected.not_to raise_error }


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->
All of the api.yaml files have been inlined.

This PR removes the ability to use any ERB logic in the api.yaml files only.

This PR will be a no-op.




<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
