### PR TITLE
Remove confusing truthy methods

### DIFF
--- a/provider/core.rb
+++ b/provider/core.rb
@@ -378,14 +378,6 @@ module Provider
       raise 'Unimplemented build_url for this provider'
     end
 
-    def true?(obj)
-      obj.to_s.casecmp('true').zero?
-    end
-
-    def false?(obj)
-      obj.to_s.casecmp('false').zero?
-    end
-
     # Filter the properties to keep only the ones requiring custom update
     # method and group them by update url & verb.
     def properties_by_custom_update(properties)

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -320,7 +320,7 @@ def resource_to_request(module):
             return_vals[k] = v
 
     return return_vals
-<% unless false?(object.unwrap_resource) -%>
+<% if object.unwrap_resource -%>
 <%
   urf_code = [
     'return {',


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

<!-- Your regular pull request description goes here -->
Remove confusing truthy methods. They are unused except for one confusing use of `false?` that can be replaced as the variable is a boolean. Should be no-op



<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
