### PR TITLE
replacing the items key with the resources key

### DIFF
--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -51,8 +51,8 @@ EXAMPLES = '''
 
 RETURN = '''
 <%= to_yaml({
-  'items' => {
-    'description' => 'List of items',
+  'resources' => {
+    'description' => 'List of resources',
     'returned' => 'always',
     'type' => 'complex',
     'contains' => object.all_user_properties.map { |p| returns_for_property(p) }.reduce({}, :merge)
@@ -107,7 +107,7 @@ def main():
     else:
         items = []
     return_value = {
-        'items': items
+        'resources': items
     }
     module.exit_json(**return_value)
 

--- a/templates/ansible/verifiers/facts.yaml.erb
+++ b/templates/ansible/verifiers/facts.yaml.erb
@@ -39,8 +39,8 @@
       - <%= lines(object.facts.test.does_not_exist) -%>
 <% else # object.facts.test -%>
 <% if object.facts.has_filters -%>
-      - results['items'] | length == <%= _state == 'present' ? 1 : 0 %>
+      - results['resources'] | length == <%= _state == 'present' ? 1 : 0 %>
 <% else # object.has_filters -%>
-      - results['items'] | length <%= _state == 'present' ? '>= 1' : '== 0' %>
+      - results['resources'] | length <%= _state == 'present' ? '>= 1' : '== 0' %>
 <% end  # object.has_filters -%>
 <% end # object.facts.test -%>


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

See: https://github.com/ansible/ansible/issues/55824

This shouldn't break existing users, as they can still use `items` because Python.




<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
