### PR TITLE
[terraform-beta] adding AUTH_NONE to enums for istio addon_config

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -214,8 +214,9 @@ func resourceContainerCluster() *schema.Resource {
 									},
 									"auth": {
 										Type:         schema.TypeString,
+										Default:      "AUTH_NONE",
 										Optional:     true,
-										ValidateFunc: validation.StringInSlice([]string{"AUTH_MUTUAL_TLS"}, false),
+										ValidateFunc: validation.StringInSlice([]string{"AUTH_NONE", "AUTH_MUTUAL_TLS"}, false),
 									},
 								},
 							},


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

<!-- Your regular pull request description goes here -->

Adding a missing enum to the istio addons_config. Without this terraform cannot create a cluster. Will paste an error message shortly.

API docs [here](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.IstioAuthMode)



<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
adding `AUTH_NONE` to enums for istio addon_config
## [ansible]
## [inspec]
