### PR TITLE
terraform transport replaceVars always escapes all variables using url.PathEscape

### DIFF
--- a/third_party/terraform/utils/transport_test.go
+++ b/third_party/terraform/utils/transport_test.go
@@ -126,6 +126,14 @@ func TestReplaceVars(t *testing.T) {
 			},
 			Expected: "projects/project1/zones/zone1/instances/instance1",
 		},
+		"escape": {
+			Template: "b/{{bucket}}/o/{{object}}",
+			SchemaValues: map[string]interface{}{
+				"bucket": "bucket1",
+				"object": "path/to/object",
+			},
+			Expected: "b/bucket1/o/path%2Fto%2Fobject",
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

<!-- Your regular pull request description goes here -->

Moving from https://github.com/terraform-providers/terraform-provider-google/pull/3347
Reverts the changes from 0dad6e1df
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/2895

## Description

According to https://cloud.google.com/storage/docs/json_api/#encoding URI path parts need to be encoded.

For example in [`google_storage_object_access_control`](https://www.terraform.io/docs/providers/google/r/storage_object_access_control.html) if the object name contains a `/`, the request will fail with:

```
* google_storage_object_access_control.public_rule: Error creating ObjectAccessControl: googleapi: got HTTP response code 404 with body: Not Found
```

To my knowledge, `replaceVars()` is specifically for replacing variables in URLs (due to the name of the parameter `linkTmpl`), so I'm assuming this would work globally. Maybe this function should be renamed to `replaceURLVars()`?

The change from 0dad6e1df allowed prepending the variable name with `%`, but I think the user should not be aware of this API limitation (of needing to escape). Also note that only variables inserted to URLs should be escaped (as opposed to variables used in the body of the API request), so it may be confusing for the user who specified he wants to escape the variable but then the variable is not always escaped across the different API requests.