### PR TITLE
Better debugging output for bad api.yaml values

### DIFF
--- a/api/product.rb
+++ b/api/product.rb
@@ -39,6 +39,13 @@ module Api
       JSON.pretty_generate(self)
     end
 
+    # Prints a dot notation path to where the field is nested within the parent
+    # object when called on a property. eg: parent.meta.label.foo
+    # Redefined on Product to terminate the calls up the parent chain.
+    def lineage
+      name
+    end
+
     def to_json(opts = nil)
       json_out = {}
 

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -172,6 +172,13 @@ module Api
       JSON.pretty_generate(self)
     end
 
+    # Prints a dot notation path to where the field is nested within the parent
+    # object when called on a property. eg: parent.meta.label.foo
+    # Redefined on Resource to terminate the calls up the parent chain.
+    def lineage
+      name
+    end
+
     def to_json(opts = nil)
       # ignore fields that will contain references to parent resources
       ignored_fields = %i[@__product @__parent @__resource @api_name @collection_url_response]

--- a/api/type.rb
+++ b/api/type.rb
@@ -84,6 +84,10 @@ module Api
       JSON.pretty_generate(self)
     end
 
+    # Prints a dot notation path to where the field is nested within the parent
+    # object. eg: parent.meta.label.foo
+    # The only intended purpose is to allow better error messages. Some objects
+    # and at some points in the build this doesn't ouput a valid output.
     def lineage
       return name if __parent.nil?
 

--- a/api/type.rb
+++ b/api/type.rb
@@ -84,6 +84,12 @@ module Api
       JSON.pretty_generate(self)
     end
 
+    def lineage
+      return name if __parent.nil?
+
+      __parent.lineage + '.' + name
+    end
+
     def to_json(opts = nil)
       # ignore fields that will contain references to parent resources and
       # those which will be added later
@@ -454,6 +460,8 @@ module Api
       end
 
       def properties
+        raise "Field '#{lineage}' properties are nil!" if @properties.nil?
+
         @properties.reject(&:exclude)
       end
 

--- a/google/yaml_validator.rb
+++ b/google/yaml_validator.rb
@@ -59,8 +59,9 @@ module Google
         value = instance_variable_get("@#{variable}")
       end
 
-      # Check if value is required.
-      raise "#{lineage} > Missing '#{variable}'" if value.nil? && opts[:required]
+      # Check if value is required. Print nested path if available.
+      lineage_path = respond_to?('lineage') ? lineage : ''
+      raise "#{lineage_path} > Missing '#{variable}'" if value.nil? && opts[:required]
       return if value.nil?
 
       # Check type
@@ -68,7 +69,7 @@ module Google
 
       # Check item_type
       if value.is_a?(Array)
-        raise "#{lineage} > #{variable} must have item_type on arrays" unless opts[:item_type]
+        raise "#{lineage_path} > #{variable} must have item_type on arrays" unless opts[:item_type]
 
         value.each_with_index do |o, index|
           check_property_value("#{variable}[#{index}]", o, opts[:item_type])

--- a/google/yaml_validator.rb
+++ b/google/yaml_validator.rb
@@ -60,7 +60,7 @@ module Google
       end
 
       # Check if value is required.
-      raise "Missing '#{variable}'" if value.nil? && opts[:required]
+      raise "#{lineage} > Missing '#{variable}'" if value.nil? && opts[:required]
       return if value.nil?
 
       # Check type
@@ -68,7 +68,7 @@ module Google
 
       # Check item_type
       if value.is_a?(Array)
-        raise "#{variable} must have item_type on arrays" unless opts[:item_type]
+        raise "#{lineage} > #{variable} must have item_type on arrays" unless opts[:item_type]
 
         value.each_with_index do |o, index|
           check_property_value("#{variable}[#{index}]", o, opts[:item_type])

--- a/overrides/validator.rb
+++ b/overrides/validator.rb
@@ -69,12 +69,20 @@ module Overrides
 
     # Returns a property (or throws an error if it does not exist)
     def find_property(properties, path, res_name = '')
+      # Add context for debugging property name typos
+      available = []
+      prefix = ''
+
       prop = nil
       path.each do |part|
+        available = properties.map { |p| prefix + p.name } unless properties.empty?
+        prefix = prefix + part + '.'
+
         prop = properties.select { |o| o.name == part }.first
         properties = prop&.nested_properties || []
       end
-      raise "#{path.join('.')} does not exist on #{res_name}" unless prop
+      raise "#{path.join('.')} does not exist on #{res_name}.\n Possible values #{available}" \
+        unless prop
 
       prop
     end

--- a/spec/override_validator_spec.rb
+++ b/spec/override_validator_spec.rb
@@ -34,7 +34,7 @@ describe Overrides::Validator do
       it {
         runner = Overrides::Validator.new(api, overrides)
         expect { runner.run }.to raise_error(RuntimeError,
-                                             '@blahbad does not exist on AnotherResource')
+                                             /@blahbad does not exist on AnotherResource/)
       }
     end
     describe 'should be able identify a bad property' do
@@ -54,7 +54,7 @@ describe Overrides::Validator do
       it {
         runner = Overrides::Validator.new(api, overrides)
         expect { runner.run }.to raise_error(RuntimeError,
-                                             'blahbad does not exist on AnotherResource')
+                                             /blahbad does not exist on AnotherResource/)
       }
     end
 


### PR DESCRIPTION
* When a property is missing a description, output the property name in the error
* Print the path to a property in the error message. This will help when there
are multiple instances of a property name in a given resource
* Suggest property values when an override is not found.

Example error output:

```
/Users/chrisst/work/go/src/github.com/GoogleCloudPlatform/magic-modules/overrides/validator.rb:84:in `find_property': metadata.generateNamez.foo does not exist on Service. (RuntimeError)
 Possible values ["metadata.generateName", "metadata.name", "metadata.deletionGracePeriodSeconds", "metadata.clusterName", "metadata.finalizers", "metadata.deletionTimestamp", "metadata.ownerReferences", "metadata.creationTimestamp", "metadata.labels", "metadata.initializers", "metadata.generation", "metadata.resourceVersion", "metadata.selfLink", "metadata.uid", "metadata.namespace", "metadata.annotations"]
```
and
```
magic-modules/google/yaml_validator.rb:63:in `check': status.address.hostname > Missing 'description' (RuntimeError)
```

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

<!-- Your regular pull request description goes here -->




<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
