### PR TITLE
[terraform] adding support for DNSSEC.

### DIFF
--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -122,6 +122,61 @@ objects:
                     This should be formatted like
                     `https://www.googleapis.com/compute/v1/projects/{project}/global/networks/{network}`
       - !ruby/object:Api::Type::NestedObject
+        name: 'dnssecConfig'
+        description: |
+          DNSSEC configuration.
+        update_verb: :PATCH
+        update_url: 'projects/{{project}}/managedZones/{{name}}'
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: 'defaultKeySpecs'
+            description: |
+              Specifies parameters that will be used for generating initial DnsKeys for this ManagedZone. Output only while state is not OFF.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:              
+                - !ruby/object:Api::Type::String
+                  name: 'algorithm'
+                  description: |
+                    String mnemonic specifying the DNSSEC algorithm of this key. Acceptable values are:
+                    * "ecdsap256sha256"
+                    * "ecdsap384sha384"
+                    * "rsasha1"
+                    * "rsasha256"
+                    * "rsasha512"
+                - !ruby/object:Api::Type::Integer
+                  name: 'keyLength'
+                  description: |
+                    Length of the keys in bits.
+                - !ruby/object:Api::Type::String
+                  name: 'keyType'
+                  description: |
+                    Specifies whether this is a key signing key (KSK) or a zone signing key (ZSK). Key signing keys have the Secure Entry Point flag set and, when active, will only be used to sign resource record sets of type DNSKEY. Zone signing keys do not have the Secure Entry Point flag set and will be used to sign all other types of resource record sets. Acceptable values are:
+                    * "keySigning"
+                    * "zoneSigning"
+                - !ruby/object:Api::Type::String
+                  name: 'kind'
+                  description: |
+                    Identifies what kind of resource this is. Value needs to be fixed string "dns#dnsKeySpec".
+          - !ruby/object:Api::Type::String
+            name: 'kind'
+            description: |
+              Identifies what kind of resource this is. Value need to be fixed string "dns#managedZoneDnsSecConfig".
+          - !ruby/object:Api::Type::String
+            name: 'nonExistence'
+            description: |
+              Specifies the mechanism used to provide authenticated denial-of-existence responses. Output only while state is not OFF.
+              Acceptable values are:
+              * "nsec"
+              * "nsec3"
+          - !ruby/object:Api::Type::String
+            name: 'state'
+            description: |
+              Specifies whether DNSSEC is enabled, and what mode it is in. 
+              Acceptable values are:
+              * "off"
+              * "on"
+              * "transfer"
+      - !ruby/object:Api::Type::NestedObject
         name: 'forwardingConfig'
         description: |
           The presence for this field indicates that outbound forwarding is enabled


### PR DESCRIPTION
The cloud.gov team has a use case for DNSSEC support in terraform, this adds generator support for the GCP terraform provider.

Signed-off-by: Mike Lloyd <mike.lloyd@gsa.gov>

