### PR TITLE
Improve to_json output

### DIFF
--- a/api/resource.rb
+++ b/api/resource.rb
@@ -181,15 +181,16 @@ module Api
 
     def to_json(opts = nil)
       # ignore fields that will contain references to parent resources
-      ignored_fields = %i[@__product @__parent @__resource @api_name @collection_url_response]
+      ignored_fields = %i[@__product @__parent @__resource @api_name
+                          @collection_url_response @properties @parameters]
       json_out = {}
 
       instance_variables.each do |v|
         json_out[v] = instance_variable_get(v) unless ignored_fields.include? v
       end
 
-      json_out[:@properties] = properties.map { |p| [p.name, p] }.to_h
-      json_out[:@parameters] = parameters.map { |p| [p.name, p] }.to_h
+      json_out.merge!(properties.map { |p| [p.name, p] }.to_h)
+      json_out.merge!(parameters.map { |p| [p.name, p] }.to_h)
 
       JSON.generate(json_out, opts)
     end

--- a/api/type.rb
+++ b/api/type.rb
@@ -97,7 +97,8 @@ module Api
     def to_json(opts = nil)
       # ignore fields that will contain references to parent resources and
       # those which will be added later
-      ignored_fields = %i[@resource @__parent @__resource @api_name]
+      ignored_fields = %i[@resource @__parent @__resource @api_name @update_verb
+                          @__name @name @properties]
       json_out = {}
 
       instance_variables.each do |v|
@@ -111,7 +112,7 @@ module Api
       end
 
       # convert properties to a hash based on name for nested readability
-      json_out[:@properties] = properties&.map { |p| [p.name, p] }.to_h \
+      json_out.merge!(properties&.map { |p| [p.name, p] }.to_h) \
         if respond_to? 'properties'
 
       JSON.generate(json_out, opts)


### PR DESCRIPTION
For deeply nested resources the existence of the `@properties` object was
making it hard to read and doubling the nesting. This will remove that
special property and just surface the properties as JSON properties on the
object.

Variables for a given field will be JSON properties up with the @var name
while child properties will not have the @ prefix.

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

<!-- Your regular pull request description goes here -->

Example new json output:
```json
"metadata": {
      "@description": "Metadata associated with this Service, including name, namespace, labels,\nand annotations.",
      "@required": true,
      "creationTimestamp": {
        "@description": "CreationTimestamp is a timestamp representing the server time when this\nobject was created. It is not guaranteed to be set in happens-before order\nacross separate operations. Clients may not set this value. It is\nrepresented in RFC3339 form and is in UTC.\n\nPopulated by the system.\nRead-only.\nNull for lists.\nMore info:\nhttps://git.k8s.io/community/contributors/devel/api-conventions.md#metadata\n+optional",
        "@output": true
      },
      "labels": {
        "@description": "Map of string keys and values that can be used to organize and categorize\n(scope and select) objects. May match selectors of replication controllers\nand routes.\nMore info: http://kubernetes.io/docs/user-guide/labels\n+optional"
      },
      "ownerReferences": {
        "@description": "List of objects that own this object. If ALL objects in the list have\nbeen deleted, this object will be garbage collected.\n+optional",
        "@item_type": {
          "@description": "A nested object resource",
          "blockOwnerDeletion": {
            "@description": "If true, AND if the owner has the \"foregroundDeletion\" finalizer, then\nthe owner cannot be deleted from the key-value store until this\nreference is removed.\nDefaults to false.\nTo set this field, a user needs \"delete\" permission of the owner,\notherwise 422 (Unprocessable Entity) will be returned.\n+optional"
          },
          "apiVersion": {
            "@description": "API version of the referent."
          },
          "name": {
            "@description": "Name of the referent.\nMore info: http://kubernetes.io/docs/user-guide/identifiers#names"
          },
          "uid": {
            "@description": "UID of the referent.\nMore info: http://kubernetes.io/docs/user-guide/identifiers#uids"
          },
          "controller": {
            "@description": "If true, this reference points to the managing controller.\n+optional"
          }
        }
      }
    },
```


