### PR TITLE
Flatten all base urls in MM proper

### DIFF
--- a/api/resource.rb
+++ b/api/resource.rb
@@ -348,7 +348,11 @@ module Api
       end
     end
 
-    # Returns self link in two parts - base_url + product_url
+    # Returns the "self_link_url" which is generally really the resource's GET
+    # URL. In older resources generally, this was the self_link value & was the
+    # product.base_url + resource.base_url + '/name'
+    # In newer resources there is much less standardisation in terms of value.
+    # Generally for them though, it's the product.base_url + resource.name
     def self_link_url
       base_url = @__product.base_url.split("\n").map(&:strip).compact
       if @self_link.nil?

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -352,10 +352,10 @@ module Api
     def self_link_url
       base_url = @__product.base_url.split("\n").map(&:strip).compact
       if @self_link.nil?
-        [base_url, [@base_url, '{{name}}'].join('/')]
+        [base_url, [@base_url, '{{name}}'].join('/')].flatten.join
       else
         self_link = @self_link.split("\n").map(&:strip).compact
-        [base_url, self_link]
+        [base_url, self_link].flatten.join
       end
     end
 
@@ -363,13 +363,13 @@ module Api
       [
         @__product.base_url.split("\n").map(&:strip).compact,
         @base_url.split("\n").map(&:strip).compact
-      ]
+      ].flatten.join
     end
 
     def async_operation_url
       raise 'Not an async resource' if async.nil?
 
-      [@__product.base_url, async.operation.base_url]
+      [@__product.base_url, async.operation.base_url].flatten.join
     end
 
     def default_create_url
@@ -389,7 +389,7 @@ module Api
         [
           @__product.base_url.split("\n").map(&:strip).compact,
           @create_url.split("\n").map(&:strip).compact
-        ]
+        ].flatten.join
       end
     end
 
@@ -400,13 +400,13 @@ module Api
         [
           @__product.base_url.split("\n").map(&:strip).compact,
           @delete_url
-        ]
+        ].flatten.join
       end
     end
 
     # A regex to check if a full URL was returned or just a shortname.
     def regex_url
-      self_link_url.join.gsub('{{project}}', '.*')
+      self_link_url.gsub('{{project}}', '.*')
                    .gsub('{{name}}', '[a-z1-9\-]*')
                    .gsub('{{zone}}', '[a-z1-9\-]*')
     end

--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -321,9 +321,7 @@ objects:
       CAA, MX, CNAME, NS, etc)
     base_url: |
       projects/{{project}}/managedZones/{{managed_zone}}/changes
-    self_link: |
-      projects/{{project}}/managedZones/{{managed_zone}}/rrsets
-      ?name={{name}}&type={{type}}
+    self_link: 'projects/{{project}}/managedZones/{{managed_zone}}/rrsets?name={{name}}&type={{type}}'
     nested_query: !ruby/object:Api::Resource::NestedQuery
       kind: 'dns#resourceRecordSetsListResponse'
       keys: ['rrsets']

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -79,14 +79,8 @@ module Provider
         return "u#{quote_string(string)}" unless string.include? 'u\''
       end
 
-      def build_url(url_parts, _extra = false)
-        full_url = if url_parts.is_a? Array
-                     url_parts.flatten.join
-                   else
-                     url_parts
-                   end
-
-        "\"#{full_url.gsub('{{', '{').gsub('}}', '}')}\""
+      def build_url(url)
+        "\"#{url.gsub('{{', '{').gsub('}}', '}')}\""
       end
 
       # Returns the name of the module according to Ansible naming standards.

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -364,11 +364,6 @@ module Provider
       }
     end
 
-    # This is used within Terraform and Ansible but they implement their own
-    def build_url(_url_parts, _extra = false)
-      raise 'Unimplemented build_url for this provider'
-    end
-
     # Filter the properties to keep only the ones requiring custom update
     # method and group them by update url & verb.
     def properties_by_custom_update(properties)
@@ -381,7 +376,7 @@ module Provider
     end
 
     def update_url(resource, url_part)
-      return build_url(resource.self_link_url) if url_part.nil?
+      return resource.self_link_url if url_part.nil?
 
       [resource.__product.base_url, url_part].flatten.join
     end

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -93,10 +93,6 @@ module Provider
                              force_new?(property.parent, resource))))
     end
 
-    def build_url(url_parts, _extra = false)
-      url_parts.flatten.join
-    end
-
     # Transforms a format string with field markers to a regex string with
     # capture groups.
     #

--- a/spec/provider_terraform_spec.rb
+++ b/spec/provider_terraform_spec.rb
@@ -63,7 +63,7 @@ describe Provider::Terraform do
     end
 
     describe '#collection_url' do
-      subject { provider.build_url(resource.collection_url) }
+      subject { resource.collection_url }
       it do
         version = product.version_obj_or_default(nil)
         product.set_properties_based_on_version(version)
@@ -72,7 +72,7 @@ describe Provider::Terraform do
     end
 
     describe '#collection_url beta' do
-      subject { provider.build_url(resource.collection_url) }
+      subject { resource.collection_url }
       it do
         version = product.version_obj_or_default('beta')
         product.set_properties_based_on_version(version)
@@ -81,7 +81,7 @@ describe Provider::Terraform do
     end
 
     describe '#self_link_url' do
-      subject { provider.build_url(resource.self_link_url) }
+      subject { resource.self_link_url }
       it do
         version = product.version_obj_or_default(nil)
         product.set_properties_based_on_version(version)
@@ -92,7 +92,7 @@ describe Provider::Terraform do
     end
 
     describe '#self_link_url beta' do
-      subject { provider.build_url(resource.self_link_url) }
+      subject { resource.self_link_url }
       it do
         version = product.version_obj_or_default('beta')
         product.set_properties_based_on_version(version)

--- a/templates/ansible/async.erb
+++ b/templates/ansible/async.erb
@@ -6,7 +6,7 @@
   err_msg = object.async.error.message
 -%>
 <%=
-  lines(emit_link('async_op_url', build_url(object.async_operation_url, true), object, true), 2)
+  lines(emit_link('async_op_url', build_url(object.async_operation_url), object, true), 2)
 -%>
 def wait_for_operation(module, response):
     op_result = <%= method_call('return_if_object',

--- a/templates/inspec/iam_policy/iam_policy.erb
+++ b/templates/inspec/iam_policy/iam_policy.erb
@@ -38,10 +38,10 @@ class <%= object.name -%>IamPolicy < GcpResourceBase
   private
 
   def product_url
-    '<%= object.product_url %>'
+    '<%= object.product_url || object.__product.base_url %>'
   end
 
-<% individual_url = format_url(object.self_link_url[1]) -%>
+<% individual_url = object.self_link || object.base_url + '/{{name}}' -%>
   def resource_base_url
     '<%= individual_url -%>/getIamPolicy'
   end

--- a/templates/inspec/iam_policy/iam_policy.erb
+++ b/templates/inspec/iam_policy/iam_policy.erb
@@ -38,7 +38,7 @@ class <%= object.name -%>IamPolicy < GcpResourceBase
   private
 
   def product_url
-    '<%= object.product_url || object.self_link_url[0].join %>'
+    '<%= object.product_url %>'
   end
 
 <% individual_url = format_url(object.self_link_url[1]) -%>

--- a/templates/inspec/iam_policy/iam_policy.md.erb
+++ b/templates/inspec/iam_policy/iam_policy.md.erb
@@ -9,7 +9,7 @@ A `<%= iam_resource_name -%>` is used to test a Google <%= object.name -%> Iam P
 
 ## Examples
 <%
-identifiers = extract_identifiers(format_url(object.self_link_url[1]))
+identifiers = extract_identifiers(format_url(object.self_link_url))
 identifiers_out = identifiers.map { |id| "#{id}: #{id.inspect}" }.join(', ')
 -%>
 ```

--- a/templates/inspec/plural_resource.erb
+++ b/templates/inspec/plural_resource.erb
@@ -88,7 +88,7 @@ link_query_items = object&.nested_query&.keys&.first || object.collection_url_re
   private
 
   def product_url
-    '<%= object.product_url || object.self_link_url[0].join %>'
+    '<%= object.product_url %>'
   end
 
   def resource_base_url

--- a/templates/inspec/plural_resource.erb
+++ b/templates/inspec/plural_resource.erb
@@ -88,10 +88,10 @@ link_query_items = object&.nested_query&.keys&.first || object.collection_url_re
   private
 
   def product_url
-    '<%= object.product_url %>'
+    '<%= object.product_url || object.__product.base_url %>'
   end
 
   def resource_base_url
-    '<%= format_url(object.base_url) %>'
+    '<%= object.base_url %>'
   end
 end

--- a/templates/inspec/singular_resource.erb
+++ b/templates/inspec/singular_resource.erb
@@ -101,7 +101,7 @@ best_guess_identifier = extract_identifiers(individual_url).last
   private
 
   def product_url
-    '<%= object.product_url || object.self_link_url[0].join %>'
+    '<%= object.product_url %>'
   end
 
   def resource_base_url

--- a/templates/inspec/singular_resource.erb
+++ b/templates/inspec/singular_resource.erb
@@ -87,7 +87,7 @@ class <%= object.name -%> < GcpResourceBase
   end
 
 <% 
-individual_url = format_url(object.self_link_url[1])
+individual_url = format_url(object.self_link_url)
 best_guess_identifier = extract_identifiers(individual_url).last 
 -%>
   def to_s
@@ -101,10 +101,10 @@ best_guess_identifier = extract_identifiers(individual_url).last
   private
 
   def product_url
-    '<%= object.product_url %>'
+    '<%= object.product_url || object.__product.base_url %>'
   end
 
   def resource_base_url
-    '<%= individual_url %>'
+    '<%= object.self_link || object.base_url + '/{{name}}' %>'
   end
 end

--- a/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/templates/terraform/examples/base_configs/test_file.go.erb
@@ -114,7 +114,7 @@ func testAccCheck<%= resource_name -%>Destroy(s *terraform.State) error {
 
 	config := testAccProvider.Meta().(*Config)
 
-	url, err := replaceVarsForTest(rs, "<%= build_url(object.self_link_url) -%>")
+	url, err := replaceVarsForTest(rs, "<%= object.self_link_url -%>")
 	if err != nil {
 		return err
 	}

--- a/templates/terraform/operation.go.erb
+++ b/templates/terraform/operation.go.erb
@@ -19,7 +19,7 @@ func (w *<%= product_name -%>OperationWaiter) QueryOp() (interface{}, error) {
     return nil, fmt.Errorf("Cannot query operation, it's unset or nil.")
   }
   // Returns the proper get.
-  url := fmt.Sprintf("<%= build_url([object.__product.base_url, async.operation.base_url]).gsub('{{op_id}}', '%s') -%>", w.CommonOperationWaiter.Op.Name)
+  url := fmt.Sprintf("<%= [object.__product.base_url, async.operation.base_url].flatten.join.gsub('{{op_id}}', '%s') -%>", w.CommonOperationWaiter.Op.Name)
   return sendRequest(w.Config, "GET", url, nil)
 }
 

--- a/templates/terraform/post_create/labels.erb
+++ b/templates/terraform/post_create/labels.erb
@@ -16,7 +16,7 @@ if v, ok := d.GetOkExists("labels"); !isEmptyValue(reflect.ValueOf(v)) && (ok ||
     labelFingerprintProp := d.Get("label_fingerprint")
     obj["labelFingerprint"] = labelFingerprintProp
 
-    url, err = replaceVars(d, config, "<%= build_url(object.self_link_url) -%>/setLabels")
+    url, err = replaceVars(d, config, "<%= object.self_link_url -%>/setLabels")
     if err != nil {
         return err
     }

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -149,7 +149,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     defer mutexKV.Unlock(lockName)
 <%  end -%>
 
-    url, err := replaceVars(d, config, "<%= build_url(object.full_create_url) -%>")
+    url, err := replaceVars(d, config, "<%= object.full_create_url -%>")
     if err != nil {
         return err
     }
@@ -207,7 +207,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{}) error {
     config := meta.(*Config)
 
-    url, err := replaceVars(d, config, "<%= build_url(object.self_link_url) -%>")
+    url, err := replaceVars(d, config, "<%= object.self_link_url -%>")
     if err != nil {
         return err
     }
@@ -520,7 +520,7 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
     defer mutexKV.Unlock(lockName)
 <%  end -%>
 
-    url, err := replaceVars(d, config, "<%= build_url(object.full_delete_url) -%>")
+    url, err := replaceVars(d, config, "<%= object.full_delete_url -%>")
     if err != nil {
         return err
     }


### PR DESCRIPTION
All providers need to join url_parts, and none of them seem to do anything significant with them. Flatten them all instead of relying on providers to do it.

This also guarantees that these urls will be string types; previously, they could be arrays or they could be strings.

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
