### PR TITLE
Diff suppress storage transfer job start_time_of_day

### DIFF
--- a/third_party/terraform/resources/resource_storage_transfer_job.go
+++ b/third_party/terraform/resources/resource_storage_transfer_job.go
@@ -96,11 +96,12 @@ func resourceStorageTransferJob() *schema.Resource {
 							Elem:     dateObjectSchema(),
 						},
 						"start_time_of_day": {
-							Type:     schema.TypeList,
-							Optional: true,
-							ForceNew: true,
-							MaxItems: 1,
-							Elem:     timeObjectSchema(),
+							Type:             schema.TypeList,
+							Optional:         true,
+							ForceNew:         true,
+							MaxItems:         1,
+							Elem:             timeObjectSchema(),
+							DiffSuppressFunc: diffSuppressEmptyStartTimeOfDay,
 						},
 					},
 				},
@@ -299,6 +300,10 @@ func httpDataSchema() *schema.Resource {
 			},
 		},
 	}
+}
+
+func diffSuppressEmptyStartTimeOfDay(k, old, new string, d *schema.ResourceData) bool {
+	return k == "schedule.0.start_time_of_day.#" && old == "1" && new == "0"
 }
 
 func resourceStorageTransferJobCreate(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

<!-- Your regular pull request description goes here -->
When start_time_of_day is not specified, the API returns `start_time_of_day: {}`, which Terraform then sets as `"start_time_of_day" = map[string]string{ "hours": 0, "minutes": 0, ...}`. 

We want a diff suppress here so that:

- users can still supply empty value (no start_time_of_day or start_time_of_day = []) for modules or in general. Terraform will read the API default value in and the diff on second apply will be ignored.
- if the user changes it to an empty value, Terraform will only show a diff (and forcenew) if the previous value was not zero'd out. e.g. TF will ignore start_time_of_day.#: 1 => 0 but won't ignore .hours: 10 -> 0, and thus will still recreate it with an "empty" start time

Related to https://github.com/terraform-providers/terraform-provider-google/issues/3626
<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]Diff suppress storage transfer job start_time_of_day
### [terraform-beta]Diff suppress storage transfer job start_time_of_day
## [ansible]
## [inspec]
