### PR TITLE
Use Redis URL fields for their intended purposes

### DIFF
--- a/products/redis/api.yaml
+++ b/products/redis/api.yaml
@@ -44,9 +44,8 @@ async: !ruby/object:Api::Async
 objects:
   - !ruby/object:Api::Resource
     name: 'Instance'
-    base_url: |
-      projects/{{project}}/locations/{{region}}/instances?instanceId={{name}}
-    self_link: projects/{{project}}/locations/{{region}}/instances/{{name}}
+    base_url: projects/{{project}}/locations/{{region}}/instances
+    create_url: projects/{{project}}/locations/{{region}}/instances?instanceId={{name}}
     update_verb: :PATCH
     update_mask: true
     description: |


### PR DESCRIPTION
Between https://github.com/GoogleCloudPlatform/magic-modules/pull/1788 and writing the codelab with Redis, I noticed that we were overloading `base_url` with create-only behaviour in Redis. Use the fields for their intended purpose.

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
