### PR TITLE
[Ansible] remove client side validation on enums

### DIFF
--- a/provider/ansible/module.rb
+++ b/provider/ansible/module.rb
@@ -32,7 +32,6 @@ module Provider
             'required' => (true if prop.required && !prop.default_value),
             'default' => prop.default_value,
             'type' => python_type(prop),
-            'choices' => (prop.values if prop.is_a?(Api::Type::Enum)),
             'elements' => (python_type(prop.item_type) \
               if prop.is_a?(Api::Type::Array) && python_type(prop.item_type)),
             'aliases' => prop.aliases,


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->
For enum values, Ansible currently does client-side validation (if you put in a bad value, Ansible will error out before making any API requests).

I now believe this is the wrong behavior. If our API definition is out-of-date, I don't want users to have to wait for us to update the Ansible modules validation before a value will work properly in the module. I'd much rather let the GCP API do the validation since the API's validation will always be up-to-date.

We'll still want to update our list of valid values because we build documentation against that list. But, our list of valid values shouldn't block users from using new API values.




<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
