### PR TITLE
Don't use bundle install in CI 

### DIFF
--- a/.ci/containers/go-ruby-python/Dockerfile
+++ b/.ci/containers/go-ruby-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/magic-modules/go-ruby:1.11.5-2.6.0
+FROM gcr.io/magic-modules/go-ruby:1.11.5-2.6.0-v2
 
 # Install python & python libraries.
 RUN apt-get update

--- a/.ci/containers/go-ruby/Dockerfile
+++ b/.ci/containers/go-ruby/Dockerfile
@@ -33,5 +33,6 @@ RUN gem update --system "$RUBYGEMS_VERSION"
 RUN gem install bundler --version "$BUNDLER_VERSION" --force
 
 ADD Gemfile Gemfile
+ADD Gemfile.lock Gemfile.lock
 RUN bundle install
 RUN rbenv rehash

--- a/.ci/containers/go-ruby/Gemfile
+++ b/.ci/containers/go-ruby/Gemfile
@@ -5,8 +5,13 @@ gem 'binding_of_caller'
 gem 'rake'
 
 group :test do
+  gem 'erb_lint'
   gem 'mocha', '~> 1.3.0'
   gem 'parallel_tests'
   gem 'rspec'
   gem 'rubocop', '~> 0.63.1'
+end
+
+group :pr_script do
+  gem 'octokit'
 end

--- a/.ci/containers/go-ruby/Gemfile.lock
+++ b/.ci/containers/go-ruby/Gemfile.lock
@@ -1,0 +1,120 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actionview (5.2.3)
+      activesupport (= 5.2.3)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    activesupport (5.2.3)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    ast (2.4.0)
+    better_html (1.0.13)
+      actionview (>= 4.0)
+      activesupport (>= 4.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      html_tokenizer (~> 0.0.6)
+      parser (>= 2.4)
+      smart_properties
+    binding_of_caller (0.8.0)
+      debug_inspector (>= 0.0.1)
+    builder (3.2.3)
+    concurrent-ruby (1.1.5)
+    crass (1.0.4)
+    debug_inspector (0.0.3)
+    diff-lcs (1.3)
+    erb_lint (0.0.28)
+      activesupport
+      better_html (~> 1.0.7)
+      html_tokenizer
+      rainbow
+      rubocop (~> 0.51)
+      smart_properties
+    erubi (1.8.0)
+    faraday (0.15.4)
+      multipart-post (>= 1.2, < 3)
+    html_tokenizer (0.0.7)
+    i18n (1.6.0)
+      concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.2)
+    loofah (2.2.3)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    metaclass (0.0.4)
+    mini_portile2 (2.4.0)
+    minitest (5.11.3)
+    mocha (1.3.0)
+      metaclass (~> 0.0.1)
+    multipart-post (2.0.0)
+    nokogiri (1.10.2)
+      mini_portile2 (~> 2.4.0)
+    octokit (4.13.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    parallel (1.12.1)
+    parallel_tests (2.23.0)
+      parallel
+    parser (2.6.0.0)
+      ast (~> 2.4.0)
+    powerpack (0.1.2)
+    public_suffix (3.0.3)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
+    rainbow (3.0.0)
+    rake (12.3.1)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    rubocop (0.63.1)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.4.0)
+    ruby-progressbar (1.10.0)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
+    smart_properties (1.13.1)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    unicode-display_width (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport
+  binding_of_caller
+  erb_lint
+  mocha (~> 1.3.0)
+  octokit
+  parallel_tests
+  rake
+  rspec
+  rubocop (~> 0.63.1)
+
+BUNDLED WITH
+   1.17.2

--- a/.ci/magic-modules/generate-ansible.sh
+++ b/.ci/magic-modules/generate-ansible.sh
@@ -9,7 +9,6 @@ source "$(dirname "$0")/helpers.sh"
 PATCH_DIR="$(pwd)/patches"
 pushd magic-modules-branched
 LAST_COMMIT_AUTHOR="$(git log --pretty="%an <%ae>" -n1 HEAD)"
-bundle install
 for i in $(find products/ -name 'ansible.yaml' -printf '%h\n');
 do
   bundle exec compiler -p $i -e ansible -o "build/ansible/"

--- a/.ci/magic-modules/generate-ansible.yml
+++ b/.ci/magic-modules/generate-ansible.yml
@@ -8,7 +8,7 @@ image_resource:
     type: docker-image
     source:
         repository: gcr.io/magic-modules/go-ruby-python
-        tag: '1.11.5-2.6.0-2.7'
+        tag: '1.11.5-2.6.0-2.7-v2'
 
 inputs:
     - name: magic-modules-branched

--- a/.ci/magic-modules/generate-inspec.sh
+++ b/.ci/magic-modules/generate-inspec.sh
@@ -9,7 +9,6 @@ source "$(dirname "$0")/helpers.sh"
 PATCH_DIR="$(pwd)/patches"
 pushd magic-modules-branched
 LAST_COMMIT_AUTHOR="$(git log --pretty="%an <%ae>" -n1 HEAD)"
-bundle install
 for i in $(find products/ -name 'inspec.yaml' -printf '%h\n');
 do
   bundle exec compiler -p $i -e inspec -o "build/inspec/"

--- a/.ci/magic-modules/generate-inspec.yml
+++ b/.ci/magic-modules/generate-inspec.yml
@@ -8,7 +8,7 @@ image_resource:
     type: docker-image
     source:
         repository: gcr.io/magic-modules/go-ruby-python
-        tag: '1.11.5-2.6.0-2.7'
+        tag: '1.11.5-2.6.0-2.7-v2'
 
 inputs:
     - name: magic-modules-branched

--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -39,7 +39,6 @@ popd
 
 pushd magic-modules-branched
 LAST_COMMIT_AUTHOR="$(git log --pretty="%an <%ae>" -n1 HEAD)"
-bundle install
 
 # Build all terraform products
 if [ -n "$OVERRIDE_PROVIDER" ] && [ "$OVERRIDE_PROVIDER" != "null" ]; then

--- a/.ci/magic-modules/generate-terraform.yml
+++ b/.ci/magic-modules/generate-terraform.yml
@@ -8,7 +8,7 @@ image_resource:
     type: docker-image
     source:
         repository: gcr.io/magic-modules/go-ruby-python
-        tag: '1.11.5-2.6.0-2.7'
+        tag: '1.11.5-2.6.0-2.7-v2'
 
 inputs:
     - name: magic-modules-branched

--- a/.ci/magic-modules/merge.yml
+++ b/.ci/magic-modules/merge.yml
@@ -7,7 +7,7 @@ image_resource:
     type: docker-image
     source:
         repository: gcr.io/magic-modules/go-ruby
-        tag: '1.11.5-2.6.0-v2'
+        tag: '1.11.5-2.6.0'
 
 inputs:
     - name: mm-approved-prs

--- a/.ci/magic-modules/merge.yml
+++ b/.ci/magic-modules/merge.yml
@@ -7,7 +7,7 @@ image_resource:
     type: docker-image
     source:
         repository: gcr.io/magic-modules/go-ruby
-        tag: '1.11.5-2.6.0'
+        tag: '1.11.5-2.6.0-v2'
 
 inputs:
     - name: mm-approved-prs

--- a/.ci/magic-modules/point-to-submodules.yml
+++ b/.ci/magic-modules/point-to-submodules.yml
@@ -8,7 +8,7 @@ image_resource:
     type: docker-image
     source:
         repository: gcr.io/magic-modules/go-ruby
-        tag: '1.11.5-2.6.0'
+        tag: '1.11.5-2.6.0-v2'
 
 inputs:
     - name: magic-modules-branched

--- a/.ci/magic-modules/point-to-submodules.yml
+++ b/.ci/magic-modules/point-to-submodules.yml
@@ -8,7 +8,7 @@ image_resource:
     type: docker-image
     source:
         repository: gcr.io/magic-modules/go-ruby
-        tag: '1.11.5-2.6.0-v2'
+        tag: '1.11.5-2.6.0'
 
 inputs:
     - name: magic-modules-branched

--- a/.ci/unit-tests/task.yml
+++ b/.ci/unit-tests/task.yml
@@ -5,7 +5,7 @@ image_resource:
   type: docker-image
   source:
     repository: gcr.io/magic-modules/go-ruby-python
-    tag: '1.11.5-2.6.0-2.7'
+    tag: '1.11.5-2.6.0-2.7-v2'
 run:
   path: magic-modules/.ci/unit-tests/run.sh
 params:

--- a/.ci/unit-tests/test-terraform.yml
+++ b/.ci/unit-tests/test-terraform.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: gcr.io/magic-modules/go-ruby-python
-    tag: '1.11.5-2.6.0-2.7'
+    tag: '1.11.5-2.6.0-2.7-v2'
 run:
   path: magic-modules/.ci/unit-tests/run.sh
   args:


### PR DESCRIPTION
This should speed up generation times once all the caches on the workers are up to date.

Originally that was meant to fail.

-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
