### PR TITLE
[Ansible] client side validation can't have docs with explicit choices

### DIFF
--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -99,7 +99,7 @@ module Provider
       end
 
       def choices_description(prop)
-        "Some valid choices include: #{prop.values.map { |x| quote_string(x.to_s) }.join(', ')}"
+        "Some valid choices include: #{prop.values.map(&:to_s).join(', ')}"
       end
 
       # MM puts descriptions in a text block. Ansible needs it in bullets

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -30,7 +30,9 @@ module Provider
             'description' => [
               format_description(prop.description),
               (resourceref_description(prop) \
-               if prop.is_a?(Api::Type::ResourceRef) && !prop.resource_ref.readonly)
+               if prop.is_a?(Api::Type::ResourceRef) && !prop.resource_ref.readonly),
+              (choices_description(prop) \
+               if prop.is_a?(Api::Type::Enum))
             ].flatten.compact,
             'required' => required,
             'default' => (
@@ -42,7 +44,6 @@ module Provider
             'type' => ('bool' if prop.is_a? Api::Type::Boolean),
             'aliases' => prop.aliases,
             'version_added' => (version_added(prop)&.to_f),
-            'choices' => (prop.values.map(&:to_s) if prop.is_a? Api::Type::Enum),
             'suboptions' => (
                 if prop.nested_properties?
                   prop.nested_properties.reject(&:output).map { |p| documentation_for_property(p) }
@@ -95,6 +96,10 @@ module Provider
           "#{module_name(prop.resource_ref)} task",
           "and then set this #{prop.name.underscore} field to \"{{ name-of-resource }}\""
         ].join(' ')
+      end
+
+      def choices_description(prop)
+        "Some valid choices include: #{prop.values.map { |x| quote_string(x) }.join(', ')}"
       end
 
       # MM puts descriptions in a text block. Ansible needs it in bullets

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -99,7 +99,7 @@ module Provider
       end
 
       def choices_description(prop)
-        "Some valid choices include: #{prop.values.map(&:to_s).join(', ')}"
+        "Some valid choices include: #{prop.values.map { |x| "\"#{x}\"" }.join(', ')}"
       end
 
       # MM puts descriptions in a text block. Ansible needs it in bullets

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -99,7 +99,7 @@ module Provider
       end
 
       def choices_description(prop)
-        "Some valid choices include: #{prop.values.map { |x| quote_string(x) }.join(', ')}"
+        "Some valid choices include: #{prop.values.map { |x| quote_string(x.to_s) }.join(', ')}"
       end
 
       # MM puts descriptions in a text block. Ansible needs it in bullets

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -121,7 +121,7 @@ module Provider
 
     def run_formatter(command)
       output = %x(#{command} 2>&1)
-      Google::LOGGER.error output unless $CHILD_STATUS.to_i.zero?
+      Google::LOGGER.error output
     end
 
     def relative_path(target, base)

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -121,7 +121,7 @@ module Provider
 
     def run_formatter(command)
       output = %x(#{command} 2>&1)
-      Google::LOGGER.error output
+      Google::LOGGER.error output unless $CHILD_STATUS.to_i.zero?
     end
 
     def relative_path(target, base)


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->
Upstream doesn't like the fact that the docs explicitly say that we have choices, while the validation code says we don't.

The solution is to move the (partial) list of choices into the textual description.




<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
