### PR TITLE
Send external gateway interface id if empty

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -7836,6 +7836,7 @@ objects:
         description: |
           The interface ID of the external VPN gateway to which this VPN tunnel is connected.
         min_version: beta
+        send_empty_value: true
       - !ruby/object:Api::Type::ResourceRef
         name: 'peerGcpGateway'
         description: |


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

<!-- Your regular pull request description goes here -->

Send external gateway interface id if empty. I believe this field can be 0, similar to `vpnGatewayInterface` so it will need to explicitly send if empty


<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
