### PR TITLE
Fix two issues in instance template resources

### DIFF
--- a/third_party/terraform/resources/resource_compute_instance_from_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_from_template.go
@@ -202,6 +202,12 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *Config, it 
 		// scratch disks were not overridden, so use the ones from the instance template
 		for _, disk := range it.Properties.Disks {
 			if disk.Type == "SCRATCH" {
+				// diskType is required to be the name for instance templates but the URL for instances
+				dt, err := readDiskType(config, zone, project, disk.InitializeParams.DiskType)
+				if err != nil {
+					return nil, fmt.Errorf("Error loading disk type %q: %s", disk.InitializeParams.DiskType, err)
+				}
+				disk.InitializeParams.DiskType = dt.SelfLink
 				disks = append(disks, disk)
 			}
 		}

--- a/third_party/terraform/resources/resource_compute_instance_from_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_from_template.go
@@ -181,10 +181,12 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *Config, it 
 		// boot disk was not overridden, so use the one from the instance template
 		for _, disk := range it.Properties.Disks {
 			if disk.Boot {
-				if dt := disk.InitializeParams.DiskType; dt != "" {
-					// Instances need a URL for the disk type, but instance templates
-					// only have the name (since they're global).
-					disk.InitializeParams.DiskType = fmt.Sprintf("zones/%s/diskTypes/%s", zone.Name, dt)
+				if disk.InitializeParams != nil {
+					if dt := disk.InitializeParams.DiskType; dt != "" {
+						// Instances need a URL for the disk type, but instance templates
+						// only have the name (since they're global).
+						disk.InitializeParams.DiskType = fmt.Sprintf("zones/%s/diskTypes/%s", zone.Name, dt)
+					}
 				}
 				disks = append(disks, disk)
 				break
@@ -202,12 +204,13 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *Config, it 
 		// scratch disks were not overridden, so use the ones from the instance template
 		for _, disk := range it.Properties.Disks {
 			if disk.Type == "SCRATCH" {
-				// diskType is required to be the name for instance templates but the URL for instances
-				dt, err := readDiskType(config, zone, project, disk.InitializeParams.DiskType)
-				if err != nil {
-					return nil, fmt.Errorf("Error loading disk type %q: %s", disk.InitializeParams.DiskType, err)
+				if disk.InitializeParams != nil {
+					if dt := disk.InitializeParams.DiskType; dt != "" {
+						// Instances need a URL for the disk type, but instance templates
+						// only have the name (since they're global).
+						disk.InitializeParams.DiskType = fmt.Sprintf("zones/%s/diskTypes/%s", zone.Name, dt)
+					}
 				}
-				disk.InitializeParams.DiskType = dt.SelfLink
 				disks = append(disks, disk)
 			}
 		}
@@ -232,6 +235,13 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *Config, it 
 					// Instances need a URL for the disk source, but instance templates
 					// only have the name (since they're global).
 					disk.Source = fmt.Sprintf("zones/%s/disks/%s", zone.Name, s)
+				}
+				if disk.InitializeParams != nil {
+					if dt := disk.InitializeParams.DiskType; dt != "" {
+						// Instances need a URL for the disk type, but instance templates
+						// only have the name (since they're global).
+						disk.InitializeParams.DiskType = fmt.Sprintf("zones/%s/diskTypes/%s", zone.Name, dt)
+					}
 				}
 				disks = append(disks, disk)
 			}

--- a/third_party/terraform/resources/resource_compute_instance_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_template.go
@@ -764,24 +764,85 @@ func diskCharacteristicsFromMap(m map[string]interface{}) diskCharacteristics {
 	return dc
 }
 
-func flattenDisks(disks []*computeBeta.AttachedDisk, d *schema.ResourceData, defaultProject string) ([]map[string]interface{}, error) {
-	result := make([]map[string]interface{}, len(disks))
+func flattenDisk(disk *computeBeta.AttachedDisk, defaultProject string) (map[string]interface{}, error) {
+	diskMap := make(map[string]interface{})
+	if disk.InitializeParams != nil {
+		if disk.InitializeParams.SourceImage != "" {
+			selfLink, err := resolvedImageSelfLink(defaultProject, disk.InitializeParams.SourceImage)
+			if err != nil {
+				return nil, errwrap.Wrapf("Error expanding source image input to self_link: {{err}}", err)
+			}
+			path, err := getRelativePath(selfLink)
+			if err != nil {
+				return nil, errwrap.Wrapf("Error getting relative path for source image: {{err}}", err)
+			}
+			diskMap["source_image"] = path
+		} else {
+			diskMap["source_image"] = ""
+		}
+		diskMap["disk_type"] = disk.InitializeParams.DiskType
+		diskMap["disk_name"] = disk.InitializeParams.DiskName
+		diskMap["disk_size_gb"] = disk.InitializeParams.DiskSizeGb
+	}
 
-	// Disks aren't necessarily returned from the API in the same order they were sent, so gather
-	// information about the ones in state that we can use later to map it back.
+	if disk.DiskEncryptionKey != nil {
+		encryption := make([]map[string]interface{}, 1)
+		encryption[0] = make(map[string]interface{})
+		encryption[0]["kms_key_self_link"] = disk.DiskEncryptionKey.KmsKeyName
+		diskMap["disk_encryption_key"] = encryption
+	}
+
+	diskMap["auto_delete"] = disk.AutoDelete
+	diskMap["boot"] = disk.Boot
+	diskMap["device_name"] = disk.DeviceName
+	diskMap["interface"] = disk.Interface
+	diskMap["source"] = ConvertSelfLinkToV1(disk.Source)
+	diskMap["mode"] = disk.Mode
+	diskMap["type"] = disk.Type
+
+	return diskMap, nil
+}
+
+func reorderDisks(configDisks []interface{}, apiDisks []map[string]interface{}) []map[string]interface{} {
+	if len(apiDisks) != len(configDisks) {
+		// There are different numbers of disks in state and returned from the API, so it's not
+		// worth trying to reorder them since it'll be a diff anyway.
+		return apiDisks
+	}
+
+	result := make([]map[string]interface{}, len(apiDisks), len(apiDisks))
+
+	/*
+		Disks aren't necessarily returned from the API in the same order they were sent, so gather
+		information about the ones in state that we can use to map it back. We can't do this by
+		just looping over all of the disks, because you could end up matching things in the wrong
+		order. For example, if the config disks contain the following disks:
+		disk 1: auto delete = false, size = 10
+		disk 2: auto delete = false, size = 10, device name = "disk 2"
+		disk 3: type = scratch
+		And the disks returned from the API are:
+		disk a: auto delete = false, size = 10, device name = "disk 2"
+		disk b: auto delete = false, size = 10, device name = "disk 1"
+		disk c: type = scratch
+		Then disk a will match disk 1, disk b won't match any disk, and c will match 3, making the
+		final order a, c, b, which is wrong. To get disk a to match disk 2, we have to go in order
+		of fields most specifically able to identify a disk to least.
+	*/
+	disksByDeviceName := map[string]int{}
+	scratchDisksByInterface := map[string][]int{}
 	attachedDisksBySource := map[string]int{}
-	attachedDisksByDeviceName := map[string]int{}
 	attachedDisksByDiskName := map[string]int{}
 	attachedDisksByCharacteristics := []int{}
-	scratchDisksByInterface := map[string][]int{}
 
-	for i, d := range d.Get("disk").([]interface{}) {
+	for i, d := range configDisks {
 		if i == 0 {
 			// boot disk
 			continue
 		}
 		disk := d.(map[string]interface{})
-		if v := disk["type"]; v.(string) == "SCRATCH" {
+		if v := disk["device_name"]; v.(string) != "" {
+			disksByDeviceName[v.(string)] = i
+		} else if v := disk["type"]; v.(string) == "SCRATCH" {
 			iface := disk["interface"].(string)
 			if iface == "" {
 				// apply-time default
@@ -790,8 +851,6 @@ func flattenDisks(disks []*computeBeta.AttachedDisk, d *schema.ResourceData, def
 			scratchDisksByInterface[iface] = append(scratchDisksByInterface[iface], i)
 		} else if v := disk["source"]; v.(string) != "" {
 			attachedDisksBySource[v.(string)] = i
-		} else if v := disk["device_name"]; v.(string) != "" {
-			attachedDisksByDeviceName[v.(string)] = i
 		} else if v := disk["disk_name"]; v.(string) != "" {
 			attachedDisksByDiskName[v.(string)] = i
 		} else {
@@ -799,100 +858,81 @@ func flattenDisks(disks []*computeBeta.AttachedDisk, d *schema.ResourceData, def
 		}
 	}
 
-	for _, disk := range disks {
-		diskMap := make(map[string]interface{})
-		if disk.InitializeParams != nil {
-			if disk.InitializeParams.SourceImage != "" {
-				selfLink, err := resolvedImageSelfLink(defaultProject, disk.InitializeParams.SourceImage)
-				if err != nil {
-					return nil, errwrap.Wrapf("Error expanding source image input to self_link: {{err}}", err)
-				}
-				path, err := getRelativePath(selfLink)
-				if err != nil {
-					return nil, errwrap.Wrapf("Error getting relative path for source image: {{err}}", err)
-				}
-				diskMap["source_image"] = path
-			} else {
-				diskMap["source_image"] = ""
-			}
-			diskMap["disk_type"] = disk.InitializeParams.DiskType
-			diskMap["disk_name"] = disk.InitializeParams.DiskName
-			diskMap["disk_size_gb"] = disk.InitializeParams.DiskSizeGb
-		}
-
-		if disk.DiskEncryptionKey != nil {
-			encryption := make([]map[string]interface{}, 1)
-			encryption[0] = make(map[string]interface{})
-			encryption[0]["kms_key_self_link"] = disk.DiskEncryptionKey.KmsKeyName
-			diskMap["disk_encryption_key"] = encryption
-		}
-
-		diskMap["auto_delete"] = disk.AutoDelete
-		diskMap["boot"] = disk.Boot
-		diskMap["device_name"] = disk.DeviceName
-		diskMap["interface"] = disk.Interface
-		diskMap["source"] = ConvertSelfLinkToV1(disk.Source)
-		diskMap["mode"] = disk.Mode
-		diskMap["type"] = disk.Type
-
-		// Disks aren't necessarily returned from the API in the same order they were sent, so try
-		// to figure out how to align them:
+	// Align the disks, going from the most specific criteria to the least.
+	for _, apiDisk := range apiDisks {
 		// 1. This resource only works if the boot disk is the first one (which should be fixed
 		//	  separately), so put the boot disk first.
-		if disk.Boot {
-			result[0] = diskMap
+		if apiDisk["boot"].(bool) {
+			result[0] = apiDisk
 
 			// 2. All disks have a unique device name
-		} else if i, ok := attachedDisksByDeviceName[diskMap["device_name"].(string)]; ok {
-			result[i] = diskMap
+		} else if i, ok := disksByDeviceName[apiDisk["device_name"].(string)]; ok {
+			result[i] = apiDisk
 
 			// 3. Scratch disks are all the same except device name and interface, so match them by
 			//    interface.
-		} else if disk.Type == "SCRATCH" {
-			indexes := scratchDisksByInterface[disk.Interface]
+		} else if apiDisk["type"].(string) == "SCRATCH" {
+			iface := apiDisk["interface"].(string)
+			indexes := scratchDisksByInterface[iface]
 			if len(indexes) > 0 {
-				result[indexes[0]] = diskMap
-				scratchDisksByInterface[disk.Interface] = indexes[1:]
+				result[indexes[0]] = apiDisk
+				scratchDisksByInterface[iface] = indexes[1:]
 			} else {
-				result = append(result, diskMap)
+				result = append(result, apiDisk)
 			}
 
 			// 4. Each attached disk will have a different source, so match by that.
-		} else if i, ok := attachedDisksBySource[diskMap["source"].(string)]; ok {
-			result[i] = diskMap
+		} else if i, ok := attachedDisksBySource[apiDisk["source"].(string)]; ok {
+			result[i] = apiDisk
 
 			// 5. If a disk was created for this resource via initializeParams, it will have a
 			//    unique name.
-		} else if v, ok := diskMap["disk_name"]; ok && attachedDisksByDiskName[v.(string)] != 0 {
-			result[attachedDisksByDiskName[v.(string)]] = diskMap
+		} else if v, ok := apiDisk["disk_name"]; ok && attachedDisksByDiskName[v.(string)] != 0 {
+			result[attachedDisksByDiskName[v.(string)]] = apiDisk
 
 			// 6. If no unique keys exist on this disk, then use a combination of its remaining
 			//    characteristics to see whether it matches exactly.
 		} else {
 			found := false
-			for _, i := range attachedDisksByCharacteristics {
-				diskInState := d.Get(fmt.Sprintf("disk.%d", i)).(map[string]interface{})
-				stateDc := diskCharacteristicsFromMap(diskInState)
-				readDc := diskCharacteristicsFromMap(diskMap)
+			for arrayIndex, i := range attachedDisksByCharacteristics {
+				configDisk := configDisks[i].(map[string]interface{})
+				stateDc := diskCharacteristicsFromMap(configDisk)
+				readDc := diskCharacteristicsFromMap(apiDisk)
 				if reflect.DeepEqual(stateDc, readDc) {
-					result[i] = diskMap
+					result[i] = apiDisk
+					attachedDisksByCharacteristics = append(attachedDisksByCharacteristics[:arrayIndex], attachedDisksByCharacteristics[arrayIndex+1:]...)
 					found = true
+					break
 				}
 			}
 			if !found {
-				result = append(result, diskMap)
+				result = append(result, apiDisk)
 			}
 		}
 	}
 
-	// Remove nils from map in case there were disks in the config that were not present on read
+	// Remove nils from map in case there were disks that could not be matched
 	ds := []map[string]interface{}{}
 	for _, d := range result {
 		if d != nil {
 			ds = append(ds, d)
 		}
 	}
-	return ds, nil
+	return ds
+}
+
+func flattenDisks(disks []*computeBeta.AttachedDisk, d *schema.ResourceData, defaultProject string) ([]map[string]interface{}, error) {
+	apiDisks := make([]map[string]interface{}, len(disks))
+
+	for i, disk := range disks {
+		d, err := flattenDisk(disk, defaultProject)
+		if err != nil {
+			return nil, err
+		}
+		apiDisks[i] = d
+	}
+
+	return reorderDisks(d.Get("disk").([]interface{}), apiDisks), nil
 }
 
 func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{}) error {

--- a/third_party/terraform/tests/resource_compute_instance_from_template_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_from_template_test.go
@@ -241,6 +241,12 @@ resource "google_compute_instance_template" "foobar" {
 		boot = false
 	}
 
+	disk {
+		disk_type = "local-ssd"
+		type = "SCRATCH"
+		interface = "NVME"
+	}
+
 	network_interface {
 		network = "default"
 	}

--- a/third_party/terraform/tests/resource_compute_instance_template_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_template_test.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -15,6 +16,150 @@ import (
 )
 
 const DEFAULT_MIN_CPU_TEST_VALUE = "Intel Haswell"
+
+func TestComputeInstanceTemplate_reorderDisks(t *testing.T) {
+	t.Parallel()
+
+	cBoot := map[string]interface{}{
+		"source": "boot-source",
+	}
+	cFallThrough := map[string]interface{}{
+		"auto_delete": true,
+	}
+	cDeviceName := map[string]interface{}{
+		"device_name": "disk-1",
+	}
+	cScratch := map[string]interface{}{
+		"type": "SCRATCH",
+	}
+	cSource := map[string]interface{}{
+		"source": "disk-source",
+	}
+	cScratchNvme := map[string]interface{}{
+		"type":      "SCRATCH",
+		"interface": "NVME",
+	}
+
+	aBoot := map[string]interface{}{
+		"source": "boot-source",
+		"boot":   true,
+	}
+	aScratchNvme := map[string]interface{}{
+		"device_name": "scratch-1",
+		"type":        "SCRATCH",
+		"interface":   "NVME",
+	}
+	aSource := map[string]interface{}{
+		"device_name": "disk-2",
+		"source":      "disk-source",
+	}
+	aScratchScsi := map[string]interface{}{
+		"device_name": "scratch-2",
+		"type":        "SCRATCH",
+		"interface":   "SCSI",
+	}
+	aFallThrough := map[string]interface{}{
+		"device_name": "disk-3",
+		"auto_delete": true,
+		"source":      "fake-source",
+	}
+	aFallThrough2 := map[string]interface{}{
+		"device_name": "disk-4",
+		"auto_delete": true,
+		"source":      "fake-source",
+	}
+	aDeviceName := map[string]interface{}{
+		"device_name": "disk-1",
+		"auto_delete": true,
+		"source":      "fake-source-2",
+	}
+	aNoMatch := map[string]interface{}{
+		"device_name": "disk-2",
+		"source":      "disk-source-doesn't-match",
+	}
+
+	cases := map[string]struct {
+		ConfigDisks    []interface{}
+		ApiDisks       []map[string]interface{}
+		ExpectedResult []map[string]interface{}
+	}{
+		"all disks represented": {
+			ApiDisks: []map[string]interface{}{
+				aBoot, aScratchNvme, aSource, aScratchScsi, aFallThrough, aDeviceName,
+			},
+			ConfigDisks: []interface{}{
+				cBoot, cFallThrough, cDeviceName, cScratch, cSource, cScratchNvme,
+			},
+			ExpectedResult: []map[string]interface{}{
+				aBoot, aFallThrough, aDeviceName, aScratchScsi, aSource, aScratchNvme,
+			},
+		},
+		"one non-match": {
+			ApiDisks: []map[string]interface{}{
+				aBoot, aNoMatch, aScratchNvme, aScratchScsi, aFallThrough, aDeviceName,
+			},
+			ConfigDisks: []interface{}{
+				cBoot, cFallThrough, cDeviceName, cScratch, cSource, cScratchNvme,
+			},
+			ExpectedResult: []map[string]interface{}{
+				aBoot, aFallThrough, aDeviceName, aScratchScsi, aScratchNvme, aNoMatch,
+			},
+		},
+		"two fallthroughs": {
+			ApiDisks: []map[string]interface{}{
+				aBoot, aScratchNvme, aFallThrough, aSource, aScratchScsi, aFallThrough2, aDeviceName,
+			},
+			ConfigDisks: []interface{}{
+				cBoot, cFallThrough, cDeviceName, cScratch, cFallThrough, cSource, cScratchNvme,
+			},
+			ExpectedResult: []map[string]interface{}{
+				aBoot, aFallThrough, aDeviceName, aScratchScsi, aFallThrough2, aSource, aScratchNvme,
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		t.Run(tn, func(t *testing.T) {
+			// Disks read using d.Get will always have values for all keys, so set those values
+			for _, disk := range tc.ConfigDisks {
+				d := disk.(map[string]interface{})
+				for _, k := range []string{"auto_delete", "boot"} {
+					if _, ok := d[k]; !ok {
+						d[k] = false
+					}
+				}
+				for _, k := range []string{"device_name", "disk_name", "interface", "mode", "source", "type"} {
+					if _, ok := d[k]; !ok {
+						d[k] = ""
+					}
+				}
+			}
+
+			// flattened disks always set auto_delete, boot, device_name, interface, mode, source, and type
+			for _, d := range tc.ApiDisks {
+				for _, k := range []string{"auto_delete", "boot"} {
+					if _, ok := d[k]; !ok {
+						d[k] = false
+					}
+				}
+
+				for _, k := range []string{"device_name", "interface", "mode", "source"} {
+					if _, ok := d[k]; !ok {
+						d[k] = ""
+					}
+				}
+				if _, ok := d["type"]; !ok {
+					d["type"] = "PERSISTENT"
+				}
+			}
+
+			result := reorderDisks(tc.ConfigDisks, tc.ApiDisks)
+			if !reflect.DeepEqual(tc.ExpectedResult, result) {
+				t.Errorf("reordering did not match\nExpected: %+v\nActual: %+v", tc.ExpectedResult, result)
+			}
+		})
+	}
+}
 
 func TestAccComputeInstanceTemplate_basic(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

<!-- Your regular pull request description goes here -->
Make sure disk type is expanded to a URL when creating an instance from template:
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/3693
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/3713

Attempt to put disks in state in the same order they were specified. This was exposed when writing a test for the first issue, which is why they're in the same PR.

It doesn't solve the issue 100%: you can't reorder disks, and importing will still put them in an arbitrary order. A better CustomizeDiff would solve this, but because of the way state is merged, we can't get a clear picture of before and after inside the diff function. Turning disks into a set also won't work because disks contains fields that are optional+computed.

Looking for feedback especially on whether this amount of testing is sufficient or whether I should add more.


<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
