### PR TITLE
Remove deprecated collection_url_response from KMS

### DIFF
--- a/products/kms/api.yaml
+++ b/products/kms/api.yaml
@@ -33,7 +33,6 @@ objects:
     input: true
     description: |
       A `KeyRing` is a toplevel logical grouping of `CryptoKeys`.
-    collection_url_key: 'keyRings'
     properties:
       - !ruby/object:Api::Type::String
         name: 'name'

--- a/products/kms/api.yaml
+++ b/products/kms/api.yaml
@@ -33,8 +33,7 @@ objects:
     input: true
     description: |
       A `KeyRing` is a toplevel logical grouping of `CryptoKeys`.
-    collection_url_response: !ruby/object:Api::Resource::ResponseList
-      items: 'keyRings'
+    collection_url_key: 'keyRings'
     properties:
       - !ruby/object:Api::Type::String
         name: 'name'


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->

<!-- Your regular pull request description goes here -->

#1793 added a new file with deprecated field (#1851) 

<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
