### PR TITLE
GKE Cluster - adding more fields

### DIFF
--- a/products/container/ansible.yaml
+++ b/products/container/ansible.yaml
@@ -41,12 +41,17 @@ datasources: !ruby/object:Overrides::ResourceOverrides
     exclude: true
 overrides: !ruby/object:Overrides::ResourceOverrides
   Cluster: !ruby/object:Overrides::Ansible::ResourceOverride
+    notes:
+      - This module does not create any node pools (including default). Please use
+        the M(gcp_container_node_pool) module to create node pools.
     transport: !ruby/object:Overrides::Ansible::Transport
       encoder: encode_request
     properties:
       location: !ruby/object:Overrides::Ansible::PropertyOverride
         aliases:
           - zone
+    post_create: |
+      delete_default_nodepool(module)
     provider_helpers:
       - 'products/container/helpers/python/provider_cluster.py'
   KubeConfig: !ruby/object:Overrides::Ansible::ResourceOverride

--- a/products/container/ansible.yaml
+++ b/products/container/ansible.yaml
@@ -51,7 +51,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         aliases:
           - zone
     post_create: |
-      delete_default_nodepool(module)
+      delete_default_node_pool(module)
     provider_helpers:
       - 'products/container/helpers/python/provider_cluster.py'
   KubeConfig: !ruby/object:Overrides::Ansible::ResourceOverride

--- a/products/container/ansible.yaml
+++ b/products/container/ansible.yaml
@@ -47,9 +47,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     transport: !ruby/object:Overrides::Ansible::Transport
       encoder: encode_request
     properties:
+      locations: !ruby/object:Overrides::Ansible::PropertyOverride
+        aliases: ['nodeLocations']
       location: !ruby/object:Overrides::Ansible::PropertyOverride
-        aliases:
-          - zone
+        aliases: ['zone']
     post_create: |
       delete_default_node_pool(module)
     provider_helpers:

--- a/products/container/ansible_version_added.yaml
+++ b/products/container/ansible_version_added.yaml
@@ -35,12 +35,34 @@
         :version_added: '2.6'
       :preemptible:
         :version_added: '2.6'
+      :accelerators:
+        :version_added: '2.9'
+        :acceleratorCount:
+          :version_added: '2.9'
+        :acceleratorType:
+          :version_added: '2.9'
+      :diskType:
+        :version_added: '2.9'
+      :minCpuPlatform:
+        :version_added: '2.9'
+      :taints:
+        :version_added: '2.9'
+        :key:
+          :version_added: '2.9'
+        :value:
+          :version_added: '2.9'
+        :effect:
+          :version_added: '2.9'
     :masterAuth:
       :version_added: '2.6'
       :username:
         :version_added: '2.6'
       :password:
         :version_added: '2.6'
+      :clientCertificateConfig:
+        :version_added: '2.9'
+        :issueClientCertificate:
+          :version_added: '2.9'
     :loggingService:
       :version_added: '2.6'
     :monitoringService:
@@ -67,8 +89,34 @@
         :version_added: '2.6'
         :disabled:
           :version_added: '2.6'
+      :networkPolicyConfig:
+        :version_added: '2.9'
+        :disabled:
+          :version_added: '2.9'
     :subnetwork:
       :version_added: '2.6'
+    :locations:
+      :version_added: '2.9'
+    :resourceLabels:
+      :version_added: '2.9'
+    :legacyAbac:
+      :version_added: '2.9'
+      :enabled:
+        :version_added: '2.9'
+    :networkPolicy:
+      :version_added: '2.9'
+      :provider:
+        :version_added: '2.9'
+      :enabled:
+        :version_added: '2.9'
+    :defaultMaxPodsConstraint:
+      :version_added: '2.9'
+      :maxPodsPerNode:
+        :version_added: '2.9'
+    :enableTpu:
+      :version_added: '2.9'
+    :tpuIpv4CidrBlock:
+      :version_added: '2.9'
     :location:
       :version_added: '2.8'
   :NodePool:

--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -250,13 +250,6 @@ objects:
         description: |
           The authentication information for accessing the master endpoint.
         properties:
-          # TODO(nelsonjr): Make this a ResourceRef pointing to the Compute
-          # resources (external to this product)
-          # | - !ruby/object:Api::Type::ResourceRef
-          # |   name: 'machineType'
-          # |   product: 'Compute'
-          # |   resource: 'MachineType'
-          # |   imports: 'name'
           - !ruby/object:Api::Type::String
             name: 'username'
             description: |
@@ -268,6 +261,16 @@ objects:
               The password to use for HTTP basic authentication to the master
               endpoint. Because the master endpoint is open to the Internet, you
               should create a strong password.
+          - !ruby/object:Api::Type::NestedObject
+            name: 'clientCertificateConfig'
+            description: |
+              Configuration for client certificate authentication on the
+              cluster. For clusters before v1.12, if no configuration is
+              specified, a client certificate is issued.
+            properties:
+              - !ruby/object:Api::Type::Boolean
+                name: 'issueClientCertificate'
+                description: Issue a client certificate.
           - !ruby/object:Api::Type::String
             name: 'clusterCaCertificate'
             description: |
@@ -399,15 +402,77 @@ objects:
                   the cluster. When enabled, it ensures that a Heapster pod is
                   running in the cluster, which is also used by the Cloud
                   Monitoring service.
-      # TODO(nelsonjr): This is a ResourceRef but on a resource on another
-      # product (Compute). Figure out how to represent/implement this. For now
-      # making it a string.
+          # kubernetesDashboard is deprecated.
+          - !ruby/object:Api::Type::NestedObject
+            name: 'networkPolicyConfig'
+            description: |
+              Configuration for NetworkPolicy. This only tracks whether the
+              addon is enabled or not on the Master, it does not track whether
+              network policy is enabled for the nodes.
+            properties:
+              - !ruby/object:Api::Type::Boolean
+                name: 'disabled'
+                description: Whether NetworkPolicy is enabled for this cluster.
       - !ruby/object:Api::Type::String
         name: 'subnetwork'
         description: |
           The name of the Google Compute Engine subnetwork to which the cluster
           is connected.
-      # 'enableKubernetesAlpha' not supported: we are only producing GA API.
+      # TODO: figure out nodePools[]
+      - !ruby/object:Api::Type::Array
+        name: 'locations'
+        description: |
+          The list of Google Compute Engine zones in which the cluster's nodes
+          should be located.
+        item_type: Api::Type::String
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'resourceLabels'
+        description: |
+          The resource labels for the cluster to use to annotate any related
+          Google Compute Engine resources.
+      - !ruby/object:Api::Type::Fingerprint
+        name: 'labelFingerprint'
+        description: The fingerprint of the set of labels for this cluster.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'legacyAbac'
+        description: Configuration for the legacy ABAC authorization mode.
+        properties:
+          - !ruby/object:Api::Type::Boolean
+            name: 'enabled'
+            description: |
+              Whether the ABAC authorizer is enabled for this cluster. When
+              enabled, identities in the system, including service accounts,
+              nodes, and controllers, will have statically granted permissions
+              beyond those provided by the RBAC configuration or IAM.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'networkPolicy'
+        description: |
+          Configuration options for the NetworkPolicy feature.
+        properties:
+          - !ruby/object:Api::Type::Enum
+            name: 'provider'
+            description: The selected network policy provider.
+            values:
+              - "PROVIDER_UNSPECIFIED"
+              - "CALICO"
+          - !ruby/object:Api::Type::Boolean
+            name: 'enabled'
+            description: Whether network policy is enabled on the cluster.
+      - !ruby/object:Api::Type::NestedObject
+            name: 'defaultMaxPodsConstraint'
+            description: |
+              The default constraint on the maximum number of pods that can be
+              run simultaneously on a node in the node pool of this cluster.
+              Only honored if cluster created with IP Alias support.
+            properties:
+              - !ruby/object:Api::Type::String
+                name: 'maxPodsPerNode'
+                description: Constraint enforced on the max num of pods per node.
+
+
+
+
+
       - !ruby/object:Api::Type::String
         name: 'endpoint'
         description: |
@@ -442,8 +507,22 @@ objects:
         description: |
           The time the cluster was created, in RFC3339 text format.
         output: true
-      # | 'status' is not applicable for state enforcement
-      # | 'statusMessage' is not applicable for state enforcement
+      - !ruby/object:Api::Type::Enum
+        name: 'status'
+        description: The current status of this cluster.
+        output: true
+        values: 
+          - STATUS_UNSPECIFIED
+          - PROVISIONING
+          - RUNNING
+          - RECONCILING
+          - STOPPING
+          - ERROR
+          - DEGRADED
+      - !ruby/object:Api::Type::String
+        name: 'statusMessage'
+        description: Additional information about the current status of this cluster, if available.
+        output: true
       - !ruby/object:Api::Type::Integer
         name: 'nodeIpv4CidrSize'
         description: |
@@ -469,6 +548,24 @@ objects:
           The time the cluster will be automatically deleted in RFC3339 text
           format.
         output: true
+      - !ruby/object:Api::Type::Boolean
+        name: 'enableTpu'
+        description: Enable the ability to use Cloud TPUs in this cluster.
+      - !ruby/object:Api::Type::String
+        name: 'tpuIpv4CidrBlock'
+        description: The IP address range of the Cloud TPUs in this cluster, in CIDR notation
+      - !ruby/object:Api::Type::Array
+        name: 'conditions'
+        description: Which conditions caused the current cluster state.
+        output: true
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'code'
+              description: Machine-friendly representation of the condition
+            - !ruby/object:Api::Type::String
+              name: 'message'
+              description: Human-friendly representation of the condition
   - !ruby/object:Api::Resource
     name: 'NodePool'
     base_url: projects/{{project}}/zones/{{location}}/clusters/{{cluster}}/nodePools

--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -78,7 +78,8 @@ objects:
           object, since this configuration (along with the "nodeConfig") will be
           used to create a "NodePool" object with an auto-generated name. Do not
           use this and a nodePool at the same time.
-        required: true
+
+          This field has been deprecated. Please use nodePool.initial_node_count instead.
         input: true
       - !ruby/object:Api::Type::NestedObject
         name: 'nodeConfig'
@@ -194,6 +195,56 @@ objects:
               Whether the nodes are created as preemptible VM instances. See:
               https://cloud.google.com/compute/docs/instances/preemptible for
               more information about preemptible VM instances.
+          - !ruby/object:Api::Type::Array
+            name: 'accelerators'
+            description: |
+              A list of hardware accelerators to be attached to each node. See
+              https://cloud.google.com/compute/docs/gpus for more information
+              about support for GPUs.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                  # API calls for a String, despite this being a number.
+                - !ruby/object:Api::Type::String
+                  name: 'acceleratorCount'
+                  description: The number of accelerator cards exposed to an instance.
+                - !ruby/object:Api::Type::String
+                  name: 'acceleratorType'
+                  description: The accelerator type resource name
+          - !ruby/object:Api::Type::String
+            name: 'diskType'
+            description: |
+              Type of the disk attached to each node (e.g. 'pd-standard'
+              or 'pd-ssd')
+
+              If unspecified, the default disk type is 'pd-standard'
+          - !ruby/object:Api::Type::String
+            name: 'minCpuPlatform'
+            description: |
+              Minimum CPU platform to be used by this instance. The instance
+              may be scheduled on the specified or newer CPU platform.
+          - !ruby/object:Api::Type::Array
+            name: 'taints'
+            description: >
+              List of kubernetes taints to be applied to each node.
+
+              For more information, including usage and the valid values, see:
+              https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'key'
+                  description: Key for taint
+                - !ruby/object:Api::Type::String
+                  name: 'value'
+                  description: Value for taint
+                - !ruby/object:Api::Type::Enum
+                  name: 'effect'
+                  description: Effect for taint
+                  values:
+                    - "EFFECT_UNSPECIFIED"
+                    - "NO_SCHEDULE"
+                    - "PREFER_NO_SCHEDULE"
+                    - "NO_EXECUTE"
       - !ruby/object:Api::Type::NestedObject
         name: 'masterAuth'
         description: |

--- a/products/container/examples/ansible/cluster.yaml
+++ b/products/container/examples/ansible/cluster.yaml
@@ -22,7 +22,7 @@ task: !ruby/object:Provider::Ansible::Task
     node_config:
       machine_type: "n1-standard-4"
       disk_size_gb: 500
-    zone: 'us-central1-a'
+    location: 'us-central1-a'
     project: <%= ctx[:project] %>
     auth_kind: <%= ctx[:auth_kind] %>
     service_account_file: <%= ctx[:service_account_file] %>

--- a/products/container/examples/ansible/cluster.yaml
+++ b/products/container/examples/ansible/cluster.yaml
@@ -22,7 +22,7 @@ task: !ruby/object:Provider::Ansible::Task
     node_config:
       machine_type: "n1-standard-4"
       disk_size_gb: 500
-    location: 'us-central1-a'
+    zone: 'us-central1-a'
     project: <%= ctx[:project] %>
     auth_kind: <%= ctx[:auth_kind] %>
     service_account_file: <%= ctx[:service_account_file] %>

--- a/products/container/helpers/python/provider_cluster.py
+++ b/products/container/helpers/python/provider_cluster.py
@@ -29,6 +29,6 @@ def encode_request(resource_request, module):
 # Deletes the default node pool on default creation.
 def delete_default_node_pool(module):
     auth = GcpSession(module, 'container')
-    link = "https://container.googleapis.com/v1/projects/%s/zones/%s/clusters/%s/nodePools/default" % \
-        module.params['project'], module.params['location'], module.params['name']
+    link = "https://container.googleapis.com/v1/projects/%s/locations/%s/clusters/%s/nodePools/default-pool" % \
+        (module.params['project'], module.params['location'], module.params['name'])
     return wait_for_operation(module, auth.delete(link))

--- a/products/container/helpers/python/provider_cluster.py
+++ b/products/container/helpers/python/provider_cluster.py
@@ -25,3 +25,10 @@ def encode_request(resource_request, module):
     return {
         'cluster': resource_request
     }
+
+# Deletes the default node pool on default creation.
+def delete_default_node_pool(module):
+    auth = GcpSession(module, 'container')
+    link = "https://container.googleapis.com/v1/projects/%s/zones/%s/clusters/%s/nodePools/default" % \
+        module.params['project'], module.params['location'], module.params['name']
+    return wait_for_operation(module, auth.delete(link))

--- a/provider/ansible/gcp_utils.py
+++ b/provider/ansible/gcp_utils.py
@@ -49,6 +49,10 @@ def remove_nones_from_dict(obj):
         value = obj[key]
         if value is not None and value != {} and value != []:
             new_obj[key] = value
+
+    # Blank dictionaries should return None or GCP API may complain.
+    if not new_obj:
+        return None
     return new_obj
 
 


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.
-->
Getting the Ansible GKE Cluster module up-to-parity  with GKE fields

* Custom code to delete the default NodePool from a new Cluster (in line with Terraform)

* A bunch of new fields

* Logic in utils file to send blank values instead of empty dictionaries (GKE had issues with empty dictionaries)



<!--
For each repository you expect to modify with this PR, fill in a repo-specific
PR title under the corresponding tag. We use repo-specified PR titles to ensure
that each downstream has a clear, easy to understand history.

If the Magician generates a PR for a repo with no specified title, it will use
the title of this PR. [terraform-beta] will inherit the title of [terraform]
if it has no specified title.
-->

<!-- Optional PR titles that describe your downstream changes -->
-----------------------------------------------------------------
# [all]
## [terraform]
### [terraform-beta]
## [ansible]
## [inspec]
