### PR TITLE
Remove version format validation

### DIFF
--- a/third_party/terraform/tests/data_source_tpu_tensorflow_versions_test.go
+++ b/third_party/terraform/tests/data_source_tpu_tensorflow_versions_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"regexp"
 )
 
 func TestAccTpuTensorflowVersions_basic(t *testing.T) {
@@ -54,13 +53,9 @@ func testAccCheckGoogleTpuTensorflowVersions(n string) resource.TestCheckFunc {
 
 		for i := 0; i < cnt; i++ {
 			idx := fmt.Sprintf("versions.%d", i)
-			v, ok := rs.Primary.Attributes[idx]
+			_, ok := rs.Primary.Attributes[idx]
 			if !ok {
 				return fmt.Errorf("expected %q, version not found", idx)
-			}
-
-			if !regexp.MustCompile(`^([0-9]+\.)+[0-9]+$`).MatchString(v) {
-				return fmt.Errorf("unexpected version format for %q, value is %v", idx, v)
 			}
 		}
 		return nil


### PR DESCRIPTION
There are a few versions coming back that don't follow the pattern any more, such as:
1.14.1.dev20190508
nightly

Validating the format of the version string doesn't provide much benefit so I'm stripping that out but keeping the logic to validate the existence of a version string.