### PR TITLE
Added oidcToken to pubsub api.

### DIFF
--- a/products/pubsub/api.yaml
+++ b/products/pubsub/api.yaml
@@ -92,6 +92,29 @@ objects:
           configure it. An empty pushConfig signifies that the subscriber will
           pull and ack messages using API methods.
         properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: 'oidcToken'
+            description: |
+              If specified, Pub/Sub will generate and attach an OIDC JWT token as
+              an Authorization header in the HTTP request for every pushed message.
+            properties:
+              - !ruby/object:Api::Type::String
+                name: 'serviceAccountEmail'
+                required: true
+                description: |
+                  Service account email to be used for generating the OIDC token.
+                  The caller (for subscriptions.create, subscriptions.patch, and
+                  subscriptions.modifyPushConfig RPCs) must have the
+                  iam.serviceAccounts.actAs permission for the service account.
+              - !ruby/object:Api::Type::String
+                name: 'audience'
+                description: |
+                  Audience to be used when generating OIDC token. The audience claim
+                  identifies the recipients that the JWT is intended for. The audience
+                  value is a single case-sensitive string. Having multiple values (array)
+                  for the audience field is not supported. More info about the OIDC JWT
+                  token audience here: https://tools.ietf.org/html/rfc7519#section-4.1.3
+                  Note: if not specified, the Push endpoint URL will be used.
           - !ruby/object:Api::Type::String
             name: 'pushEndpoint'
             description: |


### PR DESCRIPTION
This commit adds the property oidcToken to the pubsub creation. A new NestedObject
property(oidcToken) got added to the PushConfig object. oidcToken contains two
properties as follow:

- serviceAccountEmail: string
Service account email to be used for generating the OIDC token. The caller
(for subscriptions.create, subscriptions.patch, and subscriptions.modifyPushConfig
RPCs) must have the iam.serviceAccounts.actAs permission for the service account.

- audience: string
Audience to be used when generating OIDC token. The audience claim identifies the
recipients that the JWT is intended for. The audience value is a single
case-sensitive string. Having multiple values (array) for the audience field is
not supported.