### PR TITLE
WIP: Ansible: gcp_iam_service_account_key: python3 TypeError - add binary option to file open

### DIFF
--- a/products/iam/helpers/ansible/service_account_key_template.erb
+++ b/products/iam/helpers/ansible/service_account_key_template.erb
@@ -76,7 +76,7 @@ def main():
 def create(module):
     auth = GcpSession(module, 'iam')
     json_content = return_if_object(module, auth.post(self_link(module), resource_to_request(module)))
-    with open(module.params['path'], 'w') as f:
+    with open(module.params['path'], 'wb') as f:
         private_key_contents = base64.b64decode(json_content['privateKeyData'])
         f.write(private_key_contents)
 


### PR DESCRIPTION
This is one of (at least) 2 possible options for #1893 
