### PR TITLE
Remove bad AUTH_NONE default for GKE Istio Config

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -218,7 +218,8 @@ func resourceContainerCluster() *schema.Resource {
 									"auth": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										DiffSuppressFunc: istioConfigAuthDiffSuppress,
+										// We can't use a Terraform-level default because it won't be true when the block is disabled: true
+										DiffSuppressFunc: emptyOrDefaultStringSuppress("AUTH_NONE"),
 										ValidateFunc: validation.StringInSlice([]string{"AUTH_NONE", "AUTH_MUTUAL_TLS"}, false),
 									},
 								},
@@ -2651,13 +2652,6 @@ func containerClusterPrivateClusterConfigSuppress(k, old, new string, d *schema.
 }
 
 <% unless version == 'ga' -%>
-func istioConfigAuthDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	// if old is "" and new is "AUTH_NONE", return true. Fall through to string-based diff otherwise.
-	// We can't use a default + default_if_empty style behaviour because the field will also be empty
-	// when the Istio on GKE addon isn't enabled (disabled: true).
-	return old == "" && new == "AUTH_NONE"
-}
-
 func podSecurityPolicyCfgSuppress(k, old, new string, r *schema.ResourceData) bool {
 	if k == "pod_security_policy_config.#" && old == "1" && new == "0" {
 		if v, ok := r.GetOk("pod_security_policy_config"); ok {

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -217,8 +217,8 @@ func resourceContainerCluster() *schema.Resource {
 									},
 									"auth": {
 										Type:         schema.TypeString,
-										Default:      "AUTH_NONE",
 										Optional:     true,
+										DiffSuppressFunc: istioConfigAuthDiffSuppress,
 										ValidateFunc: validation.StringInSlice([]string{"AUTH_NONE", "AUTH_MUTUAL_TLS"}, false),
 									},
 								},
@@ -2651,6 +2651,13 @@ func containerClusterPrivateClusterConfigSuppress(k, old, new string, d *schema.
 }
 
 <% unless version == 'ga' -%>
+func istioConfigAuthDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// if old is "" and new is "AUTH_NONE", return true. Fall through to string-based diff otherwise.
+	// We can't use a default + default_if_empty style behaviour because the field will also be empty
+	// when the Istio on GKE addon isn't enabled (disabled: true).
+	return old == "" && new == "AUTH_NONE"
+}
+
 func podSecurityPolicyCfgSuppress(k, old, new string, r *schema.ResourceData) bool {
 	if k == "pod_security_policy_config.#" && old == "1" && new == "0" {
 		if v, ok := r.GetOk("pod_security_policy_config"); ok {

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2169,6 +2169,7 @@ resource "google_container_cluster" "with_istio_enabled" {
 	addons_config {
 		istio_config {
 			disabled = false
+			auth     = "AUTH_NONE"
 		}
 	}
 }`, clusterName)


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/3807

Remove the default value of `AUTH_NONE` introduced in https://github.com/GoogleCloudPlatform/magic-modules/pull/1716.

It's true that `AUTH_NONE` is the default value for Istio auth when it's been enabled. Unfortunately, the presence of the `istio_config` block doesn't mean that it's been enabled. As a result, we can't set a Terraform-side default.

This should suppress diffs when users specify `AUTH_NONE` and API returns the empty string. Users going from `2.8.0` -> `2.9.0` will see no diff either way; if they defined the block in config, the DSF will remove the diff. If they didn't, it was recorded as the empty string based on the API returning no value regardless.