### PR TITLE
Converting names from short-name to partial URIs

### DIFF
--- a/api/resource.rb
+++ b/api/resource.rb
@@ -98,6 +98,11 @@ module Api
       # often used to extract an object from a parent object or a collection.
       attr_reader :nested_query
 
+      # [Optional] If a resource requires a partial URL when sending the name
+      # in the API request, this is the pattern that maps a name to a
+      # partial URL.
+      attr_reader :name_pattern
+
       # ====================
       # IAM Configuration
       # ====================
@@ -154,6 +159,7 @@ module Api
       check :read_verb, type: Symbol, default: :GET, allowed: %i[GET POST]
       check :delete_verb, type: Symbol, default: :DELETE, allowed: %i[POST PUT PATCH DELETE]
       check :update_verb, type: Symbol, default: :PUT, allowed: %i[POST PUT PATCH]
+      check :name_pattern, type: String
 
       check :input, type: :boolean
       check :min_version, type: String

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -359,13 +359,6 @@ module Api
       end
     end
 
-    # A regex to check if a full URL was returned or just a shortname.
-    def regex_url
-      self_link_url.gsub('{{project}}', '.*')
-                   .gsub('{{name}}', '[a-z1-9\-]*')
-                   .gsub('{{zone}}', '[a-z1-9\-]*')
-    end
-
     # ====================
     # Debugging Methods
     # ====================

--- a/products/sourcerepo/ansible.yaml
+++ b/products/sourcerepo/ansible.yaml
@@ -18,8 +18,6 @@ datasources: !ruby/object:Overrides::ResourceOverrides
     facts: !ruby/object:Provider::Ansible::FactsOverride
       has_filters: false
 overrides: !ruby/object:Overrides::ResourceOverrides
-  Repository: !ruby/object:Overrides::Ansible::ResourceOverride
-    self_link: "{{name}}"
 files: !ruby/object:Provider::Config::Files
   compile:
 <%= lines(indent(compile('provider/ansible/product~compile.yaml'), 4)) -%>

--- a/products/sourcerepo/api.yaml
+++ b/products/sourcerepo/api.yaml
@@ -37,6 +37,7 @@ objects:
         'Official Documentation': 'https://cloud.google.com/source-repositories/'
       api: 'https://cloud.google.com/source-repositories/docs/reference/rest/v1/projects.repos'
     collection_url_key: 'repos'
+    name_pattern: 'projects/{{project}}/repos/{{name}}'
     description: |
       A repository (or repo) is a Git repository storing versioned source content.
     properties:

--- a/products/sourcerepo/examples/ansible/repository.yaml
+++ b/products/sourcerepo/examples/ansible/repository.yaml
@@ -15,7 +15,7 @@
 task: !ruby/object:Provider::Ansible::Task
   name: gcp_sourcerepo_repository
   code:
-    name: "projects/<%= ctx[:project] -%>/repos/<%= ctx[:name] %>"
+    name: "<%= ctx[:name] %>"
     project: <%= ctx[:project] %>
     auth_kind: <%= ctx[:auth_kind] %>
     service_account_file: <%= ctx[:service_account_file] %>

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -324,7 +324,7 @@ module Provider
 
     # Convert a URL to a regex.
     def regex_url(url)
-      url.gsub(/{{.*}}/, '.*')
+      url.gsub(/{{[a-z]*}}/, '.*')
     end
   end
 end

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -321,5 +321,10 @@ module Provider
         parts.map { |pt| object.all_user_properties.select { |p| p.name == pt }[0] }
       end.flatten
     end
+
+    # Convert a URL to a regex.
+    def regex_url(url)
+      url.gsub(/{{.*}}/, '.*')
+    end
   end
 end

--- a/provider/ansible/request.rb
+++ b/provider/ansible/request.rb
@@ -48,10 +48,6 @@ module Provider
       # This is outputting code and code is easier to read on one line.
       # rubocop:disable Metrics/LineLength
       def response_output(prop, hash_name, module_name)
-        # If name + name_pattern, use the function.
-        return "name_full_to_partial(#{hash_name}.get('name'), #{module_name}.params)" \
-          if prop.name == 'name' && prop.__resource.name_pattern
-
         # If input true, treat like request, but use module names.
         return request_output(prop, "#{module_name}.params", module_name) \
           if prop.input

--- a/provider/ansible/request.rb
+++ b/provider/ansible/request.rb
@@ -48,6 +48,10 @@ module Provider
       # This is outputting code and code is easier to read on one line.
       # rubocop:disable Metrics/LineLength
       def response_output(prop, hash_name, module_name)
+        # If name + name_pattern, use the function.
+        return "name_full_to_partial(#{hash_name}.get('name'), #{module_name}.params)" \
+          if prop.name == 'name' && prop.__resource.name_pattern
+
         # If input true, treat like request, but use module names.
         return request_output(prop, "#{module_name}.params", module_name) \
           if prop.input
@@ -63,6 +67,10 @@ module Provider
       end
 
       def request_output(prop, hash_name, module_name)
+        # If name + name_pattern, use the function.
+        return "name_partial_to_full(#{hash_name}.get('name'), module.params)" \
+          if prop.name == 'name' && prop.__resource.name_pattern
+
         return "response.get(#{quote_string(prop.name)})" \
           if prop.is_a? Api::Type::FetchedExternal
 

--- a/templates/ansible/name_pattern.py.erb
+++ b/templates/ansible/name_pattern.py.erb
@@ -5,19 +5,6 @@ def name_partial_to_full(name, params):
     url = r<%= lines(build_url(regex_url(object.name_pattern))) -%>
 
     if not re.match(url, name):
-        name = <%= build_url(object.name_pattern) -%>.format(**module.params)
-
-    return name
-
-
-def name_full_to_partial(name, params):
-    
-    if name is None:
-        return
-
-    url = r<%= lines(build_url(regex_url(object.name_pattern))) -%>
-
-    if not re.match(url, name):
-        name = name.split('/')[-1]
+        name = <%= build_url(object.name_pattern) -%>.format(**params)
 
     return name

--- a/templates/ansible/name_pattern.py.erb
+++ b/templates/ansible/name_pattern.py.erb
@@ -2,20 +2,22 @@ def name_partial_to_full(name, params):
     if name is None:
         return
 
-    url = r<%= lines(build_url(object.name_pattern)) -%>
+    url = r<%= lines(build_url(regex_url(object.name_pattern))) -%>
 
     if not re.match(url, name):
         name = <%= build_url(object.name_pattern) -%>.format(**module.params)
 
     return name
 
+
 def name_full_to_partial(name, params):
+    
     if name is None:
         return
 
-    url = r<%= lines(build_url(object.name_pattern)) -%>
+    url = r<%= lines(build_url(regex_url(object.name_pattern))) -%>
 
     if not re.match(url, name):
-        name = <%= build_url(object.name_pattern) -%>.format(**params)
+        name = name.split('/')[-1]
 
     return name

--- a/templates/ansible/name_pattern.py.erb
+++ b/templates/ansible/name_pattern.py.erb
@@ -1,0 +1,21 @@
+def name_partial_to_full(name, params):
+    if name is None:
+        return
+
+    url = r<%= lines(build_url(object.name_pattern)) -%>
+
+    if not re.match(url, name):
+        name = <%= build_url(object.name_pattern) -%>.format(**module.params)
+
+    return name
+
+def name_full_to_partial(name, params):
+    if name is None:
+        return
+
+    url = r<%= lines(build_url(object.name_pattern)) -%>
+
+    if not re.match(url, name):
+        name = <%= build_url(object.name_pattern) -%>.format(**params)
+
+    return name

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -30,7 +30,9 @@ __metaclass__ = type
 <%= lines(import) -%>
 import json
 <%
-  imports = object.imports + ['time', 're']
+  imports = object.imports || []
+  imports << 'time' if object.async
+  imports << 're' if !readonly_selflink_rrefs.empty? || object.name_pattern
 -%>
 <%= lines(imports.sort.uniq.map { |i| "import #{i}" }) -%>
 

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -428,7 +428,7 @@ def response_to_hash(module, response):
 def <%= resource.name.underscore -%>_selflink(name, params):
     if name is None:
         return
-    url = r<%= lines(build_url(resource.regex_url)) -%>
+    url = r<%= lines(build_url(regex_url(resource.self_link_url))) -%>
     if not re.match(url, name):
         name = <%= build_url(resource.self_link_url).gsub('{name}', '%s') -%>.format(**params) % name
     return name

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -419,6 +419,9 @@ def is_different(module, response):
 # This is for doing comparisons with Ansible's current parameters.
 def response_to_hash(module, response):
     return <%= lines(python_literal(response_properties(object.properties), use_hash_brackets: true)) -%>
+<% if object.name_pattern -%>
+<%= lines(compile('templates/ansible/name_pattern.py.erb')) -%>
+<% end -%>
 <% readonly_selflink_rrefs.each do |resource| -%>
 
 

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -30,9 +30,7 @@ __metaclass__ = type
 <%= lines(import) -%>
 import json
 <%
-  imports = object.imports || []
-  imports << 'time' if object.async
-  imports << 're' unless readonly_selflink_rrefs.empty?
+  imports = object.imports + ['time', 're']
 -%>
 <%= lines(imports.sort.uniq.map { |i| "import #{i}" }) -%>
 


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
This addresses https://github.com/GoogleCloudPlatform/magic-modules/issues/937

Magic Modules assumes that all names are the name of the resource. Newer APIs actually expect the names to be partial URIs (think `projects/{project}/regions/{region}/{name}`). It isn't ideal for users to write that out in configs.

Currently, Terraform solves this problem through a series of templates and Ansible doesn't solve this problem at all (users have to write the whole long string).

This PR introduces `name_pattern` which is the expected URL pattern that we expect names to follow. Ansible will check to see if names follow this pattern and make them follow the pattern if they don't.

Currently, this is only being used in Source Repositories.