### PR TITLE
use generated names for all resources in GFR ILB test

### DIFF
--- a/third_party/terraform/tests/resource_compute_global_forwarding_rule_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_global_forwarding_rule_test.go.erb
@@ -128,6 +128,8 @@ func TestAccComputeGlobalForwardingRule_internalLoadBalancing(t *testing.T) {
 	backend := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
 	hc := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
 	urlmap := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
+	igm := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
+	it := fmt.Sprintf("forwardrule-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -135,7 +137,7 @@ func TestAccComputeGlobalForwardingRule_internalLoadBalancing(t *testing.T) {
 		CheckDestroy: testAccCheckComputeGlobalForwardingRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeGlobalForwardingRule_internalLoadBalancing(fr, proxy, backend, hc, urlmap),
+				Config: testAccComputeGlobalForwardingRule_internalLoadBalancing(fr, proxy, backend, hc, urlmap, igm, it),
 			},
 			{
 				ResourceName:      "google_compute_global_forwarding_rule.forwarding_rule",
@@ -369,7 +371,7 @@ func testAccComputeGlobalForwardingRule_ipv6(fr, proxy, backend, hc, urlmap stri
 }
 
 <% unless version == 'ga' -%>
-func testAccComputeGlobalForwardingRule_internalLoadBalancing(fr, proxy, backend, hc, urlmap string) string {
+func testAccComputeGlobalForwardingRule_internalLoadBalancing(fr, proxy, backend, hc, urlmap, igm, it string) string {
 	return fmt.Sprintf(`
 resource "google_compute_global_forwarding_rule" "forwarding_rule" {
   name                  = "%s"
@@ -439,7 +441,7 @@ data "google_compute_image" "debian_image" {
 }
 
 resource "google_compute_instance_group_manager" "igm" {
-  name               = "igm-internal"
+  name               = "%s"
   version {
     instance_template  = "${google_compute_instance_template.instance_template.self_link}"
     name               = "primary"
@@ -450,7 +452,7 @@ resource "google_compute_instance_group_manager" "igm" {
 }
 
 resource "google_compute_instance_template" "instance_template" {
-  name         = "instance-template-internal"
+  name         = "%s"
   machine_type = "n1-standard-1"
 
   network_interface {
@@ -462,6 +464,6 @@ resource "google_compute_instance_template" "instance_template" {
     auto_delete  = true
     boot         = true
   }
-}`, fr, proxy, backend, hc, urlmap)
+}`, fr, proxy, backend, hc, urlmap, igm, it)
 }
 <% end -%>


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Fixes TestAccComputeGlobalForwardingRule_internalLoadBalancing, which is currently failing in beta CI.