### PR TITLE
also enable http load balancing in gke cloud run test

### DIFF
--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2199,6 +2199,9 @@ resource "google_container_cluster" "with_cloudrun_enabled" {
 	initial_node_count = 1
 
 	addons_config {
+		http_load_balancing {
+			disabled = false
+		}
 		istio_config {
 			disabled = false
 		}


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Fixes TestAccContainerCluster_withCloudRunEnabled, which is currently failing in beta CI.