### PR TITLE
fix beta dataproc resources by adding min_cpu_platform in master/worker config instead of preemptible

### DIFF
--- a/third_party/terraform/resources/resource_dataproc_cluster.go.erb
+++ b/third_party/terraform/resources/resource_dataproc_cluster.go.erb
@@ -208,12 +208,7 @@ func resourceDataprocCluster() *schema.Resource {
 									// It always uses whatever is specified for the worker_config
 									// "machine_type": { ... }
 <% unless version == 'ga' -%>
-									"min_cpu_platform": {
-										Type:     schema.TypeString,
-										Optional: true,
-										Computed: true,
-										ForceNew: true,
-									},
+									// "min_cpu_platform": { ... }
 <% end -%>
 									"disk_config": {
 										Type:     schema.TypeList,
@@ -670,12 +665,6 @@ func expandPreemptibleInstanceGroupConfig(cfg map[string]interface{}) *dataproc.
 			}
 		}
 	}
-
-	<% unless version == 'ga' -%>
-	if v, ok := cfg["min_cpu_platform"]; ok {
-		icg.MinCpuPlatform = v.(string)
-	}
-	<% end -%>
 	return icg
 }
 
@@ -948,9 +937,6 @@ func flattenPreemptibleInstanceGroupConfig(d *schema.ResourceData, icg *dataproc
 	if icg != nil {
 		data["num_instances"] = icg.NumInstances
 		data["instance_names"] = icg.InstanceNames
-		<% unless version == 'ga' -%>
-		data["min_cpu_platform"] = icg.MinCpuPlatform
-		<% end -%>
 		if icg.DiskConfig != nil {
 			disk["boot_disk_size_gb"] = icg.DiskConfig.BootDiskSizeGb
 			disk["num_local_ssds"] = icg.DiskConfig.NumLocalSsds

--- a/third_party/terraform/resources/resource_dataproc_cluster.go.erb
+++ b/third_party/terraform/resources/resource_dataproc_cluster.go.erb
@@ -366,6 +366,14 @@ func instanceConfigSchema() *schema.Schema {
 					ForceNew: true,
 				},
 
+<% unless version == 'ga' -%>
+				"min_cpu_platform": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+<% end -%>
 				"disk_config": {
 					Type:     schema.TypeList,
 					Optional: true,
@@ -662,6 +670,12 @@ func expandPreemptibleInstanceGroupConfig(cfg map[string]interface{}) *dataproc.
 			}
 		}
 	}
+
+	<% unless version == 'ga' -%>
+	if v, ok := cfg["min_cpu_platform"]; ok {
+		icg.MinCpuPlatform = v.(string)
+	}
+	<% end -%>
 	return icg
 }
 
@@ -934,6 +948,9 @@ func flattenPreemptibleInstanceGroupConfig(d *schema.ResourceData, icg *dataproc
 	if icg != nil {
 		data["num_instances"] = icg.NumInstances
 		data["instance_names"] = icg.InstanceNames
+		<% unless version == 'ga' -%>
+		data["min_cpu_platform"] = icg.MinCpuPlatform
+		<% end -%>
 		if icg.DiskConfig != nil {
 			disk["boot_disk_size_gb"] = icg.DiskConfig.BootDiskSizeGb
 			disk["num_local_ssds"] = icg.DiskConfig.NumLocalSsds

--- a/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package google
 
 import (
@@ -12,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 
-	"google.golang.org/api/dataproc/v1"
+	dataproc "google.golang.org/api/dataproc/v1beta2"
 	"google.golang.org/api/googleapi"
 )
 
@@ -523,7 +524,7 @@ func testAccCheckDataprocClusterDestroy() resource.TestCheckFunc {
 				return err
 			}
 
-			_, err = config.clientDataproc.Projects.Regions.Clusters.Get(
+			_, err = config.clientDataprocBeta.Projects.Regions.Clusters.Get(
 				project, attributes["region"], rs.Primary.ID).Do()
 
 			if err != nil {
@@ -623,6 +624,9 @@ func validateDataprocCluster_withConfigOverrides(n string, cluster *dataproc.Clu
 			{"cluster_config.0.master_config.0.disk_config.0.boot_disk_type", "pd-ssd", cluster.Config.MasterConfig.DiskConfig.BootDiskType},
 			{"cluster_config.0.master_config.0.machine_type", "n1-standard-1", GetResourceNameFromSelfLink(cluster.Config.MasterConfig.MachineTypeUri)},
 			{"cluster_config.0.master_config.0.instance_names.#", "3", strconv.Itoa(len(cluster.Config.MasterConfig.InstanceNames))},
+			<% unless version == 'ga' -%>
+			{"cluster_config.0.master_config.0.min_cpu_platform", "Intel Skylake", cluster.Config.MasterConfig.MinCpuPlatform},
+			<% end -%>
 
 			{"cluster_config.0.worker_config.0.num_instances", "3", strconv.Itoa(int(cluster.Config.WorkerConfig.NumInstances))},
 			{"cluster_config.0.worker_config.0.disk_config.0.boot_disk_size_gb", "16", strconv.Itoa(int(cluster.Config.WorkerConfig.DiskConfig.BootDiskSizeGb))},
@@ -630,6 +634,9 @@ func validateDataprocCluster_withConfigOverrides(n string, cluster *dataproc.Clu
 			{"cluster_config.0.worker_config.0.disk_config.0.boot_disk_type", "pd-standard", cluster.Config.WorkerConfig.DiskConfig.BootDiskType},
 			{"cluster_config.0.worker_config.0.machine_type", "n1-standard-1", GetResourceNameFromSelfLink(cluster.Config.WorkerConfig.MachineTypeUri)},
 			{"cluster_config.0.worker_config.0.instance_names.#", "3", strconv.Itoa(len(cluster.Config.WorkerConfig.InstanceNames))},
+			<% unless version == 'ga' -%>
+			{"cluster_config.0.worker_config.0.min_cpu_platform", "Intel Broadwell", cluster.Config.WorkerConfig.MinCpuPlatform},
+			<% end -%>
 
 			{"cluster_config.0.preemptible_worker_config.0.num_instances", "1", strconv.Itoa(int(cluster.Config.SecondaryWorkerConfig.NumInstances))},
 			{"cluster_config.0.preemptible_worker_config.0.disk_config.0.boot_disk_size_gb", "17", strconv.Itoa(int(cluster.Config.SecondaryWorkerConfig.DiskConfig.BootDiskSizeGb))},
@@ -669,7 +676,7 @@ func testAccCheckDataprocClusterExists(n string, cluster *dataproc.Cluster) reso
 			return err
 		}
 
-		found, err := config.clientDataproc.Projects.Regions.Clusters.Get(
+		found, err := config.clientDataprocBeta.Projects.Regions.Clusters.Get(
 			project, rs.Primary.Attributes["region"], rs.Primary.ID).Do()
 		if err != nil {
 			return err
@@ -863,6 +870,9 @@ resource "google_dataproc_cluster" "with_config_overrides" {
 				boot_disk_type    = "pd-ssd"
 				boot_disk_size_gb = 15
 			}
+<% unless version == 'ga' -%>
+			min_cpu_platform = "Intel Skylake"
+<% end -%>
 		}
 
 		worker_config {
@@ -873,6 +883,9 @@ resource "google_dataproc_cluster" "with_config_overrides" {
 				boot_disk_size_gb = 16
 				num_local_ssds    = 1
 			}
+<% unless version == 'ga' -%>
+			min_cpu_platform = "Intel Broadwell"
+<% end -%>
 		}
 
 		preemptible_worker_config {

--- a/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -383,6 +383,11 @@ will be set for you based on whatever was set for the `worker_config.machine_typ
     computed value if not set (currently 500GB). Note: If SSDs are not
 	attached, it also contains the HDFS data blocks and Hadoop working directories.
 
+* `min_cpu_platform` - (Optional, Computed, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) The name of a minimum generation of CPU family
+   for the master. If not specified, GCP will default to a predetermined computed value
+   for each zone. See [the guide](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform)
+   for details about which CPU families are available (and defaulted) for each zone.
+
 	* `num_local_ssds` - (Optional) The amount of local SSD disks that will be
 	attached to each preemptible worker node. Defaults to 0.
 

--- a/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -383,11 +383,6 @@ will be set for you based on whatever was set for the `worker_config.machine_typ
     computed value if not set (currently 500GB). Note: If SSDs are not
 	attached, it also contains the HDFS data blocks and Hadoop working directories.
 
-* `min_cpu_platform` - (Optional, Computed, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) The name of a minimum generation of CPU family
-   for the master. If not specified, GCP will default to a predetermined computed value
-   for each zone. See [the guide](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform)
-   for details about which CPU families are available (and defaulted) for each zone.
-
 	* `num_local_ssds` - (Optional) The amount of local SSD disks that will be
 	attached to each preemptible worker node. Defaults to 0.
 


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
