### PR TITLE
removing name param from gcp_storage_object module

### DIFF
--- a/products/storage/examples/ansible/object.yaml
+++ b/products/storage/examples/ansible/object.yaml
@@ -14,7 +14,6 @@
 task: !ruby/object:Provider::Ansible::Task
   name: gcp_storage_object
   code:
-    name: 'ansible-storage-module'
     action: download
     bucket: ansible-bucket
     src: modules.zip


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Backporting https://github.com/ansible/ansible/pull/57802