### PR TITLE
changing endpoints on container cluster/nodepool

### DIFF
--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -32,7 +32,7 @@ async: !ruby/object:Api::Async
   operation: !ruby/object:Api::Async::Operation
     kind: 'container#operation'
     path: 'name'
-    base_url: 'projects/{{project}}/zones/{{zone}}/operations/{{op_id}}'
+    base_url: 'projects/{{project}}/locations/{{location}}/operations/{{op_id}}'
     wait_ms: 1000
   result: !ruby/object:Api::Async::Result
     path: 'targetLink'
@@ -568,7 +568,7 @@ objects:
               description: Human-friendly representation of the condition
   - !ruby/object:Api::Resource
     name: 'NodePool'
-    base_url: projects/{{project}}/zones/{{location}}/clusters/{{cluster}}/nodePools
+    base_url: projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/nodePools
     description: |
       NodePool contains the name and configuration for a cluster's node pool.
       Node pools are a set of nodes (i.e. VM's), with a common configuration and


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
GKE has two sets of endpoints: zones + locations.

The location endpoints are favored and should be used.