### PR TITLE
test fixes from items -> resources migration

### DIFF
--- a/products/container/ansible.yaml
+++ b/products/container/ansible.yaml
@@ -21,9 +21,9 @@ datasources: !ruby/object:Overrides::ResourceOverrides
       has_filters: false
       test: !ruby/object:Provider::Ansible::AnsibleFactsTestInformation
         exists: |
-          "'my-cluster' in \"{{ results['items'] | map(attribute='name') | list }}\""
+          "'my-cluster' in \"{{ results['resources'] | map(attribute='name') | list }}\""
         does_not_exist: |
-          "'my-cluster' not in \"{{ results['items'] | map(attribute='name') | list }}\""
+          "'my-cluster' not in \"{{ results['resources'] | map(attribute='name') | list }}\""
   NodePool: !ruby/object:Overrides::Ansible::ResourceOverride
     properties:
       location: !ruby/object:Overrides::Ansible::PropertyOverride
@@ -34,9 +34,9 @@ datasources: !ruby/object:Overrides::ResourceOverrides
       has_filters: false
       test: !ruby/object:Provider::Ansible::AnsibleFactsTestInformation
         exists: |
-          "'my-pool' in \"{{ results['items'] | map(attribute='name') | list }}\""
+          "'my-pool' in \"{{ results['resources'] | map(attribute='name') | list }}\""
         does_not_exist: |
-          "'my-pool' not in \"{{ results['items'] | map(attribute='name') | list }}\""
+          "'my-pool' not in \"{{ results['resources'] | map(attribute='name') | list }}\""
   KubeConfig: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
 overrides: !ruby/object:Overrides::ResourceOverrides

--- a/products/dns/ansible.yaml
+++ b/products/dns/ansible.yaml
@@ -21,9 +21,9 @@ datasources: !ruby/object:Overrides::ResourceOverrides
       has_filters: false
       test: !ruby/object:Provider::Ansible::AnsibleFactsTestInformation
         exists: |
-          "'www.testzone-4.com.'in \"{{ results['items'] | map(attribute='name') | list }}\""
+          "'www.testzone-4.com.'in \"{{ results['resources'] | map(attribute='name') | list }}\""
         does_not_exist: |
-          "'www.testzone-4.com.'not in \"{{ results['items'] | map(attribute='name') | list }}\""
+          "'www.testzone-4.com.'not in \"{{ results['resources'] | map(attribute='name') | list }}\""
     collection: "https://www.googleapis.com/dns/v1/projects/{project}/managedZones/{managed_zone}/rrsets"
   ManagedZone: !ruby/object:Overrides::Ansible::ResourceOverride
     facts: !ruby/object:Provider::Ansible::FactsOverride

--- a/products/pubsub/ansible.yaml
+++ b/products/pubsub/ansible.yaml
@@ -18,17 +18,17 @@ datasources: !ruby/object:Overrides::ResourceOverrides
       has_filters: false
       test: !ruby/object:Provider::Ansible::AnsibleFactsTestInformation
         exists: |
-          "'test-topic1' in \"{{ results['items'] | map(attribute='name') | list }}\""
+          "'test-topic1' in \"{{ results['resources'] | map(attribute='name') | list }}\""
         does_not_exist: |
-          "'test-topic1' not in \"{{ results['items'] | map(attribute='name') | list }}\""
+          "'test-topic1' not in \"{{ results['resources'] | map(attribute='name') | list }}\""
   Subscription: !ruby/object:Overrides::Ansible::ResourceOverride
     facts: !ruby/object:Provider::Ansible::FactsOverride
       has_filters: false
       test: !ruby/object:Provider::Ansible::AnsibleFactsTestInformation
         exists: |
-          "\"{{resource_name}}\" in \"{{ results['items'] | map(attribute='name') | list }}\""
+          "\"{{resource_name}}\" in \"{{ results['resources'] | map(attribute='name') | list }}\""
         does_not_exist: |
-          "\"{{resource_name}}\" not in \"{{ results['items'] | map(attribute='name') | list }}\""
+          "\"{{resource_name}}\" not in \"{{ results['resources'] | map(attribute='name') | list }}\""
 overrides: !ruby/object:Overrides::ResourceOverrides
   Topic: !ruby/object:Overrides::Ansible::ResourceOverride
     transport: !ruby/object:Overrides::Ansible::Transport

--- a/products/spanner/ansible.yaml
+++ b/products/spanner/ansible.yaml
@@ -18,17 +18,17 @@ datasources: !ruby/object:Overrides::ResourceOverrides
       has_filters: false
       test: !ruby/object:Provider::Ansible::AnsibleFactsTestInformation
         exists: |
-          "\"{{resource_name}}\" in \"{{ results['items'] | map(attribute='name') | list }}\""
+          "\"{{resource_name}}\" in \"{{ results['resources'] | map(attribute='name') | list }}\""
         does_not_exist: |
-          "\"{{resource_name}}\" not in \"{{ results['items'] | map(attribute='name') | list }}\""
+          "\"{{resource_name}}\" not in \"{{ results['resources'] | map(attribute='name') | list }}\""
   Database: !ruby/object:Overrides::Ansible::ResourceOverride
     facts: !ruby/object:Provider::Ansible::FactsOverride
       has_filters: false
       test: !ruby/object:Provider::Ansible::AnsibleFactsTestInformation
         exists: |
-          "'webstore' in \"{{ results['items'] | map(attribute='name') | list }}\""
+          "'webstore' in \"{{ results['resources'] | map(attribute='name') | list }}\""
         does_not_exist: |
-          "'webstore' not in \"{{ results['items'] | map(attribute='name') | list }}\""
+          "'webstore' not in \"{{ results['resources'] | map(attribute='name') | list }}\""
   # Virtual => true objects that don't need dedicated resources.
   InstanceConfig: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true

--- a/products/sql/ansible.yaml
+++ b/products/sql/ansible.yaml
@@ -21,17 +21,17 @@ datasources: !ruby/object:Overrides::ResourceOverrides
       has_filters: false
       test: !ruby/object:Provider::Ansible::AnsibleFactsTestInformation
         exists: |
-          "\"{{resource_name}}\" in \"{{ results['items'] | map(attribute='name') | list }}\""
+          "\"{{resource_name}}\" in \"{{ results['resources'] | map(attribute='name') | list }}\""
         does_not_exist: |
-          "\"{{resource_name}}\" not in \"{{ results['items'] | map(attribute='name') | list }}\""
+          "\"{{resource_name}}\" not in \"{{ results['resources'] | map(attribute='name') | list }}\""
   User: !ruby/object:Overrides::Ansible::ResourceOverride
     facts: !ruby/object:Provider::Ansible::FactsOverride
       has_filters: false
       test: !ruby/object:Provider::Ansible::AnsibleFactsTestInformation
         exists: |
-          "'test-user' in \"{{ results['items'] | map(attribute='name') | list }}\""
+          "'test-user' in \"{{ results['resources'] | map(attribute='name') | list }}\""
         does_not_exist: |
-          "'test-user' not in \"{{ results['items'] | map(attribute='name') | list }}\""
+          "'test-user' not in \"{{ results['resources'] | map(attribute='name') | list }}\""
   Tier: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
   SslCert: !ruby/object:Overrides::Ansible::ResourceOverride


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
A while back, I migrated the `facts` modules to return information under the `resources` key instead of `items`.

I didn't migrate all of the tests to do the same.