### PR TITLE
Ansible Markdown Parser

### DIFF
--- a/.ci/containers/go-ruby-python/Dockerfile
+++ b/.ci/containers/go-ruby-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/magic-modules/go-ruby:1.11.5-2.6.0-v2
+FROM gcr.io/magic-modules/go-ruby:1.11.5-2.6.0-v3
 
 # Install python & python libraries.
 RUN apt-get update

--- a/.ci/containers/go-ruby/Gemfile
+++ b/.ci/containers/go-ruby/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'activesupport'
 gem 'binding_of_caller'
 gem 'rake'
+gem 'redcarpet'
 
 group :test do
   gem 'erb_lint'

--- a/.ci/containers/go-ruby/Gemfile.lock
+++ b/.ci/containers/go-ruby/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
       loofah (~> 2.2, >= 2.2.2)
     rainbow (3.0.0)
     rake (12.3.1)
+    redcarpet (3.4.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -113,6 +114,7 @@ DEPENDENCIES
   octokit
   parallel_tests
   rake
+  redcarpet
   rspec
   rubocop (~> 0.63.1)
 

--- a/.ci/magic-modules/generate-ansible.yml
+++ b/.ci/magic-modules/generate-ansible.yml
@@ -8,7 +8,7 @@ image_resource:
     type: docker-image
     source:
         repository: gcr.io/magic-modules/go-ruby-python
-        tag: '1.11.5-2.6.0-2.7-v2'
+        tag: '1.11.5-2.6.0-2.7-v3'
 
 inputs:
     - name: magic-modules-branched

--- a/.ci/magic-modules/generate-inspec.yml
+++ b/.ci/magic-modules/generate-inspec.yml
@@ -8,7 +8,7 @@ image_resource:
     type: docker-image
     source:
         repository: gcr.io/magic-modules/go-ruby-python
-        tag: '1.11.5-2.6.0-2.7-v2'
+        tag: '1.11.5-2.6.0-2.7-v3'
 
 inputs:
     - name: magic-modules-branched

--- a/.ci/magic-modules/generate-terraform.yml
+++ b/.ci/magic-modules/generate-terraform.yml
@@ -8,7 +8,7 @@ image_resource:
     type: docker-image
     source:
         repository: gcr.io/magic-modules/go-ruby-python
-        tag: '1.11.5-2.6.0-2.7-v2'
+        tag: '1.11.5-2.6.0-2.7-v3'
 
 inputs:
     - name: magic-modules-branched

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'activesupport'
 gem 'binding_of_caller'
 gem 'rake'
+gem 'redcarpet'
 
 group :test do
   gem 'erb_lint'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
       loofah (~> 2.2, >= 2.2.2)
     rainbow (3.0.0)
     rake (12.3.1)
+    redcarpet (3.4.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -113,6 +114,7 @@ DEPENDENCIES
   octokit
   parallel_tests
   rake
+  redcarpet
   rspec
   rubocop (~> 0.63.1)
 

--- a/provider/ansible/markdown.rb
+++ b/provider/ansible/markdown.rb
@@ -28,9 +28,10 @@ module Provider
         # Description texts should have leading + trailing spaces
         # removed so that they are not mistaken for code blocks by the
         # Markdown parser.
-        Redcarpet::Markdown.new(AnsibleDescriptionRender)
-                           .render(text.strip)
-                           .split(DELIMITER)
+        test = Redcarpet::Markdown.new(AnsibleDescriptionRender)
+                                  .render(text.strip.squeeze("\n"))
+                                  .split(DELIMITER)
+                                  .map(&:strip)
       end
 
       # This is a rendering class that takes in
@@ -48,7 +49,7 @@ module Provider
           text.split(".\n").map do |paragraph|
             paragraph += '.' unless paragraph.end_with?('.')
             paragraph = format_url(paragraph)
-            paragraph.tr("\n", ' ').strip.squeeze(' ')
+            paragraph.tr("\n", ' ').squeeze(' ')
           end.join(DELIMITER)
         end
 

--- a/provider/ansible/markdown.rb
+++ b/provider/ansible/markdown.rb
@@ -54,7 +54,7 @@ module Provider
         end
 
         def codespan(code)
-          code
+          "\"#{code}\""
         end
 
         def normal_text(text)

--- a/provider/ansible/markdown.rb
+++ b/provider/ansible/markdown.rb
@@ -49,7 +49,6 @@ module Provider
           end.join(DELIMITER)
         end
 
-        
         def codespan(code)
           "`#{code}`"
         end
@@ -58,7 +57,7 @@ module Provider
           text
         end
 
-        def link(link, title, content)
+        def link(link, _title, content)
           if content
             "L(#{content},#{link})"
           else
@@ -66,14 +65,14 @@ module Provider
           end
         end
 
-        def list(content, list_type)
+        def list(content, _list_type)
           content.split(LIST_DELIMITER).join(', ')
         end
 
         # List items come first. We have to place special delimiters
         # because all of the list strings are joined together before
         # list() is called.
-        def list_item(text, list_type)
+        def list_item(text, _list_type)
           "#{text.sub("\n", '')}#{LIST_DELIMITER}"
         end
 

--- a/provider/ansible/markdown.rb
+++ b/provider/ansible/markdown.rb
@@ -28,10 +28,10 @@ module Provider
         # Description texts should have leading + trailing spaces
         # removed so that they are not mistaken for code blocks by the
         # Markdown parser.
-        test = Redcarpet::Markdown.new(AnsibleDescriptionRender)
-                                  .render(text.strip.squeeze("\n"))
-                                  .split(DELIMITER)
-                                  .map(&:strip)
+        Redcarpet::Markdown.new(AnsibleDescriptionRender)
+                           .render(text.strip.squeeze("\n"))
+                           .split(DELIMITER)
+                           .map(&:strip)
       end
 
       # This is a rendering class that takes in

--- a/provider/ansible/markdown.rb
+++ b/provider/ansible/markdown.rb
@@ -54,7 +54,7 @@ module Provider
         end
 
         def codespan(code)
-          "`#{code}`"
+          code
         end
 
         def normal_text(text)

--- a/provider/ansible/markdown.rb
+++ b/provider/ansible/markdown.rb
@@ -42,8 +42,9 @@ module Provider
         LIST_DELIMITER = '%%%'.freeze
         # Returns a paragraph with delimiters showing where it should be split.
         def paragraph(text)
-          text.split(". ").map do |paragraph|
+          text.split(/\.[ \n]/).map do |paragraph|
             paragraph += '.' unless paragraph.end_with?('.')
+            format_url(paragraph)
             paragraph.tr("\n", ' ').strip.squeeze(' ')
           end.join(DELIMITER)
         end
@@ -74,6 +75,20 @@ module Provider
         # list() is called.
         def list_item(text, list_type)
           "#{text.sub("\n", '')}#{LIST_DELIMITER}"
+        end
+
+        private
+
+        # Find URLs and surround with U()
+        # If there's a period at the end of the URL, make sure the
+        # period is outside of the ()
+        def format_url(paragraph)
+          paragraph.gsub(%r{
+            https?:\/\/(?:www\.|(?!www))[a-zA-Z0-9]
+            [a-zA-Z0-9-]+[a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9][a-zA-Z0-9-]+
+            [a-zA-Z0-9]\.[^\s]{2,}|https?:\/\/(?:www\.|(?!www))
+            [a-zA-Z0-9]\.[^\s]{2,}|www\.[a-zA-Z0-9]\.[^\s]{2,}
+          }x, 'U(\\0)').gsub('.)', ').')
         end
       end
     end

--- a/provider/ansible/markdown.rb
+++ b/provider/ansible/markdown.rb
@@ -42,7 +42,7 @@ module Provider
         LIST_DELIMITER = '%%%'.freeze
         # Returns a paragraph with delimiters showing where it should be split.
         def paragraph(text)
-          text.split(/\.[ \n]/).map do |paragraph|
+          text.split(/\.\n/).map do |paragraph|
             paragraph += '.' unless paragraph.end_with?('.')
             format_url(paragraph)
             paragraph.tr("\n", ' ').strip.squeeze(' ')

--- a/provider/ansible/markdown.rb
+++ b/provider/ansible/markdown.rb
@@ -42,9 +42,9 @@ module Provider
         LIST_DELIMITER = '%%%'.freeze
         # Returns a paragraph with delimiters showing where it should be split.
         def paragraph(text)
-          text.split(/\.\n/).map do |paragraph|
+          text.split(".\n").map do |paragraph|
             paragraph += '.' unless paragraph.end_with?('.')
-            format_url(paragraph)
+            paragraph = format_url(paragraph)
             paragraph.tr("\n", ' ').strip.squeeze(' ')
           end.join(DELIMITER)
         end

--- a/provider/ansible/markdown.rb
+++ b/provider/ansible/markdown.rb
@@ -1,0 +1,81 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'compile/core'
+require 'provider/config'
+require 'provider/core'
+require 'redcarpet'
+
+module Provider
+  module Ansible
+    # Responsible for building out YAML documentation
+    # from Markdown
+    # This is primarily done for parsing descriptions.
+    module Markdown
+      DELIMITER = '$$$'.freeze
+
+      def description(text)
+        Redcarpet::Markdown.new(AnsibleDescriptionRender)
+                           .render(text.gsub(/\n^\n/, ' '))
+                           .split(DELIMITER)
+      end
+
+      # This is a rendering class that takes in
+      # a Markdown description and returns an
+      # array of strings. This is used exclusively for
+      # description documentation.
+      #
+      # Redcarpet will return a String (because that's the expectation of markdown).
+      # Ansible wants an array of strings, so this class will return a single string
+      # with the '$$$' character denoting where the string should be split.
+      class AnsibleDescriptionRender < Redcarpet::Render::Base
+        LIST_DELIMITER = '%%%'.freeze
+        # Returns a paragraph with delimiters showing where it should be split.
+        def paragraph(text)
+          text.split(". ").map do |paragraph|
+            paragraph += '.' unless paragraph.end_with?('.')
+            paragraph.tr("\n", ' ').strip.squeeze(' ')
+          end.join(DELIMITER)
+        end
+
+        
+        def codespan(code)
+          "`#{code}`"
+        end
+
+        def normal_text(text)
+          text
+        end
+
+        def link(link, title, content)
+          if content
+            "L(#{content},#{link})"
+          else
+            "U(#{link})"
+          end
+        end
+
+        def list(content, list_type)
+          content.split(LIST_DELIMITER).join(', ')
+        end
+
+        # List items come first. We have to place special delimiters
+        # because all of the list strings are joined together before
+        # list() is called.
+        def list_item(text, list_type)
+          "#{text.sub("\n", '')}#{LIST_DELIMITER}"
+        end
+      end
+    end
+  end
+end

--- a/provider/ansible/markdown.rb
+++ b/provider/ansible/markdown.rb
@@ -25,8 +25,11 @@ module Provider
       DELIMITER = '$$$'.freeze
 
       def description(text)
+        # Description texts should have leading + trailing spaces
+        # removed so that they are not mistaken for code blocks by the
+        # Markdown parser.
         Redcarpet::Markdown.new(AnsibleDescriptionRender)
-                           .render(text.gsub(/\n^\n/, ' '))
+                           .render(text.strip)
                            .split(DELIMITER)
       end
 

--- a/templates/ansible/documentation.erb
+++ b/templates/ansible/documentation.erb
@@ -14,7 +14,7 @@ DOCUMENTATION = '''
 ---
 <%= to_yaml({
   'module' => module_name(object),
-  'description' => format_description(object.description),
+  'description' => description(object.description),
   'short_description' => "Creates a GCP #{object.name}",
   'version_added' => version_added(object).to_f,
   'author' => "Google Inc. (@googlecloudplatform)",

--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -34,7 +34,7 @@ DOCUMENTATION = '''
   'options' => [
     ({
       object.facts.filter.name.underscore => {
-        'description' => format_description(object.facts.filter.description)
+        'description' => description(object.facts.filter.description)
       }
     } if object.facts.has_filters),
     uri_props.map { |p| documentation_for_property(p) }


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
We've talked in the past about how we should assume all descriptions are Markdown.

This is a proper Markdown parser for the Ansible docs. It takes in Markdown (the Markdown types I've seen directly in api.yaml so far) and converts it to an Ansible text description.

My goal right now is to get the docs as close as possible. There will be future changes to make things look nicer, but the goal is to make this large diff more palatable.