### PR TITLE
WIP: Fixes base_url for crypto_keys

### DIFF
--- a/products/kms/api.yaml
+++ b/products/kms/api.yaml
@@ -58,8 +58,8 @@ objects:
       api: 'https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings'
   - !ruby/object:Api::Resource
     name: 'CryptoKey'
-    base_url: '{{key_ring}}/cryptoKeys?cryptoKeyId={{name}}'
-    self_link: '{{key_ring}}/cryptoKeys/{{name}}'
+    base_url: 'projects/{{project}}/keyRings/{{key_ring}}/cryptoKeys?cryptoKeyId={{name}}'
+    self_link: 'projects/{{projects}}/keyRings/{{key_ring}}/cryptoKeys/{{name}}'
     update_verb: :PATCH
     update_mask: true
     description: |


### PR DESCRIPTION
Fixes terraform-providers/terraform-provider-google#3889.

I'm surprised this previously passed the [acceptance testing](https://github.com/GoogleCloudPlatform/magic-modules/pull/1856#issuecomment-502464749).