### PR TITLE
Add override ability for an api.yaml

### DIFF
--- a/api/compiler.rb
+++ b/api/compiler.rb
@@ -31,7 +31,7 @@ module Api
 
     def run
       # Compile step #1: compile with generic class to instantiate target class
-      config = Google::YamlValidator.parse(File.read(@catalog))
+      config = Google::YamlValidator.parse(@catalog)
       unless config.class <= Api::Product
         raise StandardError, "#{@catalog} is #{config.class}"\
           ' instead of Api::Product' \

--- a/api/object.rb
+++ b/api/object.rb
@@ -26,6 +26,37 @@ module Api
         attr_reader :name
       end
 
+      def deep_merge(arr1, arr2)
+        # Merge any elements that exist in both
+        result = arr1.map do |el1|
+          other = arr2.select { |el2| el1.name == el2.name }.first
+          other.nil? ? el1 : el1.merge(other)
+        end
+
+        # Add any elements of arr2 that don't exist in arr1
+        result + arr2.reject do |el2|
+          arr1.any? { |el1| el2.name == el1.name }
+        end
+      end
+
+      def merge(other)
+        result = self.class.new
+        instance_variables.each do |v|
+          result.instance_variable_set(v, instance_variable_get(v))
+        end
+
+        other.instance_variables.each do |v|
+          if other.instance_variable_get(v).class == Array
+            result.instance_variable_set(v, deep_merge(result.instance_variable_get(v),
+                                                       other.instance_variable_get(v)))
+          else
+            result.instance_variable_set(v, other.instance_variable_get(v))
+          end
+        end
+
+        result
+      end
+
       include Properties
 
       # original value of :name before the provider override happens

--- a/api/product.rb
+++ b/api/product.rb
@@ -16,7 +16,6 @@ require 'api/product/api_reference'
 require 'api/product/version'
 require 'google/logger'
 require 'compile/core'
-require 'overrides/resources'
 require 'json'
 
 module Api

--- a/api/product.rb
+++ b/api/product.rb
@@ -16,6 +16,7 @@ require 'api/product/api_reference'
 require 'api/product/version'
 require 'google/logger'
 require 'compile/core'
+require 'overrides/resources'
 require 'json'
 
 module Api

--- a/spec/compiler_spec.rb
+++ b/spec/compiler_spec.rb
@@ -16,14 +16,14 @@ require 'api/compiler'
 
 describe Api::Compiler do
   context 'should fail if file does not exist' do
-    subject { -> { Api::Compiler.new('spec/data/somedummyfile').run } }
+    subject { -> { Api::Compiler.new(File.read('spec/data/somedummyfile')).run } }
     it { is_expected.to raise_error(Errno::ENOENT) }
   end
 
   context 'should use the file provided' do
     let(:reader) { mock('reader') }
 
-    subject { -> { Api::Compiler.new('my-file-to-parse.yaml').run } }
+    subject { -> { Api::Compiler.new(File.read('my-file-to-parse.yaml')).run } }
 
     before do
       # File will only be read once because there's no
@@ -40,7 +40,7 @@ describe Api::Compiler do
   end
 
   context 'parses file' do
-    subject { Api::Compiler.new('spec/data/good-file.yaml').run }
+    subject { Api::Compiler.new(File.read('spec/data/good-file.yaml')).run }
 
     before do
       subject.validate
@@ -55,7 +55,7 @@ describe Api::Compiler do
     let(:reader) { mock('reader') }
 
     subject do
-      -> { Api::Compiler.new('my-file-to-parse.yaml').run.validate }
+      -> { Api::Compiler.new(File.read('my-file-to-parse.yaml')).run.validate }
     end
 
     before do

--- a/spec/override_runner_spec.rb
+++ b/spec/override_runner_spec.rb
@@ -29,7 +29,7 @@ describe Overrides::Runner do
           )
         )
       end
-      let(:api) { Api::Compiler.new('spec/data/good-file.yaml').run }
+      let(:api) { Api::Compiler.new(File.read('spec/data/good-file.yaml')).run }
 
       it {
         new_api = Overrides::Runner.build(api, overrides)
@@ -45,7 +45,7 @@ describe Overrides::Runner do
           )
         )
       end
-      let(:api) { Api::Compiler.new('spec/data/good-file.yaml').run }
+      let(:api) { Api::Compiler.new(File.read('spec/data/good-file.yaml')).run }
 
       it {
         new_api = Overrides::Runner.build(api, overrides)
@@ -66,7 +66,7 @@ describe Overrides::Runner do
           )
         )
       end
-      let(:api) { Api::Compiler.new('spec/data/good-file.yaml').run }
+      let(:api) { Api::Compiler.new(File.read('spec/data/good-file.yaml')).run }
 
       it {
         new_api = Overrides::Runner.build(api, overrides)
@@ -90,7 +90,7 @@ describe Overrides::Runner do
           )
         )
       end
-      let(:api) { Api::Compiler.new('spec/data/good-file.yaml').run }
+      let(:api) { Api::Compiler.new(File.read('spec/data/good-file.yaml')).run }
 
       it {
         new_api = Overrides::Runner.build(api, overrides)
@@ -113,7 +113,7 @@ describe Overrides::Runner do
           )
         )
       end
-      let(:api) { Api::Compiler.new('spec/data/good-file.yaml').run }
+      let(:api) { Api::Compiler.new(File.read('spec/data/good-file.yaml')).run }
 
       it {
         new_api = Overrides::Runner.build(api, overrides)
@@ -135,7 +135,7 @@ describe Overrides::Runner do
           )
         )
       end
-      let(:api) { Api::Compiler.new('spec/data/good-file.yaml').run }
+      let(:api) { Api::Compiler.new(File.read('spec/data/good-file.yaml')).run }
 
       it {
         new_api = Overrides::Runner.build(api, overrides)
@@ -157,7 +157,7 @@ describe Overrides::Runner do
           )
         )
       end
-      let(:api) { Api::Compiler.new('spec/data/good-file.yaml').run }
+      let(:api) { Api::Compiler.new(File.read('spec/data/good-file.yaml')).run }
 
       it {
         new_api = Overrides::Runner.build(api, overrides, TestResourceOverride)

--- a/spec/override_validator_spec.rb
+++ b/spec/override_validator_spec.rb
@@ -29,7 +29,7 @@ describe Overrides::Validator do
           )
         )
       end
-      let(:api) { Api::Compiler.new('spec/data/good-file.yaml').run }
+      let(:api) { Api::Compiler.new(File.read('spec/data/good-file.yaml')).run }
 
       it {
         runner = Overrides::Validator.new(api, overrides)
@@ -49,7 +49,7 @@ describe Overrides::Validator do
           )
         )
       end
-      let(:api) { Api::Compiler.new('spec/data/good-file.yaml').run }
+      let(:api) { Api::Compiler.new(File.read('spec/data/good-file.yaml')).run }
 
       it {
         runner = Overrides::Validator.new(api, overrides)
@@ -70,7 +70,7 @@ describe Overrides::Validator do
           )
         )
       end
-      let(:api) { Api::Compiler.new('spec/data/good-file.yaml').run }
+      let(:api) { Api::Compiler.new(File.read('spec/data/good-file.yaml')).run }
 
       it {
         runner = Overrides::Validator.new(api, overrides)
@@ -91,7 +91,7 @@ describe Overrides::Validator do
           )
         )
       end
-      let(:api) { Api::Compiler.new('spec/data/good-file.yaml').run }
+      let(:api) { Api::Compiler.new(File.read('spec/data/good-file.yaml')).run }
 
       it {
         runner = Overrides::Validator.new(api, overrides)

--- a/spec/provider_terraform_import_spec.rb
+++ b/spec/provider_terraform_import_spec.rb
@@ -23,7 +23,7 @@ end
 
 describe Provider::Terraform do
   context 'static' do
-    let(:product) { Api::Compiler.new('spec/data/good-file.yaml').run }
+    let(:product) { Api::Compiler.new(File.read('spec/data/good-file.yaml')).run }
     let(:config) do
       Provider::Config.parse('spec/data/terraform-config.yaml', product)[1]
     end

--- a/spec/provider_terraform_spec.rb
+++ b/spec/provider_terraform_spec.rb
@@ -22,7 +22,7 @@ end
 
 describe Provider::Terraform do
   context 'good file product' do
-    let(:product) { Api::Compiler.new('spec/data/good-file.yaml').run }
+    let(:product) { Api::Compiler.new(File.read('spec/data/good-file.yaml')).run }
     let(:config) do
       Provider::Config.parse('spec/data/terraform-config.yaml', product)[1]
     end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -16,7 +16,7 @@ require 'api/object'
 
 describe Api::Resource do
   context 'uses the correct API version' do
-    let(:product) { Api::Compiler.new('spec/data/good-file.yaml').run }
+    let(:product) { Api::Compiler.new(File.read('spec/data/good-file.yaml')).run }
 
     before { product.validate }
 


### PR DESCRIPTION
This allows specifiying a directory on the command line that contains other
products which will override existing properties or add new properties.
It will allow alpha/eap product definitions to be defined in a different
directory sourced at run time.

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTERS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
