### PR TITLE
Rename to_yaml method used in Ansible templates

### DIFF
--- a/compile/core.rb
+++ b/compile/core.rb
@@ -150,7 +150,7 @@ module Compile
       compiled
     end
 
-    def to_yaml(obj, options = {})
+    def ansible_style_yaml(obj, options = {})
       if obj.is_a?(::Hash)
         obj.reject { |_, v| v.nil? }.to_yaml(options).sub("---\n", '')
       else

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -97,11 +97,11 @@ module Provider
       end
 
       def build_test(state, object, noop = false)
-        to_yaml([build_task(state, INTEGRATION_TEST_DEFAULTS, object, noop)])
+        ansible_style_yaml([build_task(state, INTEGRATION_TEST_DEFAULTS, object, noop)])
       end
 
       def build_example(state, object)
-        to_yaml([build_task(state, EXAMPLE_DEFAULTS, object)])
+        ansible_style_yaml([build_task(state, EXAMPLE_DEFAULTS, object)])
       end
 
       private

--- a/templates/ansible/documentation.erb
+++ b/templates/ansible/documentation.erb
@@ -12,7 +12,7 @@ ANSIBLE_METADATA = {'metadata_version': <%= metadata_version -%>,
 
 DOCUMENTATION = '''
 ---
-<%= to_yaml({
+<%= ansible_style_yaml({
   'module' => module_name(object),
   'description' => format_description(object.description),
   'short_description' => "Creates a GCP #{object.name}",
@@ -53,5 +53,5 @@ EXAMPLES = '''
 <% end -%>
 
 RETURN = '''
-<%= to_yaml(object.all_user_properties.map { |p| returns_for_property(p) }.reduce({}, :merge)) -%>
+<%= ansible_style_yaml(object.all_user_properties.map { |p| returns_for_property(p) }.reduce({}, :merge)) -%>
 '''

--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -24,7 +24,7 @@ ANSIBLE_METADATA = {'metadata_version': <%= metadata_version -%>,
 
 DOCUMENTATION = '''
 ---
-<%= to_yaml({
+<%= ansible_style_yaml({
   'module' => "#{module_name(object)}_facts",
   'description' => ["Gather facts for GCP #{object.name}"],
   'short_description' => "Gather facts for GCP #{object.name}",
@@ -50,7 +50,7 @@ EXAMPLES = '''
 <% end -%>
 
 RETURN = '''
-<%= to_yaml({
+<%= ansible_style_yaml({
   'resources' => {
     'description' => 'List of resources',
     'returned' => 'always',

--- a/templates/ansible/integration_test_variables.erb
+++ b/templates/ansible/integration_test_variables.erb
@@ -15,7 +15,7 @@
 <% autogen_exception -%>
 ---
 <%=
-  to_yaml({
+  ansible_style_yaml({
     'resource_name' => '{{ resource_prefix }}'
   }.merge(example.vars))
 -%>


### PR DESCRIPTION
The overloading of to_yaml ended up bleeding into the default to_yaml method
for most objects in MM. Renaming o allow other objects to use vanilla to_yaml

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTERS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
