### PR TITLE
Sort IAM policy bindings by their role name to get simpler diffs

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_iam_policy.go
+++ b/third_party/terraform/data_sources/data_source_google_iam_policy.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"encoding/json"
+	"sort"
 	"strconv"
 
 	"github.com/hashicorp/terraform/helper/hashcode"
@@ -102,6 +103,11 @@ func dataSourceGoogleIamPolicyRead(d *schema.ResourceData, meta interface{}) err
 			Members: convertStringSet(binding["members"].(*schema.Set)),
 		}
 	}
+
+	// Sort bindings by their role name to get simpler diffs as it's what the API does
+	sort.Slice(bindings, func(i, j int) bool {
+		return bindings[i].Role < bindings[j].Role
+	})
 
 	// Convert each audit_config into a cloudresourcemanager.AuditConfig
 	policy.AuditConfigs = expandAuditConfig(aset)

--- a/third_party/terraform/data_sources/data_source_google_iam_policy.go
+++ b/third_party/terraform/data_sources/data_source_google_iam_policy.go
@@ -98,9 +98,14 @@ func dataSourceGoogleIamPolicyRead(d *schema.ResourceData, meta interface{}) err
 	// Convert each config binding into a cloudresourcemanager.Binding
 	for i, v := range bset.List() {
 		binding := v.(map[string]interface{})
+		members := convertStringSet(binding["members"].(*schema.Set))
+
+		// Sort members to get simpler diffs as it's what the API does
+		sort.Strings(members)
+
 		policy.Bindings[i] = &cloudresourcemanager.Binding{
 			Role:    binding["role"].(string),
-			Members: convertStringSet(binding["members"].(*schema.Set)),
+			Members: members,
 		}
 	}
 


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Upstreams https://github.com/terraform-providers/terraform-provider-google/pull/3855.

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTERS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
iam: sort bindings in google_*_iam_policy resources to get simpler diffs
```
