### PR TITLE
removing some stray puppet references

### DIFF
--- a/compile/core.rb
+++ b/compile/core.rb
@@ -82,28 +82,7 @@ module Compile
     # It would generate an output like:
     #
     #   We're compiling object 'Disk' for 'Google Compute Engine'.
-    #   This file is named 'build/puppet/compute/TEST.md'.
-    #
-    # The ERB compiler uses a local variable (_erbout) to track the output to be
-    # emitted and on every new instance of the ERB the output is overwritten. To
-    # enable this function to be reentrant we will store the _erbout variable to
-    # preserve the original content and combine the result of the run. Saving
-    # this context is similar to stack push/pop used in Assembly when entering
-    # and leaving a function:
-    #
-    # PROC myfunc
-    #   PUSH EBP
-    #   MOV EBP, ESP
-    #   ...
-    #   ...
-    #   POP EBP
-    # ENDP
-    #
-    # Also note that variables can be overwritten when calling the next level.
-    # For example if you want to overwrite a variable, e.g. indent_level, one
-    # can simply update the variable and call compile. But note that it is the
-    # caller responsibility to restore the variable before exiting the context
-    # (similarly to the PROC specification above).
+    #   This file is named 'build/provider/compute/TEST.md'.
     #
     # If you want to avoid the load/save you can use one helper functions, such
     # as Provider::Core.compile_file(), which take a hash with overrides. For

--- a/compiler.rb
+++ b/compiler.rb
@@ -16,7 +16,7 @@ $LOAD_PATH.unshift File.dirname(__FILE__)
 
 # Run from compiler dir so all references are relative to the compiler
 # executable. This allows the following command line:
-#   puppet-google-compute$ ../puppet-codegen/compiler products/compute $PWD
+#   ruby compiler.rb -p products/compute -e ansible -o build/ansible
 Dir.chdir(File.dirname(__FILE__))
 
 # Our default timezone is UTC, to avoid local time compromise test code seed

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1016,8 +1016,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       nextHopGateway: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'compareSelfLinkOrResourceName'
         custom_expand: templates/terraform/custom_expand/route_gateway.erb
-        # Description here is overridden because puppet won't compile if you ask
-        # it to include docs greater than 80 characters.
         description: |+
           URL to a gateway that should handle matching packets.
           Currently, you can only specify the internet gateway, using a full or
@@ -1028,8 +1026,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           * The string `default-internet-gateway`.
       nextHopInstance: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_expand: templates/terraform/custom_expand/route_instance.erb
-        # Description here is overridden because puppet won't compile if you ask
-        # it to include docs greater than 80 characters.
         description: |+
           URL to an instance that should handle matching packets.
           You can specify this as a full or partial URL. For example:


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
These are the last of the Puppet references!

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTERS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
