### PR TITLE
[ansible] kubectl format() fix

### DIFF
--- a/products/container/helpers/python/kubectl.py
+++ b/products/container/helpers/python/kubectl.py
@@ -20,7 +20,7 @@ class Kubectl(object):
     """
     def _contents(self):
         token = self._auth_token()
-        endpoint = "https://{}".format(self.fetch["endpoint"])
+        endpoint = "https://%s" % self.fetch["endpoint"]
         context = self.module.params.get('kubectl_context')
         if not context:
             context = self.module.params['name']


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Ansible CI was complaining about a format function I used in #1944, so I changed it

(Why is Ansible CI complaining but not our CI?. I'm going to look into it. I'm pretty sure it's because they run their CI on 4 different versions of Python and we just run it on the oldest version of Python because running it 4 times would take forever)

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTERS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
