### PR TITLE
measure timeouts in minutes

### DIFF
--- a/api/timeout.rb
+++ b/api/timeout.rb
@@ -18,13 +18,13 @@ module  Api
   class Timeouts < Api::Object
     # Default timeout for all operation types is 4 minutes. This can be
     # overridden for each resource.
-    DEFAULT_INSERT_TIMEOUT_SEC = 4 * 60
-    DEFAULT_UPDATE_TIMEOUT_SEC = 4 * 60
-    DEFAULT_DELETE_TIMEOUT_SEC = 4 * 60
+    DEFAULT_INSERT_TIMEOUT_MINUTES = 4
+    DEFAULT_UPDATE_TIMEOUT_MINUTES = 4
+    DEFAULT_DELETE_TIMEOUT_MINUTES = 4
 
-    attr_reader :insert_sec
-    attr_reader :update_sec
-    attr_reader :delete_sec
+    attr_reader :insert_minutes
+    attr_reader :update_minutes
+    attr_reader :delete_minutes
 
     def initialize
       validate
@@ -33,9 +33,9 @@ module  Api
     def validate
       super
 
-      check :insert_sec, type: Integer, default: DEFAULT_INSERT_TIMEOUT_SEC
-      check :update_sec, type: Integer, default: DEFAULT_UPDATE_TIMEOUT_SEC
-      check :delete_sec, type: Integer, default: DEFAULT_DELETE_TIMEOUT_SEC
+      check :insert_minutes, type: Integer, default: DEFAULT_INSERT_TIMEOUT_MINUTES
+      check :update_minutes, type: Integer, default: DEFAULT_UPDATE_TIMEOUT_MINUTES
+      check :delete_minutes, type: Integer, default: DEFAULT_DELETE_TIMEOUT_MINUTES
     end
   end
 end

--- a/products/accesscontextmanager/terraform.yaml
+++ b/products/accesscontextmanager/terraform.yaml
@@ -15,9 +15,9 @@
 overrides: !ruby/object:Overrides::ResourceOverrides
   AccessPolicy: !ruby/object:Overrides::Terraform::ResourceOverride
     timeouts: !ruby/object:Api::Timeouts
-      insert_sec: 360
-      update_sec: 360
-      delete_sec: 360
+      insert_minutes: 6
+      update_minutes: 6
+      delete_minutes: 6
     autogen_async: true
     import_format: ["{{name}}"]
     examples:
@@ -34,9 +34,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       post_create: templates/terraform/post_create/accesspolicy.erb
   AccessLevel: !ruby/object:Overrides::Terraform::ResourceOverride
     timeouts: !ruby/object:Api::Timeouts
-      insert_sec: 360
-      update_sec: 360
-      delete_sec: 360
+      insert_minutes: 6
+      update_minutes: 6
+      delete_minutes: 6
     autogen_async: true
     id_format: "{{name}}"
     import_format: ["{{name}}"]
@@ -57,9 +57,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       custom_import: templates/terraform/custom_import/access_level_self_link_as_name_and_set_parent.go.erb
   ServicePerimeter: !ruby/object:Overrides::Terraform::ResourceOverride
     timeouts: !ruby/object:Api::Timeouts
-      insert_sec: 360
-      update_sec: 360
-      delete_sec: 360
+      insert_minutes: 6
+      update_minutes: 6
+      delete_minutes: 6
     autogen_async: true
     id_format: "{{name}}"
     import_format: ["{{name}}"]

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -1316,7 +1316,7 @@ objects:
         # Larger disks were timing out at creation. Bumping up to 5 minutes.
         # https://github.com/terraform-providers/terraform-provider-google/issues/703
         timeouts: !ruby/object:Api::Timeouts
-          insert_sec: 300 # 5 minutes
+          insert_minutes: 5
       result: !ruby/object:Api::Async::Result
         path: 'targetLink'
       status: !ruby/object:Api::Async::Status
@@ -3692,9 +3692,9 @@ objects:
         # Users were experiencing timeouts. Bumping up to 6 minutes.
         # https://github.com/terraform-providers/terraform-provider-google/issues/852
         timeouts: !ruby/object:Api::Timeouts
-          insert_sec: 360 # 6 minutes
-          update_sec: 360 # 6 minutes
-          delete_sec: 360 # 6 minutes
+          insert_minutes: 6
+          update_minutes: 6
+          delete_minutes: 6
       result: !ruby/object:Api::Async::Result
         path: 'targetLink'
       status: !ruby/object:Api::Async::Status
@@ -5739,7 +5739,7 @@ objects:
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
         timeouts: !ruby/object:Api::Timeouts
-          insert_sec: 300 # 5 minutes
+          insert_minutes: 5
       result: !ruby/object:Api::Async::Result
         path: 'targetLink'
       status: !ruby/object:Api::Async::Status
@@ -6423,9 +6423,9 @@ objects:
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
         timeouts: !ruby/object:Api::Timeouts
-          insert_sec: 300 # 5 minutes
-          update_sec: 300 # 5 minutes
-          delete_sec: 300 # 5 minutes
+          insert_minutes: 5
+          update_minutes: 5
+          delete_minutes: 5
       result: !ruby/object:Api::Async::Result
         path: 'targetLink'
       status: !ruby/object:Api::Async::Status
@@ -6657,11 +6657,11 @@ objects:
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
         timeouts: !ruby/object:Api::Timeouts
-          insert_sec: 360 # 6 minutes
-          update_sec: 360 # 6 minutes
+          insert_minutes: 6
+          update_minutes: 6
           # Deletes can take 20-30 minutes to complete, since they depend
           # on the provisioning process either succeeding or failing completely.
-          delete_sec: 1800 # 30 minutes
+          delete_minutes: 30
       result: !ruby/object:Api::Async::Result
         path: 'targetLink'
       status: !ruby/object:Api::Async::Status
@@ -6883,9 +6883,9 @@ objects:
         # Users were experiencing timeout. Bumping up to 6 minutes.
         # https://github.com/terraform-providers/terraform-provider-google/issues/718
         timeouts: !ruby/object:Api::Timeouts
-          insert_sec: 360 # 6 minutes
-          update_sec: 360 # 6 minutes
-          delete_sec: 360 # 6 minutes
+          insert_minutes: 6
+          update_minutes: 6
+          delete_minutes: 6
       result: !ruby/object:Api::Async::Result
         path: 'targetLink'
       status: !ruby/object:Api::Async::Status

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -306,7 +306,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     # Larger disks were timing out at creation. Bumping up to 5 minutes.
     # https://github.com/terraform-providers/terraform-provider-google/issues/703
     timeouts: !ruby/object:Api::Timeouts
-      insert_sec: 300 # 5 minutes
+      insert_minutes: 5
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
@@ -685,9 +685,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     # Users were experiencing timeouts. Bumping up to 6 minutes.
     # https://github.com/terraform-providers/terraform-provider-google/issues/852
     timeouts: !ruby/object:Api::Timeouts
-      insert_sec: 360 # 6 minutes
-      update_sec: 360 # 6 minutes
-      delete_sec: 360 # 6 minutes
+      insert_minutes: 6
+      update_minutes: 6
+      delete_minutes: 6
     exclude: true
   InstanceGroup: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true
@@ -931,7 +931,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
   RegionDisk: !ruby/object:Overrides::Terraform::ResourceOverride
     timeouts: !ruby/object:Api::Timeouts
-      insert_sec: 300 # 5 minutes
+      insert_minutes: 5
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
@@ -1067,9 +1067,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
   Snapshot: !ruby/object:Overrides::Terraform::ResourceOverride
     timeouts: !ruby/object:Api::Timeouts
-      insert_sec: 300 # 5 minutes
-      update_sec: 300 # 5 minutes
-      delete_sec: 300 # 5 minutes
+      insert_minutes: 5
+      update_minutes: 5
+      delete_minutes: 5
     create_url: projects/{{project}}/zones/{{zone}}/disks/{{source_disk}}/createSnapshot
     examples:
       - !ruby/object:Provider::Terraform::Examples
@@ -1109,11 +1109,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       extra_schema_entry: templates/terraform/extra_schema_entry/snapshot.erb
   ManagedSslCertificate: !ruby/object:Overrides::Terraform::ResourceOverride
     timeouts: !ruby/object:Api::Timeouts
-      insert_sec: 360 # 6 minutes
-      update_sec: 360 # 6 minutes
+      insert_minutes: 6
+      update_minutes: 6
       # Deletes can take 20-30 minutes to complete, since they depend
       # on the provisioning process either succeeding or failing completely.
-      delete_sec: 1800 # 30 minutes
+      delete_minutes: 30
     docs: !ruby/object:Provider::Terraform::Docs
       warning: |
         This resource should be used with extreme caution!  Provisioning an SSL
@@ -1251,9 +1251,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     # Users were experiencing timeout. Bumping up to 6 minutes.
     # https://github.com/terraform-providers/terraform-provider-google/issues/718
     timeouts: !ruby/object:Api::Timeouts
-      insert_sec: 360 # 6 minutes
-      update_sec: 360 # 6 minutes
-      delete_sec: 360 # 6 minutes
+      insert_minutes: 6
+      update_minutes: 6
+      delete_minutes: 6
     id_format: "{{region}}/{{name}}"
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/products/filestore/terraform.yaml
+++ b/products/filestore/terraform.yaml
@@ -15,9 +15,9 @@
 overrides: !ruby/object:Overrides::ResourceOverrides
   Instance: !ruby/object:Overrides::Terraform::ResourceOverride
     timeouts: !ruby/object:Api::Timeouts
-      insert_sec: 360
-      update_sec: 360
-      delete_sec: 360
+      insert_minutes: 6
+      update_minutes: 6
+      delete_minutes: 6
     autogen_async: true
     id_format: "{{project}}/{{zone}}/{{name}}"
     import_format: ["projects/{{project}}/locations/{{zone}}/instances/{{name}}"]

--- a/products/firestore/terraform.yaml
+++ b/products/firestore/terraform.yaml
@@ -15,9 +15,9 @@
 overrides: !ruby/object:Overrides::ResourceOverrides
   Index: !ruby/object:Overrides::Terraform::ResourceOverride
     timeouts: !ruby/object:Api::Timeouts
-      insert_sec: 600
-      update_sec: 600
-      delete_sec: 600
+      insert_minutes: 10
+      update_minutes: 10
+      delete_minutes: 10
     autogen_async: true
     import_format: ["{{name}}"]
     description: |

--- a/products/redis/terraform.yaml
+++ b/products/redis/terraform.yaml
@@ -15,9 +15,9 @@
 overrides: !ruby/object:Overrides::ResourceOverrides
   Instance: !ruby/object:Overrides::Terraform::ResourceOverride
     timeouts: !ruby/object:Api::Timeouts
-      insert_sec: 600
-      update_sec: 600
-      delete_sec: 600
+      insert_minutes: 10
+      update_minutes: 10
+      delete_minutes: 10
     autogen_async: true
     id_format: "{{project}}/{{region}}/{{name}}"
     import_format: ["projects/{{project}}/locations/{{region}}/instances/{{name}}"]

--- a/products/sql/terraform.yaml
+++ b/products/sql/terraform.yaml
@@ -23,9 +23,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
                     "{{instance}}/{{name}}",
                     "{{name}}"]
     timeouts: !ruby/object:Api::Timeouts
-      insert_sec: 900
-      update_sec: 600
-      delete_sec: 600
+      insert_minutes: 15
+      update_minutes: 10
+      delete_minutes: 10
     properties:
       collation: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true

--- a/products/tpu/terraform.yaml
+++ b/products/tpu/terraform.yaml
@@ -15,9 +15,9 @@
 overrides: !ruby/object:Overrides::ResourceOverrides
   Node: !ruby/object:Overrides::Terraform::ResourceOverride
     timeouts: !ruby/object:Api::Timeouts
-      insert_sec: 900
-      update_sec: 900
-      delete_sec: 900
+      insert_minutes: 15
+      update_minutes: 15
+      delete_minutes: 15
     id_format: "{{project}}/{{zone}}/{{name}}"
     import_format: ["projects/{{project}}/locations/{{zone}}/nodes/{{name}}"]
     autogen_async: true

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -59,11 +59,11 @@ func resource<%= resource_name -%>() *schema.Resource {
 <%      end -%>
 
         Timeouts: &schema.ResourceTimeout {
-            Create: schema.DefaultTimeout(<%= timeouts.insert_minutes  -%> * time.Minutes),
+            Create: schema.DefaultTimeout(<%= timeouts.insert_minutes  -%> * time.Minute),
 <%          if updatable?(object, properties) -%>
-            Update: schema.DefaultTimeout(<%= timeouts.update_minutes -%> * time.Minutes),
+            Update: schema.DefaultTimeout(<%= timeouts.update_minutes -%> * time.Minute),
 <%          end -%>
-            Delete: schema.DefaultTimeout(<%= timeouts.delete_minutes -%> * time.Minutes),
+            Delete: schema.DefaultTimeout(<%= timeouts.delete_minutes -%> * time.Minute),
         },
 
 <%      if object.schema_version -%>

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -59,11 +59,11 @@ func resource<%= resource_name -%>() *schema.Resource {
 <%      end -%>
 
         Timeouts: &schema.ResourceTimeout {
-            Create: schema.DefaultTimeout(<%= timeouts.insert_sec  -%> * time.Second),
+            Create: schema.DefaultTimeout(<%= timeouts.insert_minutes  -%> * time.Minutes),
 <%          if updatable?(object, properties) -%>
-            Update: schema.DefaultTimeout(<%= timeouts.update_sec -%> * time.Second),
+            Update: schema.DefaultTimeout(<%= timeouts.update_minutes -%> * time.Minutes),
 <%          end -%>
-            Delete: schema.DefaultTimeout(<%= timeouts.delete_sec -%> * time.Second),
+            Delete: schema.DefaultTimeout(<%= timeouts.delete_minutes -%> * time.Minutes),
         },
 
 <%      if object.schema_version -%>

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -172,11 +172,11 @@ In addition to the arguments listed above, the following computed attributes are
 This resource provides the following
 [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
 
-- `create` - Default is <%= timeouts.insert_sec / 60 -%> minutes.
+- `create` - Default is <%= timeouts.insert_minutes -%> minutes.
 <% if updatable?(object, properties) -%>
-- `update` - Default is <%= timeouts.update_sec / 60 -%> minutes.
+- `update` - Default is <%= timeouts.update_minutes -%> minutes.
 <% end -%>
-- `delete` - Default is <%= timeouts.delete_sec / 60 -%> minutes.
+- `delete` - Default is <%= timeouts.delete_minutes -%> minutes.
 
 ## Import
 


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
We've never used a finer granularity than minute for timeouts, so make the code/config a bit easier to read by using minutes instead of seconds.
<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTERS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
