### PR TITLE
kubernetes_dashboard is disabled by default

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -2454,6 +2454,12 @@ func flattenClusterAddonsConfig(c *containerBeta.AddonsConfig) []map[string]inte
 				"disabled": c.KubernetesDashboard.Disabled,
 			},
 		}
+	} else {
+		result["kubernetes_dashboard"] = []map[string]interface{}{
+			{
+				"disabled": true,
+			},
+		}
 	}
 	if c.NetworkPolicyConfig != nil {
 		result["network_policy_config"] = []map[string]interface{}{

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -187,6 +187,7 @@ func resourceContainerCluster() *schema.Resource {
 									"disabled": {
 										Type:     schema.TypeBool,
 										Optional: true,
+										Default:  true,
 									},
 								},
 							},
@@ -2452,12 +2453,6 @@ func flattenClusterAddonsConfig(c *containerBeta.AddonsConfig) []map[string]inte
 		result["kubernetes_dashboard"] = []map[string]interface{}{
 			{
 				"disabled": c.KubernetesDashboard.Disabled,
-			},
-		}
-	} else {
-		result["kubernetes_dashboard"] = []map[string]interface{}{
-			{
-				"disabled": true,
 			},
 		}
 	}

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -325,7 +325,7 @@ The `addons_config` block supports:
 
 * `kubernetes_dashboard` - (Optional) The status of the Kubernetes Dashboard
     add-on, which controls whether the Kubernetes Dashboard is enabled for this cluster.
-    It is enabled by default; set `disabled = true` to disable.
+    It is disabled by default; set `disabled = false` to enable.
 
 * `network_policy_config` - (Optional) Whether we should enable the network policy addon
     for the master.  This must be enabled in order to enable network policy for the nodes.


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Mentioned in a comment in the original PR, but the change to the resource file doesn't really do anything at the moment since we have a bug causing a crash when an empty block is added, and that's the only way for this default to show up. However, since the API-side default is now to disable by default, it's still worth adding this for the docs changes (and in case that bug ever gets fixed)

Upstreams https://github.com/terraform-providers/terraform-provider-google/pull/3011/.
<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTERS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
