### PR TITLE
weird issue on ansible integration tests

### DIFF
--- a/.ci/containers/ansible/Dockerfile
+++ b/.ci/containers/ansible/Dockerfile
@@ -6,7 +6,15 @@ RUN apt-get install -y python python-pip
 RUN pip install beautifulsoup4 mistune
 
 # Install man for hacking/env-setup
-RUN apt-get install -y man
+RUN apt-get install -y man locales
 
 # Install python dependencies for ansible
 RUN pip install google-auth requests tox
+
+# Make sure locales set properly.
+# This ensures that Ansible can read in
+# config files properly (it's an ascii issue)
+RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+RUN echo "LANG=en_US.UTF-8" > /etc/locale.conf
+RUN locale-gen en_US.UTF-8


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Ansible now has an issue where it expects `LC_ALL` to be specifically set or else a whole bunch of ascii vs. unicode issues pop up.

Ansible has an issue + a contributor doing some testing, so this could just be a temporary issue. Nonetheless, I want my tests working soon.

Integration tests now run, so that's good.

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTERS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
