### PR TITLE
[ansible] `kubectlpath` is mistakenly required true

### DIFF
--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -67,7 +67,6 @@ objects:
           Any existing file at this path will be completely overwritten.
 
           This requires the PyYaml library.
-        required: true
       - !ruby/object:Api::Type::String
         name: 'kubectlContext'
         description: 'The name of the context for the kubectl config file. Will default to the cluster name'


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Creating a kubeconfig file is optional and the path shouldn't be required.

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
