### PR TITLE
[ansible] using a better jinja2 filter to make tests less flakey

### DIFF
--- a/templates/ansible/verifiers/facts.yaml.erb
+++ b/templates/ansible/verifiers/facts.yaml.erb
@@ -41,6 +41,11 @@
 <% if object.facts.has_filters -%>
       - results['resources'] | length == <%= _state == 'present' ? 1 : 0 %>
 <% else # object.has_filters -%>
+<% # use maps on names to make tests less flakey -%>
+<% if object.all_user_properties.any? { |x| x.name == 'name' } -%>
+      - results['resources'] | map(attribute='name') | select("equalto", "<%= @parameters['name'] -%>") | length == <%= _state == 'present' ? 1 : 0 %>
+<% else -%>
       - results['resources'] | length <%= _state == 'present' ? '>= 1' : '== 0' %>
+<% end # x.name == 'name' -%>
 <% end  # object.has_filters -%>
 <% end # object.facts.test -%>

--- a/templates/ansible/verifiers/facts.yaml.erb
+++ b/templates/ansible/verifiers/facts.yaml.erb
@@ -43,7 +43,7 @@
 <% else # object.has_filters -%>
 <% # use maps on names to make tests less flakey -%>
 <% if object.all_user_properties.any? { |x| x.name == 'name' } -%>
-      - results['resources'] | map(attribute='name') | select("equalto", "<%= @parameters['name'] -%>") | length == <%= _state == 'present' ? 1 : 0 %>
+      - results['resources'] | map(attribute='name') | select("match", ".*<%= name_parameter -%>.*") | list | length == <%= _state == 'present' ? 1 : 0 %>
 <% else -%>
       - results['resources'] | length <%= _state == 'present' ? '>= 1' : '== 0' %>
 <% end # x.name == 'name' -%>


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Originally, I was verifying if tests passed / failed if there was 1/0 resources existing. You can see how this would create flakes.

Jinja2 has more powerful templating than I thought, so I built a much better filter.

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
