### PR TITLE
Terraform.yaml overrides

### DIFF
--- a/compiler.rb
+++ b/compiler.rb
@@ -136,7 +136,6 @@ product_names.each do |product_name|
     Google::LOGGER.info "Skipping product '#{product_name}' as no #{provider_name}.yaml file exists"
     next
   end
-  # provider_yaml = File.read(provider_yaml_path)
 
   raise "Output path '#{output_path}' does not exist or is not a directory" \
     unless Dir.exist?(output_path)
@@ -155,8 +154,15 @@ product_names.each do |product_name|
     next
   end
 
-  product_api, provider_config, = \
-    Provider::Config.parse(provider_yaml_path, product_api, version)
+  if File.exist?(provider_yaml_path)
+    product_api, provider_config, = \
+      Provider::Config.parse(provider_yaml_path, product_api, version)
+  end
+  # Load any dynamic overrides passed in with -r
+  if File.exist?(provider_override_path)
+    product_api, provider_config, = \
+      Provider::Config.parse(provider_override_path, product_api, version)
+  end
 
   pp provider_config if ENV['COMPILER_DEBUG']
 

--- a/spec/provider_terraform_resource_override_spec.rb
+++ b/spec/provider_terraform_resource_override_spec.rb
@@ -23,6 +23,47 @@ class File
 end
 
 describe Overrides::Terraform::ResourceOverride do
+  context 'advanced overrides' do
+    describe 'should not override a previously overridden property with a default' do
+      let(:overrides) do
+        Overrides::ResourceOverrides.new(
+          'AnotherResource' => Overrides::Terraform::ResourceOverride.new(
+            'properties' => {
+              'array-property' => Overrides::Terraform::PropertyOverride.new(
+                'is_set' => true
+              )
+            }
+          )
+        )
+      end
+      let(:overrides2) do
+        Overrides::ResourceOverrides.new(
+          'AnotherResource' => Overrides::Terraform::ResourceOverride.new(
+            'properties' => {
+              'array-property' => Overrides::Terraform::PropertyOverride.new(
+              )
+            }
+          )
+        )
+      end
+      let(:api) { Api::Compiler.new(File.read('spec/data/good-file.yaml')).run }
+
+      it {
+        new_api = Overrides::Runner.build(api, overrides,
+                                          Overrides::Terraform::ResourceOverride,
+                                          Overrides::Terraform::PropertyOverride)
+        final_api = Overrides::Runner.build(new_api, overrides2,
+                                            Overrides::Terraform::ResourceOverride,
+                                            Overrides::Terraform::PropertyOverride)
+        resource = final_api.objects.select { |p| p.name == 'AnotherResource' }.first
+        prop = resource.properties.select { |p| p.name == 'array-property' }.first
+        expect(prop.is_set).to eq(
+          true
+        )
+      }
+    end
+  end
+
   context 'good resource' do
     let(:resource) do
       Overrides::Terraform::ResourceOverride.parse(

--- a/spec/provider_terraform_resource_override_spec.rb
+++ b/spec/provider_terraform_resource_override_spec.rb
@@ -40,8 +40,7 @@ describe Overrides::Terraform::ResourceOverride do
         Overrides::ResourceOverrides.new(
           'AnotherResource' => Overrides::Terraform::ResourceOverride.new(
             'properties' => {
-              'array-property' => Overrides::Terraform::PropertyOverride.new(
-              )
+              'array-property' => Overrides::Terraform::PropertyOverride.new
             }
           )
         )
@@ -58,6 +57,35 @@ describe Overrides::Terraform::ResourceOverride do
         resource = final_api.objects.select { |p| p.name == 'AnotherResource' }.first
         prop = resource.properties.select { |p| p.name == 'array-property' }.first
         expect(prop.is_set).to eq(
+          true
+        )
+      }
+    end
+
+    describe 'should not override a previously overridden resource field with a default' do
+      let(:overrides) do
+        Overrides::ResourceOverrides.new(
+          'AnotherResource' => Overrides::Terraform::ResourceOverride.new(
+            'exclude_import' => true
+          )
+        )
+      end
+      let(:overrides2) do
+        Overrides::ResourceOverrides.new(
+          'AnotherResource' => Overrides::Terraform::ResourceOverride.new
+        )
+      end
+      let(:api) { Api::Compiler.new(File.read('spec/data/good-file.yaml')).run }
+
+      it {
+        new_api = Overrides::Runner.build(api, overrides,
+                                          Overrides::Terraform::ResourceOverride,
+                                          Overrides::Terraform::PropertyOverride)
+        final_api = Overrides::Runner.build(new_api, overrides2,
+                                            Overrides::Terraform::ResourceOverride,
+                                            Overrides::Terraform::PropertyOverride)
+        resource = final_api.objects.select { |p| p.name == 'AnotherResource' }.first
+        expect(resource.exclude_import).to eq(
           true
         )
       }


### PR DESCRIPTION
This will allow eap/alpha overrides to be specified in another terraform.yaml
in a different dir.

Added extra logic to the override runner to avoid default values in the
override classes to clobber previously set values.

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
