### PR TITLE
[ansible] container kubectl property => parameter

### DIFF
--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -69,6 +69,7 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'kubectlContext'
         description: 'The name of the context for the kubectl config file. Will default to the cluster name'
+    properties:
       - !ruby/object:Api::Type::String
         name: 'name'
         description: |
@@ -76,7 +77,6 @@ objects:
           and location, and can be up to 40 characters. Must be Lowercase letters,
           numbers, and hyphens only. Must start with a letter. Must end with a
           number or a letter.
-    properties:
       - !ruby/object:Api::Type::String
         name: 'description'
         description: 'An optional description of this cluster.'

--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -56,7 +56,6 @@ objects:
         name: 'location'
         description: 'The location where the cluster is deployed'
         required: true
-    properties:
       - !ruby/object:Api::Type::String
         name: 'kubectlPath'
         description: |
@@ -77,6 +76,7 @@ objects:
           and location, and can be up to 40 characters. Must be Lowercase letters,
           numbers, and hyphens only. Must start with a letter. Must end with a
           number or a letter.
+    properties:
       - !ruby/object:Api::Type::String
         name: 'description'
         description: 'An optional description of this cluster.'


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
By moving these properties from properties to parameters, it makes sure that Ansible doesn't ever send them in updates.

If you try to update your cluster + build a Kubectl file, you'll get an error right now.

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
