### PR TITLE
[ansible] rename facts modules to info modules

### DIFF
--- a/.ci/magic-modules/generate-ansible.sh
+++ b/.ci/magic-modules/generate-ansible.sh
@@ -13,6 +13,10 @@ pushd magic-modules-branched
 # Choose the author of the most recent commit as the downstream author
 COMMIT_AUTHOR="$(git log --pretty="%an <%ae>" -n1 HEAD)"
 
+# Remove all modules so that old files are removed in process.
+rm build/ansible/lib/ansible/modules/cloud/google/gcp_*
+rm -r build/ansible/test/integration/targets/gcp_*
+
 bundle exec compiler -a -e ansible -o "build/ansible/"
 
 ANSIBLE_COMMIT_MSG="$(cat .git/title)"

--- a/.ci/magic-modules/generate-ansible.sh
+++ b/.ci/magic-modules/generate-ansible.sh
@@ -15,7 +15,6 @@ COMMIT_AUTHOR="$(git log --pretty="%an <%ae>" -n1 HEAD)"
 
 # Remove all modules so that old files are removed in process.
 rm build/ansible/lib/ansible/modules/cloud/google/gcp_*
-rm -r build/ansible/test/integration/targets/gcp_*
 
 bundle exec compiler -a -e ansible -o "build/ansible/"
 

--- a/.ci/magic-modules/release-ansible.sh
+++ b/.ci/magic-modules/release-ansible.sh
@@ -72,7 +72,7 @@ for filename in mm-bug*; do
 
   while read p; do
     git checkout magician/devel -- "lib/ansible/modules/cloud/google/$p.py"
-    if [[ $p != *"facts"* ]]; then
+    if [[ $p != *"info"* ]]; then
       git checkout magician/devel -- "test/integration/targets/$p"
     fi
   done < $filename
@@ -104,7 +104,7 @@ while read module; do
   git checkout -b $module
 
   git checkout magician/devel -- "lib/ansible/modules/cloud/google/$module.py"
-  if [[ $module != *"facts"* ]]; then
+  if [[ $module != *"info"* ]]; then
     git checkout magician/devel -- "test/integration/targets/$module"
   fi
 

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -288,7 +288,7 @@ module Provider
 
         # Generate symlink for old `facts` modules.
         File.symlink "#{name}_info.py",
-                     "build/ansible/lib/ansible/modules/cloud/google/#{name}_facts.py",
+                     "build/ansible/lib/ansible/modules/cloud/google/#{name}_facts.py"
 
       end
 

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -52,9 +52,6 @@ module Provider
       class AnsibleProductFileTemplate < Provider::ProductFileTemplate
         # The Ansible example object.
         attr_accessor :example
-
-        # The suffix used for differenating between facts/info modules.
-        attr_accessor :module_suffix
       end
 
       def api_version_setup(version_name)
@@ -283,19 +280,16 @@ module Provider
 
       def compile_datasource(data)
         target_folder = data.output_folder
-        data.module_suffix = 'info'
-        name = "#{module_name(data.object)}_info"
+        name = "#{module_name(data.object)}"
         data.generate('templates/ansible/facts.erb',
                       File.join(target_folder,
-                                "lib/ansible/modules/cloud/google/#{name}.py"),
+                                "lib/ansible/modules/cloud/google/#{name}_info.py"),
                       self)
 
-        data.module_suffix = 'facts'
-        name = "#{module_name(data.object)}_facts"
-        data.generate('templates/ansible/facts.erb',
-                      File.join(target_folder,
-                                "lib/ansible/modules/cloud/google/#{name}.py"),
-                      self)
+        # Generate symlink for old `facts` modules.
+        File.symlink "build/ansible/lib/ansible/modules/cloud/google/#{name}_info.py",
+                     "build/ansible/lib/ansible/modules/cloud/google/#{name}_facts.py"
+
       end
 
       def generate_objects(output_folder, types, version_name)

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -287,8 +287,11 @@ module Provider
                       self)
 
         # Generate symlink for old `facts` modules.
-        deprecated_facts_path = File.join(target_folder, "lib/ansible/modules/cloud/google/_#{name}_facts.py")
-        File.symlink "#{name}_info.py", deprecated_facts_path unless File.exists?(deprecated_facts_path)
+        deprecated_facts_path = File.join(target_folder,
+                                          "lib/ansible/modules/cloud/google/_#{name}_facts.py")
+        return if File.exist?(deprecated_facts_path)
+
+        File.symlink "#{name}_info.py", deprecated_facts_path
       end
 
       def generate_objects(output_folder, types, version_name)

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -52,6 +52,9 @@ module Provider
       class AnsibleProductFileTemplate < Provider::ProductFileTemplate
         # The Ansible example object.
         attr_accessor :example
+
+        # The suffix used for differenating between facts/info modules.
+        attr_accessor :module_suffix
       end
 
       def api_version_setup(version_name)
@@ -280,14 +283,14 @@ module Provider
 
       def compile_datasource(data)
         target_folder = data.output_folder
-        module_suffix = 'info'
+        data.module_suffix = 'info'
         name = "#{module_name(data.object)}_info"
         data.generate('templates/ansible/facts.erb',
                       File.join(target_folder,
                                 "lib/ansible/modules/cloud/google/#{name}.py"),
                       self)
 
-        module_suffix = 'facts'
+        data.module_suffix = 'facts'
         name = "#{module_name(data.object)}_facts"
         data.generate('templates/ansible/facts.erb',
                       File.join(target_folder,

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -280,7 +280,15 @@ module Provider
 
       def compile_datasource(data)
         target_folder = data.output_folder
+        module_suffix = 'info'
         name = "#{module_name(data.object)}_info"
+        data.generate('templates/ansible/facts.erb',
+                      File.join(target_folder,
+                                "lib/ansible/modules/cloud/google/#{name}.py"),
+                      self)
+
+        module_suffix = 'facts'
+        name = "#{module_name(data.object)}_facts"
         data.generate('templates/ansible/facts.erb',
                       File.join(target_folder,
                                 "lib/ansible/modules/cloud/google/#{name}.py"),

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -287,8 +287,8 @@ module Provider
                       self)
 
         # Generate symlink for old `facts` modules.
-        File.symlink "build/ansible/lib/ansible/modules/cloud/google/#{name}_info.py",
-                     "build/ansible/lib/ansible/modules/cloud/google/#{name}_facts.py"
+        File.symlink "#{name}_info.py",
+                     "build/ansible/lib/ansible/modules/cloud/google/#{name}_facts.py",
 
       end
 

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -280,7 +280,7 @@ module Provider
 
       def compile_datasource(data)
         target_folder = data.output_folder
-        name = "#{module_name(data.object)}_facts"
+        name = "#{module_name(data.object)}_info"
         data.generate('templates/ansible/facts.erb',
                       File.join(target_folder,
                                 "lib/ansible/modules/cloud/google/#{name}.py"),

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -288,7 +288,7 @@ module Provider
 
         # Generate symlink for old `facts` modules.
         File.symlink "#{name}_info.py",
-                     "build/ansible/lib/ansible/modules/cloud/google/#{name}_facts.py"
+                     File.join(target_folder, "/lib/ansible/modules/cloud/google/_#{name}_facts.py")
       end
 
       def generate_objects(output_folder, types, version_name)

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -287,8 +287,8 @@ module Provider
                       self)
 
         # Generate symlink for old `facts` modules.
-        File.symlink "#{name}_info.py",
-                     File.join(target_folder, "/lib/ansible/modules/cloud/google/_#{name}_facts.py")
+        deprecated_facts_path = File.join(target_folder, "lib/ansible/modules/cloud/google/_#{name}_facts.py")
+        File.symlink "#{name}_info.py", deprecated_facts_path unless File.exists?(deprecated_facts_path)
       end
 
       def generate_objects(output_folder, types, version_name)

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -280,7 +280,7 @@ module Provider
 
       def compile_datasource(data)
         target_folder = data.output_folder
-        name = "#{module_name(data.object)}"
+        name = module_name(data.object)
         data.generate('templates/ansible/facts.erb',
                       File.join(target_folder,
                                 "lib/ansible/modules/cloud/google/#{name}_info.py"),
@@ -289,7 +289,6 @@ module Provider
         # Generate symlink for old `facts` modules.
         File.symlink "#{name}_info.py",
                      "build/ansible/lib/ansible/modules/cloud/google/#{name}_facts.py"
-
       end
 
       def generate_objects(output_folder, types, version_name)

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -347,7 +347,7 @@ module Provider
         @code = build_code(object, INTEGRATION_TEST_DEFAULTS)
         @name = ["gcp_#{object.__product.api_name}",
                  object.name.underscore,
-                 'facts'].join('_')
+                 'info'].join('_')
         super(state, object, noop)
       end
 
@@ -355,7 +355,7 @@ module Provider
         @code = build_code(object, EXAMPLE_DEFAULTS)
         @name = ["gcp_#{object.__product.api_name}",
                  object.name.underscore,
-                 'facts'].join('_')
+                 'info'].join('_')
         super(state, object)
       end
 

--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -25,8 +25,10 @@ ANSIBLE_METADATA = {'metadata_version': <%= metadata_version -%>,
 DOCUMENTATION = '''
 ---
 <%= ansible_style_yaml({
-  'module' => "#{module_name(object)}_info",
-  'description' => ["Gather facts for GCP #{object.name}"],
+  'module' => "#{module_name(object)}_#{module_suffix}",
+  'description' => ["Gather facts for GCP #{object.name}",
+                    (version_added(object, :facts) < '2.9' ? "This module was previously called #{module_name(object)}_facts. The usage has not changed" : nil)
+                   ].compact,
   'short_description' => "Gather facts for GCP #{object.name}",
   'version_added' => version_added(object, :facts).to_f,
   'author' => "Google Inc. (@googlecloudplatform)",
@@ -88,6 +90,9 @@ def main():
   })), 12)
 -%>
     )
+<% if version_added(object, :facts) < '2.9' && module_suffix == 'facts' -%>
+    module.deprecate("The '<%= module_name(object) -%>_facts' has been renamed to '<%= module_name(object) -%>_info'", version='2.13')
+<% end -%>
 
     if not module.params['scopes']:
         module.params['scopes'] = <%= python_literal(object.__product.scopes) %>

--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -91,6 +91,7 @@ def main():
 -%>
     )
 <% if version_added(object, :facts) < '2.9' -%>
+
     if module._name == '<%= module_name(object) -%>_facts:
         module.deprecate("The '<%= module_name(object) -%>_facts' has been renamed to '<%= module_name(object) -%>_info'", version='2.13')
 <% end -%>

--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'metadata_version': <%= metadata_version -%>,
 DOCUMENTATION = '''
 ---
 <%= ansible_style_yaml({
-  'module' => "#{module_name(object)}_#{module_suffix}",
+  'module' => "#{module_name(object)}_info",
   'description' => ["Gather facts for GCP #{object.name}",
                     (version_added(object, :facts) < '2.9' ? "This module was previously called #{module_name(object)}_facts. The usage has not changed" : nil)
                    ].compact,
@@ -90,8 +90,9 @@ def main():
   })), 12)
 -%>
     )
-<% if version_added(object, :facts) < '2.9' && module_suffix == 'facts' -%>
-    module.deprecate("The '<%= module_name(object) -%>_facts' has been renamed to '<%= module_name(object) -%>_info'", version='2.13')
+<% if version_added(object, :facts) < '2.9' -%>
+    if module._name == '<%= module_name(object) -%>_facts:
+        module.deprecate("The '<%= module_name(object) -%>_facts' has been renamed to '<%= module_name(object) -%>_info'", version='2.13')
 <% end -%>
 
     if not module.params['scopes']:

--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -25,7 +25,7 @@ ANSIBLE_METADATA = {'metadata_version': <%= metadata_version -%>,
 DOCUMENTATION = '''
 ---
 <%= ansible_style_yaml({
-  'module' => "#{module_name(object)}_facts",
+  'module' => "#{module_name(object)}_info",
   'description' => ["Gather facts for GCP #{object.name}"],
   'short_description' => "Gather facts for GCP #{object.name}",
   'version_added' => version_added(object, :facts).to_f,

--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -92,7 +92,7 @@ def main():
     )
 <% if version_added(object, :facts) < '2.9' -%>
 
-    if module._name == '<%= module_name(object) -%>_facts:
+    if module._name == '<%= module_name(object) -%>_facts':
         module.deprecate("The '<%= module_name(object) -%>_facts' has been renamed to '<%= module_name(object) -%>_info'", version='2.13')
 <% end -%>
 

--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -27,7 +27,7 @@ DOCUMENTATION = '''
 <%= ansible_style_yaml({
   'module' => "#{module_name(object)}_info",
   'description' => ["Gather facts for GCP #{object.name}",
-                    (version_added(object, :facts) < '2.9' ? "This module was previously called #{module_name(object)}_facts. The usage has not changed" : nil)
+                    (version_added(object, :facts) < '2.9' ? "This module was previously called #{module_name(object)}_facts before Ansible 2.9. The usage has not changed" : nil)
                    ].compact,
   'short_description' => "Gather facts for GCP #{object.name}",
   'version_added' => version_added(object, :facts).to_f,
@@ -93,7 +93,7 @@ def main():
 <% if version_added(object, :facts) < '2.9' -%>
 
     if module._name == '<%= module_name(object) -%>_facts':
-        module.deprecate("The '<%= module_name(object) -%>_facts' has been renamed to '<%= module_name(object) -%>_info'", version='2.13')
+        module.deprecate("The '<%= module_name(object) -%>_facts' module has been renamed to '<%= module_name(object) -%>_info'", version='2.13')
 <% end -%>
 
     if not module.params['scopes']:

--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -26,10 +26,10 @@ DOCUMENTATION = '''
 ---
 <%= ansible_style_yaml({
   'module' => "#{module_name(object)}_info",
-  'description' => ["Gather facts for GCP #{object.name}",
+  'description' => ["Gather info for GCP #{object.name}",
                     (version_added(object, :facts) < '2.9' ? "This module was previously called #{module_name(object)}_facts before Ansible 2.9. The usage has not changed" : nil)
                    ].compact,
-  'short_description' => "Gather facts for GCP #{object.name}",
+  'short_description' => "Gather info for GCP #{object.name}",
   'version_added' => version_added(object, :facts).to_f,
   'author' => "Google Inc. (@googlecloudplatform)",
   'requirements' => ["python >= 2.6", "requests >= 2.18.4", "google-auth >= 1.3.0"],

--- a/templates/ansible/verifiers/facts.yaml.erb
+++ b/templates/ansible/verifiers/facts.yaml.erb
@@ -1,7 +1,7 @@
 <%
   module_name = ["gcp_#{object.__product.api_name}",
                  object.name.underscore,
-                 'facts'].join('_')
+                 'info'].join('_')
 -%>
 - name: verify that <%= object.name.underscore -%> was <%= lines(verbs[_state.to_sym]) -%>
   <%= module_name -%>:


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
For the 2.9 release, Ansible is renaming all `facts` modules to `info` modules. Technically, this is done by "deprecating" the facts modules and introducing a bunch of "info" modules. This PR needs to accomplish the following:

* Add in deprecation messages on the facts modules.
* Start creating the facts module files as info modules.
* Symlink the newly deprecated facts modules to the info module files.
* Change test + example references to use the new names.

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
