### PR TITLE
Fix regexp and name for downstreaming changelog script

### DIFF
--- a/.ci/magic-modules/downstream_changelog_metadata.py
+++ b/.ci/magic-modules/downstream_changelog_metadata.py
@@ -71,8 +71,8 @@ def set_changelog_info(gh_pull, release_note, labels_to_add):
   gh_pull.set_labels(*labels_to_set)
 
 if __name__ == '__main__':
-  downstream_urls = os.environ.get('DOWNSTREAM_REPOS').split(',')
-  if len(downstream_urls) == 0:
+  downstream_repos = os.environ.get('DOWNSTREAM_REPOS').split(',')
+  if len(downstream_repos) == 0:
     print "Skipping, no downstreams repos given to downstream changelog info for"
     sys.exit(0)
 
@@ -84,4 +84,4 @@ if __name__ == '__main__':
 
     # TODO(emilymye): Replace this no-op print statement with code after
     # verifying w/ pipeline.
-    downstream_changelog_info(gh, pr_num, downstream_urls)
+    downstream_changelog_info(gh, pr_num, downstream_repos)

--- a/.ci/magic-modules/downstream_changelog_metadata.py
+++ b/.ci/magic-modules/downstream_changelog_metadata.py
@@ -34,10 +34,13 @@ def downstream_changelog_info(gh, upstream_pr_num, changelog_repos):
     [l.name for l in upstream_pr.labels],
     CHANGELOG_LABEL_PREFIX)
 
+  if not labels_to_add and not release_note:
+    print "skipping - no release note and labels"
+
   print "Applying changelog info to downstreams for upstream PR %d:" % (
     upstream_pr.number)
   print "Release Note: \"%s\"" % release_note
-  print "Labels: [%s]" % labels_to_add
+  print "Labels: %s" % labels_to_add
 
   parsed_urls = downstreams.get_parsed_downstream_urls(gh, upstream_pr_num)
   for repo_name, pulls in parsed_urls:

--- a/.ci/magic-modules/pyutils/strutils.py
+++ b/.ci/magic-modules/pyutils/strutils.py
@@ -1,6 +1,6 @@
 import re
 
-RELEASE_NOTE_RE = r'```releasenote[\s]*(?P<release_note>[^`{3}]*)```'
+RELEASE_NOTE_RE = r'```releasenote(?P<release_note>.*)```'
 
 def find_dependency_urls_in_comment(body):
   """Util to parse downstream dependencies from a given comment body.
@@ -54,7 +54,7 @@ def get_release_note(body):
   Returns:
     Release note if found or empty string.
   """
-  m = re.search(RELEASE_NOTE_RE, body, re.MULTILINE)
+  m = re.search(RELEASE_NOTE_RE, body, re.S)
   return m.groupdict("")["release_note"].strip() if m else ""
 
 def set_release_note(release_note, body):


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

It wasn't catching newlines or release notes with inline code formatting (`) - I really don't want to use mistune/beautiful soup like we were before (which parses markdown into html blocks and then searches for the appropriate block) but I might switch it back eventually if I continue to be bad at regexp. 

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
