### PR TITLE
Set empty security policy

### DIFF
--- a/templates/terraform/post_create/compute_backend_service_security_policy.go.erb
+++ b/templates/terraform/post_create/compute_backend_service_security_policy.go.erb
@@ -1,6 +1,6 @@
 // security_policy isn't set by Create / Update
-if v, ok := d.GetOk("security_policy"); ok {
-  pol, err := ParseSecurityPolicyFieldValue(v.(string), d, config)
+if o, n := d.GetChange("security_policy"); o.(string) != n.(string) {
+		pol, err := ParseSecurityPolicyFieldValue(n.(string), d, config)
   if err != nil {
     return errwrap.Wrapf("Error parsing Backend Service security policy: {{err}}", err)
   }

--- a/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
@@ -316,13 +316,26 @@ func TestAccComputeBackendService_withSecurityPolicy(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckComputeBackendServiceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccComputeBackendService_withSecurityPolicy(serviceName, checkName, polName),
+			{
+				Config: testAccComputeBackendService_withSecurityPolicy(serviceName, checkName, polName, "${google_compute_security_policy.policy.self_link}"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeBackendServiceExists(
 						"google_compute_backend_service.foobar", &svc),
 					resource.TestMatchResourceAttr("google_compute_backend_service.foobar", "security_policy", regexp.MustCompile(polName)),
 				),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withSecurityPolicy(serviceName, checkName, polName, ""),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -1017,12 +1030,12 @@ resource "google_compute_http_health_check" "zero" {
 `, serviceName, checkName)
 }
 
-func testAccComputeBackendService_withSecurityPolicy(serviceName, checkName, polName string) string {
+func testAccComputeBackendService_withSecurityPolicy(serviceName, checkName, polName, polLink string) string {
 	return fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
   name          = "%s"
   health_checks = ["${google_compute_http_health_check.zero.self_link}"]
-  security_policy = "${google_compute_security_policy.policy.self_link}"
+  security_policy = "%s"
 }
 
 resource "google_compute_http_health_check" "zero" {
@@ -1036,7 +1049,7 @@ resource "google_compute_security_policy" "policy" {
 	name        = "%s"
 	description = "basic security policy"
 }
-`, serviceName, checkName, polName)
+`, serviceName, polLink, checkName, polName)
 }
 
 func testAccComputeBackendService_withMaxConnections(


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-google/issues/3948

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
Allow security policy to be removed from `google_backend_service`
```
