### PR TITLE
[ansible] better error message if example missing

### DIFF
--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -218,6 +218,11 @@ module Provider
             .reject(&:empty?)
       end
 
+      def example
+        return @example if @example
+        raise "No example exists! Please write one or place 'exclude: true' inside the overrides"
+      end
+
       private
 
       def get_example(cfg_file)


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
```bash
NameError: undefined local variable or method `example' for #<Provider::Ansible::Core:0x000055af66c1a550>
```
If you're missing an example for Ansible, the compiler will crash. The error message is very verbose and not very helpful.

This will give an error message that better explains what to do. 

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
