### PR TITLE
Simplify the parse command

### DIFF
--- a/overrides/runner.rb
+++ b/overrides/runner.rb
@@ -51,6 +51,9 @@ module Overrides
 
       def build(api, overrides, res_override_class = Overrides::ResourceOverride,
                 prop_override_class = Overrides::PropertyOverride)
+
+        overrides = Overrides::ResourceOverrides.new if overrides.nil?
+
         validator = Overrides::Validator.new(api, overrides)
         validator.run
         build_product(api, overrides, resource: res_override_class, property: prop_override_class)

--- a/provider/config.rb
+++ b/provider/config.rb
@@ -53,14 +53,10 @@ module Provider
       # Compile step #1: compile with generic class to instantiate target class
       source = compile(cfg_file)
       config = Google::YamlValidator.parse(source)
-      # Compile step 2: compile with target class (this is in case the config
-      # requires info from the config to compile)
-      source = config.compile(cfg_file)
-      config = Google::YamlValidator.parse(source)
+
       raise "Config #{cfg_file}(#{config.class}) is not a Provider::Config" \
         unless config.class <= Provider::Config
 
-      config.validate
       api = Overrides::Runner.build(api, config.overrides,
                                     config.resource_override,
                                     config.property_override)
@@ -82,8 +78,7 @@ module Provider
       super
 
       check :files, type: Provider::Config::Files
-      check :overrides, type: Overrides::ResourceOverrides,
-                        default: Overrides::ResourceOverrides.new
+      check :overrides, type: Overrides::ResourceOverrides
     end
 
     # Provides the API object to any type that requires, e.g. for validation


### PR DESCRIPTION
Most providers no longer need the compiler called multiple times in sequenece
so removing that logic.
Stop adding a default Override during validate - this has resulted in calling
validate excessively and before fully resources are fully populated.

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
