### PR TITLE
Stop rspec checking copyrights on untracked files

### DIFF
--- a/spec/copyright_spec.rb
+++ b/spec/copyright_spec.rb
@@ -31,7 +31,8 @@ describe 'ensure files have copyright notice' do
                   !my_tests && !artifacts && !vendor && !presubmit && !version_added
                 end
     checker = Google::CopyrightChecker.new(files)
-    missing = checker.check_missing.collect { |f| "  - #{f}" }
+    # Ignore copywright for files not tracked by git
+    missing = checker.check_missing.select { |m| system("git ls-files --error-unmatch #{m}") }
     raise "Files missing (or outdated) copyright:\n#{missing.join("\n")}" \
       unless missing.empty?
   end


### PR DESCRIPTION
This allows developers to run rspec without seeing test failures when they have
unstaged local changes. Copyright validation will still get caught in CI

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
