### PR TITLE
[ansible] adding more specific metrics

### DIFF
--- a/provider/ansible/gcp_doc_frag.py
+++ b/provider/ansible/gcp_doc_frag.py
@@ -36,6 +36,12 @@ options:
         description:
             - Array of scopes to be used.
         type: list
+    env_type:
+        description:
+            - Specifies which Ansible environment you're running this module within.
+            - This should not be set unless you know what you're doing.
+            - This only alters the User Agent string for any API requests.
+        type: str
 notes:
   - for authentication, you can set service_account_file using the
     c(gcp_service_account_file) env variable.

--- a/provider/ansible/gcp_utils.py
+++ b/provider/ansible/gcp_utils.py
@@ -165,9 +165,14 @@ class GcpSession(object):
             self.module.fail_json(msg="Credential type '%s' not implemented" % cred_type)
 
     def _headers(self):
-        return {
-            'User-Agent': "Google-Ansible-MM-{0}".format(self.product)
-        }
+        if self.module.params.get('env_type'):
+            return {
+                'User-Agent': "Google-Ansible-MM-{0}".format(self.module.params.get('env_type'))
+            }
+        else:
+            return {
+                'User-Agent': "Google-Ansible-MM-{0}".format(self.product)
+            }
 
     def _merge_dictionaries(self, a, b):
         new = a.copy()
@@ -208,7 +213,11 @@ class GcpModule(AnsibleModule):
                 scopes=dict(
                     required=False,
                     fallback=(env_fallback, ['GCP_SCOPES']),
-                    type='list')
+                    type='list'),
+                env_type=dict(
+                    required=False,
+                    fallback=(env_fallback, ['GCP_ENV_TYPE']),
+                    type='str')
             )
         )
 

--- a/provider/ansible/gcp_utils.py
+++ b/provider/ansible/gcp_utils.py
@@ -167,7 +167,7 @@ class GcpSession(object):
     def _headers(self):
         if self.module.params.get('env_type'):
             return {
-                'User-Agent': "Google-Ansible-MM-{0}-{1}".format(self.module.params.get('env_type'), self.product)
+                'User-Agent': "Google-Ansible-MM-{0}-{1}".format(self.product, self.module.params.get('env_type'))
             }
         else:
             return {

--- a/provider/ansible/gcp_utils.py
+++ b/provider/ansible/gcp_utils.py
@@ -167,7 +167,7 @@ class GcpSession(object):
     def _headers(self):
         if self.module.params.get('env_type'):
             return {
-                'User-Agent': "Google-Ansible-MM-{0}".format(self.module.params.get('env_type'))
+                'User-Agent': "Google-Ansible-MM-{0}-{1}".format(self.module.params.get('env_type'), self.product)
             }
         else:
             return {


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Right now, there's no way to add additional metric metadata to Ansible requests. It would be great to be able to separate Tower usage (or role usage, collections, etc) from regular Ansible usage.

There's a PR out on Tower to have tower set the `GCP_ENV_TYPE` environment variable to "tower". This is the other half of that: plumbing such values through the user agent headers.

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
