### PR TITLE
Fix example names

### DIFF
--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -27,8 +27,8 @@ module Provider
     }.freeze
 
     EXAMPLE_DEFAULTS = {
-      name: 'test_object',
-      project: 'test_project',
+      name: 'test-object',
+      project: 'test-project',
       auth_kind: 'serviceaccount',
       service_account_file: '/tmp/auth.pem'
     }.freeze


### PR DESCRIPTION
GCP doesn't allow underscores for project or object names. This throws an API error for every example in the docs.

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
