### PR TITLE
Add request batching to service usage

### DIFF
--- a/.ci/magic-modules/pyutils/strutils.py
+++ b/.ci/magic-modules/pyutils/strutils.py
@@ -84,10 +84,13 @@ def set_release_note(release_note, body):
   Returns:
     Modified text
   """
-  edited = ""
-  for segment in re.split(r'`{3}releasenote', body, re.S):
-    idx = segment.find('```\n')
-    edited += segment if idx < 0 else segment[idx+3:]
+  edited = body
+  tkns = re.split(RELEASE_NOTE_SUB_RE, body, re.S)
+  if len(tkns) > 1:
+    edited = tkns[0]
+    for tkn in tkns[1:]:
+      idx = tkn.find("```")
+      edited += tkn if idx < 0 else tkn[idx+3:]
 
   release_note = release_note.strip()
   if release_note:

--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -112,6 +112,8 @@ module Provider
                         'third_party/terraform/utils/service_scope.go'],
                        ['google/kms_utils.go',
                         'third_party/terraform/utils/kms_utils.go']
+                       ['google/batcher.go',
+                        'third_party/terraform/utils/batcher.go']
                      ])
     end
 

--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -111,9 +111,9 @@ module Provider
                        ['google/service_scope.go',
                         'third_party/terraform/utils/service_scope.go'],
                        ['google/kms_utils.go',
-                        'third_party/terraform/utils/kms_utils.go']
+                        'third_party/terraform/utils/kms_utils.go'],
                        ['google/batcher.go',
-                        'third_party/terraform/utils/batcher.go']
+                        'third_party/terraform/utils/batcher.go'],
                      ])
     end
 

--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -113,7 +113,7 @@ module Provider
                        ['google/kms_utils.go',
                         'third_party/terraform/utils/kms_utils.go'],
                        ['google/batcher.go',
-                        'third_party/terraform/utils/batcher.go'],
+                        'third_party/terraform/utils/batcher.go']
                      ])
     end
 

--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -257,7 +257,7 @@ func resourceGoogleProjectCreate(d *schema.ResourceData, meta interface{}) error
 	// a network and deleting it in the background.
 	if !d.Get("auto_create_network").(bool) {
 		// The compute API has to be enabled before we can delete a network.
-		if err = enableServiceUsageProjectServices([]string{"compute.googleapis.com"}, project.ProjectId, config); err != nil {
+		if err = enableServiceUsageProjectServices([]string{"compute.googleapis.com"}, project.ProjectId, config, d.Timeout(schema.TimeoutCreate)); err != nil {
 			return fmt.Errorf("Error enabling the Compute Engine API required to delete the default network: %s", err)
 		}
 

--- a/third_party/terraform/resources/resource_google_project_service.go
+++ b/third_party/terraform/resources/resource_google_project_service.go
@@ -23,9 +23,9 @@ func resourceGoogleProjectService() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"service": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
 				ValidateFunc: StringNotInSlice(ignoredProjectServices, false),
 			},
 			"project": {

--- a/third_party/terraform/resources/resource_google_project_service.go
+++ b/third_party/terraform/resources/resource_google_project_service.go
@@ -2,7 +2,10 @@ package google
 
 import (
 	"fmt"
+	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/googleapi"
+	"google.golang.org/api/serviceusage/v1"
 	"log"
 	"strings"
 )
@@ -23,6 +26,7 @@ func resourceGoogleProjectService() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				ValidateFunc: StringNotInSlice(ignoredProjectServices, false),
 			},
 			"project": {
 				Type:     schema.TypeString,
@@ -64,7 +68,7 @@ func resourceGoogleProjectServiceCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	srv := d.Get("service").(string)
-	err = enableServiceUsageProjectServices([]string{srv}, project, config)
+	err = globalBatchEnableServices([]string{srv}, project, config)
 	if err != nil {
 		return err
 	}
@@ -84,19 +88,16 @@ func resourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return err
 	}
+	srv := d.Get("service").(string)
 
-	enabledServices, err := readEnabledServiceUsageProjectServices(project, config)
+	enabled, err := isServiceEnabled(project, srv, config)
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("Project Service %s", d.Id()))
 	}
-
-	srv := d.Get("service")
-	for _, s := range enabledServices {
-		if s == srv {
-			d.Set("project", project)
-			d.Set("service", s)
-			return nil
-		}
+	if enabled {
+		d.Set("project", project)
+		d.Set("service", srv)
+		return nil
 	}
 
 	// The service is was not found in enabled services - remove it from state
@@ -133,4 +134,32 @@ func resourceGoogleProjectServiceUpdate(d *schema.ResourceData, meta interface{}
 	// This update method is no-op because the only updatable fields
 	// are state/config-only, i.e. they aren't sent in requests to the API.
 	return nil
+}
+
+// Retrieve enablement state for a given project's service
+func isServiceEnabled(project, serviceName string, config *Config) (bool, error) {
+	// Verify project for services still exists
+	p, err := config.clientResourceManager.Projects.Get(project).Do()
+	if err != nil {
+		return false, err
+	}
+	if p.LifecycleState == "DELETE_REQUESTED" {
+		// Construct a 404 error for handleNotFoundError
+		return false, &googleapi.Error{
+			Code:    404,
+			Message: "Project deletion was requested",
+		}
+	}
+
+	resourceName := fmt.Sprintf("projects/%s/services/%s", project, serviceName)
+	var srv *serviceusage.GoogleApiServiceusageV1Service
+	err = retryTime(func() error {
+		var currErr error
+		srv, currErr = config.clientServiceUsage.Services.Get(resourceName).Do()
+		return currErr
+	}, 10)
+	if err != nil {
+		return false, errwrap.Wrapf(fmt.Sprintf("Failed to list enabled services for project %s: {{err}}", project), err)
+	}
+	return srv.State == "ENABLED", nil
 }

--- a/third_party/terraform/resources/resource_google_project_service.go
+++ b/third_party/terraform/resources/resource_google_project_service.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/api/serviceusage/v1"
 	"log"
 	"strings"
+	"time"
 )
 
 func resourceGoogleProjectService() *schema.Resource {
@@ -19,6 +20,12 @@ func resourceGoogleProjectService() *schema.Resource {
 
 		Importer: &schema.ResourceImporter{
 			State: resourceGoogleProjectServiceImport,
+		},
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Read:   schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -68,7 +75,7 @@ func resourceGoogleProjectServiceCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	srv := d.Get("service").(string)
-	err = globalBatchEnableServices([]string{srv}, project, config)
+	err = globalBatchEnableServices([]string{srv}, project, d, config)
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_google_project_service.go
+++ b/third_party/terraform/resources/resource_google_project_service.go
@@ -24,8 +24,9 @@ func resourceGoogleProjectService() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),
+			Update: schema.DefaultTimeout(20 * time.Minute),
 			Read:   schema.DefaultTimeout(10 * time.Minute),
-			Delete: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -129,7 +130,7 @@ func resourceGoogleProjectServiceDelete(d *schema.ResourceData, meta interface{}
 
 	service := d.Get("service").(string)
 	disableDependencies := d.Get("disable_dependent_services").(bool)
-	if err = disableServiceUsageProjectService(service, project, config, disableDependencies); err != nil {
+	if err = disableServiceUsageProjectService(service, project, d, config, disableDependencies); err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("Project Service %s", d.Id()))
 	}
 

--- a/third_party/terraform/resources/resource_google_project_services.go
+++ b/third_party/terraform/resources/resource_google_project_services.go
@@ -29,6 +29,12 @@ func resourceGoogleProjectServices() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+			Read:   schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"project": {
 				Type:     schema.TypeString,
@@ -69,7 +75,7 @@ func resourceGoogleProjectServicesCreateUpdate(d *schema.ResourceData, meta inte
 	}
 
 	log.Printf("[DEBUG]: Enabling Project Services for %s: %+v", d.Id(), services)
-	if err := setServiceUsageProjectEnabledServices(services, project, config); err != nil {
+	if err := setServiceUsageProjectEnabledServices(services, project, d, config); err != nil {
 		return fmt.Errorf("Error authoritatively enabling Project %s Services: %v", project, err)
 	}
 	log.Printf("[DEBUG]: Finished enabling Project Services for %s: %+v", d.Id(), services)
@@ -110,7 +116,7 @@ func resourceGoogleProjectServicesDelete(d *schema.ResourceData, meta interface{
 
 	log.Printf("[DEBUG]: Disabling Project Services %s: %+v", project, services)
 	for _, s := range services {
-		if err := disableServiceUsageProjectService(s, project, config, true); err != nil {
+		if err := disableServiceUsageProjectService(s, project, d, config, true); err != nil {
 			return fmt.Errorf("Unable to destroy google_project_services for %s: %s", d.Id(), err)
 		}
 	}
@@ -122,7 +128,7 @@ func resourceGoogleProjectServicesDelete(d *schema.ResourceData, meta interface{
 
 // setServiceUsageProjectEnabledServices *authoritatively* sets the enabled
 // services for a set of project services.
-func setServiceUsageProjectEnabledServices(services []string, project string, config *Config) error {
+func setServiceUsageProjectEnabledServices(services []string, project string, d *schema.ResourceData, config *Config) error {
 	currentlyEnabled, err := listCurrentlyEnabledServices(project, config)
 	if err != nil {
 		return err
@@ -136,7 +142,7 @@ func setServiceUsageProjectEnabledServices(services []string, project string, co
 		}
 	}
 
-	if err := globalBatchEnableServices(toEnable, project, config); err != nil {
+	if err := globalBatchEnableServices(toEnable, project, d, config); err != nil {
 		return fmt.Errorf("unable to enable Project Services %s (%+v): %s", project, services, err)
 	}
 
@@ -146,7 +152,7 @@ func setServiceUsageProjectEnabledServices(services []string, project string, co
 		// in our list of acceptable services.
 		if _, ok := srvSet[srv]; !ok {
 			log.Printf("[DEBUG] Disabling project %s service %s", project, srv)
-			if err := disableServiceUsageProjectService(srv, project, config, true); err != nil {
+			if err := disableServiceUsageProjectService(srv, project, d, config, true); err != nil {
 				return fmt.Errorf("unable to disable unwanted Project Service %s %s): %s", project, srv, err)
 			}
 		}
@@ -154,8 +160,8 @@ func setServiceUsageProjectEnabledServices(services []string, project string, co
 	return nil
 }
 
-func disableServiceUsageProjectService(service, project string, config *Config, disableDependentServices bool) error {
-	err := retryTime(func() error {
+func disableServiceUsageProjectService(service, project string, d *schema.ResourceData, config *Config, disableDependentServices bool) error {
+	err := retryTimeDuration(func() error {
 		name := fmt.Sprintf("projects/%s/services/%s", project, service)
 		sop, err := config.clientServiceUsage.Services.Disable(name, &serviceusage.DisableServiceRequest{
 			DisableDependentServices: disableDependentServices,
@@ -169,7 +175,7 @@ func disableServiceUsageProjectService(service, project string, config *Config, 
 			return waitErr
 		}
 		return nil
-	}, 10)
+	}, d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return fmt.Errorf("Error disabling service %q for project %q: %v", service, project, err)
 	}
@@ -193,7 +199,7 @@ func listCurrentlyEnabledServices(project string, config *Config) (map[string]st
 
 	log.Printf("[DEBUG] Listing enabled services for project %s", project)
 	apiServices := make(map[string]struct{})
-	err = retryTime(func() error {
+	err = retryTimeDuration(func() error {
 		ctx := context.Background()
 		return config.clientServiceUsage.Services.
 			List(fmt.Sprintf("projects/%s", project)).
@@ -217,7 +223,7 @@ func listCurrentlyEnabledServices(project string, config *Config) (map[string]st
 }
 
 // WARNING: Use globalBatchEnableServices for better batching if possible.
-func enableServiceUsageProjectServices(services []string, project string, config *Config) error {
+func enableServiceUsageProjectServices(services []string, project string, d *schema.ResourceData, config *Config) error {
 	// ServiceUsage does not allow more than 20 services to be enabled per
 	// batchEnable API call. See
 	// https://cloud.google.com/service-usage/docs/reference/rest/v1/services/batchEnable
@@ -239,13 +245,13 @@ func enableServiceUsageProjectServices(services []string, project string, config
 	}
 
 	log.Printf("[DEBUG] Verifying that all services are enabled")
-	return waitForServiceUsageEnabledServices(services, project, config)
+	return waitForServiceUsageEnabledServices(services, project, d, config)
 }
 
 // waitForServiceUsageEnabledServices doesn't resend enable requests - it just
 // waits for service enablement status to propagate. Essentially, it waits until
 // all services show up as enabled when listing services on the project.
-func waitForServiceUsageEnabledServices(services []string, project string, config *Config) error {
+func waitForServiceUsageEnabledServices(services []string, project string, d *schema.ResourceData, config *Config) error {
 	missing := make([]string, 0, len(services))
 	delay := time.Duration(0)
 	interval := time.Second

--- a/third_party/terraform/tests/resource_google_project_service_test.go
+++ b/third_party/terraform/tests/resource_google_project_service_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -135,7 +136,7 @@ func testAccCheckProjectService(services []string, pid string, expectEnabled boo
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
 
-		currentlyEnabled, err := listCurrentlyEnabledServices(pid, config)
+		currentlyEnabled, err := listCurrentlyEnabledServices(pid, config, time.Minute*10)
 		if err != nil {
 			return fmt.Errorf("Error listing services for project %q: %v", pid, err)
 		}
@@ -176,6 +177,7 @@ resource "google_project_service" "test2" {
   project = "${google_project.acceptance.project_id}"
   service = "%s"
 }
+
 `, pid, name, org, services[0], services[1])
 }
 

--- a/third_party/terraform/tests/resource_google_project_services_test.go
+++ b/third_party/terraform/tests/resource_google_project_services_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -43,7 +44,7 @@ func TestAccProjectServices_basic(t *testing.T) {
 			{
 				PreConfig: func() {
 					config := testAccProvider.Meta().(*Config)
-					if err := enableServiceUsageProjectServices([]string{oobService}, pid, config); err != nil {
+					if err := enableServiceUsageProjectServices([]string{oobService}, pid, config, time.Minute*20); err != nil {
 						t.Fatalf("Error enabling %q: %v", oobService, err)
 					}
 				},
@@ -88,7 +89,7 @@ func TestAccProjectServices_authoritative(t *testing.T) {
 			{
 				PreConfig: func() {
 					config := testAccProvider.Meta().(*Config)
-					if err := enableServiceUsageProjectServices([]string{oobService}, pid, config); err != nil {
+					if err := enableServiceUsageProjectServices([]string{oobService}, pid, config, time.Minute*20); err != nil {
 						t.Fatalf("Error enabling %q: %v", oobService, err)
 					}
 				},
@@ -129,7 +130,7 @@ func TestAccProjectServices_authoritative2(t *testing.T) {
 				PreConfig: func() {
 					config := testAccProvider.Meta().(*Config)
 					for _, s := range oobServices {
-						if err := enableServiceUsageProjectServices([]string{s}, pid, config); err != nil {
+						if err := enableServiceUsageProjectServices([]string{s}, pid, config, time.Minute*20); err != nil {
 							t.Fatalf("Error enabling %q: %v", s, err)
 						}
 					}
@@ -301,7 +302,7 @@ func testProjectServicesMatch(services []string, pid string) resource.TestCheckF
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
 
-		currentlyEnabled, err := listCurrentlyEnabledServices(pid, config)
+		currentlyEnabled, err := listCurrentlyEnabledServices(pid, config, time.Minute*10)
 		if err != nil {
 			return fmt.Errorf("Error listing services for project %q: %v", pid, err)
 		}

--- a/third_party/terraform/utils/batcher.go
+++ b/third_party/terraform/utils/batcher.go
@@ -1,0 +1,197 @@
+package google
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"time"
+)
+
+const defaultBatchSendIntervalSec = 10
+
+// RequestBatcher a global batcher object.
+type RequestBatcher struct {
+	sync.Mutex
+
+	*batchingConfig
+	batches map[string]*startedBatch
+}
+
+// BatchRequest represents a single request to a global batcher.
+type BatchRequest struct {
+	// ResourceName determine the resource name to be passed to SendF.
+	ResourceName string
+
+	// Body is this request's data to be passed to SendF, and may be combined
+	// with other bodies using CombineF.
+	Body interface{}
+
+	// CombineF function determines how to combine bodies from two batches.
+	CombineF batcherCombineFunc
+
+	// CombineF function determines how to actually send a batched request to a
+	// third party service.
+	SendF batcherSendFunc
+
+	// ID for debugging request. This should be specific to a single request
+	// (i.e. per Terraform resource)
+	DebugId string
+}
+
+// These types are meant to be the public interface to batchers. They define
+// logic to manage batch data type and behavior, and require service-specific
+// implementations per type of request per service.
+// Function type for combine existing batches and additional batch data
+type batcherCombineFunc func(body interface{}, toAdd interface{}) (interface{}, error)
+
+// Function type for sending a batch request
+type batcherSendFunc func(resourceName string, body interface{}) (interface{}, error)
+
+// batchResponse bundles an API response (data, error) tuple.
+type batchResponse struct {
+	body interface{}
+	err  error
+}
+
+// startedBatch refers to a processed batch whose timer to send the request has
+// already been started. The responses for the request is sent to each listener
+// channel, representing parallel callers that are waiting on requests
+// combined into this batch.
+type startedBatch struct {
+	*BatchRequest
+
+	listeners []chan batchResponse
+	timer     *time.Timer
+}
+
+// batchingConfig contains user configuration for controlling batch requests.
+type batchingConfig struct {
+	sendAfter       time.Duration
+	disableBatching bool
+}
+
+// Initializes a new batcher
+func NewRequestBatcher(config *batchingConfig) *RequestBatcher {
+	return &RequestBatcher{
+		batchingConfig: config,
+		batches:        make(map[string]*startedBatch),
+	}
+}
+
+// SendRequestWithTimeout is expected to be called per parallel call.
+// It manages waiting on the result of a batch request.
+func (b *RequestBatcher) SendRequestWithTimeout(batchType string, request *BatchRequest, timeout time.Duration) (interface{}, error) {
+	if request == nil {
+		return nil, fmt.Errorf("error, cannot request batching for nil BatchRequest")
+	}
+	if request.CombineF == nil {
+		return nil, fmt.Errorf("error, cannot request batching for BatchRequest with nil CombineF")
+	}
+	if request.SendF == nil {
+		return nil, fmt.Errorf("error, cannot request batching for BatchRequest with nil SendF")
+	}
+	if b.disableBatching {
+		log.Printf("[DEBUG] Batching is disabled, sending single request for %q", request.DebugId)
+		return request.SendF(request.ResourceName, request.Body)
+	}
+
+	respCh, err := b.startBatchRequest(batchType, request)
+	if err != nil {
+		return nil, fmt.Errorf("error adding request to batch: %s", err)
+	}
+
+	timer := time.NewTimer(timeout)
+
+	select {
+	case resp := <-respCh:
+		if resp.err != nil {
+			return nil, fmt.Errorf("Batch %q Request %q returned error: %v", batchType, request.DebugId, resp.err)
+		}
+		return resp.body, nil
+	case <-timer.C:
+		break
+	}
+	return nil, fmt.Errorf("Request %s timed out after %v", batchType, timeout)
+}
+
+// startBatchRequest manages batching logic that access shared information
+// (i.e. existing batches)
+func (b *RequestBatcher) startBatchRequest(batchType string, newRequest *BatchRequest) (<-chan batchResponse, error) {
+	b.Lock()
+	defer b.Unlock()
+
+	// The calling goroutine will need a channel to wait on for a response.
+	respCh := make(chan batchResponse, 1)
+
+	batchId := fmt.Sprintf("%s:%s", batchType, newRequest.ResourceName)
+	// If batch already exists, combine this request into existing request.
+	if batch, ok := b.batches[batchId]; ok {
+		log.Printf("[DEBUG] Adding batch request %q to existing batch %q", newRequest.DebugId, batchId)
+		if batch.CombineF == nil {
+			return nil, fmt.Errorf("Provider Error: unable to add request %q to batch %q with no CombineF", newRequest.DebugId, batchId)
+		}
+
+		newBody, err := batch.CombineF(batch.Body, newRequest.Body)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to combine request %q data into existing batch %q: %v", newRequest.DebugId, batchId, err)
+		}
+
+		batch.Body = newBody
+		log.Printf("[DEBUG] Added batch request %q to batch. New batch body: %v", newRequest.DebugId, batch.Body)
+		batch.listeners = append(batch.listeners, respCh)
+		return respCh, nil
+	}
+
+	log.Printf("[DEBUG] Creating new batch %q from request %q", newRequest.DebugId, batchId)
+	// Create a new batch.
+	b.batches[batchId] = &startedBatch{
+		BatchRequest: newRequest,
+		listeners:    []chan batchResponse{respCh},
+	}
+
+	// Start a timer to send the request
+	b.batches[batchId].timer = time.AfterFunc(b.sendAfter, func() {
+		batch := b.popBatch(batchId)
+
+		var resp batchResponse
+		if batch == nil {
+			log.Printf("[DEBUG] Batch not found in saved batches, running single request batch %q", batchId)
+			resp = newRequest.send()
+		} else {
+			log.Printf("[DEBUG] Sending batch %q combining %d requests)", batchId, len(batch.listeners))
+			resp = batch.send()
+		}
+
+		// Send message to all goroutines waiting on result.
+		for _, ch := range batch.listeners {
+			ch <- resp
+			close(ch)
+		}
+	})
+
+	return respCh, nil
+}
+
+func (b *RequestBatcher) popBatch(batchId string) *startedBatch {
+	b.Lock()
+	defer b.Unlock()
+
+	batch, ok := b.batches[batchId]
+	if !ok {
+		log.Printf("[DEBUG] Batch with ID %q not found in batcher", batchId)
+		return nil
+	}
+
+	delete(b.batches, batchId)
+	return batch
+}
+
+func (req *BatchRequest) send() batchResponse {
+	if req.SendF == nil {
+		return batchResponse{
+			err: fmt.Errorf("provider error: Batch request has no SendBatch function"),
+		}
+	}
+	v, err := req.SendF(req.ResourceName, req.Body)
+	return batchResponse{v, err}
+}

--- a/third_party/terraform/utils/batcher.go
+++ b/third_party/terraform/utils/batcher.go
@@ -22,7 +22,7 @@ type RequestBatcher struct {
 	*batchingConfig
 	parentCtx context.Context
 	batches   map[string]*startedBatch
-	debugId string
+	debugId   string
 }
 
 // BatchRequest represents a single request to a global batcher.
@@ -94,8 +94,8 @@ func NewRequestBatcher(debugId string, ctx context.Context, config *batchingConf
 
 	go func(b *RequestBatcher) {
 		select {
-			case <- ctx.Done():
-				b.stop()
+		case <-ctx.Done():
+			b.stop()
 		}
 	}(batcher)
 

--- a/third_party/terraform/utils/batcher.go
+++ b/third_party/terraform/utils/batcher.go
@@ -70,8 +70,8 @@ type startedBatch struct {
 
 // batchingConfig contains user configuration for controlling batch requests.
 type batchingConfig struct {
-	sendAfter       time.Duration
-	disableBatching bool
+	sendAfter      time.Duration
+	enableBatching bool
 }
 
 // Initializes a new batcher
@@ -98,7 +98,7 @@ func (b *RequestBatcher) SendRequestWithTimeout(batchKey string, request *BatchR
 	if request.SendF == nil {
 		return nil, fmt.Errorf("error, cannot request batching for BatchRequest with nil SendF")
 	}
-	if b.disableBatching {
+	if !b.enableBatching {
 		log.Printf("[DEBUG] Batching is disabled, sending single request for %q", request.DebugId)
 		return request.SendF(batchKey, request.Body)
 	}

--- a/third_party/terraform/utils/batcher.go
+++ b/third_party/terraform/utils/batcher.go
@@ -149,9 +149,10 @@ func (b *RequestBatcher) SendRequestWithTimeout(batchKey string, request *BatchR
 	}
 
 	ctx, cancel := context.WithTimeout(b.parentCtx, timeout)
+	defer cancel()
+
 	select {
 	case resp := <-respCh:
-		defer cancel()
 		if resp.err != nil {
 			return nil, fmt.Errorf("Batch %q for request %q returned error: %v", batchKey, request.DebugId, resp.err)
 		}

--- a/third_party/terraform/utils/batcher.go
+++ b/third_party/terraform/utils/batcher.go
@@ -93,10 +93,8 @@ func NewRequestBatcher(debugId string, ctx context.Context, config *batchingConf
 	}
 
 	go func(b *RequestBatcher) {
-		select {
-		case <-ctx.Done():
-			b.stop()
-		}
+		<-ctx.Done()
+		b.stop()
 	}(batcher)
 
 	return batcher

--- a/third_party/terraform/utils/batcher_test.go
+++ b/third_party/terraform/utils/batcher_test.go
@@ -1,0 +1,210 @@
+package google
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRequestBatcher_batchSingle(t *testing.T) {
+	testBasicCountBatches(t, "test-single", 1)
+}
+
+func TestRequestBatcher_batchMultiple(t *testing.T) {
+	testBasicCountBatches(t, "test-multiple", 10)
+}
+
+func TestRequestBatcher_errInCombine(t *testing.T) {
+	testBatcher := NewRequestBatcher(&batchingConfig{
+		sendAfter: time.Duration(5) * time.Second,
+	})
+
+	combineErrText := "this is an expected error in combine"
+	testCombine := func(_ interface{}, _ interface{}) (interface{}, error) {
+		return nil, errors.New(combineErrText)
+	}
+
+	// sendBatchF is no-op
+	testSendBatch := func(_ string, _ interface{}) (interface{}, error) {
+		return nil, nil
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	// First call should no-op.
+	go func() {
+		defer wg.Done()
+
+		req := &BatchRequest{
+			DebugId:      "errInCombine first",
+			ResourceName: "test-resource",
+			Body:         nil,
+			CombineF:     testCombine,
+			SendF:        testSendBatch,
+		}
+
+		_, err := testBatcher.SendRequestWithTimeout("testCombineErr", req, time.Duration(10)*time.Second)
+		if err != nil {
+			t.Errorf("expected no error, got: %s", err)
+		}
+	}()
+
+	// Second call should fail when being combined with original batch
+	go func() {
+		time.Sleep(time.Second)
+		defer wg.Done()
+
+		req := &BatchRequest{
+			DebugId:      "errInCombine second",
+			ResourceName: "test-resource",
+			Body:         nil,
+			CombineF:     testCombine,
+			SendF:        testSendBatch,
+		}
+
+		_, err := testBatcher.SendRequestWithTimeout("testCombineErr", req, time.Duration(10)*time.Second)
+		if err == nil {
+			t.Errorf("expected error, got none")
+		} else if !strings.Contains(err.Error(), combineErrText) {
+			t.Errorf("error does not contain expected error %s. Got: %s", combineErrText, err)
+		}
+	}()
+
+	wg.Wait()
+}
+
+func TestRequestBatcher_errInSend(t *testing.T) {
+	testBatcher := NewRequestBatcher(&batchingConfig{
+		sendAfter: time.Duration(5) * time.Second,
+	})
+
+	testResource := "resource for send error"
+	sendErrTmpl := "this is an expected error in send batch for resource %q"
+
+	// combineF is no-op
+	testCombine := func(_ interface{}, _ interface{}) (interface{}, error) {
+		return nil, nil
+	}
+
+	testSendBatch := func(resourceName string, cnt interface{}) (interface{}, error) {
+		return cnt, errors.New(fmt.Sprintf(sendErrTmpl, resourceName))
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer wg.Done()
+
+			req := &BatchRequest{
+				DebugId:      fmt.Sprintf("sendError %d", i),
+				ResourceName: testResource,
+				Body:         nil,
+				CombineF:     testCombine,
+				SendF:        testSendBatch,
+			}
+
+			_, err := testBatcher.SendRequestWithTimeout("batchSendError", req, time.Duration(10)*time.Second)
+			if err == nil {
+				t.Errorf("expected error, got none")
+				return
+			}
+			expectedErr := fmt.Sprintf(sendErrTmpl, testResource)
+			if !strings.Contains(err.Error(), fmt.Sprintf(sendErrTmpl, testResource)) {
+				t.Errorf("expected error %q, got error: %v", expectedErr, err)
+			}
+		}()
+	}
+
+	wg.Wait()
+}
+
+func TestRequestBatcher_errTimeout(t *testing.T) {
+	testBatcher := NewRequestBatcher(&batchingConfig{
+		sendAfter: time.Duration(5) * time.Second,
+	})
+
+	testResource := "resource for send error"
+
+	// no-op
+	testCombine := func(v interface{}, _ interface{}) (interface{}, error) {
+		return v, nil
+	}
+	// no-op
+	testSendBatch := func(resourceName string, cnt interface{}) (interface{}, error) {
+		return nil, nil
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		req := &BatchRequest{
+			DebugId:      fmt.Sprintf("timeout test"),
+			ResourceName: testResource,
+			Body:         1,
+			CombineF:     testCombine,
+			SendF:        testSendBatch,
+		}
+
+		_, err := testBatcher.SendRequestWithTimeout("batchTimeout", req, time.Duration(1)*time.Second)
+		if err == nil {
+			t.Errorf("expected error, got none")
+		} else if !strings.Contains(err.Error(), "timed out") {
+			t.Errorf("expected timeout error, got %v", err)
+		}
+	}()
+
+	wg.Wait()
+}
+
+func testBasicCountBatches(t *testing.T, testName string, numBatches int) {
+	testBatcher := NewRequestBatcher(&batchingConfig{
+		sendAfter: time.Duration(1) * time.Second,
+	})
+
+	testCombine := func(currV interface{}, toAddV interface{}) (interface{}, error) {
+		return currV.(int) + toAddV.(int), nil
+	}
+
+	testSendBatch := func(name string, body interface{}) (interface{}, error) {
+		return fmt.Sprintf("%s: %d", name, body), nil
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(numBatches)
+
+	for i := 0; i < numBatches; i++ {
+		go func() {
+			defer wg.Done()
+
+			req := &BatchRequest{
+				DebugId:      fmt.Sprintf("Test '%s' Request #%d", testName, i),
+				ResourceName: testName,
+				Body:         1,
+				CombineF:     testCombine,
+				SendF:        testSendBatch,
+			}
+
+			respV, err := testBatcher.SendRequestWithTimeout("testBatching", req, time.Duration(6)*time.Second)
+			if err != nil {
+				t.Errorf("got unexpected error %s", err)
+			}
+			resp, ok := respV.(string)
+			if !ok {
+				t.Errorf("test returned an non-string response: %v", resp)
+			}
+			expected := fmt.Sprintf("%s: %d", testName, numBatches)
+			if resp != expected {
+				t.Errorf("expected response %s, got %s", expected, resp)
+			}
+		}()
+	}
+}

--- a/third_party/terraform/utils/batcher_test.go
+++ b/third_party/terraform/utils/batcher_test.go
@@ -98,11 +98,11 @@ func TestRequestBatcher_errInSend(t *testing.T) {
 	wg.Add(2)
 
 	for i := 0; i < 2; i++ {
-		go func() {
+		go func(idx int) {
 			defer wg.Done()
 
 			req := &BatchRequest{
-				DebugId:      fmt.Sprintf("sendError %d", i),
+				DebugId:      fmt.Sprintf("sendError %d", idx),
 				ResourceName: testResource,
 				Body:         nil,
 				CombineF:     testCombine,
@@ -118,7 +118,7 @@ func TestRequestBatcher_errInSend(t *testing.T) {
 			if !strings.Contains(err.Error(), fmt.Sprintf(sendErrTmpl, testResource)) {
 				t.Errorf("expected error %q, got error: %v", expectedErr, err)
 			}
-		}()
+		}(i)
 	}
 
 	wg.Wait()

--- a/third_party/terraform/utils/batcher_test.go
+++ b/third_party/terraform/utils/batcher_test.go
@@ -1,6 +1,7 @@
 package google
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
@@ -18,10 +19,13 @@ func TestRequestBatcher_batchMultiple(t *testing.T) {
 }
 
 func TestRequestBatcher_disableBatching(t *testing.T) {
-	testBatcher := NewRequestBatcher(&batchingConfig{
-		sendAfter:      time.Duration(1) * time.Second,
-		enableBatching: false,
-	})
+	testBatcher := NewRequestBatcher(
+		"testBatcher",
+		context.Background(),
+		&batchingConfig{
+			sendAfter:      time.Duration(1) * time.Second,
+			enableBatching: false,
+		})
 
 	testCombine := func(currV interface{}, toAddV interface{}) (interface{}, error) {
 		return currV.(int) + toAddV.(int), nil
@@ -63,10 +67,13 @@ func TestRequestBatcher_disableBatching(t *testing.T) {
 }
 
 func TestRequestBatcher_errInCombine(t *testing.T) {
-	testBatcher := NewRequestBatcher(&batchingConfig{
-		sendAfter:      time.Duration(5) * time.Second,
-		enableBatching: true,
-	})
+	testBatcher := NewRequestBatcher(
+		"testBatcher",
+		context.Background(),
+		&batchingConfig{
+			sendAfter:      time.Duration(5) * time.Second,
+			enableBatching: true,
+		})
 
 	combineErrText := "this is an expected error in combine"
 	testCombine := func(_ interface{}, _ interface{}) (interface{}, error) {
@@ -124,10 +131,13 @@ func TestRequestBatcher_errInCombine(t *testing.T) {
 }
 
 func TestRequestBatcher_errInSend(t *testing.T) {
-	testBatcher := NewRequestBatcher(&batchingConfig{
-		sendAfter:      time.Duration(5) * time.Second,
-		enableBatching: true,
-	})
+	testBatcher := NewRequestBatcher(
+		"testBatcher",
+		context.Background(),
+		&batchingConfig{
+			sendAfter:      time.Duration(5) * time.Second,
+			enableBatching: true,
+		})
 
 	testResource := "resource for send error"
 	sendErrTmpl := "this is an expected error in send batch for resource %q"
@@ -172,10 +182,13 @@ func TestRequestBatcher_errInSend(t *testing.T) {
 }
 
 func TestRequestBatcher_errTimeout(t *testing.T) {
-	testBatcher := NewRequestBatcher(&batchingConfig{
-		sendAfter:      time.Duration(5) * time.Second,
-		enableBatching: true,
-	})
+	testBatcher := NewRequestBatcher(
+		"testBatcher",
+		context.Background(),
+		&batchingConfig{
+			sendAfter:      time.Duration(5) * time.Second,
+			enableBatching: true,
+		})
 
 	testResource := "resource for send error"
 
@@ -214,10 +227,13 @@ func TestRequestBatcher_errTimeout(t *testing.T) {
 }
 
 func testBasicCountBatches(t *testing.T, testName string, numBatches int) {
-	testBatcher := NewRequestBatcher(&batchingConfig{
-		sendAfter:      time.Duration(1) * time.Second,
-		enableBatching: true,
-	})
+	testBatcher := NewRequestBatcher(
+		"testBatcher",
+		context.Background(),
+		&batchingConfig{
+			sendAfter:      time.Duration(1) * time.Second,
+			enableBatching: true,
+		})
 
 	testCombine := func(currV interface{}, toAddV interface{}) (interface{}, error) {
 		return currV.(int) + toAddV.(int), nil

--- a/third_party/terraform/utils/batcher_test.go
+++ b/third_party/terraform/utils/batcher_test.go
@@ -91,7 +91,7 @@ func TestRequestBatcher_errInSend(t *testing.T) {
 	}
 
 	testSendBatch := func(resourceName string, cnt interface{}) (interface{}, error) {
-		return cnt, errors.New(fmt.Sprintf(sendErrTmpl, resourceName))
+		return cnt, fmt.Errorf(sendErrTmpl, resourceName)
 	}
 
 	wg := sync.WaitGroup{}
@@ -182,11 +182,11 @@ func testBasicCountBatches(t *testing.T, testName string, numBatches int) {
 	wg.Add(numBatches)
 
 	for i := 0; i < numBatches; i++ {
-		go func() {
+		go func(idx int) {
 			defer wg.Done()
 
 			req := &BatchRequest{
-				DebugId:      fmt.Sprintf("Test '%s' Request #%d", testName, i),
+				DebugId:      fmt.Sprintf("Test '%s' Request #%d", testName, idx),
 				ResourceName: testName,
 				Body:         1,
 				CombineF:     testCombine,
@@ -205,6 +205,6 @@ func testBasicCountBatches(t *testing.T, testName string, numBatches int) {
 			if resp != expected {
 				t.Errorf("expected response %s, got %s", expected, resp)
 			}
-		}()
+		}(i)
 	}
 }

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -61,12 +61,13 @@ import (
 // Config is the configuration structure used to instantiate the Google
 // provider.
 type Config struct {
-	Credentials string
-	AccessToken string
-	Project     string
-	Region      string
-	Zone        string
-	Scopes      []string
+	Credentials 	 string
+	AccessToken 	 string
+	Project     	 string
+	Region      	 string
+	Zone        	 string
+	Scopes         []string
+	BatchingConfig *batchingConfig
 
 	client    *http.Client
 	userAgent string
@@ -172,8 +173,9 @@ type Config struct {
 	ServiceManagementBasePath string
 	clientServiceMan          *servicemanagement.APIService
 
-	ServiceUsageBasePath string
-	clientServiceUsage   *serviceusage.Service
+	ServiceUsageBasePath       string
+	clientServiceUsage         *serviceusage.Service
+	requestBatcherServiceUsage *RequestBatcher
 
 	BigQueryBasePath string
 	clientBigQuery   *bigquery.Service
@@ -429,6 +431,7 @@ func (c *Config) LoadAndValidate() error {
 	}
 	c.clientServiceUsage.UserAgent = userAgent
 	c.clientServiceUsage.BasePath = serviceUsageClientBasePath
+	c.requestBatcherServiceUsage = NewRequestBatcher(c.BatchingConfig)
 
 	cloudBillingClientBasePath := removeBasePathVersion(c.CloudBillingBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud Billing client for path %s", cloudBillingClientBasePath)
@@ -585,6 +588,36 @@ func (c *Config) LoadAndValidate() error {
 	<% end -%>
 
 	return nil
+}
+
+func expandProviderBatchingConfig(v interface{}) (*batchingConfig, error) {
+	config := &batchingConfig{
+		sendAfter:       time.Second * defaultBatchSendIntervalSec,
+		disableBatching: false,
+	}
+
+	if v == nil {
+		return config, nil
+	}
+	ls := v.([]interface{})
+	if len(ls) == 0 {
+		return config, nil
+	}
+
+	cfgV := ls[0].(map[string]interface{})
+	if sendAfterV, ok := cfgV["send_after"]; ok {
+		sendAfter, err := time.ParseDuration(sendAfterV.(string))
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse duration from 'send_after' value %q", sendAfterV)
+		}
+		config.sendAfter = sendAfter
+	}
+
+	if disable, ok := cfgV["disable_batching"]; ok && disable.(bool) {
+		config.disableBatching = true
+	}
+
+	return config, nil
 }
 
 func (c *Config) getTokenSource(clientScopes []string) (oauth2.TokenSource, error) {

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -592,8 +592,8 @@ func (c *Config) LoadAndValidate() error {
 
 func expandProviderBatchingConfig(v interface{}) (*batchingConfig, error) {
 	config := &batchingConfig{
-		sendAfter:       time.Second * defaultBatchSendIntervalSec,
-		disableBatching: false,
+		sendAfter:      time.Second * defaultBatchSendIntervalSec,
+		enableBatching: true,
 	}
 
 	if v == nil {
@@ -613,8 +613,8 @@ func expandProviderBatchingConfig(v interface{}) (*batchingConfig, error) {
 		config.sendAfter = sendAfter
 	}
 
-	if disable, ok := cfgV["disable_batching"]; ok && disable.(bool) {
-		config.disableBatching = true
+	if enable, ok := cfgV["enable_batching"]; ok && enable.(bool) {
+		config.enableBatching = true
 	}
 
 	return config, nil

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -613,8 +613,8 @@ func expandProviderBatchingConfig(v interface{}) (*batchingConfig, error) {
 		config.sendAfter = sendAfter
 	}
 
-	if enable, ok := cfgV["enable_batching"]; ok && enable.(bool) {
-		config.enableBatching = true
+	if enable, ok := cfgV["enable_batching"]; ok {
+		config.enableBatching = enable.(bool)
 	}
 
 	return config, nil

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -600,7 +600,7 @@ func expandProviderBatchingConfig(v interface{}) (*batchingConfig, error) {
 		return config, nil
 	}
 	ls := v.([]interface{})
-	if len(ls) == 0 {
+	if len(ls) == 0 || ls[0] == nil {
 		return config, nil
 	}
 

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -431,7 +431,7 @@ func (c *Config) LoadAndValidate() error {
 	}
 	c.clientServiceUsage.UserAgent = userAgent
 	c.clientServiceUsage.BasePath = serviceUsageClientBasePath
-	c.requestBatcherServiceUsage = NewRequestBatcher(c.BatchingConfig)
+	c.requestBatcherServiceUsage = NewRequestBatcher("Service Usage", context, c.BatchingConfig)
 
 	cloudBillingClientBasePath := removeBasePathVersion(c.CloudBillingBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud Billing client for path %s", cloudBillingClientBasePath)

--- a/third_party/terraform/utils/config_test.go
+++ b/third_party/terraform/utils/config_test.go
@@ -191,8 +191,8 @@ func TestConfigLoadAndValidate_customBatchingConfig(t *testing.T) {
 	if batchCfg.sendAfter != time.Second {
 		t.Fatalf("expected batchCfg sendAfter to be 1 second, got %v", batchCfg.sendAfter)
 	}
-	if !batchCfg.enableBatching {
-		t.Fatalf("expected batchCfg enableBatching to be true")
+	if batchCfg.enableBatching {
+		t.Fatalf("expected enableBatching to be false")
 	}
 
 	config := &Config{

--- a/third_party/terraform/utils/config_test.go
+++ b/third_party/terraform/utils/config_test.go
@@ -181,8 +181,8 @@ func TestConfigLoadAndValidate_defaultBatchingConfig(t *testing.T) {
 func TestConfigLoadAndValidate_customBatchingConfig(t *testing.T) {
 	batchCfg, err := expandProviderBatchingConfig([]interface{}{
 		map[string]interface{}{
-			"send_after":       "1s",
-			"disable_batching": true,
+			"send_after":      "1s",
+			"enable_batching": false,
 		},
 	})
 	if err != nil {
@@ -191,8 +191,8 @@ func TestConfigLoadAndValidate_customBatchingConfig(t *testing.T) {
 	if batchCfg.sendAfter != time.Second {
 		t.Fatalf("expected batchCfg sendAfter to be 1 second, got %v", batchCfg.sendAfter)
 	}
-	if !batchCfg.disableBatching {
-		t.Fatalf("expected batchCfg disableBatching to be true")
+	if !batchCfg.enableBatching {
+		t.Fatalf("expected batchCfg enableBatching to be true")
 	}
 
 	config := &Config{
@@ -214,7 +214,7 @@ func TestConfigLoadAndValidate_customBatchingConfig(t *testing.T) {
 			config.requestBatcherServiceUsage.sendAfter)
 	}
 
-	if !config.requestBatcherServiceUsage.disableBatching {
-		t.Fatalf("expected disableBatching to be true")
+	if config.requestBatcherServiceUsage.enableBatching {
+		t.Fatalf("expected enableBatching to be false")
 	}
 }

--- a/third_party/terraform/utils/config_test.go
+++ b/third_party/terraform/utils/config_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"golang.org/x/oauth2/google"

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -77,7 +77,7 @@ func Provider() terraform.ResourceProvider {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
-			"global_batching": {
+			"batching": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
@@ -409,7 +409,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		config.Scopes[i] = scope.(string)
 	}
 
-	batchCfg, err := expandProviderBatchingConfig(d.Get("global_batching"))
+	batchCfg, err := expandProviderBatchingConfig(d.Get("batching"))
 	if err != nil {
 		return nil, err
 	}

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -77,6 +77,26 @@ func Provider() terraform.ResourceProvider {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
+			"global_batching": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"send_after": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "10s",
+						},
+						"disable_batching": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+					},
+				},
+			},
+
 			// Generated Products
 			<% unless version == 'ga' -%>
 			// start beta-only products
@@ -388,6 +408,12 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	for i, scope := range scopes {
 		config.Scopes[i] = scope.(string)
 	}
+
+	batchCfg, err := expandProviderBatchingConfig(d.Get("global_batching"))
+	if err != nil {
+		return nil, err
+	}
+	config.BatchingConfig = batchCfg
 
 	<% unless version == 'ga' -%>
 	config.BinaryAuthorizationBasePath = d.Get(BinaryAuthorizationCustomEndpointEntryKey).(string)

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -87,11 +87,12 @@ func Provider() terraform.ResourceProvider {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "10s",
+							ValidateFunc: validateNonNegativeDuration(),
 						},
-						"disable_batching": {
+						"enable_batching": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  false,
+							Default:  true,
 						},
 					},
 				},

--- a/third_party/terraform/utils/serviceusage_batching.go
+++ b/third_party/terraform/utils/serviceusage_batching.go
@@ -3,6 +3,7 @@ package google
 import (
 	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
+	"time"
 )
 
 const (
@@ -17,7 +18,7 @@ func globalBatchEnableServices(services []string, project string, d *schema.Reso
 		ResourceName: project,
 		Body:         services,
 		CombineF:     combineServiceUsageServicesBatches,
-		SendF:        sendBatchFuncEnableServices(config),
+		SendF:        sendBatchFuncEnableServices(config, d.Timeout(schema.TimeoutCreate)),
 		DebugId:      fmt.Sprintf("Enable Project Services %s: %+v", project, services),
 	}
 
@@ -41,12 +42,12 @@ func combineServiceUsageServicesBatches(srvsRaw interface{}, toAddRaw interface{
 	return append(srvs, toAdd...), nil
 }
 
-func sendBatchFuncEnableServices(config *Config) batcherSendFunc {
+func sendBatchFuncEnableServices(config *Config, timeout time.Duration) batcherSendFunc {
 	return func(project string, toEnableRaw interface{}) (interface{}, error) {
 		toEnable, ok := toEnableRaw.([]string)
 		if !ok {
 			return nil, fmt.Errorf("Expected batch body type to be []string, got %v. This is a provider error.", toEnableRaw)
 		}
-		return nil, enableServiceUsageProjectServices(toEnable, project, config)
+		return nil, enableServiceUsageProjectServices(toEnable, project, config, timeout)
 	}
 }

--- a/third_party/terraform/utils/serviceusage_batching.go
+++ b/third_party/terraform/utils/serviceusage_batching.go
@@ -1,0 +1,52 @@
+package google
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	batchTypeServiceUsageEnableServices = "project/services:batchEnable"
+)
+
+// globalBatchEnableServices can be used to batch requests to enable services
+// across resource nodes, i.e. to batch creation of several
+// google_project_service(s) resources.
+func globalBatchEnableServices(services []string, project string, config *Config) error {
+	req := &BatchRequest{
+		DebugId:      fmt.Sprintf("Enable Project Services %s: %+v", project, services),
+		ResourceName: project,
+		Body:         services,
+		CombineF:     combineServiceUsageServicesBatches,
+		SendF:        sendBatchFuncEnableServices(config),
+	}
+
+	_, err := config.requestBatcherServiceUsage.SendRequestWithTimeout(
+		batchTypeServiceUsageEnableServices,
+		req,
+		time.Minute*10)
+	return err
+}
+
+func combineServiceUsageServicesBatches(srvsRaw interface{}, toAddRaw interface{}) (interface{}, error) {
+	srvs, ok := srvsRaw.([]string)
+	if !ok {
+		return nil, fmt.Errorf("Expected batch body type to be []string, got %v. This is a provider error.", srvsRaw)
+	}
+	toAdd, ok := toAddRaw.([]string)
+	if !ok {
+		return nil, fmt.Errorf("Expected new request body type to be []string, got %v. This is a provider error.", toAdd)
+	}
+
+	return append(srvs, toAdd...), nil
+}
+
+func sendBatchFuncEnableServices(config *Config) batcherSendFunc {
+	return func(project string, toEnableRaw interface{}) (interface{}, error) {
+		toEnable, ok := toEnableRaw.([]string)
+		if !ok {
+			return nil, fmt.Errorf("Expected batch body type to be []string, got %v. This is a provider error.", toEnableRaw)
+		}
+		return nil, enableServiceUsageProjectServices(toEnable, project, config)
+	}
+}

--- a/third_party/terraform/utils/serviceusage_batching.go
+++ b/third_party/terraform/utils/serviceusage_batching.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	batchTypeServiceUsageEnableServices = "project/services:batchEnable"
+	batchKeyTmplServiceUsageEnableServices = "project/%s/services:batchEnable"
 )
 
 // globalBatchEnableServices can be used to batch requests to enable services
@@ -14,15 +14,15 @@ const (
 // google_project_service(s) resources.
 func globalBatchEnableServices(services []string, project string, config *Config) error {
 	req := &BatchRequest{
-		DebugId:      fmt.Sprintf("Enable Project Services %s: %+v", project, services),
 		ResourceName: project,
 		Body:         services,
 		CombineF:     combineServiceUsageServicesBatches,
 		SendF:        sendBatchFuncEnableServices(config),
+		DebugId:      fmt.Sprintf("Enable Project Services %s: %+v", project, services),
 	}
 
 	_, err := config.requestBatcherServiceUsage.SendRequestWithTimeout(
-		batchTypeServiceUsageEnableServices,
+		fmt.Sprintf(batchKeyTmplServiceUsageEnableServices, project),
 		req,
 		time.Minute*10)
 	return err

--- a/third_party/terraform/utils/serviceusage_batching.go
+++ b/third_party/terraform/utils/serviceusage_batching.go
@@ -2,7 +2,7 @@ package google
 
 import (
 	"fmt"
-	"time"
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 const (
@@ -12,7 +12,7 @@ const (
 // globalBatchEnableServices can be used to batch requests to enable services
 // across resource nodes, i.e. to batch creation of several
 // google_project_service(s) resources.
-func globalBatchEnableServices(services []string, project string, config *Config) error {
+func globalBatchEnableServices(services []string, project string, d *schema.ResourceData, config *Config) error {
 	req := &BatchRequest{
 		ResourceName: project,
 		Body:         services,
@@ -24,7 +24,7 @@ func globalBatchEnableServices(services []string, project string, config *Config
 	_, err := config.requestBatcherServiceUsage.SendRequestWithTimeout(
 		fmt.Sprintf(batchKeyTmplServiceUsageEnableServices, project),
 		req,
-		time.Minute*10)
+		d.Timeout(schema.TimeoutCreate))
 	return err
 }
 

--- a/third_party/terraform/utils/validation.go
+++ b/third_party/terraform/utils/validation.go
@@ -218,6 +218,29 @@ func validateDuration() schema.SchemaValidateFunc {
 	}
 }
 
+func validateNonNegativeDuration() schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		v, ok := i.(string)
+		if !ok {
+			es = append(es, fmt.Errorf("expected type of %s to be string", k))
+			return
+		}
+
+		dur, err := time.ParseDuration(v)
+		if err != nil {
+			es = append(es, fmt.Errorf("expected %s to be a duration, but parsing gave an error: %s", k, err.Error()))
+			return
+		}
+
+		if dur < 0 {
+			es = append(es, fmt.Errorf("duration %v must be a non-negative duration", dur))
+			return
+		}
+
+		return
+	}
+}
+
 // StringNotInSlice returns a SchemaValidateFunc which tests if the provided value
 // is of type string and that it matches none of the element in the invalid slice.
 // if ignorecase is true, case is ignored.

--- a/third_party/terraform/website/docs/provider_reference.html.markdown
+++ b/third_party/terraform/website/docs/provider_reference.html.markdown
@@ -34,7 +34,7 @@ provider "google-beta" {
 }
 ```
 
-## Example Usage - Using beta features with `google-beta` 
+## Example Usage - Using beta features with `google-beta`
 
 To use Google Cloud Platform features that are in beta, you need to both:
 
@@ -68,7 +68,7 @@ provider "google-beta" {}
 The following attributes can be used to configure the provider. The quick
 reference should be sufficient for most use cases, but see the full reference
 if you're interested in more details. Both `google` and `google-beta` share the
-same configuration. 
+same configuration.
 
 ### Quick Reference
 
@@ -103,6 +103,15 @@ the service. This can be used to configure the Google provider to communicate
 with GCP-like APIs such as [the Cloud Functions emulator](https://github.com/googlearchive/cloud-functions-emulator).
 Values are expected to include the version of the service, such as
 `https://www.googleapis.com/compute/v1/`.
+
+* `batching` - (Optional) This block controls batching GCP calls for groups of specific resource types. Structure is documented below.
+~>**NOTE**: Batching is not implemented for the majority or resources/request types and is bounded by the core [`-parallelism`](https://www.terraform.io/docs/commands/apply.html#parallelism-n) flag. Adding or changing this config likely won't affect a Terraform run at all unless the user is creating enough of a particular type of resource to run into quota issues.
+
+The `batching` fields supports:
+
+* `send_after` - (Optional) A duration string representing the amount of time after which a request should be sent. Defaults to 10s.
+
+* `disable_batching` - (Optional) Defaults to false. If true, disables batching and each request is sent normally.
 
 ### Full Reference
 
@@ -278,3 +287,22 @@ as their versioned counterpart but that won't necessarily always be the case.
 [service accounts]: https://cloud.google.com/docs/authentication/getting-started
 [GCE metadata]: https://cloud.google.com/docs/authentication/production#obtaining_credentials_on_compute_engine_kubernetes_engine_app_engine_flexible_environment_and_cloud_functions
 [scopes]: https://developers.google.com/identity/protocols/googlescopes
+
+---
+
+* `batching` - (Optional) Controls batching for specific GCP request types where users have encountered quota or speed issues using `count` with resources that affect the same GCP resource (e.g. `google_project_service`). It is not used for every resource/request type and can only group parallel similar calls for nodes at a similar traversal time in the graph during `terraform apply` (e.g. resources created using `count` that affect a single `project`). Thus, it is also bounded by the `terraform` [`-parallelism`](https://www.terraform.io/docs/commands/apply.html#parallelism-n) flag, as reducing the number of parallel calls will reduce the number of simultaneous requests being added to a batcher.
+
+~> **NOTE**: Not every resource or request has had batching implemented for it.
+In addition, if you're not completely sure you need it, you should avoid using or changing this configuration, as it doesn't affect runs for smaller configs or config using the majority of resources.
+
+In general, batching is really only needed for resources where several requests are made at the same time to an underlying GCP resource protected by a fairly low default quota, or with very slow operations with slower eventual propagatation. This specifically has included the following example configs:
+
+* enabling a large number of services with several `google_project_service` resources
+* Setting global (project/org/folder) IAM policies using several `bindings` or `members` (batching not implemented yet)
+
+
+The `batching` block supports the following fields.
+
+* `send_after` - (Optional) A duration string representing the amount of time after which a request should be sent. Defaults to 10s. Should be a non-negative sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+
+* `disable_batching` - (Optional) Defaults to false. If true, disables global batching and each request is sent normally.

--- a/third_party/terraform/website/docs/provider_reference.html.markdown
+++ b/third_party/terraform/website/docs/provider_reference.html.markdown
@@ -109,9 +109,11 @@ Values are expected to include the version of the service, such as
 
 The `batching` fields supports:
 
-* `send_after` - (Optional) A duration string representing the amount of time after which a request should be sent. Defaults to 10s.
+* `send_after` - (Optional) A duration string representing the amount of time
+after which a request should be sent. Defaults to 10s.
 
-* `disable_batching` - (Optional) Defaults to false. If true, disables batching and each request is sent normally.
+* `enable_batching` - (Optional) Defaults to true. If false, disables batching
+   so requests that have batching capabilities are instead is sent one by one.
 
 ### Full Reference
 
@@ -290,19 +292,35 @@ as their versioned counterpart but that won't necessarily always be the case.
 
 ---
 
-* `batching` - (Optional) Controls batching for specific GCP request types where users have encountered quota or speed issues using `count` with resources that affect the same GCP resource (e.g. `google_project_service`). It is not used for every resource/request type and can only group parallel similar calls for nodes at a similar traversal time in the graph during `terraform apply` (e.g. resources created using `count` that affect a single `project`). Thus, it is also bounded by the `terraform` [`-parallelism`](https://www.terraform.io/docs/commands/apply.html#parallelism-n) flag, as reducing the number of parallel calls will reduce the number of simultaneous requests being added to a batcher.
+* `batching` - (Optional) Controls batching for specific GCP request types
+  where users have encountered quota or speed issues using `count` with
+  resources that affect the same GCP resource (e.g. `google_project_service`). 
+  It is not used for every resource/request type and can only group parallel
+  similar calls for nodes at a similar traversal time in the graph during
+  `terraform apply` (e.g. resources created using `count` that affect a single
+  `project`). Thus, it is also bounded by the `terraform` 
+  [`-parallelism`](https://www.terraform.io/docs/commands/apply.html#parallelism-n) 
+  flag, as reducing the number of parallel calls will reduce the number of
+  simultaneous requests being added to a batcher.
 
-~> **NOTE**: Not every resource or request has had batching implemented for it.
-In addition, if you're not completely sure you need it, you should avoid using or changing this configuration, as it doesn't affect runs for smaller configs or config using the majority of resources.
+  ~> **NOTE** Most resources/GCP request do not have batching implemented (see
+  below for requests which use batching) Batching is really only needed for
+  resources where several requests are made at the same time to an underlying
+  GCP resource protected by a fairly low default quota, or with very slow
+  operations with slower eventual propagatation. If you're not completely sure
+  what you are doing, avoid setting custom batching configuration.
 
-In general, batching is really only needed for resources where several requests are made at the same time to an underlying GCP resource protected by a fairly low default quota, or with very slow operations with slower eventual propagatation. This specifically has included the following example configs:
+**So far, batching is implemented for**:
 
-* enabling a large number of services with several `google_project_service` resources
-* Setting global (project/org/folder) IAM policies using several `bindings` or `members` (batching not implemented yet)
-
+* enabling project services using `google_project_service` or
+  `google_project_services`
 
 The `batching` block supports the following fields.
 
-* `send_after` - (Optional) A duration string representing the amount of time after which a request should be sent. Defaults to 10s. Should be a non-negative sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+* `send_after` - (Optional) A duration string representing the amount of time
+after which a request should be sent. Defaults to 10s. Should be a non-negative
+integer or float string with a unit suffix, such as "300ms", "1.5h" or "2h45m".
+Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
-* `disable_batching` - (Optional) Defaults to false. If true, disables global batching and each request is sent normally.
+* `disable_batching` - (Optional) Defaults to false. If true, disables global
+batching and each request is sent normally.


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
* Add RequestBatcher for global request batching
* Create request batcher for serviceusage
* Some small refactors to serviceusage 
* Fix changelog python script to actually parse release notes properly 


<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
* serviceusage: Add global batching (across resources) for enabling services to reduce number of requests for quota and improve speed
```
