### PR TITLE
gcp_compute_instance_group doc update for 2.8

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -4193,8 +4193,7 @@ objects:
     description: |
       Represents an Instance Group resource. Instance groups are self-managed
       and can contain identical or different instances. Instance groups do not
-      use an instance template. Unlike managed instance groups, you must create
-      and add instances to an instance group manually.
+      use an instance template. 
     async: !ruby/object:Api::Async
       operation: !ruby/object:Api::Async::Operation
         kind: 'compute#operation'


### PR DESCRIPTION
The removed stanza is no longer true, an instance parameter exists, and if instances are manually added, they will be removed or overwritten in current versions. The instance parameter is already documented: https://docs.ansible.com/ansible/devel/modules/gcp_compute_instance_group_module.html#parameters
.

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
