### PR TITLE
adding ansible types in documentation

### DIFF
--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -41,7 +41,7 @@ module Provider
               else
                 prop.default_value&.to_s
               end),
-            'type' => ('bool' if prop.is_a? Api::Type::Boolean),
+            'type' => python_type(prop),
             'aliases' => prop.aliases,
             'version_added' => (version_added(prop)&.to_f),
             'suboptions' => (


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Ansible is moving the goalposts on documentation.

They used to do some magic to grab the type information from the source code. Now, it has to be added directly into the documentation block (which seems like the correct behavior?)

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
