### PR TITLE
Remove nodepool autoscaling when disabled

### DIFF
--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -547,12 +547,16 @@ func flattenNodePool(d *schema.ResourceData, config *Config, np *containerBeta.N
 		"version":             np.Version,
 	}
 
-	if np.Autoscaling != nil && np.Autoscaling.Enabled {
-		nodePool["autoscaling"] = []map[string]interface{}{
-			map[string]interface{}{
-				"min_node_count": np.Autoscaling.MinNodeCount,
-				"max_node_count": np.Autoscaling.MaxNodeCount,
-			},
+	if np.Autoscaling != nil {
+		if np.Autoscaling.Enabled {
+			nodePool["autoscaling"] = []map[string]interface{}{
+				{
+					"min_node_count": np.Autoscaling.MinNodeCount,
+					"max_node_count": np.Autoscaling.MaxNodeCount,
+				},
+			}
+		} else {
+			nodePool["autoscaling"] = []map[string]interface{}{}
 		}
 	}
 


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-google/issues/3978
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
`google_container_node_pool` Correctly set nodepool autoscaling in state when disabled in the API
```
