### PR TITLE
Fix release note parsing to actually replace the release note.

### DIFF
--- a/.ci/magic-modules/pyutils/strutils.py
+++ b/.ci/magic-modules/pyutils/strutils.py
@@ -1,7 +1,7 @@
 import re
 
-RELEASE_NOTE_RE = r'```releasenote(?P<release_note>.*)```'
-
+RELEASE_NOTE_RE = r'`{3}releasenote(?P<release_note>.*?)`{3}'
+RELEASE_NOTE_SUB_RE = r'`{3}releasenote'
 def find_dependency_urls_in_comment(body):
   """Util to parse downstream dependencies from a given comment body.
 
@@ -62,7 +62,9 @@ def set_release_note(release_note, body):
 
   For a given text block, removes any existing "releasenote" markdown code
   blocks and adds the given release note at the end.
-
+```releasenote
+      This should be replaced
+      ```
   Example:
     # Set a release note
     > print set_release_note(
@@ -82,7 +84,11 @@ def set_release_note(release_note, body):
   Returns:
     Modified text
   """
-  edited = re.sub(RELEASE_NOTE_RE, '', body)
+  edited = ""
+  for segment in re.split(r'`{3}releasenote', body, re.S):
+    idx = segment.find('```\n')
+    edited += segment if idx < 0 else segment[idx+3:]
+
   release_note = release_note.strip()
   if release_note:
     edited += "\n```releasenote\n%s\n```\n" % release_note.strip()

--- a/.ci/magic-modules/pyutils/strutils_test.py
+++ b/.ci/magic-modules/pyutils/strutils_test.py
@@ -109,8 +109,11 @@ class TestStringUtils(unittest.TestCase):
     self.assertIn("More text\n", replaced)
 
   def test_find_prefixed_labels(self):
-    self.assertFalse(find_prefixed_labels([]))
-    self.assertFalse(find_prefixed_labels(["", ""]))
+    self.assertFalse(find_prefixed_labels([], "test: "))
+    self.assertFalse(find_prefixed_labels(["", ""], "test: "))
+    labels = find_prefixed_labels(["foo", "bar"], "")
+    self.assertIn("foo", labels)
+    self.assertIn("bar", labels)
 
     test_labels = [
       "test: foo",


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

- Also fix the labels test and add another test for empty prefix

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
