### PR TITLE
ansible needs to ship doc fragments too

### DIFF
--- a/.ci/magic-modules/release-ansible.sh
+++ b/.ci/magic-modules/release-ansible.sh
@@ -78,6 +78,7 @@ for filename in mm-bug*; do
   done < $filename
 
   git checkout magician/devel -- "lib/ansible/module_utils/gcp_utils.py"
+  git checkout magician/devel -- "lib/ansible/plugins/doc_fragments/gcp.py"
 
   # This commit may be empty
   set +e


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
My release script wasn't shipping out the shared doc fragment (didn't need to until I added the `env_type` field).

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
```
