### PR TITLE
Better messages, template formatting for auto-changelog

### DIFF
--- a/.ci/magic-modules/downstream_changelog_metadata.py
+++ b/.ci/magic-modules/downstream_changelog_metadata.py
@@ -37,6 +37,7 @@ def downstream_changelog_info(gh, upstream_pr_num, changelog_repos):
   if not labels_to_add and not release_note:
     print "skipping upstream PR %d with no release note/labels" % (
       upstream_pr_num)
+    return
 
   print "Applying changelog info to downstreams for upstream PR %d:" % (
     upstream_pr.number)
@@ -46,6 +47,7 @@ def downstream_changelog_info(gh, upstream_pr_num, changelog_repos):
   parsed_urls = downstreams.get_parsed_downstream_urls(gh, upstream_pr_num)
   if not parsed_urls:
     print "Skipping downstreaming for upstream PR %d - no downstreams"
+    return
 
   for repo_name, pulls in parsed_urls:
     if repo_name not in changelog_repos:

--- a/.ci/magic-modules/downstream_changelog_metadata.py
+++ b/.ci/magic-modules/downstream_changelog_metadata.py
@@ -35,7 +35,8 @@ def downstream_changelog_info(gh, upstream_pr_num, changelog_repos):
     CHANGELOG_LABEL_PREFIX)
 
   if not labels_to_add and not release_note:
-    print "skipping - no release note and labels"
+    print "skipping upstream PR %d with no release note/labels" % (
+      upstream_pr_num)
 
   print "Applying changelog info to downstreams for upstream PR %d:" % (
     upstream_pr.number)
@@ -43,6 +44,9 @@ def downstream_changelog_info(gh, upstream_pr_num, changelog_repos):
   print "Labels: %s" % labels_to_add
 
   parsed_urls = downstreams.get_parsed_downstream_urls(gh, upstream_pr_num)
+  if not parsed_urls:
+    print "Skipping downstreaming for upstream PR %d - no downstreams"
+
   for repo_name, pulls in parsed_urls:
     if repo_name not in changelog_repos:
       print "[DEBUG] skipping repo %s with no CHANGELOG" % repo_name

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,4 +23,5 @@ Please also add any of the following appropriate labels to the PR:
 -->
 # Release Note for Downstream PRs (will be copied)
 ```releasenote
+
 ```


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
