### PR TITLE
[ansible] ssl certs are formatted wrong

### DIFF
--- a/products/compute/examples/ansible/ssl_certificate.yaml
+++ b/products/compute/examples/ansible/ssl_certificate.yaml
@@ -16,7 +16,7 @@ task: !ruby/object:Provider::Ansible::Task
   code:
     name: <%= ctx[:name] %>
     description: A certificate for testing. Do not use this certificate in production
-    certificate: >
+    certificate: |
       -----BEGIN CERTIFICATE-----
       MIICqjCCAk+gAwIBAgIJAIuJ+0352Kq4MAoGCCqGSM49BAMCMIGwMQswCQYDVQQG
       EwJVUzETMBEGA1UECAwKV2FzaGluZ3RvbjERMA8GA1UEBwwIS2lya2xhbmQxFTAT
@@ -34,7 +34,7 @@ task: !ruby/object:Provider::Ansible::Task
       M3jcqgA4fSW/oKw6UJxp+M6a+nGMX+UJR3YgAiEAvvl39QRVAiv84hdoCuyON0lJ
       zqGNhIPGq2ULqXKK8BY=
       -----END CERTIFICATE-----
-    private_key: >
+    private_key: |
       -----BEGIN EC PRIVATE KEY-----
       MHcCAQEEIObtRo8tkUqoMjeHhsOh2ouPpXCgBcP+EDxZCB/tws15oAoGCCqGSM49
       AwEHoUQDQgAEHGzpcRJ4XzfBJCCPMQeXQpTXwlblimODQCuQ4mzkzTv0dXyB750f

--- a/products/compute/examples/ansible/target_https_proxy.yaml
+++ b/products/compute/examples/ansible/target_https_proxy.yaml
@@ -61,7 +61,7 @@ dependencies:
     code:
       name: <%= dependency_name('sslCert', 'targetHttpsProxy') %>
       description: A certificate for testing. Do not use this certificate in production
-      certificate: >
+      certificate: |
         -----BEGIN CERTIFICATE-----
         MIICqjCCAk+gAwIBAgIJAIuJ+0352Kq4MAoGCCqGSM49BAMCMIGwMQswCQYDVQQG
         EwJVUzETMBEGA1UECAwKV2FzaGluZ3RvbjERMA8GA1UEBwwIS2lya2xhbmQxFTAT
@@ -79,7 +79,7 @@ dependencies:
         M3jcqgA4fSW/oKw6UJxp+M6a+nGMX+UJR3YgAiEAvvl39QRVAiv84hdoCuyON0lJ
         zqGNhIPGq2ULqXKK8BY=
         -----END CERTIFICATE-----
-      private_key: >
+      private_key: |
         -----BEGIN EC PRIVATE KEY-----
         MHcCAQEEIObtRo8tkUqoMjeHhsOh2ouPpXCgBcP+EDxZCB/tws15oAoGCCqGSM49
         AwEHoUQDQgAEHGzpcRJ4XzfBJCCPMQeXQpTXwlblimODQCuQ4mzkzTv0dXyB750f

--- a/products/compute/examples/ansible/target_ssl_proxy.yaml
+++ b/products/compute/examples/ansible/target_ssl_proxy.yaml
@@ -56,7 +56,7 @@ dependencies:
     code:
       name: <%= dependency_name('sslCert', 'targetSslProxy') %>
       description: A certificate for testing. Do not use this certificate in production
-      certificate: >
+      certificate: |
         -----BEGIN CERTIFICATE-----
         MIICqjCCAk+gAwIBAgIJAIuJ+0352Kq4MAoGCCqGSM49BAMCMIGwMQswCQYDVQQG
         EwJVUzETMBEGA1UECAwKV2FzaGluZ3RvbjERMA8GA1UEBwwIS2lya2xhbmQxFTAT
@@ -74,7 +74,7 @@ dependencies:
         M3jcqgA4fSW/oKw6UJxp+M6a+nGMX+UJR3YgAiEAvvl39QRVAiv84hdoCuyON0lJ
         zqGNhIPGq2ULqXKK8BY=
         -----END CERTIFICATE-----
-      private_key: >
+      private_key: |
         -----BEGIN EC PRIVATE KEY-----
         MHcCAQEEIObtRo8tkUqoMjeHhsOh2ouPpXCgBcP+EDxZCB/tws15oAoGCCqGSM49
         AwEHoUQDQgAEHGzpcRJ4XzfBJCCPMQeXQpTXwlblimODQCuQ4mzkzTv0dXyB750f

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -135,7 +135,7 @@ module Provider
         elsif code.is_a?(Hash)
           code.map { |k, vv| [k, compiled_code(vv, hash)] }.to_h
         elsif code.is_a?(TrueClass) || code.is_a?(FalseClass) || code.is_a?(String)
-          compile_string(hash, code.to_s.delete("\n")).join
+          compile_string(hash, code.to_s).join("\n")
         else
           code
         end


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Fixes https://github.com/GoogleCloudPlatform/magic-modules/issues/2041

SSL Certs were being outputted in a weird way, which led to test failures

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
