### PR TITLE
Adding 'service_account_file' type

### DIFF
--- a/provider/ansible/gcp_doc_frag.py
+++ b/provider/ansible/gcp_doc_frag.py
@@ -27,6 +27,7 @@ options:
     service_account_file:
         description:
             - The path of a Service Account JSON file if serviceaccount is selected as type.
+        type: path
     service_account_email:
         description:
             - An optional service account email address if machineaccount is selected


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
This is super annoying (collections will fix this issue, otherwise I'd fix it myself).

Ansible's CI now wants types everywhere, which is a new thing. I'm missing another type which their CI didn't complain about earlier when it started giving me error messages.

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
