### PR TITLE
Fix internal field diff in monitoring uptime check

### DIFF
--- a/products/monitoring/terraform.yaml
+++ b/products/monitoring/terraform.yaml
@@ -99,6 +99,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           group_display_name: "uptime-check-group"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/self_link_as_name.erb
+      decoder: 'templates/terraform/decoders/monitoring_uptime_check_internal.go.erb'
       extra_schema_entry: 'templates/terraform/extra_schema_entry/monitoring_uptime_check_config_internal.go.erb'
       post_create: templates/terraform/post_create/set_computed_name.erb
     properties:

--- a/templates/terraform/decoders/monitoring_uptime_check_internal.go.erb
+++ b/templates/terraform/decoders/monitoring_uptime_check_internal.go.erb
@@ -1,0 +1,2 @@
+d.Set("internal_checkers", nil)
+return res, nil


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/3963

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
Fix diff in `google_monitoring_uptime_check_config` on a deprecated field.
```
