### PR TITLE
Add ability to use an alternate directory within provider configs

### DIFF
--- a/compiler.rb
+++ b/compiler.rb
@@ -164,7 +164,7 @@ product_names.each do |product_name|
   # Load any dynamic overrides passed in with -r
   if File.exist?(provider_override_path)
     product_api, provider_config, = \
-      Provider::Config.parse(provider_override_path, product_api, version)
+      Provider::Config.parse(provider_override_path, product_api, version, override_dir)
   end
 
   pp provider_config if ENV['COMPILER_DEBUG']

--- a/provider/config.rb
+++ b/provider/config.rb
@@ -54,9 +54,13 @@ module Provider
 
       # Compile step #1: compile with generic class to instantiate target class
       source = compile(cfg_file)
-      # Replace overrides directory if needed
-      override_replace = source.gsub("{{override_path}}", provider_override_path)
-      config = Google::YamlValidator.parse(override_replace)
+
+      unless provider_override_path.nil?
+        # Replace overrides directory if we are running with a provider override
+        # This allows providers to reference files in their override path
+        source = source.gsub('{{override_path}}', provider_override_path)
+      end
+      config = Google::YamlValidator.parse(source)
 
       raise "Config #{cfg_file}(#{config.class}) is not a Provider::Config" \
         unless config.class <= Provider::Config

--- a/provider/config.rb
+++ b/provider/config.rb
@@ -66,7 +66,6 @@ module Provider
                                     config.property_override)
       config.spread_api config, api, [], '' unless api.nil?
       config.validate
-      config.provider_override_path = provider_override_path
       api.validate
       [api, config]
     end

--- a/provider/config.rb
+++ b/provider/config.rb
@@ -49,12 +49,14 @@ module Provider
       end
     end
 
-    def self.parse(cfg_file, api = nil, version_name = 'ga')
+    def self.parse(cfg_file, api = nil, version_name = 'ga', provider_override_path = nil)
       raise 'Version passed to the compiler cannot be nil' if version_name.nil?
 
       # Compile step #1: compile with generic class to instantiate target class
       source = compile(cfg_file)
-      config = Google::YamlValidator.parse(source)
+      # Replace overrides directory if needed
+      override_replace = source.gsub("{{override_path}}", provider_override_path)
+      config = Google::YamlValidator.parse(override_replace)
 
       raise "Config #{cfg_file}(#{config.class}) is not a Provider::Config" \
         unless config.class <= Provider::Config
@@ -64,6 +66,7 @@ module Provider
                                     config.property_override)
       config.spread_api config, api, [], '' unless api.nil?
       config.validate
+      config.provider_override_path = provider_override_path
       api.validate
       [api, config]
     end


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Provides ability to reference files that do not exist in another directory
<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
