### PR TITLE
[ansible] stop databases from being deleted

### DIFF
--- a/products/spanner/ansible.yaml
+++ b/products/spanner/ansible.yaml
@@ -30,12 +30,16 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     custom_update_resource: true
     provider_helpers:
       - 'products/spanner/helpers/python/instance_helpers.py.erb'
+    update: |
+      module.fail_json(msg="Spanner objects can't be updated to ensure data safety")
   Database: !ruby/object:Overrides::Ansible::ResourceOverride
     transport: !ruby/object:Overrides::Ansible::Transport
       encoder: encode_request
       decoder: decode_response
     provider_helpers:
       - 'products/spanner/helpers/python/database_helpers.py.erb'
+    update: |
+      module.fail_json(msg="Spanner objects can't be updated to ensure data safety")
   # Virtual => true objects that don't need dedicated resources.
   InstanceConfig: !ruby/object:Overrides::Ansible::ResourceOverride
     transport: !ruby/object:Overrides::Ansible::Transport

--- a/products/sql/ansible.yaml
+++ b/products/sql/ansible.yaml
@@ -43,9 +43,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     access_api_results: true
     return_if_object: |
 <%= lines(indent(compile('products/sql/helpers/ansible/return_if_object.py'), 6)) -%>
+    update: |
+      module.fail_json(msg="SQL objects can't be updated to ensure data safety")
   Database: !ruby/object:Overrides::Ansible::ResourceOverride
     return_if_object: |
 <%= lines(indent(compile('products/sql/helpers/ansible/return_if_object.py'), 6)) -%>
+    update: |
+      module.fail_json(msg="SQL objects can't be updated to ensure data safety")
   User: !ruby/object:Overrides::Ansible::ResourceOverride
     unwrap_resource: true
     return_if_object: |


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
TF will delete + recreate databases because users can use `terraform plan` to ensure that bad things don't happen.

Ansible doesn't have support for a plan (or the ability to stop deletions at a global level). 

Even if all of that stuff existed, deleting + recreating a database *terrifies* me. I would rather error out than have a database deleted in any unintentional case (even if intended).

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
