### PR TITLE
[ansible] stop some async errors from being suppressed

### DIFF
--- a/templates/ansible/async.erb
+++ b/templates/ansible/async.erb
@@ -18,7 +18,7 @@ def wait_for_operation(module, response):
 <% if object.nested_query.nil? -%>
     wait_done = wait_for_completion(status, op_result, module)
 <% if object.async.result.resource_inside_response -%>
-    raise_if_errors(op_result, <%= err_path -%>, module)
+    raise_if_errors(wait_done, <%= err_path -%>, module)
     return navigate_hash(wait_done, ['response'])
 <% else #if object.async.result.resource_inside_response -%>
 <% res_path = python_literal(object.async.result.path.split('/')) -%>


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Some Ansible erros in Operations were being accidentally suppressed.

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
