### PR TITLE
adding state info to docs

### DIFF
--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -230,7 +230,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   TargetPool: !ruby/object:Overrides::Ansible::ResourceOverride
     transport: !ruby/object:Overrides::Ansible::Transport
       encoder: encode_request
-      decoder: decode_request
+      decoder: decode_response
     provider_helpers:
       - 'products/compute/helpers/python/provider_target_pool.py'
   TargetVpnGateway: !ruby/object:Overrides::Ansible::ResourceOverride

--- a/products/compute/helpers/python/provider_target_pool.py
+++ b/products/compute/helpers/python/provider_target_pool.py
@@ -26,7 +26,7 @@ def encode_request(request, module):
 
 # Mask healthChecks into a single element.
 # @see encode_request for details
-def decode_request(response, module):
+def decode_response(response, module):
     if response['kind'] != 'compute#targetPool':
         return response
 

--- a/templates/ansible/documentation.erb
+++ b/templates/ansible/documentation.erb
@@ -24,7 +24,8 @@ DOCUMENTATION = '''
       'state' => {
         'description' => ['Whether the given object should exist in GCP'],
         'choices' => ['present', 'absent'],
-        'default' => 'present'
+        'default' => 'present',
+        'type' => 'str'
       },
     },
     object.all_user_properties.reject(&:output).map { |p| documentation_for_property(p) }


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Almost done with these doc changes. Now getting issues about `state` missing its type information.

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
