### PR TITLE
Add datasource for google_compute_resource_policy

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_compute_resource_policy.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_resource_policy.go
@@ -1,0 +1,62 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceGoogleComputeResourcePolicy() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleComputeResourcePolicyRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"region": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"self_link": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGoogleComputeResourcePolicyRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+	name := d.Get("name").(string)
+	resourcePolicy, err := config.clientCompute.ResourcePolicies.Get(project, region, name).Do()
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("ResourcePolicy Not Found : %s", name))
+	}
+	d.Set("self_link", resourcePolicy.SelfLink)
+	d.Set("description", resourcePolicy.Description)
+	d.SetId(resourcePolicy.Name)
+	return nil
+}

--- a/third_party/terraform/data_sources/data_source_google_compute_resource_policy.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_resource_policy.go
@@ -3,7 +3,7 @@ package google
 import (
 	"fmt"
 
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func dataSourceGoogleComputeResourcePolicy() *schema.Resource {

--- a/third_party/terraform/data_sources/data_source_google_compute_resource_policy.go.erb
+++ b/third_party/terraform/data_sources/data_source_google_compute_resource_policy.go.erb
@@ -1,5 +1,7 @@
+<% autogen_exception -%>
 package google
 
+<% unless version == 'ga' -%>
 import (
 	"fmt"
 
@@ -60,3 +62,4 @@ func dataSourceGoogleComputeResourcePolicyRead(d *schema.ResourceData, meta inte
 	d.SetId(resourcePolicy.Name)
 	return nil
 }
+<% end -%>

--- a/third_party/terraform/tests/data_source_google_compute_resource_policy_test.go
+++ b/third_party/terraform/tests/data_source_google_compute_resource_policy_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 

--- a/third_party/terraform/tests/data_source_google_compute_resource_policy_test.go
+++ b/third_party/terraform/tests/data_source_google_compute_resource_policy_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccDataSourceComputeResourcePolicy(t *testing.T) {

--- a/third_party/terraform/tests/data_source_google_compute_resource_policy_test.go
+++ b/third_party/terraform/tests/data_source_google_compute_resource_policy_test.go
@@ -1,0 +1,110 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceComputeResourcePolicy(t *testing.T) {
+	t.Parallel()
+
+	rsName := "foo"
+	rsFullName := fmt.Sprintf("google_compute_resource_policy.%s", rsName)
+	dsName := "my_policy"
+	dsFullName := fmt.Sprintf("data.google_compute_resource_policy.%s", dsName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDataSourceComputeResourcePolicyDestroy(rsFullName),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceComputeResourcePolicyConfig(rsName, dsName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceComputeResourcePolicyCheck(dsFullName, rsFullName),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceComputeResourcePolicyCheck(dataSourceName string, resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ds, ok := s.RootModule().Resources[dataSourceName]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", dataSourceName)
+		}
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("can't find %s in state", resourceName)
+		}
+
+		dsAttr := ds.Primary.Attributes
+		rsAttr := rs.Primary.Attributes
+
+		policyAttrsToTest := []string{
+			"self_link",
+			"name",
+		}
+
+		for _, attrToCheck := range policyAttrsToTest {
+			if dsAttr[attrToCheck] != rsAttr[attrToCheck] {
+				return fmt.Errorf(
+					"%s is %s; want %s",
+					attrToCheck,
+					dsAttr[attrToCheck],
+					rsAttr[attrToCheck],
+				)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckDataSourceComputeResourcePolicyDestroy(resourceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*Config)
+
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("can't find %s in state", resourceName)
+		}
+
+		policyAttrs := rs.Primary.Attributes
+
+		_, err := config.clientCompute.ResourcePolicies.Get(
+			config.Project, policyAttrs["region"], policyAttrs["name"]).Do()
+		if err == nil {
+			return fmt.Errorf("Resource Policy still exists")
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourceComputeResourcePolicyConfig(rsName, dsName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_resource_policy" "%s" {
+  name = "policy"
+  region = "us-central1"
+  snapshot_schedule_policy {
+    schedule {
+      daily_schedule {
+        days_in_cycle = 1
+        start_time = "04:00"
+      }
+    }
+  }
+}
+
+data "google_compute_resource_policy" "%s" {
+  name     = "${google_compute_resource_policy.%s.name}"
+  region   = "${google_compute_resource_policy.%s.region}"
+}
+`, rsName, dsName, rsName, rsName)
+}

--- a/third_party/terraform/tests/data_source_google_compute_resource_policy_test.go.erb
+++ b/third_party/terraform/tests/data_source_google_compute_resource_policy_test.go.erb
@@ -1,9 +1,12 @@
+<% autogen_exception -%>
 package google
 
+<% unless version == 'ga' -%>
 import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -11,9 +14,11 @@ import (
 func TestAccDataSourceComputeResourcePolicy(t *testing.T) {
 	t.Parallel()
 
-	rsName := "foo"
+	randomSuffix := acctest.RandString(10)
+
+	rsName := "foo_" + randomSuffix
 	rsFullName := fmt.Sprintf("google_compute_resource_policy.%s", rsName)
-	dsName := "my_policy"
+	dsName := "my_policy_" + randomSuffix
 	dsFullName := fmt.Sprintf("data.google_compute_resource_policy.%s", dsName)
 
 	resource.Test(t, resource.TestCase{
@@ -22,7 +27,7 @@ func TestAccDataSourceComputeResourcePolicy(t *testing.T) {
 		CheckDestroy: testAccCheckDataSourceComputeResourcePolicyDestroy(rsFullName),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceComputeResourcePolicyConfig(rsName, dsName),
+				Config: testAccDataSourceComputeResourcePolicyConfig(rsName, dsName, randomSuffix),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceComputeResourcePolicyCheck(dsFullName, rsFullName),
 				),
@@ -87,10 +92,10 @@ func testAccCheckDataSourceComputeResourcePolicyDestroy(resourceName string) res
 	}
 }
 
-func testAccDataSourceComputeResourcePolicyConfig(rsName, dsName string) string {
+func testAccDataSourceComputeResourcePolicyConfig(rsName, dsName, randomSuffix string) string {
 	return fmt.Sprintf(`
 resource "google_compute_resource_policy" "%s" {
-  name = "policy"
+  name = "policy-%s"
   region = "us-central1"
   snapshot_schedule_policy {
     schedule {
@@ -106,5 +111,6 @@ data "google_compute_resource_policy" "%s" {
   name     = "${google_compute_resource_policy.%s.name}"
   region   = "${google_compute_resource_policy.%s.region}"
 }
-`, rsName, dsName, rsName, rsName)
+`, rsName, randomSuffix, dsName, rsName, rsName)
 }
+<% end -%>

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -162,6 +162,9 @@ func Provider() terraform.ResourceProvider {
 			"google_compute_node_types":                        dataSourceGoogleComputeNodeTypes(),
 			"google_compute_regions":                           dataSourceGoogleComputeRegions(),
 			"google_compute_region_instance_group":             dataSourceGoogleComputeRegionInstanceGroup(),
+			<% unless version == 'ga' -%>
+			"google_compute_resource_policy":                   dataSourceGoogleComputeResourcePolicy(),
+			<% end -%>
 			"google_compute_ssl_certificate":                   dataSourceGoogleComputeSslCertificate(),
 			"google_compute_ssl_policy":                        dataSourceGoogleComputeSslPolicy(),
 			"google_compute_subnetwork":                        dataSourceGoogleComputeSubnetwork(),

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -98,6 +98,11 @@
       <li<%%= sidebar_current("docs-google-datasource-compute-region-instance-group") %>>
       <a href="/docs/providers/google/d/datasource_compute_region_instance_group.html">google_compute_region_instance_group</a>
       </li>
+<% unless version == 'ga' -%>
+      <li<%%= sidebar_current("docs-google-datasource-compute-resource-policy") %>>
+          <a href="/docs/providers/google/d/google_compute_resource_policy.html">google_compute_resource_policy</a>
+      </li>
+<% end  -%>
       <li<%%= sidebar_current("docs-google-datasource-compute-ssl-certificate") %>>
         <a href="/docs/providers/google/d/datasource_compute_ssl_certificate.html">google_compute_ssl_certificate</a>
       </li>

--- a/third_party/terraform/website/docs/d/google_compute_resource_policy.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_resource_policy.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "google"
+page_title: "Google: google_compute_resource_policy"
+sidebar_current: "docs-google-datasource-compute-resource-policy"
+description: |-
+  Provide access to a Resource Policy's attributes
+---
+
+# google\_compute\_resource\_policy
+
+Provide access to a Resource Policy's attributes. For more information see [the official documentation](https://cloud.google.com/compute/docs/disks/scheduled-snapshots) or the [API](https://cloud.google.com/compute/docs/reference/rest/beta/resourcePolicies).
+
+~> **Warning:** This datasource is in beta, and should be used with the terraform-provider-google-beta provider.
+See [Provider Versions](https://terraform.io/docs/providers/google/provider_versions.html) for more details on beta resources.
+
+```hcl
+provider "google-beta" {
+  region = "us-central1"
+  zone   = "us-central1-a"
+}
+
+data "google_compute_resource_policy" "daily" {
+  provider = "google-beta"
+  name     = "daily"
+  region   = "us-central1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` (Required) - The name of the Resource Policy.
+* `project` (Optional) - Project from which to list the Resource Policy. Defaults to project declared in the provider.
+* `region` (Required) - Region where the Resource Policy resides.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `description` - Description of this Resource Policy.
+* `self_link` - The URI of the resource.


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Hey,

I added a datasource for the `google_compute_resource_policy` resource. Tests are passing and the new datasource works as well with a local build. For example one can use:
```hcl
provider "google-beta" {
  project     = "<your-project-name>"
  region      = "europe-west1"
}

resource "google_compute_resource_policy" "foo" {
  provider = "google-beta"
  name = "policy"
  region = "europe-west1"
  snapshot_schedule_policy {
    schedule {
      daily_schedule {
        days_in_cycle = 1
        start_time = "04:00"
      }
    }
  }
}

data "google_compute_resource_policy" "daily" {
  provider = "google-beta"
  name     = "policy"
  region   = "europe-west1"
}

output "resource_policy" {
  value = data.google_compute_resource_policy.daily
}
```
Kind regards,
Jan


<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
Add datasource for google_compute_resource_policy
```
