### PR TITLE
gcp_storage_object: Check remote_object before operation

### DIFF
--- a/products/storage/helpers/ansible/object_template.erb
+++ b/products/storage/helpers/ansible/object_template.erb
@@ -63,7 +63,7 @@ def main():
         module.fail_json(msg="File does not exist on disk")
 
     # Check if we'll be overwriting files.
-    if not module.params['overwrite']:
+    if remote_object and not module.params['overwrite']:
         remote_object['changed'] = False
         if module.params['action'] == 'download' and local_file_exists:
             # If files differ, throw an error


### PR DESCRIPTION
Fixes: ansible/ansible#59372

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
gcp_storage_object: Check remote_object before performing upload or download operation (https://github.com/ansible/ansible/issues/59372).
```
