### PR TITLE
[ansible] removing state from facts examples

### DIFF
--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -107,9 +107,12 @@ module Provider
       private
 
       def build_task(state, hash, _object, noop = false)
+        code = compiled_code(@code, hash)
+        code = code.merge('state' => state) if state != 'facts'
+
         {
           'name' => message(state, @name, noop),
-          @name => compiled_code(@code, hash).merge('state' => state),
+          @name => code,
           'register' => @register
         }.reject { |_, v| v.nil? }
       end


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Upstreams + extends https://github.com/ansible/ansible/pull/59274 to all facts modules.

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
