### PR TITLE
Restrict forwarding rule IPAddress

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -472,6 +472,33 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       IPAddress: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validateIpAddress'
+        description: |
+          The IP address that this forwarding rule is serving on behalf of.
+
+          Addresses are restricted based on the forwarding rule's load balancing
+          scheme (EXTERNAL or INTERNAL) and scope (global or regional).
+
+          When the load balancing scheme is EXTERNAL, for global forwarding
+          rules, the address must be a global IP, and for regional forwarding
+          rules, the address must live in the same region as the forwarding
+          rule. If this field is empty, an ephemeral IPv4 address from the same
+          scope (global or regional) will be assigned. A regional forwarding
+          rule supports IPv4 only. A global forwarding rule supports either IPv4
+          or IPv6.
+
+          When the load balancing scheme is INTERNAL, this can only be an RFC
+          1918 IP address belonging to the network/subnet configured for the
+          forwarding rule. By default, if this field is empty, an ephemeral
+          internal IP address will be automatically allocated from the IP range
+          of the subnet or network configured for this forwarding rule.
+
+          An address must be specified by a literal IP address. ~> **NOTE**: While
+          the API allows you to specify various resource paths for an address resource
+          instead, Terraform requires this to specifically be an IP address to
+          avoid needing to fetching the IP address from resource paths on refresh
+          or unnecessary diffs.
       IPProtocol: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'caseDiffSuppress'
         default_from_api: true
@@ -546,6 +573,33 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         exclude: true
       IPAddress: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validateIpAddress'
+        description: |
+          The IP address that this forwarding rule is serving on behalf of.
+
+          Addresses are restricted based on the forwarding rule's load balancing
+          scheme (EXTERNAL or INTERNAL) and scope (global or regional).
+
+          When the load balancing scheme is EXTERNAL, for global forwarding
+          rules, the address must be a global IP, and for regional forwarding
+          rules, the address must live in the same region as the forwarding
+          rule. If this field is empty, an ephemeral IPv4 address from the same
+          scope (global or regional) will be assigned. A regional forwarding
+          rule supports IPv4 only. A global forwarding rule supports either IPv4
+          or IPv6.
+
+          When the load balancing scheme is INTERNAL, this can only be an RFC
+          1918 IP address belonging to the network/subnet configured for the
+          forwarding rule. By default, if this field is empty, an ephemeral
+          internal IP address will be automatically allocated from the IP range
+          of the subnet or network configured for this forwarding rule.
+
+          An address must be specified by a literal IP address. ~> **NOTE**: While
+          the API allows you to specify various resource paths for an address resource
+          instead, Terraform requires this to specifically be an IP address to
+          avoid needing to fetching the IP address from resource paths on refresh
+          or unnecessary diffs.
       IPProtocol: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'caseDiffSuppress'
         default_from_api: true

--- a/third_party/terraform/utils/validation.go
+++ b/third_party/terraform/utils/validation.go
@@ -241,7 +241,6 @@ func validateNonNegativeDuration() schema.SchemaValidateFunc {
 	}
 }
 
-
 func validateIpAddress(i interface{}, val string) ([]string, []error) {
 	ip := net.ParseIP(i.(string))
 	if ip == nil {

--- a/third_party/terraform/utils/validation.go
+++ b/third_party/terraform/utils/validation.go
@@ -241,6 +241,15 @@ func validateNonNegativeDuration() schema.SchemaValidateFunc {
 	}
 }
 
+
+func validateIpAddress(i interface{}, val string) ([]string, []error) {
+	ip := net.ParseIP(i.(string))
+	if ip == nil {
+		return nil, []error{fmt.Errorf("could not parse %q to IP address", val)}
+	}
+	return nil, nil
+}
+
 // StringNotInSlice returns a SchemaValidateFunc which tests if the provided value
 // is of type string and that it matches none of the element in the invalid slice.
 // if ignorecase is true, case is ignored.


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4072

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
`ip_address` for `google_compute_forwarding_rule` and `google_compute_global_forwarding_rule` now only accepts literal IP addresses (e.g. `126.0.0.1`) and will reject address self links in order to prevent permadiffs. 
```
