### PR TITLE
Cloud tasks (Ansible)

### DIFF
--- a/products/cloudtasks/ansible.yaml
+++ b/products/cloudtasks/ansible.yaml
@@ -20,7 +20,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   Queue: !ruby/object:Overrides::Ansible::ResourceOverride
     post_action: |
       if fetch:
-          instance = QueueStatus(module, fetch.get('status'))
+          instance = QueueStatus(module, fetch.get('state'))
           instance.run()
           if module.params.get('status'):
               fetch.update({'status': module.params['status']})

--- a/products/cloudtasks/ansible.yaml
+++ b/products/cloudtasks/ansible.yaml
@@ -1,0 +1,31 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Ansible::Config
+datasources: !ruby/object:Overrides::ResourceOverrides
+  Queue: !ruby/object:Overrides::Ansible::ResourceOverride
+    facts: !ruby/object:Provider::Ansible::FactsOverride
+      has_filters: false
+overrides: !ruby/object:Overrides::ResourceOverrides
+  Queue: !ruby/object:Overrides::Ansible::ResourceOverride
+    post_action: |
+      if fetch:
+          instance = QueueStatus(module, fetch.get('status'))
+          instance.run()
+          if module.params.get('status'):
+              fetch.update({'status': module.params['status']})
+    provider_helpers:
+      - 'products/cloudtasks/helpers/ansible/queue_status.py'
+files: !ruby/object:Provider::Config::Files
+  resource:
+<%= lines(indent(compile('provider/ansible/resource~compile.yaml'), 4)) -%>

--- a/products/cloudtasks/ansible_version_added.yaml
+++ b/products/cloudtasks/ansible_version_added.yaml
@@ -33,7 +33,7 @@
         :version_added: '2.9'
       :maxDoublings:
         :version_added: '2.9'
-    :state:
+    :status:
       :version_added: '2.9'
     :location:
       :version_added: '2.9'

--- a/products/cloudtasks/ansible_version_added.yaml
+++ b/products/cloudtasks/ansible_version_added.yaml
@@ -1,0 +1,39 @@
+---
+:facts:
+  :Queue:
+    :version_added: '2.9'
+:regular:
+  :Queue:
+    :version_added: '2.9'
+    :name:
+      :version_added: '2.9'
+    :appEngineRoutingOverride:
+      :version_added: '2.9'
+      :service:
+        :version_added: '2.9'
+      :version:
+        :version_added: '2.9'
+      :instance:
+        :version_added: '2.9'
+    :rateLimits:
+      :version_added: '2.9'
+      :maxDispatchesPerSecond:
+        :version_added: '2.9'
+      :maxConcurrentDispatches:
+        :version_added: '2.9'
+    :retryConfig:
+      :version_added: '2.9'
+      :maxAttempts:
+        :version_added: '2.9'
+      :maxRetryDuration:
+        :version_added: '2.9'
+      :minBackoff:
+        :version_added: '2.9'
+      :maxBackoff:
+        :version_added: '2.9'
+      :maxDoublings:
+        :version_added: '2.9'
+    :state:
+      :version_added: '2.9'
+    :location:
+      :version_added: '2.9'

--- a/products/cloudtasks/api.yaml
+++ b/products/cloudtasks/api.yaml
@@ -36,10 +36,15 @@ objects:
         # This is output-only in the API but we need to alter it in order to pause/resume the
         # task queue.
         output: false
+        description: The current state of the queue.
         values:
           - RUNNING
           - PAUSED
           - DISABLED
+      - !ruby/object:Api::Type::String
+        name: 'location'
+        required: true
+        description: The location of the queue
     properties:
       - !ruby/object:Api::Type::String
         name: 'name'

--- a/products/cloudtasks/api.yaml
+++ b/products/cloudtasks/api.yaml
@@ -1,0 +1,151 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: CloudTasks
+display_name: Cloud Tasks
+versions:
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://cloudtasks.googleapis.com/v2/
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: Cloud Tasks
+    url: https://console.cloud.google.com/apis/library/cloudtasks.googleapis.com/
+objects:
+  - !ruby/object:Api::Resource
+    name: 'Queue'
+    base_url: projects/{{project}}/locations/{{location}}/queues/
+    description: |
+      A named resource to which messages are sent by publishers.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: The queue name.
+        pattern: projects/{{project}}/locations/{{location}}/queues/{{name}}
+      - !ruby/object:Api::Type::NestedObject
+        name: appEngineRoutingOverride
+        description: |
+          Overrides for task-level appEngineRouting. These settings apply only
+          to App Engine tasks in this queue
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'service'
+            description: |
+              App service.
+
+              By default, the task is sent to the service which is the default service when the task is attempted.
+          - !ruby/object:Api::Type::String
+            name: 'version'
+            description: |
+              App version.
+
+              By default, the task is sent to the version which is the default version when the task is attempted.
+          - !ruby/object:Api::Type::String
+            name: 'instance'
+            description: |
+              App instance.
+
+              By default, the task is sent to an instance which is available when the task is attempted.
+          - !ruby/object:Api::Type::String
+            name: 'host'
+            output: true
+            description: The host that the task is sent to.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'rateLimits'
+        description: |
+          Rate limits for task dispatches. 
+
+          The queue's actual dispatch rate is the result of:
+
+          * Number of tasks in the queue
+          * User-specified throttling: rateLimits, retryConfig, and the queue's state.
+          * System throttling due to 429 (Too Many Requests) or 503 (Service
+            Unavailable) responses from the worker, high error rates, or to
+            smooth sudden large traffic spikes.
+        properties:
+          - !ruby/object:Api::Type::Integer
+            name: 'maxDispatchesPerSecond'
+            description: |
+              The maximum rate at which tasks are dispatched from this queue.
+
+              If unspecified when the queue is created, Cloud Tasks will pick the default.
+          - !ruby/object:Api::Type::Integer
+            name: 'maxConcurrentDispatches'
+            description: |
+              The maximum number of concurrent tasks that Cloud Tasks allows to
+              be dispatched for this queue. After this threshold has been
+              reached, Cloud Tasks stops dispatching tasks until the number of
+              concurrent requests decreases.
+          - !ruby/object:Api::Type::Integer
+            name: 'maxBurstSize'
+            output: true
+            description: |
+              The max burst size.
+
+              Max burst size limits how fast tasks in queue are processed when many tasks are
+              in the queue and the rate is high. This field allows the queue to have a high
+              rate so processing starts shortly after a task is enqueued, but still limits
+              resource usage when many tasks are enqueued in a short period of time.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'retryConfig'
+        description: Settings that determine the retry behavior.
+        properties:
+          - !ruby/object:Api::Type::Integer
+            name: 'maxAttempts'
+            description: |
+              Number of attempts per task.
+
+              Cloud Tasks will attempt the task maxAttempts times (that is, if
+              the first attempt fails, then there will be maxAttempts - 1
+              retries). Must be >= -1.
+
+              If unspecified when the queue is created, Cloud Tasks will pick
+              the default.
+
+              -1 indicates unlimited attempts.
+          - !ruby/object:Api::Type::String
+            name: maxRetryDuration
+            description: |
+              If positive, maxRetryDuration specifies the time limit for
+              retrying a failed task, measured from when the task was first
+              attempted. Once maxRetryDuration time has passed and the task has
+              been attempted maxAttempts times, no further attempts will be
+              made and the task will be deleted.
+
+              If zero, then the task age is unlimited.
+          - !ruby/object:Api::Type::String
+            name: 'minBackoff'
+            description: |
+              A task will be scheduled for retry between minBackoff and
+              maxBackoff duration after it fails, if the queue's RetryConfig
+              specifies that the task should be retried.
+          - !ruby/object:Api::Type::String
+            name: 'maxBackoff'
+            description: |
+              A task will be scheduled for retry between minBackoff and
+              maxBackoff duration after it fails, if the queue's RetryConfig
+              specifies that the task should be retried.
+          - !ruby/object:Api::Type::Integer
+            name: 'maxDoublings'
+            description: |
+              The time between retries will double maxDoublings times.
+
+              A task's retry interval starts at minBackoff, then doubles maxDoublings times,
+              then increases linearly, and finally retries retries at intervals of maxBackoff
+              up to maxAttempts times.
+      - !ruby/object:Api::Type::NestedObject
+
+

--- a/products/cloudtasks/api.yaml
+++ b/products/cloudtasks/api.yaml
@@ -27,12 +27,13 @@ apis_required:
 objects:
   - !ruby/object:Api::Resource
     name: 'Queue'
-    base_url: projects/{{project}}/locations/{{location}}/queues/
+    base_url: projects/{{project}}/locations/{{location}}/queues
     description: |
       A named resource to which messages are sent by publishers.
     parameters:
       - !ruby/object:Api::Type::Enum
-        name: 'state'
+        name: 'status'
+        api_name: 'state'
         # This is output-only in the API but we need to alter it in order to pause/resume the
         # task queue.
         output: false

--- a/products/cloudtasks/api.yaml
+++ b/products/cloudtasks/api.yaml
@@ -30,6 +30,16 @@ objects:
     base_url: projects/{{project}}/locations/{{location}}/queues/
     description: |
       A named resource to which messages are sent by publishers.
+    parameters:
+      - !ruby/object:Api::Type::Enum
+        name: 'state'
+        # This is output-only in the API but we need to alter it in order to pause/resume the
+        # task queue.
+        output: false
+        values:
+          - RUNNING
+          - PAUSED
+          - DISABLED
     properties:
       - !ruby/object:Api::Type::String
         name: 'name'
@@ -146,6 +156,10 @@ objects:
               A task's retry interval starts at minBackoff, then doubles maxDoublings times,
               then increases linearly, and finally retries retries at intervals of maxBackoff
               up to maxAttempts times.
-      - !ruby/object:Api::Type::NestedObject
+          - !ruby/object:Api::Type::Time
+            name: 'purgeTime'
+            output: true
+            description: The last time this queue was purged.
+
 
 

--- a/products/cloudtasks/examples/ansible/queue.yaml
+++ b/products/cloudtasks/examples/ansible/queue.yaml
@@ -1,0 +1,21 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- !ruby/object:Provider::Ansible::Example
+task: !ruby/object:Provider::Ansible::Task
+  name: gcp_cloudtasks_queue
+  code:
+    name: <%= ctx[:name] %>
+    location: us-central1
+    project: <%= ctx[:project] %>
+    auth_kind: <%= ctx[:auth_kind] %>
+    service_account_file: <%= ctx[:service_account_file] %>

--- a/products/cloudtasks/helpers/ansible/queue_status.py
+++ b/products/cloudtasks/helpers/ansible/queue_status.py
@@ -14,9 +14,9 @@ class QueueStatus(object):
         if GcpRequest({'status': self.current_status}) == GcpRequest({'status': self.desired_status}):
             return
         elif self.desired_status == 'PAUSED':
-            self.start()
-        elif self.desired_status == 'RUNNING':
             self.stop()
+        elif self.desired_status == 'RUNNING':
+            self.start()
 
     def start(self):
         auth = GcpSession(self.module, 'cloudtasks')
@@ -27,7 +27,7 @@ class QueueStatus(object):
         return_if_object(self.module, auth.post(self._stop_url()))
 
     def _start_url(self):
-        return "https://www.googleapis.com/compute/v1/projects/{project}/locations/{location}/queue/{name}/resume".format(**self.module.params)
+        return "https://cloudtasks.googleapis.com/v2/projects/{project}/locations/{location}/queues/{name}:resume".format(**self.module.params)
 
     def _stop_url(self):
-        return "https://www.googleapis.com/compute/v1/projects/{project}/locations/{location}/queue/{name}/pause".format(**self.module.params)
+        return "https://cloudtasks.googleapis.com/v2/projects/{project}/locations/{location}/queues/{name}:pause".format(**self.module.params)

--- a/products/cloudtasks/helpers/ansible/queue_status.py
+++ b/products/cloudtasks/helpers/ansible/queue_status.py
@@ -1,0 +1,33 @@
+<%
+# Queue Pause/Resume logic
+# This code handles the turning a queue on/off depending on user input.
+# It should be run after all normal create/update/delete logic.
+-%>
+class QueueStatus(object):
+    def __init__(self, module, current_status):
+        self.module = module
+        self.current_status = current_status
+        self.desired_status = self.module.params.get('status')
+
+    def run(self):
+        # GcpRequest handles unicode text handling
+        if GcpRequest({'status': self.current_status}) == GcpRequest({'status': self.desired_status}):
+            return
+        elif self.desired_status == 'PAUSED':
+            self.start()
+        elif self.desired_status == 'RUNNING':
+            self.stop()
+
+    def start(self):
+        auth = GcpSession(self.module, 'cloudtasks')
+        return_if_object(self.module, auth.post(self._start_url()))
+
+    def stop(self):
+        auth = GcpSession(self.module, 'cloudtasks')
+        return_if_object(self.module, auth.post(self._stop_url()))
+
+    def _start_url(self):
+        return "https://www.googleapis.com/compute/v1/projects/{project}/locations/{location}/queue/{name}/resume".format(**self.module.params)
+
+    def _stop_url(self):
+        return "https://www.googleapis.com/compute/v1/projects/{project}/locations/{location}/queue/{name}/pause".format(**self.module.params)


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
This is support for Cloud Task Queues on Ansible.

One thing I'm questioning:

Queues can be 'purged' by hitting the `purge` endpoint. We could purge queues in the same way we start/stop the queue (alter the status). It's not very idempotent though. If you purge something once, on every single re-run, it'll purge the queue again. Probably not the intended use-case.

Right now, I'm leaning towards just not supporting purging. Thoughts?

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
