### PR TITLE
Allow updating workload identity in GKE clusters

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -730,13 +730,11 @@ func resourceContainerCluster() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
-				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"identity_namespace": {
 							Type:     schema.TypeString,
 							Required: true,
-							ForceNew: true,
 						},
 					},
 				},
@@ -1847,6 +1845,35 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			d.SetPartial("vertical_pod_autoscaling")
 		}
 	}
+
+	if d.HasChange("workload_identity_config") {
+		// Because GKE uses a non-RESTful update function, when removing the
+		// feature you need to specify a fairly full request body or it fails:
+		// "update": {"desiredWorkloadIdentityConfig": {"identityNamespace": ""}}
+		req := &containerBeta.UpdateClusterRequest{}
+		if v, ok := d.GetOk("workload_identity_config"); !ok {
+			req.Update = &containerBeta.ClusterUpdate{
+				DesiredWorkloadIdentityConfig: &containerBeta.WorkloadIdentityConfig{
+					IdentityNamespace: "",
+					ForceSendFields:   []string{"IdentityNamespace"},
+				},
+			}
+		} else {
+			req.Update = &containerBeta.ClusterUpdate{
+				DesiredWorkloadIdentityConfig: expandWorkloadIdentityConfig(v),
+			}
+		}
+
+		updateF := updateFunc(req, "updating GKE cluster workload identity config")
+		// Call update serially.
+		if err := lockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s workload identity config has been updated", d.Id())
+
+		d.SetPartial("workload_identity_config")
+	}
 <% end -%>
 
 	if d.HasChange("resource_labels") {
@@ -2327,7 +2354,7 @@ func expandVerticalPodAutoscaling(configured interface{}) *containerBeta.Vertica
 
 func expandWorkloadIdentityConfig(configured interface{}) *containerBeta.WorkloadIdentityConfig {
 	l := configured.([]interface{})
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 	config := l[0].(map[string]interface{})

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1330,6 +1330,33 @@ func TestAccContainerCluster_withWorkloadIdentityConfig(t *testing.T) {
 				ImportState:         true,
 				ImportStateVerify:   true,
 			},
+			{
+				Config: testAccContainerCluster_updateWorkloadMetadataConfig(pid, clusterName, "SECURE"),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_workload_identity_config",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+			{
+				Config: testAccContainerCluster_updateWorkloadIdentityConfig(pid, clusterName, false),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_workload_identity_config",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+			{
+				Config: testAccContainerCluster_updateWorkloadIdentityConfig(pid, clusterName, true),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_workload_identity_config",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
 		},
 	})
 
@@ -2248,6 +2275,30 @@ resource "google_container_cluster" "with_workload_metadata_config" {
 `, acctest.RandString(10))
 }
 
+func testAccContainerCluster_updateWorkloadMetadataConfig(projectID string, clusterName string, workloadMetadataConfig string) string {
+	return fmt.Sprintf(`
+data "google_project" "project" {
+	project_id = "%s"
+}
+
+resource "google_container_cluster" "with_workload_identity_config" {
+	name = "%s"
+	zone = "us-central1-a"
+	initial_node_count = 1
+
+  node_config {
+		oauth_scopes = [
+			"https://www.googleapis.com/auth/logging.write",
+			"https://www.googleapis.com/auth/monitoring"
+		]
+
+		workload_metadata_config {
+			node_metadata = "%s"
+		}
+  }
+}`, projectID, clusterName, workloadMetadataConfig)
+}
+
 func testAccContainerCluster_withSandboxConfig() string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
@@ -2971,6 +3022,28 @@ resource "google_container_cluster" "with_workload_identity_config" {
 	}
 }
 `, projectID, clusterName)
+}
+
+func testAccContainerCluster_updateWorkloadIdentityConfig(projectID string, clusterName string, enable bool) string {
+	workloadIdentityConfig := ""
+	if enable {
+		workloadIdentityConfig = `
+			workload_identity_config {
+			identity_namespace = "${data.google_project.project.project_id}.svc.id.goog"
+		}`
+	}
+	return fmt.Sprintf(`
+data "google_project" "project" {
+	project_id = "%s"
+}
+
+resource "google_container_cluster" "with_workload_identity_config" {
+	name = "%s"
+	zone = "us-central1-a"
+	initial_node_count = 1
+
+	%s
+}`, projectID, clusterName, workloadIdentityConfig)
 }
 
 func testAccContainerCluster_withBinaryAuthorization(clusterName string, enabled bool) string {


### PR DESCRIPTION
Upstreams https://github.com/terraform-providers/terraform-provider-google-beta/pull/896

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
container: `workload_identity_config` in `google_container_cluster` can now be updated without recreating the cluster.
```
