### PR TITLE
Binary Authorization: globalPolicyEvaluationMode

### DIFF
--- a/products/binaryauthorization/api.yaml
+++ b/products/binaryauthorization/api.yaml
@@ -155,6 +155,15 @@ objects:
       - !ruby/object:Api::Type::String
         name: description
         description: A descriptive comment.
+      - !ruby/object:Api::Type::Enum
+        name: globalPolicyEvaluationMode
+        description: |
+          Controls the evaluation of a Google-maintained global admission policy
+          for common system-level images. Images not covered by the global
+          policy will be subject to the project admission policy.
+        values:
+          - :ENABLE
+          - :DISABLE
       - !ruby/object:Api::Type::Array
         name: admissionWhitelistPatterns
         description: |

--- a/products/binaryauthorization/terraform.yaml
+++ b/products/binaryauthorization/terraform.yaml
@@ -63,7 +63,16 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       vars:
         attestor_name: "test-attestor"
         note_name: "test-attestor-note"
+     - !ruby/object:Provider::Terraform::Examples
+      name: "binary_authorization_policy_global_evaluation"
+      primary_resource_id: "policy"
+      skip_test: true
+      vars:
+        attestor_name: "test-attestor"
+        note_name: "test-attestor-note"
     properties:
+      globalPolicyEvaluationMode: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       clusterAdmissionRules: !ruby/object:Overrides::Terraform::PropertyOverride
         is_set: true
         set_hash_func: |-

--- a/templates/terraform/examples/binary_authorization_policy_global_evaluation.tf.erb
+++ b/templates/terraform/examples/binary_authorization_policy_global_evaluation.tf.erb
@@ -1,0 +1,27 @@
+resource "google_binary_authorization_policy" "<%= ctx[:primary_resource_id] %>" {
+
+  default_admission_rule {
+    evaluation_mode = "REQUIRE_ATTESTATION"
+    enforcement_mode = "ENFORCED_BLOCK_AND_AUDIT_LOG"
+    require_attestations_by = ["${google_binary_authorization_attestor.attestor.name}"]
+  }
+
+  global_policy_evaluation_mode = "ENABLE"
+
+}
+
+resource "google_container_analysis_note" "note" {
+  name = "<%= ctx[:vars]["note_name"] %>"
+  attestation_authority {
+    hint {
+      human_readable_name = "My attestor"
+    }
+  }
+}
+
+resource "google_binary_authorization_attestor" "attestor" {
+  name = "<%= ctx[:vars]["attestor_name"] %>"
+  attestation_authority_note {
+    note_reference = "${google_container_analysis_note.note.name}"
+  }
+}

--- a/third_party/terraform/tests/resource_binaryauthorization_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_binaryauthorization_policy_test.go.erb
@@ -39,7 +39,6 @@ func TestAccBinaryAuthorizationPolicy_basic(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccBinaryAuthorizationPolicy_full(t *testing.T) {
 	t.Parallel()
 
@@ -54,7 +53,7 @@ func TestAccBinaryAuthorizationPolicy_full(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBinaryAuthorizationPolicyFull(pid, pname, org, billingId, note, attestor),
+				Config: testAccBinaryAuthorizationPolicyFull(pid, pname, org, billingId, note, attestor, "DISABLE"),
 			},
 			{
 				ResourceName:      "google_binary_authorization_policy.policy",
@@ -125,7 +124,15 @@ func TestAccBinaryAuthorizationPolicy_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBinaryAuthorizationPolicyFull(pid, pname, org, billingId, note, attestor),
+				Config: testAccBinaryAuthorizationPolicyFull(pid, pname, org, billingId, note, attestor, "DISABLE"),
+			},
+			{
+				ResourceName:      "google_binary_authorization_policy.policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBinaryAuthorizationPolicyFull(pid, pname, org, billingId, note, attestor, "ENABLE"),
 			},
 			{
 				ResourceName:      "google_binary_authorization_policy.policy",
@@ -149,12 +156,7 @@ func TestAccBinaryAuthorizationPolicy_update(t *testing.T) {
 		},
 	})
 }
-<% else -%>
 
-// Because Container Analysis is still in beta, we can't run any of the tests that call that
-// resource without vendoring in the full beta provider.
-
-<% end -%>
 func testAccCheckBinaryAuthorizationPolicyDefault(pid string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
@@ -210,8 +212,7 @@ resource "google_binary_authorization_policy" "policy" {
 `, pid, pname, org, billing)
 }
 
-<% unless version == 'ga' -%>
-func testAccBinaryAuthorizationPolicyFull(pid, pname, org, billing, note, attestor string) string {
+func testAccBinaryAuthorizationPolicyFull(pid, pname, org, billing, note, attestor, gpmode string) string {
 	return fmt.Sprintf(`
 // Use a separate project since each project can only have one policy
 resource "google_project" "project" {
@@ -269,8 +270,10 @@ resource "google_binary_authorization_policy" "policy" {
     enforcement_mode = "ENFORCED_BLOCK_AND_AUDIT_LOG"
     require_attestations_by = ["${google_binary_authorization_attestor.attestor.name}"]
   }
+
+  global_policy_evaluation mode = "%s"
 }
-`, pid, pname, org, billing, note, attestor)
+`, pid, pname, org, billing, note, attestor, gpmode)
 }
 
 func testAccBinaryAuthorizationPolicy_separateProject(pid, pname, org, billing, note, attestor string) string {
@@ -334,5 +337,3 @@ resource "google_binary_authorization_policy" "policy" {
 }
 `, pid, pname, org, billing, note, attestor)
 }
-
-<% end -%>

--- a/third_party/terraform/tests/resource_binaryauthorization_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_binaryauthorization_policy_test.go.erb
@@ -39,6 +39,7 @@ func TestAccBinaryAuthorizationPolicy_basic(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
 func TestAccBinaryAuthorizationPolicy_full(t *testing.T) {
 	t.Parallel()
 
@@ -53,7 +54,7 @@ func TestAccBinaryAuthorizationPolicy_full(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBinaryAuthorizationPolicyFull(pid, pname, org, billingId, note, attestor, "DISABLE"),
+				Config: testAccBinaryAuthorizationPolicyFull(pid, pname, org, billingId, note, attestor, "ENABLE"),
 			},
 			{
 				ResourceName:      "google_binary_authorization_policy.policy",
@@ -124,7 +125,7 @@ func TestAccBinaryAuthorizationPolicy_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBinaryAuthorizationPolicyFull(pid, pname, org, billingId, note, attestor, "DISABLE"),
+				Config: testAccBinaryAuthorizationPolicyFull(pid, pname, org, billingId, note, attestor, "ENABLE"),
 			},
 			{
 				ResourceName:      "google_binary_authorization_policy.policy",
@@ -132,7 +133,7 @@ func TestAccBinaryAuthorizationPolicy_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBinaryAuthorizationPolicyFull(pid, pname, org, billingId, note, attestor, "ENABLE"),
+				Config: testAccBinaryAuthorizationPolicyFull(pid, pname, org, billingId, note, attestor, "DISABLE"),
 			},
 			{
 				ResourceName:      "google_binary_authorization_policy.policy",
@@ -156,7 +157,12 @@ func TestAccBinaryAuthorizationPolicy_update(t *testing.T) {
 		},
 	})
 }
+<% else -%>
 
+// Because Container Analysis is still in beta, we can't run any of the tests that call that
+// resource without vendoring in the full beta provider.
+
+<% end -%>
 func testAccCheckBinaryAuthorizationPolicyDefault(pid string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
@@ -212,6 +218,7 @@ resource "google_binary_authorization_policy" "policy" {
 `, pid, pname, org, billing)
 }
 
+<% unless version == 'ga' -%>
 func testAccBinaryAuthorizationPolicyFull(pid, pname, org, billing, note, attestor, gpmode string) string {
 	return fmt.Sprintf(`
 // Use a separate project since each project can only have one policy
@@ -271,7 +278,7 @@ resource "google_binary_authorization_policy" "policy" {
     require_attestations_by = ["${google_binary_authorization_attestor.attestor.name}"]
   }
 
-  global_policy_evaluation mode = "%s"
+  global_policy_evaluation_mode = "%s"
 }
 `, pid, pname, org, billing, note, attestor, gpmode)
 }
@@ -337,3 +344,5 @@ resource "google_binary_authorization_policy" "policy" {
 }
 `, pid, pname, org, billing, note, attestor)
 }
+
+<% end -%>


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
Adds `globalPolicyEvaluationMode` to `google_binary_authorization_policy`.
```

Fixes terraform-providers/terraform-provider-google#4104