### PR TITLE
Allow the use of region selflinks in provider configs.

### DIFF
--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -564,6 +564,7 @@ func (c *Config) LoadAndValidate() error {
 	c.clientHealthcare.BasePath = healthcareClientBasePath
 	<% end -%>
 
+	c.Region = GetRegionFromRegionSelfLink(c.Region)
 	return nil
 }
 

--- a/third_party/terraform/utils/self_link_helpers.go
+++ b/third_party/terraform/utils/self_link_helpers.go
@@ -145,3 +145,15 @@ func GetLocationalResourcePropertiesFromSelfLinkString(selfLink string) (string,
 	s := strings.Split(parsed.Path, "/")
 	return s[4], s[6], s[8], nil
 }
+
+// return the region a selfLink is referring to
+func GetRegionFromRegionSelfLink(selfLink string) string {
+	re := regexp.MustCompile("/compute/[a-zA-Z0-9]*/projects/[a-zA-Z0-9-]*/regions/([a-zA-Z0-9-]*)")
+	switch {
+	case re.MatchString(selfLink):
+		if res := re.FindStringSubmatch(selfLink); len(res) == 2 && res[1] != "" {
+			return res[1]
+		}
+	}
+	return selfLink
+}

--- a/third_party/terraform/utils/self_link_helpers_test.go
+++ b/third_party/terraform/utils/self_link_helpers_test.go
@@ -110,3 +110,15 @@ func TestSelfLinkNameHash(t *testing.T) {
 		}
 	}
 }
+
+func TestGetRegionFromRegionSelfLink(t *testing.T) {
+	cases := map[string]string{
+		"https://www.googleapis.com/compute/v1/projects/test/regions/europe-west3": "europe-west3",
+		"europe-west3": "europe-west3",
+	}
+	for input, expected := range cases {
+		if result := GetRegionFromRegionSelfLink(input); result != expected {
+			t.Errorf("expected to get %q from %q, got %q", expected, input, result)
+		}
+	}
+}


### PR DESCRIPTION
When configuring the provider, currently we only accept the name of a
region. As per terraform-providers/terraform-provider-google#4133, being
able to use self_links for regions here would be helpful. I added a
utility function to pull the region's name from a self_link, tests for
that behavior, and then used it when setting up our Config object. It'll
either return what the user passed in, or if it recognizes it as a
region self_link, it'll just return the name part of the region. I also
left it open to expand on potentially more formats in the future.

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
provider: allow provider's region to be specified as a self_link
```
