### PR TITLE
[ansible] adding type info for facts filter

### DIFF
--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -34,7 +34,8 @@ DOCUMENTATION = '''
   'options' => [
     ({
       object.facts.filter.name.underscore => {
-        'description' => format_description(object.facts.filter.description)
+        'description' => format_description(object.facts.filter.description),
+        'type' => python_type(object.facts.filter)
       }
     } if object.facts.has_filters),
     uri_props.map { |p| documentation_for_property(p) }


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Yep, more of this stuff again.

The 'facts' modules all have documentation exceptions because the filters field is missing type information in the documentation. Time to fix that!

These are frustrating because I have permission to commit the fixes, but not permission to turn off the warnings (which means I have to wait for an Ansible core member to merge the upstream PRs)

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
