### PR TITLE
Changes to info->facts module rename

### DIFF
--- a/.ci/magic-modules/generate-ansible.sh
+++ b/.ci/magic-modules/generate-ansible.sh
@@ -15,7 +15,6 @@ COMMIT_AUTHOR="$(git log --pretty="%an <%ae>" -n1 HEAD)"
 
 # Remove all modules so that old files are removed in process.
 rm build/ansible/lib/ansible/modules/cloud/google/gcp_*
-rm build/ansible/lib/ansible/modules/cloud/google/*facts
 
 bundle exec compiler -a -e ansible -o "build/ansible/"
 

--- a/.ci/magic-modules/generate-ansible.sh
+++ b/.ci/magic-modules/generate-ansible.sh
@@ -15,6 +15,7 @@ COMMIT_AUTHOR="$(git log --pretty="%an <%ae>" -n1 HEAD)"
 
 # Remove all modules so that old files are removed in process.
 rm build/ansible/lib/ansible/modules/cloud/google/gcp_*
+rm build/ansible/lib/ansible/modules/cloud/google/*facts
 
 bundle exec compiler -a -e ansible -o "build/ansible/"
 

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -287,7 +287,7 @@ module Provider
                       self)
 
         # Generate symlink for old `facts` modules.
-        return if version_added(data.object, :facts) < '2.9'
+        return if version_added(data.object, :facts) >= '2.9'
 
         deprecated_facts_path = File.join(target_folder,
                                           "lib/ansible/modules/cloud/google/_#{name}_facts.py")

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -287,6 +287,8 @@ module Provider
                       self)
 
         # Generate symlink for old `facts` modules.
+        return if data.object.version_added.to_f >= 2.9
+
         deprecated_facts_path = File.join(target_folder,
                                           "lib/ansible/modules/cloud/google/_#{name}_facts.py")
         return if File.exist?(deprecated_facts_path)

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -287,7 +287,7 @@ module Provider
                       self)
 
         # Generate symlink for old `facts` modules.
-        return if data.object.version_added.to_f >= 2.9
+        return if version_added(data.object, :facts) < '2.9'
 
         deprecated_facts_path = File.join(target_folder,
                                           "lib/ansible/modules/cloud/google/_#{name}_facts.py")

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -132,7 +132,7 @@ module Provider
                   end
           "#{verb} a #{object_name_from_module_name(name)}#{again}"
         else
-          "get info on a #{object_name_from_module_name(name)}" 
+          "get info on a #{object_name_from_module_name(name)}"
         end
       end
 

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -150,7 +150,7 @@ module Provider
 
       def object_name_from_module_name(mod_name)
         product_name = mod_name.match(/gcp_[a-z]*_(.*)/).captures.first
-        product_name.tr('_', ' ')
+        product_name.gsub('_info', '').tr('_', ' ')
       end
 
       def dependency_name(dependency, resource)

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -118,18 +118,22 @@ module Provider
       end
 
       def message(state, name, noop)
-        verb = {
-          present: 'create',
-          absent: 'delete'
-        }[state.to_sym]
-        again = if noop && state == 'present'
-                  ' that already exists'
-                elsif noop && state == 'absent'
-                  ' that does not exist'
-                else
-                  ''
-                end
-        "#{verb} a #{object_name_from_module_name(name)}#{again}"
+        if state != 'facts'
+          verb = {
+            present: 'create',
+            absent: 'delete'
+          }[state.to_sym]
+          again = if noop && state == 'present'
+                    ' that already exists'
+                  elsif noop && state == 'absent'
+                    ' that does not exist'
+                  else
+                    ''
+                  end
+          "#{verb} a #{object_name_from_module_name(name)}#{again}"
+        else
+          "get info on a #{object_name_from_module_name(name)}" 
+        end
       end
 
       def compiled_code(code, hash)

--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -27,7 +27,7 @@ DOCUMENTATION = '''
 <%= ansible_style_yaml({
   'module' => "#{module_name(object)}_info",
   'description' => ["Gather info for GCP #{object.name}",
-                    (version_added(object, :facts) < '2.9' ? "This module was previously called #{module_name(object)}_facts before Ansible 2.9. The usage has not changed" : nil)
+                    (version_added(object, :facts) < '2.9' ? "This module was called C({{ old_name }}) before Ansible 2.9. The usage has not changed." : nil)
                    ].compact,
   'short_description' => "Gather info for GCP #{object.name}",
   'version_added' => version_added(object, :facts).to_f,

--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -27,7 +27,7 @@ DOCUMENTATION = '''
 <%= ansible_style_yaml({
   'module' => "#{module_name(object)}_info",
   'description' => ["Gather info for GCP #{object.name}",
-                    (version_added(object, :facts) < '2.9' ? "This module was called C({{ old_name }}) before Ansible 2.9. The usage has not changed." : nil)
+                    (version_added(object, :facts) < '2.9' ? "This module was called C(#{module_name(object)}_facts) before Ansible 2.9. The usage has not changed." : nil)
                    ].compact,
   'short_description' => "Gather info for GCP #{object.name}",
   'version_added' => version_added(object, :facts).to_f,


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
In response to https://github.com/ansible/ansible/pull/60172, the Ansible core folks had some suggestions for the facts->info rename.

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
