### PR TITLE
have the magician tag a reviewer for external PRs

### DIFF
--- a/.ci/magic-modules/welcome-contributor.sh
+++ b/.ci/magic-modules/welcome-contributor.sh
@@ -11,7 +11,7 @@ I have detected that you are a community contributor, so your PR will be assigne
 
 Thanks for your contribution!  A human will be with you soon.
 
-$ASSIGNEE, please review this PR or find an appropriate assignee.
+@$ASSIGNEE, please review this PR or find an appropriate assignee.
 EOF
 
 # Something is preventing the magician from actually assigning the PRs.

--- a/.ci/magic-modules/welcome-contributor.sh
+++ b/.ci/magic-modules/welcome-contributor.sh
@@ -2,14 +2,20 @@
 
 set -x
 
+ASSIGNEE=$(shuf -n 1 <(printf "danawillow\nrambleraptor\nemilymye\nrileykarson\nSirGitsalot\nslevenick\ntysen"))
+
 cat > comment/pr_comment << EOF
 Hello!  I am a robot who works on Magic Modules PRs.
 
 I have detected that you are a community contributor, so your PR will be assigned to someone with a commit-bit on this repo for initial review.  They will authorize it to run through our CI pipeline, which will generate downstream PRs.
 
 Thanks for your contribution!  A human will be with you soon.
+
+$ASSIGNEE, please review this PR or find an appropriate assignee.
 EOF
 
-shuf -n 1 <(printf "danawillow\nrambleraptor\nchrisst\nrileykarson\nSirGitsalot\nslevenick\ntysen") > comment/assignee
-
+# Something is preventing the magician from actually assigning the PRs.
+# Leave this part in so we know what was supposed to happen, but the real
+# logic is above.
+echo $ASSIGNEE > comment/assignee
 cat comment/assignee


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
This was easier than trying to figure out the actual problem, and almost as good.
<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
