### PR TITLE
[ansible] Backport doc changes from facts->info change

### DIFF
--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -154,10 +154,10 @@ module Provider
       end
 
       def object_name_from_module_name(mod_name)
-        words_to_capitalize = %w[https http tcp ssl]
+        words_to_capitalize = %w[https http tcp ssl url]
         product_name = mod_name.match(/gcp_[a-z]*_(.*)/).captures.first
-        product_name.gsub('_info', '').tr('_', ' ')
-        words_to_capitalize.each { |w| product_name.gsub(w, w.upcase) }
+        product_name = product_name.gsub('_info', '').tr('_', ' ')
+        words_to_capitalize.each { |w| product_name.gsub!(w, w.upcase) }
         product_name
       end
 

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -150,6 +150,8 @@ module Provider
       end
 
       def a_or_an(item_name)
+        words_to_use_a = %w[user]
+        return 'a' if words_to_use_a.include?(item_name.split(' ').first)
         %w[a e i o u].include?(item_name[0].downcase) ? 'an' : 'a'
       end
 

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -132,7 +132,8 @@ module Provider
                   end
           "#{verb} a #{object_name_from_module_name(name)}#{again}"
         else
-          "get info on a #{object_name_from_module_name(name)}"
+          item_name = object_name_from_module_name(name)
+          "get info on #{a_or_an(item_name)} #{item_name}"
         end
       end
 
@@ -148,9 +149,16 @@ module Provider
         end
       end
 
+      def a_or_an(item_name)
+        %w[a e i o u].include?(item_name[0].downcase) ? 'an' : 'a'
+      end
+
       def object_name_from_module_name(mod_name)
+        words_to_capitalize = %w[https http tcp ssl]
         product_name = mod_name.match(/gcp_[a-z]*_(.*)/).captures.first
         product_name.gsub('_info', '').tr('_', ' ')
+        words_to_capitalize.each { |w| product_name.gsub(w, w.upcase) }
+        product_name
       end
 
       def dependency_name(dependency, resource)

--- a/provider/ansible/example.rb
+++ b/provider/ansible/example.rb
@@ -152,6 +152,7 @@ module Provider
       def a_or_an(item_name)
         words_to_use_a = %w[user]
         return 'a' if words_to_use_a.include?(item_name.split(' ').first)
+
         %w[a e i o u].include?(item_name[0].downcase) ? 'an' : 'a'
       end
 


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
As part of the [PR](https://github.com/ansible/ansible/pull/60172) to rename the facts modules to info modules, Ansible had some suggestions on doc changes. I made those changes in that PR to speed up the merge process.

The changes were entirely:

* Use a/an properly
* Capitalize protocol names (HTTP, HTTPS, TCP, SSL)

This backports those changes.

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
