### PR TITLE
add support for user project overrides

### DIFF
--- a/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/templates/terraform/examples/base_configs/test_file.go.erb
@@ -123,7 +123,7 @@ func testAccCheck<%= resource_name -%>Destroy(s *terraform.State) error {
 		return err
 	}
 
-	_, err = sendRequest(config, "<%= object.read_verb.to_s.upcase -%>", url, nil)
+	_, err = sendRequest(config, "<%= object.read_verb.to_s.upcase -%>", "", url, nil)
 	if err == nil {
 			return fmt.Errorf("<%= resource_name -%> still exists at %s", url)
 		}

--- a/templates/terraform/iam_policy.go.erb
+++ b/templates/terraform/iam_policy.go.erb
@@ -115,7 +115,14 @@ func <%= resource_name -%>IdParseFunc(d *schema.ResourceData, config *Config) er
 func (u *<%= resource_name -%>IamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Policy, error) {
 	url := u.qualify<%= object.name -%>Url("getIamPolicy")
 
-	policy, err := sendRequest(u.Config, "GET", url, nil)
+<% if resource_params.include?('project') -%>
+	project, err := getProject(u.d, u.Config)
+	if err != nil {
+		return nil, err
+	}
+<% end -%>
+
+	policy, err := sendRequest(u.Config, "GET", <% if resource_params.include?('project')  %>project<% else %>""<% end %>, url, nil)
 	if err != nil {
 		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}
@@ -140,7 +147,14 @@ func (u *<%= resource_name -%>IamUpdater) SetResourceIamPolicy(policy *cloudreso
 
 	url := u.qualify<%= object.name -%>Url("setIamPolicy")
 	
-	_, err = sendRequestWithTimeout(u.Config, "POST", url, obj, u.d.Timeout(schema.TimeoutCreate))
+<% if resource_params.include?('project') -%>
+	project, err := getProject(u.d, u.Config)
+	if err != nil {
+		return err
+	}
+<% end -%>
+
+	_, err = sendRequestWithTimeout(u.Config, "POST", <% if resource_params.include?('project')  %>project<% else %>""<% end %>, url, obj, u.d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return errwrap.Wrapf(fmt.Sprintf("Error setting IAM policy for %s: {{err}}", u.DescribeResource()), err)
 	}

--- a/templates/terraform/operation.go.erb
+++ b/templates/terraform/operation.go.erb
@@ -11,6 +11,9 @@ import (
 
 type <%= product_name -%>OperationWaiter struct {
   Config *Config
+<% if has_project -%>
+  Project string
+<% end -%>
   CommonOperationWaiter
 }
 
@@ -20,7 +23,7 @@ func (w *<%= product_name -%>OperationWaiter) QueryOp() (interface{}, error) {
   }
   // Returns the proper get.
   url := fmt.Sprintf("<%= [object.__product.base_url, async.operation.base_url].flatten.join.gsub('{{op_id}}', '%s') -%>", w.CommonOperationWaiter.Op.Name)
-  return sendRequest(w.Config, "GET", url, nil)
+  return sendRequest(w.Config, "GET", <% if has_project %>w.Project<% else %>""<% end %>, url, nil)
 }
 
 func <%= product_name.camelize(:lower) -%>OperationWaitTime(config *Config, op map[string]interface{},<% if has_project -%> project,<% end -%> activity string, timeoutMinutes int) error {
@@ -30,6 +33,9 @@ func <%= product_name.camelize(:lower) -%>OperationWaitTime(config *Config, op m
   }
   w := &<%= product_name -%>OperationWaiter{
     Config: config,
+<% if has_project -%>
+    Project: project,
+<% end -%>
   }
   if err := w.CommonOperationWaiter.SetOp(op); err != nil {
     return err

--- a/templates/terraform/post_create/labels.erb
+++ b/templates/terraform/post_create/labels.erb
@@ -20,7 +20,7 @@ if v, ok := d.GetOkExists("labels"); !isEmptyValue(reflect.ValueOf(v)) && (ok ||
     if err != nil {
         return err
     }
-    res, err = sendRequest(config, "POST", url, obj)
+    res, err = sendRequest(config, "POST", project, url, obj)
     if err != nil {
       return fmt.Errorf("Error adding labels to <%= resource_name -%> %q: %s", d.Id(), err)
     }

--- a/templates/terraform/pre_delete/detach_disk.erb
+++ b/templates/terraform/pre_delete/detach_disk.erb
@@ -1,4 +1,4 @@
-readRes, err := sendRequest(config, "GET", url, nil)
+readRes, err := sendRequest(config, "GET", project, url, nil)
 if err != nil {
 	return handleNotFoundError(err, d, fmt.Sprintf("ComputeDisk %q", d.Id()))
 }

--- a/templates/terraform/pre_delete/detach_network.erb
+++ b/templates/terraform/pre_delete/detach_network.erb
@@ -8,7 +8,7 @@ if d.Get("networks.#").(int) > 0 {
 		return err
 	}
 
-	_, err = sendRequestWithTimeout(config, "PATCH", url, patched, d.Timeout(schema.TimeoutUpdate))
+	_, err = sendRequestWithTimeout(config, "PATCH", project, url, patched, d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
 		return fmt.Errorf("Error updating Policy %q: %s", d.Id(), err)
 	}

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -160,7 +160,13 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     }
 
     log.Printf("[DEBUG] Creating new <%= object.name -%>: %#v", obj)
-    res, err := sendRequestWithTimeout(config, "<%= object.create_verb.to_s.upcase -%>", url, obj, d.Timeout(schema.TimeoutCreate) <%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
+<%  if has_project -%>
+    project, err := getProject(d, config)
+    if err != nil {
+        return err
+    }
+<%  end -%>
+    res, err := sendRequestWithTimeout(config, "<%= object.create_verb.to_s.upcase -%>", <% if has_project %>project<% else %>""<% end %>, url, obj, d.Timeout(schema.TimeoutCreate) <%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
     if err != nil {
         return fmt.Errorf("Error creating <%= object.name -%>: %s", err)
     }
@@ -173,12 +179,6 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     d.SetId(id)
 
 <%  if !object.async.nil? && object.async.allow?('create') -%>
-<%  if has_project -%>
-    project, err := getProject(d, config)
-    if err != nil {
-        return err
-    }
-<%  end -%>
 <% if object.autogen_async -%>
     waitErr := <%= client_name_camel -%>OperationWaitTime(
     config, res,<% if has_project -%> project, <% end -%> "Creating <%= object.name -%>",
@@ -217,7 +217,13 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
         return err
     }
 
-res, err := sendRequest(config, "<%= object.read_verb.to_s.upcase -%>", url, nil)
+<%  if has_project -%>
+    project, err := getProject(d, config)
+    if err != nil {
+        return err
+    }
+<%  end -%>
+    res, err := sendRequest(config, "<%= object.read_verb.to_s.upcase -%>", <% if has_project %>project<% else %>""<% end %>, url, nil)
     if err != nil {
         return handleNotFoundError(err, d, fmt.Sprintf("<%= resource_name -%> %q", d.Id()))
     }
@@ -251,10 +257,6 @@ res, err := sendRequest(config, "<%= object.read_verb.to_s.upcase -%>", url, nil
 <%  end -%>
 
 <%  if has_project -%>
-    project, err := getProject(d, config)
-    if err != nil {
-        return err
-    }
     if err := d.Set("project", project); err != nil {
         return fmt.Errorf("Error reading <%= object.name -%>: %s", err)
     }
@@ -300,6 +302,13 @@ res, err := sendRequest(config, "<%= object.read_verb.to_s.upcase -%>", url, nil
 <% if updatable?(object, object.root_properties) -%>
 func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{}) error {
     config := meta.(*Config)
+
+<%  if has_project -%>
+    project, err := getProject(d, config)
+    if err != nil {
+        return err
+    }
+<%  end -%>
 
 <%  if object.input -%>
     d.Partial(true)
@@ -352,21 +361,15 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
             return err
         }
 <%      if object.async.nil? -%>
-        _, err = sendRequestWithTimeout(config, "<%= key[:update_verb] -%>", url, obj, d.Timeout(schema.TimeoutUpdate))
+        _, err = sendRequestWithTimeout(config, "<%= key[:update_verb] -%>", <% if has_project %>project<% else %>""<% end %>, url, obj, d.Timeout(schema.TimeoutUpdate))
 <%      else -%>
-        res, err := sendRequestWithTimeout(config, "<%= key[:update_verb] -%>", url, obj, d.Timeout(schema.TimeoutUpdate))
+        res, err := sendRequestWithTimeout(config, "<%= key[:update_verb] -%>", <% if has_project %>project<% else %>""<% end %>, url, obj, d.Timeout(schema.TimeoutUpdate))
 <%      end -%>
         if err != nil {
             return fmt.Errorf("Error updating <%= object.name -%> %q: %s", d.Id(), err)
         }
 
 <%      if !object.async.nil? && object.async.allow?('update') -%>
-<%      if has_project -%>
-        project, err := getProject(d, config)
-        if err != nil {
-            return err
-        }
-<%      end -%>
 <% if object.autogen_async -%>
 
         err = <%= client_name_camel -%>OperationWaitTime(
@@ -446,9 +449,9 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
 <%= lines(compile('templates/terraform/update_mask.erb')) if object.update_mask -%>
 <%= lines(compile(object.custom_code.pre_update)) if object.custom_code.pre_update -%>
 <%  if object.async.nil? -%>
-    _, err = sendRequestWithTimeout(config, "<%= object.update_verb -%>", url, obj, d.Timeout(schema.TimeoutUpdate))
+    _, err = sendRequestWithTimeout(config, "<%= object.update_verb -%>", <% if has_project %>project<% else %>""<% end %>, url, obj, d.Timeout(schema.TimeoutUpdate))
 <%  else -%>
-    res, err := sendRequestWithTimeout(config, "<%= object.update_verb -%>", url, obj, d.Timeout(schema.TimeoutUpdate))
+    res, err := sendRequestWithTimeout(config, "<%= object.update_verb -%>", <% if has_project %>project<% else %>""<% end %>, url, obj, d.Timeout(schema.TimeoutUpdate))
 <% end -%>
 
     if err != nil {
@@ -456,12 +459,6 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
     }
 
 <%  if !object.async.nil? && object.async.allow?('update') -%>
-<%  if has_project -%>
-    project, err := getProject(d, config)
-    if err != nil {
-        return err
-    }
-<%  end -%>
 <% if object.autogen_async && object.async.allow?('update') -%>
 
     err = <%= client_name_camel -%>OperationWaitTime(
@@ -496,6 +493,13 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
 <% else -%>
     config := meta.(*Config)
 
+<%  if has_project -%>
+    project, err := getProject(d, config)
+    if err != nil {
+        return err
+    }
+<%  end -%>
+
 <%  if object.mutex -%>
     lockName, err := replaceVars(d, config, "<%= object.mutex -%>")
     if err != nil {
@@ -514,18 +518,13 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
     var obj map[string]interface{}
 <%= lines(compile(object.custom_code.pre_delete)) if object.custom_code.pre_delete -%>
     log.Printf("[DEBUG] Deleting <%= object.name -%> %q", d.Id())
-    res, err := sendRequestWithTimeout(config, "<%= object.delete_verb.to_s.upcase -%>", url, obj, d.Timeout(schema.TimeoutDelete))
+
+    res, err := sendRequestWithTimeout(config, "<%= object.delete_verb.to_s.upcase -%>", <% if has_project %>project<% else %>""<% end %>, url, obj, d.Timeout(schema.TimeoutDelete))
     if err != nil {
         return handleNotFoundError(err, d, "<%= object.name -%>")
     }
 
 <%  if !object.async.nil? && object.async.allow?('delete') -%>
-<%  if has_project -%>
-    project, err := getProject(d, config)
-    if err != nil {
-        return err
-    }
-<%  end -%>
 <% if object.autogen_async && object.async.allow?('delete') -%>
 
     err = <%= client_name_camel -%>OperationWaitTime(

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -174,3 +174,9 @@ $ terraform import <% if object.min_version.name == 'beta' %>-provider=google-be
 
 -> If you're importing a resource with beta features, make sure to include `-provider=google-beta`
 as an argument so that Terraform uses the correct provider to import your resource.
+
+<% if object.base_url.include?("{{project}}")-%>
+## User Project Overrides
+
+This resource supports [User Project Overrides](https://www.terraform.io/docs/providers/google/provider_reference.html#user_project_override).
+<% end -%>

--- a/templates/terraform/resource_iam.html.markdown.erb
+++ b/templates/terraform/resource_iam.html.markdown.erb
@@ -156,3 +156,9 @@ $ terraform import <%= terraform_name -%>_member.editor "<%= object.id_format.gs
 
 -> If you're importing a resource with beta features, make sure to include `-provider=google-beta`
 as an argument so that Terraform uses the correct provider to import your resource.
+
+<% if object.base_url.include?("{{project}}")-%>
+## User Project Overrides
+
+This resource supports [User Project Overrides](https://www.terraform.io/docs/providers/google/provider_reference.html#user_project_override).
+<% end -%>

--- a/third_party/terraform/data_sources/data_source_google_client_openid_userinfo.go
+++ b/third_party/terraform/data_sources/data_source_google_client_openid_userinfo.go
@@ -24,7 +24,7 @@ func dataSourceGoogleClientOpenIDUserinfoRead(d *schema.ResourceData, meta inter
 
 	// See https://github.com/golang/oauth2/issues/306 for a recommendation to do this from a Go maintainer
 	// URL retrieved from https://accounts.google.com/.well-known/openid-configuration
-	res, err := sendRequest(config, "GET", "https://openidconnect.googleapis.com/v1/userinfo", nil)
+	res, err := sendRequest(config, "GET", "", "https://openidconnect.googleapis.com/v1/userinfo", nil)
 	if err != nil {
 		return fmt.Errorf("error retrieving userinfo for your provider credentials; have you enabled the 'https://www.googleapis.com/auth/userinfo.email' scope? error: %s", err)
 	}

--- a/third_party/terraform/data_sources/data_source_google_composer_image_versions.go
+++ b/third_party/terraform/data_sources/data_source_google_composer_image_versions.go
@@ -61,7 +61,7 @@ func dataSourceGoogleComposerImageVersionsRead(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	versions, err := paginatedListRequest(url, config, flattenGoogleComposerImageVersions)
+	versions, err := paginatedListRequest(project, url, config, flattenGoogleComposerImageVersions)
 	if err != nil {
 		return fmt.Errorf("Error listing Composer image versions: %s", err)
 	}

--- a/third_party/terraform/data_sources/data_source_google_kms_crypto_key_version.go
+++ b/third_party/terraform/data_sources/data_source_google_kms_crypto_key_version.go
@@ -65,7 +65,12 @@ func dataSourceGoogleKmsCryptoKeyVersionRead(d *schema.ResourceData, meta interf
 	}
 
 	log.Printf("[DEBUG] Getting attributes for CryptoKeyVersion: %#v", url)
-	res, err := sendRequest(config, "GET", url, nil)
+
+	cryptoKeyId, err := parseKmsCryptoKeyId(d.Get("crypto_key").(string), config)
+	if err != nil {
+		return err
+	}
+	res, err := sendRequest(config, "GET", cryptoKeyId.KeyRingId.Project, url, nil)
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("KmsCryptoKeyVersion %q", d.Id()))
 	}
@@ -89,7 +94,7 @@ func dataSourceGoogleKmsCryptoKeyVersionRead(d *schema.ResourceData, meta interf
 	}
 
 	log.Printf("[DEBUG] Getting purpose of CryptoKey: %#v", url)
-	res, err = sendRequest(config, "GET", url, nil)
+	res, err = sendRequest(config, "GET", cryptoKeyId.KeyRingId.Project, url, nil)
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("KmsCryptoKey %q", d.Id()))
 	}
@@ -100,7 +105,7 @@ func dataSourceGoogleKmsCryptoKeyVersionRead(d *schema.ResourceData, meta interf
 			return err
 		}
 		log.Printf("[DEBUG] Getting public key of CryptoKeyVersion: %#v", url)
-		res, _ = sendRequest(config, "GET", url, nil)
+		res, _ = sendRequest(config, "GET", cryptoKeyId.KeyRingId.Project, url, nil)
 
 		if err := d.Set("public_key", flattenKmsCryptoKeyVersionPublicKey(res, d)); err != nil {
 			return fmt.Errorf("Error reading CryptoKeyVersion public key: %s", err)

--- a/third_party/terraform/data_sources/data_source_google_projects.go
+++ b/third_party/terraform/data_sources/data_source_google_projects.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -44,7 +45,7 @@ func datasourceGoogleProjectsRead(d *schema.ResourceData, meta interface{}) erro
 			return err
 		}
 
-		res, err := sendRequest(config, "GET", url, nil)
+		res, err := sendRequest(config, "GET", "", url, nil)
 		if err != nil {
 			return fmt.Errorf("Error retrieving projects: %s", err)
 		}

--- a/third_party/terraform/data_sources/data_source_google_storage_bucket_object.go
+++ b/third_party/terraform/data_sources/data_source_google_storage_bucket_object.go
@@ -35,7 +35,7 @@ func dataSourceGoogleStorageBucketObjectRead(d *schema.ResourceData, meta interf
 	// Using REST apis because the storage go client doesn't support folders
 	url := fmt.Sprintf("https://www.googleapis.com/storage/v1/b/%s/o/%s", bucket, name)
 
-	res, err := sendRequest(config, "GET", url, nil)
+	res, err := sendRequest(config, "GET", "", url, nil)
 	if err != nil {
 		return fmt.Errorf("Error retrieving storage bucket object: %s", err)
 	}

--- a/third_party/terraform/data_sources/data_source_tpu_tensorflow_versions.go
+++ b/third_party/terraform/data_sources/data_source_tpu_tensorflow_versions.go
@@ -50,7 +50,7 @@ func dataSourceTpuTensorFlowVersionsRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	versionsRaw, err := paginatedListRequest(url, config, flattenTpuTensorflowVersions)
+	versionsRaw, err := paginatedListRequest(project, url, config, flattenTpuTensorflowVersions)
 	if err != nil {
 		return fmt.Errorf("Error listing TPU Tensorflow versions: %s", err)
 	}

--- a/third_party/terraform/resources/resource_service_networking_connection.go
+++ b/third_party/terraform/resources/resource_service_networking_connection.go
@@ -177,15 +177,16 @@ func resourceServiceNetworkingConnectionDelete(d *schema.ResourceData, meta inte
 	obj["name"] = peering
 	url := fmt.Sprintf("%s%s/removePeering", config.ComputeBasePath, serviceNetworkingNetworkName)
 
-	res, err := sendRequestWithTimeout(config, "POST", url, obj, d.Timeout(schema.TimeoutUpdate))
-	if err != nil {
-		return handleNotFoundError(err, d, fmt.Sprintf("ServiceNetworkingConnection %q", d.Id()))
-	}
-
 	project, err := getProject(d, config)
 	if err != nil {
 		return err
 	}
+
+	res, err := sendRequestWithTimeout(config, "POST", project, url, obj, d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("ServiceNetworkingConnection %q", d.Id()))
+	}
+
 	op := &compute.Operation{}
 	err = Convert(res, op)
 	if err != nil {

--- a/third_party/terraform/tests/resource_access_context_manager_access_level_test.go.erb
+++ b/third_party/terraform/tests/resource_access_context_manager_access_level_test.go.erb
@@ -73,7 +73,7 @@ func testAccCheckAccessContextManagerAccessLevelDestroy(s *terraform.State) erro
 			return err
 		}
 
-		_, err = sendRequest(config, "GET", url, nil)
+		_, err = sendRequest(config, "GET", "", url, nil)
 		if err == nil {
 			return fmt.Errorf("AccessLevel still exists at %s", url)
 		}

--- a/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
@@ -73,7 +73,7 @@ func testAccCheckAccessContextManagerAccessPolicyDestroy(s *terraform.State) err
 			return err
 		}
 
-		_, err = sendRequest(config, "GET", url, nil)
+		_, err = sendRequest(config, "GET", "", url, nil)
 		if err == nil {
 			return fmt.Errorf("AccessPolicy still exists at %s", url)
 		}

--- a/third_party/terraform/tests/resource_access_context_manager_service_perimeter_test.go.erb
+++ b/third_party/terraform/tests/resource_access_context_manager_service_perimeter_test.go.erb
@@ -72,7 +72,7 @@ func testAccCheckAccessContextManagerServicePerimeterDestroy(s *terraform.State)
 			return err
 		}
 
-		_, err = sendRequest(config, "GET", url, nil)
+		_, err = sendRequest(config, "GET", "", url, nil)
 		if err == nil {
 			return fmt.Errorf("ServicePerimeter still exists at %s", url)
 		}

--- a/third_party/terraform/tests/resource_bigquery_data_transfer_config_test.go
+++ b/third_party/terraform/tests/resource_bigquery_data_transfer_config_test.go
@@ -91,7 +91,7 @@ func testAccCheckBigqueryDataTransferConfigDestroy(s *terraform.State) error {
 			return err
 		}
 
-		_, err = sendRequest(config, "GET", url, nil)
+		_, err = sendRequest(config, "GET", "", url, nil)
 		if err == nil {
 			return fmt.Errorf("BigqueryDataTransferConfig still exists at %s", url)
 		}

--- a/third_party/terraform/tests/resource_binaryauthorization_attestor_test.go.erb
+++ b/third_party/terraform/tests/resource_binaryauthorization_attestor_test.go.erb
@@ -129,7 +129,7 @@ func testAccCheckBinaryAuthorizationAttestorDestroy(s *terraform.State) error {
 		name := rs.Primary.Attributes["name"]
 
 		url := fmt.Sprintf("https://binaryauthorization.googleapis.com/v1beta1/projects/%s/attestors/%s", project, name)
-		_, err = sendRequest(config, "GET", url, nil)
+		_, err = sendRequest(config, "GET", "", url, nil)
 
 		if err == nil {
 			return fmt.Errorf("Error, attestor %s still exists", name)

--- a/third_party/terraform/tests/resource_binaryauthorization_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_binaryauthorization_policy_test.go.erb
@@ -167,7 +167,7 @@ func testAccCheckBinaryAuthorizationPolicyDefault(pid string) resource.TestCheck
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
 		url := fmt.Sprintf("https://binaryauthorization.googleapis.com/v1beta1/projects/%s/policy", pid)
-		pol, err := sendRequest(config, "GET", url, nil)
+		pol, err := sendRequest(config, "GET", "", url, nil)
 		if err != nil {
 			return err
 		}

--- a/third_party/terraform/tests/resource_compute_backend_bucket_signed_url_key_test.go
+++ b/third_party/terraform/tests/resource_compute_backend_bucket_signed_url_key_test.go
@@ -92,7 +92,7 @@ func checkComputeBackendBucketSignedUrlKeyExists(s *terraform.State) (bool, erro
 			return false, err
 		}
 
-		res, err := sendRequest(config, "GET", url, nil)
+		res, err := sendRequest(config, "GET", "", url, nil)
 		if err != nil {
 			return false, err
 		}

--- a/third_party/terraform/tests/resource_compute_backend_service_signed_url_key_test.go
+++ b/third_party/terraform/tests/resource_compute_backend_service_signed_url_key_test.go
@@ -92,7 +92,7 @@ func checkComputeBackendServiceSignedUrlKeyExists(s *terraform.State) (bool, err
 			return false, err
 		}
 
-		res, err := sendRequest(config, "GET", url, nil)
+		res, err := sendRequest(config, "GET", "", url, nil)
 		if err != nil {
 			return false, err
 		}

--- a/third_party/terraform/tests/resource_compute_network_endpoint_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_network_endpoint_test.go.erb
@@ -227,7 +227,7 @@ func testAccComputeNetworkEndpointsListEndpointPorts(negId string) (map[string]s
 	config := testAccProvider.Meta().(*Config)
 
 	url := fmt.Sprintf("https://www.googleapis.com/compute/beta/%s/listNetworkEndpoints", negId)
-	res, err := sendRequest(config, "POST", url, nil)
+	res, err := sendRequest(config, "POST", "", url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/third_party/terraform/tests/resource_healthcare_dataset_test.go.erb
+++ b/third_party/terraform/tests/resource_healthcare_dataset_test.go.erb
@@ -123,7 +123,7 @@ func testAccCheckHealthcareDatasetDestroy(s *terraform.State) error {
 			return err
 		}
 
-		_, err = sendRequest(config, "GET", url, nil)
+		_, err = sendRequest(config, "GET", "", url, nil)
 		if err == nil {
 			return fmt.Errorf("HealthcareDataset still exists at %s", url)
 		}

--- a/third_party/terraform/tests/resource_healthcare_dicom_store_test.go.erb
+++ b/third_party/terraform/tests/resource_healthcare_dicom_store_test.go.erb
@@ -164,7 +164,7 @@ func testAccCheckHealthcareDicomStoreDestroy(s *terraform.State) error {
 			return err
 		}
 
-		_, err = sendRequest(config, "GET", url, nil)
+		_, err = sendRequest(config, "GET", "", url, nil)
 		if err == nil {
 			return fmt.Errorf("HealthcareDicomStore still exists at %s", url)
 		}

--- a/third_party/terraform/tests/resource_healthcare_fhir_store_test.go.erb
+++ b/third_party/terraform/tests/resource_healthcare_fhir_store_test.go.erb
@@ -172,7 +172,7 @@ func testAccCheckHealthcareFhirStoreDestroy(s *terraform.State) error {
 			return err
 		}
 
-		_, err = sendRequest(config, "GET", url, nil)
+		_, err = sendRequest(config, "GET", "", url, nil)
 		if err == nil {
 			return fmt.Errorf("HealthcareFhirStore still exists at %s", url)
 		}

--- a/third_party/terraform/tests/resource_healthcare_hl7_v2_store_test.go.erb
+++ b/third_party/terraform/tests/resource_healthcare_hl7_v2_store_test.go.erb
@@ -169,7 +169,7 @@ func testAccCheckHealthcareHl7V2StoreDestroy(s *terraform.State) error {
 			return err
 		}
 
-		_, err = sendRequest(config, "GET", url, nil)
+		_, err = sendRequest(config, "GET", "", url, nil)
 		if err == nil {
 			return fmt.Errorf("HealthcareHl7V2Store still exists at %s", url)
 		}

--- a/third_party/terraform/tests/resource_monitoring_alert_policy_test.go
+++ b/third_party/terraform/tests/resource_monitoring_alert_policy_test.go
@@ -122,7 +122,7 @@ func testAccCheckAlertPolicyDestroy(s *terraform.State) error {
 		name := rs.Primary.Attributes["name"]
 
 		url := fmt.Sprintf("https://monitoring.googleapis.com/v3/%s", name)
-		_, err := sendRequest(config, "GET", url, nil)
+		_, err := sendRequest(config, "GET", "", url, nil)
 
 		if err == nil {
 			return fmt.Errorf("Error, alert policy %s still exists", name)

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -61,13 +61,14 @@ import (
 // Config is the configuration structure used to instantiate the Google
 // provider.
 type Config struct {
-	Credentials 	 string
-	AccessToken 	 string
-	Project     	 string
-	Region      	 string
-	Zone        	 string
-	Scopes         []string
-	BatchingConfig *batchingConfig
+	Credentials 	 	string
+	AccessToken 	 	string
+	Project     	 	string
+	Region      	 	string
+	Zone        	 	string
+	Scopes         		[]string
+	BatchingConfig		*batchingConfig
+	UserProjectOverride bool
 
 	client    *http.Client
 	userAgent string

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -98,6 +98,11 @@ func Provider() terraform.ResourceProvider {
 				},
 			},
 
+			"user_project_override": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			// Generated Products
 			<% products.each do |product_name| -%>
 			<%= product_name -%>CustomEndpointEntryKey: <%= product_name -%>CustomEndpointEntry,
@@ -344,9 +349,10 @@ func ResourceMapWithErrors() (map[string]*schema.Resource, error) {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		Project: d.Get("project").(string),
-		Region:  d.Get("region").(string),
-		Zone:    d.Get("zone").(string),
+		Project:             d.Get("project").(string),
+		Region:              d.Get("region").(string),
+		Zone:                d.Get("zone").(string),
+		UserProjectOverride: d.Get("user_project_override").(bool),
 	}
 
 	// Add credential source

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -5,9 +5,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/terraform-providers/terraform-provider-random/random"
@@ -196,8 +200,47 @@ func TestAccProviderBasePath_setInvalidBasePath(t *testing.T) {
 		CheckDestroy: testAccCheckComputeAddressDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProviderBasePath_setBasePath("https://www.example.com/compute/beta/", acctest.RandString(10)),
+				Config:      testAccProviderBasePath_setBasePath("https://www.example.com/compute/beta/", acctest.RandString(10)),
 				ExpectError: regexp.MustCompile("got HTTP response code 404 with body"),
+			},
+		},
+	})
+}
+
+func TestAccProviderUserProjectOverride(t *testing.T) {
+	t.Parallel()
+
+	org := getTestOrgFromEnv(t)
+	billing := getTestBillingAccountFromEnv(t)
+	pid := "terraform-" + acctest.RandString(10)
+	sa := "terraform-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		// No TestDestroy since that's not really the point of this test
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProviderUserProjectOverride(pid, pname, org, billing, sa),
+				Check: func(s *terraform.State) error {
+					time.Sleep(2 * time.Minute)
+					return nil
+				},
+			},
+			{
+				Config:      testAccProviderUserProjectOverride_step2(pid, pname, org, billing, sa, false),
+				ExpectError: regexp.MustCompile("Binary Authorization API has not been used"),
+			},
+			{
+				Config: testAccProviderUserProjectOverride_step2(pid, pname, org, billing, sa, true),
+			},
+			{
+				ResourceName:      "google_binary_authorization_policy.project-2-policy",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccProviderUserProjectOverride_step3(pid, pname, org, billing, sa, true),
 			},
 		},
 	})
@@ -212,6 +255,115 @@ provider "google" {
 resource "google_compute_address" "default" {
 	name = "address-test-%s"
 }`, endpoint, name)
+}
+
+// Set up two projects. Project 1 has a service account that is used to create a
+// binauthz policy in project 2. The binauthz API is only enabled in project 2,
+// which causes the create to fail unless user_project_override is set to true.
+func testAccProviderUserProjectOverride(pid, name, org, billing, sa string) string {
+	return fmt.Sprintf(`
+provider "google" {
+  scopes = [
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/userinfo.email",
+  ]
+}
+
+resource "google_project" "project-1" {
+	project_id      = "%s"
+	name            = "%s"
+	org_id          = "%s"
+	billing_account = "%s"
+}
+
+resource "google_service_account" "project-1" {
+	project    = google_project.project-1.project_id
+    account_id = "%s"
+}
+
+resource "google_project" "project-2" {
+	project_id      = "%s-2"
+	name            = "%s-2"
+	org_id          = "%s"
+	billing_account = "%s"
+}
+
+resource "google_project_service" "project-2-binauthz" {
+	project = google_project.project-2.project_id
+	service = "binaryauthorization.googleapis.com"
+}
+
+// Permission needed for user_project_override
+resource "google_project_iam_member" "project-2-serviceusage" {
+	project = google_project.project-2.project_id
+	role    = "roles/serviceusage.serviceUsageConsumer"
+	member  = "serviceAccount:${google_service_account.project-1.email}"
+}
+
+resource "google_project_iam_member" "project-2-binauthz" {
+	project = google_project.project-2.project_id
+	role    = "roles/binaryauthorization.policyEditor"
+	member  = "serviceAccount:${google_service_account.project-1.email}"
+}
+
+data "google_client_openid_userinfo" "me" {}
+
+// Enable the test runner to get an access token on behalf of
+// the project 1 service account
+resource "google_service_account_iam_member" "token-creator-iam" {
+	service_account_id = google_service_account.project-1.name
+	role               = "roles/iam.serviceAccountTokenCreator"
+	member             = "serviceAccount:${data.google_client_openid_userinfo.me.email}"
+}
+`, pid, name, org, billing, sa, pid, name, org, billing)
+}
+
+func testAccProviderUserProjectOverride_step2(pid, name, org, billing, sa string, override bool) string {
+	return fmt.Sprintf(`
+// See step 3 below, which is really step 2 minus the binauthz policy.
+// Step 3 exists because provider configurations can't be removed while objects
+// created by that provider still exist in state. Step 3 will remove the
+// binauthz policy so the whole config can be deleted.
+%s
+
+resource "google_binary_authorization_policy" "project-2-policy" {
+	provider = google.project-1-token
+	project  = google_project.project-2.project_id
+
+	admission_whitelist_patterns {
+		name_pattern= "gcr.io/google_containers/*"
+	}
+
+	default_admission_rule {
+		evaluation_mode = "ALWAYS_DENY"
+		enforcement_mode = "ENFORCED_BLOCK_AND_AUDIT_LOG"
+	}
+}
+`, testAccProviderUserProjectOverride_step3(pid, name, org, billing, sa, override))
+}
+
+func testAccProviderUserProjectOverride_step3(pid, name, org, billing, sa string, override bool) string {
+	return fmt.Sprintf(`
+%s
+
+data "google_service_account_access_token" "project-1-token" {
+	// This data source would have a depends_on t
+	// google_service_account_iam_binding.token-creator-iam, but depends_on
+	// in data sources makes them always have a diff in apply:
+	// https://www.terraform.io/docs/configuration/data-sources.html#data-resource-dependencies
+	// Instead, rely on the other test step completing before this one.
+
+	target_service_account = google_service_account.project-1.email
+	scopes = ["userinfo-email", "https://www.googleapis.com/auth/cloud-platform"]
+	lifetime = "300s"
+}
+
+provider "google" {
+	alias  = "project-1-token"
+	access_token = data.google_service_account_access_token.project-1-token.access_token
+	user_project_override = %v
+}
+`, testAccProviderUserProjectOverride(pid, name, org, billing, sa), override)
 }
 
 // getTestRegion has the same logic as the provider's getRegion, to be used in tests.

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -223,6 +223,8 @@ func TestAccProviderUserProjectOverride(t *testing.T) {
 			{
 				Config: testAccProviderUserProjectOverride(pid, pname, org, billing, sa),
 				Check: func(s *terraform.State) error {
+					// The token creator IAM API call returns success long before the policy is
+					// actually usable. Wait a solid 2 minutes to ensure we can use it.
 					time.Sleep(2 * time.Minute)
 					return nil
 				},

--- a/third_party/terraform/utils/transport.go
+++ b/third_party/terraform/utils/transport.go
@@ -34,14 +34,20 @@ func isEmptyValue(v reflect.Value) bool {
 	return false
 }
 
-func sendRequest(config *Config, method, rawurl string, body map[string]interface{}) (map[string]interface{}, error) {
-	return sendRequestWithTimeout(config, method, rawurl, body, DefaultRequestTimeout)
+func sendRequest(config *Config, method, project, rawurl string, body map[string]interface{}) (map[string]interface{}, error) {
+	return sendRequestWithTimeout(config, method, project, rawurl, body, DefaultRequestTimeout)
 }
 
-func sendRequestWithTimeout(config *Config, method, rawurl string, body map[string]interface{}, timeout time.Duration, errorRetryPredicates ...func(e error) (bool, string)) (map[string]interface{}, error) {
+func sendRequestWithTimeout(config *Config, method, project, rawurl string, body map[string]interface{}, timeout time.Duration, errorRetryPredicates ...func(e error) (bool, string)) (map[string]interface{}, error) {
 	reqHeaders := make(http.Header)
 	reqHeaders.Set("User-Agent", config.userAgent)
 	reqHeaders.Set("Content-Type", "application/json")
+
+	if config.UserProjectOverride && project != "" {
+		// Pass the project into this fn instead of parsing it from the URL because
+		// both project names and URLs can have colons in them.
+		reqHeaders.Set("X-Goog-User-Project", project)
+	}
 
 	if timeout == 0 {
 		timeout = time.Duration(1) * time.Hour

--- a/third_party/terraform/utils/utils.go.erb
+++ b/third_party/terraform/utils/utils.go.erb
@@ -470,8 +470,8 @@ func serviceAccountFQN(serviceAccount string, d TerraformResourceData, config *C
 	return fmt.Sprintf("projects/-/serviceAccounts/%s@%s.iam.gserviceaccount.com", serviceAccount, project), nil
 }
 
-func paginatedListRequest(baseUrl string, config *Config, flattener func(map[string]interface{}) []interface{}) ([]interface{}, error) {
-	res, err := sendRequest(config, "GET", baseUrl, nil)
+func paginatedListRequest(project, baseUrl string, config *Config, flattener func(map[string]interface{}) []interface{}) ([]interface{}, error) {
+	res, err := sendRequest(config, "GET", project, baseUrl, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -483,7 +483,7 @@ func paginatedListRequest(baseUrl string, config *Config, flattener func(map[str
 			break
 		}
 		url := fmt.Sprintf("%s?pageToken=%s", baseUrl, pageToken.(string))
-		res, err = sendRequest(config, "GET", url, nil)
+		res, err = sendRequest(config, "GET", project, url, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/third_party/terraform/website/docs/provider_reference.html.markdown
+++ b/third_party/terraform/website/docs/provider_reference.html.markdown
@@ -97,6 +97,11 @@ authenticate HTTP requests to GCP APIs. This is an alternative to `credentials`,
 and ignores the `scopes` field. If both are specified, `access_token` will be
 used over the `credentials` field.
 
+* `user_project_override` - (Optional) Defaults to false. If true, uses the
+resource project for preconditions, quota, and billing, instead of the project
+the credentials belong to. Not all resources support this- see the
+documentation for each resource to learn whether it does.
+
 * `{{service}}_custom_endpoint` - (Optional) The endpoint for a service's APIs,
 such as `compute_custom_endpoint`. Defaults to the production GCP endpoint for
 the service. This can be used to configure the Google provider to communicate
@@ -324,3 +329,20 @@ Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 
 * `disable_batching` - (Optional) Defaults to false. If true, disables global
 batching and each request is sent normally.
+
+---
+
+* `user_project_override` - (Optional) Defaults to false. If true, uses the
+resource project for preconditions, quota, and billing, instead of the project
+the credentials belong to. Not all resources support this- see the
+documentation for each resource to learn whether it does.
+
+When set to false, the project the credentials belong to will be billed for the
+request, and quota / API enablement checks will be done against that project.
+For service account credentials, this is the project the service account was
+created in. For credentials that come from the gcloud tool, this is a project
+owned by Google. In order to properly use credentials that come from gcloud
+with Terraform, it is recommended to set this property to true.
+
+When set to true, the caller must have `serviceusage.services.use` permission
+on the resource project.


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
This adds support for the userProject/X-Goog-User-Project system parameter mentioned in https://cloud.google.com/apis/docs/system-parameters. This allows users to opt-in to using resource projects for quota/billing/api checks instead of the project their credentials come from.

Doing this just in transport.go by parsing the project from the URL was an option, but since both projects and urls can contain colons (i.e. project id google.com:my-project and url https://googleapis.com/stuff/projects/my-project:setIamPolicy), I opted to pass the project through everywhere to make sure we didn't introduce bugs with parsing project names.

This change makes it easier for customers who wish to use their gcloud credentials with TF (which they might do for development for ease of IAM), since some APIs are not enabled on the gcloud project.

Also see https://github.com/terraform-providers/terraform-provider-google/issues/1538 for user confusion around this (it's old, but still relevant).

Also looking for feedback on the field name. I'm not a huge fan of `user_project_override`, but I don't have anything better at the moment.
<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
provider: Adds new provider-level field `user_project_override`, which allows billing, quota checks, and service enablement checks to occur against the project a resource is in instead of the project the credentials are from.
```
