### PR TITLE
Add support for oauth and oidc tokens to cloud_scheduler_job

### DIFF
--- a/products/cloudscheduler/api.yaml
+++ b/products/cloudscheduler/api.yaml
@@ -258,3 +258,37 @@ objects:
               This map contains the header field names and values. 
               Repeated headers are not supported, but a header value can contain commas.
             required: false
+          - !ruby/object:Api::Type::NestedObject
+            name: 'oauthToken'
+            description: |
+              Contains information needed for generating an OAuth token.
+              This type of authorization should be used when sending requests to a GCP endpoint.
+            input: true
+            properties:
+              - !ruby/object:Api::Type::String
+                name: serviceAccountEmail
+                description: |
+                  Service account email to be used for generating OAuth token.
+                  The service account must be within the same project as the job.
+              - !ruby/object:Api::Type::String
+                name: scope
+                description: |
+                  OAuth scope to be used for generating OAuth access token. If not specified,
+                  "https://www.googleapis.com/auth/cloud-platform" will be used.
+          - !ruby/object:Api::Type::NestedObject
+            name: 'oidcToken'
+            description: |
+              Contains information needed for generating an OpenID Connect token.
+              This type of authorization should be used when sending requests to third party endpoints or Cloud Run.
+            input: true
+            properties:
+              - !ruby/object:Api::Type::String
+                name: serviceAccountEmail
+                description: |
+                  Service account email to be used for generating OAuth token.
+                  The service account must be within the same project as the job.
+              - !ruby/object:Api::Type::String
+                name: audience
+                description: |
+                  Audience to be used when generating OIDC token. If not specified,
+                  the URI specified in target will be used.

--- a/products/cloudscheduler/terraform.yaml
+++ b/products/cloudscheduler/terraform.yaml
@@ -14,6 +14,9 @@
 --- !ruby/object:Provider::Terraform::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
   Job: !ruby/object:Overrides::Terraform::ResourceOverride
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      constants: templates/terraform/constants/scheduler_auth.erb
+      resource_definition: templates/terraform/resource_definition/scheduler_auth.erb
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "scheduler_job_pubsub"
@@ -31,6 +34,19 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "job"
         vars:
           job_name: "test-job"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "scheduler_job_oauth"
+        primary_resource_id: "job"
+        vars:
+          job_name: "test-job"
+        test_env_vars:
+          project_name: :PROJECT_NAME
+          region: :REGION
+      - !ruby/object:Provider::Terraform::Examples
+        name: "scheduler_job_oidc"
+        primary_resource_id: "job"
+        vars:
+          job_name: "test-job"
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/cloudscheduler_job_name.erb'
@@ -39,6 +55,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_flatten: 'templates/terraform/custom_flatten/http_headers.erb'
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateHttpHeaders()'
+      httpTarget.oauthToken: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: 'authHeaderDiffSuppress'
+      httpTarget.oidcToken: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: 'authHeaderDiffSuppress'
       appEngineHttpTarget.headers: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/http_headers.erb'
         validation: !ruby/object:Provider::Terraform::Validation

--- a/templates/terraform/constants/scheduler_auth.erb
+++ b/templates/terraform/constants/scheduler_auth.erb
@@ -1,0 +1,41 @@
+// Both oidc and oauth headers cannot be set
+func validateAuthHeaders(diff *schema.ResourceDiff, v interface{}) error {
+    httpBlock := diff.Get("http_target.0").(map[string]interface{})
+
+    if httpBlock != nil {
+        oauth := httpBlock["oauth_token"]
+        oidc := httpBlock["oidc_token"]
+
+        if oauth != nil && oidc != nil {
+            if len(oidc.([]interface{})) > 0 && len(oauth.([]interface{})) > 0 {
+                return fmt.Errorf("Errof in http_target: only one of oauth_token or oidc_token can be specified, but not both.")
+            }
+        }
+    }
+
+    return nil
+}
+
+func authHeaderDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+    b := strings.Split(k, ".")
+    if b[0] == "http_target" && len(b) > 4 {
+        block := b[2]
+        attr := b[4]
+
+        if block == "oauth_token" && attr == "scope" {
+            if old == "https://www.googleapis.com/auth/cloud-platform" && new == "" {
+                return true
+            }
+        }
+
+        if block == "oidc_token" && attr == "audience" {
+            uri := d.Get(strings.Join(b[0:2], ".")+".uri")
+            if old == uri && new == "" {
+                return true
+            }
+        }
+
+    }
+
+    return false
+}

--- a/templates/terraform/constants/scheduler_auth.erb
+++ b/templates/terraform/constants/scheduler_auth.erb
@@ -8,7 +8,7 @@ func validateAuthHeaders(diff *schema.ResourceDiff, v interface{}) error {
 
         if oauth != nil && oidc != nil {
             if len(oidc.([]interface{})) > 0 && len(oauth.([]interface{})) > 0 {
-                return fmt.Errorf("Errof in http_target: only one of oauth_token or oidc_token can be specified, but not both.")
+                return fmt.Errorf("Error in http_target: only one of oauth_token or oidc_token can be specified, but not both.")
             }
         }
     }
@@ -16,18 +16,26 @@ func validateAuthHeaders(diff *schema.ResourceDiff, v interface{}) error {
     return nil
 }
 
+
+
 func authHeaderDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
     b := strings.Split(k, ".")
     if b[0] == "http_target" && len(b) > 4 {
         block := b[2]
         attr := b[4]
 
+        // If generating an oauth_token and scope is not provided in the configuration,
+        // the default "https://www.googleapis.com/auth/cloud-platform" scope will be used.
+        // Although not in the configuration, this is returned and will be stored in state.
         if block == "oauth_token" && attr == "scope" {
-            if old == "https://www.googleapis.com/auth/cloud-platform" && new == "" {
+            if old == canonicalizeServiceScope("cloud-platform") && new == "" {
                 return true
             }
         }
 
+        // If generating an oidc_token and audience is not provided in the configuration,
+        // the URI specified in target will be used. Although not in the configuration,
+        // this is returned and will be stored in state.
         if block == "oidc_token" && attr == "audience" {
             uri := d.Get(strings.Join(b[0:2], ".")+".uri")
             if old == uri && new == "" {

--- a/templates/terraform/constants/scheduler_auth.erb
+++ b/templates/terraform/constants/scheduler_auth.erb
@@ -19,23 +19,24 @@ func validateAuthHeaders(diff *schema.ResourceDiff, v interface{}) error {
 
 
 func authHeaderDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+    // If generating an `oauth_token` and `scope` is not provided in the configuration,
+    // the default "https://www.googleapis.com/auth/cloud-platform" scope will be used.
+    // Similarly, if generating an `oidc_token` and `audience` is not provided in the
+    // configuration, the URI specified in target will be used. Although not in the 
+    // configuration, in both cases the default is returned in the object, but is not in.
+    // state. We suppress the diff if the values are these defaults but are not stored in state.
+
     b := strings.Split(k, ".")
     if b[0] == "http_target" && len(b) > 4 {
         block := b[2]
         attr := b[4]
 
-        // If generating an oauth_token and scope is not provided in the configuration,
-        // the default "https://www.googleapis.com/auth/cloud-platform" scope will be used.
-        // Although not in the configuration, this is returned and will be stored in state.
         if block == "oauth_token" && attr == "scope" {
             if old == canonicalizeServiceScope("cloud-platform") && new == "" {
                 return true
             }
         }
 
-        // If generating an oidc_token and audience is not provided in the configuration,
-        // the URI specified in target will be used. Although not in the configuration,
-        // this is returned and will be stored in state.
         if block == "oidc_token" && attr == "audience" {
             uri := d.Get(strings.Join(b[0:2], ".")+".uri")
             if old == uri && new == "" {

--- a/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/templates/terraform/examples/base_configs/test_file.go.erb
@@ -55,7 +55,7 @@ func TestAcc<%= test_slug -%>(t *testing.T) {
 		<% elsif var_type == :CREDENTIALS -%>
 			"<%= var_name -%>": getTestCredsFromEnv(t),
 		<% elsif var_type == :REGION -%>
-			"<%= var_name -%>": getTestRegionFromEnv(t),
+			"<%= var_name -%>": getTestRegionFromEnv(),
 		<% elsif var_type == :ORG_TARGET -%>
 			"<%= var_name -%>": getTestOrgTargetFromEnv(t),
 		<% elsif var_type == :BILLING_ACCT -%>

--- a/templates/terraform/examples/scheduler_job_oauth.tf.erb
+++ b/templates/terraform/examples/scheduler_job_oauth.tf.erb
@@ -1,0 +1,18 @@
+data "google_compute_default_service_account" "default" { }
+
+resource "google_cloud_scheduler_job" "job" {
+  name     = "<%= ctx[:vars]['job_name'] %>"
+  description = "test http job"
+  schedule = "*/8 * * * *"
+  time_zone = "America/New_York"
+
+  http_target {
+    http_method = "GET"
+    uri = "https://cloudscheduler.googleapis.com/v1/projects/<%= ctx[:test_env_vars]['project_name'] %>/locations/<%= ctx[:test_env_vars]['region'] %>/jobs"
+
+    oauth_token {
+      service_account_email = "${data.google_compute_default_service_account.default.email}"
+    }
+  }
+}
+

--- a/templates/terraform/examples/scheduler_job_oidc.tf.erb
+++ b/templates/terraform/examples/scheduler_job_oidc.tf.erb
@@ -1,0 +1,18 @@
+data "google_compute_default_service_account" "default" { }
+
+resource "google_cloud_scheduler_job" "job" {
+  name     = "<%= ctx[:vars]['job_name'] %>"
+  description = "test http job"
+  schedule = "*/8 * * * *"
+  time_zone = "America/New_York"
+
+  http_target {
+    http_method = "GET"
+    uri = "https://example.com/ping"
+
+    oidc_token {
+      service_account_email = "${data.google_compute_default_service_account.default.email}"
+    }
+  }
+}
+

--- a/templates/terraform/resource_definition/scheduler_auth.erb
+++ b/templates/terraform/resource_definition/scheduler_auth.erb
@@ -1,0 +1,15 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2017 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+CustomizeDiff: validateAuthHeaders,


### PR DESCRIPTION
As referenced in terraform-providers/terraform-provider-google#4089 adding support for oauth_token and also oidc_token on the cloud_scheduler job

# Release Note for Downstream PRs (will be copied)
```releasenote
Add support for `oauth_token` and `oidc_token` on resource `google_cloud_scheduler_job`
```
