### PR TITLE
Add note about cluster cidr range behaviours to GKE cluster

### DIFF
--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -153,8 +153,12 @@ deprecated in favour of `node_locations`.
 * `addons_config` - (Optional) The configuration for addons supported by GKE.
     Structure is documented below.
 
-* `cluster_ipv4_cidr` - (Optional) The IP address range of the kubernetes pods in
-    this cluster. Default is an automatically assigned CIDR.
+* `cluster_ipv4_cidr` - (Optional) The IP address range of the Kubernetes pods
+in this cluster in CIDR notation (e.g. 10.96.0.0/14). Leave blank to have one
+automatically chosen or specify a /14 block in 10.0.0.0/8. This field will only
+work if your cluster is not VPC-native- when an `ip_allocation_policy` block is
+not defined, or `ip_allocation_policy.use_ip_aliases` is set to false. If your
+cluster is VPC-native, use `ip_allocation_policy.cluster_ipv4_cidr_block`. 
 
 * `cluster_autoscaling` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html))
 Per-cluster configuration of Node Auto-Provisioning with Cluster Autoscaler to
@@ -424,10 +428,12 @@ API is `false`; afterwards, it's `true`.
     subnetwork.
 
 * `cluster_ipv4_cidr_block` - (Optional) The IP address range for the cluster pod IPs.
-    Set to blank to have a range chosen with the default size. Set to /netmask (e.g. /14)
-    to have a range chosen with a specific netmask. Set to a CIDR notation (e.g. 10.96.0.0/14)
-    from the RFC-1918 private networks (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to
-    pick a specific range to use.
+Set to blank to have a range chosen with the default size. Set to /netmask (e.g. /14)
+to have a range chosen with a specific netmask. Set to a CIDR notation (e.g. 10.96.0.0/14)
+from the RFC-1918 private networks (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to
+pick a specific range to use. This field will only work if your cluster is
+VPC-native- when `ip_allocation_policy.use_ip_aliases` is undefined or set to
+true. If your cluster is not VPC-native, use `cluster_ipv4_cidr`. 
 
 * `node_ipv4_cidr_block` - (Optional) The IP address range of the node IPs in this cluster.
     This should be set only if `create_subnetwork` is true.


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

The behaviour of these fields was confusing. Clarify exactly how they work.

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4181. https://github.com/terraform-providers/terraform-provider-google/issues/4203 tracks unifying the behaviour of the fields, I'd like to file a bug against GKE to see if we can get it for free before doing anything TF-side.

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
