### PR TITLE
added some fileds to CloudRun status

### DIFF
--- a/products/cloudrun/api.yaml
+++ b/products/cloudrun/api.yaml
@@ -498,6 +498,36 @@ objects:
           name: type
           output: true
           description: Type of domain mapping condition.
+    - !ruby/object:Api::Type::String
+      name: url
+      description: |-
+        From RouteStatus. URL holds the url that will distribute traffic over the provided traffic
+        targets. It generally has the form
+        https://{route-hash}-{project-hash}-{cluster-level-suffix}.a.run.app
+      output: true
+    - !ruby/object:Api::Type::Integer
+      name: observedGeneration
+      description: |-
+        ObservedGeneration is the 'Generation' of the Route that was last processed by the
+        controller.
+
+        Clients polling for completed reconciliation should poll until observedGeneration =
+        metadata.generation and the Ready condition's status is True or False.
+      output: true
+    - !ruby/object:Api::Type::String
+      name: latestCreatedRevisionName
+      description: |-
+        From ConfigurationStatus. LatestCreatedRevisionName is the last revision that was created
+        from this Service's Configuration. It might not be ready yet, for that use
+        LatestReadyRevisionName.
+      output: true
+    - !ruby/object:Api::Type::String
+      name: latestReadyRevisionName
+      description: |-
+        From ConfigurationStatus. LatestReadyRevisionName holds the name of the latest Revision
+        stamped out from this Service's Configuration that has had its "Ready" condition become
+        "True".
+      output: true
 
   - !ruby/object:Api::Type::NestedObject
     name: metadata


### PR DESCRIPTION
I added some fields to CloudRun status, namely

- url
- observedGeneration
- latestCreatedRevisionName
- latestReadyRevisionName

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
