### PR TITLE
CI script fix for downstreaming again

### DIFF
--- a/.ci/magic-modules/downstream_changelog_metadata.py
+++ b/.ci/magic-modules/downstream_changelog_metadata.py
@@ -76,7 +76,7 @@ def set_changelog_info(gh_pull, release_note, labels_to_add):
     release_note: String of release note text to set
     labels_to_add: List of strings. Changelog-related labels to add/replace.
   """
-  print "Setting changelog info for downstream PR %d" % gh_pull.url
+  print "Setting changelog info for downstream PR %s" % gh_pull.url
   edited_body = strutils.set_release_note(release_note, gh_pull.body)
   gh_pull.edit(body=edited_body)
 

--- a/.ci/magic-modules/downstream_changelog_metadata.py
+++ b/.ci/magic-modules/downstream_changelog_metadata.py
@@ -100,7 +100,4 @@ if __name__ == '__main__':
   assert len(sys.argv) == 2, "expected id filename as argument"
   with open(sys.argv[1]) as f:
     pr_num = int(f.read())
-
-    # TODO(emilymye): Replace this no-op print statement with code after
-    # verifying w/ pipeline.
     downstream_changelog_info(gh, pr_num, downstream_repos)


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
