### PR TITLE
Adding next_hop_ilb attribute to compute route resource

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -6403,6 +6403,18 @@ objects:
         output: true
         description: |
           URL to a Network that should handle matching packets.
+      - !ruby/object:Api::Type::ResourceRef
+        name: 'nextHopIlb'
+        resource: 'ForwardingRule'
+        imports: 'selfLink'
+        description: |
+          The URL to a forwarding rule of type loadBalancingScheme=INTERNAL that should handle matching packets.
+          You can only specify the forwarding rule as a partial or full URL. For example, the following are all valid URLs:
+          https://www.googleapis.com/compute/v1/projects/project/regions/region/forwardingRules/forwardingRule
+          regions/region/forwardingRules/forwardingRule
+          Note that this can only be used when the destinationRange is a public (non-RFC 1918) IP CIDR range.
+        input: true
+        min_version: beta
   - !ruby/object:Api::Resource
     name: 'Router'
     kind: 'compute#router'


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
This adds the beta feature to the route resource for next-hop internal load balancer. https://cloud.google.com/compute/docs/reference/rest/beta/routes/insert 
# Release Note for Downstream PRs (will be copied)
```releasenote
compute: The compute routes includes next_hop_ilb attribute support in beta.
```
