### PR TITLE
Make run version and product version explicit properties of providers.

### DIFF
--- a/compile/core.rb
+++ b/compile/core.rb
@@ -118,20 +118,18 @@ module Compile
     # WARNING: Do *NOT* change caller_frame = 1 value unless you really know
     # what you're doing. It is reserved for future use.
     def compile(file, caller_frame = 1)
-      begin
-        ctx = binding.of_caller(caller_frame)
-        has_erbout = ctx.local_variables.include?(:_erbout)
-        content = ctx.local_variable_get(:_erbout) if has_erbout # save code
-        ctx.local_variable_set(:compiler, compiler)
-        Google::LOGGER.debug "Compiling #{file}"
-        input = ERB.new get_helper_file(file), trim_mode: '->'
-        compiled = input.result(ctx)
-        ctx.local_variable_set(:_erbout, content) if has_erbout # restore code
-        compiled
-      rescue
-        Google::LOGGER.fatal "Error compiling #{file}"
-        raise
-      end
+      ctx = binding.of_caller(caller_frame)
+      has_erbout = ctx.local_variables.include?(:_erbout)
+      content = ctx.local_variable_get(:_erbout) if has_erbout # save code
+      ctx.local_variable_set(:compiler, compiler)
+      Google::LOGGER.debug "Compiling #{file}"
+      input = ERB.new get_helper_file(file), trim_mode: '->'
+      compiled = input.result(ctx)
+      ctx.local_variable_set(:_erbout, content) if has_erbout # restore code
+      compiled
+    rescue StandardError
+      Google::LOGGER.fatal "Error compiling #{file}"
+      raise
     end
 
     def ansible_style_yaml(obj, options = {})

--- a/compile/core.rb
+++ b/compile/core.rb
@@ -118,15 +118,20 @@ module Compile
     # WARNING: Do *NOT* change caller_frame = 1 value unless you really know
     # what you're doing. It is reserved for future use.
     def compile(file, caller_frame = 1)
-      ctx = binding.of_caller(caller_frame)
-      has_erbout = ctx.local_variables.include?(:_erbout)
-      content = ctx.local_variable_get(:_erbout) if has_erbout # save code
-      ctx.local_variable_set(:compiler, compiler)
-      Google::LOGGER.debug "Compiling #{file}"
-      input = ERB.new get_helper_file(file), trim_mode: '->'
-      compiled = input.result(ctx)
-      ctx.local_variable_set(:_erbout, content) if has_erbout # restore code
-      compiled
+      begin
+        ctx = binding.of_caller(caller_frame)
+        has_erbout = ctx.local_variables.include?(:_erbout)
+        content = ctx.local_variable_get(:_erbout) if has_erbout # save code
+        ctx.local_variable_set(:compiler, compiler)
+        Google::LOGGER.debug "Compiling #{file}"
+        input = ERB.new get_helper_file(file), trim_mode: '->'
+        compiled = input.result(ctx)
+        ctx.local_variable_set(:_erbout, content) if has_erbout # restore code
+        compiled
+      rescue
+        Google::LOGGER.fatal "Error compiling #{file}"
+        raise
+      end
     end
 
     def ansible_style_yaml(obj, options = {})

--- a/compiler.rb
+++ b/compiler.rb
@@ -34,7 +34,7 @@ require 'provider/terraform_oics'
 require 'provider/terraform_object_library'
 require 'pp' if ENV['COMPILER_DEBUG']
 
-products_to_compile = nil
+products_to_generate = nil
 all_products = false
 yaml_dump = false
 output_path = nil
@@ -49,8 +49,8 @@ Google::LOGGER.level = Logger::INFO
 
 # rubocop:disable Metrics/BlockLength
 OptionParser.new do |opt|
-  opt.on('-p', '--product PRODUCT', Array, 'Folder[,Folder...] with product catalog') do |p|
-    products_to_compile = p
+  opt.on('-p', '--product PRODUCT', Array, 'Folder[,Folder...] to generate resources from') do |p|
+    products_to_generate = p
   end
   opt.on('-a', '--all', 'Build all products. Cannot be used with --product.') do
     all_products = true
@@ -87,9 +87,9 @@ end.parse!
 # rubocop:enable Metrics/BlockLength
 
 raise 'Cannot use -p/--products and -a/--all simultaneously' \
-  if products_to_compile && all_products
+  if products_to_generate && all_products
 raise 'Either -p/--products OR -a/--all must be present' \
-  if products_to_compile.nil? && !all_products
+  if products_to_generate.nil? && !all_products
 raise 'Option -o/--output is a required parameter' if output_path.nil?
 raise 'Option -e/--engine is a required parameter' if provider_name.nil?
 
@@ -105,11 +105,12 @@ if override_dir
   end
 end
 
-products_to_compile = all_product_files if all_products
-
-raise 'No api.yaml files found. Check provider/engine name.' if products_to_compile.empty?
+products_to_generate = all_product_files if all_products
+raise 'No api.yaml files found. Check your provider (-e) name.' if products_to_generate.empty?
 
 start_time = Time.now
+Google::LOGGER.info "Generating MM output to '#{output_path}'"
+Google::LOGGER.info "Using #{version} version"
 
 # products_for_version entries are a hash of product definitions (:definitions)
 # and provider config (:overrides) for the product
@@ -118,15 +119,16 @@ provider = nil
 # rubocop:disable Metrics/BlockLength
 all_product_files.each do |product_name|
   product_override_path = ''
-  provider_override_path = ''
   product_override_path = File.join(override_dir, product_name, 'api.yaml') if override_dir
   product_yaml_path = File.join(product_name, 'api.yaml')
+
+  provider_override_path = ''
   provider_override_path = File.join(override_dir, product_name, "#{provider_name}.yaml") \
     if override_dir
   provider_yaml_path = File.join(product_name, "#{provider_name}.yaml")
 
   unless File.exist?(product_yaml_path) || File.exist?(product_override_path)
-    raise "Product '#{product_name}' does not have an api.yaml file"
+    raise "#{product_name} does not contain an api.yaml file"
   end
 
   if File.exist?(product_override_path)
@@ -141,14 +143,12 @@ all_product_files.each do |product_name|
   end
 
   unless File.exist?(provider_yaml_path) || File.exist?(provider_override_path)
-    Google::LOGGER.info "Skipping product '#{product_name}' as no #{provider_name}.yaml file exists"
+    Google::LOGGER.info "#{product_name}: Skipped as no #{provider_name}.yaml file exists"
     next
   end
 
   raise "Output path '#{output_path}' does not exist or is not a directory" \
     unless Dir.exist?(output_path)
-
-  Google::LOGGER.info "Loading '#{product_name}' (at #{version})'"
 
   product_api = Api::Compiler.new(product_yaml).run
   product_api.validate
@@ -169,22 +169,12 @@ all_product_files.each do |product_name|
     product_api, provider_config, = \
       Provider::Config.parse(provider_override_path, product_api, version, override_dir)
   end
-  products_for_version.push(definitions: product_api, overrides: provider_config)
 
-  unless products_to_compile.include?(product_name)
-    Google::LOGGER.info "Skipping product '#{product_name}' as it was not specified to be compiled"
-    next
-  end
-
-  Google::LOGGER.info "Compiling '#{product_name}' (at #{version}) output to '#{output_path}'"
-  Google::LOGGER.info \
-    "Generating types: #{types_to_generate.empty? ? 'ALL' : types_to_generate}"
-
+  Google::LOGGER.info "#{product_name}: Compiling provider config"
   pp provider_config if ENV['COMPILER_DEBUG']
 
   if force_provider.nil?
-    provider = provider_config.provider.new(provider_config, product_api, start_time)
-
+    provider = provider_config.provider.new(provider_config, product_api, version, start_time)
   else
     override_providers = {
       'oics' => Provider::TerraformOiCS,
@@ -198,21 +188,30 @@ all_product_files.each do |product_name|
     end
 
     provider = \
-      override_providers[force_provider].new(provider_config, product_api, start_time)
+      override_providers[force_provider].new(provider_config, product_api, version, start_time)
   end
 
-  provider.generate output_path, types_to_generate, version, product_name, yaml_dump
+  # provider_config is mutated by instantiating a provider
+  products_for_version.push(definitions: product_api, overrides: provider_config)
+
+  unless products_to_generate.include?(product_name)
+    Google::LOGGER.info "#{product_name}: Not specified, skipping generation"
+    next
+  end
+
+  Google::LOGGER.info \
+    "#{product_name}: Generating types: #{types_to_generate.empty? ? 'ALL' : types_to_generate}"
+  provider.generate output_path, types_to_generate, product_name, yaml_dump
 end
 
 # In order to only copy/compile files once per provider this must be called outside
 # of the products loop. This will get called with the provider from the final iteration
 # of the loop
-provider&.copy_common_files(output_path, version)
+provider&.copy_common_files(output_path)
 Google::LOGGER.info "Compiling common files for #{provider_name}"
 common_compile_file = "provider/#{provider_name}/common~compile.yaml"
 provider&.compile_common_files(
   output_path,
-  version,
   products_for_version.sort_by { |p| p[:definitions].name },
   common_compile_file
 )
@@ -221,7 +220,6 @@ if override_dir
   common_compile_file = "#{override_dir}/common~compile.yaml"
   provider&.compile_common_files(
     output_path,
-    version,
     products_for_version.sort_by { |p| p[:definitions].name },
     common_compile_file,
     override_dir

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -298,7 +298,7 @@ module Provider
         File.symlink "#{name}_info.py", deprecated_facts_path
       end
 
-      def generate_objects(output_folder, types, version_name)
+      def generate_objects(output_folder, types)
         # We have two sets of overrides - one for regular modules, one for
         # datasources.
         # When building regular modules, we will potentially need some
@@ -360,8 +360,8 @@ module Provider
       compile_file_list(data.output_folder, files, file_template)
     end
 
-    def copy_common_files(output_folder, version_name = 'ga', provider_name = 'ansible')
-      super(output_folder, version_name, provider_name)
+    def copy_common_files(output_folder, provider_name = 'ansible')
+      super(output_folder, provider_name)
     end
   end
 end

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -54,10 +54,10 @@ module Provider
         attr_accessor :example
       end
 
-    def initialize(config, api, version_name, start_time)
-      super(config, api, version_name, start_time)
-      @version_added = build_version_added
-    end
+      def initialize(config, api, version_name, start_time)
+        super(config, api, version_name, start_time)
+        @version_added = build_version_added
+      end
 
       # Returns a string representation of the corresponding Python type
       # for a MM type.

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -54,14 +54,10 @@ module Provider
         attr_accessor :example
       end
 
-      def api_version_setup(version_name)
-        version = @api.version_obj_or_closest(version_name)
-        @api.set_properties_based_on_version(version)
-
-        # Generate version_added_file
-        @version_added = build_version_added
-        version
-      end
+    def initialize(config, api, version_name, start_time)
+      super(config, api, version_name, start_time)
+      @version_added = build_version_added
+    end
 
       # Returns a string representation of the corresponding Python type
       # for a MM type.

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -29,7 +29,6 @@ module Provider
       @config = config
       @api = api
 
-
       # @target_version_name is the version specified by MM for this generation
       # run. That's distinct from @version below, which is the best-fit version
       # supported by the product.
@@ -76,10 +75,7 @@ module Provider
       end
     end
 
-    # Main entry point for the compiler. As this method is simply invoking other
-    # generators, it is okay to ignore Rubocop warnings about method size and
-    # complexity.
-    #
+    # Main entry point for generation.
     def generate(output_folder, types, product_path, dump_yaml)
       generate_objects(output_folder, types)
       copy_files(output_folder) \
@@ -121,7 +117,9 @@ module Provider
       # version_name is actually used because all of the variables in scope in this method
       # are made available within the templates by the compile call.
       # TODO: remove version_name, use @target_version_name or pass it in expicitly
+      # rubocop:disable Lint/UselessAssignment
       version_name = @target_version_name
+      # rubocop:enable Lint/UselessAssignment
       provider_name ||= self.class.name.split('::').last.downcase
       return unless File.exist?("provider/#{provider_name}/common~copy.yaml")
 

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -183,11 +183,11 @@ module Provider
                     filepath, self)
     end
 
-    def generate_operation(output_folder, _types, version_name)
+    def generate_operation(output_folder, _types)
       return if @api.objects.select(&:autogen_async).empty?
 
       product_name = @api.name.underscore
-      data = build_object_data(@api.objects.first, output_folder, version_name)
+      data = build_object_data(@api.objects.first, output_folder, @target_version_name)
       target_folder = File.join(data.output_folder, folder_name(data.version))
 
       data.object = @api.objects.select(&:autogen_async).first

--- a/provider/terraform/common~compile.yaml
+++ b/provider/terraform/common~compile.yaml
@@ -13,7 +13,7 @@
 # These files contains code that needs to be compiled before being delivered to
 # the final module tree structure:
 <%
-  dir = version_name == 'ga' ? 'google' : "google-#{version_name}"
+  dir = @target_version_name == 'ga' ? 'google' : "google-#{@target_version_name}"
 -%>
 'website/google.erb': 'third_party/terraform/website-compiled/google.erb'
 <%  Dir["third_party/terraform/tests/*.go.erb"].each do |file_path|

--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -16,10 +16,9 @@ require 'provider/terraform_oics'
 module Provider
   # Code generator for a library converting terraform state to gcp objects.
   class TerraformObjectLibrary < Provider::Terraform
-    def generate(output_folder, types, version_name, _product_path, _dump_yaml)
-      version = @api.version_obj_or_closest(version_name)
-      @base_url = version.base_url
-      generate_objects(output_folder, types, version.name)
+    def generate(output_folder, types, _product_path, _dump_yaml)
+      @base_url = @version.base_url
+      generate_objects(output_folder, types)
     end
 
     def generate_object(object, output_folder, version_name)
@@ -41,11 +40,11 @@ module Provider
                     self)
     end
 
-    def compile_common_files(output_folder, version_name, products, _common_compile_file)
+    def compile_common_files(output_folder, products, _common_compile_file)
       Google::LOGGER.info 'Compiling common files.'
       file_template = ProviderFileTemplate.new(
         output_folder,
-        version_name,
+        @target_version_name,
         build_env,
         products
       )
@@ -60,7 +59,7 @@ module Provider
                         file_template)
     end
 
-    def copy_common_files(output_folder, _version_name)
+    def copy_common_files(output_folder)
       Google::LOGGER.info 'Copying common files.'
       copy_file_list(output_folder, [
                        ['google/constants.go',

--- a/provider/terraform_oics.rb
+++ b/provider/terraform_oics.rb
@@ -19,17 +19,16 @@ module Provider
   class TerraformOiCS < Provider::Terraform
     # We don't want *any* static generation, so we override generate to only
     # generate objects.
-    def generate(output_folder, types, version_name, _product_path, _dump_yaml)
-      generate_objects(output_folder, types, version_name)
+    def generate(output_folder, types, _product_path, _dump_yaml)
+      generate_objects(output_folder, types)
     end
 
     # Create a directory of examples per resource
     def generate_resource(data)
-      version = @api.version_obj_or_closest(data.version)
       examples = data.object.examples
                      .reject(&:skip_test)
                      .reject { |e| !e.test_env_vars.nil? && e.test_env_vars.any? }
-                     .reject { |e| version < @api.version_obj_or_closest(e.min_version) }
+                     .reject { |e| @version < @api.version_obj_or_closest(e.min_version) }
 
       examples.each do |example|
         target_folder = data.output_folder

--- a/spec/provider_terraform_import_spec.rb
+++ b/spec/provider_terraform_import_spec.rb
@@ -27,7 +27,7 @@ describe Provider::Terraform do
     let(:config) do
       Provider::Config.parse('spec/data/terraform-config.yaml', product)[1]
     end
-    let(:provider) { Provider::Terraform.new(config, product, Time.now) }
+    let(:provider) { Provider::Terraform.new(config, product, 'ga', Time.now) }
 
     before do
       allow_open 'spec/data/good-file.yaml'

--- a/spec/provider_terraform_spec.rb
+++ b/spec/provider_terraform_spec.rb
@@ -26,7 +26,7 @@ describe Provider::Terraform do
     let(:config) do
       Provider::Config.parse('spec/data/terraform-config.yaml', product)[1]
     end
-    let(:provider) { Provider::Terraform.new(config, product, Time.now) }
+    let(:provider) { Provider::Terraform.new(config, product, 'ga', Time.now) }
     let(:resource) { product.objects[0] }
 
     before do


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/magic-modules/issues/2214

This PR gets a bunch done at once (sorry for the wide scope!). It should end up being a no-op, though.

* Catch exceptions while compiling files, write the name of the template before reraising.

* Always load every product provider, standardise frontend logging

* Move versions to instance variables on providers, use `target_version_name` to strongly disambiguate run version vs product version.

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
