### PR TITLE
Remove debugging start_time line

### DIFF
--- a/provider/core.rb
+++ b/provider/core.rb
@@ -129,7 +129,6 @@ module Provider
     end
 
     def copy_file_list(output_folder, files)
-      puts "start_time is #{@start_time}"
       files.map do |target, source|
         Thread.new do
           target_file = File.join(output_folder, target)


### PR DESCRIPTION
<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
