### PR TITLE
private-googleapis data source support

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_netblock_ip_ranges.go
+++ b/third_party/terraform/data_sources/data_source_google_netblock_ip_ranges.go
@@ -68,8 +68,14 @@ func dataSourceGoogleNetblockIpRangesRead(d *schema.ResourceData, meta interface
 		d.Set("cidr_blocks_ipv6", CidrBlocks["cidr_blocks_ipv6"])
 	// Static ranges
 	case "restricted-googleapis":
-		// https://cloud.google.com/vpc/docs/configure-private-google-access-hybrid
+		// https://cloud.google.com/vpc/docs/private-access-options#domain-vips
 		CidrBlocks["cidr_blocks_ipv4"] = append(CidrBlocks["cidr_blocks_ipv4"], "199.36.153.4/30")
+		CidrBlocks["cidr_blocks"] = CidrBlocks["cidr_blocks_ipv4"]
+		d.Set("cidr_blocks", CidrBlocks["cidr_blocks"])
+		d.Set("cidr_blocks_ipv4", CidrBlocks["cidr_blocks_ipv4"])
+	case "private-googleapis":
+		// https://cloud.google.com/vpc/docs/private-access-options#domain-vips
+		CidrBlocks["cidr_blocks_ipv4"] = append(CidrBlocks["cidr_blocks_ipv4"], "199.36.153.8/30")
 		CidrBlocks["cidr_blocks"] = CidrBlocks["cidr_blocks_ipv4"]
 		d.Set("cidr_blocks", CidrBlocks["cidr_blocks"])
 		d.Set("cidr_blocks_ipv4", CidrBlocks["cidr_blocks_ipv4"])

--- a/third_party/terraform/tests/data_source_google_netblock_ip_ranges_test.go
+++ b/third_party/terraform/tests/data_source_google_netblock_ip_ranges_test.go
@@ -62,6 +62,19 @@ func TestAccDataSourceGoogleNetblockIpRanges_basic(t *testing.T) {
 				),
 			},
 			{
+				Config: testAccNetblockIpRangesConfig_private,
+				Check: resource.ComposeTestCheckFunc(
+					// Private Google Access Unrestricted VIP
+					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.private", "cidr_blocks.#", "1"),
+					resource.TestMatchResourceAttr("data.google_netblock_ip_ranges.private",
+						"cidr_blocks.0", regexp.MustCompile("^(?:[0-9a-fA-F./:]{1,4}){1,2}.*/[0-9]{1,3}$")),
+					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.private", "cidr_blocks_ipv4.#", "1"),
+					resource.TestMatchResourceAttr("data.google_netblock_ip_ranges.private",
+						"cidr_blocks_ipv4.0", regexp.MustCompile("^(?:[0-9]{1,3}.){3}[0-9]{1,3}/[0-9]{1,2}$")),
+					resource.TestCheckResourceAttr("data.google_netblock_ip_ranges.private", "cidr_blocks_ipv6.#", "0"),
+				),
+			},
+			{
 				Config: testAccNetblockIpRangesConfig_dns,
 				Check: resource.ComposeTestCheckFunc(
 					// DNS outbound forwarding
@@ -130,6 +143,12 @@ data "google_netblock_ip_ranges" "google" {
 const testAccNetblockIpRangesConfig_restricted = `
 data "google_netblock_ip_ranges" "restricted" {
   range_type = "restricted-googleapis"
+}
+`
+
+const testAccNetblockIpRangesConfig_private = `
+data "google_netblock_ip_ranges" "private" {
+  range_type = "private-googleapis"
 }
 `
 

--- a/third_party/terraform/website/docs/d/datasource_google_netblock_ip_ranges.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_netblock_ip_ranges.html.markdown
@@ -64,7 +64,9 @@ The following arguments are supported:
 
   * `google-netblocks` - Corresponds to IP addresses used for Google services. [More details.](https://support.google.com/a/answer/33786?hl=en)
 
-  * `restricted-googleapis` - Corresponds to the IP addresses used for Private Google Access and/or VPC Service Controls API access. [More details.](https://cloud.google.com/vpc/docs/configure-private-google-access-hybrid)
+  * `restricted-googleapis` - Corresponds to the IP addresses used for Private Google Access only for services that support VPC Service Controls API access. [More details.](https://cloud.google.com/vpc/docs/private-access-options#domain-vips)
+
+  * `private-googleapis` - Corresponds to the IP addresses used for Private Google Access for services that do not support VPC Service Controls. [More details.](https://cloud.google.com/vpc/docs/private-access-options#domain-vips)
 
   * `dns-forwarders` - Corresponds to the IP addresses used to originate Cloud DNS outbound forwarding. [More details.](https://cloud.google.com/dns/zones/#creating-forwarding-zones)
 


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
adds support for private.googleapis.com range (199.36.153.8/30) to google_netblock_ip_ranges data source.
```