### PR TITLE
Fix initialisms in product names

### DIFF
--- a/compiler.rb
+++ b/compiler.rb
@@ -224,7 +224,7 @@ Google::LOGGER.info "Compiling common files for #{provider_name}"
 common_compile_file = "provider/#{provider_name}/common~compile.yaml"
 provider&.compile_common_files(
   output_path,
-  products_for_version.sort_by { |p| p[:definitions].name },
+  products_for_version.sort_by { |p| p[:definitions].name.downcase },
   common_compile_file
 )
 if override_dir
@@ -232,7 +232,7 @@ if override_dir
   common_compile_file = "#{override_dir}/common~compile.yaml"
   provider&.compile_common_files(
     output_path,
-    products_for_version.sort_by { |p| p[:definitions].name },
+    products_for_version.sort_by { |p| p[:definitions].name.downcase },
     common_compile_file,
     override_dir
   )

--- a/compiler.rb
+++ b/compiler.rb
@@ -23,6 +23,7 @@ Dir.chdir(File.dirname(__FILE__))
 # generation.
 ENV['TZ'] = 'UTC'
 
+require 'active_support/inflector'
 require 'api/compiler'
 require 'google/logger'
 require 'optparse'
@@ -85,6 +86,17 @@ OptionParser.new do |opt|
   end
 end.parse!
 # rubocop:enable Metrics/BlockLength
+
+# We use ActiveSupport Inflections to perform common string operations like
+# going from camelCase/PascalCase -> snake_case -> Title Case.
+# In order to not break the world, they've frozen the list of inflections the
+# library uses by default.
+# Particularly for initialisms, it may need a little help to generate great
+# code.
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'TPU'
+  inflect.acronym 'VPC'
+end
 
 raise 'Cannot use -p/--products and -a/--all simultaneously' \
   if products_to_generate && all_products

--- a/google/extensions.rb
+++ b/google/extensions.rb
@@ -18,14 +18,6 @@ class String
     Google::StringUtils.underscore(self)
   end
 
-  def camelize(style = :lower)
-    Google::StringUtils.camelize(self, style)
-  end
-
-  def uncombine
-    Google::StringUtils.uncombine(self)
-  end
-
   def symbolize
     Google::StringUtils.symbolize(self)
   end

--- a/google/string_utils.rb
+++ b/google/string_utils.rb
@@ -14,7 +14,6 @@
 module Google
   # Helper class to process and mutate strings.
   class StringUtils
-
     # Converts string from camel case to underscore
     def self.underscore(source)
       source.gsub(/::/, '/')

--- a/google/string_utils.rb
+++ b/google/string_utils.rb
@@ -14,19 +14,6 @@
 module Google
   # Helper class to process and mutate strings.
   class StringUtils
-    # Converts string from underscore to camel case
-    def self.camelize(source, style = :lower)
-      camelized = source.gsub(/_(.)/, &:upcase).delete('_')
-      case style
-      when :lower
-        camelized[0] = camelized[0].downcase
-      when :upper
-        camelized[0] = camelized[0].upcase
-      else
-        raise "Unknown camel case style: #{style}"
-      end
-      camelized
-    end
 
     # Converts string from camel case to underscore
     def self.underscore(source)
@@ -36,11 +23,6 @@ module Google
             .tr('-', '_')
             .tr('.', '_')
             .downcase
-    end
-
-    # Add spaces before every capitalized word except first.
-    def self.uncombine(source)
-      source.gsub(/(?=[A-Z])/, ' ').strip
     end
 
     # rubocop:disable Style/SafeNavigation # support Ruby < 2.3.0

--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Dns
+name: DNS
 display_name: Cloud DNS
 versions:
   - !ruby/object:Api::Product::Version

--- a/products/iam/api.yaml
+++ b/products/iam/api.yaml
@@ -14,7 +14,7 @@
 # TODO(nelsonjr): Make all Zone and Region resource ref
 
 --- !ruby/object:Api::Product
-name: Iam
+name: IAM
 display_name: Cloud IAM
 versions:
   - !ruby/object:Api::Product::Version

--- a/products/kms/api.yaml
+++ b/products/kms/api.yaml
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Kms
+name: KMS
 display_name: Cloud KMS
 versions:
   - !ruby/object:Api::Product::Version

--- a/products/sql/api.yaml
+++ b/products/sql/api.yaml
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Sql
+name: SQL
 display_name: Cloud SQL
 versions:
   - !ruby/object:Api::Product::Version

--- a/products/tpu/api.yaml
+++ b/products/tpu/api.yaml
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: Tpu
+name: TPU
 display_name: Google Cloud TPU
 versions:
   - !ruby/object:Api::Product::Version

--- a/products/vpcaccess/api.yaml
+++ b/products/vpcaccess/api.yaml
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 --- !ruby/object:Api::Product
-name: VpcAccess
+name: VPCAccess
 display_name: Serverless VPC Access
 versions:
   - !ruby/object:Api::Product::Version

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -120,9 +120,7 @@ module Provider
     # Capitalize the first letter of a property name.
     # E.g. "creationTimestamp" becomes "CreationTimestamp".
     def titlelize_property(property)
-      p = property.name.clone
-      p[0] = p[0].capitalize
-      p
+      property.name.camelize(:upper)
     end
 
     private

--- a/spec/string_utils_spec.rb
+++ b/spec/string_utils_spec.rb
@@ -14,11 +14,6 @@
 require 'spec_helper'
 
 describe Google::StringUtils do
-  context '#camelize' do
-    subject { described_class.camelize('some_string_with_underscores') }
-    it { is_expected.to eq 'someStringWithUnderscores' }
-  end
-
   context '#underscore' do
     subject { described_class.underscore('aStringInCamelCase') }
     it { is_expected.to eq 'a_string_in_camel_case' }

--- a/templates/ansible/documentation.erb
+++ b/templates/ansible/documentation.erb
@@ -43,7 +43,7 @@ DOCUMENTATION = '''
 
 <% if example -%>
 EXAMPLES = '''
-<% res_readable_name = object.name.uncombine -%>
+<% res_readable_name = object.name.titleize -%>
 <% if example.dependencies -%>
 <%   example.dependencies.each do |depend| -%>
 <%= lines(depend.build_test('present', object, false), 1) -%>

--- a/templates/ansible/integration_test.erb
+++ b/templates/ansible/integration_test.erb
@@ -8,7 +8,7 @@
 <% end # if example.dependencies -%>
 <%= lines(example.task.build_test('absent', object, false)) -%>
 #----------------------------------------------------------
-<% resource_name = object.name.uncombine.downcase -%>
+<% resource_name = object.name.titleize.downcase -%>
 <%= lines(example.task.build_test('present', object, false)) -%>
   register: result
 <% if object.readonly -%>

--- a/templates/terraform/examples/base_configs/tutorial.md.erb
+++ b/templates/terraform/examples/base_configs/tutorial.md.erb
@@ -1,5 +1,5 @@
 <% autogen_exception -%>
-<%= "# #{example.name.camelize(:upper).uncombine} - Terraform" %>
+<%= "# #{example.name.camelize(:upper).titleize} - Terraform" %>
 
 ## Setup
 

--- a/templates/terraform/pre_delete/detach_network.erb
+++ b/templates/terraform/pre_delete/detach_network.erb
@@ -3,7 +3,7 @@ if d.Get("networks.#").(int) > 0 {
 	patched := make(map[string]interface{})
 	patched["networks"] = nil
 
-	url, err := replaceVars(d, config, "{{DnsBasePath}}projects/{{project}}/policies/{{name}}")
+	url, err := replaceVars(d, config, "{{DNSBasePath}}projects/{{project}}/policies/{{name}}")
 	if err != nil {
 		return err
 	}

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -24,11 +24,10 @@ package google
     update_body_properties = object.settable_properties
     update_body_properties = object.settable_properties.reject(&:input) if object.update_verb == :PATCH
     # Handwritten TF Operation objects will be shaped like accessContextManager while the Google Go Client will have a name like accesscontextmanager
-    client_name_camel = String.new(if @config.client_name then @config.client_name else product_ns end)
-    client_name_camel[0] = client_name_camel[0].downcase
-    client_name_pascal = String.new(client_name_camel)
-    client_name_pascal[0] = client_name_pascal[0].upcase
-    client_name_lower = client_name_camel.downcase
+    client_name = @config.client_name || product_ns
+    client_name_camel = client_name.camelize(:lower)
+    client_name_pascal = client_name.camelize(:upper)
+    client_name_lower = client_name.downcase
     has_project = object.base_url.include?('{{project}}')
     has_region = object.base_url.include?('{{region}}') && object.parameters.any?{ |p| p.name == 'region' && p.ignore_read }
     timeouts = object.async.nil? ? Api::Timeouts.new : object.timeouts

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -88,7 +88,7 @@ To get more information about <%= object.name -%>, see:
   </a>
 </div>
     <%- end -%>
-## Example Usage - <%= example.name.camelize(:upper).uncombine %>
+## Example Usage - <%= example.name.camelize(:upper).titleize %>
 
 
 <%= example.config_documentation -%>

--- a/templates/terraform/state_migrations/kms_crypto_key.go.erb
+++ b/templates/terraform/state_migrations/kms_crypto_key.go.erb
@@ -1,4 +1,4 @@
-func resourceKmsCryptoKeyResourceV0() *schema.Resource {
+func resourceKMSCryptoKeyResourceV0() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -24,7 +24,7 @@ func resourceKmsCryptoKeyResourceV0() *schema.Resource {
 	}
 }
 
-func resourceKmsCryptoKeyUpgradeV0(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+func resourceKMSCryptoKeyUpgradeV0(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
 	log.Printf("[DEBUG] Attributes before migration: %#v", rawState)
 
 	config := meta.(*Config)

--- a/third_party/terraform/data_sources/data_source_google_kms_crypto_key.go
+++ b/third_party/terraform/data_sources/data_source_google_kms_crypto_key.go
@@ -5,7 +5,7 @@ import (
 )
 
 func dataSourceGoogleKmsCryptoKey() *schema.Resource {
-	dsSchema := datasourceSchemaFromResourceSchema(resourceKmsCryptoKey().Schema)
+	dsSchema := datasourceSchemaFromResourceSchema(resourceKMSCryptoKey().Schema)
 	addRequiredFieldsToSchema(dsSchema, "name")
 	addRequiredFieldsToSchema(dsSchema, "key_ring")
 
@@ -31,5 +31,5 @@ func dataSourceGoogleKmsCryptoKeyRead(d *schema.ResourceData, meta interface{}) 
 
 	d.SetId(cryptoKeyId.cryptoKeyId())
 
-	return resourceKmsCryptoKeyRead(d, meta)
+	return resourceKMSCryptoKeyRead(d, meta)
 }

--- a/third_party/terraform/data_sources/data_source_google_kms_crypto_key_version.go
+++ b/third_party/terraform/data_sources/data_source_google_kms_crypto_key_version.go
@@ -59,7 +59,7 @@ func dataSourceGoogleKmsCryptoKeyVersion() *schema.Resource {
 func dataSourceGoogleKmsCryptoKeyVersionRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	url, err := replaceVars(d, config, "{{KmsBasePath}}{{crypto_key}}/cryptoKeyVersions/{{version}}")
+	url, err := replaceVars(d, config, "{{KMSBasePath}}{{crypto_key}}/cryptoKeyVersions/{{version}}")
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func dataSourceGoogleKmsCryptoKeyVersionRead(d *schema.ResourceData, meta interf
 		return fmt.Errorf("Error reading CryptoKeyVersion: %s", err)
 	}
 
-	url, err = replaceVars(d, config, "{{KmsBasePath}}{{crypto_key}}")
+	url, err = replaceVars(d, config, "{{KMSBasePath}}{{crypto_key}}")
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func dataSourceGoogleKmsCryptoKeyVersionRead(d *schema.ResourceData, meta interf
 	}
 
 	if res["purpose"] == "ASYMMETRIC_SIGN" || res["purpose"] == "ASYMMETRIC_DECRYPT" {
-		url, err = replaceVars(d, config, "{{KmsBasePath}}{{crypto_key}}/cryptoKeyVersions/{{version}}/publicKey")
+		url, err = replaceVars(d, config, "{{KMSBasePath}}{{crypto_key}}/cryptoKeyVersions/{{version}}/publicKey")
 		if err != nil {
 			return err
 		}

--- a/third_party/terraform/data_sources/data_source_google_kms_key_ring.go
+++ b/third_party/terraform/data_sources/data_source_google_kms_key_ring.go
@@ -5,7 +5,7 @@ import (
 )
 
 func dataSourceGoogleKmsKeyRing() *schema.Resource {
-	dsSchema := datasourceSchemaFromResourceSchema(resourceKmsKeyRing().Schema)
+	dsSchema := datasourceSchemaFromResourceSchema(resourceKMSKeyRing().Schema)
 	addRequiredFieldsToSchema(dsSchema, "name")
 	addRequiredFieldsToSchema(dsSchema, "location")
 	addOptionalFieldsToSchema(dsSchema, "project")
@@ -31,5 +31,5 @@ func dataSourceGoogleKmsKeyRingRead(d *schema.ResourceData, meta interface{}) er
 	}
 	d.SetId(keyRingId.terraformId())
 
-	return resourceKmsKeyRingRead(d, meta)
+	return resourceKMSKeyRingRead(d, meta)
 }

--- a/third_party/terraform/tests/data_source_dns_managed_zone_test.go
+++ b/third_party/terraform/tests/data_source_dns_managed_zone_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceDnsManagedZone_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDnsManagedZoneDestroy,
+		CheckDestroy: testAccCheckDNSManagedZoneDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceDnsManagedZone_basic(),

--- a/third_party/terraform/tests/data_source_tpu_tensorflow_versions_test.go
+++ b/third_party/terraform/tests/data_source_tpu_tensorflow_versions_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccTpuTensorflowVersions_basic(t *testing.T) {
+func TestAccTPUTensorflowVersions_basic(t *testing.T) {
 	t.Parallel()
 
 	resource.Test(t, resource.TestCase{

--- a/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
+++ b/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccDnsManagedZone_update(t *testing.T) {
+func TestAccDNSManagedZone_update(t *testing.T) {
 	t.Parallel()
 
 	zoneSuffix := acctest.RandString(10)
@@ -17,7 +17,7 @@ func TestAccDnsManagedZone_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDnsManagedZoneDestroy,
+		CheckDestroy: testAccCheckDNSManagedZoneDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDnsManagedZone_basic(zoneSuffix, "description1"),
@@ -39,7 +39,7 @@ func TestAccDnsManagedZone_update(t *testing.T) {
 	})
 }
 
-func TestAccDnsManagedZone_privateUpdate(t *testing.T) {
+func TestAccDNSManagedZone_privateUpdate(t *testing.T) {
 	t.Parallel()
 
 	zoneSuffix := acctest.RandString(10)
@@ -47,7 +47,7 @@ func TestAccDnsManagedZone_privateUpdate(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDnsManagedZoneDestroy,
+		CheckDestroy: testAccCheckDNSManagedZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDnsManagedZone_privateUpdate(zoneSuffix, "network-1", "network-2"),
@@ -69,7 +69,7 @@ func TestAccDnsManagedZone_privateUpdate(t *testing.T) {
 	})
 }
 
-func TestAccDnsManagedZone_dnssec_on(t *testing.T) {
+func TestAccDNSManagedZone_dnssec_on(t *testing.T) {
 	t.Parallel()
 
 	zoneSuffix := acctest.RandString(10)
@@ -77,7 +77,7 @@ func TestAccDnsManagedZone_dnssec_on(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDnsManagedZoneDestroy,
+		CheckDestroy: testAccCheckDNSManagedZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDnsManagedZone_dnssec_on(zoneSuffix),
@@ -91,7 +91,7 @@ func TestAccDnsManagedZone_dnssec_on(t *testing.T) {
 	})
 }
 
-func TestAccDnsManagedZone_dnssec_off(t *testing.T) {
+func TestAccDNSManagedZone_dnssec_off(t *testing.T) {
 	t.Parallel()
 
 	zoneSuffix := acctest.RandString(10)
@@ -99,7 +99,7 @@ func TestAccDnsManagedZone_dnssec_off(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDnsManagedZoneDestroy,
+		CheckDestroy: testAccCheckDNSManagedZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDnsManagedZone_dnssec_off(zoneSuffix),
@@ -114,7 +114,7 @@ func TestAccDnsManagedZone_dnssec_off(t *testing.T) {
 }
 
 <% unless version.nil? || version == 'ga' -%>
-func TestAccDnsManagedZone_privateForwardingUpdate(t *testing.T) {
+func TestAccDNSManagedZone_privateForwardingUpdate(t *testing.T) {
 	t.Parallel()
 
 	zoneSuffix := acctest.RandString(10)
@@ -122,7 +122,7 @@ func TestAccDnsManagedZone_privateForwardingUpdate(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDnsManagedZoneDestroy,
+		CheckDestroy: testAccCheckDNSManagedZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDnsManagedZone_privateForwardingUpdate(zoneSuffix, "172.16.1.10", "172.16.1.20"),
@@ -334,7 +334,7 @@ func TestDnsManagedZoneImport_parseImportId(t *testing.T) {
 	}
 }
 
-func TestAccDnsManagedZone_importWithProject(t *testing.T) {
+func TestAccDNSManagedZone_importWithProject(t *testing.T) {
 	t.Parallel()
 
 	zoneSuffix := acctest.RandString(10)
@@ -343,7 +343,7 @@ func TestAccDnsManagedZone_importWithProject(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDnsManagedZoneDestroy,
+		CheckDestroy: testAccCheckDNSManagedZoneDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDnsManagedZone_basicWithProject(zoneSuffix, "description1", project),

--- a/third_party/terraform/tests/resource_dns_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_dns_policy_test.go.erb
@@ -10,7 +10,7 @@ import (
 )
 
 <% unless version.nil? || version == 'ga' -%>
-func TestAccDnsPolicy_update(t *testing.T) {
+func TestAccDNSPolicy_update(t *testing.T) {
 	t.Parallel()
 
 	policySuffix := acctest.RandString(10)
@@ -18,7 +18,7 @@ func TestAccDnsPolicy_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckDnsPolicyDestroy,
+		CheckDestroy: testAccCheckDNSPolicyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDnsPolicy_privateUpdate(policySuffix, "true", "172.16.1.10", "network-1"),

--- a/third_party/terraform/tests/resource_dns_record_set_test.go
+++ b/third_party/terraform/tests/resource_dns_record_set_test.go
@@ -34,7 +34,7 @@ func TestIpv6AddressDiffSuppress(t *testing.T) {
 	}
 }
 
-func TestAccDnsRecordSet_basic(t *testing.T) {
+func TestAccDNSRecordSet_basic(t *testing.T) {
 	t.Parallel()
 
 	zoneName := fmt.Sprintf("dnszone-test-%s", acctest.RandString(10))
@@ -67,7 +67,7 @@ func TestAccDnsRecordSet_basic(t *testing.T) {
 	})
 }
 
-func TestAccDnsRecordSet_modify(t *testing.T) {
+func TestAccDNSRecordSet_modify(t *testing.T) {
 	t.Parallel()
 
 	zoneName := fmt.Sprintf("dnszone-test-%s", acctest.RandString(10))
@@ -101,7 +101,7 @@ func TestAccDnsRecordSet_modify(t *testing.T) {
 	})
 }
 
-func TestAccDnsRecordSet_changeType(t *testing.T) {
+func TestAccDNSRecordSet_changeType(t *testing.T) {
 	t.Parallel()
 
 	zoneName := fmt.Sprintf("dnszone-test-%s", acctest.RandString(10))
@@ -128,7 +128,7 @@ func TestAccDnsRecordSet_changeType(t *testing.T) {
 	})
 }
 
-func TestAccDnsRecordSet_ns(t *testing.T) {
+func TestAccDNSRecordSet_ns(t *testing.T) {
 	t.Parallel()
 
 	zoneName := fmt.Sprintf("dnszone-test-ns-%s", acctest.RandString(10))
@@ -154,7 +154,7 @@ func TestAccDnsRecordSet_ns(t *testing.T) {
 	})
 }
 
-func TestAccDnsRecordSet_nestedNS(t *testing.T) {
+func TestAccDNSRecordSet_nestedNS(t *testing.T) {
 	t.Parallel()
 
 	zoneName := fmt.Sprintf("dnszone-test-ns-%s", acctest.RandString(10))
@@ -174,7 +174,7 @@ func TestAccDnsRecordSet_nestedNS(t *testing.T) {
 	})
 }
 
-func TestAccDnsRecordSet_quotedTXT(t *testing.T) {
+func TestAccDNSRecordSet_quotedTXT(t *testing.T) {
 	t.Parallel()
 
 	zoneName := fmt.Sprintf("dnszone-test-txt-%s", acctest.RandString(10))
@@ -194,7 +194,7 @@ func TestAccDnsRecordSet_quotedTXT(t *testing.T) {
 	})
 }
 
-func TestAccDnsRecordSet_uppercaseMX(t *testing.T) {
+func TestAccDNSRecordSet_uppercaseMX(t *testing.T) {
 	t.Parallel()
 
 	zoneName := fmt.Sprintf("dnszone-test-txt-%s", acctest.RandString(10))

--- a/third_party/terraform/tests/resource_kms_crypto_key_test.go
+++ b/third_party/terraform/tests/resource_kms_crypto_key_test.go
@@ -149,7 +149,7 @@ func TestCryptoKeyStateUpgradeV0(t *testing.T) {
 	}
 	for tn, tc := range cases {
 		t.Run(tn, func(t *testing.T) {
-			actual, err := resourceKmsCryptoKeyUpgradeV0(tc.Attributes, tc.Meta)
+			actual, err := resourceKMSCryptoKeyUpgradeV0(tc.Attributes, tc.Meta)
 
 			if err != nil {
 				t.Error(err)

--- a/third_party/terraform/tests/resource_tpu_node_test.go
+++ b/third_party/terraform/tests/resource_tpu_node_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccTpuNode_tpuNodeBUpdateTensorFlowVersion(t *testing.T) {
+func TestAccTPUNode_tpuNodeBUpdateTensorFlowVersion(t *testing.T) {
 	t.Parallel()
 
 	nodeId := acctest.RandomWithPrefix("tf-test")
@@ -16,7 +16,7 @@ func TestAccTpuNode_tpuNodeBUpdateTensorFlowVersion(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckTpuNodeDestroy,
+		CheckDestroy: testAccCheckTPUNodeDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccTpuNode_tpuNodeTensorFlow(nodeId, 0),

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -268,7 +268,7 @@ func (c *Config) LoadAndValidate() error {
 	c.clientContainerBeta.UserAgent = userAgent
 	c.clientContainerBeta.BasePath = containerBetaClientBasePath
 
-	dnsClientBasePath := removeBasePathVersion(c.DnsBasePath) + "v1/projects/"
+	dnsClientBasePath := removeBasePathVersion(c.DNSBasePath) + "v1/projects/"
 	log.Printf("[INFO] Instantiating Google Cloud DNS client for path %s", dnsClientBasePath)
 	c.clientDns, err = dns.NewService(context, option.WithHTTPClient(client))
 	if err != nil {
@@ -286,7 +286,7 @@ func (c *Config) LoadAndValidate() error {
 	c.clientDnsBeta.UserAgent = userAgent
 	c.clientDnsBeta.BasePath = dnsBetaClientBasePath
 
-	kmsClientBasePath := removeBasePathVersion(c.KmsBasePath)
+	kmsClientBasePath := removeBasePathVersion(c.KMSBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud KMS client for path %s", kmsClientBasePath)
 	c.clientKms, err = cloudkms.NewService(context, option.WithHTTPClient(client))
 	if err != nil {
@@ -313,7 +313,7 @@ func (c *Config) LoadAndValidate() error {
 	c.clientStorage.UserAgent = userAgent
 	c.clientStorage.BasePath = storageClientBasePath
 
-	sqlClientBasePath := removeBasePathVersion(c.SqlBasePath) + "v1beta4/"
+	sqlClientBasePath := removeBasePathVersion(c.SQLBasePath) + "v1beta4/"
 	log.Printf("[INFO] Instantiating Google SqlAdmin client for path %s", sqlClientBasePath)
 	c.clientSqlAdmin, err = sqladmin.NewService(context, option.WithHTTPClient(client))
 	if err != nil {


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

For a handful of products, we've collapsed initialisms like `TPU` into `Tpu`. This should correct a handful of those. Previously, no providers cared, but KCC will.

In addition, this moves off some janky string manipulation code onto ActiveSupport ones.

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
