### PR TITLE
Fix missed occurence of TpuBasePath

### DIFF
--- a/third_party/terraform/data_sources/data_source_tpu_tensorflow_versions.go
+++ b/third_party/terraform/data_sources/data_source_tpu_tensorflow_versions.go
@@ -45,7 +45,7 @@ func dataSourceTpuTensorFlowVersionsRead(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	url, err := replaceVars(d, config, "{{TpuBasePath}}projects/{{project}}/locations/{{zone}}/tensorflowVersions")
+	url, err := replaceVars(d, config, "{{TPUBasePath}}projects/{{project}}/locations/{{zone}}/tensorflowVersions")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

Followup / fix for #2272, I missed an occurrence of `s/Tpu/TPU/`.

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
