### PR TITLE
Add validation for scratch disks in Instance Template

### DIFF
--- a/third_party/terraform/resources/resource_compute_instance_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_template.go
@@ -529,6 +529,10 @@ func resourceComputeInstanceTemplateScratchDiskCustomizeDiff(diff *schema.Resour
 		if typee == "SCRATCH" && diskType != "local-ssd" {
 			return fmt.Errorf("SCRATCH disks must have a disk_type of local-ssd. disk %d has disk_type %s", i, diskType)
 		}
+
+		if diskType == "local-ssd" && typee != "SCRATCH" {
+			return fmt.Errorf("disks with a disk_type of local-ssd must be SCRATCH disks. disk %d is a %s disk", i, typee)
+		}
 	}
 
 	return nil

--- a/third_party/terraform/tests/resource_compute_instance_template_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_template_test.go
@@ -1886,10 +1886,12 @@ resource "google_compute_instance_template" "foobar" {
 
 func testAccComputeInstanceTemplate_invalidDiskType() string {
 	return fmt.Sprintf(`
-data "google_compute_image" "my_image" {
-	family  = "centos-7"
-	project = "gce-uefi-images"
-}
+# Use this datasource insead of hardcoded values when https://github.com/hashicorp/terraform/issues/22679
+# is resolved.
+# data "google_compute_image" "my_image" {
+# 	family  = "centos-7"
+# 	project = "gce-uefi-images"
+# }
 
 resource "google_compute_instance_template" "foobar" {
 	name = "instancet-test-%s"
@@ -1897,7 +1899,7 @@ resource "google_compute_instance_template" "foobar" {
 	can_ip_forward = false
 
 	disk {
-		source_image = "${data.google_compute_image.my_image.self_link}"
+		source_image = "https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/centos-7-v20190729"
 		auto_delete = true
 		boot = true
 	}
@@ -1909,7 +1911,7 @@ resource "google_compute_instance_template" "foobar" {
 	}
 
 	disk {
-		source_image = "${data.google_compute_image.my_image.self_link}"
+		source_image = "https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/centos-7-v20190729"
 		auto_delete = true
 		type = "SCRATCH"
 	}

--- a/third_party/terraform/tests/resource_compute_instance_template_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_template_test.go
@@ -1903,7 +1903,6 @@ resource "google_compute_instance_template" "foobar" {
 	}
 
 	disk {
-		source_image = "${data.google_compute_image.my_image.self_link}"
 		auto_delete = true
 		type = "SCRATCH"
 		disk_type = "local-ssd"

--- a/third_party/terraform/tests/resource_compute_instance_template_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_template_test.go
@@ -736,6 +736,21 @@ func TestAccComputeInstanceTemplate_shieldedVmConfig2(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstanceTemplate_invalidDiskType(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccComputeInstanceTemplate_invalidDiskType(),
+				ExpectError: regexp.MustCompile("SCRATCH disks must have a disk_type of local-ssd"),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeInstanceTemplateDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -1867,4 +1882,41 @@ resource "google_compute_instance_template" "foobar" {
 		enable_integrity_monitoring = %t
 	}
 }`, acctest.RandString(10), enableSecureBoot, enableVtpm, enableIntegrityMonitoring)
+}
+
+func testAccComputeInstanceTemplate_invalidDiskType() string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+	family  = "centos-7"
+	project = "gce-uefi-images"
+}
+
+resource "google_compute_instance_template" "foobar" {
+	name = "instancet-test-%s"
+	machine_type = "n1-standard-1"
+	can_ip_forward = false
+
+	disk {
+		source_image = "${data.google_compute_image.my_image.self_link}"
+		auto_delete = true
+		boot = true
+	}
+
+	disk {
+		source_image = "${data.google_compute_image.my_image.self_link}"
+		auto_delete = true
+		type = "SCRATCH"
+		disk_type = "local-ssd"
+	}
+
+	disk {
+		source_image = "${data.google_compute_image.my_image.self_link}"
+		auto_delete = true
+		type = "SCRATCH"
+	}
+
+	network_interface {
+		network = "default"
+	}
+}`, acctest.RandString(10))
 }


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4386

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```release-note:breaking-change
compute: made `google_compute_instance_template` fail at plan time when scratch disks do not have `disk_type` `"local-ssd"`.
```
