### PR TITLE
Add metric descriptor unit to google_logging_metric

### DIFF
--- a/products/logging/api.yaml
+++ b/products/logging/api.yaml
@@ -71,7 +71,7 @@ objects:
             description: |
               The unit in which the metric value is reported. It is only applicable if the valueType is
               `INT64`, `DOUBLE`, or `DISTRIBUTION`. The supported units are a subset of
-              The Unified Code for Units of Measure[http://unitsofmeasure.org/ucum.html] standard
+              [The Unified Code for Units of Measure](http://unitsofmeasure.org/ucum.html) standard
           - !ruby/object:Api::Type::Enum
             name: valueType
             description: |

--- a/products/logging/api.yaml
+++ b/products/logging/api.yaml
@@ -72,6 +72,7 @@ objects:
               The unit in which the metric value is reported. It is only applicable if the valueType is
               `INT64`, `DOUBLE`, or `DISTRIBUTION`. The supported units are a subset of
               [The Unified Code for Units of Measure](http://unitsofmeasure.org/ucum.html) standard
+            default_value: "1"
           - !ruby/object:Api::Type::Enum
             name: valueType
             description: |

--- a/products/logging/api.yaml
+++ b/products/logging/api.yaml
@@ -66,6 +66,12 @@ objects:
           The metric descriptor associated with the logs-based metric.
         required: true
         properties:
+          - !ruby/object:Api::Type::String
+            name: unit
+            description: |
+              The unit in which the metric value is reported. It is only applicable if the valueType is
+              `INT64`, `DOUBLE`, or `DISTRIBUTION`. The supported units are a subset of
+              The Unified Code for Units of Measure[http://unitsofmeasure.org/ucum.html] standard
           - !ruby/object:Api::Type::Enum
             name: valueType
             description: |

--- a/products/logging/terraform.yaml
+++ b/products/logging/terraform.yaml
@@ -38,6 +38,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       metricDescriptor.labels.valueType: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
+      metricDescriptor.unit: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
   OrganizationLogSink: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true
 

--- a/products/logging/terraform.yaml
+++ b/products/logging/terraform.yaml
@@ -38,8 +38,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       metricDescriptor.labels.valueType: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
-      metricDescriptor.unit: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
   OrganizationLogSink: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true
 

--- a/templates/terraform/examples/logging_metric_basic.tf.erb
+++ b/templates/terraform/examples/logging_metric_basic.tf.erb
@@ -4,6 +4,7 @@ resource "google_logging_metric" "<%= ctx[:primary_resource_id] %>" {
   metric_descriptor {
     metric_kind = "DELTA"
     value_type = "DISTRIBUTION"
+    unit = "1"
     labels {
         key = "mass"
         value_type = "STRING"


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/3881

added `metric_descriptor.unit` to `google_logging_metric` resource

# Release Note for Downstream PRs (will be copied)
```releasenote
added `metric_descriptor.unit` to `google_logging_metric` resource
```
