### PR TITLE
add mode option to google compute instance boot disk

### DIFF
--- a/third_party/terraform/resources/resource_compute_instance.go
+++ b/third_party/terraform/resources/resource_compute_instance.go
@@ -126,6 +126,14 @@ func resourceComputeInstance() *schema.Resource {
 							},
 						},
 
+						"mode": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							Default:      "READ_WRITE",
+							ValidateFunc: validation.StringInSlice([]string{"READ_WRITE", "READ_ONLY"}, false),
+						},
+
 						"source": {
 							Type:             schema.TypeString,
 							Optional:         true,
@@ -1664,6 +1672,10 @@ func expandBootDisk(d *schema.ResourceData, config *Config, project string) (*co
 		}
 	}
 
+	if v, ok := d.GetOk("boot_disk.0.mode"); ok {
+		disk.Mode = v.(string)
+	}
+
 	return disk, nil
 }
 
@@ -1671,6 +1683,7 @@ func flattenBootDisk(d *schema.ResourceData, disk *computeBeta.AttachedDisk, con
 	result := map[string]interface{}{
 		"auto_delete": disk.AutoDelete,
 		"device_name": disk.DeviceName,
+		"mode":        disk.Mode,
 		"source":      ConvertSelfLinkToV1(disk.Source),
 		// disk_encryption_key_raw is not returned from the API, so copy it from what the user
 		// originally specified to avoid diffs.

--- a/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_test.go
@@ -522,6 +522,25 @@ func TestAccComputeInstance_bootDisk_type(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_bootDisk_mode(t *testing.T) {
+	t.Parallel()
+
+	var instanceName = fmt.Sprintf("instance-test-%s", acctest.RandString(10))
+	var diskMode = "READ_WRITE"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_bootDisk_mode(instanceName, diskMode),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+		},
+	})
+}
+
 func TestAccComputeInstance_scratchDisk(t *testing.T) {
 	t.Parallel()
 
@@ -2691,6 +2710,34 @@ resource "google_compute_instance" "foobar" {
 	}
 }
 `, instance, diskType)
+}
+
+func testAccComputeInstance_bootDisk_mode(instance string, diskMode string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+	family  = "debian-9"
+	project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+	name         = "%s"
+	machine_type = "n1-standard-1"
+	zone         = "us-central1-a"
+
+	boot_disk {
+		initialize_params {
+			image	= "${data.google_compute_image.my_image.self_link}"
+			type	= "pd-ssd"
+		}
+
+		mode = "%s"
+	}
+
+	network_interface {
+		network = "default"
+	}
+}
+`, instance, diskMode)
 }
 
 func testAccComputeInstance_scratchDisk(instance string) string {

--- a/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -148,6 +148,9 @@ The `boot_disk` block supports:
 * `device_name` - (Optional) Name with which attached disk will be accessible.
     On the instance, this device will be `/dev/disk/by-id/google-{{device_name}}`.
 
+* `mode` - (Optional) The mode in which to attach this disk, either `READ_WRITE`
+  or `READ_ONLY`. If not specified, the default is to attach the disk in `READ_WRITE` mode.
+
 * `disk_encryption_key_raw` - (Optional) A 256-bit [customer-supplied encryption key]
     (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption),
     encoded in [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)

--- a/third_party/validator/compute_instance.go
+++ b/third_party/validator/compute_instance.go
@@ -226,8 +226,18 @@ func expandBootDisk(d TerraformResourceData, config *Config, project string) (*c
 	}
 
 	if v, ok := d.GetOk("boot_disk.0.disk_encryption_key_raw"); ok {
-		disk.DiskEncryptionKey = &computeBeta.CustomerEncryptionKey{
-			RawKey: v.(string),
+		if v != "" {
+			disk.DiskEncryptionKey = &computeBeta.CustomerEncryptionKey{
+				RawKey: v.(string),
+			}
+		}
+	}
+
+	if v, ok := d.GetOk("boot_disk.0.kms_key_self_link"); ok {
+		if v != "" {
+			disk.DiskEncryptionKey = &computeBeta.CustomerEncryptionKey{
+				KmsKeyName: v.(string),
+			}
 		}
 	}
 
@@ -264,6 +274,14 @@ func expandBootDisk(d TerraformResourceData, config *Config, project string) (*c
 
 			disk.InitializeParams.SourceImage = imageUrl
 		}
+
+		if _, ok := d.GetOk("boot_disk.0.initialize_params.0.labels"); ok {
+			disk.InitializeParams.Labels = expandStringMap(d, "boot_disk.0.initialize_params.0.labels")
+		}
+	}
+
+	if v, ok := d.GetOk("boot_disk.0.mode"); ok {
+		disk.Mode = v.(string)
 	}
 
 	return disk, nil


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4284

add `mode` option to `google_compute_instance.boot_disk`

# Release Note for Downstream PRs (will be copied)
```releasenote
add `mode` option to `google_compute_instance.boot_disk`
```
