### PR TITLE
version_added fix

### DIFF
--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -44,7 +44,7 @@ module Provider
               end),
             'type' => python_type(prop),
             'aliases' => prop.aliases,
-            'version_added' => (version_added(prop)&.to_f),
+            'version_added' => version_added(prop),
             'suboptions' => (
                 if prop.nested_properties?
                   prop.nested_properties.reject(&:output).map { |p| documentation_for_property(p) }

--- a/templates/ansible/documentation.erb
+++ b/templates/ansible/documentation.erb
@@ -16,7 +16,7 @@ DOCUMENTATION = '''
   'module' => module_name(object),
   'description' => format_description(object.description),
   'short_description' => "Creates a GCP #{object.name}",
-  'version_added' => version_added(object).to_f,
+  'version_added' => version_added(object),
   'author' => "Google Inc. (@googlecloudplatform)",
   'requirements' => ["python >= 2.6", "requests >= 2.18.4", "google-auth >= 1.3.0"],
   'options' => [

--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -30,7 +30,7 @@ DOCUMENTATION = '''
                     (version_added(object, :facts) < '2.9' ? "This module was called C(#{module_name(object)}_facts) before Ansible 2.9. The usage has not changed." : nil)
                    ].compact,
   'short_description' => "Gather info for GCP #{object.name}",
-  'version_added' => version_added(object, :facts).to_f,
+  'version_added' => version_added(object, :facts),
   'author' => "Google Inc. (@googlecloudplatform)",
   'requirements' => ["python >= 2.6", "requests >= 2.18.4", "google-auth >= 1.3.0"],
   'options' => [


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->
Making another PR to stop the spurious PRs.

This fixes the version_added, so that the numbers aren't floats that lose decimal places.

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
