### PR TITLE
fix for issues terraform-providers#2198 and terraform-providers#3098

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -2277,7 +2277,9 @@ func expandMasterAuth(configured interface{}) *containerBeta.MasterAuth {
 func expandMasterAuthorizedNetworksConfig(configured interface{}) *containerBeta.MasterAuthorizedNetworksConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 {
-		return nil
+		return &containerBeta.MasterAuthorizedNetworksConfig{
+			Enabled: false,
+		}
 	}
 	result := &containerBeta.MasterAuthorizedNetworksConfig{
 		Enabled: true,
@@ -2659,7 +2661,7 @@ func flattenClusterAutoscaling(a *containerBeta.ClusterAutoscaling) []map[string
 
 
 func flattenMasterAuthorizedNetworksConfig(c *containerBeta.MasterAuthorizedNetworksConfig) []map[string]interface{} {
-	if c == nil {
+	if c == nil || !c.Enabled {
 		return nil
 	}
 	result := make(map[string]interface{})


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
This is a bugfix for following issues:
- https://github.com/terraform-providers/terraform-provider-google/issues/3098
- https://github.com/terraform-providers/terraform-provider-google/issues/2198

In short (details are in the bugs):
The Terraform google provider does not handle the API object `masterAuthorizedNetworksConfig` in GKE correctly. In the GKE API, this object normally exists as an empty list {} if the cluster was enabled manually and the feature is disabled. If used in TF, the `masterAuthorizedNetworksConfig` block must have a value and it cannot be removed afterwards.
If the Terraform google provider tries to remove the block it interpretes the GKE API response that it does exist. But when trying to apply the change, following error comes back from Google:
Error: Error applying plan:
1 error occurred:
        * module.k8s.google_container_cluster.cluster: 1 error occurred:
        * google_container_cluster.cluster: googleapi: Error 400: Must specify a field to update., badRequest

This bugfix uses the Enabled flag to correctly set and determine the state of the `masterAuthorizedNetworksConfig`.
```
