### PR TITLE
allow master authorized networks config to be removed

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -2277,7 +2277,9 @@ func expandMasterAuth(configured interface{}) *containerBeta.MasterAuth {
 func expandMasterAuthorizedNetworksConfig(configured interface{}) *containerBeta.MasterAuthorizedNetworksConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 {
-		return nil
+		return &containerBeta.MasterAuthorizedNetworksConfig{
+			Enabled: false,
+		}
 	}
 	result := &containerBeta.MasterAuthorizedNetworksConfig{
 		Enabled: true,
@@ -2659,7 +2661,7 @@ func flattenClusterAutoscaling(a *containerBeta.ClusterAutoscaling) []map[string
 
 
 func flattenMasterAuthorizedNetworksConfig(c *containerBeta.MasterAuthorizedNetworksConfig) []map[string]interface{} {
-	if c == nil {
+	if c == nil || !c.Enabled {
 		return nil
 	}
 	result := make(map[string]interface{})

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -415,6 +415,15 @@ func TestAccContainerCluster_withMasterAuthorizedNetworksConfig(t *testing.T) {
 				ImportState:		 true,
 				ImportStateVerify:	 true,
 			},
+			{
+				Config: testAccContainerCluster_removeMasterAuthorizedNetworksConfig(clusterName),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_master_authorized_networks",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
 		},
 	})
 }
@@ -1959,13 +1968,23 @@ func testAccContainerCluster_withMasterAuthorizedNetworksConfig(clusterName stri
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_master_authorized_networks" {
 	name = "%s"
-	zone = "us-central1-a"
+	location = "us-central1-a"
 	initial_node_count = 1
 
 	master_authorized_networks_config {
 		%s
 	}
 }`, clusterName, cidrBlocks)
+}
+
+func testAccContainerCluster_removeMasterAuthorizedNetworksConfig(clusterName string) string {
+
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_master_authorized_networks" {
+	name = "%s"
+	location = "us-central1-a"
+	initial_node_count = 1
+}`, clusterName)
 }
 
 func testAccContainerCluster_regional(clusterName string) string {

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1978,7 +1978,6 @@ resource "google_container_cluster" "with_master_authorized_networks" {
 }
 
 func testAccContainerCluster_removeMasterAuthorizedNetworksConfig(clusterName string) string {
-
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_master_authorized_networks" {
 	name = "%s"


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/3098

Fix error when `master_authorized_networks_config` is removed from the `google_container_cluster` configuration.

# Release Note for Downstream PRs (will be copied)
```releasenote
Fix error when `master_authorized_networks_config` is removed from the `google_container_cluster` configuration.
```
