### PR TITLE
update docs and add `clustering` to big query table

### DIFF
--- a/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -115,6 +115,10 @@ The following arguments are supported:
 * `time_partitioning` - (Optional) If specified, configures time-based
     partitioning for this table. Structure is documented below.
 
+* `clustering` - (Optional) Specifies column names to use for data clustering.
+    Up to four top-level columns are allowed, and should be specified in
+    descending priority order.
+
 * `view` - (Optional) If specified, configures this table as a view.
     Structure is documented below.
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4245

I think this was actually fixed with https://github.com/terraform-providers/terraform-provider-google/pull/4223 but the documentation was not updated, so I added it here.  Let me know if you think there is more to be done than just the documentation update.

# Release Note for Downstream PRs (will be copied)
```releasenote
Update documentation to include `clustering` for resource `google_bigquery_table`
```
