### PR TITLE
add guest os features to compute image

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -3773,31 +3773,20 @@ objects:
       - !ruby/object:Api::Type::Array
         name: 'guestOsFeatures'
         description: |
-            A list of features to enable on the guest OS. Applicable for
-            bootable images only. Currently, only one feature can be enabled,
-            VIRTIO_SCSI_MULTIQUEUE, which allows each virtual CPU to have its
-            own queue. For Windows images, you can only enable
-            VIRTIO_SCSI_MULTIQUEUE on images with driver version 1.2.0.1621 or
-            higher. Linux images with kernel versions 3.17 and higher will
-            support VIRTIO_SCSI_MULTIQUEUE.
-
-            For new Windows images, the server might also populate this field
-            with the value WINDOWS, to indicate that this is a Windows image.
-            This value is purely informational and does not enable or disable
-            any features.
+            A list of features to enable on the guest operating system.
+            Applicable only for bootable images.
         item_type: !ruby/object:Api::Type::NestedObject
           properties:
             - !ruby/object:Api::Type::Enum
               name: 'type'
               description: |
-                The type of supported feature. Currently only
-                VIRTIO_SCSI_MULTIQUEUE is supported. For newer Windows images,
-                the server might also populate this property with the value
-                WINDOWS to indicate that this is a Windows image. This value is
-                purely informational and does not enable or disable any
-                features.
+                The type of supported feature.
               values:
+                - :MULTI_IP_SUBNET
+                - :SECURE_BOOT
+                - :UEFI_COMPATIBLE
                 - :VIRTIO_SCSI_MULTIQUEUE
+                - :WINDOWS
       - !ruby/object:Api::Type::Integer
         name: 'id'
         description: |

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -3780,7 +3780,7 @@ objects:
             - !ruby/object:Api::Type::Enum
               name: 'type'
               description: |
-                The type of supported feature.
+                The type of supported feature. Read [Enabling guest operating system features](https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#guest-os-features) to see a list of available options.
               values:
                 - :MULTI_IP_SUBNET
                 - :SECURE_BOOT

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -787,14 +787,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "example"
         vars:
           image_name: "example-image"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "image_guest_os"
+        primary_resource_id: "example"
+        vars:
+          image_name: "example-image"
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
       diskSizeGb: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       deprecated: !ruby/object:Overrides::Terraform::PropertyOverride
-        exclude: true
-      guestOsFeatures: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
       imageEncryptionKey: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true

--- a/templates/terraform/examples/image_guest_os.tf.erb
+++ b/templates/terraform/examples/image_guest_os.tf.erb
@@ -1,0 +1,15 @@
+resource "google_compute_image" "example" {
+  name = "<%= ctx[:vars]['image_name'] %>"
+
+  raw_disk {
+    source = "https://storage.googleapis.com/bosh-cpi-artifacts/bosh-stemcell-3262.4-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz"
+  }
+
+  guest_os_features {
+    type = "SECURE_BOOT"
+  }
+
+  guest_os_features {
+    type = "MULTI_IP_SUBNET"
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/2366

Add support for guest_os_features.  Ideally I'd like to make this just a list of Enums, however, it was already in api.yaml as a list of objects (with type being the only key), so I kept it that way.

# Release Note for Downstream PRs (will be copied)
```releasenote
Add support for `guest_os_features` to resource `google_compute_image`
```
