### PR TITLE
Cloud Build Trigger's trigger template should be required.

### DIFF
--- a/products/cloudbuild/api.yaml
+++ b/products/cloudbuild/api.yaml
@@ -101,6 +101,7 @@ objects:
           Branch and tag names in trigger templates are interpreted as regular
           expressions. Any branch or tag change that matches that regular
           expression will trigger a build.
+        required: true
         properties:
           - !ruby/object:Api::Type::String
             name: 'projectId'

--- a/products/cloudbuild/terraform.yaml
+++ b/products/cloudbuild/terraform.yaml
@@ -28,9 +28,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: 'trigger_id'
       build.steps: !ruby/object:Overrides::Terraform::PropertyOverride
         name: 'step'
-      triggerTemplate: !ruby/object:Overrides::Terraform::PropertyOverride
-        description: |
-          {{description}}This field is required, and will be validated as such in 3.0.0.
       triggerTemplate.projectId: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
Make Cloud Build Trigger's trigger template required to match API requirements.
```
