### PR TITLE
Do not generate downstreams when PRs are opened against non-master branches.

### DIFF
--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -43,6 +43,7 @@ resources:
           access_token: ((github-account.password))
           community_only: true
           no_label: community
+          base: master
 
     - name: magic-modules-external-prs
       type: github-pull-request
@@ -51,6 +52,7 @@ resources:
           private_key: ((repo-key.private_key))
           access_token: ((github-account.password))
           community_only: true
+          base: master
 
     - name: magic-modules-new-prs
       type: github-pull-request
@@ -60,6 +62,7 @@ resources:
           access_token: ((github-account.password))
           authorship_restriction: true
           no_label: automerged
+          base: master
 
 {% for v in vars.terraform_v.itervalues() %}
     - name: {{ v.short_name }}-intermediate
@@ -91,6 +94,7 @@ resources:
           require_review_approval: true
           check_dependent_prs: true
           label: downstream-generated
+          base: master
 
     - name: merged-prs
       type: merged-downstreams


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote
CI changes only.
```
