### PR TITLE
Release note downstreaming changes

### DIFF
--- a/.ci/containers/python/Dockerfile
+++ b/.ci/containers/python/Dockerfile
@@ -3,6 +3,8 @@ from python:2.7-stretch
 run pip install pygithub
 run pip install absl-py
 run pip install autopep8
+run pip install beautifulsoup4 mistune
+
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts
 RUN echo "UserKnownHostsFile /known_hosts" >> /etc/ssh/ssh_config

--- a/.ci/magic-modules/downstream-changelog-metadata.yml
+++ b/.ci/magic-modules/downstream-changelog-metadata.yml
@@ -11,7 +11,7 @@ platform: linux
 image_resource:
     type: docker-image
     source:
-        # This task requires python + pip package 'pygithub'.
+        # Requires python + pip packages 'pygithub', 'mistune', 'beautifulsoup4'
         repository: gcr.io/magic-modules/python
         tag: '1.0'
 

--- a/.ci/magic-modules/downstream_changelog_metadata.py
+++ b/.ci/magic-modules/downstream_changelog_metadata.py
@@ -10,11 +10,10 @@ Note that release_note/labels are authoritative - if empty or not set in the MM
 upstream PR, release notes will be removed from downstreams and labels
 unset.
 """
-from pyutils import strutils, downstreams
-import github
 import os
 import sys
-import argparse
+import github
+from pyutils import strutils, downstreams
 
 CHANGELOG_LABEL_PREFIX = "changelog: "
 
@@ -30,19 +29,19 @@ def downstream_changelog_info(gh, upstream_pr_num, changelog_repos):
   print "Fetching upstream PR '%s'..." % upstream_pr_num
   upstream_pr = gh.get_repo(downstreams.UPSTREAM_REPO)\
                   .get_pull(upstream_pr_num)
-  release_note = strutils.get_release_note(upstream_pr.body)
+  release_notes = strutils.get_release_notes(upstream_pr.body)
   labels_to_add = strutils.find_prefixed_labels(
     [l.name for l in upstream_pr.labels],
     CHANGELOG_LABEL_PREFIX)
 
-  if not labels_to_add and not release_note:
+  if not labels_to_add and not release_notes:
     print "No release note or labels found, skipping PR %d" % (
       upstream_pr_num)
     return
 
   print "Found changelog info on upstream PR %d:" % (
     upstream_pr.number)
-  print "Release Note: \"%s\"" % release_note
+  print "Release Note: \"%s\"" % release_notes
   print "Labels: %s" % labels_to_add
 
   parsed_urls = downstreams.get_parsed_downstream_urls(gh, upstream_pr.number)
@@ -64,12 +63,12 @@ def downstream_changelog_info(gh, upstream_pr_num, changelog_repos):
     for _r, prnum in pulls:
       print "Fetching %s PR %d" % (repo_name, prnum)
       pr = ghrepo.get_pull(int(prnum))
-      set_changelog_info(pr, release_note, labels_to_add)
+      set_changelog_info(pr, release_notes, labels_to_add)
 
   if not found:
     print "No downstreams found for upstream PR %d, returning!" % upstream_pr.number
 
-def set_changelog_info(gh_pull, release_note, labels_to_add):
+def set_changelog_info(gh_pull, release_notes, labels_to_add):
   """Set release note and labels on a downstream PR in Github.
 
   Args:
@@ -78,7 +77,7 @@ def set_changelog_info(gh_pull, release_note, labels_to_add):
     labels_to_add: List of strings. Changelog-related labels to add/replace.
   """
   print "Setting changelog info for downstream PR %s" % gh_pull.url
-  edited_body = strutils.set_release_note(release_note, gh_pull.body)
+  edited_body = strutils.set_release_notes(release_notes, gh_pull.body)
   gh_pull.edit(body=edited_body)
 
   # Get all non-changelog-related labels
@@ -96,12 +95,9 @@ if __name__ == '__main__':
     print "Skipping, no downstreams repos given to downstream changelog info for"
     sys.exit(0)
 
-  gh = github.Github(os.environ.get('GITHUB_TOKEN'))
   assert len(sys.argv) == 2, "expected id filename as argument"
   with open(sys.argv[1]) as f:
     pr_num = int(f.read())
-    try:
-      downstream_changelog_info(gh, pr_num, downstream_repos)
-    except e:
-      print "got error %s" % e
-      raise e
+    downstream_changelog_info(
+      github.Github(os.environ.get('GITHUB_TOKEN')),
+      pr_num, downstream_repos)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,9 +24,9 @@ Otherwise, fill the template out below
 ```
 
 <!-- GUIDE FOR WRITING RELEASE NOTES
-Release notes should be formatted with one of the following headings. If
-you need a new type, preface your block with "release-note:my-category"
+Release notes should be formatted with one of the following headings.
 - release-note:bug
+- release-note:note
 - release-note:new-resource
 - release-note:new-datasource
 - release-note:deprecation
@@ -40,7 +40,7 @@ Notes SHOULD:
 - Only use present tense in imperative sentences to suggest future behavior for
   breaking changes/deprecations ("Use X" vs "You should use X" or "Users should use X")
 - Impersonal third person (no “I”, “you”, etc.)
-- Start with `service` if changing an existing resource (see compute exampels below)
+- Start with `{{service}}` if changing an existing resource (see exampels below)
 
 DO:
 
@@ -56,7 +56,7 @@ container: fixed perma-diff in `google_container_cluster`
 project: made `iam_policy` authoritative
 ```
 
-```release-note:breaking-change
+```release-note:deprecation
 container: deprecated `region` and `zone` on `google_container_unicorn`. Use `location` instead.
 ```
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- 
+<!--
 Note: You may see "This branch is out-of-date with the base branch"
 when you submit a pull request. This is fine! We don't use the GitHub
 merge button to merge PRs, and you can safely ignore that message.
@@ -6,22 +6,76 @@ merge button to merge PRs, and you can safely ignore that message.
 Thanks for contributing!
 -->
 
-<!-- CHANGELOG for Downstream PRs.
+<!-- AUTOCHANGELOG for Downstream PRs.
 EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!
 
 For some repos (currently Terraform GA/beta providers), we have the
 ability to autogenerate CHANGELOGs.
 
-Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)
+NO CHANGELOG NOTE: If you do not want a release note,
+please add the "changelog: no-release-note" label to this PR.
 
-Please also add any of the following appropriate labels to the PR:
-- changelog: bugfix
-- changelog: new-resource
-- changelog: new-datasource
-- changelog: deprecation
-- changelog: breaking-change
+Otherwise, fill the template out below
 -->
-# Release Note for Downstream PRs (will be copied)
-```releasenote
+
+# Release Note Template for Downstream PRs (will be copied)
+```release-note:enhancement
 
 ```
+
+<!-- GUIDE FOR WRITING RELEASE NOTES
+Release notes should be formatted with one of the following headings. If
+you need a new type, preface your block with "release-note:my-category"
+- release-note:bug
+- release-note:new-resource
+- release-note:new-datasource
+- release-note:deprecation
+- release-note:breaking-change
+
+Guide for writing release notes:
+
+Notes SHOULD:
+- Start with a verb
+- Use past tense (added/fixed/resolved) as much as possible
+- Only use present tense in imperative sentences to suggest future behavior for
+  breaking changes/deprecations ("Use X" vs "You should use X" or "Users should use X")
+- Impersonal third person (no “I”, “you”, etc.)
+- Start with `service` if changing an existing resource (see compute exampels below)
+
+DO:
+
+```release-note:enhancement
+compute: added `foo_bar` field to `google_compute_foo` resource
+```
+
+```release-note:bug
+container: fixed perma-diff in `google_container_cluster`
+```
+
+```release-note:breaking-change
+project: made `iam_policy` authoritative
+```
+
+```release-note:breaking-change
+container: deprecated `region` and `zone` on `google_container_unicorn`. Use `location` instead.
+```
+
+Note no service name or *New Resource* tag:
+```release-note:new-resource
+`google_compute_new_resource`
+```
+
+Note no service name or *New Datasource* tag:
+```release-note:new-datasource
+`google_compute_new_datasource`
+```
+
+DON'T DO:
+- Add compute_instance resource
+- Fix bug
+- fixed a bug in google_compute_network
+- `google_project` now supports `blah`
+- You can now create google_sql_instances in us-central1
+- Adds support for `google_source_repo_repository`’s `url` field
+- Users should now use location instead of zone/region on `google_container_unicorn`
+-->


### PR DESCRIPTION
NOTES:
- Release notes are now expected to have `release-note:section` code headings in Markdown blocks
- Labels will still be downstreamed but will not be used in CHANGELOG generation

<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```release-note:test
This is a release note test
```
