### PR TITLE
Make guest_os_features computed on Image

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -813,6 +813,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       deprecated: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
+      guestOsFeatures: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       imageEncryptionKey: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
       licenses: !ruby/object:Overrides::Terraform::PropertyOverride


### PR DESCRIPTION
<!-- 
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

This fixes some integration test failures.

Before:

```
------- Stdout: -------
=== RUN   TestAccComputeImage_basedondisk
=== PAUSE TestAccComputeImage_basedondisk
=== CONT  TestAccComputeImage_basedondisk
--- FAIL: TestAccComputeImage_basedondisk (51.72s)
    testing.go:569: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: google_compute_image.foobar
          archive_size_bytes:       "536431424" => "<computed>"
          creation_timestamp:       "2019-09-22T21:41:06.349-07:00" => "<computed>"
          description:              "" => ""
          disk_size_gb:             "10" => "<computed>"
          family:                   "" => ""
          guest_os_features.#:      "1" => "0" (forces new resource)
          guest_os_features.0.type: "VIRTIO_SCSI_MULTIQUEUE" => "" (forces new resource)
          id:                       "image-test-qi9xaob7h1" => "<computed>"
          label_fingerprint:        "42WmSpB8rSM=" => "<computed>"
          licenses:                 "" => "<computed>"
          licenses.#:               "1" => ""
          licenses.0:               "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/licenses/debian-9-stretch" => ""
          name:                     "image-test-qi9xaob7h1" => "image-test-qi9xaob7h1"
...
```

<!-- CHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

Fill in the following release note code block to have it be added to the CHANGELOG, or leave the block empty if you don't expect this to be added to a downstream PR (i.e. docs-only changes or non-user facing changes)

Please also add any of the following appropriate labels to the PR:
- changelog: bugfix
- changelog: new-resource
- changelog: new-datasource
- changelog: deprecation
- changelog: breaking-change
-->
# Release Note for Downstream PRs (will be copied)
```releasenote

```
