### PR TITLE
Fix error message for folder IAM test

### DIFF
--- a/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
+++ b/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
@@ -247,6 +247,29 @@ func testAccCheckGoogleFolderIamBindingExists(expected *cloudresourcemanager.Bin
 	}
 }
 
+func getFolderIamPolicyByParentAndDisplayName(parent, displayName string, config *Config) (*cloudresourcemanager.Policy, error) {
+	queryString := fmt.Sprintf("lifecycleState=ACTIVE AND parent=%s AND displayName=%s", parent, displayName)
+	searchRequest := &resourceManagerV2Beta1.SearchFoldersRequest{
+		Query: queryString,
+	}
+	searchResponse, err := config.clientResourceManagerV2Beta1.Folders.Search(searchRequest).Do()
+	if err != nil {
+		if isGoogleApiErrorWithCode(err, 404) {
+			return nil, fmt.Errorf("Folder not found: %s,%s", parent, displayName)
+		}
+
+		return nil, errwrap.Wrapf("Error reading folders: {{err}}", err)
+	}
+
+	folders := searchResponse.Folders
+	if len(folders) != 1 {
+		return nil, fmt.Errorf("expected exactly 1 folder, found %d", len(folders))
+	}
+
+	return getFolderIamPolicyByFolderName(folders[0].Name, config)
+}
+
+
 func testAccFolderIamBasic(org, fname string) string {
 	return fmt.Sprintf(`
 resource "google_folder" "acceptance" {

--- a/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
+++ b/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
@@ -5,10 +5,12 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/cloudresourcemanager/v1"
+	resourceManagerV2Beta1 "google.golang.org/api/cloudresourcemanager/v2beta1"
 )
 
 // Test that an IAM binding can be applied to a folder

--- a/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
+++ b/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
@@ -269,7 +269,6 @@ func getFolderIamPolicyByParentAndDisplayName(parent, displayName string, config
 	return getFolderIamPolicyByFolderName(folders[0].Name, config)
 }
 
-
 func testAccFolderIamBasic(org, fname string) string {
 	return fmt.Sprintf(`
 resource "google_folder" "acceptance" {

--- a/third_party/terraform/utils/iam_folder.go
+++ b/third_party/terraform/utils/iam_folder.go
@@ -113,6 +113,7 @@ func getFolderIamPolicyByFolderName(folderName string, config *Config) (*cloudre
 	return v1Policy, nil
 }
 
+// only used in tests
 func getFolderIamPolicyByParentAndDisplayName(parent, displayName string, config *Config) (*cloudresourcemanager.Policy, error) {
 	queryString := fmt.Sprintf("lifecycleState=ACTIVE AND parent=%s AND displayName=%s", parent, displayName)
 	searchRequest := &resourceManagerV2Beta1.SearchFoldersRequest{
@@ -129,7 +130,7 @@ func getFolderIamPolicyByParentAndDisplayName(parent, displayName string, config
 
 	folders := searchResponse.Folders
 	if len(folders) != 1 {
-		return nil, fmt.Errorf("More than one folder found")
+		return nil, fmt.Errorf("expected exactly 1 folder, found %d", len(folders))
 	}
 
 	return getFolderIamPolicyByFolderName(folders[0].Name, config)

--- a/third_party/terraform/utils/iam_folder.go
+++ b/third_party/terraform/utils/iam_folder.go
@@ -112,26 +112,3 @@ func getFolderIamPolicyByFolderName(folderName string, config *Config) (*cloudre
 
 	return v1Policy, nil
 }
-
-// only used in tests
-func getFolderIamPolicyByParentAndDisplayName(parent, displayName string, config *Config) (*cloudresourcemanager.Policy, error) {
-	queryString := fmt.Sprintf("lifecycleState=ACTIVE AND parent=%s AND displayName=%s", parent, displayName)
-	searchRequest := &resourceManagerV2Beta1.SearchFoldersRequest{
-		Query: queryString,
-	}
-	searchResponse, err := config.clientResourceManagerV2Beta1.Folders.Search(searchRequest).Do()
-	if err != nil {
-		if isGoogleApiErrorWithCode(err, 404) {
-			return nil, fmt.Errorf("Folder not found: %s,%s", parent, displayName)
-		}
-
-		return nil, errwrap.Wrapf("Error reading folders: {{err}}", err)
-	}
-
-	folders := searchResponse.Folders
-	if len(folders) != 1 {
-		return nil, fmt.Errorf("expected exactly 1 folder, found %d", len(folders))
-	}
-
-	return getFolderIamPolicyByFolderName(folders[0].Name, config)
-}


### PR DESCRIPTION
<!--
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

While this won't fix any tests, it will make the error message much less confusing when no matches are found.

<!-- AUTOCHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

NO CHANGELOG NOTE: If you do not want a release note,
please add the "changelog: no-release-note" label to this PR.

Otherwise, fill the template out below
-->

# Release Note Template for Downstream PRs (will be copied)
```release-note:enhancement

```

<!-- GUIDE FOR WRITING RELEASE NOTES
Release notes should be formatted with one of the following headings.
- release-note:bug
- release-note:note
- release-note:new-resource
- release-note:new-datasource
- release-note:deprecation
- release-note:breaking-change

Guide for writing release notes:

Notes SHOULD:
- Start with a verb
- Use past tense (added/fixed/resolved) as much as possible
- Only use present tense in imperative sentences to suggest future behavior for
  breaking changes/deprecations ("Use X" vs "You should use X" or "Users should use X")
- Impersonal third person (no “I”, “you”, etc.)
- Start with `{{service}}` if changing an existing resource (see exampels below)

DO:

```release-note:enhancement
compute: added `foo_bar` field to `google_compute_foo` resource
```

```release-note:bug
container: fixed perma-diff in `google_container_cluster`
```

```release-note:breaking-change
project: made `iam_policy` authoritative
```

```release-note:deprecation
container: deprecated `region` and `zone` on `google_container_unicorn`. Use `location` instead.
```

Note no service name or *New Resource* tag:
```release-note:new-resource
`google_compute_new_resource`
```

Note no service name or *New Datasource* tag:
```release-note:new-datasource
`google_compute_new_datasource`
```

DON'T DO:
- Add compute_instance resource
- Fix bug
- fixed a bug in google_compute_network
- `google_project` now supports `blah`
- You can now create google_sql_instances in us-central1
- Adds support for `google_source_repo_repository`’s `url` field
- Users should now use location instead of zone/region on `google_container_unicorn`
-->
