### PR TITLE
Enable GKE pods_per_node flags in GA

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -961,11 +961,9 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		ResourceLabels: expandStringMap(d, "resource_labels"),
 	}
 
-<% unless version == 'ga' -%>
 	if v, ok := d.GetOk("default_max_pods_per_node"); ok {
 		cluster.DefaultMaxPodsConstraint = expandDefaultMaxPodsConstraint(v)
 	}
-<% end -%>
 
 	// Only allow setting node_version on create if it's set to the equivalent master version,
 	// since `InitialClusterVersion` only accepts valid master-style versions.

--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -99,9 +99,6 @@ var schemaNodePool = map[string]*schema.Schema{
 	},
 
 	"max_pods_per_node": &schema.Schema{
-<% if version.nil? || version == 'ga' -%>
-		Removed: "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
-<% end -%>
 		Type:       schema.TypeInt,
 		Optional:   true,
 		ForceNew:   true,
@@ -516,13 +513,11 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*containerBeta.NodeP
 		}
 	}
 
-	<% unless version == 'ga' -%>
 	if v, ok := d.GetOk(prefix + "max_pods_per_node"); ok {
 		np.MaxPodsConstraint = &containerBeta.MaxPodsConstraint{
 			MaxPodsPerNode: int64(v.(int)),
 		}
 	}
-	<% end -%>
 
 	if v, ok := d.GetOk(prefix + "management"); ok {
 		managementConfig := v.([]interface{})[0].(map[string]interface{})
@@ -583,11 +578,9 @@ func flattenNodePool(d *schema.ResourceData, config *Config, np *containerBeta.N
 		}
 	}
 
-	<% unless version == 'ga' -%>
 	if np.MaxPodsConstraint != nil {
 		nodePool["max_pods_per_node"] = np.MaxPodsConstraint.MaxPodsPerNode
 	}
-	<% end -%>
 
 	nodePool["management"] = []map[string]interface{}{
 		{


### PR DESCRIPTION
As far as I can tell from the documentation at
https://cloud.google.com/kubernetes-engine/docs/how-to/flexible-pod-cidr,
these features are now GA, so they should be made available in the
"google" provider, not just the "google-beta" provider.

<!--
Note: You may see "This branch is out-of-date with the base branch"
when you submit a pull request. This is fine! We don't use the GitHub
merge button to merge PRs, and you can safely ignore that message.

Thanks for contributing!
-->

<!-- AUTOCHANGELOG for Downstream PRs.
EXTERNAL CONTRIBUTORS: Your reviewer will most likely fill this in for you, so don't worry about this section!

For some repos (currently Terraform GA/beta providers), we have the
ability to autogenerate CHANGELOGs.

NO CHANGELOG NOTE: If you do not want a release note,
please add the "changelog: no-release-note" label to this PR.

Otherwise, fill the template out below
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement

```

<!-- GUIDE FOR WRITING RELEASE NOTES
Release notes should be formatted with one of the following headings.
- release-note:bug
- release-note:note
- release-note:new-resource
- release-note:new-datasource
- release-note:deprecation
- release-note:breaking-change

Guide for writing release notes:

Notes SHOULD:
- Start with a verb
- Use past tense (added/fixed/resolved) as much as possible
- Only use present tense in imperative sentences to suggest future behavior for
  breaking changes/deprecations ("Use X" vs "You should use X" or "Users should use X")
- Impersonal third person (no “I”, “you”, etc.)
- Start with `{{service}}` if changing an existing resource (see exampels below)

DO:

HEADER: release-note:enhancement
compute: added `foo_bar` field to `google_compute_foo` resource

HEADER: release-note:bug
NOTE: container: fixed perma-diff in `google_container_cluster`


HEADER: release-note:breaking-change
NOTE: project: made `iam_policy` authoritative

HEADER: release-note:deprecation
NOTE: container: deprecated `region` and `zone` on `google_container_unicorn`. Use `location` instead.

Note no service name or *New Resource* tag:
HEADER: release-note:new-resource
NOTE: `google_compute_new_resource`

Note no service name or *New Datasource* tag:
HEADER: release-note:new-datasource
NOTE: `google_compute_new_datasource`

DON'T DO:
- Add compute_instance resource
- Fix bug
- fixed a bug in google_compute_network
- `google_project` now supports `blah`
- You can now create google_sql_instances in us-central1
- Adds support for `google_source_repo_repository`’s `url` field
- Users should now use location instead of zone/region on `google_container_unicorn`
-->
