### PR TITLE
Remove bgp from router nat test, add a failing bgp test

### DIFF
--- a/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
@@ -315,9 +315,6 @@ resource "google_compute_router" "foobar"{
 	name    = "router-nat-test-%s"
 	region  = "${google_compute_subnetwork.foobar.region}"
 	network = "${google_compute_network.foobar.self_link}"
-	bgp {
-		asn = 64514
-	}
 }
 
 resource "google_compute_network" "foobar" {

--- a/third_party/terraform/tests/resource_compute_router_test.go
+++ b/third_party/terraform/tests/resource_compute_router_test.go
@@ -111,6 +111,44 @@ func TestAccComputeRouter_update(t *testing.T) {
 	})
 }
 
+func TestAccComputeRouter_updateAddRemoveBGP(t *testing.T) {
+	t.Parallel()
+
+	testId := acctest.RandString(10)
+	region := getTestRegionFromEnv()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeRouterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterBasic(testId, region),
+			},
+			{
+				ResourceName:      "google_compute_router.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouter_noBGP(testId, region),
+			},
+			{
+				ResourceName:      "google_compute_router.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterBasic(testId, region),
+			},
+			{
+				ResourceName:      "google_compute_router.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccComputeRouterBasic(testId, resourceRegion string) string {
 	return fmt.Sprintf(`
 		resource "google_compute_network" "foobar" {
@@ -179,4 +217,24 @@ func testAccComputeRouterFull(testId string) string {
 			}
 		}
 	`, testId, testId)
+}
+
+func testAccComputeRouter_noBGP(testId, resourceRegion string) string {
+	return fmt.Sprintf(`
+		resource "google_compute_network" "foobar" {
+			name = "router-test-%s"
+			auto_create_subnetworks = false
+		}
+		resource "google_compute_subnetwork" "foobar" {
+			name = "router-test-subnetwork-%s"
+			network = "${google_compute_network.foobar.self_link}"
+			ip_cidr_range = "10.0.0.0/16"
+			region = "%s"
+		}
+		resource "google_compute_router" "foobar" {
+			name = "router-test-%s"
+			region = "${google_compute_subnetwork.foobar.region}"
+			network = "${google_compute_network.foobar.name}"
+		}
+	`, testId, testId, resourceRegion, testId)
 }


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

Tested this locally and then forgot to push 🤦‍♀ 

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```