### PR TITLE
deprecated-->removed event notification config

### DIFF
--- a/third_party/terraform/resources/resource_cloudiot_registry.go
+++ b/third_party/terraform/resources/resource_cloudiot_registry.go
@@ -56,27 +56,16 @@ func resourceCloudIoTRegistry() *schema.Resource {
 					[]string{"", "NONE", "ERROR", "INFO", "DEBUG"}, false),
 			},
 			"event_notification_config": {
-				Type:          schema.TypeMap,
-				Optional:      true,
-				Computed:      true,
-				Deprecated:    "eventNotificationConfig has been deprecated in favor of eventNotificationConfigs (plural). Please switch to using the plural field.",
-				ConflictsWith: []string{"event_notification_configs"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"pubsub_topic_name": {
-							Type:             schema.TypeString,
-							Required:         true,
-							DiffSuppressFunc: compareSelfLinkOrResourceName,
-						},
-					},
-				},
+				Type:     schema.TypeMap,
+				Optional: true,
+				Computed: true,
+				Removed:  "Please use event_notification_configs instead",
 			},
 			"event_notification_configs": {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Computed:      true,
 				MaxItems:      10,
-				ConflictsWith: []string{"event_notification_config"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"pubsub_topic_name": {
@@ -241,9 +230,6 @@ func createDeviceRegistry(d *schema.ResourceData) *cloudiot.DeviceRegistry {
 	deviceRegistry := &cloudiot.DeviceRegistry{}
 	if v, ok := d.GetOk("event_notification_configs"); ok {
 		deviceRegistry.EventNotificationConfigs = buildEventNotificationConfigs(v.([]interface{}))
-	} else if v, ok := d.GetOk("event_notification_config"); ok {
-		deviceRegistry.EventNotificationConfigs = []*cloudiot.EventNotificationConfig{
-			buildEventNotificationConfig(v.(map[string]interface{}))}
 	}
 
 	if v, ok := d.GetOk("state_notification_config"); ok {
@@ -311,15 +297,6 @@ func resourceCloudIoTRegistryUpdate(d *schema.ResourceData, meta interface{}) er
 		updateMask = append(updateMask, "event_notification_configs")
 		if v, ok := d.GetOk("event_notification_configs"); ok {
 			deviceRegistry.EventNotificationConfigs = buildEventNotificationConfigs(v.([]interface{}))
-		}
-	}
-
-	if d.HasChange("event_notification_config") {
-		hasChanged = true
-		updateMask = append(updateMask, "event_notification_configs")
-		if v, ok := d.GetOk("event_notification_config"); ok {
-			deviceRegistry.EventNotificationConfigs = []*cloudiot.EventNotificationConfig{
-				buildEventNotificationConfig(v.(map[string]interface{}))}
 		}
 	}
 
@@ -402,14 +379,8 @@ func resourceCloudIoTRegistryRead(d *schema.ResourceData, meta interface{}) erro
 		if err := d.Set("event_notification_configs", cfgs); err != nil {
 			return fmt.Errorf("Error reading Registry: %s", err)
 		}
-		if err := d.Set("event_notification_config", map[string]string{
-			"pubsub_topic_name": res.EventNotificationConfigs[0].PubsubTopicName,
-		}); err != nil {
-			return fmt.Errorf("Error reading Registry: %s", err)
-		}
 	} else {
 		d.Set("event_notification_configs", nil)
-		d.Set("event_notification_config", nil)
 	}
 
 	pubsubTopicName := res.StateNotificationConfig.PubsubTopicName

--- a/third_party/terraform/tests/resource_cloudiot_registry_test.go
+++ b/third_party/terraform/tests/resource_cloudiot_registry_test.go
@@ -118,7 +118,7 @@ func TestAccCloudIoTRegistry_update(t *testing.T) {
 	})
 }
 
-func TestAccCloudIoTRegistry_eventNotificationConfigDeprecatedSingleToPlural(t *testing.T) {
+func TestAccCloudIoTRegistry_eventNotificationConfigsSing;e(t *testing.T) {
 	t.Parallel()
 
 	registryName := fmt.Sprintf("tf-registry-test-%s", acctest.RandString(10))
@@ -130,29 +130,18 @@ func TestAccCloudIoTRegistry_eventNotificationConfigDeprecatedSingleToPlural(t *
 		CheckDestroy: testAccCheckCloudIoTRegistryDestroy,
 		Steps: []resource.TestStep{
 			{
-				// Use deprecated field (event_notification_config) to create
-				Config: testAccCloudIoTRegistry_singleEventNotificationConfig(topic, registryName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"google_cloudiot_registry.foobar", "event_notification_configs.#", "1"),
-				),
+				Config: testAccCloudIoTRegistry_singleEventNotificationConfigs(topic, registryName),
 			},
 			{
 				ResourceName:      "google_cloudiot_registry.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			{
-				// Use new field (event_notification_configs) to see if plan changed
-				Config:             testAccCloudIoTRegistry_pluralEventNotificationConfigs(topic, registryName),
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: false,
-			},
 		},
 	})
 }
 
-func TestAccCloudIoTRegistry_eventNotificationConfigMultiple(t *testing.T) {
+func TestAccCloudIoTRegistry_eventNotificationConfigsMultiple(t *testing.T) {
 	t.Parallel()
 
 	registryName := fmt.Sprintf("tf-registry-test-%s", acctest.RandString(10))
@@ -170,40 +159,6 @@ func TestAccCloudIoTRegistry_eventNotificationConfigMultiple(t *testing.T) {
 				ResourceName:      "google_cloudiot_registry.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func TestAccCloudIoTRegistry_eventNotificationConfigPluralToDeprecatedSingle(t *testing.T) {
-	t.Parallel()
-
-	registryName := fmt.Sprintf("tf-registry-test-%s", acctest.RandString(10))
-	topic := fmt.Sprintf("tf-registry-test-%s", acctest.RandString(10))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckCloudIoTRegistryDestroy,
-		Steps: []resource.TestStep{
-			{
-				// Use new field (event_notification_configs) to create
-				Config: testAccCloudIoTRegistry_pluralEventNotificationConfigs(topic, registryName),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(
-						"google_cloudiot_registry.foobar", "event_notification_configs.#", "1"),
-				),
-			},
-			{
-				ResourceName:      "google_cloudiot_registry.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				// Use old field (event_notification_config) to see if plan changed
-				Config:             testAccCloudIoTRegistry_singleEventNotificationConfig(topic, registryName),
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: false,
 			},
 		},
 	})
@@ -342,6 +297,30 @@ resource "google_cloudiot_registry" "foobar" {
 `, topic, registryName)
 }
 
+func testAccCloudIoTRegistry_singleEventNotificationConfigs(topic, registryName string) string {
+	return fmt.Sprintf(`
+resource "google_project_iam_binding" "cloud-iot-iam-binding" {
+  members = ["serviceAccount:cloud-iot@system.gserviceaccount.com"]
+  role    = "roles/pubsub.publisher"
+}
+
+resource "google_pubsub_topic" "event-topic-1" {
+  name = "%s"
+}
+
+resource "google_cloudiot_registry" "foobar" {
+  depends_on = ["google_project_iam_binding.cloud-iot-iam-binding"]
+
+  name = "%s"
+
+  event_notification_config {
+    pubsub_topic_name = "${google_pubsub_topic.event-topic-1.id}"
+	subfolder_matches = ""
+  }
+}
+`, topic, registryName)
+}
+
 func testAccCloudIoTRegistry_multipleEventNotificationConfigs(topic, registryName string) string {
 	return fmt.Sprintf(`
 resource "google_project_iam_binding" "cloud-iot-iam-binding" {
@@ -367,7 +346,7 @@ resource "google_cloudiot_registry" "foobar" {
 	subfolder_matches = "test"
   }
 
-  event_notification_configs {
+  event_notification_config {
     pubsub_topic_name = "${google_pubsub_topic.event-topic-2.id}"
 	subfolder_matches = ""
   }

--- a/third_party/terraform/tests/resource_cloudiot_registry_test.go
+++ b/third_party/terraform/tests/resource_cloudiot_registry_test.go
@@ -313,7 +313,7 @@ resource "google_cloudiot_registry" "foobar" {
 
   name = "%s"
 
-  event_notification_config {
+  event_notification_configs {
     pubsub_topic_name = "${google_pubsub_topic.event-topic-1.id}"
 	subfolder_matches = ""
   }
@@ -346,7 +346,7 @@ resource "google_cloudiot_registry" "foobar" {
 	subfolder_matches = "test"
   }
 
-  event_notification_config {
+  event_notification_configs {
     pubsub_topic_name = "${google_pubsub_topic.event-topic-2.id}"
 	subfolder_matches = ""
   }

--- a/third_party/terraform/tests/resource_cloudiot_registry_test.go
+++ b/third_party/terraform/tests/resource_cloudiot_registry_test.go
@@ -118,7 +118,7 @@ func TestAccCloudIoTRegistry_update(t *testing.T) {
 	})
 }
 
-func TestAccCloudIoTRegistry_eventNotificationConfigsSing;e(t *testing.T) {
+func TestAccCloudIoTRegistry_eventNotificationConfigsSingle(t *testing.T) {
 	t.Parallel()
 
 	registryName := fmt.Sprintf("tf-registry-test-%s", acctest.RandString(10))

--- a/third_party/terraform/website/docs/r/cloudiot_registry.html.markdown
+++ b/third_party/terraform/website/docs/r/cloudiot_registry.html.markdown
@@ -65,8 +65,6 @@ The following arguments are supported:
 
 * `region` - (Optional) The Region in which the created address should reside. If it is not provided, the provider region is used.
 
-* `event_notification_config` - (Deprecated) Use `event_notification_configs` instead.
-
 * `event_notification_configs` - (Optional) List of configurations for event notification, such as
 PubSub topics to publish device events to. Structure is documented below.
 


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
`cloudiot`: Removed `event_notification_config` (singular) from `google_cloudiot_registry`. Use plural `event_notification_configs` instead.
```