### PR TITLE
Add bigtable GCPolicy resource

### DIFF
--- a/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -1,0 +1,231 @@
+package google
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"cloud.google.com/go/bigtable"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+const (
+	GCPolicyModeIntersection = "INTERSECTION"
+	GCPolicyModeUnion        = "UNION"
+)
+
+func resourceBigtableGCPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceBigtableGCPolicyCreate,
+		Read:   resourceBigtableGCPolicyRead,
+		Delete: resourceBigtableGCPolicyDestroy,
+
+		Schema: map[string]*schema.Schema{
+			"instance_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"table": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"column_family": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{GCPolicyModeIntersection, GCPolicyModeUnion}, false),
+			},
+
+			"max_age": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"days": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+					},
+				},
+			},
+
+			"max_version": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"number": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+					},
+				},
+			},
+
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceBigtableGCPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	ctx := context.Background()
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	instanceName := d.Get("instance_name").(string)
+	c, err := config.bigtableClientFactory.NewAdminClient(project, instanceName)
+	if err != nil {
+		return fmt.Errorf("Error starting admin client. %s", err)
+	}
+
+	defer c.Close()
+
+	gcPolicy, err := generateBigtableGCPolicy(d)
+	if err != nil {
+		return err
+	}
+
+	tableName := d.Get("table").(string)
+	columnFamily := d.Get("column_family").(string)
+
+	if err := c.SetGCPolicy(ctx, tableName, columnFamily, gcPolicy); err != nil {
+		return err
+	}
+
+	table, err := c.TableInfo(ctx, tableName)
+	if err != nil {
+		return fmt.Errorf("Error retrieving table. Could not find %s in %s. %s", tableName, instanceName, err)
+	}
+
+	for _, i := range table.FamilyInfos {
+		if i.Name == columnFamily {
+			d.SetId(i.GCPolicy)
+		}
+	}
+
+	return resourceBigtableGCPolicyRead(d, meta)
+}
+
+func resourceBigtableGCPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	ctx := context.Background()
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	instanceName := d.Get("instance_name").(string)
+	c, err := config.bigtableClientFactory.NewAdminClient(project, instanceName)
+	if err != nil {
+		return fmt.Errorf("Error starting admin client. %s", err)
+	}
+
+	defer c.Close()
+
+	name := d.Get("table").(string)
+	ti, err := c.TableInfo(ctx, name)
+	if err != nil {
+		log.Printf("[WARN] Removing %s because it's gone", name)
+		d.SetId("")
+		return fmt.Errorf("Error retrieving table. Could not find %s in %s. %s", name, instanceName, err)
+	}
+
+	for _, fi := range ti.FamilyInfos {
+		if fi.Name == name {
+			d.SetId(fi.GCPolicy)
+			break
+		}
+	}
+
+	d.Set("project", project)
+
+	return nil
+}
+
+func resourceBigtableGCPolicyDestroy(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	ctx := context.Background()
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	instanceName := d.Get("instance_name").(string)
+	c, err := config.bigtableClientFactory.NewAdminClient(project, instanceName)
+	if err != nil {
+		return fmt.Errorf("Error starting admin client. %s", err)
+	}
+
+	defer c.Close()
+
+	if err := c.SetGCPolicy(ctx, d.Get("table").(string), d.Get("column_family").(string), bigtable.NoGcPolicy()); err != nil {
+		return err
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func generateBigtableGCPolicy(d *schema.ResourceData) (bigtable.GCPolicy, error) {
+	var policies []bigtable.GCPolicy
+	mode := d.Get("mode").(string)
+	ma, aok := d.GetOk("max_age")
+	mv, vok := d.GetOk("max_version")
+
+	if !aok && !vok {
+		return bigtable.NoGcPolicy(), nil
+	}
+
+	if mode == "" && aok && vok {
+		return nil, fmt.Errorf("If multiple policies are set, mode can't be empty")
+	}
+
+	if aok {
+		l, _ := ma.([]interface{})
+		d, _ := l[0].(map[string]interface{})["days"].(int)
+
+		policies = append(policies, bigtable.MaxAgePolicy(time.Duration(d)*time.Hour*24))
+	}
+
+	if vok {
+		l, _ := mv.([]interface{})
+		n, _ := l[0].(map[string]interface{})["number"].(int)
+
+		policies = append(policies, bigtable.MaxVersionsPolicy(n))
+	}
+
+	switch mode {
+	case GCPolicyModeUnion:
+		return bigtable.UnionPolicy(policies...), nil
+	case GCPolicyModeIntersection:
+		return bigtable.IntersectionPolicy(policies...), nil
+	}
+
+	return policies[0], nil
+}

--- a/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -1,0 +1,199 @@
+package google
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccBigtableGCPolicy_basic(t *testing.T) {
+	t.Parallel()
+
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	tableName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	familyName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBigtableGCPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigtableGCPolicy(instanceName, tableName, familyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccBigtableGCPolicyExists(
+						"google_bigtable_gc_policy.policy"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccBigtableGCPolicy_union(t *testing.T) {
+	t.Parallel()
+
+	instanceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	tableName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	familyName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBigtableGCPolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigtableGCPolicyUnion(instanceName, tableName, familyName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccBigtableGCPolicyExists(
+						"google_bigtable_gc_policy.policy"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckBigtableGCPolicyDestroy(s *terraform.State) error {
+	var ctx = context.Background()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "google_bigtable_gc_policy" {
+			continue
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		c, err := config.bigtableClientFactory.NewAdminClient(config.Project, rs.Primary.Attributes["instance_name"])
+		if err != nil {
+			// The instance is already gone
+			return nil
+		}
+
+		table, err := c.TableInfo(ctx, rs.Primary.Attributes["name"])
+		if err != nil {
+			// The table is already gone
+			return nil
+		}
+
+		for _, i := range table.FamilyInfos {
+			if i.Name == rs.Primary.Attributes["column_family"] {
+				if i.GCPolicy != "<never>" {
+					return fmt.Errorf("GC Policy still present. Found %s in %s.", i.GCPolicy, rs.Primary.Attributes["column_family"])
+				}
+			}
+		}
+
+		c.Close()
+	}
+
+	return nil
+}
+
+func testAccBigtableGCPolicyExists(n string) resource.TestCheckFunc {
+	var ctx = context.Background()
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		config := testAccProvider.Meta().(*Config)
+		c, err := config.bigtableClientFactory.NewAdminClient(config.Project, rs.Primary.Attributes["instance_name"])
+		if err != nil {
+			return fmt.Errorf("Error starting admin client. %s", err)
+		}
+
+		defer c.Close()
+
+		table, err := c.TableInfo(ctx, rs.Primary.Attributes["table"])
+		if err != nil {
+			return fmt.Errorf("Error retrieving table. Could not find %s in %s.", rs.Primary.Attributes["table"], rs.Primary.Attributes["instance_name"])
+		}
+
+		for _, i := range table.FamilyInfos {
+			if i.Name == rs.Primary.Attributes["column_family"] {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("Error retrieving gc policy. Could not find policy in family %s", rs.Primary.Attributes["column_family"])
+	}
+}
+
+func testAccBigtableGCPolicy(instanceName, tableName, family string) string {
+	return fmt.Sprintf(`
+resource "google_bigtable_instance" "instance" {
+  name          = "%s"
+
+  cluster {
+    cluster_id = "%s"
+    zone       = "us-central1-b"
+  }
+
+  instance_type = "DEVELOPMENT"
+}
+
+resource "google_bigtable_table" "table" {
+  name          = "%s"
+  instance_name = "${google_bigtable_instance.instance.name}"
+
+  column_family {
+    family = "%s"
+  }
+}
+
+resource "google_bigtable_gc_policy" "policy" {
+  instance_name = "${google_bigtable_instance.instance.name}"
+  table         = "${google_bigtable_table.table.name}"
+  column_family = "%s"
+
+  max_age {	
+    days = 3
+  }
+}
+`, instanceName, instanceName, tableName, family, family)
+}
+
+func testAccBigtableGCPolicyUnion(instanceName, tableName, family string) string {
+	return fmt.Sprintf(`
+resource "google_bigtable_instance" "instance" {
+  name          = "%s"
+
+  cluster {
+    cluster_id = "%s"
+    zone       = "us-central1-b"
+  }
+
+  instance_type = "DEVELOPMENT"
+}
+
+resource "google_bigtable_table" "table" {
+  name          = "%s"
+  instance_name = "${google_bigtable_instance.instance.name}"
+
+  column_family {
+    family = "%s"
+  }
+}
+
+resource "google_bigtable_gc_policy" "policy" {
+  instance_name = "${google_bigtable_instance.instance.name}"
+  table         = "${google_bigtable_table.table.name}"
+  column_family = "%s"
+
+  mode = "UNION"
+
+  max_age {
+    days = 3
+  }
+
+  max_version {
+    number = 10
+  }
+}
+`, instanceName, instanceName, tableName, family, family)
+}

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -267,6 +267,7 @@ end     # products.each do
 			map[string]*schema.Resource{
 				"google_app_engine_application":                resourceAppEngineApplication(),
 				"google_bigquery_table":                        resourceBigQueryTable(),
+				"google_bigtable_gc_policy":                    resourceBigtableGCPolicy(),
 				"google_bigtable_instance":                     resourceBigtableInstance(),
 				"google_bigtable_instance_iam_binding":         ResourceIamBinding(IamBigtableInstanceSchema, NewBigtableInstanceUpdater, BigtableInstanceIdParseFunc),
 				"google_bigtable_instance_iam_member":          ResourceIamMember(IamBigtableInstanceSchema, NewBigtableInstanceUpdater, BigtableInstanceIdParseFunc),

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -253,6 +253,10 @@
       <a href="/docs/providers/google/r/bigtable_app_profile.html">google_bigtable_app_profile</a>
       </li>
 
+      <li<%%= sidebar_current("docs-google-bigtable-gc-policy") %>>
+      <a href="/docs/providers/google/r/bigtable_gc_policy.html">google_bigtable_gc_policy</a>
+      </li>
+
       <li<%%= sidebar_current("docs-google-bigtable-instance") %>>
       <a href="/docs/providers/google/r/bigtable_instance.html">google_bigtable_instance</a>
       </li>

--- a/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
@@ -1,0 +1,98 @@
+---
+layout: "google"
+page_title: "Google: google_bigtable_gc_policy"
+sidebar_current: "docs-google-bigtable-gc-policy"
+description: |-
+  Creates a Google Cloud Bigtable GC Policy inside a family.
+---
+
+# google_bigtable_gc_policy
+
+Creates a Google Cloud Bigtable GC Policy inside a family. For more information see
+[the official documentation](https://cloud.google.com/bigtable/) and
+[API](https://cloud.google.com/bigtable/docs/go/reference).
+
+
+## Example Usage
+
+```hcl
+resource "google_bigtable_instance" "instance" {
+  name         = "tf-instance"
+  cluster_id   = "tf-instance-cluster"
+  zone         = "us-central1-b"
+  num_nodes    = 3
+  storage_type = "HDD"
+}
+
+resource "google_bigtable_table" "table" {
+  name          = "tf-table"
+  instance_name = "${google_bigtable_instance.instance.name}"
+  
+  column_family {
+    family = "name"
+  }
+}
+
+resource "google_bigtable_gc_policy" "policy" {
+  instance_name = "${google_bigtable_instance.instance.name}"
+  table         = "${google_bigtable_table.table.name}"
+  column_family = "name"
+  
+  max_age {
+    days = 7
+  }
+}
+```
+
+Multiple conditions is also supported. `UNION` when any of its sub-policies apply (OR). `INTERSECTION` when all its sub-policies apply (AND)
+```
+resource "google_bigtable_gc_policy" "policy" {
+  instance_name = "${google_bigtable_instance.instance.name}"
+  table         = "${google_bigtable_table.table.name}"
+  column_family = "name"
+  
+  mode = "UNION"
+  
+  max_age {
+    days = 7
+  }
+  
+  max_version {
+    number = 10
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the table.
+
+* `instance_name` - (Required) The name of the Bigtable instance.
+
+* `family` - (Required) The name of the column family.
+
+* `project` - (Optional) The ID of the project in which the resource belongs. If it is not provided, the provider project is used.
+
+* `mode` - (Optional) If multiple policies are set, you should choose between `UNION` OR `INTERSECTION`.
+
+* `max_age` - (Optional) GC policy that applies to all cells older than the given age.
+
+* `max_version` - (Optional) GC policy that applies to all versions of a cell except for the most recent.
+
+-----
+
+`max_age` supports the following arguments:
+
+* `days` - (Required) Number of days before applying GC policy.
+
+-----
+
+`max_version` supports the following arguments:
+
+* `number` - (Required) Number of version before applying the GC policy.
+
+## Attributes Reference
+
+Only the arguments listed above are exposed as attributes.


### PR DESCRIPTION
Upstreams https://github.com/terraform-providers/terraform-provider-google/pull/3293

~I want to amend the sidebar as part of this PR, so I'll add a `depends:` on the downstream, merge it, and then generate downstreams again.~

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_bigtable_gc_policy`
```