### PR TITLE
Ignore the new bigquerystorage.googleapis.com.

### DIFF
--- a/third_party/terraform/resources/resource_google_project_services.go
+++ b/third_party/terraform/resources/resource_google_project_services.go
@@ -13,7 +13,7 @@ import (
 
 const maxServiceUsageBatchSize = 20
 
-var ignoredProjectServices = []string{"dataproc-control.googleapis.com", "source.googleapis.com", "stackdriverprovisioning.googleapis.com"}
+var ignoredProjectServices = []string{"dataproc-control.googleapis.com", "source.googleapis.com", "stackdriverprovisioning.googleapis.com", "bigquerystorage.googleapis.com"}
 
 // These services can only be enabled as a side-effect of enabling other services,
 // so don't bother storing them in the config or using them for diffing.

--- a/third_party/terraform/resources/resource_google_project_services.go
+++ b/third_party/terraform/resources/resource_google_project_services.go
@@ -13,7 +13,7 @@ import (
 
 const maxServiceUsageBatchSize = 20
 
-var ignoredProjectServices = []string{"dataproc-control.googleapis.com", "source.googleapis.com", "stackdriverprovisioning.googleapis.com", "bigquerystorage.googleapis.com"}
+var ignoredProjectServices = []string{"dataproc-control.googleapis.com", "source.googleapis.com", "stackdriverprovisioning.googleapis.com", "bigquerystorage.googleapis.com", "cloudtrace.googleapis.com", "storage-component.googleapis.com"}
 
 // These services can only be enabled as a side-effect of enabling other services,
 // so don't bother storing them in the config or using them for diffing.


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Fix `google_project_services` permadiff when bigquery-json is enabled.
```