### PR TITLE
Upstream network_peering import

### DIFF
--- a/third_party/terraform/resources/resource_compute_network_peering.go.erb
+++ b/third_party/terraform/resources/resource_compute_network_peering.go.erb
@@ -19,7 +19,9 @@ func resourceComputeNetworkPeering() *schema.Resource {
 		Create: resourceComputeNetworkPeeringCreate,
 		Read:   resourceComputeNetworkPeeringRead,
 		Delete: resourceComputeNetworkPeeringDelete,
-
+		Importer: &schema.ResourceImporter{
+			State: resourceComputeNetworkPeeringImporter,
+		},
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:         schema.TypeString,
@@ -74,6 +76,22 @@ func resourceComputeNetworkPeering() *schema.Resource {
 			<% end -%>
 		},
 	}
+}
+
+func resourceComputeNetworkPeeringImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	config := meta.(*Config)
+	if err := parseImportId([]string{"(?P<network>[^/]+)/(?P<name>[^/]+)"}, d, config); err != nil {
+		return nil, err
+	}
+
+	// Replace import id for the resource id
+	id, err := replaceVars(d, config, "{{name}}")
+	if err != nil {
+		return nil, fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceComputeNetworkPeeringCreate(d *schema.ResourceData, meta interface{}) error {

--- a/third_party/terraform/tests/resource_compute_network_peering_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_network_peering_test.go.erb
@@ -39,6 +39,11 @@ func TestAccComputeNetworkPeering_basic(t *testing.T) {
 					<% end -%>
 				),
 			},
+			{
+				ResourceName:      "google_compute_network_peering.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 

--- a/third_party/terraform/website/docs/r/compute_network_peering.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_network_peering.html.markdown
@@ -64,3 +64,10 @@ exported:
 * `state` - State for the peering.
 
 * `state_details` - Details about the current state of the peering.
+
+## Import
+VPC Peering Networks can be imported using the name of the network the peering exists in and the name of the peering network
+
+```
+$ terraform import google_compute_network_peering.peering_network network-name/peering-network-name
+```


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->
Upstreams https://github.com/terraform-providers/terraform-provider-google/pull/4291
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
`compute`: Add import functionality for `google_compute_network_peering`
```