### PR TITLE
allowGlobalAccess for internal forwarding rule

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2094,6 +2094,15 @@ objects:
           addressed to any ports to be forwarded to the backends configured
           with this forwarding rule. Used with backend service. Cannot be set
           if port or portRange are set.
+      - !ruby/object:Api::Type::Boolean
+        name: 'allowGlobalAccess'
+        description: |
+          If true, clients can access ILB from all regions.
+          Otherwise only allows from the local region the ILB is located at.
+        send_empty_value: true
+        update_verb: :PATCH
+        update_url:  projects/{{project}}/regions/{{region}}/forwardingRules/{{name}}
+        min_version: beta
       - !ruby/object:Api::Type::Enum
         name: 'networkTier'
         description: |

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -476,6 +476,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           forwarding_rule_name: "website-forwarding-rule"
           backend_name: "website-backend"
           network_name: "website-net"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "forwarding_rule_global_internallb"
+        primary_resource_id: "default"
+        min_version: beta
+        vars:
+          forwarding_rule_name: "website-forwarding-rule"
+          backend_name: "website-backend"
+          network_name: "website-net"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       post_create: templates/terraform/post_create/labels.erb
     properties:

--- a/templates/terraform/examples/forwarding_rule_global_internallb.tf.erb
+++ b/templates/terraform/examples/forwarding_rule_global_internallb.tf.erb
@@ -1,22 +1,29 @@
 // Forwarding rule for Internal Load Balancing
 resource "google_compute_forwarding_rule" "<%= ctx[:primary_resource_id] %>" {
+  provider = "google-beta"
+
   name                  = "<%= ctx[:vars]['forwarding_rule_name'] %>"
   region                = "us-central1"
 
   load_balancing_scheme = "INTERNAL"
   backend_service       = "${google_compute_region_backend_service.backend.self_link}"
   all_ports             = true
+  allow_global_access   = true
   network               = "${google_compute_network.default.name}"
   subnetwork            = "${google_compute_subnetwork.default.name}"
 }
 
 resource "google_compute_region_backend_service" "backend" {
+  provider = "google-beta"
+
   name                  = "<%= ctx[:vars]['backend_name'] %>"
   region                = "us-central1"
   health_checks         = ["${google_compute_health_check.hc.self_link}"]
 }
 
 resource "google_compute_health_check" "hc" {
+  provider = "google-beta"
+
   name               = "check-<%= ctx[:vars]['backend_name'] %>"
   check_interval_sec = 1
   timeout_sec        = 1
@@ -27,11 +34,15 @@ resource "google_compute_health_check" "hc" {
 }
 
 resource "google_compute_network" "default" {
+  provider = "google-beta"
+
   name = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "default" {
+  provider = "google-beta"
+
   name          = "<%= ctx[:vars]['network_name'] %>"
   ip_cidr_range = "10.0.0.0/16"
   region        = "us-central1"

--- a/templates/terraform/examples/forwarding_rule_internallb.tf.erb
+++ b/templates/terraform/examples/forwarding_rule_internallb.tf.erb
@@ -6,6 +6,7 @@ resource "google_compute_forwarding_rule" "<%= ctx[:primary_resource_id] %>" {
   load_balancing_scheme = "INTERNAL"
   backend_service       = "${google_compute_region_backend_service.backend.self_link}"
   all_ports             = true
+  allow_global_access   = true
   network               = "${google_compute_network.default.name}"
   subnetwork            = "${google_compute_subnetwork.default.name}"
 }


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:allowGlobalAccess for INTERNAL forwardingRules

```