### PR TITLE
Fix downstream changelog body replacement

### DIFF
--- a/.ci/magic-modules/pyutils/strutils.py
+++ b/.ci/magic-modules/pyutils/strutils.py
@@ -95,7 +95,12 @@ def set_release_notes(release_notes, body):
   Returns:
     Modified text
   """
-  edited = re.sub(r'`{3}[^`]*`{3}', "", body, flags=re.DOTALL)
+  edited = ""
+  md = mistune.markdown(body)
+  soup = BeautifulSoup(md, 'html.parser')
+  for blob in soup.find_all('p'):
+    edited += blob.get_text().strip() + "\n\n"
+
   for heading, note in release_notes:
     edited += "\n```%s\n%s\n```\n" % (heading, note.strip())
   return edited

--- a/.ci/magic-modules/pyutils/strutils_test.py
+++ b/.ci/magic-modules/pyutils/strutils_test.py
@@ -109,19 +109,19 @@ This is a release note
 
   def test_set_release_notes(self):
     downstream_body = """
-      All of the blocks below should be replaced
+All of the blocks below should be replaced
 
-      ```releasenote
-      This should be replaced
-      ```
+```releasenote
+This should be replaced
+```
 
-      More text
+More text
 
-      ```releasenote
-      ```
+```releasenote
+```
 
-      ```test
-      ```
+```test
+```
       """
     release_notes = [
       ("release-note:foo", "new message foo"),


### PR DESCRIPTION
Just yank out paragraphs as text to keep and add release notes at end. 