### PR TITLE
release pipeline fix

### DIFF
--- a/.ci/containers/hub/Dockerfile
+++ b/.ci/containers/hub/Dockerfile
@@ -1,4 +1,4 @@
-from gcr.io/magic-modules/go-ruby:1.11.5-2.6.0
+from gcr.io/magic-modules/go-ruby-python:1.11.5-2.6.0-2.7-v4
 
 RUN apt-get update
 RUN apt-get install -y ca-certificates

--- a/.ci/magic-modules/release-ansible.sh
+++ b/.ci/magic-modules/release-ansible.sh
@@ -23,7 +23,7 @@ get_all_modules() {
 }
 
 # Install dependencies for Template Generator
-pushd "magic-modules-new-prs"
+pushd "magic-modules-gcp"
 bundle install
 
 # Setup SSH keys.
@@ -55,7 +55,7 @@ popd
 # Copy code into ansible/ansible + commit to our fork
 # By using the "ansible_devel" provider, we get versions of the resources that work
 # with ansible devel.
-pushd "magic-modules-new-prs"
+pushd "magic-modules-gcp"
 ruby compiler.rb -a -e ansible -f ansible_devel -o ../ansible/
 popd
 

--- a/.ci/magic-modules/release-ansible.sh
+++ b/.ci/magic-modules/release-ansible.sh
@@ -22,9 +22,6 @@ get_all_modules() {
   done
 }
 
-# Clone ansible/ansible
-ssh-agent bash -c "ssh-add ~/github_private_key; git clone git@github.com:modular-magician/ansible.git"
-
 # Install dependencies for Template Generator
 pushd "magic-modules-new-prs"
 bundle install
@@ -39,6 +36,10 @@ echo "$CREDS" > ~/github_private_key
 set -x
 chmod 400 ~/github_private_key
 popd
+
+# Clone ansible/ansible
+ssh-agent bash -c "ssh-add ~/github_private_key; git clone git@github.com:modular-magician/ansible.git"
+
 
 # Setup Git config and remotes.
 pushd "ansible"

--- a/.ci/magic-modules/release-ansible.sh
+++ b/.ci/magic-modules/release-ansible.sh
@@ -101,7 +101,7 @@ for filename in mm-bug*; do
   git commit -m "Bug fixes for GCP modules"
 
   # Create a PR message + save to file
-  ruby ../../tools/ansible-pr/generate_template.rb > bug_fixes$filename
+  ruby ../magic-modules-gcp/tools/ansible-pr/generate_template.rb > bug_fixes$filename
 
   # Create PR
   ssh-agent bash -c "ssh-add ~/github_private_key; git push origin bug_fixes$filename --force"
@@ -129,7 +129,7 @@ while read module; do
   # Create a PR message + save to file
   set +e
   git commit -m "New Module: $module"
-  ruby ../../tools/ansible-pr/generate_template.rb --new-module-name $module > $module
+  ruby ../magic-modules-gcp/tools/ansible-pr/generate_template.rb --new-module-name $module > $module
 
   # Create PR
   ssh-agent bash -c "ssh-add ~/github_private_key; git push origin $module --force"

--- a/.ci/magic-modules/release-ansible.sh
+++ b/.ci/magic-modules/release-ansible.sh
@@ -15,7 +15,7 @@ get_all_modules() {
   file_name=$remote_name
   ssh-agent bash -c "ssh-add ~/github_private_key; git fetch $remote_name"
   git checkout $remote_name/devel
-  git ls-files -- plugins/modules/gcp_* | cut -d/ -f 6 | cut -d. -f 1 > $file_name
+  git ls-files -- lib/ansible/modules/cloud/google/gcp_* | cut -d/ -f 6 | cut -d. -f 1 > $file_name
   
   for i in "${ignored_modules[@]}"; do
     sed -i "/$i/d" $file_name
@@ -40,7 +40,6 @@ popd
 # Clone ansible/ansible
 ssh-agent bash -c "ssh-add ~/github_private_key; git clone git@github.com:modular-magician/ansible.git"
 
-
 # Setup Git config and remotes.
 pushd "ansible"
 git config --global user.email "magic-modules@google.com"
@@ -64,7 +63,7 @@ popd
 pushd "ansible"
 git add lib/ansible/modules/cloud/google/gcp_* test/integration/targets/gcp_*
 git commit -m "Migrating code from collection"
-ssh-agent bash -c "ssh-add ~/github_private_key; git push origin devel"
+ssh-agent bash -c "ssh-add ~/github_private_key; git push magician devel"
 
 set -e
 

--- a/.ci/magic-modules/release-ansible.sh
+++ b/.ci/magic-modules/release-ansible.sh
@@ -23,10 +23,10 @@ get_all_modules() {
 }
 
 # Clone ansible/ansible
-git clone git@github.com:modular-magician/ansible.git
+ssh-agent bash -c "ssh-add ~/github_private_key; git clone git@github.com:modular-magician/ansible.git"
 
 # Install dependencies for Template Generator
-pushd "magic-modules-gcp"
+pushd "magic-modules-new-prs"
 bundle install
 
 # Setup SSH keys.
@@ -55,7 +55,7 @@ popd
 # Copy code into ansible/ansible + commit to our fork
 # By using the "ansible_devel" provider, we get versions of the resources that work
 # with ansible devel.
-pushd "magic-modules-gcp"
+pushd "magic-modules-new-prs"
 ruby compiler.rb -a -e ansible -f ansible_devel -o ../ansible/
 popd
 

--- a/.ci/magic-modules/release-ansible.yml
+++ b/.ci/magic-modules/release-ansible.yml
@@ -10,10 +10,10 @@ image_resource:
         tag: '1.2'
 
 inputs:
-    - name: magic-modules-new-prs
+    - name: magic-modules-gcp
 
 run:
-    path: "magic-modules-new-prs/.ci/magic-modules/release-ansible.sh"
+    path: "magic-modules-gcp/.ci/magic-modules/release-ansible.sh"
 
 params:
   GITHUB_TOKEN: ""

--- a/.ci/magic-modules/release-ansible.yml
+++ b/.ci/magic-modules/release-ansible.yml
@@ -10,10 +10,10 @@ image_resource:
         tag: '1.1'
 
 inputs:
-    - name: magic-modules-gcp
+    - name: magic-modules-new-prs
 
 run:
-    path: "magic-modules-gcp/.ci/magic-modules/release-ansible.sh"
+    path: "magic-modules-new-prs/.ci/magic-modules/release-ansible.sh"
 
 params:
   GITHUB_TOKEN: ""

--- a/.ci/magic-modules/release-ansible.yml
+++ b/.ci/magic-modules/release-ansible.yml
@@ -7,7 +7,7 @@ image_resource:
     type: docker-image
     source:
         repository: gcr.io/magic-modules/hub
-        tag: '1.1'
+        tag: '1.2'
 
 inputs:
     - name: magic-modules-new-prs

--- a/.ci/release.yml.tmpl
+++ b/.ci/release.yml.tmpl
@@ -26,16 +26,6 @@ resources:
           uri: git@github.com:GoogleCloudPlatform/magic-modules.git
           private_key: ((repo-key.private_key))
 
-    - name: magic-modules-new-prs
-      type: github-pull-request
-      source:
-          repo: GoogleCloudPlatform/magic-modules
-          private_key: ((repo-key.private_key))
-          access_token: ((github-account.password))
-          authorship_restriction: true
-          no_label: automerged
-          base: master
-
     - name: gcp-bucket
       type: gcs-resource
       source:
@@ -60,7 +50,7 @@ jobs:
       plan:
           - get: night-trigger
             trigger: true
-          - get: magic-modules-new-prs
+          - get: magic-modules-gcp
             trigger: false
           - task: build
             file: magic-modules-new-prs/.ci/magic-modules/release-ansible.yml

--- a/.ci/release.yml.tmpl
+++ b/.ci/release.yml.tmpl
@@ -53,7 +53,7 @@ jobs:
           - get: magic-modules-gcp
             trigger: false
           - task: build
-            file: magic-modules-new-prs/.ci/magic-modules/release-ansible.yml
+            file: magic-modules-gcp-prs/.ci/magic-modules/release-ansible.yml
             params:
                 GITHUB_TOKEN: ((github-account.password))
                 CREDS: ((repo-key.private_key))

--- a/.ci/release.yml.tmpl
+++ b/.ci/release.yml.tmpl
@@ -53,7 +53,7 @@ jobs:
           - get: magic-modules-gcp
             trigger: false
           - task: build
-            file: magic-modules-gcp-prs/.ci/magic-modules/release-ansible.yml
+            file: magic-modules-gcp/.ci/magic-modules/release-ansible.yml
             params:
                 GITHUB_TOKEN: ((github-account.password))
                 CREDS: ((repo-key.private_key))

--- a/.ci/release.yml.tmpl
+++ b/.ci/release.yml.tmpl
@@ -26,6 +26,16 @@ resources:
           uri: git@github.com:GoogleCloudPlatform/magic-modules.git
           private_key: ((repo-key.private_key))
 
+    - name: magic-modules-new-prs
+      type: github-pull-request
+      source:
+          repo: GoogleCloudPlatform/magic-modules
+          private_key: ((repo-key.private_key))
+          access_token: ((github-account.password))
+          authorship_restriction: true
+          no_label: automerged
+          base: master
+
     - name: gcp-bucket
       type: gcs-resource
       source:
@@ -50,10 +60,10 @@ jobs:
       plan:
           - get: night-trigger
             trigger: true
-          - get: magic-modules-gcp
+          - get: magic-modules-new-prs
             trigger: false
           - task: build
-            file: magic-modules-gcp/.ci/magic-modules/release-ansible.yml
+            file: magic-modules-new-prs/.ci/magic-modules/release-ansible.yml
             params:
                 GITHUB_TOKEN: ((github-account.password))
                 CREDS: ((repo-key.private_key))

--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -203,7 +203,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - timeout_seconds
   Image: !ruby/object:Overrides::Ansible::ResourceOverride
     properties:
-      guestOsFeatures: !ruby/object:Overrides::Ansible::PropertyOverride
+      guestOsFeatures.type: !ruby/object:Overrides::Ansible::PropertyOverride
         # Changing this description because of line length issues.
         description: The type of supported feature.
   InstanceGroup: !ruby/object:Overrides::Ansible::ResourceOverride

--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -201,6 +201,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       timeoutSec: !ruby/object:Overrides::Ansible::PropertyOverride
         aliases:
           - timeout_seconds
+  Image: !ruby/object:Overrides::Ansible::ResourceOverride
+    properties:
+      guestOsFeatures: !ruby/object:Overrides::Ansible::PropertyOverride
+        # Changing this description because of line length issues.
+        description: The type of supported feature.
   InstanceGroup: !ruby/object:Overrides::Ansible::ResourceOverride
     properties:
       instances: !ruby/object:Overrides::Ansible::PropertyOverride

--- a/products/container/ansible_version_added.yaml
+++ b/products/container/ansible_version_added.yaml
@@ -138,15 +138,15 @@
     :tpuIpv4CidrBlock:
       :version_added: '2.9'
     :masterAuthorizedNetworksConfig:
-      :version_added: '2.9'
+      :version_added: '2.10'
       :enabled:
-        :version_added: '2.9'
+        :version_added: '2.10'
       :cidrBlocks:
-        :version_added: '2.9'
+        :version_added: '2.10'
         :displayName:
-          :version_added: '2.9'
+          :version_added: '2.10'
         :cidrBlock:
-          :version_added: '2.9'
+          :version_added: '2.10'
     :location:
       :version_added: '2.8'
     :kubectlPath:


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->
Context: Ansible modules will live in ansible/ansible for just a bit longer. That means we have to keep two copies of each module (the collection, which is the source of truth and the ansible/ansible version). To avoid more ansible clones, I have a second "provider" that creates ansible/ansible compliant versions of the modules + then this release pipeline that now ships from collection -> ansible/ansible (instead of our fork -> ansible/ansible).

Not ideal, I know.

I did some live testing and made some bug fixes.

This fixes the pipeline and fixes some long-standing issues with the modules that prevents them from being merged into ansible/ansible. I ignored those issues because I didn't think we would be dealing with ansible/ansible again.

@ndmckinley - I bumped up a container. I'm 99% sure nothing will be affected, but can you verify?

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```