### PR TITLE
Configure release channel when creating GKE clusters

### DIFF
--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -467,20 +467,6 @@ objects:
               nodes, and controllers, will have statically granted permissions
               beyond those provided by the RBAC configuration or IAM.
       - !ruby/object:Api::Type::NestedObject
-        name: 'releaseChannel'
-        min_version: beta
-        description: |
-          Release channel configuration.
-        properties:
-          - !ruby/object:Api::Type::Enum
-            name: 'channel'
-            description: channel specifies which release channel the cluster is subscribed to.
-            values:
-              - "UNSPECIFIED"
-              - "RAPID"
-              - "REGULAR"
-              - "STABLE"
-      - !ruby/object:Api::Type::NestedObject
         name: 'networkPolicy'
         description: |
           Configuration options for the NetworkPolicy feature.

--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -467,6 +467,20 @@ objects:
               nodes, and controllers, will have statically granted permissions
               beyond those provided by the RBAC configuration or IAM.
       - !ruby/object:Api::Type::NestedObject
+        name: 'releaseChannel'
+        min_version: beta
+        description: |
+          Release channel configuration.
+        properties:
+          - !ruby/object:Api::Type::Enum
+            name: 'channel'
+            description: channel specifies which release channel the cluster is subscribed to.
+            values:
+              - "UNSPECIFIED"
+              - "RAPID"
+              - "REGULAR"
+              - "STABLE"
+      - !ruby/object:Api::Type::NestedObject
         name: 'networkPolicy'
         description: |
           Configuration options for the NetworkPolicy feature.

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -717,6 +717,19 @@ func resourceContainerCluster() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
+			"resource_labels": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"default_max_pods_per_node": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+
 <% unless version == 'ga' -%>
 			"release_channel": {
 				Type:     schema.TypeList,
@@ -738,20 +751,6 @@ func resourceContainerCluster() *schema.Resource {
 				},
 			},
 
-			"resource_labels": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-
-			"default_max_pods_per_node": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
-			},
-
-<% unless version == 'ga' -%>
 			"vertical_pod_autoscaling": {
 				Type:     schema.TypeList,
 				MaxItems: 1,

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -718,7 +718,7 @@ func resourceContainerCluster() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"provider": {
+						"channel": {
 							Type:             schema.TypeString,
 							Default:          "UNSPECIFIED",
 							Optional:         true,
@@ -975,6 +975,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			Enabled:         d.Get("enable_shielded_nodes").(bool),
 			ForceSendFields: []string{"Enabled"},
 		},
+		ReleaseChannel:          expandReleaseChannel(d.Get("release_channel")),
 		EnableTpu:               d.Get("enable_tpu").(bool),
 		BinaryAuthorization: &containerBeta.BinaryAuthorization{
 			Enabled:         d.Get("enable_binary_authorization").(bool),
@@ -1238,6 +1239,9 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	if err := d.Set("authenticator_groups_config", flattenAuthenticatorGroupsConfig(cluster.AuthenticatorGroupsConfig)); err != nil {
 		return err
 	}
+  if err := d.Set("release_channel", flattenReleaseChannel(cluster.ReleaseChannel)); err != nil {
+    return err
+  }
 	d.Set("enable_intranode_visibility", cluster.NetworkConfig.EnableIntraNodeVisibility)
 <% else -%>
 	if err := d.Set("cluster_autoscaling", nil); err != nil {
@@ -2376,6 +2380,17 @@ func expandPrivateClusterConfig(configured interface{}) *containerBeta.PrivateCl
 }
 
 <% unless version == 'ga' -%>
+func expandReleaseChannel(configured interface{}) *containerBeta.ReleaseChannel {
+	l := configured.([]interface{})
+	if len(l) == 0 {
+		return nil
+	}
+	config := l[0].(map[string]interface{})
+	return &containerBeta.ReleaseChannel{
+		Channel: config["channel"].(string),
+	}
+}
+
 func expandDatabaseEncryption(configured interface{}) *containerBeta.DatabaseEncryption {
 	l := configured.([]interface{})
 	if len(l) == 0 {
@@ -2582,6 +2597,21 @@ func flattenPrivateClusterConfig(c *containerBeta.PrivateClusterConfig) []map[st
 }
 
 <% unless version == 'ga' -%>
+func flattenReleaseChannel(c *containerBeta.ReleaseChannel) []map[string]interface{} {
+	result := []map[string]interface{}{}
+	if c != nil {
+		result = append(result, map[string]interface{}{
+			"channel": c.Channel,
+		})
+	} else {
+		// Explicitly set the network policy to the default.
+		result = append(result, map[string]interface{}{
+			"channel": "UNSPECIFIED",
+		})
+	}
+	return result
+}
+
 func flattenVerticalPodAutoscaling(c *containerBeta.VerticalPodAutoscaling) []map[string]interface{} {
 	if c == nil {
 		return nil

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -713,6 +713,7 @@ func resourceContainerCluster() *schema.Resource {
 
 			"release_channel": {
 				Type:     schema.TypeList,
+				ForceNew: true,
 				Optional: true,
 				Computed: true,
 				MaxItems: 1,
@@ -722,7 +723,9 @@ func resourceContainerCluster() *schema.Resource {
 							Type:             schema.TypeString,
 							Default:          "UNSPECIFIED",
 							Optional:         true,
+							ForceNew:         true,
 							ValidateFunc:     validation.StringInSlice([]string{"UNSPECIFIED", "RAPID", "REGULAR", "STABLE"}, false),
+							DiffSuppressFunc: emptyOrDefaultStringSuppress("UNSPECIFIED"),
 						},
 					},
 				},
@@ -2381,7 +2384,7 @@ func expandPrivateClusterConfig(configured interface{}) *containerBeta.PrivateCl
 <% unless version == 'ga' -%>
 func expandReleaseChannel(configured interface{}) *containerBeta.ReleaseChannel {
 	l := configured.([]interface{})
-	if len(l) == 0 {
+	if len(l) == 0 || l[0] == nil {
 		return nil
 	}
 	config := l[0].(map[string]interface{})

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -717,12 +717,6 @@ func resourceContainerCluster() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
-			"resource_labels": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-
 			"default_max_pods_per_node": {
 				Type:     schema.TypeInt,
 				Optional: true,

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -711,6 +711,24 @@ func resourceContainerCluster() *schema.Resource {
 				},
 			},
 
+			"release_channel": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"provider": {
+							Type:             schema.TypeString,
+							Default:          "UNSPECIFIED",
+							Optional:         true,
+							ValidateFunc:     validation.StringInSlice([]string{"UNSPECIFIED", "RAPID", "REGULAR", "STABLE"}, false),
+							DiffSuppressFunc: emptyOrDefaultStringSuppress("UNSPECIFIED"),
+						},
+					},
+				},
+			},
+
 			"resource_labels": {
 				Type:     schema.TypeMap,
 				Optional: true,

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -728,9 +728,11 @@ func resourceContainerCluster() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"channel": {
 							Type:             schema.TypeString,
+							Default:          "UNSPECIFIED",
 							Optional:         true,
 							ForceNew:         true,
 							ValidateFunc:     validation.StringInSlice([]string{"UNSPECIFIED", "RAPID", "REGULAR", "STABLE"}, false),
+							DiffSuppressFunc: emptyOrDefaultStringSuppress("UNSPECIFIED"),
 						},
 					},
 				},
@@ -2609,6 +2611,11 @@ func flattenReleaseChannel(c *containerBeta.ReleaseChannel) []map[string]interfa
 	if c != nil {
 		result = append(result, map[string]interface{}{
 			"channel": c.Channel,
+		})
+	} else {
+		// Explicitly set the release channel to the default.
+		result = append(result, map[string]interface{}{
+			"channel": "UNSPECIFIED",
 		})
 	}
 	return result

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1241,9 +1241,9 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	if err := d.Set("authenticator_groups_config", flattenAuthenticatorGroupsConfig(cluster.AuthenticatorGroupsConfig)); err != nil {
 		return err
 	}
-  if err := d.Set("release_channel", flattenReleaseChannel(cluster.ReleaseChannel)); err != nil {
-    return err
-  }
+	if err := d.Set("release_channel", flattenReleaseChannel(cluster.ReleaseChannel)); err != nil {
+		return err
+	}
 	d.Set("enable_intranode_visibility", cluster.NetworkConfig.EnableIntraNodeVisibility)
 <% else -%>
 	if err := d.Set("cluster_autoscaling", nil); err != nil {

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -711,6 +711,13 @@ func resourceContainerCluster() *schema.Resource {
 				},
 			},
 
+			"resource_labels": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+<% unless version == 'ga' -%>
 			"release_channel": {
 				Type:     schema.TypeList,
 				ForceNew: true,
@@ -721,11 +728,9 @@ func resourceContainerCluster() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"channel": {
 							Type:             schema.TypeString,
-							Default:          "UNSPECIFIED",
 							Optional:         true,
 							ForceNew:         true,
 							ValidateFunc:     validation.StringInSlice([]string{"UNSPECIFIED", "RAPID", "REGULAR", "STABLE"}, false),
-							DiffSuppressFunc: emptyOrDefaultStringSuppress("UNSPECIFIED"),
 						},
 					},
 				},
@@ -2604,11 +2609,6 @@ func flattenReleaseChannel(c *containerBeta.ReleaseChannel) []map[string]interfa
 	if c != nil {
 		result = append(result, map[string]interface{}{
 			"channel": c.Channel,
-		})
-	} else {
-		// Explicitly set the network policy to the default.
-		result = append(result, map[string]interface{}{
-			"channel": "UNSPECIFIED",
 		})
 	}
 	return result

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -723,7 +723,6 @@ func resourceContainerCluster() *schema.Resource {
 							Default:          "UNSPECIFIED",
 							Optional:         true,
 							ValidateFunc:     validation.StringInSlice([]string{"UNSPECIFIED", "RAPID", "REGULAR", "STABLE"}, false),
-							DiffSuppressFunc: emptyOrDefaultStringSuppress("UNSPECIFIED"),
 						},
 					},
 				},

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -361,6 +361,29 @@ func TestAccContainerCluster_withNetworkPolicyEnabled(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
+func TestAccContainerCluster_withReleaseChannel(t *testing.T) {
+	t.Parallel()
+	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withReleaseChannel(clusterName, "STABLE"),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_release_channel",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+<% end -%>
+
 func TestAccContainerCluster_withMasterAuthorizedNetworksConfig(t *testing.T) {
 	t.Parallel()
 
@@ -1969,6 +1992,21 @@ resource "google_container_cluster" "with_network_policy_enabled" {
 	}
 }`, clusterName)
 }
+
+<% unless version == 'ga' -%>
+func testAccContainerCluster_withReleaseChannel(clusterName string, channel string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_release_channel" {
+	name               = "%s"
+	location           = "us-central1-a"
+	initial_node_count = 1
+
+  release_channel {
+    channel = "%s"
+  }
+}`, clusterName, channel)
+}
+<% end -%>
 
 func testAccContainerCluster_removeNetworkPolicy(clusterName string) string {
 	return fmt.Sprintf(`

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -362,7 +362,7 @@ func TestAccContainerCluster_withNetworkPolicyEnabled(t *testing.T) {
 }
 
 <% unless version == 'ga' -%>
-func TestAccContainerCluster_withReleaseChannel(t *testing.T) {
+func TestAccContainerCluster_withReleaseChannelEnabled(t *testing.T) {
 	t.Parallel()
 	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
@@ -371,7 +371,46 @@ func TestAccContainerCluster_withReleaseChannel(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withReleaseChannel(clusterName, "STABLE"),
+				Config: testAccContainerCluster_withReleaseChannelEnabled(clusterName, "STABLE"),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_release_channel",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+			{
+				Config: testAccContainerCluster_withReleaseChannelEnabled(clusterName, "REGULAR"),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_release_channel",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+			{
+				Config: testAccContainerCluster_withReleaseChannelEnabled(clusterName, "RAPID"),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_release_channel",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
+func TestAccContainerCluster_withReleaseChannelDisabled(t *testing.T) {
+	t.Parallel()
+	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+      {
+				Config: testAccContainerCluster_withReleaseChannelDisabled(clusterName),
 			},
 			{
 				ResourceName:        "google_container_cluster.with_release_channel",
@@ -1994,7 +2033,7 @@ resource "google_container_cluster" "with_network_policy_enabled" {
 }
 
 <% unless version == 'ga' -%>
-func testAccContainerCluster_withReleaseChannel(clusterName string, channel string) string {
+func testAccContainerCluster_withReleaseChannelEnabled(clusterName string, channel string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_release_channel" {
 	name               = "%s"
@@ -2005,6 +2044,17 @@ resource "google_container_cluster" "with_release_channel" {
     channel = "%s"
   }
 }`, clusterName, channel)
+}
+
+func testAccContainerCluster_withReleaseChannelDisabled(clusterName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_release_channel" {
+	name               = "%s"
+	location           = "us-central1-a"
+	initial_node_count = 1
+
+  release_channel {}
+}`, clusterName)
 }
 <% end -%>
 

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -397,11 +397,20 @@ func TestAccContainerCluster_withReleaseChannelEnabled(t *testing.T) {
 				ImportState:         true,
 				ImportStateVerify:   true,
 			},
+			{
+				Config: testAccContainerCluster_withReleaseChannelEnabled(clusterName, "UNSPECIFIED"),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_release_channel",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
 		},
 	})
 }
 
-func TestAccContainerCluster_withReleaseChannelDisabled(t *testing.T) {
+func TestAccContainerCluster_withInvalidReleaseChannel(t *testing.T) {
 	t.Parallel()
 	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
@@ -410,13 +419,8 @@ func TestAccContainerCluster_withReleaseChannelDisabled(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withReleaseChannelDisabled(clusterName),
-			},
-			{
-				ResourceName:        "google_container_cluster.with_release_channel",
-				ImportStateIdPrefix: "us-central1-a/",
-				ImportState:         true,
-				ImportStateVerify:   true,
+				Config: testAccContainerCluster_withReleaseChannelEnabled(clusterName, "CANARY"),
+				ExpectError: regexp.MustCompile(`config is invalid: expected release_channel\.0\.channel to be one of \[UNSPECIFIED RAPID REGULAR STABLE\], got CANARY`),
 			},
 		},
 	})
@@ -2044,17 +2048,6 @@ resource "google_container_cluster" "with_release_channel" {
     channel = "%s"
   }
 }`, clusterName, channel)
-}
-
-func testAccContainerCluster_withReleaseChannelDisabled(clusterName string) string {
-	return fmt.Sprintf(`
-resource "google_container_cluster" "without_release_channel" {
-	name               = "%s"
-	location           = "us-central1-a"
-	initial_node_count = 1
-
-  release_channel {}
-}`, clusterName)
 }
 <% end -%>
 

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -410,6 +410,27 @@ func TestAccContainerCluster_withReleaseChannelEnabled(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withReleaseChannelDefault(t *testing.T) {
+	t.Parallel()
+	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withReleaseChannelDefault(clusterName),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_default_release_channel",
+				ImportStateIdPrefix: "us-central1-a/",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_withInvalidReleaseChannel(t *testing.T) {
 	t.Parallel()
 	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
@@ -2048,6 +2069,16 @@ resource "google_container_cluster" "with_release_channel" {
     channel = "%s"
   }
 }`, clusterName, channel)
+}
+
+func testAccContainerCluster_withReleaseChannelDefault(clusterName string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_default_release_channel" {
+	name               = "%s"
+	location           = "us-central1-a"
+	initial_node_count = 1
+	release_channel {}
+}`, clusterName)
 }
 <% end -%>
 

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -409,7 +409,7 @@ func TestAccContainerCluster_withReleaseChannelDisabled(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
-      {
+			{
 				Config: testAccContainerCluster_withReleaseChannelDisabled(clusterName),
 			},
 			{

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2048,7 +2048,7 @@ resource "google_container_cluster" "with_release_channel" {
 
 func testAccContainerCluster_withReleaseChannelDisabled(clusterName string) string {
 	return fmt.Sprintf(`
-resource "google_container_cluster" "with_release_channel" {
+resource "google_container_cluster" "without_release_channel" {
 	name               = "%s"
 	location           = "us-central1-a"
 	initial_node_count = 1

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -156,7 +156,7 @@ in this cluster in CIDR notation (e.g. 10.96.0.0/14). Leave blank to have one
 automatically chosen or specify a /14 block in 10.0.0.0/8. This field will only
 work if your cluster is not VPC-native- when an `ip_allocation_policy` block is
 not defined, or `ip_allocation_policy.use_ip_aliases` is set to false. If your
-cluster is VPC-native, use `ip_allocation_policy.cluster_ipv4_cidr_block`. 
+cluster is VPC-native, use `ip_allocation_policy.cluster_ipv4_cidr_block`.
 
 * `cluster_autoscaling` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html))
 Per-cluster configuration of Node Auto-Provisioning with Cluster Autoscaler to
@@ -288,6 +288,10 @@ to the datasource. A `region` can have a different set of supported versions tha
 
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
+
+* `release_channel` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) Configuration options for the
+    [Release channel](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels)
+    feature, which provide more control over automatic upgrades of your GKE clusters. Structure is documented below.
 
 * `remove_default_node_pool` - (Optional) If `true`, deletes the default node
     pool upon cluster creation. If you're using `google_container_node_pool`
@@ -433,7 +437,7 @@ to have a range chosen with a specific netmask. Set to a CIDR notation (e.g. 10.
 from the RFC-1918 private networks (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to
 pick a specific range to use. This field will only work if your cluster is
 VPC-native- when `ip_allocation_policy.use_ip_aliases` is undefined or set to
-true. If your cluster is not VPC-native, use `cluster_ipv4_cidr`. 
+true. If your cluster is not VPC-native, use `cluster_ipv4_cidr`.
 
 * `node_ipv4_cidr_block` - (Optional) The IP address range of the node IPs in this cluster.
     This should be set only if `create_subnetwork` is true.
@@ -547,7 +551,7 @@ The `node_config` block supports:
     are preemptible. See the [official documentation](https://cloud.google.com/container-engine/docs/preemptible-vm)
     for more information. Defaults to false.
 
-* `sandbox_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) [GKE Sandbox](https://cloud.google.com/kubernetes-engine/docs/how-to/sandbox-pods) configuration. When enabling this feature you must specify `image_type = "COS_CONTAINERD"` and `node_version = "1.12.7-gke.17"` or later to use it. 
+* `sandbox_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) [GKE Sandbox](https://cloud.google.com/kubernetes-engine/docs/how-to/sandbox-pods) configuration. When enabling this feature you must specify `image_type = "COS_CONTAINERD"` and `node_version = "1.12.7-gke.17"` or later to use it.
     Structure is documented below.
 
 * `service_account` - (Optional) The service account to be used by the Node VMs.
@@ -613,6 +617,15 @@ The `sandbox_type` block supports:
     Accepted values are:
 
     * `"gvisor"`: Pods run within a gVisor sandbox.
+
+The `release_channel` block supports:
+
+* `channel` - (Optional) The selected release channel. Defaults to `UNSPECIFIED`.
+    Accepted values are:
+    * UNSPECIFIED: Not set.
+    * RAPID: Weekly upgrade cadence; Early testers and developers who requires new features.
+    * REGULAR: Multiple per month upgrade cadence; Production users who need features not yet offered in the Stable channel.
+    * STABLE: Every few months upgrade cadence; Production users who need stability above all else, and for whom frequent upgrades are too risky.
 
 The `resource_usage_export_config` block supports:
 


### PR DESCRIPTION
Allow the configuration of release channels when creating GKE clusters.

TODOs:
- [x] Implement release channel argument in `google_container_cluster` resource.
- [x] Implement tests
- [x] Update terraform documentation
- [x] Update terraform-provider-google-beta module dependency: https://github.com/terraform-providers/terraform-provider-google-beta/pull/1231

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME
Allow the configuration of release channels when creating GKE clusters.
```