### PR TITLE
Enable cloudbuild to receive Github events.

### DIFF
--- a/products/cloudbuild/api.yaml
+++ b/products/cloudbuild/api.yaml
@@ -147,10 +147,6 @@ objects:
         min_version: beta
         properties:
           - !ruby/object:Api::Type::String
-            name: 'installationId'
-            description: |
-                The installationID that emits the GitHub event.
-          - !ruby/object:Api::Type::String
             name: 'owner'
             description: |
                 Owner of the repository. For example: The owner for

--- a/products/cloudbuild/api.yaml
+++ b/products/cloudbuild/api.yaml
@@ -18,6 +18,14 @@ versions:
   - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://cloudbuild.googleapis.com/v1/
+  - !ruby/object:Api::Product::Version
+    name: beta
+    # This is correct even though it's the same base_url as v1.
+    # Some features in this API are beta, even though they're all
+    # released as v1.  This is not ideal, but it's not something
+    # we can fix - we just want to protect our users from APIs that
+    # might change unexpectedly.
+    base_url: https://cloudbuild.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 apis_required:
@@ -136,6 +144,7 @@ objects:
         name: 'github'
         description: |
             Describes the configuration of a trigger that creates a build whenever a GitHub event is received.
+        min_version: beta
         properties:
           - !ruby/object:Api::Type::String
             name: 'installationId'

--- a/products/cloudbuild/api.yaml
+++ b/products/cloudbuild/api.yaml
@@ -133,6 +133,54 @@ objects:
             description: |
               Explicit commit SHA to build. Exactly one of a branch name, tag, or commit SHA must be provided.
       - !ruby/object:Api::Type::NestedObject
+        name: 'github'
+        description: |
+            Describes the configuration of a trigger that creates a build whenever a GitHub event is received.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'installationId'
+            description: |
+                The installationID that emits the GitHub event.
+          - !ruby/object:Api::Type::String
+            name: 'owner'
+            description: |
+                Owner of the repository. For example: The owner for
+                https://github.com/googlecloudplatform/cloud-builders is "googlecloudplatform".
+          - !ruby/object:Api::Type::String
+            name: 'name'
+            description: |
+                Name of the repository. For example: The name for
+                https://github.com/googlecloudplatform/cloud-builders is "cloud-builders".
+          - !ruby/object:Api::Type::NestedObject
+            name: 'pullRequest'
+            description: |
+                filter to match changes in pull requests.  Specify only one of pullRequest or push.
+            properties:
+              - !ruby/object:Api::Type::String
+                name: 'branch'
+                description: |
+                    Regex of branches to match.
+              - !ruby/object:Api::Type::Enum
+                name: 'commentControl'
+                description: |
+                    Whether to block builds on a "/gcbrun" comment from a repository owner or collaborator.
+                values:
+                  - :COMMENTS_DISABLED
+                  - :COMMENTS_ENABLED
+          - !ruby/object:Api::Type::NestedObject
+            name: 'push'
+            description: |
+                filter to match changes in refs, like branches or tags.  Specify only one of pullRequest or push.
+            properties:
+              - !ruby/object:Api::Type::String
+                name: 'branch'
+                description: |
+                    Regex of branches to match.  Specify only one of branch or tag.
+              - !ruby/object:Api::Type::String
+                name: 'tag'
+                description: |
+                    Regex of tags to match.  Specify only one of branch or tag.
+      - !ruby/object:Api::Type::NestedObject
         name: 'build'
         description: |
           Contents of the build template. Either a filename or build template must be provided.

--- a/templates/terraform/examples/cloudbuild_trigger_github.tf.erb
+++ b/templates/terraform/examples/cloudbuild_trigger_github.tf.erb
@@ -1,0 +1,22 @@
+resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
+  trigger_template {
+    branch_name = "master"
+    repo_name   = "my-repo"
+  }
+
+  substitutions = {
+    _FOO = "bar"
+    _BAZ = "qux"
+  }
+
+  github {
+    installation_id = "abc123"
+    owner = "terraform-providers"
+    name = "terraform-provider-google-beta"
+    push {
+      branch = "feature-.*"
+    }
+  }
+
+  filename = "cloudbuild.yaml"
+}

--- a/templates/terraform/examples/cloudbuild_trigger_github.tf.erb
+++ b/templates/terraform/examples/cloudbuild_trigger_github.tf.erb
@@ -1,16 +1,5 @@
 resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
-  trigger_template {
-    branch_name = "master"
-    repo_name   = "my-repo"
-  }
-
-  substitutions = {
-    _FOO = "bar"
-    _BAZ = "qux"
-  }
-
   github {
-    installation_id = "abc123"
     owner = "terraform-providers"
     name = "terraform-provider-google-beta"
     push {


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Support `github` field in `google_cloudbuild_trigger`.
```