### PR TITLE
fix integration test pipeline

### DIFF
--- a/.ci/acceptance-tests/ansible-integration.sh
+++ b/.ci/acceptance-tests/ansible-integration.sh
@@ -18,11 +18,7 @@ popd
 # Build newest modules
 pushd magic-modules-gcp
 bundle install
-for i in $(find products/ -name 'ansible.yaml' -printf '%h\n');
-do
-  bundle exec compiler -p $i -e ansible -o "build/ansible/"
-done
-popd
+bundle exec compiler -a -e ansible -o build/ansible
 
 # Install collection
 pushd magic-modules-gcp/build/ansible

--- a/.ci/acceptance-tests/ansible-integration.sh
+++ b/.ci/acceptance-tests/ansible-integration.sh
@@ -8,7 +8,14 @@ echo "${ANSIBLE_TEMPLATE}" > /tmp/ansible-template.ini
 set -e
 set -x
 
-# Get the newest version of Ansible from the PR
+# Install ansible from source
+git clone https://github.com/ansible/ansible.git
+pushd ansible
+pip install -r requirements.txt
+source hacking/env-setup
+popd
+
+# Build newest modules
 pushd magic-modules-gcp
 bundle install
 for i in $(find products/ -name 'ansible.yaml' -printf '%h\n');
@@ -17,17 +24,15 @@ do
 done
 popd
 
-# Go to the newly-compiled version of Ansible
+# Install collection
 pushd magic-modules-gcp/build/ansible
+ansible-galaxy build .
+ansible-galaxy install ~/.ansible/collections
+popd
 
 # Setup Cloud configuration template with variables
-cp /tmp/ansible-template.ini test/integration/cloud-config-gcp.ini
-
-# Install dependencies for ansible
-pip install -r requirements.txt
-
-# Setup ansible
-source hacking/env-setup
+pushd ~/.ansible/collections/ansible_collections/google/cloud
+cp /tmp/ansible-template.ini tests/integration/cloud-config-gcp.ini
 
 # Run ansible
 ansible-test integration -v --allow-unsupported --continue-on-error $(find test/integration/targets -name "gcp*" -type d -printf "%P ")


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->
Now that the release pipeline works, it's time to get integration tests working again!

All of our release pipelines only work on HEAD, which is a huge pain. I can temporarily change this, but it involves temporarily changing a lot of config (which then you have to remember to unchange). It's a pain. If this doesn't work after a round (or two tops), I'll go through that effort.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```