### PR TITLE
Add InSpec support for runtime config and variable resources

### DIFF
--- a/products/runtimeconfig/api.yaml
+++ b/products/runtimeconfig/api.yaml
@@ -40,7 +40,39 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'name'
         description: |
-          The name of the RuntimeConfig resource
+          The name of the runtime config.
         required: true
         input: true
-    properties: []
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          The description to associate with the runtime config.
+  - !ruby/object:Api::Resource
+    name: 'Variable'
+    base_url: projects/{{project}}/configs/{{config}}/variables
+    self_link: projects/{{project}}/configs/{{config}}/variables/{{name}}
+    description: |
+      Describes a single variable within a runtime config resource.
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          The name of the variable resource.
+        required: true
+        input: true
+      - !ruby/object:Api::Type::String
+        name: 'config'
+        description: |
+          The name of the runtime config that this variable belongs to.
+        required: true
+        input: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'value'
+        description: |
+          The binary value of the variable. Either this or `text` can be set.
+      - !ruby/object:Api::Type::String
+        name: 'text'
+        description: |
+          The string value of the variable. Either this or `value` can be set.

--- a/products/runtimeconfig/api.yaml
+++ b/products/runtimeconfig/api.yaml
@@ -27,7 +27,7 @@ apis_required:
 objects:
   - !ruby/object:Api::Resource
     name: 'Config'
-    base_url: projects/{{project}}/configs/{{name}}
+    base_url: projects/{{project}}/configs
     self_link: projects/{{project}}/configs/{{name}}
     description: |
       A RuntimeConfig resource is the primary resource in the Cloud RuntimeConfig service.

--- a/products/runtimeconfig/inspec.yaml
+++ b/products/runtimeconfig/inspec.yaml
@@ -1,0 +1,15 @@
+# Copyright 2019 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Inspec::Config
+overrides: !ruby/object:Overrides::ResourceOverrides

--- a/products/runtimeconfig/inspec.yaml
+++ b/products/runtimeconfig/inspec.yaml
@@ -13,3 +13,5 @@
 
 --- !ruby/object:Provider::Inspec::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
+  Variable: !ruby/object:Overrides::Inspec::ResourceOverride
+    base_url: projects/{{project}}/configs/{{config}}/variables?returnValues=true

--- a/products/runtimeconfig/terraform.yaml
+++ b/products/runtimeconfig/terraform.yaml
@@ -25,6 +25,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_name: "fmt.Sprintf(\"my-config%s\", context[\"random_suffix\"])"
         vars:
           config_name: "my-config"
+  Variable: !ruby/object:Overrides::Terraform::ResourceOverride
+    exclude: true
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.

--- a/templates/inspec/examples/google_runtime_config_config/google_runtime_config_config.erb
+++ b/templates/inspec/examples/google_runtime_config_config/google_runtime_config_config.erb
@@ -1,0 +1,10 @@
+<% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
+<% runtimeconfig_config = grab_attributes['runtimeconfig_config'] -%>
+describe google_runtime_config_config(project: <%= gcp_project_id -%>, name: <%= doc_generation ? "'#{runtimeconfig_config['name']}'" : "runtimeconfig_config['name']" -%>) do
+  it { should exist }
+  its('description') { should cmp <%= doc_generation ? "'#{runtimeconfig_config['description']}'" : "runtimeconfig_config['description']" -%> }
+end
+
+describe google_runtime_config_config(project: <%= gcp_project_id -%>, name: 'nonexistent') do
+  it { should_not exist }
+end

--- a/templates/inspec/examples/google_runtime_config_config/google_runtime_config_config_attributes.erb
+++ b/templates/inspec/examples/google_runtime_config_config/google_runtime_config_config_attributes.erb
@@ -1,0 +1,2 @@
+gcp_project_id = attribute(:gcp_project_id, default: '<%= external_attribute('gcp_project_id') -%>', description: 'The GCP project identifier.')
+runtimeconfig_config = attribute('runtimeconfig_config', default: <%= grab_attributes['runtimeconfig_config'] -%>)

--- a/templates/inspec/examples/google_runtime_config_config/google_runtime_config_configs.erb
+++ b/templates/inspec/examples/google_runtime_config_config/google_runtime_config_configs.erb
@@ -1,0 +1,10 @@
+<% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
+<% runtimeconfig_config = grab_attributes['runtimeconfig_config'] -%>
+describe google_runtime_config_config(project: <%= gcp_project_id -%>, name: <%= doc_generation ? "'#{runtimeconfig_config['name']}'" : "runtimeconfig_config['name']" -%>) do
+  it { should exist }
+  its('description') { should cmp <%= doc_generation ? "'#{runtimeconfig_config['description']}'" : "runtimeconfig_config['description']" -%> }
+end
+
+describe google_runtime_config_config(project: <%= gcp_project_id -%>, name: 'nonexistent') do
+  it { should_not exist }
+end

--- a/templates/inspec/examples/google_runtime_config_config/google_runtime_config_configs.erb
+++ b/templates/inspec/examples/google_runtime_config_config/google_runtime_config_configs.erb
@@ -1,10 +1,5 @@
 <% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
 <% runtimeconfig_config = grab_attributes['runtimeconfig_config'] -%>
-describe google_runtime_config_config(project: <%= gcp_project_id -%>, name: <%= doc_generation ? "'#{runtimeconfig_config['name']}'" : "runtimeconfig_config['name']" -%>) do
-  it { should exist }
-  its('description') { should cmp <%= doc_generation ? "'#{runtimeconfig_config['description']}'" : "runtimeconfig_config['description']" -%> }
-end
-
-describe google_runtime_config_config(project: <%= gcp_project_id -%>, name: 'nonexistent') do
-  it { should_not exist }
+describe google_runtime_config_configs(project: <%= gcp_project_id -%>) do
+  its('descriptions') { should include <%= doc_generation ? "'#{runtimeconfig_config['description']}'" : "runtimeconfig_config['description']" -%> }
 end

--- a/templates/inspec/examples/google_runtime_config_variable/google_runtime_config_variable.erb
+++ b/templates/inspec/examples/google_runtime_config_variable/google_runtime_config_variable.erb
@@ -1,0 +1,10 @@
+<% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
+<% runtimeconfig_config = grab_attributes['runtimeconfig_config'] -%>
+describe google_runtime_config_config(project: <%= gcp_project_id -%>, name: <%= doc_generation ? "'#{runtimeconfig_config['name']}'" : "runtimeconfig_config['name']" -%>) do
+  it { should exist }
+  its('description') { should cmp <%= doc_generation ? "'#{runtimeconfig_config['description']}'" : "runtimeconfig_config['description']" -%> }
+end
+
+describe google_runtime_config_config(project: <%= gcp_project_id -%>, name: 'nonexistent') do
+  it { should_not exist }
+end

--- a/templates/inspec/examples/google_runtime_config_variable/google_runtime_config_variable.erb
+++ b/templates/inspec/examples/google_runtime_config_variable/google_runtime_config_variable.erb
@@ -1,10 +1,11 @@
 <% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
 <% runtimeconfig_config = grab_attributes['runtimeconfig_config'] -%>
-describe google_runtime_config_config(project: <%= gcp_project_id -%>, name: <%= doc_generation ? "'#{runtimeconfig_config['name']}'" : "runtimeconfig_config['name']" -%>) do
+<% runtimeconfig_variable = grab_attributes['runtimeconfig_variable'] -%>
+describe google_runtime_config_variable(project: <%= gcp_project_id -%>, config: <%= doc_generation ? "'#{runtimeconfig_config['name']}'" : "runtimeconfig_config['name']" -%>, name: <%= doc_generation ? "'#{runtimeconfig_variable['name']}'" : "runtimeconfig_variable['name']" -%>) do
   it { should exist }
-  its('description') { should cmp <%= doc_generation ? "'#{runtimeconfig_config['description']}'" : "runtimeconfig_config['description']" -%> }
+  its('text') { should cmp <%= doc_generation ? "'#{runtimeconfig_variable['text']}'" : "runtimeconfig_variable['text']" -%> }
 end
 
-describe google_runtime_config_config(project: <%= gcp_project_id -%>, name: 'nonexistent') do
+describe google_runtime_config_variable(project: <%= gcp_project_id -%>, config: <%= doc_generation ? "'#{runtimeconfig_config['name']}'" : "runtimeconfig_config['name']" -%>, name: 'nonexistent') do
   it { should_not exist }
 end

--- a/templates/inspec/examples/google_runtime_config_variable/google_runtime_config_variable_attributes.erb
+++ b/templates/inspec/examples/google_runtime_config_variable/google_runtime_config_variable_attributes.erb
@@ -1,0 +1,2 @@
+gcp_project_id = attribute(:gcp_project_id, default: '<%= external_attribute('gcp_project_id') -%>', description: 'The GCP project identifier.')
+runtimeconfig_config = attribute('runtimeconfig_config', default: <%= grab_attributes['runtimeconfig_config'] -%>)

--- a/templates/inspec/examples/google_runtime_config_variable/google_runtime_config_variable_attributes.erb
+++ b/templates/inspec/examples/google_runtime_config_variable/google_runtime_config_variable_attributes.erb
@@ -1,2 +1,3 @@
 gcp_project_id = attribute(:gcp_project_id, default: '<%= external_attribute('gcp_project_id') -%>', description: 'The GCP project identifier.')
 runtimeconfig_config = attribute('runtimeconfig_config', default: <%= grab_attributes['runtimeconfig_config'] -%>)
+runtimeconfig_variable = attribute('runtimeconfig_variable', default: <%= grab_attributes['runtimeconfig_variable'] -%>)

--- a/templates/inspec/examples/google_runtime_config_variable/google_runtime_config_variables.erb
+++ b/templates/inspec/examples/google_runtime_config_variable/google_runtime_config_variables.erb
@@ -1,0 +1,10 @@
+<% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
+<% runtimeconfig_config = grab_attributes['runtimeconfig_config'] -%>
+describe google_runtime_config_config(project: <%= gcp_project_id -%>, name: <%= doc_generation ? "'#{runtimeconfig_config['name']}'" : "runtimeconfig_config['name']" -%>) do
+  it { should exist }
+  its('description') { should cmp <%= doc_generation ? "'#{runtimeconfig_config['description']}'" : "runtimeconfig_config['description']" -%> }
+end
+
+describe google_runtime_config_config(project: <%= gcp_project_id -%>, name: 'nonexistent') do
+  it { should_not exist }
+end

--- a/templates/inspec/examples/google_runtime_config_variable/google_runtime_config_variables.erb
+++ b/templates/inspec/examples/google_runtime_config_variable/google_runtime_config_variables.erb
@@ -1,10 +1,6 @@
 <% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
 <% runtimeconfig_config = grab_attributes['runtimeconfig_config'] -%>
-describe google_runtime_config_config(project: <%= gcp_project_id -%>, name: <%= doc_generation ? "'#{runtimeconfig_config['name']}'" : "runtimeconfig_config['name']" -%>) do
-  it { should exist }
-  its('description') { should cmp <%= doc_generation ? "'#{runtimeconfig_config['description']}'" : "runtimeconfig_config['description']" -%> }
-end
-
-describe google_runtime_config_config(project: <%= gcp_project_id -%>, name: 'nonexistent') do
-  it { should_not exist }
+<% runtimeconfig_variable = grab_attributes['runtimeconfig_variable'] -%>
+describe google_runtime_config_variables(project: <%= gcp_project_id -%>, config: <%= doc_generation ? "'#{runtimeconfig_config['name']}'" : "runtimeconfig_config['name']" -%>) do
+  its('texts') { should include <%= doc_generation ? "'#{runtimeconfig_variable['text']}'" : "runtimeconfig_variable['text']" -%> }
 end

--- a/templates/inspec/tests/integration/build/gcp-mm.tf
+++ b/templates/inspec/tests/integration/build/gcp-mm.tf
@@ -169,6 +169,14 @@ variable "folder_sink" {
   type = "map"
 }
 
+variable "runtimeconfig_config" {
+  type = "map"
+}
+
+variable "runtimeconfig_variable" {
+  type = "map"
+}
+
 resource "google_compute_ssl_policy" "custom-ssl-policy" {
   name            = "${var.ssl_policy["name"]}"
   min_tls_version = "${var.ssl_policy["min_tls_version"]}"
@@ -712,4 +720,17 @@ resource "google_logging_folder_sink" "folder-sink" {
   destination = "storage.googleapis.com/${google_storage_bucket.generic-storage-bucket.name}"
 
   filter      = var.folder_sink.filter
+}
+
+resource "google_runtimeconfig_config" "inspec-runtime-config" {
+  project = var.gcp_project_id
+  name = var.runtimeconfig_config["name"]
+  description = var.runtimeconfig_config["description"]
+}
+
+resource "google_runtimeconfig_variable" "inspec-runtime-variable" {
+  project = var.gcp_project_id
+  parent = "${google_runtimeconfig_config.my-runtime-config.name}"
+  name = var.runtimeconfig_variable["name"]
+  text = var.runtimeconfig_variable["text"]
 }

--- a/templates/inspec/tests/integration/build/gcp-mm.tf
+++ b/templates/inspec/tests/integration/build/gcp-mm.tf
@@ -730,7 +730,7 @@ resource "google_runtimeconfig_config" "inspec-runtime-config" {
 
 resource "google_runtimeconfig_variable" "inspec-runtime-variable" {
   project = var.gcp_project_id
-  parent = "${google_runtimeconfig_config.my-runtime-config.name}"
+  parent = "${google_runtimeconfig_config.inspec-runtime-config.name}"
   name = var.runtimeconfig_variable["name"]
   text = var.runtimeconfig_variable["text"]
 }

--- a/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -280,3 +280,11 @@ filestore_instance:
 folder_sink:
   name: inspec-gcp-folder-sink
   filter: resource.type = gce_instance AND severity >= ERROR
+
+runtimeconfig_config:
+  name: inspec-gcp-runtime-config
+  description: My runtime configurations
+
+runtimeconfig_variable:
+  name: prod-variables/hostname
+  text: example.com


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```