### PR TITLE
Add support for renamed services in google_project_service* resources.

### DIFF
--- a/third_party/terraform/resources/resource_google_project_services.go
+++ b/third_party/terraform/resources/resource_google_project_services.go
@@ -100,8 +100,10 @@ func resourceGoogleProjectServicesRead(d *schema.ResourceData, meta interface{})
 		_, ook := sset[ov]
 		_, nok := sset[nv]
 
-		// preserve any values set in prior state. If none were set, only store
-		// the old value.
+		// preserve the values set in prior state if they're identical. If none
+		// were set, we  delete the new value if it exists. By doing that that
+		// we only store the old value if the service is enabled, and no value
+		// if it isn't.
 		if ook && nok {
 			continue
 		} else if ook {

--- a/third_party/terraform/resources/resource_google_project_services.go
+++ b/third_party/terraform/resources/resource_google_project_services.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/serviceusage/v1"
 	"log"
+	"strings"
 	"time"
 )
 
@@ -90,10 +91,33 @@ func resourceGoogleProjectServicesRead(d *schema.ResourceData, meta interface{})
 	if err != nil {
 		return err
 	}
+
+	// use old services to set the correct renamed service names in state
+	s, _ := expandServiceUsageProjectServicesServices(d.Get("services"), d, config)
+	log.Printf("[DEBUG] Saw services in state on Read: %s ", s)
+	sset := golangSetFromStringSlice(s)
+	for ov, nv := range renamedServices {
+		_, ook := sset[ov]
+		_, nok := sset[nv]
+
+		// preserve any values set in prior state. If none were set, only store
+		// the old value.
+		if ook && nok {
+			continue
+		} else if ook {
+			delete(enabledSet, nv)
+		} else if nok {
+			delete(enabledSet, ov)
+		} else {
+			delete(enabledSet, nv)
+		}
+	}
+
 	services := stringSliceFromGolangSet(enabledSet)
 
 	d.Set("project", d.Id())
 	d.Set("services", flattenServiceUsageProjectServicesServices(services, d))
+
 	return nil
 }
 
@@ -132,25 +156,59 @@ func setServiceUsageProjectEnabledServices(services []string, project string, d 
 		return err
 	}
 
-	toEnable := make([]string, 0, len(services))
+	toEnable := map[string]struct{}{}
 	for _, srv := range services {
 		// We don't have to enable a service if it's already enabled.
 		if _, ok := currentlyEnabled[srv]; !ok {
-			toEnable = append(toEnable, srv)
+			toEnable[srv] = struct{}{}
 		}
 	}
 
-	if err := BatchRequestEnableServices(toEnable, project, d, config); err != nil {
-		return fmt.Errorf("unable to enable Project Services %s (%+v): %s", project, services, err)
+	if len(toEnable) > 0 {
+		log.Printf("[DEBUG] Enabling services: %s", toEnable)
+		if err := BatchRequestEnableServices(toEnable, project, d, config); err != nil {
+			return fmt.Errorf("unable to enable Project Services %s (%+v): %s", project, services, err)
+		}
+	} else {
+		log.Printf("[DEBUG] No services to enable.")
 	}
 
 	srvSet := golangSetFromStringSlice(services)
+
+	srvSetWithRenames := map[string]struct{}{}
+
+	// we'll always list both names for renamed services, so allow both forms if
+	// we see both.
+	for k := range srvSet {
+		srvSetWithRenames[k] = struct{}{}
+		if v, ok := renamedServicesByOldAndNewServiceNames[k]; ok {
+			srvSetWithRenames[v] = struct{}{}
+		}
+	}
+
 	for srv := range currentlyEnabled {
 		// Disable any services that are currently enabled for project but are not
 		// in our list of acceptable services.
-		if _, ok := srvSet[srv]; !ok {
+		if _, ok := srvSetWithRenames[srv]; !ok {
+			// skip deleting services by their new names and prefer the old name.
+			if _, ok := renamedServicesByNewServiceNames[srv]; ok {
+				continue
+			}
+
 			log.Printf("[DEBUG] Disabling project %s service %s", project, srv)
-			if err := disableServiceUsageProjectService(srv, project, d, config, true); err != nil {
+			err := disableServiceUsageProjectService(srv, project, d, config, true)
+			if err != nil {
+				log.Printf("[DEBUG] Saw error %s deleting service %s", err, srv)
+
+				// if we got the right error and the service is renamed, delete by the new name
+				if n, ok := renamedServices[srv]; ok && strings.Contains(err.Error(), "not found or permission denied.") {
+					log.Printf("[DEBUG] Failed to delete service %s, it doesn't exist. Trying %s", srv, n)
+					err = disableServiceUsageProjectService(n, project, d, config, true)
+					if err == nil {
+						return nil
+					}
+				}
+
 				return fmt.Errorf("unable to disable unwanted Project Service %s %s): %s", project, srv, err)
 			}
 		}
@@ -222,6 +280,9 @@ func expandServiceUsageProjectServicesServices(v interface{}, d TerraformResourc
 }
 
 // Retrieve a project's services from the API
+// if a service has been renamed, this function will list both the old and new
+// forms of the service. LIST responses are expected to return only the old or
+// new form, but we'll always return both.
 func listCurrentlyEnabledServices(project string, config *Config, timeout time.Duration) (map[string]struct{}, error) {
 	// Verify project for services still exists
 	p, err := config.clientResourceManager.Projects.Get(project).Do()
@@ -246,10 +307,19 @@ func listCurrentlyEnabledServices(project string, config *Config, timeout time.D
 			Filter("state:ENABLED").
 			Pages(ctx, func(r *serviceusage.ListServicesResponse) error {
 				for _, v := range r.Services {
-					// services are returned as "projects/PROJECT/services/NAME"
+					// services are returned as "projects/{{project}}/services/{{name}}"
 					name := GetResourceNameFromSelfLink(v.Name)
+
+					// if name not in ignoredProjectServicesSet
 					if _, ok := ignoredProjectServicesSet[name]; !ok {
 						apiServices[name] = struct{}{}
+
+						// if a service has been renamed, set both. We'll deal
+						// with setting the right values later.
+						if v, ok := renamedServicesByOldAndNewServiceNames[name]; ok {
+							log.Printf("[DEBUG] Adding service alias for %s to enabled services: %s", name, v)
+							apiServices[v] = struct{}{}
+						}
 					}
 				}
 				return nil

--- a/third_party/terraform/tests/resource_google_project_service_test.go
+++ b/third_party/terraform/tests/resource_google_project_service_test.go
@@ -132,6 +132,28 @@ func TestAccProjectService_handleNotFound(t *testing.T) {
 	})
 }
 
+func TestAccProjectService_renamedService(t *testing.T) {
+	t.Parallel()
+
+	org := getTestOrgFromEnv(t)
+	pid := "terraform-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProjectService_single("bigquery-json.googleapis.com", pid, pname, org),
+			},
+			{
+				ResourceName:            "google_project_service.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"disable_on_destroy", "disable_dependent_services"},
+			},
+		},
+	})
+}
+
 func testAccCheckProjectService(services []string, pid string, expectEnabled bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
@@ -269,4 +291,22 @@ resource "google_project_service" "test" {
   service = "%s"
 }
 `, pid, service)
+}
+
+func testAccProjectService_single(service string, pid, name, org string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+  project_id = "%s"
+  name       = "%s"
+  org_id     = "%s"
+}
+
+resource "google_project_service" "test" {
+  project = "${google_project.acceptance.project_id}"
+  service = "%s"
+
+  disable_dependent_services = true
+}
+
+`, pid, name, org, service)
 }

--- a/third_party/terraform/tests/resource_google_project_services_test.go
+++ b/third_party/terraform/tests/resource_google_project_services_test.go
@@ -179,9 +179,7 @@ func TestAccProjectServices_ignoreUnenablableServices(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProjectAssociateServicesBasic_withBilling(services, pid, pname, org, billingId),
-				Check: resource.ComposeTestCheckFunc(
-					testProjectServicesMatch(services, pid),
-				),
+				Check:  resource.ComposeTestCheckFunc(testProjectServicesMatch(services, pid)),
 			},
 		},
 	})
@@ -269,6 +267,105 @@ func TestAccProjectServices_pagination(t *testing.T) {
 	})
 }
 
+func TestAccProjectServices_renamedServices(t *testing.T) {
+	t.Parallel()
+
+	org := getTestOrgFromEnv(t)
+	pid := "terraform-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// create new
+				Config: testAccProjectAssociateServicesBasic([]string{
+					"bigquery.googleapis.com",
+					"bigquerystorage.googleapis.com",
+					"iam.googleapis.com",
+					"iamcredentials.googleapis.com",
+					"oslogin.googleapis.com",
+				}, pid, pname, org),
+			},
+			{
+				// transition to old
+				Config: testAccProjectAssociateServicesBasic([]string{
+					"bigquery-json.googleapis.com",
+					"bigquerystorage.googleapis.com",
+					"iam.googleapis.com",
+					"iamcredentials.googleapis.com",
+					"oslogin.googleapis.com",
+				}, pid, pname, org),
+			},
+			{
+				// transition to new
+				Config: testAccProjectAssociateServicesBasic([]string{
+					"bigquery.googleapis.com",
+					"bigquerystorage.googleapis.com",
+					"iam.googleapis.com",
+					"iamcredentials.googleapis.com",
+					"oslogin.googleapis.com",
+				}, pid, pname, org),
+			},
+			{
+				// remove new
+				Config: testAccProjectAssociateServicesBasic([]string{
+					"iam.googleapis.com",
+					"iamcredentials.googleapis.com",
+					"oslogin.googleapis.com",
+				}, pid, pname, org),
+			},
+			{
+				// create both
+				Config: testAccProjectAssociateServicesBasic([]string{
+					"bigquery.googleapis.com",
+					"bigquery-json.googleapis.com",
+					"bigquerystorage.googleapis.com",
+					"iam.googleapis.com",
+					"iamcredentials.googleapis.com",
+					"oslogin.googleapis.com",
+				}, pid, pname, org),
+			},
+			{
+				// remove new
+				Config: testAccProjectAssociateServicesBasic([]string{
+					"bigquery-json.googleapis.com",
+					"bigquerystorage.googleapis.com",
+					"iam.googleapis.com",
+					"iamcredentials.googleapis.com",
+					"oslogin.googleapis.com",
+				}, pid, pname, org),
+			},
+			{
+				// import imports old
+				ResourceName:            "google_project_services.acceptance",
+				ImportState:             true,
+				ImportStateId:           pid,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"disable_on_destroy"},
+			},
+			{
+				// transition to both
+				Config: testAccProjectAssociateServicesBasic([]string{
+					"bigquery.googleapis.com",
+					"bigquery-json.googleapis.com",
+					"bigquerystorage.googleapis.com",
+					"iam.googleapis.com",
+					"iamcredentials.googleapis.com",
+					"oslogin.googleapis.com",
+				}, pid, pname, org),
+			},
+			{
+				// remove both
+				Config: testAccProjectAssociateServicesBasic([]string{
+					"iam.googleapis.com",
+					"iamcredentials.googleapis.com",
+					"oslogin.googleapis.com",
+				}, pid, pname, org),
+			},
+		},
+	})
+}
+
 func testAccProjectAssociateServicesBasic(services []string, pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
@@ -308,6 +405,17 @@ func testProjectServicesMatch(services []string, pid string) resource.TestCheckF
 		if err != nil {
 			return fmt.Errorf("Error listing services for project %q: %v", pid, err)
 		}
+
+		servicesSet := golangSetFromStringSlice(services)
+		// add renamed service aliases because listCurrentlyEnabledServices will
+		// have both
+		for k := range servicesSet {
+			if v, ok := renamedServicesByOldAndNewServiceNames[k]; ok {
+				servicesSet[v] = struct{}{}
+			}
+		}
+
+		services = stringSliceFromGolangSet(servicesSet)
 
 		apiServices := stringSliceFromGolangSet(currentlyEnabled)
 		sort.Strings(services)

--- a/third_party/terraform/utils/utils.go.erb
+++ b/third_party/terraform/utils/utils.go.erb
@@ -312,6 +312,28 @@ func stringSliceFromGolangSet(sset map[string]struct{}) []string {
 	return ls
 }
 
+func reverseStringMap(m map[string]string) map[string]string {
+	o := map[string]string{}
+	for k, v := range m {
+		o[v] = k
+	}
+	return o
+}
+
+func mergeStringMaps(a, b map[string]string) map[string]string {
+	merged := make(map[string]string)
+
+	for k, v := range a {
+		merged[k] = v
+	}
+
+	for k, v := range b {
+		merged[k] = v
+	}
+
+	return merged
+}
+
 func mergeSchemas(a, b map[string]*schema.Schema) map[string]*schema.Schema {
 	merged := make(map[string]*schema.Schema)
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4590

I've handled every case I could think up, and captured most of the ones I can in a test. Locally, I've tested this with the fake old API `compute2.googleapis.com` and it's worked as expected.

If you can think of an out-there case, please try it 🙂 

**Release Note Template for Downstream PRs (will be copied)**

```release-enhancement
note: `google_project_services` users of provider versions prior to `2.17.0` should update, as past versions of the provider will not handle an upcoming rename of `bigquery-json.googleapis.com` to `bigquery.googleapis.com` well. See https://github.com/terraform-providers/terraform-provider-google/issues/4590 for details.
```

```release-enhancement
projectservice: added mitigations for bigquery-json to bigquery rename in project service resources.
```