### PR TITLE
Update service renames comment

### DIFF
--- a/third_party/terraform/resources/resource_google_project_service.go
+++ b/third_party/terraform/resources/resource_google_project_service.go
@@ -29,7 +29,7 @@ var ignoredProjectServicesSet = golangSetFromStringSlice(ignoredProjectServices)
 // We handle service renames in the provider by pretending that we've read both
 // the old and new service names from the API if we see either, and only setting
 // the one(s) that existed in prior state in config (if any). If neither exists,
-// we'll set the new service name in state.
+// we'll set the old service name in state.
 // Additionally, in case of service rename rollbacks or unexpected early
 // removals of services, if we fail to create or delete a service that's been
 // renamed we'll retry using an alternate name.


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

Oops, I'd changed my mind midway through #2424 and missed this.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```