### PR TITLE
Removing deprecated fields

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2322,16 +2322,6 @@ objects:
           A BackendService to receive the matched traffic. This is used only
           for INTERNAL load balancing.
       - !ruby/object:Api::Type::Enum
-        name: 'ipVersion'
-        deprecation_message: >-
-          ipVersion is not used for regional forwarding rules. Please remove
-          this field if you are using it.
-        description: |
-          ipVersion is not a valid field for regional forwarding rules.
-        values:
-          - :IPV4
-          - :IPV6
-      - !ruby/object:Api::Type::Enum
         name: 'loadBalancingScheme'
         description: |
           This signifies what the ForwardingRule will be used for and can only
@@ -5480,25 +5470,6 @@ objects:
         name: 'id'
         description: 'The unique identifier for the resource.'
         output: true
-      - !ruby/object:Api::Type::String
-        name: 'ipv4_range'
-        # We override this in api.yaml so that the name is more aesthetic
-        api_name: 'IPv4Range'
-        deprecation_message: >-
-          Legacy Networks are deprecated and you will no longer be able to
-          create them using this field from Feb 1, 2020 onwards.
-        input: true
-        conflicts:
-          - autoCreateSubnetworks
-        description: |
-          If this field is specified, a deprecated legacy network is created.
-          You will no longer be able to create a legacy network on Feb 1, 2020.
-          See the [legacy network docs](https://cloud.google.com/vpc/docs/legacy)
-          for more details.
-
-          The range of internal addresses that are legal on this legacy network.
-          This range is a CIDR specification, for example: `192.168.0.0/16`.
-          The resource must be recreated to modify this field.
       - !ruby/object:Api::Type::String
         name: 'name'
         description: |

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -507,6 +507,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           network_name: "website-net"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       post_create: templates/terraform/post_create/labels.erb
+      extra_schema_entry: templates/terraform/extra_schema_entry/forwarding_rule.erb
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
@@ -905,9 +906,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_value: True
         # autoCreateSubnetworks defaults to true, so we need to disable it explicitly
         conflicts: []
-      ipv4_range: !ruby/object:Overrides::Terraform::PropertyOverride
-        # autoCreateSubnetworks defaults to true, so we need to disable it explicitly
-        conflicts: []
       routingConfig: !ruby/object:Overrides::Terraform::PropertyOverride
         flatten_object: true
       routingConfig.routingMode: !ruby/object:Overrides::Terraform::PropertyOverride
@@ -921,6 +919,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       post_create: templates/terraform/post_create/compute_network_delete_default_route.erb
+      extra_schema_entry: templates/terraform/extra_schema_entry/network.erb
       encoder: templates/terraform/encoders/network.erb
   NetworkEndpoint: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: "{{project}}/{{zone}}/{{network_endpoint_group}}/{{instance}}/{{ip_address}}/{{port}}"

--- a/products/monitoring/terraform.yaml
+++ b/products/monitoring/terraform.yaml
@@ -101,7 +101,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           group_display_name: "uptime-check-group"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/self_link_as_name.erb
-      decoder: 'templates/terraform/decoders/monitoring_uptime_check_internal.go.erb'
       extra_schema_entry: 'templates/terraform/extra_schema_entry/monitoring_uptime_check_config_internal.go.erb'
       post_create: templates/terraform/post_create/set_computed_name.erb
     properties:

--- a/templates/terraform/decoders/monitoring_uptime_check_internal.go.erb
+++ b/templates/terraform/decoders/monitoring_uptime_check_internal.go.erb
@@ -1,2 +1,0 @@
-d.Set("internal_checkers", nil)
-return res, nil

--- a/templates/terraform/extra_schema_entry/forwarding_rule.erb
+++ b/templates/terraform/extra_schema_entry/forwarding_rule.erb
@@ -1,5 +1,5 @@
 <%# The license inside this block applies to this file.
-	# Copyright 2018 Google Inc.
+	# Copyright 2019 Google Inc.
 	# Licensed under the Apache License, Version 2.0 (the "License");
 	# you may not use this file except in compliance with the License.
 	# You may obtain a copy of the License at
@@ -12,11 +12,10 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-"labels": {
-	Type:      schema.TypeList,
-	Optional:  true,
-	Elem:      &schema.Schema{
-		Type: schema.TypeString,
-	},
-	Removed:   "labels is removed as it was never used. See user_labels for the correct field",
+"ip_version": {
+	Type:         schema.TypeString,
+	Optional:     true,
+	Removed:      "ipVersion is not used for regional forwarding rules. Please remove this field if you are using it.",
+	ForceNew:     true,
+	ValidateFunc: validation.StringInSlice([]string{"IPV4", "IPV6", ""}, false),
 },

--- a/templates/terraform/extra_schema_entry/forwarding_rule.erb
+++ b/templates/terraform/extra_schema_entry/forwarding_rule.erb
@@ -16,6 +16,4 @@
 	Type:         schema.TypeString,
 	Optional:     true,
 	Removed:      "ipVersion is not used for regional forwarding rules. Please remove this field if you are using it.",
-	ForceNew:     true,
-	ValidateFunc: validation.StringInSlice([]string{"IPV4", "IPV6", ""}, false),
 },

--- a/templates/terraform/extra_schema_entry/monitoring_uptime_check_config_internal.go.erb
+++ b/templates/terraform/extra_schema_entry/monitoring_uptime_check_config_internal.go.erb
@@ -16,39 +16,39 @@
   Type:       schema.TypeBool,
   Optional:   true,
   Computed:   true,
-  Deprecated: "This field never worked, and will be removed in 3.0.0.",
+  Removed:    "This field never worked, and will be removed in 3.0.0.",
 },
 "internal_checkers": {
   Type:     schema.TypeList,
   Optional: true,
   Computed: true,
-  Deprecated: "This field never worked, and will be removed in 3.0.0.",
+  Removed:  "This field never worked, and will be removed in 3.0.0.",
   Elem: &schema.Resource{
     Schema: map[string]*schema.Schema{
       "display_name": {
         Type:     schema.TypeString,
         Optional: true,
-        Deprecated: "This field never worked, and will be removed in 3.0.0.",
+        Removed:  "This field never worked, and will be removed in 3.0.0.",
       },
       "gcp_zone": {
         Type:     schema.TypeString,
         Optional: true,
-        Deprecated: "This field never worked, and will be removed in 3.0.0.",
+        Removed:  "This field never worked, and will be removed in 3.0.0.",
       },
       "name": {
         Type:     schema.TypeString,
         Optional: true,
-        Deprecated: "This field never worked, and will be removed in 3.0.0.",
+        Removed:  "This field never worked, and will be removed in 3.0.0.",
       },
       "network": {
         Type:     schema.TypeString,
         Optional: true,
-        Deprecated: "This field never worked, and will be removed in 3.0.0.",
+        Removed:  "This field never worked, and will be removed in 3.0.0.",
       },
       "peer_project_id": {
         Type:     schema.TypeString,
         Optional: true,
-        Deprecated: "This field never worked, and will be removed in 3.0.0.",
+        Removed:  "This field never worked, and will be removed in 3.0.0.",
       },
     },
   },

--- a/templates/terraform/extra_schema_entry/monitoring_uptime_check_config_internal.go.erb
+++ b/templates/terraform/extra_schema_entry/monitoring_uptime_check_config_internal.go.erb
@@ -15,13 +15,11 @@
 "is_internal": {
   Type:       schema.TypeBool,
   Optional:   true,
-  Computed:   true,
   Removed:    "This field never worked, and will be removed in 3.0.0.",
 },
 "internal_checkers": {
   Type:     schema.TypeList,
   Optional: true,
-  Computed: true,
   Removed:  "This field never worked, and will be removed in 3.0.0.",
   Elem: &schema.Resource{
     Schema: map[string]*schema.Schema{

--- a/templates/terraform/extra_schema_entry/network.erb
+++ b/templates/terraform/extra_schema_entry/network.erb
@@ -16,5 +16,4 @@
 	Type:       schema.TypeString,
 	Optional:   true,
 	Removed:    "Legacy Networks are deprecated and you will no longer be able to create them using this field from Feb 1, 2020 onwards.",
-	ForceNew:   true,
 },

--- a/templates/terraform/extra_schema_entry/network.erb
+++ b/templates/terraform/extra_schema_entry/network.erb
@@ -1,5 +1,5 @@
 <%# The license inside this block applies to this file.
-	# Copyright 2018 Google Inc.
+	# Copyright 2019 Google Inc.
 	# Licensed under the Apache License, Version 2.0 (the "License");
 	# you may not use this file except in compliance with the License.
 	# You may obtain a copy of the License at
@@ -12,11 +12,9 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-"labels": {
-	Type:      schema.TypeList,
-	Optional:  true,
-	Elem:      &schema.Schema{
-		Type: schema.TypeString,
-	},
-	Removed:   "labels is removed as it was never used. See user_labels for the correct field",
+"ipv4_range": {
+	Type:       schema.TypeString,
+	Optional:   true,
+	Removed:    "Legacy Networks are deprecated and you will no longer be able to create them using this field from Feb 1, 2020 onwards.",
+	ForceNew:   true,
 },

--- a/third_party/terraform/data_sources/data_source_google_container_engine_versions.go.erb
+++ b/third_party/terraform/data_sources/data_source_google_container_engine_versions.go.erb
@@ -28,13 +28,13 @@ func dataSourceGoogleContainerEngineVersions() *schema.Resource {
 			"zone": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				Deprecated:    "Use location instead",
+				Removed:       "Use location instead",
 				ConflictsWith: []string{"region", "location"},
 			},
 			"region": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				Deprecated:    "Use location instead",
+				Removed:       "Use location instead",
 				ConflictsWith: []string{"zone", "location"},
 			},
 			"default_cluster_version": {
@@ -76,7 +76,7 @@ func dataSourceGoogleContainerEngineVersionsRead(d *schema.ResourceData, meta in
 		return err
 	}
 	if len(location) == 0 {
-		return fmt.Errorf("Cannot determine location: set location, zone, or region in this data source or at provider-level")
+		return fmt.Errorf("Cannot determine location: set location in this data source or at provider-level")
 	}
 
 	location = fmt.Sprintf("projects/%s/locations/%s", project, location)

--- a/third_party/terraform/data_sources/data_source_google_container_engine_versions.go.erb
+++ b/third_party/terraform/data_sources/data_source_google_container_engine_versions.go.erb
@@ -23,19 +23,16 @@ func dataSourceGoogleContainerEngineVersions() *schema.Resource {
 			"location": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				ConflictsWith: []string{"zone", "region"},
 			},
 			"zone": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Removed:       "Use location instead",
-				ConflictsWith: []string{"region", "location"},
 			},
 			"region": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Removed:       "Use location instead",
-				ConflictsWith: []string{"zone", "location"},
 			},
 			"default_cluster_version": {
 				Type:     schema.TypeString,

--- a/third_party/terraform/resources/resource_compute_network_peering.go.erb
+++ b/third_party/terraform/resources/resource_compute_network_peering.go.erb
@@ -42,11 +42,11 @@ func resourceComputeNetworkPeering() *schema.Resource {
 				DiffSuppressFunc: compareSelfLinkRelativePaths,
 			},
 			// The API only accepts true as a value for exchange_subnet_routes or auto_create_routes (of which only one can be set in a valid request).
-			// Also, you can't set auto_create_routes if you use the networkPeering object. auto_create_routes is also deprecated
+			// Also, you can't set auto_create_routes if you use the networkPeering object. auto_create_routes is also removed
 			"auto_create_routes": {
 				Type:             schema.TypeBool,
 				Optional:         true,
-				Deprecated:       "auto_create_routes has been deprecated because it's redundant and not user-configurable. It can safely be removed from your config",
+				Removed:          "auto_create_routes has been removed because it's redundant and not user-configurable. It can safely be removed from your config",
 				ForceNew:         true,
 				Default:          true,
 			},

--- a/third_party/terraform/resources/resource_compute_network_peering.go.erb
+++ b/third_party/terraform/resources/resource_compute_network_peering.go.erb
@@ -48,7 +48,6 @@ func resourceComputeNetworkPeering() *schema.Resource {
 				Optional:         true,
 				Removed:          "auto_create_routes has been removed because it's redundant and not user-configurable. It can safely be removed from your config",
 				ForceNew:         true,
-				Default:          true,
 			},
 			"state": {
 				Type:             schema.TypeString,

--- a/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
+++ b/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
@@ -174,7 +174,6 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 				Type:         schema.TypeString,
 				Removed:      "This field is removed.",
 				Optional:     true,
-				Computed:     true,
 			},
 <% end -%>
 

--- a/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
+++ b/third_party/terraform/resources/resource_compute_region_instance_group_manager.go.erb
@@ -172,7 +172,7 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 <% if version.nil? || version == 'ga' -%>
 			"update_strategy": &schema.Schema{
 				Type:         schema.TypeString,
-				Deprecated:   "This field is removed.",
+				Removed:      "This field is removed.",
 				Optional:     true,
 				Computed:     true,
 			},

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -115,7 +115,7 @@ func resourceContainerCluster() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ForceNew:      true,
-				Deprecated:    "Use location instead",
+				Removed:       "Use location instead",
 				ConflictsWith: []string{"zone", "location"},
 			},
 
@@ -124,7 +124,7 @@ func resourceContainerCluster() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ForceNew:      true,
-				Deprecated:    "Use location instead",
+				Removed:       "Use location instead",
 				ConflictsWith: []string{"region", "location"},
 			},
 
@@ -138,8 +138,7 @@ func resourceContainerCluster() *schema.Resource {
 			"additional_zones": {
 				Type:       schema.TypeSet,
 				Optional:   true,
-				Computed:   true,
-				Deprecated: "Use node_locations instead",
+				Removed:    "Use node_locations instead",
 				Elem:       &schema.Schema{Type: schema.TypeString},
 			},
 
@@ -917,14 +916,6 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	// When parsing a subnetwork by name, we expect region or zone to be set.
-	// Users may have set location to either value, so set that value.
-	if isZone(location) {
-		d.Set("zone", location)
-	} else {
-		d.Set("region", location)
-	}
-
 	clusterName := d.Get("name").(string)
 
 	cluster := &containerBeta.Cluster{
@@ -981,20 +972,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	if v, ok := d.GetOk("node_locations"); ok {
 		locationsSet := v.(*schema.Set)
 		if locationsSet.Contains(location) {
-			return fmt.Errorf("when using a multi-zonal cluster, additional_zones should not contain the original 'zone'")
-		}
-
-		// GKE requires a full list of node locations
-		// but when using a multi-zonal cluster our schema only asks for the
-		// additional zones, so append the cluster location if it's a zone
-		if isZone(location) {
-			locationsSet.Add(location)
-		}
-		cluster.Locations = convertStringSet(locationsSet)
-	} else if v, ok := d.GetOk("additional_zones"); ok {
-		locationsSet := v.(*schema.Set)
-		if locationsSet.Contains(location) {
-			return fmt.Errorf("when using a multi-zonal cluster, additional_zones should not contain the original 'zone'")
+			return fmt.Errorf("when using a multi-zonal cluster, node_locations should not contain the original 'zone'")
 		}
 
 		// GKE requires a full list of node locations
@@ -1168,16 +1146,10 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	d.Set("location", cluster.Location)
-	if isZone(cluster.Location) {
-		d.Set("zone", cluster.Location)
-	} else {
-		d.Set("region", cluster.Location)
-	}
 
 	locations := schema.NewSet(schema.HashString, convertStringArrToInterface(cluster.Locations))
 	locations.Remove(cluster.Zone) // Remove the original zone since we only store additional zones
 	d.Set("node_locations", locations)
-	d.Set("additional_zones", locations)
 
 	d.Set("endpoint", cluster.Endpoint)
 	if err := d.Set("maintenance_policy", flattenMaintenancePolicy(cluster.MaintenancePolicy)); err != nil {
@@ -1463,57 +1435,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		d.SetPartial("maintenance_policy")
 	}
 
-	// we can only ever see a change to one of additional_zones and node_locations; because
-	// thy conflict with each other and are each computed, Terraform will suppress the diff
-	// on one of them even when migrating from one to the other.
-	if d.HasChange("additional_zones") {
-		azSetOldI, azSetNewI := d.GetChange("additional_zones")
-		azSetNew := azSetNewI.(*schema.Set)
-		azSetOld := azSetOldI.(*schema.Set)
-		if azSetNew.Contains(location) {
-			return fmt.Errorf("additional_zones should not contain the original 'zone'")
-		}
-		// Since we can't add & remove zones in the same request, first add all the
-		// zones, then remove the ones we aren't using anymore.
-		azSet := azSetOld.Union(azSetNew)
-
-		if isZone(location) {
-			azSet.Add(location)
-		}
-
-		req := &containerBeta.UpdateClusterRequest{
-			Update: &containerBeta.ClusterUpdate{
-				DesiredLocations: convertStringSet(azSet),
-			},
-		}
-
-		updateF := updateFunc(req, "updating GKE cluster node locations")
-		// Call update serially.
-		if err := lockedCall(lockKey, updateF); err != nil {
-			return err
-		}
-
-		if isZone(location) {
-			azSetNew.Add(location)
-		}
-		if !azSet.Equal(azSetNew) {
-			req = &containerBeta.UpdateClusterRequest{
-				Update: &containerBeta.ClusterUpdate{
-					DesiredLocations: convertStringSet(azSetNew),
-				},
-			}
-
-			updateF := updateFunc(req, "updating GKE cluster node locations")
-			// Call update serially.
-			if err := lockedCall(lockKey, updateF); err != nil {
-				return err
-			}
-		}
-
-		log.Printf("[INFO] GKE cluster %s node locations have been updated to %v", d.Id(), azSet.List())
-
-		d.SetPartial("additional_zones")
-	} else if d.HasChange("node_locations") {
+	 if d.HasChange("node_locations") {
 		azSetOldI, azSetNewI := d.GetChange("node_locations")
 		azSetNew := azSetNewI.(*schema.Set)
 		azSetOld := azSetOldI.(*schema.Set)
@@ -2745,12 +2667,6 @@ func resourceContainerClusterStateImporter(d *schema.ResourceData, meta interfac
 	}
 	d.Set("project", project)
 
-	d.Set("location", location)
-	if isZone(location) {
-		d.Set("zone", location)
-	} else {
-		d.Set("region", location)
-	}
 
 	d.Set("name", clusterName)
 	d.SetId(clusterName)

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -107,25 +107,18 @@ func resourceContainerCluster() *schema.Resource {
 				Optional:      true,
 				Computed:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{"zone", "region"},
 			},
 
 			"region": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
 				Removed:       "Use location instead",
-				ConflictsWith: []string{"zone", "location"},
 			},
 
 			"zone": {
 				Type:          schema.TypeString,
 				Optional:      true,
-				Computed:      true,
-				ForceNew:      true,
 				Removed:       "Use location instead",
-				ConflictsWith: []string{"region", "location"},
 			},
 
 			"node_locations": {

--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -56,14 +56,14 @@ func resourceContainerNodePool() *schema.Resource {
 					Type:       schema.TypeString,
 					Optional:   true,
 					Computed:   true,
-					Deprecated: "use location instead",
+					Removed:    "use location instead",
 					ForceNew:   true,
 				},
 				"region": {
 					Type:       schema.TypeString,
 					Optional:   true,
 					Computed:   true,
-					Deprecated: "use location instead",
+					Removed:    "use location instead",
 					ForceNew:   true,
 				},
 				"location": {
@@ -326,12 +326,6 @@ func resourceContainerNodePoolRead(d *schema.ResourceData, meta interface{}) err
 		d.Set(k, v)
 	}
 
-	if isZone(nodePoolInfo.location) {
-		d.Set("zone", nodePoolInfo.location)
-	} else {
-		d.Set("region", nodePoolInfo.location)
-	}
-
 	d.Set("location", nodePoolInfo.location)
 	d.Set("project", nodePoolInfo.project)
 
@@ -432,11 +426,6 @@ func resourceContainerNodePoolStateImporter(d *schema.ResourceData, meta interfa
 	switch len(parts) {
 	case 3:
 		location := parts[0]
-		if isZone(location) {
-			d.Set("zone", location)
-		} else {
-			d.Set("region", location)
-		}
 
 		d.Set("location", location)
 		d.Set("cluster", parts[1])
@@ -445,11 +434,6 @@ func resourceContainerNodePoolStateImporter(d *schema.ResourceData, meta interfa
 		d.Set("project", parts[0])
 
 		location := parts[1]
-		if isZone(location) {
-			d.Set("zone", location)
-		} else {
-			d.Set("region", location)
-		}
 
 		d.Set("location", location)
 		d.Set("cluster", parts[2])

--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -55,16 +55,12 @@ func resourceContainerNodePool() *schema.Resource {
 				"zone": {
 					Type:       schema.TypeString,
 					Optional:   true,
-					Computed:   true,
 					Removed:    "use location instead",
-					ForceNew:   true,
 				},
 				"region": {
 					Type:       schema.TypeString,
 					Optional:   true,
-					Computed:   true,
 					Removed:    "use location instead",
-					ForceNew:   true,
 				},
 				"location": {
 					Type:     schema.TypeString,

--- a/third_party/terraform/resources/resource_storage_bucket.go
+++ b/third_party/terraform/resources/resource_storage_bucket.go
@@ -149,7 +149,6 @@ func resourceStorageBucket() *schema.Resource {
 									"is_live": {
 										Type:     schema.TypeBool,
 										Optional: true,
-										Computed: true,
 										Removed:  "Please use `with_state` instead",
 									},
 									"with_state": {

--- a/third_party/terraform/resources/resource_storage_bucket.go
+++ b/third_party/terraform/resources/resource_storage_bucket.go
@@ -147,10 +147,10 @@ func resourceStorageBucket() *schema.Resource {
 										Optional: true,
 									},
 									"is_live": {
-										Type:       schema.TypeBool,
-										Optional:   true,
-										Computed:   true,
-										Deprecated: "Please use `with_state` instead",
+										Type:     schema.TypeBool,
+										Optional: true,
+										Computed: true,
+										Removed:  "Please use `with_state` instead",
 									},
 									"with_state": {
 										Type:         schema.TypeString,
@@ -877,10 +877,8 @@ func flattenBucketLifecycleRuleCondition(condition *storage.BucketLifecycleRuleC
 	} else {
 		if *condition.IsLive {
 			ruleCondition["with_state"] = "LIVE"
-			ruleCondition["is_live"] = true
 		} else {
 			ruleCondition["with_state"] = "ARCHIVED"
-			ruleCondition["is_live"] = false
 		}
 	}
 	return ruleCondition
@@ -1043,18 +1041,9 @@ func expandStorageBucketLifecycleRuleCondition(v interface{}) (*storage.BucketLi
 			transformed.IsLive = googleapi.Bool(true)
 		case "ARCHIVED":
 			transformed.IsLive = googleapi.Bool(false)
-		case "ANY":
+		case "ANY", "":
 			// This is unnecessary, but set explicitly to nil for readability.
 			transformed.IsLive = nil
-		case "":
-			// Support deprecated `is_live` behavior
-			// is_live was always read (ok always true)
-			// so it can only support LIVE/ARCHIVED.
-			// TODO: When removing is_live, combine this case with case "ANY"
-			if v, ok := condition["is_live"]; ok {
-				log.Printf("[WARN] using deprecated field `is_live` because with_state is empty")
-				transformed.IsLive = googleapi.Bool(v.(bool))
-			}
 		default:
 			return nil, fmt.Errorf("unexpected value %q for condition.with_state", withStateV.(string))
 		}
@@ -1110,32 +1099,8 @@ func resourceGCSBucketLifecycleRuleConditionHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 
-	// Note that we are keeping the boolean notation from when is_live was
-	// the only field (i.e. not deprecated) in order to prevent a diff from
-	// hash key.
-	// There are three possible states for the actual condition
-	// and correspond to the following hash codes:
-	//
-	// 1. LIVE only: "true-"
-	//    Applies for one of:
-	//      with_state = "" && is_live = true
-	//      with_state = "LIVE"
-	//
-	// 2. ARCHIVED only: "false-"
-	//    Applies for one of:
-	//      with_state = "" && is_live = false
-	//      with_state = "ARCHIVED"
-	//
-	// 3. ANY (i.e. LIVE and ARCHIVED): ""
-	//    Applies for one of:
-	//      with_state = "ANY"
-
 	withStateV, withStateOk := m["with_state"]
-	if !withStateOk || withStateV.(string) == "" {
-		if isLiveV, ok := m["is_live"]; ok {
-			buf.WriteString(fmt.Sprintf("%t-", isLiveV.(bool)))
-		}
-	} else if withStateOk {
+	if withStateOk {
 		switch withStateV.(string) {
 		case "LIVE":
 			buf.WriteString(fmt.Sprintf("%t-", true))

--- a/third_party/terraform/tests/data_source_google_container_engine_versions_test.go
+++ b/third_party/terraform/tests/data_source_google_container_engine_versions_test.go
@@ -21,7 +21,6 @@ func TestAccContainerEngineVersions_basic(t *testing.T) {
 				Config: testAccCheckGoogleContainerEngineVersionsConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleContainerEngineVersionsMeta("data.google_container_engine_versions.location"),
-					testAccCheckGoogleContainerEngineVersionsMeta("data.google_container_engine_versions.versions"),
 				),
 			},
 		},
@@ -40,24 +39,6 @@ func TestAccContainerEngineVersions_filtered(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.google_container_engine_versions.versions", "valid_master_versions.#", "0"),
 					resource.TestCheckResourceAttr("data.google_container_engine_versions.versions", "valid_node_versions.#", "0"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccContainerEngineVersions_regional(t *testing.T) {
-	t.Parallel()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccCheckGoogleContainerEngineVersionsRegionalConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleContainerEngineVersionsMeta("data.google_container_engine_versions.location"),
-					testAccCheckGoogleContainerEngineVersionsMeta("data.google_container_engine_versions.versions"),
 				),
 			},
 		},
@@ -138,25 +119,11 @@ var testAccCheckGoogleContainerEngineVersionsConfig = `
 data "google_container_engine_versions" "location" {
   location = "us-central1-b"
 }
-
-data "google_container_engine_versions" "versions" {
-  zone = "us-central1-b"
-}
 `
 
 var testAccCheckGoogleContainerEngineVersions_filtered = `
 data "google_container_engine_versions" "versions" {
-  zone           = "us-central1-b"
+  location       = "us-central1-b"
   version_prefix = "1.1."
-}
-`
-
-var testAccCheckGoogleContainerEngineVersionsRegionalConfig = `
-data "google_container_engine_versions" "location" {
-  location = "us-central1"
-}
-
-data "google_container_engine_versions" "versions" {
-  region = "us-central1"
 }
 `

--- a/third_party/terraform/tests/resource_cloudiot_registry_test.go
+++ b/third_party/terraform/tests/resource_cloudiot_registry_test.go
@@ -251,52 +251,6 @@ resource "google_cloudiot_registry" "foobar" {
 `, acctest.RandString(10), acctest.RandString(10), registryName)
 }
 
-func testAccCloudIoTRegistry_singleEventNotificationConfig(topic, registryName string) string {
-	return fmt.Sprintf(`
-resource "google_project_iam_binding" "cloud-iot-iam-binding" {
-  members = ["serviceAccount:cloud-iot@system.gserviceaccount.com"]
-  role    = "roles/pubsub.publisher"
-}
-
-resource "google_pubsub_topic" "event-topic" {
-  name = "%s"
-}
-
-resource "google_cloudiot_registry" "foobar" {
-  depends_on = ["google_project_iam_binding.cloud-iot-iam-binding"]
-
-  name = "%s"
-
-  event_notification_config = {
-    pubsub_topic_name = "${google_pubsub_topic.event-topic.id}"
-  }
-}
-`, topic, registryName)
-}
-
-func testAccCloudIoTRegistry_pluralEventNotificationConfigs(topic, registryName string) string {
-	return fmt.Sprintf(`
-resource "google_project_iam_binding" "cloud-iot-iam-binding" {
-  members = ["serviceAccount:cloud-iot@system.gserviceaccount.com"]
-  role    = "roles/pubsub.publisher"
-}
-
-resource "google_pubsub_topic" "event-topic" {
-  name = "%s"
-}
-
-resource "google_cloudiot_registry" "foobar" {
-  depends_on = ["google_project_iam_binding.cloud-iot-iam-binding"]
-
-  name = "%s"
-
-  event_notification_config = {
-    pubsub_topic_name = "${google_pubsub_topic.event-topic.id}"
-  }
-}
-`, topic, registryName)
-}
-
 func testAccCloudIoTRegistry_singleEventNotificationConfigs(topic, registryName string) string {
 	return fmt.Sprintf(`
 resource "google_project_iam_binding" "cloud-iot-iam-binding" {

--- a/third_party/terraform/tests/resource_compute_network_peering_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_network_peering_test.go.erb
@@ -151,7 +151,6 @@ func testAccComputeNetworkPeering_basic() string {
 		network = "${google_compute_network.network2.self_link}"
 		peer_network = "${google_compute_network.network1.self_link}"
 		name = "peering-test-2-%s"
-		auto_create_routes = true
 		`
 
 	<% unless version == 'ga' -%>

--- a/third_party/terraform/tests/resource_compute_network_test.go
+++ b/third_party/terraform/tests/resource_compute_network_test.go
@@ -66,31 +66,6 @@ func TestAccComputeNetwork_customSubnet(t *testing.T) {
 	})
 }
 
-func TestAccComputeNetwork_legacyNetwork(t *testing.T) {
-	t.Parallel()
-
-	var network compute.Network
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckComputeNetworkDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeNetwork_legacyNetwork(),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeNetworkExists("google_compute_network.default", &network),
-					resource.TestCheckResourceAttrSet("google_compute_network.default", "ipv4_range"),
-				),
-			},
-			{
-				ResourceName:      "google_compute_network.default",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
 func TestAccComputeNetwork_routingModeAndUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -272,15 +247,6 @@ func testAccComputeNetwork_basic() string {
 resource "google_compute_network" "bar" {
 	name = "network-test-%s"
 	auto_create_subnetworks = true
-}`, acctest.RandString(10))
-}
-
-func testAccComputeNetwork_legacyNetwork() string {
-	return fmt.Sprintf(`
-resource "google_compute_network" "default" {
-	name = "network-test-%s"
-	auto_create_subnetworks = false
-    ipv4_range = "10.0.0.0/16"
 }`, acctest.RandString(10))
 }
 

--- a/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
@@ -130,30 +130,6 @@ func TestAccRegionInstanceGroupManager_updateLifecycle(t *testing.T) {
 	})
 }
 
-<% if version.nil? || version == 'ga' -%>
-func TestAccRegionInstanceGroupManager_updateStrategy(t *testing.T) {
-	t.Parallel()
-
-	igm := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckInstanceGroupManagerDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccRegionInstanceGroupManager_updateStrategy(igm),
-			},
-			{
-				ResourceName:            "google_compute_region_instance_group_manager.igm-update-strategy",
-				ImportState:             true,
-				ImportStateVerify:       true,
-			},
-		},
-	})
-}
-<% end -%>
-
 <% unless version == 'ga' -%>
 func TestAccRegionInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 	t.Parallel()
@@ -927,53 +903,6 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 }
 	`, template, igm, strings.Join(zones, "\",\""))
 }
-
-<% if version.nil? || version == 'ga' -%>
-func testAccRegionInstanceGroupManager_updateStrategy(igm string) string {
-	return fmt.Sprintf(`
-data "google_compute_image" "my_image" {
-	family  = "debian-9"
-	project = "debian-cloud"
-}
-
-resource "google_compute_instance_template" "igm-update-strategy" {
-	machine_type   = "n1-standard-1"
-	can_ip_forward = false
-	tags           = ["terraform-testing"]
-
-	disk {
-		source_image = "${data.google_compute_image.my_image.self_link}"
-		auto_delete  = true
-		boot         = true
-	}
-
-	network_interface {
-		network = "default"
-	}
-
-	service_account {
-		scopes = ["userinfo-email", "compute-ro", "storage-ro"]
-	}
-
-	lifecycle {
-		create_before_destroy = true
-	}
-}
-
-resource "google_compute_region_instance_group_manager" "igm-update-strategy" {
-	description                = "Terraform test instance group manager"
-	name                       = "%s"
-	instance_template          = "${google_compute_instance_template.igm-update-strategy.self_link}"
-	base_instance_name         = "rigm-update-strategy"
-	region                     = "us-central1"
-	target_size                = 2
-	named_port {
-		name = "customhttp"
-		port = 8080
-	}
-}`, igm)
-}
-<% end -%>
 
 <% unless version == 'ga' -%>
 func testAccRegionInstanceGroupManager_rollingUpdatePolicy(igm string) string {

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -475,7 +475,7 @@ func TestAccContainerCluster_regionalWithNodePool(t *testing.T) {
 	})
 }
 
-func TestAccContainerCluster_regionalWithAdditionalZones(t *testing.T) {
+func TestAccContainerCluster_regionalWithNodeLocations(t *testing.T) {
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
@@ -486,19 +486,19 @@ func TestAccContainerCluster_regionalWithAdditionalZones(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_regionalAdditionalZones(clusterName),
+				Config: testAccContainerCluster_regionalNodeLocations(clusterName),
 			},
 			{
-				ResourceName:		 "google_container_cluster.with_additional_zones",
+				ResourceName:		 "google_container_cluster.with_node_locations",
 				ImportStateIdPrefix: "us-central1/",
 				ImportState:		 true,
 				ImportStateVerify:	 true,
 			},
 			{
-				Config: testAccContainerCluster_regionalUpdateAdditionalZones(clusterName),
+				Config: testAccContainerCluster_regionalUpdateNodeLocations(clusterName),
 			},
 			{
-				ResourceName:		 "google_container_cluster.with_additional_zones",
+				ResourceName:		 "google_container_cluster.with_node_locations",
 				ImportStateIdPrefix: "us-central1/",
 				ImportState:		 true,
 				ImportStateVerify:	 true,
@@ -928,7 +928,7 @@ func TestAccContainerCluster_withNodePoolResize(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withNodePoolAdditionalZones(clusterName, npName),
+				Config: testAccContainerCluster_withNodePoolNodeLocations(clusterName, npName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_cluster.with_node_pool", "node_pool.0.node_count", "2"),
 				),
@@ -1585,7 +1585,7 @@ func testAccContainerCluster_masterAuthorizedNetworksDisabled(resource_name stri
 		attributes := rs.Primary.Attributes
 
 		cluster, err := config.clientContainer.Projects.Zones.Clusters.Get(
-			config.Project, attributes["zone"], attributes["name"]).Do()
+			config.Project, attributes["location"], attributes["name"]).Do()
 		if err != nil {
 			return err
 		}
@@ -1608,7 +1608,7 @@ func testAccCheckContainerClusterDestroy(s *terraform.State) error {
 
 		attributes := rs.Primary.Attributes
 		_, err := config.clientContainer.Projects.Zones.Clusters.Get(
-			config.Project, attributes["zone"], attributes["name"]).Do()
+			config.Project, attributes["location"], attributes["name"]).Do()
 		if err == nil {
 			return fmt.Errorf("Cluster still exists")
 		}
@@ -1721,13 +1721,12 @@ func testAccContainerCluster_misc(name string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
 	name               = "%s"
-	zone               = "us-central1-a"
+	location           = "us-central1-a"
 	initial_node_count = 1
 
 	remove_default_node_pool = true
 
-	# This uses zone/additional_zones over location/node_locations to ensure we can update from old -> new
-	additional_zones = [
+	node_locations = [
 		"us-central1-b",
 		"us-central1-c"
 	]
@@ -1838,8 +1837,8 @@ resource "google_container_cluster" "primary" {
 func testAccContainerCluster_withMasterAuth(clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_master_auth" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 3
 
 	master_auth {
@@ -1852,8 +1851,8 @@ resource "google_container_cluster" "with_master_auth" {
 func testAccContainerCluster_updateMasterAuth(clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_master_auth" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 3
 
 	master_auth {
@@ -1866,8 +1865,8 @@ resource "google_container_cluster" "with_master_auth" {
 func testAccContainerCluster_disableMasterAuth(clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_master_auth" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 3
 
 	master_auth {
@@ -1880,8 +1879,8 @@ resource "google_container_cluster" "with_master_auth" {
 func testAccContainerCluster_withMasterAuthNoCert() string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_master_auth_no_cert" {
-	name = "cluster-test-%s"
-	zone = "us-central1-a"
+	name     = "cluster-test-%s"
+	location = "us-central1-a"
 	initial_node_count = 3
 
 	master_auth {
@@ -1897,8 +1896,8 @@ resource "google_container_cluster" "with_master_auth_no_cert" {
 func testAccContainerCluster_withNetworkPolicyEnabled(clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_network_policy_enabled" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 	remove_default_node_pool = true
 
@@ -1918,8 +1917,8 @@ resource "google_container_cluster" "with_network_policy_enabled" {
 func testAccContainerCluster_removeNetworkPolicy(clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_network_policy_enabled" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 	remove_default_node_pool = true
 }`, clusterName)
@@ -1928,8 +1927,8 @@ resource "google_container_cluster" "with_network_policy_enabled" {
 func testAccContainerCluster_withNetworkPolicyDisabled(clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_network_policy_enabled" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 	remove_default_node_pool = true
 
@@ -1940,8 +1939,8 @@ resource "google_container_cluster" "with_network_policy_enabled" {
 func testAccContainerCluster_withNetworkPolicyConfigDisabled(clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_network_policy_enabled" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 	remove_default_node_pool = true
 
@@ -1967,7 +1966,7 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 	name					 = "${google_compute_network.container_network.name}"
 	network					 = "${google_compute_network.container_network.name}"
 	ip_cidr_range			 = "10.0.36.0/24"
-	region					 = "us-central1"
+	location				 = "us-central1"
 	private_ip_google_access = true
 
 	secondary_ip_range {
@@ -1982,8 +1981,8 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 }
 
 resource "google_container_cluster" "with_authenticator_groups" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 	network = "${google_compute_network.container_network.name}"
 	subnetwork = "${google_compute_subnetwork.container_subnetwork.name}"
@@ -2049,8 +2048,8 @@ resource "google_container_cluster" "regional" {
 func testAccContainerCluster_regionalWithNodePool(cluster, nodePool string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "regional" {
-	name   = "%s"
-	region = "us-central1"
+	name     = "%s"
+	location = "us-central1"
 
 	node_pool {
 		name = "%s"
@@ -2058,24 +2057,23 @@ resource "google_container_cluster" "regional" {
 }`, cluster, nodePool)
 }
 
-// This uses region/additional_zones over location/node_locations to ensure we can update from old -> new
-func testAccContainerCluster_regionalAdditionalZones(clusterName string) string {
+func testAccContainerCluster_regionalNodeLocations(clusterName string) string {
 	return fmt.Sprintf(`
-resource "google_container_cluster" "with_additional_zones" {
-	name = "%s"
-	region = "us-central1"
+resource "google_container_cluster" "with_node_locations" {
+	name     = "%s"
+	location = "us-central1"
 	initial_node_count = 1
 
-	additional_zones = [
+	node_locations = [
 		"us-central1-f",
 		"us-central1-c",
 	]
 }`, clusterName)
 }
 
-func testAccContainerCluster_regionalUpdateAdditionalZones(clusterName string) string {
+func testAccContainerCluster_regionalUpdateNodeLocations(clusterName string) string {
 	return fmt.Sprintf(`
-resource "google_container_cluster" "with_additional_zones" {
+resource "google_container_cluster" "with_node_locations" {
 	name               = "%s"
 	location           = "us-central1"
 	initial_node_count = 1
@@ -2096,9 +2094,9 @@ resource "google_compute_network" "container_network" {
 }
 
 resource "google_compute_subnetwork" "container_subnetwork" {
-	name	= "${google_compute_network.container_network.name}"
-	network = "${google_compute_network.container_network.name}"
-	region	= "us-central1"
+	name	 = "${google_compute_network.container_network.name}"
+	network  = "${google_compute_network.container_network.name}"
+	location = "us-central1"
 
 	ip_cidr_range			 = "10.0.35.0/24"
 	private_ip_google_access = true
@@ -2116,7 +2114,7 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 
 resource "google_container_cluster" "with_tpu" {
 	name			   = "cluster-test-%s"
-	zone			   = "us-central1-b"
+	location		   = "us-central1-b"
 	initial_node_count = 1
 
 	enable_tpu = true
@@ -2143,8 +2141,8 @@ resource "google_container_cluster" "with_tpu" {
 func testAccContainerCluster_withIntraNodeVisibility(clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_intranode_visibility" {
-	name = "cluster-test-%s"
-	zone = "us-central1-a"
+	name     = "cluster-test-%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 	enable_intranode_visibility = true
 }`, clusterName)
@@ -2153,8 +2151,8 @@ resource "google_container_cluster" "with_intranode_visibility" {
 func testAccContainerCluster_updateIntraNodeVisibility(clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_intranode_visibility" {
-	name = "cluster-test-%s"
-	zone = "us-central1-a"
+	name     = "cluster-test-%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 	enable_intranode_visibility = false
 }`, clusterName)
@@ -2165,12 +2163,12 @@ resource "google_container_cluster" "with_intranode_visibility" {
 func testAccContainerCluster_withVersion(clusterName string) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
-	zone = "us-central1-a"
+	location = "us-central1-a"
 }
 
 resource "google_container_cluster" "with_version" {
-	name = "cluster-test-%s"
-	zone = "us-central1-a"
+	name     = "cluster-test-%s"
+	location = "us-central1-a"
 	min_master_version = "${data.google_container_engine_versions.central1a.latest_master_version}"
 	initial_node_count = 1
 }`, clusterName)
@@ -2179,12 +2177,12 @@ resource "google_container_cluster" "with_version" {
 func testAccContainerCluster_withLowerVersion(clusterName string) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
-	zone = "us-central1-a"
+	location = "us-central1-a"
 }
 
 resource "google_container_cluster" "with_version" {
-	name = "cluster-test-%s"
-	zone = "us-central1-a"
+	name     = "cluster-test-%s"
+	location = "us-central1-a"
 	min_master_version = "${data.google_container_engine_versions.central1a.valid_master_versions.2}"
 	initial_node_count = 1
 }`, clusterName)
@@ -2193,12 +2191,12 @@ resource "google_container_cluster" "with_version" {
 func testAccContainerCluster_updateVersion(clusterName string) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
-	zone = "us-central1-a"
+	location = "us-central1-a"
 }
 
 resource "google_container_cluster" "with_version" {
-	name = "cluster-test-%s"
-	zone = "us-central1-a"
+	name     = "cluster-test-%s"
+	location = "us-central1-a"
 	min_master_version = "${data.google_container_engine_versions.central1a.valid_master_versions.1}"
 	node_version = "${data.google_container_engine_versions.central1a.valid_node_versions.1}"
 	initial_node_count = 1
@@ -2208,8 +2206,8 @@ resource "google_container_cluster" "with_version" {
 func testAccContainerCluster_withNodeConfig(clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_config" {
-	name = "%s"
-	zone = "us-central1-f"
+	name     = "%s"
+	location = "us-central1-f"
 	initial_node_count = 1
 
 	node_config {
@@ -2244,8 +2242,8 @@ resource "google_container_cluster" "with_node_config" {
 func testAccContainerCluster_withNodeConfigUpdate(clusterName string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_config" {
-	name = "%s"
-	zone = "us-central1-f"
+	name     = "%s"
+	location = "us-central1-f"
 	initial_node_count = 1
 
 	node_config {
@@ -2280,8 +2278,8 @@ resource "google_container_cluster" "with_node_config" {
 func testAccContainerCluster_withNodeConfigScopeAlias() string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_config_scope_alias" {
-	name = "cluster-test-%s"
-	zone = "us-central1-f"
+	name     = "cluster-test-%s"
+	location = "us-central1-f"
 	initial_node_count = 1
 
 	node_config {
@@ -2296,8 +2294,8 @@ resource "google_container_cluster" "with_node_config_scope_alias" {
 func testAccContainerCluster_withNodeConfigTaints() string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_config" {
-	name = "cluster-test-%s"
-	zone = "us-central1-f"
+	name     = "cluster-test-%s"
+	location = "us-central1-f"
 	initial_node_count = 1
 
 	node_config {
@@ -2320,12 +2318,12 @@ resource "google_container_cluster" "with_node_config" {
 func testAccContainerCluster_withWorkloadMetadataConfig() string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
-  zone = "us-central1-a"
+  location = "us-central1-a"
 }
 
 resource "google_container_cluster" "with_workload_metadata_config" {
   name				 = "cluster-test-%s"
-  zone				 = "us-central1-a"
+  location			 = "us-central1-a"
   initial_node_count = 1
   min_master_version = "${data.google_container_engine_versions.central1a.latest_master_version}"
 
@@ -2350,8 +2348,8 @@ data "google_project" "project" {
 }
 
 resource "google_container_cluster" "with_workload_identity_config" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 
   node_config {
@@ -2370,12 +2368,12 @@ resource "google_container_cluster" "with_workload_identity_config" {
 func testAccContainerCluster_withSandboxConfig() string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
-  zone = "us-central1-a"
+  location = "us-central1-a"
 }
 
 resource "google_container_cluster" "with_sandbox_config" {
   name				 = "cluster-test-%s"
-  zone				 = "us-central1-a"
+  location			 = "us-central1-a"
   initial_node_count = 1
   min_master_version = "${data.google_container_engine_versions.central1a.latest_master_version}"
 
@@ -2404,16 +2402,16 @@ resource "google_compute_network" "container_network" {
 }
 
 resource "google_container_cluster" "with_net_ref_by_url" {
-	name = "cluster-test-%s"
-	zone = "us-central1-a"
+	name     = "cluster-test-%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 
 	network = "${google_compute_network.container_network.self_link}"
 }
 
 resource "google_container_cluster" "with_net_ref_by_name" {
-	name = "cluster-test-%s"
-	zone = "us-central1-a"
+	name     = "cluster-test-%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 
 	network = "${google_compute_network.container_network.name}"
@@ -2443,10 +2441,10 @@ resource "google_compute_http_health_check" "default" {
 
 resource "google_container_cluster" "primary" {
   name				 = "terraform-test-%s"
-  zone				 = "us-central1-a"
+  location			 = "us-central1-a"
   initial_node_count = 3
 
-  additional_zones = [
+  node_locations = [
 	"us-central1-b",
 	"us-central1-c",
   ]
@@ -2466,8 +2464,8 @@ resource "google_container_cluster" "primary" {
 func testAccContainerCluster_withNodePoolBasic(cluster, nodePool string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_pool" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 
 	node_pool {
 		name			   = "%s"
@@ -2479,12 +2477,12 @@ resource "google_container_cluster" "with_node_pool" {
 func testAccContainerCluster_withNodePoolLowerVersion(cluster, nodePool string) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
-	zone = "us-central1-a"
+	location = "us-central1-a"
 }
 
 resource "google_container_cluster" "with_node_pool" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 
 	min_master_version = "${data.google_container_engine_versions.central1a.valid_master_versions.1}"
 
@@ -2499,12 +2497,12 @@ resource "google_container_cluster" "with_node_pool" {
 func testAccContainerCluster_withNodePoolUpdateVersion(cluster, nodePool string) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
-	zone = "us-central1-a"
+	location = "us-central1-a"
 }
 
 resource "google_container_cluster" "with_node_pool" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 
 	min_master_version = "${data.google_container_engine_versions.central1a.valid_master_versions.1}"
 
@@ -2516,13 +2514,13 @@ resource "google_container_cluster" "with_node_pool" {
 }`, cluster, nodePool)
 }
 
-func testAccContainerCluster_withNodePoolAdditionalZones(cluster, nodePool string) string {
+func testAccContainerCluster_withNodePoolNodeLocations(cluster, nodePool string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_pool" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 
-	additional_zones = [
+	node_locations = [
 		"us-central1-b",
 		"us-central1-c"
 	]
@@ -2537,10 +2535,10 @@ resource "google_container_cluster" "with_node_pool" {
 func testAccContainerCluster_withNodePoolResize(cluster, nodePool string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_pool" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 
-	additional_zones = [
+	node_locations = [
 		"us-central1-b",
 		"us-central1-c"
 	]
@@ -2556,12 +2554,12 @@ resource "google_container_cluster" "with_node_pool" {
 func testAccContainerCluster_autoprovisioning(cluster string, autoprovisioning bool) string {
 	config := fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
-  zone = "us-central1-a"
+  location = "us-central1-a"
 }
 
 resource "google_container_cluster" "with_autoprovisioning" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	min_master_version = "${data.google_container_engine_versions.central1a.latest_master_version}"
 	initial_node_count = 1
 `, cluster)
@@ -2593,8 +2591,8 @@ resource "google_container_cluster" "with_autoprovisioning" {
 func testAccContainerCluster_withNodePoolAutoscaling(cluster, np string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_pool" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 
 	node_pool {
 		name			   = "%s"
@@ -2610,8 +2608,8 @@ resource "google_container_cluster" "with_node_pool" {
 func testAccContainerCluster_withNodePoolUpdateAutoscaling(cluster, np string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_pool" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 
 	node_pool {
 		name			   = "%s"
@@ -2627,8 +2625,8 @@ resource "google_container_cluster" "with_node_pool" {
 func testAccContainerCluster_withNodePoolNamePrefix() string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_pool_name_prefix" {
-	name = "tf-cluster-nodepool-test-%s"
-	zone = "us-central1-a"
+	name     = "tf-cluster-nodepool-test-%s"
+	location = "us-central1-a"
 
 	node_pool {
 		name_prefix = "tf-np-test"
@@ -2640,8 +2638,8 @@ resource "google_container_cluster" "with_node_pool_name_prefix" {
 func testAccContainerCluster_withNodePoolMultiple() string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_pool_multiple" {
-	name = "tf-cluster-nodepool-test-%s"
-	zone = "us-central1-a"
+	name     = "tf-cluster-nodepool-test-%s"
+	location = "us-central1-a"
 
 	node_pool {
 		name	   = "tf-cluster-nodepool-test-%s"
@@ -2658,8 +2656,8 @@ resource "google_container_cluster" "with_node_pool_multiple" {
 func testAccContainerCluster_withNodePoolConflictingNameFields() string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_pool_multiple" {
-	name = "tf-cluster-nodepool-test-%s"
-	zone = "us-central1-a"
+	name     = "tf-cluster-nodepool-test-%s"
+	location = "us-central1-a"
 
 	node_pool {
 		# ERROR: name and name_prefix cannot be both specified
@@ -2674,8 +2672,8 @@ func testAccContainerCluster_withNodePoolNodeConfig() string {
 	testId := acctest.RandString(10)
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_pool_node_config" {
-	name = "tf-cluster-nodepool-test-%s"
-	zone = "us-central1-a"
+	name     = "tf-cluster-nodepool-test-%s"
+	location = "us-central1-a"
 	node_pool {
 		name = "tf-cluster-nodepool-test-%s"
 		node_count = 2
@@ -2719,8 +2717,8 @@ func testAccContainerCluster_withMaintenanceWindow(clusterName string, startTime
 
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_maintenance_window" {
-	name = "cluster-test-%s"
-	zone = "us-central1-a"
+	name     = "cluster-test-%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 
 	%s
@@ -2738,7 +2736,7 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 	name		  = "${google_compute_network.container_network.name}"
 	network		  = "${google_compute_network.container_network.name}"
 	ip_cidr_range = "10.0.0.0/24"
-	region		  = "us-central1"
+	location 	  = "us-central1"
 
 	secondary_ip_range {
 		range_name	  = "pods"
@@ -2751,8 +2749,8 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 }
 
 resource "google_container_cluster" "with_ip_allocation_policy" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 
 	network = "${google_compute_network.container_network.name}"
 	subnetwork = "${google_compute_subnetwork.container_subnetwork.name}"
@@ -2775,7 +2773,7 @@ resource "google_compute_network" "container_network" {
 
 resource "google_container_cluster" "with_ip_allocation_policy" {
 	name	   = "%s"
-	zone	   = "us-central1-a"
+	location   = "us-central1-a"
 	network    = "${google_compute_network.container_network.name}"
 
 	initial_node_count = 1
@@ -2800,12 +2798,12 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 	name		  = "${google_compute_network.container_network.name}"
 	network		  = "${google_compute_network.container_network.name}"
 	ip_cidr_range = "10.0.0.0/24"
-	region		  = "us-central1"
+	location	  = "us-central1"
 }
 
 resource "google_container_cluster" "with_ip_allocation_policy" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 
 	network = "${google_compute_network.container_network.name}"
 
@@ -2824,8 +2822,8 @@ resource "google_container_cluster" "with_ip_allocation_policy" {
 func testAccContainerCluster_withIPAllocationPolicy_createSubnetwork(cluster string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_ip_allocation_policy" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 
 	initial_node_count = 1
 	ip_allocation_policy {
@@ -2838,8 +2836,8 @@ resource "google_container_cluster" "with_ip_allocation_policy" {
 func testAccContainerCluster_withIPAllocationPolicy_explicitEmpty(cluster string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_ip_allocation_policy" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 
 	initial_node_count = 1
 	ip_allocation_policy = []
@@ -2869,7 +2867,7 @@ func testAccContainerCluster_withResourceUsageExportConfig(clusterName, datasetI
 
 	resource "google_container_cluster" "with_resource_usage_export_config" {
 		name               = "cluster-test-%s"
-		zone               = "us-central1-a"
+		location           = "us-central1-a"
 		initial_node_count = 1
 		%s
 	}`, datasetId, clusterName, resourceUsageConfig)
@@ -2888,7 +2886,7 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 	name					 = "${google_compute_network.container_network.name}"
 	network					 = "${google_compute_network.container_network.name}"
 	ip_cidr_range			 = "10.0.36.0/24"
-	region					 = "us-central1"
+	location				 = "us-central1"
 	private_ip_google_access = true
 
 	secondary_ip_range {
@@ -2903,8 +2901,8 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 }
 
 resource "google_container_cluster" "with_private_cluster" {
-	name = "cluster-test-%s"
-	zone = "us-central1-a"
+	name     = "cluster-test-%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 
 	network = "${google_compute_network.container_network.name}"
@@ -2933,7 +2931,7 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 	name					 = "${google_compute_network.container_network.name}"
 	network					 = "${google_compute_network.container_network.name}"
 	ip_cidr_range			 = "10.0.36.0/24"
-	region					 = "us-central1"
+	location				 = "us-central1"
 	private_ip_google_access = true
 
 	secondary_ip_range {
@@ -2948,8 +2946,8 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 }
 
 resource "google_container_cluster" "with_private_cluster" {
-	name = "cluster-test-%s"
-	zone = "us-central1-a"
+	name     = "cluster-test-%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 
 	network = "${google_compute_network.container_network.name}"
@@ -3035,7 +3033,7 @@ resource "google_compute_network" "shared_network" {
 resource "google_compute_subnetwork" "shared_subnetwork" {
 	name		  = "test-%s"
 	ip_cidr_range = "10.0.0.0/16"
-	region		  = "us-central1"
+	location	  = "us-central1"
 	network		  = "${google_compute_network.shared_network.self_link}"
 	project		  = "${google_compute_shared_vpc_host_project.host_project.project}"
 
@@ -3052,7 +3050,7 @@ resource "google_compute_subnetwork" "shared_subnetwork" {
 
 resource "google_container_cluster" "shared_vpc_cluster" {
 	name			   = "%s"
-	zone			   = "us-central1-a"
+	location		   = "us-central1-a"
 	initial_node_count = 1
 	project			   = "${google_compute_shared_vpc_service_project.service_project.service_project}"
 
@@ -3079,8 +3077,8 @@ data "google_project" "project" {
 }
 
 resource "google_container_cluster" "with_workload_identity_config" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 
 	workload_identity_config {
@@ -3104,8 +3102,8 @@ data "google_project" "project" {
 }
 
 resource "google_container_cluster" "with_workload_identity_config" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 
 	%s
@@ -3115,8 +3113,8 @@ resource "google_container_cluster" "with_workload_identity_config" {
 func testAccContainerCluster_withBinaryAuthorization(clusterName string, enabled bool) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_binary_authorization" {
-	name = "%s"
-	zone = "us-central1-a"
+	name    = "%s"
+	locatin = "us-central1-a"
 	initial_node_count = 1
 
 	enable_binary_authorization = %v
@@ -3135,7 +3133,7 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 	name					 = "${google_compute_network.container_network.name}"
 	network					 = "${google_compute_network.container_network.name}"
 	ip_cidr_range			 = "10.0.35.0/24"
-	region					 = "us-central1"
+	location				 = "us-central1"
 	private_ip_google_access = true
 
 	secondary_ip_range {
@@ -3150,8 +3148,8 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 }
 
 resource "google_container_cluster" "with_flexible_cidr" {
-	name = "%s"
-	zone = "us-central1-a"
+	name    = "%s"
+	locatin = "us-central1-a"
 	initial_node_count = 3
 
 	network = "${google_compute_network.container_network.name}"
@@ -3190,8 +3188,8 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 }
 
 resource "google_container_cluster" "cidr_error_preempt" {
-  name = "%s"
-  zone = "us-central1-a"
+  name     = "%s"
+  location = "us-central1-a"
 
   network    = "${google_compute_network.container_network.name}"
   subnetwork = "${google_compute_subnetwork.container_subnetwork.name}"
@@ -3211,8 +3209,8 @@ func testAccContainerCluster_withCIDROverlap(initConfig, secondCluster string) s
 %s
 
 resource "google_container_cluster" "cidr_error_overlap" {
-  name = "%s"
-  zone = "us-central1-a"
+  name     = "%s"
+  location = "us-central1-a"
 
   network    = "${google_compute_network.container_network.name}"
   subnetwork = "${google_compute_subnetwork.container_subnetwork.name}"
@@ -3230,8 +3228,8 @@ resource "google_container_cluster" "cidr_error_overlap" {
 func testAccContainerCluster_withInvalidLocation(location string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_resource_labels" {
-	name = "invalid-gke-cluster"
-	zone = "%s"
+	name     = "invalid-gke-cluster"
+	location = "%s"
 	initial_node_count = 1
 }
 `, location)
@@ -3258,8 +3256,8 @@ resource "google_kms_key_ring_iam_policy" "test_key_ring_iam_policy" {
 }
 
 resource "google_container_cluster" "with_database_encryption" {
-	name = "cluster-test-%[3]s"
-	zone = "us-central1-a"
+	name     = "cluster-test-%[3]s"
+	location = "us-central1-a"
 	initial_node_count = 1
 
 	database_encryption {
@@ -3281,7 +3279,7 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 	name					 = "${google_compute_network.container_network.name}"
 	network					 = "${google_compute_network.container_network.name}"
 	ip_cidr_range			 = "10.0.36.0/24"
-	region					 = "us-central1"
+	location				 = "us-central1"
 	private_ip_google_access = true
 
 	secondary_ip_range {
@@ -3296,8 +3294,8 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 }
 
 resource "google_container_cluster" "with_private_cluster" {
-	name = "cluster-test-%s"
-	zone = "us-central1-a"
+	name     = "cluster-test-%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 
 	network = "${google_compute_network.container_network.name}"

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -683,17 +683,17 @@ func testAccCheckContainerNodePoolDestroy(s *terraform.State) error {
 		}
 
 		attributes := rs.Primary.Attributes
-		zone := attributes["zone"]
+		location := attributes["location"]
 
 		var err error
-		if zone != "" {
+		if location != "" {
 			_, err = config.clientContainer.Projects.Zones.Clusters.NodePools.Get(
-				config.Project, attributes["zone"], attributes["cluster"], attributes["name"]).Do()
+				config.Project, attributes["location"], attributes["cluster"], attributes["name"]).Do()
 		} else {
 			name := fmt.Sprintf(
 				"projects/%s/locations/%s/clusters/%s/nodePools/%s",
 				config.Project,
-				attributes["region"],
+				attributes["location"],
 				attributes["cluster"],
 				attributes["name"],
 			)
@@ -736,7 +736,7 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 	name                     = "${google_compute_network.container_network.name}"
 	network                  = "${google_compute_network.container_network.name}"
 	ip_cidr_range            = "10.0.36.0/24"
-	region                   = "us-central1"
+	location                 = "us-central1"
 	private_ip_google_access = true
 
 	secondary_ip_range {
@@ -794,7 +794,7 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 	name                     = "${google_compute_network.container_network.name}"
 	network                  = "${google_compute_network.container_network.name}"
 	ip_cidr_range            = "10.0.36.0/24"
-	region                   = "us-central1"
+	location                 = "us-central1"
 	private_ip_google_access = true
 
 	secondary_ip_range {
@@ -809,8 +809,8 @@ resource "google_compute_subnetwork" "container_subnetwork" {
 }
 
 resource "google_container_cluster" "cluster" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 3
 
 	network = "${google_compute_network.container_network.name}"
@@ -831,8 +831,8 @@ resource "google_container_cluster" "cluster" {
 }
 
 resource "google_container_node_pool" "np" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	cluster = "${google_container_cluster.cluster.name}"
 	max_pods_per_node = 30
 	initial_node_count = 2
@@ -859,13 +859,13 @@ resource "google_container_node_pool" "np" {
 func testAccContainerNodePool_namePrefix(cluster, np string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 3
 }
 resource "google_container_node_pool" "np" {
 	name_prefix = "%s"
-	zone = "us-central1-a"
+	location = "us-central1-a"
 	cluster = "${google_container_cluster.cluster.name}"
 	initial_node_count = 2
 }`, cluster, np)
@@ -874,13 +874,13 @@ resource "google_container_node_pool" "np" {
 func testAccContainerNodePool_noName(cluster string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 3
 }
 
 resource "google_container_node_pool" "np" {
-	zone = "us-central1-a"
+	location = "us-central1-a"
 	cluster = "${google_container_cluster.cluster.name}"
 	initial_node_count = 2
 }`, cluster)
@@ -889,14 +889,14 @@ resource "google_container_node_pool" "np" {
 func testAccContainerNodePool_regionalAutoscaling(cluster, np string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
-	name = "%s"
-	region = "us-central1"
+	name     = "%s"
+	location = "us-central1"
 	initial_node_count = 3
 }
 
 resource "google_container_node_pool" "np" {
-	name = "%s"
-	region = "us-central1"
+	name     = "%s"
+	location = "us-central1"
 	cluster = "${google_container_cluster.cluster.name}"
 	initial_node_count = 2
 	autoscaling {
@@ -909,14 +909,14 @@ resource "google_container_node_pool" "np" {
 func testAccContainerNodePool_autoscaling(cluster, np string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 3
 }
 
 resource "google_container_node_pool" "np" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	cluster = "${google_container_cluster.cluster.name}"
 	initial_node_count = 2
 	autoscaling {
@@ -929,14 +929,14 @@ resource "google_container_node_pool" "np" {
 func testAccContainerNodePool_updateAutoscaling(cluster, np string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 3
 }
 
 resource "google_container_node_pool" "np" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	cluster = "${google_container_cluster.cluster.name}"
 	initial_node_count = 2
 	autoscaling {
@@ -946,23 +946,22 @@ resource "google_container_node_pool" "np" {
 }`, cluster, np)
 }
 
-// This uses zone/additional_zones over location/node_locations to ensure we can update from old -> new
 func testAccContainerNodePool_additionalZones(cluster, nodePool string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 
-	additional_zones = [
+	node_locations = [
 		"us-central1-b",
 		"us-central1-c"
 	]
 }
 
 resource "google_container_node_pool" "np" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	cluster = "${google_container_cluster.cluster.name}"
 	node_count = 2
 }`, cluster, nodePool)
@@ -993,13 +992,13 @@ func testAccContainerNodePool_withManagement(cluster, nodePool, management strin
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
 	name               = "%s"
-	zone               = "us-central1-a"
+	location           = "us-central1-a"
 	initial_node_count = 1
 }
 
 resource "google_container_node_pool" "np_with_management" {
 	name               = "%s"
-	zone               = "us-central1-a"
+	location           = "us-central1-a"
 	cluster            = "${google_container_cluster.cluster.name}"
 	initial_node_count = 1
 
@@ -1016,13 +1015,13 @@ resource "google_container_node_pool" "np_with_management" {
 func testAccContainerNodePool_withNodeConfig(cluster, nodePool string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 }
 resource "google_container_node_pool" "np_with_node_config" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	cluster = "${google_container_cluster.cluster.name}"
 	initial_node_count = 1
 	node_config {
@@ -1046,13 +1045,13 @@ resource "google_container_node_pool" "np_with_node_config" {
 func testAccContainerNodePool_withNodeConfigUpdate(cluster, nodePool string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 }
 resource "google_container_node_pool" "np_with_node_config" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	cluster = "${google_container_cluster.cluster.name}"
 	initial_node_count = 1
 	node_config {
@@ -1077,13 +1076,13 @@ resource "google_container_node_pool" "np_with_node_config" {
 func testAccContainerNodePool_withNodeConfigTaints() string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
-	name = "tf-cluster-nodepool-test-%s"
-	zone = "us-central1-a"
+	name     = "tf-cluster-nodepool-test-%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 }
 resource "google_container_node_pool" "np_with_node_config" {
-	name = "tf-nodepool-test-%s"
-	zone = "us-central1-a"
+	name     = "tf-nodepool-test-%s"
+	location = "us-central1-a"
 	cluster = "${google_container_cluster.cluster.name}"
 	initial_node_count = 1
 	node_config {
@@ -1106,19 +1105,19 @@ resource "google_container_node_pool" "np_with_node_config" {
 func testAccContainerNodePool_withWorkloadMetadataConfig() string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
-  zone = "us-central1-a"
+  location = "us-central1-a"
 }
 
 resource "google_container_cluster" "cluster" {
   name               = "tf-cluster-nodepool-test-%s"
-  zone               = "us-central1-a"
+  location           = "us-central1-a"
   initial_node_count = 1
   min_master_version = "${data.google_container_engine_versions.central1a.latest_master_version}"
 }
 
 resource "google_container_node_pool" "with_workload_metadata_config" {
-  name = "tf-nodepool-test-%s"
-  zone = "us-central1-a"
+  name     = "tf-nodepool-test-%s"
+  location = "us-central1-a"
   cluster = "${google_container_cluster.cluster.name}"
   initial_node_count = 1
   node_config {
@@ -1142,12 +1141,12 @@ data "google_project" "project" {
 }
 
 data "google_container_engine_versions" "central1a" {
-  zone = "us-central1-a"
+  location = "us-central1-a"
 }
 
 resource "google_container_cluster" "cluster" {
   name               = "tf-cluster-nodepool-test-%s"
-  zone               = "us-central1-a"
+  location           = "us-central1-a"
   initial_node_count = 1
   min_master_version = "${data.google_container_engine_versions.central1a.latest_master_version}"
 
@@ -1157,8 +1156,8 @@ resource "google_container_cluster" "cluster" {
 }
 
 resource "google_container_node_pool" "with_workload_metadata_config" {
-  name = "tf-nodepool-test-%s"
-  zone = "us-central1-a"
+  name     = "tf-nodepool-test-%s"
+  location = "us-central1-a"
   cluster = "${google_container_cluster.cluster.name}"
   initial_node_count = 1
   node_config {
@@ -1179,19 +1178,19 @@ resource "google_container_node_pool" "with_workload_metadata_config" {
 func testAccContainerNodePool_withSandboxConfig() string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
-  zone = "us-central1-a"
+  location = "us-central1-a"
 }
 
 resource "google_container_cluster" "cluster" {
   name               = "tf-cluster-nodepool-test-%s"
-  zone               = "us-central1-a"
+  location           = "us-central1-a"
   initial_node_count = 1
   min_master_version = "${data.google_container_engine_versions.central1a.latest_master_version}"
 }
 
 resource "google_container_node_pool" "with_sandbox_config" {
   name = "tf-nodepool-test-%s"
-  zone = "us-central1-a"
+  location = "us-central1-a"
   cluster = "${google_container_cluster.cluster.name}"
   initial_node_count = 1
   node_config {
@@ -1212,20 +1211,20 @@ resource "google_container_node_pool" "with_sandbox_config" {
 func testAccContainerNodePool_withGPU() string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1c" {
-	zone = "us-central1-c"
+	location = "us-central1-c"
 }
 
 resource "google_container_cluster" "cluster" {
-	name = "tf-cluster-nodepool-test-%s"
-	zone = "us-central1-c"
+	name     = "tf-cluster-nodepool-test-%s"
+	location = "us-central1-c"
 	initial_node_count = 1
 	node_version = "${data.google_container_engine_versions.central1c.latest_node_version}"
 	min_master_version = "${data.google_container_engine_versions.central1c.latest_master_version}"
 }
 
 resource "google_container_node_pool" "np_with_gpu" {
-	name = "tf-nodepool-test-%s"
-	zone = "us-central1-c"
+	name     = "tf-nodepool-test-%s"
+	location = "us-central1-c"
 	cluster = "${google_container_cluster.cluster.name}"
 
 	initial_node_count = 1
@@ -1258,13 +1257,13 @@ resource "google_container_node_pool" "np_with_gpu" {
 func testAccContainerNodePool_withNodeConfigScopeAlias() string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
-	name = "tf-cluster-nodepool-test-%s"
-	zone = "us-central1-a"
+	name     = "tf-cluster-nodepool-test-%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 }
 resource "google_container_node_pool" "np_with_node_config_scope_alias" {
 	name = "tf-nodepool-test-%s"
-	zone = "us-central1-a"
+	location = "us-central1-a"
 	cluster = "${google_container_cluster.cluster.name}"
 	initial_node_count = 1
 	node_config {
@@ -1278,19 +1277,19 @@ resource "google_container_node_pool" "np_with_node_config_scope_alias" {
 func testAccContainerNodePool_version(cluster, np string) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
-	zone = "us-central1-a"
+	location = "us-central1-a"
 }
 
 resource "google_container_cluster" "cluster" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 	min_master_version = "${data.google_container_engine_versions.central1a.latest_master_version}"
 }
 
 resource "google_container_node_pool" "np" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	cluster = "${google_container_cluster.cluster.name}"
 	initial_node_count = 1
 
@@ -1301,19 +1300,19 @@ resource "google_container_node_pool" "np" {
 func testAccContainerNodePool_updateVersion(cluster, np string) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
-	zone = "us-central1-a"
+	location = "us-central1-a"
 }
 
 resource "google_container_cluster" "cluster" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	initial_node_count = 1
 	min_master_version = "${data.google_container_engine_versions.central1a.latest_master_version}"
 }
 
 resource "google_container_node_pool" "np" {
-	name = "%s"
-	zone = "us-central1-a"
+	name     = "%s"
+	location = "us-central1-a"
 	cluster = "${google_container_cluster.cluster.name}"
 	initial_node_count = 1
 
@@ -1325,13 +1324,13 @@ func testAccContainerNodePool_012_ConfigModeAttr1(cluster, np string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
 	name               = "%s"
-	zone = "us-central1-f"
+	location           = "us-central1-f"
 	initial_node_count = 3
 }
 
 resource "google_container_node_pool" "np" {
 	name               = "%s"
-	zone = "us-central1-f"
+	location           = "us-central1-f"
 	cluster            = "${google_container_cluster.cluster.name}"
 	initial_node_count = 1
 
@@ -1348,13 +1347,13 @@ func testAccContainerNodePool_012_ConfigModeAttr2(cluster, np string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
 	name               = "%s"
-	zone               = "us-central1-f"
+	location           = "us-central1-f"
 	initial_node_count = 3
 }
 
 resource "google_container_node_pool" "np" {
 	name               = "%s"
-	zone               = "us-central1-f"
+	location           = "us-central1-f"
 	cluster            = "${google_container_cluster.cluster.name}"
 	initial_node_count = 1
 
@@ -1368,13 +1367,13 @@ func testAccContainerNodePool_EmptyGuestAccelerator(cluster, np string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
 	name               = "%s"
-	zone               = "us-central1-f"
+	location           = "us-central1-f"
 	initial_node_count = 3
 }
 
 resource "google_container_node_pool" "np" {
 	name               = "%s"
-	zone               = "us-central1-f"
+	location           = "us-central1-f"
 	cluster            = "${google_container_cluster.cluster.name}"
 	initial_node_count = 1
 
@@ -1391,13 +1390,13 @@ func testAccContainerNodePool_PartialEmptyGuestAccelerator(cluster, np string, c
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
 	name               = "%s"
-	zone               = "us-central1-f"
+	location           = "us-central1-f"
 	initial_node_count = 3
 }
 
 resource "google_container_node_pool" "np" {
 	name               = "%s"
-	zone               = "us-central1-f"
+	location           = "us-central1-f"
 	cluster            = "${google_container_cluster.cluster.name}"
 	initial_node_count = 1
 
@@ -1419,13 +1418,13 @@ func testAccContainerNodePool_PartialEmptyGuestAccelerator2(cluster, np string) 
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
 	name               = "%s"
-	zone               = "us-central1-f"
+	location           = "us-central1-f"
 	initial_node_count = 3
 }
 
 resource "google_container_node_pool" "np" {
 	name               = "%s"
-	zone               = "us-central1-f"
+	location           = "us-central1-f"
 	cluster            = "${google_container_cluster.cluster.name}"
 	initial_node_count = 1
 

--- a/third_party/terraform/tests/resource_storage_bucket_test.go
+++ b/third_party/terraform/tests/resource_storage_bucket_test.go
@@ -166,30 +166,11 @@ func TestAccStorageBucket_lifecycleRuleStateLive(t *testing.T) {
 		CheckDestroy: testAccStorageBucketDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStorageBucket_lifecycleRule_IsLiveTrue(bucketName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStorageBucketExists(
-						"google_storage_bucket.bucket", bucketName, &bucket),
-					testAccCheckStorageBucketLifecycleConditionState(googleapi.Bool(true), &bucket),
-					resource.TestCheckResourceAttr(
-						"google_storage_bucket.bucket", attrPrefix+"is_live", "true"),
-					resource.TestCheckResourceAttr(
-						"google_storage_bucket.bucket", attrPrefix+"with_state", "LIVE"),
-				),
-			},
-			{
-				ResourceName:      "google_storage_bucket.bucket",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
 				Config: testAccStorageBucket_lifecycleRule_withStateLive(bucketName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
 						"google_storage_bucket.bucket", bucketName, &bucket),
 					testAccCheckStorageBucketLifecycleConditionState(googleapi.Bool(true), &bucket),
-					resource.TestCheckResourceAttr(
-						"google_storage_bucket.bucket", attrPrefix+"is_live", "true"),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", attrPrefix+"with_state", "LIVE"),
 				),
@@ -226,28 +207,7 @@ func TestAccStorageBucket_lifecycleRuleStateArchived(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckStorageBucketExists(
 						"google_storage_bucket.bucket", bucketName, &bucket),
-					testAccCheckStorageBucketLifecycleConditionState(googleapi.Bool(false), &bucket),
-					resource.TestCheckResourceAttr(
-						"google_storage_bucket.bucket", attrPrefix+"is_live", "false"),
-					resource.TestCheckResourceAttr(
-						"google_storage_bucket.bucket", attrPrefix+"with_state", "ARCHIVED"),
-				),
-			},
-			{
-				ResourceName:      "google_storage_bucket.bucket",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccStorageBucket_lifecycleRule_isLiveFalse(bucketName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckStorageBucketExists(
-						"google_storage_bucket.bucket", bucketName, &bucket),
-					testAccCheckStorageBucketLifecycleConditionState(googleapi.Bool(false), &bucket),
-					resource.TestCheckResourceAttr(
-						"google_storage_bucket.bucket", attrPrefix+"is_live", "false"),
-					resource.TestCheckResourceAttr(
-						"google_storage_bucket.bucket", attrPrefix+"with_state", "ARCHIVED"),
+					testAccCheckStorageBucketLifecycleConditionState(nil, &bucket),
 				),
 			},
 			{
@@ -261,8 +221,6 @@ func TestAccStorageBucket_lifecycleRuleStateArchived(t *testing.T) {
 					testAccCheckStorageBucketExists(
 						"google_storage_bucket.bucket", bucketName, &bucket),
 					testAccCheckStorageBucketLifecycleConditionState(googleapi.Bool(false), &bucket),
-					resource.TestCheckResourceAttr(
-						"google_storage_bucket.bucket", attrPrefix+"is_live", "false"),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", attrPrefix+"with_state", "ARCHIVED"),
 				),
@@ -1302,24 +1260,6 @@ resource "google_storage_bucket" "bucket" {
 `, bucketName)
 }
 
-func testAccStorageBucket_lifecycleRule_isLiveFalse(bucketName string) string {
-	return fmt.Sprintf(`
-resource "google_storage_bucket" "bucket" {
-  name          = "%s"
-  lifecycle_rule {
-    action {
-      type = "Delete"
-    }
-
-    condition {
-      age = 10
-      is_live = false
-    }
-  }
-}
-`, bucketName)
-}
-
 func testAccStorageBucket_lifecycleRule_withStateArchived(bucketName string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
@@ -1332,24 +1272,6 @@ resource "google_storage_bucket" "bucket" {
     condition {
       age = 10
       with_state = "ARCHIVED"
-    }
-  }
-}
-`, bucketName)
-}
-
-func testAccStorageBucket_lifecycleRule_IsLiveTrue(bucketName string) string {
-	return fmt.Sprintf(`
-resource "google_storage_bucket" "bucket" {
-  name          = "%s"
-  lifecycle_rule {
-    action {
-      type = "Delete"
-    }
-
-    condition {
-      age = 10
-      is_live = true
     }
   }
 }

--- a/third_party/terraform/website/docs/d/google_container_engine_versions.html.markdown
+++ b/third_party/terraform/website/docs/d/google_container_engine_versions.html.markdown
@@ -46,14 +46,6 @@ Must exactly match the location the cluster will be deployed in, or listed
 versions may not be available. If `location`, `region`, and `zone` are not
 specified, the provider-level zone must be set and is used instead.
 
-* `zone` (Optional, Deprecated) - Zone to list available cluster versions for.
-Should match the zone the cluster will be deployed in. `zone` has been
-deprecated in favour of `location`.
-
-* `region` (Optional, Deprecated) - Region to list available cluster versions
-for. Should match the region the cluster will be deployed in. `region` has been
-deprecated in favour of `location`.
-
 * `project` (Optional) - ID of the project to list available cluster versions for. Should match the project the cluster will be deployed to.
   Defaults to the project that the provider is authenticated with.
 

--- a/third_party/terraform/website/docs/r/compute_network_peering.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_network_peering.html.markdown
@@ -53,9 +53,6 @@ The following arguments are supported:
 
 * `peer_network` - (Required) Resource link of the peer network.
 
-* `auto_create_routes` - (Optional) If set to `true`, the routes between the two networks will
-  be created and managed automatically. Defaults to `true`.
-
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are

--- a/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -61,7 +61,6 @@ resource "google_compute_region_instance_group_manager" "appserver" {
   name = "appserver-igm"
 
   base_instance_name = "app"
-  update_strategy    = "NONE"
   region             = "us-central1"
 
   target_size  = 5

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -114,7 +114,7 @@ master will be created, as well as the default node location. If you specify a
 zone (such as `us-central1-a`), the cluster will be a zonal cluster with a
 single cluster master. If you specify a region (such as `us-west1`), the
 cluster will be a regional cluster with multiple masters spread across zones in
-the region, and with default node locations in those zones as wel
+the region, and with default node locations in those zones as well
 
 * `node_locations` - (Optional) The list of zones in which the cluster's nodes
 are located. Nodes must be in the region of their regional cluster or in the

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -114,19 +114,7 @@ master will be created, as well as the default node location. If you specify a
 zone (such as `us-central1-a`), the cluster will be a zonal cluster with a
 single cluster master. If you specify a region (such as `us-west1`), the
 cluster will be a regional cluster with multiple masters spread across zones in
-the region, and with default node locations in those zones as well.
-
-* `zone` - (Optional, Deprecated) The zone that the cluster master and nodes
-should be created in. If specified, this cluster will be a zonal cluster. `zone`
-has been deprecated in favour of `location`.
-
-* `region` (Optional, Deprecated) The region that the cluster master and nodes
-should be created in. If specified, this cluster will be a [regional clusters](https://cloud.google.com/kubernetes-engine/docs/concepts/multi-zone-and-regional-clusters#regional)
-where the cluster master and nodes (by default) will be created in several zones
-throughout the region. `region` has been deprecated in favour of `location`.
-
-~> Only one of `location`, `zone`, and `region` may be set. If none are set,
-the provider zone is used to create a zonal cluster.
+the region, and with default node locations in those zones as wel
 
 * `node_locations` - (Optional) The list of zones in which the cluster's nodes
 are located. Nodes must be in the region of their regional cluster or in the
@@ -139,14 +127,6 @@ single zone while nodes are present in each of the primary zone and the node
 locations. In contrast, in a regional cluster, cluster master nodes are present
 in multiple zones in the region. For that reason, regional clusters should be
 preferred.
-
-* `additional_zones` - (Optional) The list of zones in which the cluster's nodes
-should be located. These must be in the same region as the cluster zone for
-zonal clusters, or in the region of a regional cluster. In a multi-zonal cluster,
-the number of nodes specified in `initial_node_count` is created in
-all specified zones as well as the primary zone. If specified for a regional
-cluster, nodes will only be created in these zones. `additional_zones` has been
-deprecated in favour of `node_locations`.
 
 * `addons_config` - (Optional) The configuration for addons supported by GKE.
     Structure is documented below.
@@ -232,9 +212,9 @@ Structure is documented below.
     [the docs](https://cloud.google.com/kubernetes-engine/versioning-and-upgrades#specifying_cluster_version)
     describe the various acceptable formats for this field.
 
--> If you are using the `google_container_engine_versions` datasource with a regional cluster, ensure that you have provided a `region`
-to the datasource. A `region` can have a different set of supported versions than its corresponding `zone`s, and not all `zone`s in a
-`region` are guaranteed to support the same version.
+-> If you are using the `google_container_engine_versions` datasource with a regional cluster, ensure that you have provided a `location`
+to the datasource. A region can have a different set of supported versions than its corresponding zones, and not all zones in a
+region are guaranteed to support the same version.
 
 * `monitoring_service` - (Optional) The monitoring service that the cluster
     should write metrics to.
@@ -697,7 +677,7 @@ This resource provides the following
 
 ## Import
 
-GKE clusters can be imported using the `project` , `zone` or `region`, and `name`. If the project is omitted, the default
+GKE clusters can be imported using the `project` , `location`, and `name`. If the project is omitted, the default
 provider value will be used. Examples:
 
 ```

--- a/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -98,20 +98,11 @@ resource "google_container_cluster" "primary" {
 
 ## Argument Reference
 
-* `cluster` - (Required) The cluster to create the node pool for. Cluster must be present in `zone` provided for zonal clusters.
+* `cluster` - (Required) The cluster to create the node pool for. Cluster must be present in `location` provided for zonal clusters.
 
 - - -
 
 * `location` - (Optional) The location (region or zone) of the cluster.
-
-* `zone` - (Optional, Deprecated) The zone in which the cluster resides. `zone`
-has been deprecated in favor of `location`.
-
-* `region` - (Optional, Deprecated) The region in which the cluster resides (for
-regional clusters). `region` has been deprecated in favor of `location`.
-
--> Note: You must specify a `location` for either cluster type or the
-type-specific `region` for regional clusters / `zone` for zonal clusters.
 
 - - -
 

--- a/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -95,9 +95,7 @@ The `condition` block supports the following elements, and requires at least one
 
 * `created_before` - (Optional) Creation date of an object in RFC 3339 (e.g. `2017-06-13`) to satisfy this condition.
 
-* `with_state` - (Optional) Match to live and/or archived objects. Unversioned buckets have only live objects. Supported values include: `"LIVE"`, `"ARCHIVED"`, `"ANY"`. Unset or empty strings will be treated as `ARCHIVED` to maintain backwards compatibility with `is_live`.
-
-* `is_live` - (Optional, Deprecated) Defaults to `false` to match archived objects. If `true`, this condition matches live objects. Unversioned buckets have only live objects.
+* `with_state` - (Optional) Match to live and/or archived objects. Unversioned buckets have only live objects. Supported values include: `"LIVE"`, `"ARCHIVED"`, `"ANY"`.
 
 * `matches_storage_class` - (Optional) [Storage Class](https://cloud.google.com/storage/docs/storage-classes) of objects to satisfy this condition. Supported values include: `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`, `COLDLINE`, `STANDARD`, `DURABLE_REDUCED_AVAILABILITY`.
 

--- a/third_party/terraform/website/docs/version_3_upgrade.html.markdown
+++ b/third_party/terraform/website/docs/version_3_upgrade.html.markdown
@@ -57,6 +57,7 @@ so Terraform knows to manage them.
 - [Resource: `google_compute_forwarding_rule`](#resource-google_compute_forwarding_rule)
 - [Resource: `google_compute_network`](#resource-google_compute_network)
 - [Resource: `google_compute_network_peering`](#resource-google_compute_network_peering)
+- [Resource: `google_compute_region_instance_group_manager`](#resource-google_compute_region_instance_group_manager)
 - [Resource: `google_container_cluster`](#resource-google_container_cluster)
 - [Resource: `google_container_node_pool`](#resource-google_container_node_pool)
 - [Resource: `google_monitoring_alert_policy`](#resource-google_monitoring_alert_policy)
@@ -135,6 +136,13 @@ using this field from Feb 1, 2020 onwards.
 `auto_create_routes` has been removed because it's redundant and not
 user-configurable.
 
+## Resource: `google_compute_region_instance_group_manager`
+
+### `update_strategy` no longer has any effect and is removed
+
+With `rolling_update_policy` removed, `update_strategy` has no effect anymore.
+Before updating, remove it from your config.
+
 ## Resource: `google_container_cluster`
 
 ### `zone`, `region` and `additional_zones` are now removed
@@ -147,13 +155,6 @@ user-configurable.
 ### `zone` and `region` are now removed
 
 `zone` and `region` have been removed in favor of `location`
-
-## Resource: `google_compute_region_instance_group_manager`
-
-### `update_strategy` no longer has any effect and is removed
-
-With `rolling_update_policy` removed, `update_strategy` has no effect anymore.
-Before updating, remove it from your config.
 
 ## Resource: `google_monitoring_alert_policy`
 

--- a/third_party/terraform/website/docs/version_3_upgrade.html.markdown
+++ b/third_party/terraform/website/docs/version_3_upgrade.html.markdown
@@ -50,7 +50,17 @@ so Terraform knows to manage them.
 ## Upgrade Topics
 
 <!-- TOC depthFrom:2 depthTo:2 -->
+
+- [Provider Version Configuration](#provider-version-configuration)
+- [Data Source: `google_container_engine_versions`](#data-source-google_container_engine_versions)
+- [Resource: `google_cloudiot_registry`](#resource-google_cloudiot_registry)
+- [Resource: `google_compute_forwarding_rule`](#resource-google_compute_forwarding_rule)
+- [Resource: `google_compute_network`](#resource-google_compute_network)
+- [Resource: `google_compute_network_peering`](#resource-google_compute_network_peering)
+- [Resource: `google_monitoring_alert_policy`](#resource-google_monitoring_alert_policy)
+- [Resource: `google_monitoring_uptime_check_config`](#resource-google_monitoring_uptime_check_config)
 - [Resource: `google_project_services`](#resource-google_project_services)
+- [Resource: `google_storage_bucket`](#resource-google_storage_bucket)
 
 <!-- /TOC -->
 
@@ -89,6 +99,58 @@ provider "google" {
   version = "~> 3.0.0"
 }
 ```
+
+## Data Source: `google_container_engine_versions`
+
+### `region` and `zone` are now a removed
+
+Use `location` instead.
+
+## Resource: `google_cloudiot_registry`
+
+### `event_notification_config` is now a removed
+
+`event_notification_config` has been removed in favor of
+`event_notification_configs` (plural). Please switch to using the plural field.
+
+## Resource: `google_compute_forwarding_rule`
+
+### `ip_version` is now a removed
+
+`ip_version` is not used for regional forwarding rules.
+
+## Resource: `google_compute_network`
+
+### `ipv4_range` is now a removed
+
+Legacy Networks are deprecated and you will no longer be able to create them
+using this field from Feb 1, 2020 onwards.
+
+## Resource: `google_compute_network_peering`
+
+### `auto_create_routes` is now a removed
+
+`auto_create_routes` has been removed because it's redundant and not
+user-configurable.
+
+## Resource: `google_compute_region_instance_group_manager`
+
+### `update_strategy` no longer has any effect and is removed
+
+With `rolling_update_policy` removed, `update_strategy` has no effect anymore.
+Before updating, remove it from your config.
+
+## Resource: `google_monitoring_alert_policy`
+
+### `labels` is now a removed
+
+`labels` is removed as it was never used. See `user_labels` for the correct field.
+
+## Resource: `google_monitoring_uptime_check_config`
+
+### `is_internal` and `internal_checker` are now a removed
+
+`is_internal` and `internal_checker` never worked, and are now removed.
 
 ## Resource: `google_project_services`
 
@@ -157,3 +219,9 @@ resource "google_project_service" "project_cloudresourcemanager" {
   disable_on_destroy = false
 }
 ```
+
+## Resource: `google_storage_bucket`
+
+### `is_live` is now a removed
+
+Please use `with_state` instead, as `is_live` is now removed.

--- a/third_party/terraform/website/docs/version_3_upgrade.html.markdown
+++ b/third_party/terraform/website/docs/version_3_upgrade.html.markdown
@@ -57,6 +57,8 @@ so Terraform knows to manage them.
 - [Resource: `google_compute_forwarding_rule`](#resource-google_compute_forwarding_rule)
 - [Resource: `google_compute_network`](#resource-google_compute_network)
 - [Resource: `google_compute_network_peering`](#resource-google_compute_network_peering)
+- [Resource: `google_container_cluster`](#resource-google_container_cluster)
+- [Resource: `google_container_node_pool`](#resource-google_container_node_pool)
 - [Resource: `google_monitoring_alert_policy`](#resource-google_monitoring_alert_policy)
 - [Resource: `google_monitoring_uptime_check_config`](#resource-google_monitoring_uptime_check_config)
 - [Resource: `google_project_services`](#resource-google_project_services)
@@ -102,36 +104,49 @@ provider "google" {
 
 ## Data Source: `google_container_engine_versions`
 
-### `region` and `zone` are now a removed
+### `region` and `zone` are now removed
 
 Use `location` instead.
 
 ## Resource: `google_cloudiot_registry`
 
-### `event_notification_config` is now a removed
+### `event_notification_config` is now removed
 
 `event_notification_config` has been removed in favor of
 `event_notification_configs` (plural). Please switch to using the plural field.
 
 ## Resource: `google_compute_forwarding_rule`
 
-### `ip_version` is now a removed
+### `ip_version` is now removed
 
 `ip_version` is not used for regional forwarding rules.
 
 ## Resource: `google_compute_network`
 
-### `ipv4_range` is now a removed
+### `ipv4_range` is now removed
 
 Legacy Networks are deprecated and you will no longer be able to create them
 using this field from Feb 1, 2020 onwards.
 
 ## Resource: `google_compute_network_peering`
 
-### `auto_create_routes` is now a removed
+### `auto_create_routes` is now removed
 
 `auto_create_routes` has been removed because it's redundant and not
 user-configurable.
+
+## Resource: `google_container_cluster`
+
+### `zone`, `region` and `additional_zones` are now removed
+
+`zone` and `region` have been removed in favor of `location` and
+`additional_zones` has been removed in favor of `node_locations`
+
+## Resource: `google_container_node_pool`
+
+### `zone` and `region` are now removed
+
+`zone` and `region` have been removed in favor of `location`
 
 ## Resource: `google_compute_region_instance_group_manager`
 
@@ -142,13 +157,13 @@ Before updating, remove it from your config.
 
 ## Resource: `google_monitoring_alert_policy`
 
-### `labels` is now a removed
+### `labels` is now removed
 
 `labels` is removed as it was never used. See `user_labels` for the correct field.
 
 ## Resource: `google_monitoring_uptime_check_config`
 
-### `is_internal` and `internal_checker` are now a removed
+### `is_internal` and `internal_checker` are now removed
 
 `is_internal` and `internal_checker` never worked, and are now removed.
 
@@ -222,6 +237,6 @@ resource "google_project_service" "project_cloudresourcemanager" {
 
 ## Resource: `google_storage_bucket`
 
-### `is_live` is now a removed
+### `is_live` is now removed
 
 Please use `with_state` instead, as `is_live` is now removed.


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4507

**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
`container`: permanently removed `zone` and `region` fields from data source `google_container_engine_versions`.
```

```release-note:breaking-change
`compute`: permanently removed `ip_version` field from `google_compute_forwarding_rule`.
```

```release-note:breaking-change
`compute`: permanently removed `ipv4_range` field from `google_compute_network`.
```

```release-note:breaking-change
`monitoring`: permanently removed `is_internal` and `internal_checkers` fields from `google_monitoring_uptime_check_config`.
```

```release-note:breaking-change
`monitoring`: permanently removed `labels` field from `google_monitoring_alert_policy`.
```

```release-note:breaking-change
`compute`: permanently removed `auto_create_routes` field from `google_compute_network_peering`.
```

```release-note:breaking-change
`compute`: permanently removed `update_strategy` field from `google_compute_region_instance_group_manager`.
```

```release-note:breaking-change
`container`: permanently removed `zone`, `region` and `additional_zones` fields from `google_container_cluster`.
```

```release-note:breaking-change
`container`: permanently removed `zone` and `region` fields from `google_container_node_pool`.
```

```release-note:breaking-change
`storage`: permanently removed `is_live` flag from `google_storage_bucket`.
```