### PR TITLE
Updating appengine, bigtable, bigquery, cloudbuild, binauth to new id formats

### DIFF
--- a/products/appengine/terraform.yaml
+++ b/products/appengine/terraform.yaml
@@ -25,8 +25,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_env_vars:
           org_id: :ORG_ID
   StandardAppVersion: !ruby/object:Overrides::Terraform::ResourceOverride
-    id_format: "apps/{{project}}/services/{{service}}/versions/{{version_id}}"
-    import_format: ["apps/{{project}}/services/{{service}}/versions/{{version_id}}"]
     mutex: "apps/{{project}}/services/{{service}}"
     parameters:
       service: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/products/appengine/terraform.yaml
+++ b/products/appengine/terraform.yaml
@@ -25,6 +25,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_env_vars:
           org_id: :ORG_ID
   StandardAppVersion: !ruby/object:Overrides::Terraform::ResourceOverride
+    id_format: "apps/{{project}}/services/{{service}}/versions/{{version_id}}"
+    import_format: ["apps/{{project}}/services/{{service}}/versions/{{version_id}}"]
     mutex: "apps/{{project}}/services/{{service}}"
     parameters:
       service: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/products/appengine/terraform.yaml
+++ b/products/appengine/terraform.yaml
@@ -67,8 +67,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     exclude: true
   DomainMapping: !ruby/object:Overrides::Terraform::ResourceOverride
     self_link: 'apps/{{project}}/domainMappings/{{domain_name}}'
-    id_format: "{{domain_name}}"
-    import_format: ["{{domain_name}}"]
+    id_format: 'apps/{{project}}/domainMappings/{{domain_name}}'
+    import_format: ['apps/{{project}}/domainMappings/{{domain_name}}']
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "app_engine_domain_mapping_basic"

--- a/products/appengine/terraform.yaml
+++ b/products/appengine/terraform.yaml
@@ -14,8 +14,8 @@
 --- !ruby/object:Provider::Terraform::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
   FirewallRule: !ruby/object:Overrides::Terraform::ResourceOverride
-    id_format: "{{project}}/{{priority}}"
-    import_format: ["{{project}}/{{priority}}"]
+    id_format: "apps/{{project}}/firewall/ingressRules/{{priority}}"
+    import_format: ["apps/{{project}}/firewall/ingressRules/{{priority}}"]
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "app_engine_firewall_rule_basic"

--- a/products/bigquery/terraform.yaml
+++ b/products/bigquery/terraform.yaml
@@ -15,8 +15,8 @@
 legacy_name: 'bigquery'
 overrides: !ruby/object:Overrides::ResourceOverrides
   Dataset: !ruby/object:Overrides::Terraform::ResourceOverride
-    id_format: "{{project}}:{{dataset_id}}"
-    import_format: ["{{project}}:{{dataset_id}}", "{{project}}/{{dataset_id}}", "{{dataset_id}}"]
+    id_format: "projects/{{project}}/datasets/{{dataset_id}}"
+    import_format: ["projects/{{project}}/datasets/{{dataset_id}}"]
     delete_url: projects/{{project}}/datasets/{{dataset_id}}?deleteContents={{delete_contents_on_destroy}}
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/products/bigtable/terraform.yaml
+++ b/products/bigtable/terraform.yaml
@@ -14,7 +14,7 @@
 --- !ruby/object:Provider::Terraform::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
   AppProfile: !ruby/object:Overrides::Terraform::ResourceOverride
-    id_format: "{{project}}/{{instance}}/{{app_profile_id}}"
+    id_format: "projects/{{project}}/instances/{{instance}}/appProfiles/{{app_profile_id}}"
     import_format: ["projects/{{project}}/instances/{{instance}}/appProfiles/{{app_profile_id}}"]
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/products/binaryauthorization/terraform.yaml
+++ b/products/binaryauthorization/terraform.yaml
@@ -15,7 +15,7 @@
 overrides: !ruby/object:Overrides::ResourceOverrides
   Attestor: !ruby/object:Overrides::Terraform::ResourceOverride
     import_format: ["projects/{{project}}/attestors/{{name}}"]
-    id_format: "{{project}}/{{name}}"
+    id_format: "projects/{{project}}/attestors/{{name}}"
     examples:
      - !ruby/object:Provider::Terraform::Examples
       name: "binary_authorization_attestor_basic"
@@ -54,7 +54,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       attestationAuthorityNote.publicKeys.id: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
   Policy: !ruby/object:Overrides::Terraform::ResourceOverride
-    id_format: "{{project}}"
+    id_format: "projects/{{project}}"
     import_format: ["projects/{{project}}"]
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: 'templates/terraform/constants/binaryauthorization_policy.erb'

--- a/products/cloudbuild/terraform.yaml
+++ b/products/cloudbuild/terraform.yaml
@@ -17,7 +17,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   Trigger: !ruby/object:Overrides::Terraform::ResourceOverride
     # import by default only works with old-style self links ending in a name
     import_format: ["projects/{{project}}/triggers/{{trigger_id}}"]
-    id_format: '{{project}}/{{trigger_id}}'
+    id_format: 'projects/{{project}}/triggers/{{trigger_id}}'
     self_link: 'projects/{{project}}/triggers/{{trigger_id}}'
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/products/cloudfunctions/terraform.yaml
+++ b/products/cloudfunctions/terraform.yaml
@@ -16,7 +16,7 @@ legacy_name: 'cloudfunctions'
 overrides: !ruby/object:Overrides::ResourceOverrides
   CloudFunction: !ruby/object:Overrides::Terraform::ResourceOverride
     legacy_name: 'google_cloudfunctions_function'
-    id_format: '{{project}}/{{region}}/{{cloud_function}}'
+    id_format: 'projects/{{project}}/locations/{{region}}/functions/{{cloud_function}}'
     base_url: projects/{{project}}/locations/{{region}}/functions
     import_format: ["projects/{{project}}/locations/{{region}}/functions/{{cloud_function}}"]
     exclude_resource: true

--- a/products/cloudrun/terraform.yaml
+++ b/products/cloudrun/terraform.yaml
@@ -14,6 +14,8 @@
 --- !ruby/object:Provider::Terraform::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
   DomainMapping: !ruby/object:Overrides::Terraform::ResourceOverride
+    import_format: ['projects/{{project}}/locations/{{location}}/domainmappings/{{name}}']
+    id_format: 'projects/{{project}}/locations/{{location}}/domainmappings/{{name}}'
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "cloud_run_domain_mapping_basic"
@@ -43,6 +45,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       metadata.name: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
   Service: !ruby/object:Overrides::Terraform::ResourceOverride
+    import_format: ['projects/{{project}}/locations/{{location}}/services/{{name}}']
+    id_format: 'projects/{{project}}/locations/{{location}}/services/{{name}}'
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "cloud_run_service_basic"

--- a/third_party/terraform/resources/resource_bigquery_table.go.erb
+++ b/third_party/terraform/resources/resource_bigquery_table.go.erb
@@ -479,7 +479,7 @@ func resourceBigQueryTableCreate(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[INFO] BigQuery table %s has been created", res.Id)
 
-	d.SetId(fmt.Sprintf("%s:%s.%s", res.TableReference.ProjectId, res.TableReference.DatasetId, res.TableReference.TableId))
+	d.SetId(fmt.Sprintf("projects/%s/datasets/%s/tables/%s", res.TableReference.ProjectId, res.TableReference.DatasetId, res.TableReference.TableId))
 
 	return resourceBigQueryTableRead(d, meta)
 }
@@ -847,12 +847,11 @@ type bigQueryTableId struct {
 }
 
 func parseBigQueryTableId(id string) (*bigQueryTableId, error) {
-	// Expected format is "PROJECT:DATASET.TABLE", but the project can itself have . and : in it.
-	// Those characters are not valid dataset or table components, so just split on the last two.
-	matchRegex := regexp.MustCompile("^(.+):([^:.]+)\\.([^:.]+)$")
+	// Expected format is "projects/{{project}}/datasets/{{dataset}}/tables/{{table}}"
+	matchRegex := regexp.MustCompile("^projects/(.+)/datasets/(.+)/tables/(.+)$")
 	subMatches := matchRegex.FindStringSubmatch(id)
 	if subMatches == nil {
-		return nil, fmt.Errorf("Invalid BigQuery table specifier. Expecting {project}:{dataset-id}.{table-id}, got %s", id)
+		return nil, fmt.Errorf("Invalid BigQuery table specifier. Expecting projects/{{project}}/datasets/{{dataset}}/tables/{{table}}, got %s", id)
 	}
 	return &bigQueryTableId{
 		Project:   subMatches[1],

--- a/third_party/terraform/resources/resource_bigtable_instance.go
+++ b/third_party/terraform/resources/resource_bigtable_instance.go
@@ -131,7 +131,11 @@ func resourceBigtableInstanceCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error creating instance. %s", err)
 	}
 
-	d.SetId(conf.InstanceID)
+	id, err := replaceVars(d, config, "projects/{{project}}/instances/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
 
 	return resourceBigtableInstanceRead(d, meta)
 }
@@ -371,7 +375,7 @@ func resourceBigtableInstanceImport(d *schema.ResourceData, meta interface{}) ([
 	}
 
 	// Replace import id for the resource id
-	id, err := replaceVars(d, config, "{{name}}")
+	id, err := replaceVars(d, config, "projects/{{project}}/instances/{{name}}")
 	if err != nil {
 		return nil, fmt.Errorf("Error constructing id: %s", err)
 	}

--- a/third_party/terraform/resources/resource_bigtable_table.go
+++ b/third_party/terraform/resources/resource_bigtable_table.go
@@ -107,7 +107,11 @@ func resourceBigtableTableCreate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	d.SetId(name)
+	id, err := replaceVars(d, config, "projects/{{project}}/instances/{{instance_id}}/tables/{{name}}")
+	if err != nil {
+		return nil, fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
 
 	return resourceBigtableTableRead(d, meta)
 }


### PR DESCRIPTION
Just making sure this is what we want before I go and do a whole bunch of resources

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
