### PR TITLE
Updating bigquery id formats

### DIFF
--- a/products/bigquery/terraform.yaml
+++ b/products/bigquery/terraform.yaml
@@ -15,8 +15,8 @@
 legacy_name: 'bigquery'
 overrides: !ruby/object:Overrides::ResourceOverrides
   Dataset: !ruby/object:Overrides::Terraform::ResourceOverride
-    id_format: "{{project}}:{{dataset_id}}"
-    import_format: ["{{project}}:{{dataset_id}}", "{{project}}/{{dataset_id}}", "{{dataset_id}}"]
+    id_format: "projects/{{project}}/datasets/{{dataset_id}}"
+    import_format: ["projects/{{project}}/datasets/{{dataset_id}}"]
     delete_url: projects/{{project}}/datasets/{{dataset_id}}?deleteContents={{delete_contents_on_destroy}}
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/third_party/terraform/resources/resource_bigquery_table.go.erb
+++ b/third_party/terraform/resources/resource_bigquery_table.go.erb
@@ -479,7 +479,7 @@ func resourceBigQueryTableCreate(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[INFO] BigQuery table %s has been created", res.Id)
 
-	d.SetId(fmt.Sprintf("%s:%s.%s", res.TableReference.ProjectId, res.TableReference.DatasetId, res.TableReference.TableId))
+	d.SetId(fmt.Sprintf("projects/%s/datasets/%s/tables/%s", res.TableReference.ProjectId, res.TableReference.DatasetId, res.TableReference.TableId))
 
 	return resourceBigQueryTableRead(d, meta)
 }
@@ -847,12 +847,11 @@ type bigQueryTableId struct {
 }
 
 func parseBigQueryTableId(id string) (*bigQueryTableId, error) {
-	// Expected format is "PROJECT:DATASET.TABLE", but the project can itself have . and : in it.
-	// Those characters are not valid dataset or table components, so just split on the last two.
-	matchRegex := regexp.MustCompile("^(.+):([^:.]+)\\.([^:.]+)$")
+	// Expected format is "projects/{{project}}/datasets/{{dataset}}/tables/{{table}}"
+	matchRegex := regexp.MustCompile("^projects/(.+)/datasets/(.+)/tables/(.+)$")
 	subMatches := matchRegex.FindStringSubmatch(id)
 	if subMatches == nil {
-		return nil, fmt.Errorf("Invalid BigQuery table specifier. Expecting {project}:{dataset-id}.{table-id}, got %s", id)
+		return nil, fmt.Errorf("Invalid BigQuery table specifier. Expecting "projects/{{project}}/datasets/{{dataset}}/tables/{{table}}", got %s", id)
 	}
 	return &bigQueryTableId{
 		Project:   subMatches[1],

--- a/third_party/terraform/resources/resource_bigquery_table.go.erb
+++ b/third_party/terraform/resources/resource_bigquery_table.go.erb
@@ -851,7 +851,7 @@ func parseBigQueryTableId(id string) (*bigQueryTableId, error) {
 	matchRegex := regexp.MustCompile("^projects/(.+)/datasets/(.+)/tables/(.+)$")
 	subMatches := matchRegex.FindStringSubmatch(id)
 	if subMatches == nil {
-		return nil, fmt.Errorf("Invalid BigQuery table specifier. Expecting "projects/{{project}}/datasets/{{dataset}}/tables/{{table}}", got %s", id)
+		return nil, fmt.Errorf("Invalid BigQuery table specifier. Expecting projects/{{project}}/datasets/{{dataset}}/tables/{{table}}, got %s", id)
 	}
 	return &bigQueryTableId{
 		Project:   subMatches[1],


### PR DESCRIPTION
Update bigquery ID formats to standard form

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
