### PR TITLE
Change default id format from {{name}} to self_link_uri

### DIFF
--- a/overrides/terraform/resource_override.rb
+++ b/overrides/terraform/resource_override.rb
@@ -76,7 +76,7 @@ module Overrides
         @examples ||= []
 
         check :legacy_name, type: String
-        check :id_format, type: String, default: '{{name}}'
+        check :id_format, type: String
         check :examples, item_type: Provider::Terraform::Examples, type: Array, default: []
         check :virtual_fields,
               item_type: Provider::Terraform::VirtualFields,

--- a/products/resourcemanager/terraform.yaml
+++ b/products/resourcemanager/terraform.yaml
@@ -18,7 +18,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     autogen_async: true
     exclude: true
   Lien: !ruby/object:Overrides::Terraform::ResourceOverride
-    id_format: "liens/{{name}}"
+    id_format: "{{name}}"
     import_format: ["{{parent}}/{{name}}"]
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/products/resourcemanager/terraform.yaml
+++ b/products/resourcemanager/terraform.yaml
@@ -18,6 +18,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     autogen_async: true
     exclude: true
   Lien: !ruby/object:Overrides::Terraform::ResourceOverride
+    id_format: "liens/{{name}}"
     import_format: ["{{parent}}/{{name}}"]
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -246,5 +246,12 @@ module Provider
     def extract_identifiers(url)
       url.scan(/\{\{(\w+)\}\}/).flatten
     end
+
+    # Returns the id format of an object, or self_link_uri if none is explicitly defined
+    # We prefer the long name of a resource as the id so that users can reference
+    # resources in a standard way, and most APIs accept short name, long name or self_link
+    def id_format(object)
+      object.id_format || object.self_link_uri
+    end
   end
 end

--- a/templates/terraform/iam_policy.go.erb
+++ b/templates/terraform/iam_policy.go.erb
@@ -260,9 +260,8 @@ func (u *<%= resource_name -%>IamUpdater) qualify<%= object.name -%>Url(methodId
 	return fmt.Sprintf("<%= object.__product.base_url -%>%s<%= object.iam_policy.method_name_separator -%>%s", fmt.Sprintf("<%= import_url -%>", <%= string_qualifiers -%>), methodIdentifier)
 }
 
-<% id_format = object.id_format || object.self_link_uri -%>
 func (u *<%= resource_name -%>IamUpdater) GetResourceId() string {
-	return fmt.Sprintf("<%= id_format.gsub('{{name}}', "{{#{object.name.underscore}}}").gsub(/({{)(\w+)(}})/, '%s') -%>", <%= string_qualifiers -%>)
+	return fmt.Sprintf("<%= id_format(object).gsub('{{name}}', "{{#{object.name.underscore}}}").gsub(/({{)(\w+)(}})/, '%s') -%>", <%= string_qualifiers -%>)
 }
 
 func (u *<%= resource_name -%>IamUpdater) GetMutexKey() string {

--- a/templates/terraform/iam_policy.go.erb
+++ b/templates/terraform/iam_policy.go.erb
@@ -260,8 +260,9 @@ func (u *<%= resource_name -%>IamUpdater) qualify<%= object.name -%>Url(methodId
 	return fmt.Sprintf("<%= object.__product.base_url -%>%s<%= object.iam_policy.method_name_separator -%>%s", fmt.Sprintf("<%= import_url -%>", <%= string_qualifiers -%>), methodIdentifier)
 }
 
+<% id_format = object.id_format || object.self_link_uri -%>
 func (u *<%= resource_name -%>IamUpdater) GetResourceId() string {
-	return fmt.Sprintf("<%= object.id_format.gsub('{{name}}', "{{#{object.name.underscore}}}").gsub(/({{)(\w+)(}})/, '%s') -%>", <%= string_qualifiers -%>)
+	return fmt.Sprintf("<%= id_format.gsub('{{name}}', "{{#{object.name.underscore}}}").gsub(/({{)(\w+)(}})/, '%s') -%>", <%= string_qualifiers -%>)
 }
 
 func (u *<%= resource_name -%>IamUpdater) GetMutexKey() string {

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -191,7 +191,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     }
 
     // Store the ID now
-    id, err := replaceVars(d, config, "<%= object.id_format -%>")
+    id, err := replaceVars(d, config, "<%= object.id_format || object.self_link_uri -%>")
     if err != nil {
         return fmt.Errorf("Error constructing id: %s", err)
     }
@@ -609,7 +609,7 @@ func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{
     }
 
     // Replace import id for the resource id
-    id, err := replaceVars(d, config, "<%= object.id_format -%>")
+    id, err := replaceVars(d, config, "<%= object.id_format || object.self_link_uri -%>")
     if err != nil {
         return nil, fmt.Errorf("Error constructing id: %s", err)
     }

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -191,7 +191,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     }
 
     // Store the ID now
-    id, err := replaceVars(d, config, "<%= object.id_format || object.self_link_uri -%>")
+    id, err := replaceVars(d, config, "<%= id_format(object) -%>")
     if err != nil {
         return fmt.Errorf("Error constructing id: %s", err)
     }
@@ -609,7 +609,7 @@ func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{
     }
 
     // Replace import id for the resource id
-    id, err := replaceVars(d, config, "<%= object.id_format || object.self_link_uri -%>")
+    id, err := replaceVars(d, config, "<%= id_format(object) -%>")
     if err != nil {
         return nil, fmt.Errorf("Error constructing id: %s", err)
     }

--- a/templates/terraform/resource_iam.html.markdown.erb
+++ b/templates/terraform/resource_iam.html.markdown.erb
@@ -164,12 +164,13 @@ exported:
 
 <%= product_ns -%> <%= object.name.downcase -%> IAM resources can be imported using the project, resource identifiers, role and member.
 
+<% id_format = object.id_format || object.self_link_uri -%>
 ```
-$ terraform import <%= resource_ns_iam -%>_policy.editor <%= object.id_format.gsub('{{name}}', "{{#{object.name.underscore}}}") %>
+$ terraform import <%= resource_ns_iam -%>_policy.editor <%= id_format.gsub('{{name}}', "{{#{object.name.underscore}}}") %>
 
-$ terraform import <%= resource_ns_iam -%>_binding.editor "<%= object.id_format.gsub('{{name}}', "{{#{object.name.underscore}}}") -%> <%= object.iam_policy.allowed_iam_role -%>"
+$ terraform import <%= resource_ns_iam -%>_binding.editor "<%= id_format.gsub('{{name}}', "{{#{object.name.underscore}}}") -%> <%= object.iam_policy.allowed_iam_role -%>"
 
-$ terraform import <%= resource_ns_iam -%>_member.editor "<%= object.id_format.gsub('{{name}}', "{{#{object.name.underscore}}}") -%> <%= object.iam_policy.allowed_iam_role -%> jane@example.com"
+$ terraform import <%= resource_ns_iam -%>_member.editor "<%= id_format.gsub('{{name}}', "{{#{object.name.underscore}}}") -%> <%= object.iam_policy.allowed_iam_role -%> jane@example.com"
 ```
 
 -> If you're importing a resource with beta features, make sure to include `-provider=google-beta`

--- a/templates/terraform/resource_iam.html.markdown.erb
+++ b/templates/terraform/resource_iam.html.markdown.erb
@@ -164,13 +164,12 @@ exported:
 
 <%= product_ns -%> <%= object.name.downcase -%> IAM resources can be imported using the project, resource identifiers, role and member.
 
-<% id_format = object.id_format || object.self_link_uri -%>
 ```
-$ terraform import <%= resource_ns_iam -%>_policy.editor <%= id_format.gsub('{{name}}', "{{#{object.name.underscore}}}") %>
+$ terraform import <%= resource_ns_iam -%>_policy.editor <%= id_format(object).gsub('{{name}}', "{{#{object.name.underscore}}}") %>
 
-$ terraform import <%= resource_ns_iam -%>_binding.editor "<%= id_format.gsub('{{name}}', "{{#{object.name.underscore}}}") -%> <%= object.iam_policy.allowed_iam_role -%>"
+$ terraform import <%= resource_ns_iam -%>_binding.editor "<%= id_format(object).gsub('{{name}}', "{{#{object.name.underscore}}}") -%> <%= object.iam_policy.allowed_iam_role -%>"
 
-$ terraform import <%= resource_ns_iam -%>_member.editor "<%= id_format.gsub('{{name}}', "{{#{object.name.underscore}}}") -%> <%= object.iam_policy.allowed_iam_role -%> jane@example.com"
+$ terraform import <%= resource_ns_iam -%>_member.editor "<%= id_format(object).gsub('{{name}}', "{{#{object.name.underscore}}}") -%> <%= object.iam_policy.allowed_iam_role -%> jane@example.com"
 ```
 
 -> If you're importing a resource with beta features, make sure to include `-provider=google-beta`


### PR DESCRIPTION
This fits our goal of ids being useful by default

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
