### PR TITLE
Add userinfo.email to default scopes

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_client_openid_userinfo.go
+++ b/third_party/terraform/data_sources/data_source_google_client_openid_userinfo.go
@@ -26,7 +26,7 @@ func dataSourceGoogleClientOpenIDUserinfoRead(d *schema.ResourceData, meta inter
 	// URL retrieved from https://accounts.google.com/.well-known/openid-configuration
 	res, err := sendRequest(config, "GET", "", "https://openidconnect.googleapis.com/v1/userinfo", nil)
 	if err != nil {
-		return fmt.Errorf("error retrieving userinfo for your provider credentials; have you enabled the 'https://www.googleapis.com/auth/userinfo.email' scope? error: %s", err)
+		return fmt.Errorf("error retrieving userinfo for your provider credentials. have you enabled the 'https://www.googleapis.com/auth/userinfo.email' scope? error: %s", err)
 	}
 
 	d.SetId(time.Now().UTC().String())

--- a/third_party/terraform/tests/data_source_google_client_openid_userinfo_test.go
+++ b/third_party/terraform/tests/data_source_google_client_openid_userinfo_test.go
@@ -24,23 +24,5 @@ func TestAccDataSourceGoogleClientOpenIDUserinfo_basic(t *testing.T) {
 }
 
 const testAccCheckGoogleClientOpenIDUserinfo_basic = `
-provider "google" {
-  alias = "google-scoped"
-
-  # We need to add an additional scope to test this; because our tests rely on
-  # every env var being set, we can just add an alias with the appropriate
-  # scopes. This will fail if someone uses an access token instead of creds
-  # unless they've configured the userinfo.email scope.
-  scopes = [
-    "https://www.googleapis.com/auth/compute",
-    "https://www.googleapis.com/auth/cloud-platform",
-    "https://www.googleapis.com/auth/ndev.clouddns.readwrite",
-    "https://www.googleapis.com/auth/devstorage.full_control",
-    "https://www.googleapis.com/auth/userinfo.email",
-  ]
-}
-
-data "google_client_openid_userinfo" "me" {
-  provider = "google.google-scoped"
-}
+data "google_client_openid_userinfo" "me" {}
 `

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -193,6 +193,7 @@ var defaultClientScopes = []string{
 	"https://www.googleapis.com/auth/cloud-platform",
 	"https://www.googleapis.com/auth/ndev.clouddns.readwrite",
 	"https://www.googleapis.com/auth/devstorage.full_control",
+	"https://www.googleapis.com/auth/userinfo.email",
 }
 
 func (c *Config) LoadAndValidate() error {

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -264,13 +264,6 @@ resource "google_compute_address" "default" {
 // which causes the create to fail unless user_project_override is set to true.
 func testAccProviderUserProjectOverride(pid, name, org, billing, sa string) string {
 	return fmt.Sprintf(`
-provider "google" {
-  scopes = [
-    "https://www.googleapis.com/auth/cloud-platform",
-    "https://www.googleapis.com/auth/userinfo.email",
-  ]
-}
-
 resource "google_project" "project-1" {
 	project_id      = "%s"
 	name            = "%s"

--- a/third_party/terraform/website/docs/d/datasource_google_client_openid_userinfo.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_client_openid_userinfo.html.markdown
@@ -11,9 +11,8 @@ description: |-
 Get OpenID userinfo about the credentials used with the Google provider,
 specifically the email.
 
-When the `https://www.googleapis.com/auth/userinfo.email` scope is enabled in
-your provider block, this datasource enables you to export the email of the
-account you've authenticated the provider with; this can be used alongside
+This datasource enables you to export the email of the account you've
+authenticated the provider with; this can be used alongside
 `data.google_client_config`'s `access_token` to perform OpenID Connect
 authentication with GKE and configure an RBAC role for the email used.
 
@@ -24,16 +23,6 @@ receive an error otherwise.
 ## Example Usage - exporting an email
 
 ```hcl
-provider "google" {
-  scopes = [
-    "https://www.googleapis.com/auth/compute",
-    "https://www.googleapis.com/auth/cloud-platform",
-    "https://www.googleapis.com/auth/ndev.clouddns.readwrite",
-    "https://www.googleapis.com/auth/devstorage.full_control",
-    "https://www.googleapis.com/auth/userinfo.email",
-  ]
-}
-
 data "google_client_openid_userinfo" "me" {}
 
 output "my-email" {
@@ -44,16 +33,6 @@ output "my-email" {
 ## Example Usage - OpenID Connect w/ Kubernetes provider + RBAC IAM role
 
 ```hcl
-provider "google" {
-  scopes = [
-    "https://www.googleapis.com/auth/compute",
-    "https://www.googleapis.com/auth/cloud-platform",
-    "https://www.googleapis.com/auth/ndev.clouddns.readwrite",
-    "https://www.googleapis.com/auth/devstorage.full_control",
-    "https://www.googleapis.com/auth/userinfo.email",
-  ]
-}
-
 data "google_client_openid_userinfo" "provider_identity" {}
 
 data "google_client_config" "provider" {}

--- a/third_party/terraform/website/docs/provider_reference.html.markdown
+++ b/third_party/terraform/website/docs/provider_reference.html.markdown
@@ -213,6 +213,7 @@ an access token using the service account key specified in `credentials`.
     * https://www.googleapis.com/auth/cloud-platform
     * https://www.googleapis.com/auth/ndev.clouddns.readwrite
     * https://www.googleapis.com/auth/devstorage.full_control
+    * https://www.googleapis.com/auth/userinfo.email
 
 ---
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4672

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
added the `https://www.googleapis.com/auth/userinfo.email` scope to the provider by default
```
