### PR TITLE
Add support for one-field-at-a-time update to Subnetwork

### DIFF
--- a/api/type.rb
+++ b/api/type.rb
@@ -35,8 +35,20 @@ module Api
       attr_reader :input # If set to true value is used only on creation
       attr_reader :url_param_only # If, true will not be send in request body
       attr_reader :required
+
       attr_reader :update_verb
       attr_reader :update_url
+      # Some updates only allow updating certain fields at once (generally each
+      # top-level field can be updated one-at-a-time). If this is set, we group
+      # fields to update by (verb, url, fingerprint, id) instead of just
+      # (verb, url, fingerprint), to allow multiple fields to reuse the same
+      # endpoints.
+      attr_reader :update_id
+      # THe fingerprint value required to update this field. Downstreams should
+      # GET the resource and parse the fingerprint value while doing each update
+      # call. This ensures we can supply the fingerprint to each distinct
+      # request.
+      attr_reader :fingerprint_name
       # If true, we will include the empty value in requests made including
       # this attribute (both creates and updates).  This rarely needs to be
       # set to true, and corresponds to both the "NullFields" and
@@ -91,6 +103,8 @@ module Api
                           default: @__resource&.update_verb
 
       check :update_url, type: ::String
+      check :update_id, type: ::String
+      check :fingerprint_name, type: ::String
       check :pattern, type: ::String
 
       check_default_value_property

--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -272,6 +272,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           * https://www.googleapis.com/compute/v1/projects/project/global/gateways/default-internet-gateway
           * projects/project/global/gateways/default-internet-gateway
           * global/gateways/default-internet-gateway
+  Subnetwork: !ruby/object:Overrides::Ansible::ResourceOverride
+    properties:
+      fingerprint: !ruby/object:Overrides::Ansible::PropertyOverride
+        update_verb: :PATCH
+        update_url:  projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
   TargetPool: !ruby/object:Overrides::Ansible::ResourceOverride
     transport: !ruby/object:Overrides::Ansible::Transport
       encoder: encode_request

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -8722,14 +8722,15 @@ objects:
           Whether to enable flow logging for this subnetwork.
         update_verb: :PATCH
         update_url:  projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
+        update_id: 'enableFlowLogs'
+        fingerprint_name: 'fingerprint'
         send_empty_value: true
+      # TODO(rileykarson): Remove this field from downstreams.
       - !ruby/object:Api::Type::Fingerprint
         name: 'fingerprint'
         description: |
           Fingerprint of this resource. This field is used internally during
           updates of this resource.
-        update_verb: :PATCH
-        update_url:  projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
       - !ruby/object:Api::Type::Enum
         name: 'purpose'
         min_version: beta
@@ -8750,6 +8751,8 @@ objects:
         min_version: beta
         update_verb: :PATCH
         update_url: projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
+        update_id: 'role'
+        fingerprint_name: 'fingerprint'
         values:
           - :ACTIVE
           - :BACKUP
@@ -8768,6 +8771,8 @@ objects:
           to either primary or secondary ranges.
         update_verb: :PATCH
         update_url:  projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
+        update_id: 'secondaryIpRanges'
+        fingerprint_name: 'fingerprint'
         item_type: !ruby/object:Api::Type::NestedObject
           properties:
             - !ruby/object:Api::Type::String

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -8725,7 +8725,7 @@ objects:
         update_id: 'enableFlowLogs'
         fingerprint_name: 'fingerprint'
         send_empty_value: true
-      # TODO(rileykarson): Remove this field from downstreams.
+      # TODO(rileykarson): Work with rambleraptor to remove this field from downstreams.
       - !ruby/object:Api::Type::Fingerprint
         name: 'fingerprint'
         description: |

--- a/products/iam/helpers/ansible/service_account_key_template.erb
+++ b/products/iam/helpers/ansible/service_account_key_template.erb
@@ -21,7 +21,7 @@ __metaclass__ = type
 -%>
 
 <%
-  update_props = properties_by_custom_update(object.all_user_properties)
+  update_props = properties_by_custom_update(object.all_user_properties, :old)
   import = 'from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest'
   import += ', remove_nones_from_dict' unless properties_with_classes(object.all_user_properties).empty?
   import += ', replace_resource_dict' if nonreadonly_rrefs(object)

--- a/products/storage/helpers/ansible/object_template.erb
+++ b/products/storage/helpers/ansible/object_template.erb
@@ -21,7 +21,7 @@ __metaclass__ = type
 -%>
 
 <%
-  update_props = properties_by_custom_update(object.all_user_properties)
+  update_props = properties_by_custom_update(object.all_user_properties, :old)
   import = 'from ansible.module_utils.gcp_utils import navigate_hash, GcpSession, GcpModule, GcpRequest'
   import += ', remove_nones_from_dict' unless properties_with_classes(object.all_user_properties).empty?
   import += ', replace_resource_dict' if nonreadonly_rrefs(object)

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -282,12 +282,25 @@ module Provider
 
     # Filter the properties to keep only the ones requiring custom update
     # method and group them by update url & verb.
-    def properties_by_custom_update(properties)
+    def properties_by_custom_update(properties, behavior = :new)
       update_props = properties.reject do |p|
         p.update_url.nil? || p.update_verb.nil? || p.update_verb == :NOOP
       end
-      update_props.group_by do |p|
-        { update_url: p.update_url, update_verb: p.update_verb, update_id: p.update_id, fingerprint_name: p.fingerprint_name }
+
+      # TODO(rambleraptor): Add support to Ansible for one-at-a-time updates.
+      if behavior == :old
+        update_props.group_by do |p|
+          { update_url: p.update_url, update_verb: p.update_verb }
+        end
+      else
+        update_props.group_by do |p|
+          {
+            update_url: p.update_url,
+            update_verb: p.update_verb,
+            update_id: p.update_id,
+            fingerprint_name: p.fingerprint_name
+          }
+        end
       end
     end
 
@@ -297,7 +310,9 @@ module Provider
     # the contents of the flattened object
     def custom_update_properties_by_key(properties, key)
       properties_by_custom_update(properties).select do |k, _|
-        k[:update_url] == key[:update_url] && k[:update_id] == key[:update_id] && k[:fingerprint_name] == key[:fingerprint_name]
+        k[:update_url] == key[:update_url] &&
+          k[:update_id] == key[:update_id] &&
+          k[:fingerprint_name] == key[:fingerprint_name]
       end.first.last
       # .first is to grab the element from the select which returns a list
       # .last is because properties_by_custom_update returns a list of

--- a/provider/core.rb
+++ b/provider/core.rb
@@ -287,7 +287,7 @@ module Provider
         p.update_url.nil? || p.update_verb.nil? || p.update_verb == :NOOP
       end
       update_props.group_by do |p|
-        { update_url: p.update_url, update_verb: p.update_verb }
+        { update_url: p.update_url, update_verb: p.update_verb, update_id: p.update_id, fingerprint_name: p.fingerprint_name }
       end
     end
 
@@ -295,9 +295,9 @@ module Provider
     # that can be updated at that URL. This allows flattened objects
     # to determine which parent property in the API should be updated with
     # the contents of the flattened object
-    def custom_update_properties_by_url(properties, update_url)
+    def custom_update_properties_by_key(properties, key)
       properties_by_custom_update(properties).select do |k, _|
-        k[:update_url] == update_url
+        k[:update_url] == key[:update_url] && k[:update_id] == key[:update_id] && k[:fingerprint_name] == key[:fingerprint_name]
       end.first.last
       # .first is to grab the element from the select which returns a list
       # .last is because properties_by_custom_update returns a list of

--- a/spec/provider_terraform_spec.rb
+++ b/spec/provider_terraform_spec.rb
@@ -117,10 +117,25 @@ describe Provider::Terraform do
 
       it do
         is_expected.to eq(
-          { update_url: 'url1', update_verb: :POST } =>
+          {
+            update_url: 'url1',
+            update_verb: :POST,
+            update_id: nil,
+            fingerprint_name: nil
+          } =>
             [postUrl1, otherPostUrl1],
-          { update_url: 'url2', update_verb: :POST } => [postUrl2],
-          { update_url: 'url2', update_verb: :PUT } => [putUrl2]
+          {
+            update_url: 'url2',
+            update_verb: :POST,
+            update_id: nil,
+            fingerprint_name: nil
+          } => [postUrl2],
+          {
+            update_url: 'url2',
+            update_verb: :PUT,
+            update_id: nil,
+            fingerprint_name: nil
+          } => [putUrl2]
         )
       end
     end

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -19,7 +19,7 @@ __metaclass__ = type
                                   .map(&:resource_ref)
                                   .uniq
 
-  update_props = properties_by_custom_update(object.all_user_properties)
+  update_props = properties_by_custom_update(object.all_user_properties, :old)
 -%>
 
 <%

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -265,7 +265,6 @@ def update_fields(module, request, response):
 
 
 <% update_props.each do |key, props| -%>
-<% req_props = (key[:fingerprint_name] != nil ? props +   -%>
 <% func_name = "#{props.first.name.underscore}_update" -%>
 <% unless object.hidden.include?(func_name) -%>
 def <%= func_name -%>(module, request, response):

--- a/templates/ansible/resource.erb
+++ b/templates/ansible/resource.erb
@@ -265,6 +265,7 @@ def update_fields(module, request, response):
 
 
 <% update_props.each do |key, props| -%>
+<% req_props = (key[:fingerprint_name] != nil ? props +   -%>
 <% func_name = "#{props.first.name.underscore}_update" -%>
 <% unless object.hidden.include?(func_name) -%>
 def <%= func_name -%>(module, request, response):

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -344,7 +344,28 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
 <%  properties_by_custom_update(object.root_properties).each do |key, props| -%>
 if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' || ' -%> {
         obj := make(map[string]interface{})
-<%      custom_update_properties_by_url(properties, key[:update_url]).each do |prop| -%>
+
+<%-      unless key[:fingerprint_name] == nil -%>
+        getUrl, err := replaceVars(d, config, "<%= "{{#{object.__product.name}BasePath}}#{object.self_link_uri}" -%>")
+        if err != nil {
+            return err
+        }
+
+<%         if has_project -%>
+        project, err := getProject(d, config)
+        if err != nil {
+            return err
+        }
+<%         end -%>
+        getRes, err := sendRequest(config, "<%= object.read_verb.to_s.upcase -%>", <% if has_project %>project<% else %>""<% end %>, getUrl, nil)
+        if err != nil {
+            return handleNotFoundError(err, d, fmt.Sprintf("<%= resource_name -%> %q", d.Id()))
+        }
+
+        obj["<%= key[:fingerprint_name] %>"] = getRes["<%= key[:fingerprint_name] %>"]
+
+<%       end # unless key[:fingerprint_name] -%>
+<%      custom_update_properties_by_key(properties, key).each do |prop| -%>
         <% schemaPrefix = prop.flatten_object ? "nil" : "d.Get( \"#{prop.name.underscore}\" )" -%>
         <%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(<%= schemaPrefix -%>, d, config)
         if err != nil {
@@ -398,13 +419,13 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
         }
 
 <%      if !object.async.nil? && object.async.allow?('update') -%>
-<% if object.autogen_async -%>
+<%        if object.autogen_async -%>
 
         err = <%= client_name_camel -%>OperationWaitTime(
             config, res, <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
             int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 
-<% else -%>
+<%        else -%>
         op := &<%= client_name_lower -%>.Operation{}
         err = Convert(res, op)
         if err != nil {
@@ -415,7 +436,7 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
             config.client<%= client_name_pascal -%>, op, <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
             int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 
-<% end -%>
+<%        end -%>
         if err != nil {
             return err
         }


### PR DESCRIPTION
Part of https://github.com/terraform-providers/terraform-provider-google/issues/3628

This adds support for updating fields one at a time, a requirement for subnetwork and at least 1 other resource. This required upgrading `fingerprint` from an output-only property that's hacked in to requests to a property of the request, since the old solution could only include it in a single request. https://github.com/GoogleCloudPlatform/magic-modules/issues/2477 filed to finish that work; this makes the minimal change to subnetwork.

Followups will use `fingerprint_name` on other resources, and begin removing `Api::Type::Fingerprint` fields altogether.

/cc @rambleraptor: The Ansible changes were more involved than I wanted to make because `ansible/resource.erb` creates the request object by filtering directly on the properties of the update URL (TF had an easy point to inject the fingerprint value), so I shimmed in the legacy behaviour for now. It's pretty gross, and I'd like to remove it.

Do you have a few cycles this week/next to align Ansible with TF so that we can roll the fingerprint (property) removal forward?

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
`compute`: added support for updating multiple fields at once to `google_compute_subnetwork`
```
