### PR TITLE
[Ansible] Stop building deprecated facts modules in collections

### DIFF
--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -291,14 +291,6 @@ module Provider
                                 "plugins/modules/#{name}_info.py"),
                       self)
 
-        # Generate symlink for old `facts` modules.
-        return if version_added(data.object, :facts) >= '2.9'
-
-        deprecated_facts_path = File.join(target_folder,
-                                          "plugins/modules/_#{name}_facts.py")
-        return if File.exist?(deprecated_facts_path)
-
-        File.symlink "#{name}_info.py", deprecated_facts_path
       end
 
       def generate_objects(output_folder, types)

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -290,7 +290,6 @@ module Provider
                       File.join(target_folder,
                                 "plugins/modules/#{name}_info.py"),
                       self)
-
       end
 
       def generate_objects(output_folder, types)

--- a/templates/ansible/facts.erb
+++ b/templates/ansible/facts.erb
@@ -26,9 +26,7 @@ DOCUMENTATION = '''
 ---
 <%= ansible_style_yaml({
   'module' => "#{module_name(object)}_info",
-  'description' => ["Gather info for GCP #{object.name}",
-                    (version_added(object, :facts) < '2.9' ? "This module was called C(#{module_name(object)}_facts) before Ansible 2.9. The usage has not changed." : nil)
-                   ].compact,
+  'description' => ["Gather info for GCP #{object.name}"],
   'short_description' => "Gather info for GCP #{object.name}",
   'version_added' => version_added(object, :facts),
   'author' => "Google Inc. (@googlecloudplatform)",
@@ -91,11 +89,6 @@ def main():
   })), 12)
 -%>
     )
-<% if version_added(object, :facts) < '2.9' -%>
-
-    if module._name == '<%= module_name(object) -%>_facts':
-        module.deprecate("The '<%= module_name(object) -%>_facts' module has been renamed to '<%= module_name(object) -%>_info'", version='2.13')
-<% end -%>
 
     if not module.params['scopes']:
         module.params['scopes'] = <%= python_literal(object.__product.scopes) %>


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->
In ansible/ansible, we build two versions of "datasources": a deprecated "facts" modules and a "info" module. Both are identical.

In collections world, we've decided not to include the deprecated facts modules.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
