### PR TITLE
Add note about using 2.13.0 in google_project_services deprecation

### DIFF
--- a/third_party/terraform/resources/resource_google_project_services.go
+++ b/third_party/terraform/resources/resource_google_project_services.go
@@ -26,7 +26,8 @@ func resourceGoogleProjectServices() *schema.Resource {
 		DeprecationMessage: "google_project_services is deprecated - many users reported " +
 			"issues with dependent services that were not resolvable.  Please use google_project_service or the " +
 			"https://github.com/terraform-google-modules/terraform-google-project-factory/tree/master/modules/project_services" +
-			" module.  This resource will be removed in version 3.0.0.",
+			" module.  It's recommended that you use a provider version of 2.13.0 or higher when you migrate so that requests are" +
+			" batched to the API, reducing the request rate. This resource will be removed in version 3.0.0.",
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(20 * time.Minute),

--- a/third_party/terraform/website/docs/version_3_upgrade.html.markdown
+++ b/third_party/terraform/website/docs/version_3_upgrade.html.markdown
@@ -147,6 +147,11 @@ Users should migrate to using `google_project_service` resources, or using the
 [`"terraform-google-modules/project-factory/google//modules/project_services"`](https://registry.terraform.io/modules/terraform-google-modules/project-factory/google/3.3.0/submodules/project_services)
 module for a similar interface to `google_project_services`.
 
+-> Prior to `2.13.0`, each `google_project_service` sent separate API enablement
+requests. From `2.13.0` onwards, those requests are batched. It's recommended
+that you upgrade to `2.13.0+` before migrating if you encounter quota issues
+when you migrate off `google_project_services`.
+
 #### Old Config
 
 ```hcl


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4689

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
