### PR TITLE
only allow instance templates with 375gb scratch disks

### DIFF
--- a/third_party/terraform/resources/resource_compute_instance_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_template.go
@@ -522,6 +522,11 @@ func resourceComputeInstanceTemplateSourceImageCustomizeDiff(diff *schema.Resour
 }
 
 func resourceComputeInstanceTemplateScratchDiskCustomizeDiff(diff *schema.ResourceDiff, meta interface{}) error {
+	// separate func to allow unit testing
+	return resourceComputeInstanceTemplateScratchDiskCustomizeDiffFunc(diff)
+}
+
+func resourceComputeInstanceTemplateScratchDiskCustomizeDiffFunc(diff TerraformResourceDiff) error {
 	numDisks := diff.Get("disk.#").(int)
 	for i := 0; i < numDisks; i++ {
 		// misspelled on purpose, type is a special symbol
@@ -533,6 +538,11 @@ func resourceComputeInstanceTemplateScratchDiskCustomizeDiff(diff *schema.Resour
 
 		if diskType == "local-ssd" && typee != "SCRATCH" {
 			return fmt.Errorf("disks with a disk_type of local-ssd must be SCRATCH disks. disk %d is a %s disk", i, typee)
+		}
+
+		diskSize := diff.Get(fmt.Sprintf("disk.%d.disk_size_gb", i)).(int)
+		if typee == "SCRATCH" && diskSize != 375 {
+			return fmt.Errorf("SCRATCH disks must be exactly 375GB, disk %d is %d", i, diskSize)
 		}
 	}
 

--- a/third_party/terraform/utils/test_utils.go
+++ b/third_party/terraform/utils/test_utils.go
@@ -72,6 +72,10 @@ func (d *ResourceDiffMock) GetChange(key string) (interface{}, interface{}) {
 	return d.Before[key], d.After[key]
 }
 
+func (d *ResourceDiffMock) Get(key string) interface{} {
+	return d.After[key]
+}
+
 func (d *ResourceDiffMock) Clear(key string) error {
 	if d.Cleared == nil {
 		d.Cleared = map[string]struct{}{}

--- a/third_party/terraform/utils/utils.go.erb
+++ b/third_party/terraform/utils/utils.go.erb
@@ -30,6 +30,7 @@ type TerraformResourceData interface {
 
 type TerraformResourceDiff interface {
 	GetChange(string) (interface{}, interface{})
+	Get(string) interface{}
 	Clear(string) error
 }
 


### PR DESCRIPTION
As per docs at https://cloud.google.com/compute/docs/disks/local-ssd. Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4417.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
`compute`: added check to only allow `google_compute_instance_template`s with 375gb scratch disks
```
