### PR TITLE
Added support for GCS IAM policies

### DIFF
--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -78,6 +78,8 @@ module Provider
                         'third_party/validator/sql_database_instance.go'],
                        ['google/storage_bucket.go',
                         'third_party/validator/storage_bucket.go'],
+                       ['google/storage_bucket_iam.go',
+                        'third_party/validator/storage_bucket_iam.go'],
                        ['google/iam_helpers.go',
                         'third_party/validator/iam_helpers.go'],
                        ['google/iam_helpers_test.go',

--- a/third_party/validator/storage_bucket_iam.go
+++ b/third_party/validator/storage_bucket_iam.go
@@ -1,0 +1,52 @@
+package google
+
+import "fmt"
+
+func GetBucketIamPolicyCaiObject(d TerraformResourceData, config *Config) (Asset, error) {
+	return newBucketIamAsset(d, config, expandIamPolicyBindings)
+}
+
+func GetBucketIamBindingCaiObject(d TerraformResourceData, config *Config) (Asset, error) {
+	return newBucketIamAsset(d, config, expandIamRoleBindings)
+}
+
+func GetBucketIamMemberCaiObject(d TerraformResourceData, config *Config) (Asset, error) {
+	return newBucketIamAsset(d, config, expandIamMemberBindings)
+}
+
+func MergeBucketIamPolicy(existing, incoming Asset) Asset {
+	existing.IAMPolicy = incoming.IAMPolicy
+	return existing
+}
+
+func MergeBucketIamBinding(existing, incoming Asset) Asset {
+	return mergeIamAssets(existing, incoming, mergeAuthoritativeBindings)
+}
+
+func MergeBucketIamMember(existing, incoming Asset) Asset {
+	return mergeIamAssets(existing, incoming, mergeAdditiveBindings)
+}
+
+func newBucketIamAsset(
+	d TerraformResourceData,
+	config *Config,
+	expandBindings func(d TerraformResourceData) ([]IAMBinding, error),
+) (Asset, error) {
+	bindings, err := expandBindings(d)
+	if err != nil {
+		return Asset{}, fmt.Errorf("expanding bindings: %v", err)
+	}
+
+	name, err := assetName(d, config, "//storage.googleapis.com/{{name}}")
+	if err != nil {
+		return Asset{}, err
+	}
+
+	return Asset{
+		Name: name,
+		Type: "storage.googleapis.com/Bucket",
+		IAMPolicy: &IAMPolicy{
+			Bindings: bindings,
+		},
+	}, nil
+}


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->
Since the storage bucket mapper is manual, it would seem the IAM for it would need to be as well. This follows the same pattern of the project IAM to merge the `iam_policy` attribute into the `Asset` object.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Added support for GCS IAM policy bindings
```
