### PR TITLE
handle cloudfunctions deprecating nodejs6

### DIFF
--- a/templates/inspec/tests/integration/build/gcp-mm.tf
+++ b/templates/inspec/tests/integration/build/gcp-mm.tf
@@ -591,7 +591,7 @@ resource "google_cloudfunctions_function" "function" {
   trigger_http          = "${var.cloudfunction["trigger_http"]}"
   timeout               = "${var.cloudfunction["timeout"]}"
   entry_point           = "${var.cloudfunction["entry_point"]}"
-  runtime               = "nodejs6"
+  runtime               = "nodejs8"
 
   environment_variables = {
     MY_ENV_VAR = "${var.cloudfunction["env_var_value"]}"

--- a/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -191,7 +191,6 @@ func resourceCloudFunctionsFunction() *schema.Resource {
 			"runtime": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"nodejs8", "nodejs10", "python37", "go111"}, false),
 			},
 
 			"service_account_email": {

--- a/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -189,9 +189,9 @@ func resourceCloudFunctionsFunction() *schema.Resource {
 			},
 
 			"runtime": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Default:  "nodejs6",
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice([]string{"nodejs8", "nodejs10", "python37", "go111"}, false),
 			},
 
 			"service_account_email": {

--- a/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
+++ b/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
@@ -524,7 +524,7 @@ resource "google_storage_bucket_object" "archive" {
 
 resource "google_cloudfunctions_function" "function" {
   name                  = "%s"
-  runtime				= "nodejs8"
+  runtime               = "nodejs8"
   description           = "test function"
   available_memory_mb   = 128
   source_archive_bucket = "${google_storage_bucket.bucket.name}"
@@ -660,7 +660,7 @@ resource "google_storage_bucket_object" "archive" {
 
 resource "google_cloudfunctions_function" "function" {
   name                  = "%s"
-  runtime				= "nodejs8"
+  runtime               = "nodejs8"
   available_memory_mb   = 128
   source_archive_bucket = "${google_storage_bucket.bucket.name}"
   source_archive_object = "${google_storage_bucket_object.archive.name}"
@@ -688,7 +688,7 @@ resource "google_storage_bucket_object" "archive" {
 
 resource "google_cloudfunctions_function" "function" {
   name                  = "%s"
-  runtime				= "nodejs8"
+  runtime               = "nodejs8"
   available_memory_mb   = 128
   source_archive_bucket = "${google_storage_bucket.bucket.name}"
   source_archive_object = "${google_storage_bucket_object.archive.name}"

--- a/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
+++ b/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
@@ -524,6 +524,7 @@ resource "google_storage_bucket_object" "archive" {
 
 resource "google_cloudfunctions_function" "function" {
   name                  = "%s"
+  runtime				= "nodejs8"
   description           = "test function"
   available_memory_mb   = 128
   source_archive_bucket = "${google_storage_bucket.bucket.name}"
@@ -628,7 +629,7 @@ resource "google_storage_bucket_object" "archive" {
 
 resource "google_cloudfunctions_function" "function" {
   name                  = "%s"
-  runtime               = "nodejs6"
+  runtime               = "nodejs8"
   available_memory_mb   = 128
   source_archive_bucket = "${google_storage_bucket.bucket.name}"
   source_archive_object = "${google_storage_bucket_object.archive.name}"
@@ -659,6 +660,7 @@ resource "google_storage_bucket_object" "archive" {
 
 resource "google_cloudfunctions_function" "function" {
   name                  = "%s"
+  runtime				= "nodejs8"
   available_memory_mb   = 128
   source_archive_bucket = "${google_storage_bucket.bucket.name}"
   source_archive_object = "${google_storage_bucket_object.archive.name}"
@@ -686,6 +688,7 @@ resource "google_storage_bucket_object" "archive" {
 
 resource "google_cloudfunctions_function" "function" {
   name                  = "%s"
+  runtime				= "nodejs8"
   available_memory_mb   = 128
   source_archive_bucket = "${google_storage_bucket.bucket.name}"
   source_archive_object = "${google_storage_bucket_object.archive.name}"
@@ -702,6 +705,7 @@ func testAccCloudFunctionsFunction_sourceRepo(functionName, project string) stri
 	return fmt.Sprintf(`
 resource "google_cloudfunctions_function" "function" {
   name = "%s"
+  runtime = "nodejs8"
 
   source_repository {
     // There isn't yet an API that'll allow us to create a source repository and
@@ -733,6 +737,7 @@ data "google_compute_default_service_account" "default" { }
 
 resource "google_cloudfunctions_function" "function" {
   name = "%s"
+  runtime = "nodejs8"
 
   source_archive_bucket = "${google_storage_bucket.bucket.name}"
   source_archive_object = "${google_storage_bucket_object.archive.name}"
@@ -778,6 +783,7 @@ resource "google_storage_bucket_object" "archive" {
 
 resource "google_cloudfunctions_function" "function" {
   name     = "%s"
+  runtime  = "nodejs8"
   provider = "google-beta"
 
   description           = "test function"

--- a/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
+++ b/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
@@ -105,8 +105,8 @@ The following arguments are supported:
 
 * `name` - (Required) A user-defined name of the function. Function names must be unique globally.
 
-* `runtime` - (Required) The runtime in which the function is going to run. One
-of `"nodejs8"`, `"nodejs10"`, `"python37"`, `"go111"`.
+* `runtime` - (Required) The runtime in which the function is going to run.
+Eg. `"nodejs8"`, `"nodejs10"`, `"python37"`, `"go111"`.
 
 - - -
 

--- a/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
+++ b/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
@@ -105,10 +105,8 @@ The following arguments are supported:
 
 * `name` - (Required) A user-defined name of the function. Function names must be unique globally.
 
-* `runtime` - (Optional) The runtime in which the function is going to run. One
-of `"nodejs6"`, `"nodejs8"`, `"nodejs10"`, `"python37"`, `"go111"`. If empty,
-defaults to `"nodejs6"`. It's recommended that you override the default, as
-`"nodejs6"` is deprecated.
+* `runtime` - (Required) The runtime in which the function is going to run. One
+of `"nodejs8"`, `"nodejs10"`, `"python37"`, `"go111"`.
 
 - - -
 

--- a/third_party/terraform/website/docs/version_3_upgrade.html.markdown
+++ b/third_party/terraform/website/docs/version_3_upgrade.html.markdown
@@ -53,6 +53,7 @@ so Terraform knows to manage them.
 
 - [Provider Version Configuration](#provider-version-configuration)
 - [Data Source: `google_container_engine_versions`](#data-source-google_container_engine_versions)
+- [Resource: `google_cloudfunctions_function`](#resource-google_cloudfunctions_function)
 - [Resource: `google_cloudiot_registry`](#resource-google_cloudiot_registry)
 - [Resource: `google_compute_forwarding_rule`](#resource-google_compute_forwarding_rule)
 - [Resource: `google_compute_network`](#resource-google_compute_network)
@@ -108,6 +109,13 @@ provider "google" {
 ### `region` and `zone` are now removed
 
 Use `location` instead.
+
+## Resource: `google_cloudfunctions_function`
+
+### The `runtime` option `nodejs6` has been deprecated
+
+`nodejs6` has been deprecated and is no longer the default value for `runtime`.
+`runtime` is now required.
 
 ## Resource: `google_cloudiot_registry`
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/3604

I updated an inspec test, assuming I should, but don't know how to test that exactly.  Let me know if I need to do more for that.

I also treated this as an Enum, and made it `Required`.  Let me know if that's not how we want to approach this.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
`cloudfunctions`: deprecated `nodejs6` as option for `runtime` in `function` and made it required.
```
