### PR TITLE
Fix version behaviour in `google_compute_instance_group`

### DIFF
--- a/third_party/terraform/resources/resource_compute_instance_group.go
+++ b/third_party/terraform/resources/resource_compute_instance_group.go
@@ -71,10 +71,11 @@ func resourceComputeInstanceGroup() *schema.Resource {
 			},
 
 			"network": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: compareSelfLinkOrResourceName,
+				ForceNew:         true,
 			},
 
 			"project": {

--- a/third_party/terraform/resources/resource_compute_target_pool.go
+++ b/third_party/terraform/resources/resource_compute_target_pool.go
@@ -216,36 +216,6 @@ func resourceComputeTargetPoolCreate(d *schema.ResourceData, meta interface{}) e
 	return resourceComputeTargetPoolRead(d, meta)
 }
 
-func calcAddRemove(from []string, to []string) ([]string, []string) {
-	add := make([]string, 0)
-	remove := make([]string, 0)
-	for _, u := range to {
-		found := false
-		for _, v := range from {
-			if u == v {
-				found = true
-				break
-			}
-		}
-		if !found {
-			add = append(add, u)
-		}
-	}
-	for _, u := range from {
-		found := false
-		for _, v := range to {
-			if u == v {
-				found = true
-				break
-			}
-		}
-		if !found {
-			remove = append(remove, u)
-		}
-	}
-	return add, remove
-}
-
 func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 

--- a/third_party/terraform/utils/utils.go.erb
+++ b/third_party/terraform/utils/utils.go.erb
@@ -542,3 +542,36 @@ func getInterconnectAttachmentLink(config *Config, project, region, ic string) (
 
 	return ic, nil
 }
+
+// Given two sets of references (with "from" values in self link form),
+// determine which need to be added or removed // during an update using
+// addX/removeX APIs.
+func calcAddRemove(from []string, to []string) (add, remove []string) {
+	add = make([]string, 0)
+	remove = make([]string, 0)
+	for _, u := range to {
+		found := false
+		for _, v := range from {
+			if compareSelfLinkOrResourceName("", v, u, nil) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			add = append(add, u)
+		}
+	}
+	for _, u := range from {
+		found := false
+		for _, v := range to {
+			if compareSelfLinkOrResourceName("", u, v, nil) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			remove = append(remove, u)
+		}
+	}
+	return add, remove
+}


### PR DESCRIPTION
Fixes `TestAccComputeInstanceGroup_network`, `TestAccComputeInstanceGroup_update`

Followup to https://github.com/GoogleCloudPlatform/magic-modules/pull/2483

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
`compute`: fixed diffs in `google_compute_instance_group`'s `network` field when equivalent values were specified
```

```release-note:bug
`compute`: fixed issues updating `google_compute_instance_group`'s `instances` field when config/state values didn't match
```
