### PR TITLE
Add `scheduleOptions` to BigQuery Data Transfer.

### DIFF
--- a/products/bigquerydatatransfer/api.yaml
+++ b/products/bigquerydatatransfer/api.yaml
@@ -84,6 +84,34 @@ objects:
           about the format here:
           https://cloud.google.com/appengine/docs/flexible/python/scheduling-jobs-with-cron-yaml#the_schedule_format
           NOTE: the granularity should be at least 8 hours, or less frequent.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'scheduleOptions'
+        required: false
+        description: |
+          Options customizing the data transfer schedule.
+        properties:
+          - !ruby/object:Api::Type::Boolean
+            name: 'disableAutoScheduling'
+            required: false
+            description: |
+              If true, automatic scheduling of data transfer runs for this configuration will be disabled.
+              The runs can be started on ad-hoc basis using StartManualTransferRuns API.
+              When automatic scheduling is disabled, the TransferConfig.schedule field will be ignored.
+          - !ruby/object:Api::Type::String
+            name: 'startTime'
+            required: false
+            description: |
+              Specifies time to start scheduling transfer runs. 
+              The first run will be scheduled at or after the start time according to a recurrence pattern
+              defined in the schedule string. The start time can be changed at any moment.
+              The time when a data transfer can be trigerred manually is not limited by this option.
+          - !ruby/object:Api::Type::String
+            name: 'endTime'
+            description: |
+              Defines time to stop scheduling transfer runs. A transfer run cannot be scheduled at or after the end time.
+              The end time can be changed at any moment. 
+              The time when a data transfer can be trigerred manually is not limited by this option.
+            required: false
       - !ruby/object:Api::Type::Integer
         name: 'dataRefreshWindowDays'
         description: |


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

Adding `scheduleOptions` to BigQuery Data transfer.
It does not documented yet on [TransferConfig document](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/v1/projects.locations.transferConfigs#TransferConfig).


But already supported in [golang library](https://godoc.org/google.golang.org/api/bigquerydatatransfer/v1#ScheduleOptions) & [API Explorer](https://cloud.google.com/bigquery/docs/reference/datatransfer/rest/v1/projects.locations.transferConfigs/create).

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME
Add `scheduleOptions` to BigQuery Data Transfer.
```
