### PR TITLE
Add support for compute_router_nat to inspec

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -7720,6 +7720,7 @@ objects:
     delete_verb: :PATCH
     identity:
       - name
+    collection_url_key: nats
     nested_query: !ruby/object:Api::Resource::NestedQuery
       modify_by_patch: true
       keys:

--- a/products/compute/inspec.yaml
+++ b/products/compute/inspec.yaml
@@ -80,8 +80,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     exclude: true
   ResourcePolicy: !ruby/object:Overrides::Inspec::ResourceOverride
     exclude: true
-  RouterNat: !ruby/object:Overrides::Inspec::ResourceOverride
-    collection_url_key: nats
   Subnetwork: !ruby/object:Overrides::Inspec::ResourceOverride
     exclude_resource: true
     iam_policy: !ruby/object:Api::Resource::IamPolicy

--- a/products/compute/inspec.yaml
+++ b/products/compute/inspec.yaml
@@ -81,7 +81,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   ResourcePolicy: !ruby/object:Overrides::Inspec::ResourceOverride
     exclude: true
   RouterNat: !ruby/object:Overrides::Inspec::ResourceOverride
-    exclude: true
+    collection_url_key: nats
   Subnetwork: !ruby/object:Overrides::Inspec::ResourceOverride
     exclude_resource: true
     iam_policy: !ruby/object:Api::Resource::IamPolicy

--- a/templates/inspec/examples/google_compute_router_nat/google_compute_router_nat.erb
+++ b/templates/inspec/examples/google_compute_router_nat/google_compute_router_nat.erb
@@ -1,0 +1,16 @@
+<% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
+<% gcp_location = "#{external_attribute('gcp_location', doc_generation)}" -%>
+<% router = grab_attributes['router'] -%>
+<% router_nat = grab_attributes['router_nat'] -%>
+describe google_compute_router_nat(project: <%= gcp_project_id -%>, region: <%= gcp_location -%>, router: <%= doc_generation ? "'#{router['name']}'" : "router['name']" -%>, name: <%= doc_generation ? "'#{router_nat['name']}'" : "router_nat['name']" -%>) do
+  it { should exist }
+  its('nat_ip_allocate_option') { should cmp <%= doc_generation ? "'#{router_nat['nat_ip_allocate_option']}'" : "router_nat['nat_ip_allocate_option']" -%> }
+  its('source_subnetwork_ip_ranges_to_nat') { should cmp <%= doc_generation ? "'#{router_nat['source_subnetwork_ip_ranges_to_nat']}'" : "router_nat['source_subnetwork_ip_ranges_to_nat']" -%> }
+  its('min_ports_per_vm') { should cmp <%= doc_generation ? "'#{router_nat['min_ports_per_vm']}'" : "router_nat['min_ports_per_vm']" -%> }
+  its('log_config.enable') { should cmp <%= doc_generation ? "'#{router_nat['log_config_enable']}'" : "router_nat['log_config_enable']" -%> }
+  its('log_config.filter') { should cmp <%= doc_generation ? "'#{router_nat['log_config_filter']}'" : "router_nat['log_config_filter']" -%> }
+end
+
+describe google_compute_router(project: <%= gcp_project_id -%>, region: <%= gcp_location -%>, router: 'nonexistent', name: 'nonexistent') do
+  it { should_not exist }
+end

--- a/templates/inspec/examples/google_compute_router_nat/google_compute_router_nat_attributes.erb
+++ b/templates/inspec/examples/google_compute_router_nat/google_compute_router_nat_attributes.erb
@@ -1,0 +1,4 @@
+gcp_project_id = attribute(:gcp_project_id, default: '<%= external_attribute('gcp_project_id') -%>', description: 'The GCP project identifier.')
+gcp_location = attribute(:gcp_location, default: '<%= external_attribute('gcp_location') -%>', description: 'The GCP project region.')
+router = attribute('router', default: <%= JSON.pretty_generate(grab_attributes['router']) -%>, description: 'Compute router description')
+router_nat = attribute('router_nat', default: <%= JSON.pretty_generate(grab_attributes['router_nat']) -%>, description: 'Compute router NAT description')

--- a/templates/inspec/examples/google_compute_router_nat/google_compute_router_nats.erb
+++ b/templates/inspec/examples/google_compute_router_nat/google_compute_router_nats.erb
@@ -1,0 +1,7 @@
+<% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
+<% gcp_location = "#{external_attribute('gcp_location', doc_generation)}" -%>
+<% router = grab_attributes['router'] -%>
+<% router_nat = grab_attributes['router_nat'] -%>
+describe google_compute_router_nats(project: <%= gcp_project_id -%>, region: <%= gcp_location -%>, router: <%= doc_generation ? "'#{router['name']}'" : "router['name']" -%>) do
+  its('names') { should include <%= doc_generation ? "'#{router_nat['name']}'" : "router_nat['name']" -%> }
+end

--- a/templates/inspec/tests/integration/build/gcp-mm.tf
+++ b/templates/inspec/tests/integration/build/gcp-mm.tf
@@ -193,6 +193,10 @@ variable "node_group" {
   type = "map"
 }
 
+variable "router_nat" {
+  type = "map"
+}
+
 resource "google_compute_ssl_policy" "custom-ssl-policy" {
   name            = "${var.ssl_policy["name"]}"
   min_tls_version = "${var.ssl_policy["min_tls_version"]}"
@@ -837,4 +841,19 @@ resource "google_compute_node_group" "inspec-node-group" {
 
   size = var.node_group["size"]
   node_template = "${google_compute_node_template.inspec-template.self_link}"
+}
+
+resource "google_compute_router_nat" "inspec-nat" {
+  project                            = var.gcp_project_id
+  name                               = var.router_nat["name"]
+  router                             = google_compute_router.gcp-inspec-router.name
+  region                             = google_compute_router.gcp-inspec-router.region
+  nat_ip_allocate_option             = var.router_nat["nat_ip_allocate_option"]
+  source_subnetwork_ip_ranges_to_nat = var.router_nat["source_subnetwork_ip_ranges_to_nat"]
+  min_ports_per_vm                   = var.router_nat["min_ports_per_vm"]
+
+  log_config {
+    enable = var.router_nat["log_config_enable"]
+    filter = var.router_nat["log_config_filter"]
+  }
 }

--- a/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -316,3 +316,11 @@ node_group:
   name: inspec-node-group
   description: A description of the node group
   size: 0
+
+router_nat:
+  name: inspec-router-nat
+  nat_ip_allocate_option: AUTO_ONLY
+  source_subnetwork_ip_ranges_to_nat: ALL_SUBNETWORKS_ALL_IP_RANGES
+  min_ports_per_vm: 2
+  log_config_enable: true
+  log_config_filter: ERRORS_ONLY


### PR DESCRIPTION
Support google_compute_router_nat sub resource in inspec
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:

```
