### PR TITLE
Make GKE `taint` GA, add `initial_taint` to GKE, document taint as authoritative.

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1065,13 +1065,22 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		}
 		cluster.NodePools = nodePools
 	} else {
+		nc, err := expandNodeConfig([]interface{}{})
+		if err != nil {
+			return err
+		}
 		// Node Configs have default values that are set in the expand function,
 		// but can only be set if node pools are unspecified.
-		cluster.NodeConfig = expandNodeConfig([]interface{}{})
+		cluster.NodeConfig = nc
 	}
 
 	if v, ok := d.GetOk("node_config"); ok {
-		cluster.NodeConfig = expandNodeConfig(v)
+		nc, err := expandNodeConfig(v)
+		if err != nil {
+			return err
+		}
+
+		cluster.NodeConfig = nc
 	}
 
 <% unless version == 'ga' -%>

--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -493,10 +493,15 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*containerBeta.NodeP
 	}
 <% end -%>
 
+	nc, err := expandNodeConfig(d.Get(prefix + "node_config"))
+	if err != nil {
+		return nil, err
+	}
+
 	np := &containerBeta.NodePool{
 		Name:             name,
 		InitialNodeCount: int64(nodeCount),
-		Config:           expandNodeConfig(d.Get(prefix + "node_config")),
+		Config:           nc,
 <% unless version == 'ga' -%>
 		Locations:        locations,
 <% end -%>

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -814,7 +814,7 @@ func TestAccContainerCluster_withNodeConfigScopeAlias(t *testing.T) {
 	})
 }
 
-<% unless version.nil? || version == 'ga' -%>
+// Tests the authoritative taint field
 func TestAccContainerCluster_withNodeConfigTaints(t *testing.T) {
 	t.Parallel()
 
@@ -830,16 +830,14 @@ func TestAccContainerCluster_withNodeConfigTaints(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:			 "google_container_cluster.with_node_config",
-				ImportStateIdPrefix:	 "us-central1-f/",
-				ImportState:			 true,
-				ImportStateVerify:		 true,
+				ResourceName:			   "google_container_cluster.with_node_config",
+				ImportStateIdPrefix: "us-central1-f/",
+				ImportState:			   true,
+				ImportStateVerify:	 true,
 			},
-			// Once taints are in GA, consider merging this test with the _withNodeConfig test.
 		},
 	})
 }
-<% end -%>
 
 func TestAccContainerCluster_withNodeConfigShieldedInstanceConfig(t *testing.T) {
 	t.Parallel()
@@ -2402,6 +2400,12 @@ resource "google_container_cluster" "with_node_config" {
 		preemptible = true
 		min_cpu_platform = "Intel Broadwell"
 
+		initial_taint {
+			key = "taint_key"
+			value = "taint_value"
+			effect = "PREFER_NO_SCHEDULE"
+		}
+
 		// Updatable fields
 		image_type = "COS"
 	}
@@ -2438,6 +2442,12 @@ resource "google_container_cluster" "with_node_config" {
 		preemptible = true
 		min_cpu_platform = "Intel Broadwell"
 
+		initial_taint {
+			key = "taint_key"
+			value = "taint_value"
+			effect = "PREFER_NO_SCHEDULE"
+		}
+
 		// Updatable fields
 		image_type = "UBUNTU"
 	}
@@ -2467,12 +2477,12 @@ resource "google_container_cluster" "with_node_config" {
 	initial_node_count = 1
 
 	node_config {
-		initial_taint {
+		taint {
 			key = "taint_key"
 			value = "taint_value"
 			effect = "PREFER_NO_SCHEDULE"
 		}
-		initial_taint {
+		taint {
 			key = "taint_key2"
 			value = "taint_value2"
 			effect = "NO_EXECUTE"

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2459,7 +2459,6 @@ resource "google_container_cluster" "with_node_config_scope_alias" {
 }`, acctest.RandString(10))
 }
 
-<% unless version.nil? || version == 'ga' -%>
 func testAccContainerCluster_withNodeConfigTaints() string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_node_config" {
@@ -2468,12 +2467,12 @@ resource "google_container_cluster" "with_node_config" {
 	initial_node_count = 1
 
 	node_config {
-		taint {
+		initial_taint {
 			key = "taint_key"
 			value = "taint_value"
 			effect = "PREFER_NO_SCHEDULE"
 		}
-		taint {
+		initial_taint {
 			key = "taint_key2"
 			value = "taint_value2"
 			effect = "NO_EXECUTE"
@@ -2481,8 +2480,6 @@ resource "google_container_cluster" "with_node_config" {
 	}
 }`, acctest.RandString(10))
 }
-<% end -%>
-
 
 func testAccContainerCluster_withNodeConfigShieldedInstanceConfig(clusterName string) string {
 	return fmt.Sprintf(`

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -163,7 +163,6 @@ func TestAccContainerNodePool_withNodeConfig(t *testing.T) {
 	})
 }
 
-<% unless version.nil? || version == 'ga' -%>
 func TestAccContainerNodePool_withNodeConfigTaints(t *testing.T) {
 	t.Parallel()
 
@@ -190,7 +189,6 @@ func TestAccContainerNodePool_withNodeConfigTaints(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 <% unless version.nil? || version == 'ga' -%>
 func TestAccContainerNodePool_withWorkloadMetadataConfig(t *testing.T) {
@@ -1070,7 +1068,6 @@ resource "google_container_node_pool" "np_with_node_config" {
 }`, cluster, nodePool)
 }
 
-<% unless version.nil? || version == 'ga' -%>
 func testAccContainerNodePool_withNodeConfigTaints() string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "cluster" {
@@ -1084,12 +1081,12 @@ resource "google_container_node_pool" "np_with_node_config" {
 	cluster = "${google_container_cluster.cluster.name}"
 	initial_node_count = 1
 	node_config {
-		taint {
+		initial_taint {
 			key = "taint_key"
 			value = "taint_value"
 			effect = "PREFER_NO_SCHEDULE"
 		}
-		taint {
+		initial_taint {
 			key = "taint_key2"
 			value = "taint_value2"
 			effect = "NO_EXECUTE"
@@ -1097,7 +1094,6 @@ resource "google_container_node_pool" "np_with_node_config" {
 	}
 }`, acctest.RandString(10), acctest.RandString(10))
 }
-<% end -%>
 
 <% unless version.nil? || version == 'ga' -%>
 func testAccContainerNodePool_withWorkloadMetadataConfig() string {

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -163,6 +163,7 @@ func TestAccContainerNodePool_withNodeConfig(t *testing.T) {
 	})
 }
 
+// Authoritative taints
 func TestAccContainerNodePool_withNodeConfigTaints(t *testing.T) {
 	t.Parallel()
 
@@ -185,7 +186,6 @@ func TestAccContainerNodePool_withNodeConfigTaints(t *testing.T) {
 				// but will still cause an import diff
 				ImportStateVerifyIgnore: []string{"autoscaling.#"},
 			},
-			// Once taints are in GA, consider merging this test with the _withNodeConfig test.
 		},
 	})
 }
@@ -1032,6 +1032,12 @@ resource "google_container_node_pool" "np_with_node_config" {
 		preemptible = true
 		min_cpu_platform = "Intel Broadwell"
 
+		initial_taint {
+			key = "taint_key"
+			value = "taint_value"
+			effect = "PREFER_NO_SCHEDULE"
+		}
+
 		// Updatable fields
 		image_type = "COS"
 	}
@@ -1062,6 +1068,12 @@ resource "google_container_node_pool" "np_with_node_config" {
 		preemptible = true
 		min_cpu_platform = "Intel Broadwell"
 
+		initial_taint {
+			key = "taint_key"
+			value = "taint_value"
+			effect = "PREFER_NO_SCHEDULE"
+		}
+
 		// Updatable fields
 		image_type = "UBUNTU"
 	}
@@ -1081,12 +1093,13 @@ resource "google_container_node_pool" "np_with_node_config" {
 	cluster = "${google_container_cluster.cluster.name}"
 	initial_node_count = 1
 	node_config {
-		initial_taint {
+		taint {
 			key = "taint_key"
 			value = "taint_value"
 			effect = "PREFER_NO_SCHEDULE"
 		}
-		initial_taint {
+
+		taint {
 			key = "taint_key2"
 			value = "taint_value2"
 			effect = "NO_EXECUTE"

--- a/third_party/terraform/utils/node_config.go.erb
+++ b/third_party/terraform/utils/node_config.go.erb
@@ -2,6 +2,7 @@
 package google
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -176,7 +177,6 @@ var schemaNodeConfig = &schema.Schema{
 				Type:             schema.TypeList,
 				Optional:         true,
 				ForceNew:         true,
-				ConflictsWith:    []string{"taint"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"key": {
@@ -210,7 +210,6 @@ var schemaNodeConfig = &schema.Schema{
 				// Legacy config mode allows setting no taint explicitly.
 				// See https://www.terraform.io/docs/configuration/attr-as-blocks.html
 				// ConfigMode: schema.SchemaConfigModeAttr,
-				ConflictsWith:    []string{"initial_taint"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"key": {
@@ -275,14 +274,14 @@ var schemaNodeConfig = &schema.Schema{
 	},
 }
 
-func expandNodeConfig(v interface{}) *containerBeta.NodeConfig {
+func expandNodeConfig(v interface{}) (*containerBeta.NodeConfig, error) {
 	nodeConfigs := v.([]interface{})
 	nc := &containerBeta.NodeConfig{
 		// Defaults can't be set on a list/set in the schema, so set the default on create here.
 		OauthScopes: defaultOauthScopes,
 	}
 	if len(nodeConfigs) == 0 {
-		return nc
+		return nc, nil
 	}
 
 	nodeConfig := nodeConfigs[0].(map[string]interface{})
@@ -377,8 +376,18 @@ func expandNodeConfig(v interface{}) *containerBeta.NodeConfig {
 		nc.MinCpuPlatform = v.(string)
 	}
 
-	if v, ok := nodeConfig["taint"]; ok && len(v.([]interface{})) > 0 {
-		taints := v.([]interface{})
+	// these fields appear in multiple different places in schema, so
+	// ConflictsWith and CustomizeDiff are a pain to use.
+	v1, vOk1 := nodeConfig["taint"]
+	v2, vOk2 := nodeConfig["initial_taint"]
+
+	// this is only called on Create, so checking the computed value is safe
+	if vOk1 && vOk2 {
+		return nil, fmt.Errorf("can't set both taint and initial_taint in node config")
+	}
+
+	if vOk1 && len(v1.([]interface{})) > 0 {
+		taints := v1.([]interface{})
 		nodeTaints := make([]*containerBeta.NodeTaint, 0, len(taints))
 		for _, raw := range taints {
 			data := raw.(map[string]interface{})
@@ -390,8 +399,8 @@ func expandNodeConfig(v interface{}) *containerBeta.NodeConfig {
 			nodeTaints = append(nodeTaints, taint)
 		}
 		nc.Taints = nodeTaints
-	} else if v, ok := nodeConfig["initial_taint"]; ok && len(v.([]interface{})) > 0 {
-		taints := v.([]interface{})
+	} else if vOk2 && len(v2.([]interface{})) > 0 {
+		taints := v2.([]interface{})
 		nodeTaints := make([]*containerBeta.NodeTaint, 0, len(taints))
 		for _, raw := range taints {
 			data := raw.(map[string]interface{})
@@ -421,7 +430,7 @@ func expandNodeConfig(v interface{}) *containerBeta.NodeConfig {
 	}
 <% end -%>
 
-	return nc
+	return nc, nil
 }
 
 func flattenNodeConfig(c *containerBeta.NodeConfig) []map[string]interface{} {

--- a/third_party/terraform/utils/node_config.go.erb
+++ b/third_party/terraform/utils/node_config.go.erb
@@ -172,16 +172,45 @@ var schemaNodeConfig = &schema.Schema{
 				},
 			},
 
-			"taint": {
-<% if version.nil? || version == 'ga' -%>
-				Removed:       "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/provider_versions.html for more details.",
-<% end -%>
+			"initial_taint": {
 				Type:             schema.TypeList,
 				Optional:         true,
-				// Computed=true because GKE Sandbox will automatically add taints to nodes that can/cannot run sandboxed pods.
+				ForceNew:         true,
+				ConflictsWith:    []string{"taint"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"value": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"effect": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice([]string{"NO_SCHEDULE", "PREFER_NO_SCHEDULE", "NO_EXECUTE"}, false),
+						},
+					},
+				},
+			},
+
+			"taint": {
+				Type:             schema.TypeList,
+				// GKE Sandbox and GPUs will add taints out of band so this needs to be O+C
+				Optional:         true,
 				Computed:         true,
 				ForceNew:         true,
 				DiffSuppressFunc: taintDiffSuppress,
+				// TODO(rileykarson): Disable DSF, enable ConfigMode in 3.0.0
+				// Legacy config mode allows setting no taint explicitly.
+				// See https://www.terraform.io/docs/configuration/attr-as-blocks.html
+				// ConfigMode: schema.SchemaConfigModeAttr,
+				ConflictsWith:    []string{"initial_taint"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"key": {
@@ -348,7 +377,6 @@ func expandNodeConfig(v interface{}) *containerBeta.NodeConfig {
 		nc.MinCpuPlatform = v.(string)
 	}
 
-<% unless version == 'ga' -%>
 	if v, ok := nodeConfig["taint"]; ok && len(v.([]interface{})) > 0 {
 		taints := v.([]interface{})
 		nodeTaints := make([]*containerBeta.NodeTaint, 0, len(taints))
@@ -362,8 +390,20 @@ func expandNodeConfig(v interface{}) *containerBeta.NodeConfig {
 			nodeTaints = append(nodeTaints, taint)
 		}
 		nc.Taints = nodeTaints
+	} else if v, ok := nodeConfig["initial_taint"]; ok && len(v.([]interface{})) > 0 {
+		taints := v.([]interface{})
+		nodeTaints := make([]*containerBeta.NodeTaint, 0, len(taints))
+		for _, raw := range taints {
+			data := raw.(map[string]interface{})
+			taint := &containerBeta.NodeTaint{
+				Key:    data["key"].(string),
+				Value:  data["value"].(string),
+				Effect: data["effect"].(string),
+			}
+			nodeTaints = append(nodeTaints, taint)
+		}
+		nc.Taints = nodeTaints
 	}
-<% end -%>
 
 <% unless version == 'ga' -%>
 	if v, ok := nodeConfig["workload_metadata_config"]; ok && len(v.([]interface{})) > 0 {
@@ -405,8 +445,8 @@ func flattenNodeConfig(c *containerBeta.NodeConfig) []map[string]interface{} {
 		"preemptible":              c.Preemptible,
 		"min_cpu_platform":         c.MinCpuPlatform,
 		"shielded_instance_config": flattenShieldedInstanceConfig(c.ShieldedInstanceConfig),
-<% unless version == 'ga' -%>
 		"taint":                    flattenTaints(c.Taints),
+<% unless version == 'ga' -%>
 		"workload_metadata_config": flattenWorkloadMetadataConfig(c.WorkloadMetadataConfig),
 		"sandbox_config": 			flattenSandboxConfig(c.SandboxConfig),
 <% end -%>
@@ -441,7 +481,6 @@ func flattenShieldedInstanceConfig(c *containerBeta.ShieldedInstanceConfig) []ma
 	return result
 }
 
-<% unless version.nil? || version == 'ga' -%>
 func flattenTaints(c []*containerBeta.NodeTaint) []map[string]interface{} {
 	result := []map[string]interface{}{}
 	for _, taint := range c {
@@ -453,7 +492,6 @@ func flattenTaints(c []*containerBeta.NodeTaint) []map[string]interface{} {
 	}
 	return result
 }
-<% end -%>
 
 <% unless version.nil? || version == 'ga' -%>
 func flattenWorkloadMetadataConfig(c *containerBeta.WorkloadMetadataConfig) []map[string]interface{} {

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -567,9 +567,17 @@ The `node_config` block supports:
 * `tags` - (Optional) The list of instance tags applied to all nodes. Tags are used to identify
     valid sources or targets for network firewalls.
 
-* `taint` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) List of
-    [kubernetes taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
-    to apply to each node. Structure is documented below.
+* `initial_taint` - (Optional) A list of [Kubernetes taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
+to apply to nodes on creation. Modifying this field will cause the resource to
+be recreated. This field only changes cluster creation, and the `taint` field
+contains the current taints set on nodes. `taint` values can be updated without
+recreating the cluster inside Kubernetes such as with `kubectl`. Structure is
+documented below.
+
+* `taint` - (Optional) List of [Kubernetes taints](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
+on each node. See `initial_taint` for more info. If this field is set, Terraform
+will authoritatively manage the taints on the resource, destroying it in order
+to amend them. Structure is documented below.
 
 * `workload_metadata_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/provider_versions.html)) Metadata configuration to expose to workloads on the node pool.
     Structure is documented below.
@@ -655,6 +663,14 @@ Secure Boot helps ensure that the system only runs authentic software by verifyi
 
 Enables monitoring and attestation of the boot integrity of the instance. The attestation is performed against the integrity policy baseline. This baseline is initially derived from the implicitly trusted boot image when the instance is created.  Defaults to `true`.
 
+The `initial_taint` block supports:
+
+* `key` (Required) Key for taint.
+
+* `value` (Required) Value for taint.
+
+* `effect` (Required) Effect for taint. Accepted values are `NO_SCHEDULE`, `PREFER_NO_SCHEDULE`, and `NO_EXECUTE`.
+
 The `taint` block supports:
 
 * `key` (Required) Key for taint.
@@ -736,5 +752,6 @@ $ terraform import google_container_cluster.mycluster us-east1-a/my-cluster
 
 For example, the following fields will show diffs if set in config:
 
+- `initial_taint`
 - `min_master_version`
 - `remove_default_node_pool`


### PR DESCRIPTION
Preliminary for https://github.com/terraform-providers/terraform-provider-google/issues/4168, resolving the TODO will close it.

GKE taints are in a bit of a weird place. They're a field on GKE, but they're creation-only and managed by operators in K8S. However, certain GKE features will use K8S to manage taints, such as GPUs.

That left us in a bad spot. Adding them out of band is a somewhat normal thing to do and the only way to amend taints is to recreate the node pool / cluster (if node pools are defined inline). We introduced `taintDiffSuppress` which suppressed GPU taints, however since then at least 1 other GKE feature can introduce them, and it was never properly supported. We'll also never encapsulate user-defined taints well with the resource-as-it-was.

Based on https://github.com/terraform-providers/terraform-provider-google/issues/4168, some users clearly want to say "I have no taints on my node pool" so authoritative management can't be removed altogether. However, I'd expect most users want to express "I want this taint added to my nodes" rather than "authoritatively manage these taints". That's the purpose of `initial_taint`, which only sets values on creation.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
`container`: made `taint` field available in the `google` provider, as it's GA
```

```release-note:enhancement
`container`: added `initial_taint` to manage creation-only node taints
```
