### PR TITLE
Clarify fields that are regexes in docs.

### DIFF
--- a/products/cloudbuild/api.yaml
+++ b/products/cloudbuild/api.yaml
@@ -132,10 +132,12 @@ objects:
             name: 'branchName'
             description: |
               Name of the branch to build. Exactly one a of branch name, tag, or commit SHA must be provided.
+              This field is a regular expression.
           - !ruby/object:Api::Type::String
             name: 'tagName'
             description: |
               Name of the tag to build. Exactly one of a branch name, tag, or commit SHA must be provided.
+              This field is a regular expression.
           - !ruby/object:Api::Type::String
             name: 'commitSha'
             description: |


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:no-release-note
```
As requested in https://github.com/terraform-providers/terraform-provider-google/issues/4718, specify that these fields are regexes.