### PR TITLE
Allow defining empty taint, remove old DSF

### DIFF
--- a/third_party/terraform/utils/node_config.go.erb
+++ b/third_party/terraform/utils/node_config.go.erb
@@ -178,7 +178,9 @@ var schemaNodeConfig = &schema.Schema{
 				// Computed=true because GKE Sandbox will automatically add taints to nodes that can/cannot run sandboxed pods.
 				Computed:         true,
 				ForceNew:         true,
-				DiffSuppressFunc: taintDiffSuppress,
+				// Legacy config mode allows explicitly defining an empty taint.
+				// See https://www.terraform.io/docs/configuration/attr-as-blocks.html
+				ConfigMode: schema.SchemaConfigModeAttr,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"key": {
@@ -469,20 +471,3 @@ func flattenSandboxConfig(c *containerBeta.SandboxConfig) []map[string]interface
 	return result
 }
 <% end -%>
-
-func taintDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	if strings.HasSuffix(k, "#") {
-		oldCount, oldErr := strconv.Atoi(old)
-		newCount, newErr := strconv.Atoi(new)
-		// If either of them isn't a number somehow, or if there's one that we didn't have before.
-		return oldErr != nil || newErr != nil || oldCount == newCount+1
-	} else {
-		lastDot := strings.LastIndex(k, ".")
-		taintKey := d.Get(k[:lastDot] + ".key").(string)
-		if taintKey == "nvidia.com/gpu" {
-			return true
-		} else {
-			return false
-		}
-	}
-}


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4168

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
`container`: removed automatic suppression of GPU taints in GKE `taint`
```
