### PR TITLE
Even more handwritten ids

### DIFF
--- a/third_party/terraform/resources/resource_dataproc_cluster.go.erb
+++ b/third_party/terraform/resources/resource_dataproc_cluster.go.erb
@@ -496,7 +496,7 @@ func resourceDataprocClusterCreate(d *schema.ResourceData, meta interface{}) err
 		return fmt.Errorf("Error creating Dataproc cluster: %s", err)
 	}
 
-	d.SetId(cluster.ClusterName)
+	d.SetId(fmt.Sprintf("projects/%s/regions/%s/clusters/%s", project, region, cluster.ClusterName))
 
 	// Wait until it's created
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutCreate).Minutes())

--- a/third_party/terraform/resources/resource_sql_ssl_cert.go
+++ b/third_party/terraform/resources/resource_sql_ssl_cert.go
@@ -105,7 +105,7 @@ func resourceSqlSslCertCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	fingerprint := resp.ClientCert.CertInfo.Sha1Fingerprint
-	d.SetId(fmt.Sprintf("%s/%s", instance, fingerprint))
+	d.SetId(fmt.Sprintf("projects/%s/instances/%s/sslCerts/%s", project, instance, fingerprint))
 	d.Set("sha1_fingerprint", fingerprint)
 
 	// The private key is only returned on the initial insert so set it here.
@@ -148,7 +148,7 @@ func resourceSqlSslCertRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("create_time", sslCerts.CreateTime)
 	d.Set("expiration_time", sslCerts.ExpirationTime)
 
-	d.SetId(fmt.Sprintf("%s/%s", instance, fingerprint))
+	d.SetId(fmt.Sprintf("projects/%s/instances/%s/sslCerts/%s", project, instance, fingerprint))
 	return nil
 }
 

--- a/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -624,8 +624,10 @@ func testAccCheckDataprocClusterDestroy() resource.TestCheckFunc {
 				return err
 			}
 
+			parts := strings.Split(rs.Primary.ID, "/")
+			clusterId := parts[len(parts)-1]
 			_, err = config.clientDataprocBeta.Projects.Regions.Clusters.Get(
-				project, attributes["region"], rs.Primary.ID).Do()
+				project, attributes["region"], clusterId).Do()
 
 			if err != nil {
 				if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == http.StatusNotFound {
@@ -786,14 +788,16 @@ func testAccCheckDataprocClusterExists(n string, cluster *dataproc.Cluster) reso
 			return err
 		}
 
+		parts := strings.Split(rs.Primary.ID, "/")
+		clusterId := parts[len(parts)-1]
 		found, err := config.clientDataprocBeta.Projects.Regions.Clusters.Get(
-			project, rs.Primary.Attributes["region"], rs.Primary.ID).Do()
+			project, rs.Primary.Attributes["region"], clusterId).Do()
 		if err != nil {
 			return err
 		}
 
-		if found.ClusterName != rs.Primary.ID {
-			return fmt.Errorf("Dataproc cluster %s not found, found %s instead", rs.Primary.ID, cluster.ClusterName)
+		if found.ClusterName != clusterId {
+			return fmt.Errorf("Dataproc cluster %s not found, found %s instead", clusterId, cluster.ClusterName)
 		}
 
 		*cluster = *found

--- a/third_party/terraform/tests/resource_dataproc_job_test.go
+++ b/third_party/terraform/tests/resource_dataproc_job_test.go
@@ -283,8 +283,10 @@ func testAccCheckDataprocJobDestroy(s *terraform.State) error {
 			return err
 		}
 
+		parts := strings.Split(rs.Primary.ID, "/")
+		job_id := parts[len(parts)-1]
 		_, err = config.clientDataproc.Projects.Regions.Jobs.Get(
-			project, attributes["region"], rs.Primary.ID).Do()
+			project, attributes["region"], job_id).Do()
 		if err != nil {
 			if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 				return nil
@@ -367,7 +369,8 @@ func testAccCheckDataprocJobExists(n string, job *dataproc.Job) resource.TestChe
 		}
 
 		config := testAccProvider.Meta().(*Config)
-		jobId := s.RootModule().Resources[n].Primary.ID
+		parts := strings.Split(s.RootModule().Resources[n].Primary.ID, "/")
+		jobId := parts[len(parts)-1]
 		project, err := getTestProject(s.RootModule().Resources[n].Primary, config)
 		if err != nil {
 			return err

--- a/third_party/terraform/tests/resource_google_project_test.go
+++ b/third_party/terraform/tests/resource_google_project_test.go
@@ -200,10 +200,9 @@ func testAccCheckGoogleProjectExists(r, pid string) resource.TestCheckFunc {
 			return fmt.Errorf("No ID is set")
 		}
 
-		parts := strings.Split(rs.Primary.ID, "/")
-		foundId := parts[len(parts)-1]
-		if foundId != pid {
-			return fmt.Errorf("Expected project %q to match ID %q in state", pid, foundId)
+		projectId := fmt.Sprintf("projects/%s", pid)
+		if rs.Primary.ID != projectId {
+			return fmt.Errorf("Expected project %q to match ID %q in state", projectId, rs.Primary.ID)
 		}
 
 		return nil

--- a/third_party/terraform/tests/resource_google_project_test.go
+++ b/third_party/terraform/tests/resource_google_project_test.go
@@ -200,8 +200,10 @@ func testAccCheckGoogleProjectExists(r, pid string) resource.TestCheckFunc {
 			return fmt.Errorf("No ID is set")
 		}
 
-		if rs.Primary.ID != pid {
-			return fmt.Errorf("Expected project %q to match ID %q in state", pid, rs.Primary.ID)
+		parts := strings.Split(rs.Primary.ID, "/")
+		foundId := parts[len(parts)-1]
+		if foundId != pid {
+			return fmt.Errorf("Expected project %q to match ID %q in state", pid, foundId)
 		}
 
 		return nil


### PR DESCRIPTION
Updating more handwritten ids for 3.0.0. 
Includes:
resource_dataproc_cluster.go.erb
resource_dataproc_job.go
resource_google_project.go
resource_sql_database_instance.go
resource_sql_ssl_cert.go

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
