### PR TITLE
Say BUG FIXES instead of BUGS in changelogs

### DIFF
--- a/.ci/changelog.tmpl
+++ b/.ci/changelog.tmpl
@@ -59,7 +59,7 @@ IMPROVEMENTS:
 {{- end -}}
 {{- end -}}
 {{- if gt (len $bugs) 0}}
-BUGS:
+BUG FIXES:
 {{range $bugs | sortAlpha -}}
 * {{. }}
 {{- end -}}


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
