### PR TITLE
Add description to google_service_account

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_service_account.go
+++ b/third_party/terraform/data_sources/data_source_google_service_account.go
@@ -36,6 +36,14 @@ func dataSourceGoogleServiceAccount() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"oauth2_client_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -60,6 +68,8 @@ func dataSourceGoogleServiceAccountRead(d *schema.ResourceData, meta interface{}
 	d.Set("account_id", strings.Split(sa.Email, "@")[0])
 	d.Set("name", sa.Name)
 	d.Set("display_name", sa.DisplayName)
+	d.Set("description", sa.Description)
+	d.Set("oauth2_client_id", sa.Oauth2ClientId)
 
 	return nil
 }

--- a/third_party/terraform/tests/data_source_google_service_account_test.go
+++ b/third_party/terraform/tests/data_source_google_service_account_test.go
@@ -26,6 +26,8 @@ func TestAccDatasourceGoogleServiceAccount_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet(resourceName, "unique_id"),
 					resource.TestCheckResourceAttrSet(resourceName, "name"),
 					resource.TestCheckResourceAttrSet(resourceName, "display_name"),
+					resource.TestCheckResourceAttrSet(resourceName, "description"),
+					resource.TestCheckResourceAttrSet(resourceName, "oauth2_client_id"),
 				),
 			},
 		},
@@ -37,6 +39,7 @@ func testAccCheckGoogleServiceAccount_basic(account string) string {
 resource "google_service_account" "acceptance" {
   account_id   = "%s"
   display_name = "Testing Account"
+  description  = "An account for testing purposes"
 }
 
 data "google_service_account" "acceptance" {

--- a/third_party/terraform/tests/resource_google_service_account_test.go
+++ b/third_party/terraform/tests/resource_google_service_account_test.go
@@ -16,8 +16,8 @@ func TestAccServiceAccount_basic(t *testing.T) {
 	uniqueId := ""
 	displayName := "Terraform Test"
 	displayName2 := "Terraform Test Update"
-	desc := "test description"
-	desc2 := ""
+	description1 := ""
+	description2 := "Terraform Test service account"
 	project := getTestProjectFromEnv()
 	expectedEmail := fmt.Sprintf("%s@%s.iam.gserviceaccount.com", accountId, project)
 	vcrTest(t, resource.TestCase{
@@ -26,7 +26,7 @@ func TestAccServiceAccount_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// The first step creates a basic service account
 			{
-				Config: testAccServiceAccountBasic(accountId, displayName, desc),
+				Config: testAccServiceAccountBasic(accountId, displayName, description1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"google_service_account.acceptance", "project", project),
@@ -52,7 +52,7 @@ func TestAccServiceAccount_basic(t *testing.T) {
 			},
 			// The second step updates the service account
 			{
-				Config: testAccServiceAccountBasic(accountId, displayName2, desc2),
+				Config: testAccServiceAccountBasic(accountId, displayName2, description2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"google_service_account.acceptance", "project", project),
@@ -67,7 +67,7 @@ func TestAccServiceAccount_basic(t *testing.T) {
 			// The third step explicitly adds the same default project to the service account configuration
 			// and ensure the service account is not recreated by comparing the value of its unique_id with the one from the previous step
 			{
-				Config: testAccServiceAccountWithProject(project, accountId, displayName2),
+				Config: testAccServiceAccountWithProject(project, accountId, displayName2, description2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"google_service_account.acceptance", "project", project),
@@ -91,23 +91,23 @@ func testAccStoreServiceAccountUniqueId(uniqueId *string) resource.TestCheckFunc
 	}
 }
 
-func testAccServiceAccountBasic(account, name, desc string) string {
+func testAccServiceAccountBasic(account, name, description string) string {
 	return fmt.Sprintf(`
 resource "google_service_account" "acceptance" {
   account_id   = "%v"
   display_name = "%v"
   description  = "%v"
 }
-`, account, name, desc)
+`, account, name, description)
 }
 
-func testAccServiceAccountWithProject(project, account, name string) string {
+func testAccServiceAccountWithProject(project, account, name, description string) string {
 	return fmt.Sprintf(`
 resource "google_service_account" "acceptance" {
   project      = "%v"
   account_id   = "%v"
   display_name = "%v"
-  description  = "foo"
+  description  = "%v"
 }
-`, project, account, name)
+`, project, account, name, description)
 }

--- a/third_party/terraform/website/docs/d/datasource_google_service_account.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_service_account.html.markdown
@@ -63,3 +63,7 @@ exported:
 * `name` - The fully-qualified name of the service account.
 
 * `display_name` - The display name for the service account.
+
+* `description` - The description for the service account.
+
+* `oauth2_client_id` - The OAuth2 client id for the service account.

--- a/third_party/terraform/website/docs/r/google_service_account.html.markdown
+++ b/third_party/terraform/website/docs/r/google_service_account.html.markdown
@@ -41,6 +41,7 @@ The following arguments are supported:
 
 * `description` - (Optional) A text description of the service account.
     Must be less than or equal to 256 UTF-8 bytes.
+    Can be updated without creating a new resource.
 
 * `project` - (Optional) The ID of the project that the service account will be created in.
     Defaults to the provider project configuration.
@@ -59,6 +60,8 @@ exported:
 * `name` - The fully-qualified name of the service account.
 
 * `unique_id` - The unique id of the service account.
+
+* `oauth2_client_id` - The OAuth2 client id for the service account.
 
 ## Timeouts
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
project: added `description` to `google_service_account` data source
```
```release-note:enhancement
project: added `oauth2_client_id` to `google_service_account` data source
```
```release-note:enhancement
project: added `oauth2_client_id` to `google_service_account` resource
```
```release-note:bug
project: fixed update functionality in `google_service_account` resource to allow setting blank `description` and `display_name`
```
```release-note:enhancement
project: added validation to `display_name` in `google_service_account` resource
```
