### PR TITLE
remove kubernetes_dashboard from google_container_cluster

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -172,16 +172,14 @@ func resourceContainerCluster() *schema.Resource {
 						},
 						"kubernetes_dashboard": {
 							Type:       schema.TypeList,
-							Optional:   true,
-							Computed:   true,
-							Deprecated: "The Kubernetes Dashboard addon is deprecated for clusters on GKE.",
+							Optional:  true,
+							Removed: "The Kubernetes Dashboard addon is removed for clusters on GKE.",
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"disabled": {
 										Type:     schema.TypeBool,
 										Optional: true,
-										Default:  true,
 									},
 								},
 							},
@@ -2079,14 +2077,6 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 		}
 	}
 
-	if v, ok := config["kubernetes_dashboard"]; ok && len(v.([]interface{})) > 0 {
-		addon := v.([]interface{})[0].(map[string]interface{})
-		ac.KubernetesDashboard = &containerBeta.KubernetesDashboard{
-			Disabled:        addon["disabled"].(bool),
-			ForceSendFields: []string{"Disabled"},
-		}
-	}
-
 	if v, ok := config["network_policy_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
 		ac.NetworkPolicyConfig = &containerBeta.NetworkPolicyConfig{
@@ -2433,13 +2423,6 @@ func flattenClusterAddonsConfig(c *containerBeta.AddonsConfig) []map[string]inte
 		result["http_load_balancing"] = []map[string]interface{}{
 			{
 				"disabled": c.HttpLoadBalancing.Disabled,
-			},
-		}
-	}
-	if c.KubernetesDashboard != nil {
-		result["kubernetes_dashboard"] = []map[string]interface{}{
-			{
-				"disabled": c.KubernetesDashboard.Disabled,
 			},
 		}
 	}

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1845,7 +1845,6 @@ resource "google_container_cluster" "primary" {
 	addons_config {
 		http_load_balancing { disabled = true }
 		horizontal_pod_autoscaling { disabled = true }
-		kubernetes_dashboard { disabled = true }
 		network_policy_config { disabled = true }
 <% unless version == 'ga' -%>
 		istio_config {
@@ -1867,7 +1866,6 @@ resource "google_container_cluster" "primary" {
 
 	addons_config {
 		http_load_balancing { disabled = false }
-		kubernetes_dashboard { disabled = false }
 		horizontal_pod_autoscaling { disabled = false }
 		network_policy_config { disabled = false }
 <% unless version == 'ga' -%>

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -312,10 +312,6 @@ The `addons_config` block supports:
     controller addon, which makes it easy to set up HTTP load balancers for services in a
     cluster. It is enabled by default; set `disabled = true` to disable.
 
-* `kubernetes_dashboard` - (Optional, Deprecated) The status of the Kubernetes Dashboard
-    add-on, which controls whether the Kubernetes Dashboard is enabled for this cluster.
-    It is disabled by default; set `disabled = false` to enable.
-
 * `network_policy_config` - (Optional) Whether we should enable the network policy addon
     for the master.  This must be enabled in order to enable network policy for the nodes.
     To enable this, you must also define a [`network_policy`](#network_policy) block,

--- a/third_party/terraform/website/docs/version_3_upgrade.html.markdown
+++ b/third_party/terraform/website/docs/version_3_upgrade.html.markdown
@@ -189,6 +189,12 @@ Before updating, remove it from your config.
 
 ## Resource: `google_container_cluster`
 
+### `addons_config.kubernetes_dashboard` is now removed
+
+The `kubernetes_dashboard` addon is deprecated for clusters on GKE and
+will soon be removed. It is recommended to use alternative GCP Console
+dashboards.
+
 ### `zone`, `region` and `additional_zones` are now removed
 
 `zone` and `region` have been removed in favor of `location` and


### PR DESCRIPTION
remove kubernetes_dashboard from google_container_cluster

**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
`container`: removed `kubernetes_dashboard` from `google_container_cluster.addons_config`
```
