### PR TITLE
Add product services resource, make disk tests work with VCR 

### DIFF
--- a/products/serviceusage/api.yaml
+++ b/products/serviceusage/api.yaml
@@ -1,0 +1,52 @@
+# Copyright 2019 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- !ruby/object:Api::Product
+name: ServiceUsage
+display_name: Service Usage
+versions:
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://serviceusage.googleapis.com/v1/
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: Service Usage API
+    url: https://console.cloud.google.com/apis/library/serviceusage.googleapis.com/
+objects:
+  - !ruby/object:Api::Resource
+    name: Service
+    base_url: projects/{{project}}/services
+    self_link: projects/{{project}}/services/{{name}}
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Getting Started': 'https://cloud.google.com/service-usage/docs/getting-started'
+    description: |
+      A service that is available for use
+    properties:
+      - !ruby/object:Api::Type::String
+        name: name
+        required: true
+        description: |
+          The resource name of the service
+      - !ruby/object:Api::Type::String
+        name: parent
+        description: |
+          The name of the parent of this service. For example: `projects/123`
+      - !ruby/object:Api::Type::Enum
+        name: 'state'
+        description: Whether or not the service has been enabled for use by the consumer.
+        values:
+          - STATE_UNSPECIFIED
+          - DISABLED
+          - ENABLED

--- a/products/serviceusage/inspec.yaml
+++ b/products/serviceusage/inspec.yaml
@@ -1,0 +1,15 @@
+# Copyright 2019 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- !ruby/object:Provider::Inspec::Config
+legacy_name: project
+overrides: !ruby/object:Overrides::ResourceOverrides

--- a/templates/inspec/examples/google_compute_disk/google_compute_disk.erb
+++ b/templates/inspec/examples/google_compute_disk/google_compute_disk.erb
@@ -1,19 +1,20 @@
 <% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
 <% gcp_zone = "#{external_attribute('gcp_zone', doc_generation)}" %>
-<% gcp_compute_disk_name = "#{external_attribute('gcp_compute_disk_name', doc_generation)}" -%>
-<% gcp_compute_disk_image = "#{external_attribute('gcp_compute_disk_image', doc_generation).gsub('\'', '')}" -%>
-<% gcp_compute_disk_type = "#{external_attribute('gcp_compute_disk_type', doc_generation)}" -%>
+<% snapshot = grab_attributes['snapshot'] -%>
+<% gcp_compute_disk_name = snapshot["disk_name"] -%>
+<% gcp_compute_disk_image = snapshot["disk_image"] -%>
+<% gcp_compute_disk_type = snapshot["disk_type"] -%>
 most_recent_image = google_compute_image(project: <%= doc_generation ? "'#{gcp_compute_disk_image.split('/').first}'" : "gcp_compute_disk_image.split('/').first" -%>, name: <%= doc_generation ? "'#{gcp_compute_disk_image.split('/').last}'" : "gcp_compute_disk_image.split('/').last" -%>)
 
-describe google_compute_disk(project: <%= gcp_project_id -%>, name: <%= gcp_compute_disk_name -%>, zone: <%= gcp_zone -%>) do
+describe google_compute_disk(project: <%= gcp_project_id -%>, name: <%= doc_generation ? "'#{gcp_compute_disk_name}'" : "gcp_compute_disk_name" -%>, zone: <%= gcp_zone -%>) do
   it { should exist }
   # Test that the image is the most recent image for the family
   its('source_image') { should match most_recent_image.self_link }
-  its('type') { should match <%= gcp_compute_disk_type -%> }
+  its('type') { should match <%= doc_generation ? "'#{gcp_compute_disk_type}'" : "gcp_compute_disk_type" -%> }
 end
 
 describe.one do
-  google_compute_disk(project: <%= gcp_project_id -%>, name: <%= gcp_compute_disk_name -%>, zone: <%= gcp_zone -%>).labels.each_pair do |key, value|
+  google_compute_disk(project: <%= gcp_project_id -%>, name: <%= doc_generation ? "'#{gcp_compute_disk_name}'" : "gcp_compute_disk_name" -%>, zone: <%= gcp_zone -%>).labels.each_pair do |key, value|
     describe key do
       it { should cmp "environment" }
     end

--- a/templates/inspec/examples/google_compute_disk/google_compute_disk_attributes.erb
+++ b/templates/inspec/examples/google_compute_disk/google_compute_disk_attributes.erb
@@ -1,5 +1,6 @@
 gcp_project_id = attribute(:gcp_project_id, default: '<%= external_attribute('gcp_project_id') -%>', description: 'The GCP project identifier.')
 gcp_zone = attribute(:gcp_zone, default: '<%= external_attribute('gcp_zone') -%>', description: 'The GCP project zone.')
-gcp_compute_disk_name = attribute(:gcp_compute_disk_name, default: '<%= external_attribute('gcp_compute_disk_name') -%>', description: 'GCP Compute disk name.')
-gcp_compute_disk_image = attribute(:gcp_compute_disk_image, default: '<%= external_attribute('gcp_compute_disk_image') -%>', description: 'GCP Compute image identifier.')
-gcp_compute_disk_type = attribute(:gcp_compute_disk_type, default: '<%= external_attribute('gcp_compute_disk_type') -%>', description: 'GCP Compute disk type.')
+snapshot = attribute('snapshot', default: <%= JSON.pretty_generate(grab_attributes['snapshot']) -%>, description: 'Disk snapshot description')
+gcp_compute_disk_name = snapshot["disk_name"]
+gcp_compute_disk_image = snapshot["disk_image"]
+gcp_compute_disk_type = snapshot["disk_type"]

--- a/templates/inspec/examples/google_compute_disk/google_compute_disks.erb
+++ b/templates/inspec/examples/google_compute_disk/google_compute_disks.erb
@@ -1,7 +1,8 @@
-<% gcp_compute_disk_image = "#{external_attribute('gcp_compute_disk_image', doc_generation).gsub('\'', '')}" -%>
+<% snapshot = grab_attributes['snapshot'] -%>
+<% gcp_compute_disk_image = "#{snapshot["disk_image"].gsub('\'', '')}" -%>
 most_recent_image = google_compute_image(project: <%= doc_generation ? "'#{gcp_compute_disk_image.split('/').first}'" : "gcp_compute_disk_image.split('/').first" -%>, name: <%= doc_generation ? "'#{gcp_compute_disk_image.split('/').last}'" : "gcp_compute_disk_image.split('/').last" -%>)
 describe google_compute_disks(project: <%= "#{external_attribute('gcp_project_id', doc_generation)}" -%>, zone: <%= "#{external_attribute('gcp_zone', doc_generation)}" -%>) do
   it { should exist }
-  its('names') { should include <%= "#{external_attribute('gcp_compute_disk_name', doc_generation)}" -%> }
+  its('names') { should include <%= doc_generation ? "'#{snapshot['disk_name']}'" : "snapshot['disk_name']" -%> }
   its('source_images') { should include most_recent_image.self_link }
 end

--- a/templates/inspec/examples/google_project_service/google_project_service.erb
+++ b/templates/inspec/examples/google_project_service/google_project_service.erb
@@ -1,0 +1,6 @@
+<% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
+<% service = grab_attributes['service'] -%>
+describe google_project_service(project: <%= gcp_project_id -%>, name: <%= doc_generation ? "'#{service['name']}'" : "service['name']" -%>) do
+  it { should exist }
+  its('state') { should cmp "ENABLED" }
+end

--- a/templates/inspec/examples/google_project_service/google_project_service_attributes.erb
+++ b/templates/inspec/examples/google_project_service/google_project_service_attributes.erb
@@ -1,0 +1,2 @@
+gcp_project_id = attribute(:gcp_project_id, default: '<%= external_attribute('gcp_project_id') -%>', description: 'The GCP project identifier.')
+service = attribute('service', default: <%= JSON.pretty_generate(grab_attributes['service']) -%>, description: 'Service description')

--- a/templates/inspec/examples/google_project_service/google_project_services.erb
+++ b/templates/inspec/examples/google_project_service/google_project_services.erb
@@ -1,0 +1,9 @@
+<% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
+<% service = grab_attributes['service'] -%>
+describe.one do
+  google_project_services(project: <%= gcp_project_id -%>).names.each do |name|
+    describe name do
+      it { should match <%= doc_generation ? "'#{service['name']}'" : "service['name']" -%> }
+    end
+  end
+end

--- a/templates/inspec/tests/integration/build/gcp-mm.tf
+++ b/templates/inspec/tests/integration/build/gcp-mm.tf
@@ -197,6 +197,10 @@ variable "router_nat" {
   type = "map"
 }
 
+variable "service" {
+  type = "map"
+}
+
 resource "google_compute_ssl_policy" "custom-ssl-policy" {
   name            = "${var.ssl_policy["name"]}"
   min_tls_version = "${var.ssl_policy["min_tls_version"]}"
@@ -504,9 +508,9 @@ resource "google_compute_router" "gcp-inspec-router" {
 resource "google_compute_disk" "snapshot-disk" {
   project = "${var.gcp_project_id}"
   name  = var.snapshot["disk_name"]
-  type  = "${var.gcp_compute_disk_type}"
+  type  = var.snapshot["disk_type"]
   zone  = "${var.gcp_zone}"
-  image = "${var.gcp_compute_disk_image}"
+  image = var.snapshot["disk_image"]
   labels = {
     environment = "generic_compute_disk_label"
   }
@@ -856,4 +860,9 @@ resource "google_compute_router_nat" "inspec-nat" {
     enable = var.router_nat["log_config_enable"]
     filter = var.router_nat["log_config_filter"]
   }
+}
+
+resource "google_project_service" "project" {
+  project = var.gcp_project_id
+  service = var.service["name"]
 }

--- a/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -149,6 +149,8 @@ router:
 snapshot:
   name: inspec-gcp-disk-snapshot
   disk_name: inspec-snapshot-disk
+  disk_type: pd-standard
+  disk_image: debian-cloud/debian-10-buster-v20191014
 
 https_proxy:
   name: inspec-gcp-https-proxy
@@ -324,3 +326,6 @@ router_nat:
   min_ports_per_vm: 2
   log_config_enable: true
   log_config_filter: ERRORS_ONLY
+
+service:
+  name: maps-android-backend.googleapis.com


### PR DESCRIPTION
Add support for `google_project_service` to InSpec. Make VCR tests pass by not depending on resources with random variables
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
