### PR TITLE
[logging_sink] Add bigquery_options field to support partitioned tables

### DIFF
--- a/third_party/terraform/resources/resource_logging_billing_account_sink.go
+++ b/third_party/terraform/resources/resource_logging_billing_account_sink.go
@@ -56,11 +56,11 @@ func resourceLoggingBillingAccountSinkRead(d *schema.ResourceData, meta interfac
 func resourceLoggingBillingAccountSinkUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	sink := expandResourceLoggingSinkForUpdate(d)
+	sink, updateMask := expandResourceLoggingSinkForUpdate(d)
 
 	// The API will reject any requests that don't explicitly set 'uniqueWriterIdentity' to true.
 	_, err := config.clientLogging.BillingAccounts.Sinks.Patch(d.Id(), sink).
-		UpdateMask(defaultLogSinkUpdateMask).UniqueWriterIdentity(true).Do()
+		UpdateMask(updateMask).UniqueWriterIdentity(true).Do()
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_logging_folder_sink.go
+++ b/third_party/terraform/resources/resource_logging_folder_sink.go
@@ -70,7 +70,7 @@ func resourceLoggingFolderSinkRead(d *schema.ResourceData, meta interface{}) err
 func resourceLoggingFolderSinkUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	sink := expandResourceLoggingSinkForUpdate(d)
+	sink, updateMask := expandResourceLoggingSinkForUpdate(d)
 	// It seems the API might actually accept an update for include_children; this is not in the list of updatable
 	// properties though and might break in the future. Always include the value to prevent it changing.
 	sink.IncludeChildren = d.Get("include_children").(bool)
@@ -78,7 +78,7 @@ func resourceLoggingFolderSinkUpdate(d *schema.ResourceData, meta interface{}) e
 
 	// The API will reject any requests that don't explicitly set 'uniqueWriterIdentity' to true.
 	_, err := config.clientLogging.Folders.Sinks.Patch(d.Id(), sink).
-		UpdateMask(defaultLogSinkUpdateMask).UniqueWriterIdentity(true).Do()
+		UpdateMask(updateMask).UniqueWriterIdentity(true).Do()
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_logging_organization_sink.go
+++ b/third_party/terraform/resources/resource_logging_organization_sink.go
@@ -70,7 +70,7 @@ func resourceLoggingOrganizationSinkRead(d *schema.ResourceData, meta interface{
 func resourceLoggingOrganizationSinkUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	sink := expandResourceLoggingSinkForUpdate(d)
+	sink, updateMask := expandResourceLoggingSinkForUpdate(d)
 	// It seems the API might actually accept an update for include_children; this is not in the list of updatable
 	// properties though and might break in the future. Always include the value to prevent it changing.
 	sink.IncludeChildren = d.Get("include_children").(bool)
@@ -78,7 +78,7 @@ func resourceLoggingOrganizationSinkUpdate(d *schema.ResourceData, meta interfac
 
 	// The API will reject any requests that don't explicitly set 'uniqueWriterIdentity' to true.
 	_, err := config.clientLogging.Organizations.Sinks.Patch(d.Id(), sink).
-		UpdateMask(defaultLogSinkUpdateMask).UniqueWriterIdentity(true).Do()
+		UpdateMask(updateMask).UniqueWriterIdentity(true).Do()
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_logging_project_sink.go
+++ b/third_party/terraform/resources/resource_logging_project_sink.go
@@ -81,11 +81,11 @@ func resourceLoggingProjectSinkRead(d *schema.ResourceData, meta interface{}) er
 func resourceLoggingProjectSinkUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	sink := expandResourceLoggingSinkForUpdate(d)
+	sink, updateMask := expandResourceLoggingSinkForUpdate(d)
 	uniqueWriterIdentity := d.Get("unique_writer_identity").(bool)
 
 	_, err := config.clientLogging.Projects.Sinks.Patch(d.Id(), sink).
-		UpdateMask(defaultLogSinkUpdateMask).UniqueWriterIdentity(uniqueWriterIdentity).Do()
+		UpdateMask(updateMask).UniqueWriterIdentity(uniqueWriterIdentity).Do()
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_logging_sink.go
+++ b/third_party/terraform/resources/resource_logging_sink.go
@@ -42,7 +42,7 @@ func resourceLoggingSinkSchema() map[string]*schema.Schema {
 				Schema: map[string]*schema.Schema{
 					"use_partitioned_tables": {
 						Type:     schema.TypeBool,
-						Optional: true,
+						Required: true,
 					},
 				},
 			},

--- a/third_party/terraform/resources/resource_logging_sink.go
+++ b/third_party/terraform/resources/resource_logging_sink.go
@@ -76,7 +76,7 @@ func flattenResourceLoggingSink(d *schema.ResourceData, sink *logging.LogSink) {
 func expandResourceLoggingSinkForUpdate(d *schema.ResourceData) (sink *logging.LogSink, updateMask string) {
 	// Can only update destination/filter right now. Despite the method below using 'Patch', the API requires both
 	// destination and filter (even if unchanged).
-	sink := logging.LogSink{
+	sink = &logging.LogSink{
 		Destination:     d.Get("destination").(string),
 		Filter:          d.Get("filter").(string),
 		ForceSendFields: []string{"Destination", "Filter"},
@@ -93,7 +93,8 @@ func expandResourceLoggingSinkForUpdate(d *schema.ResourceData) (sink *logging.L
 		sink.BigqueryOptions = expandLoggingSinkBigqueryOptions(d.Get("bigquery_options"))
 		updateFields = append(updateFields, "bigqueryOptions")
 	}
-	return &sink, strings.Join(updateFields, ",")
+	updateMask = strings.Join(updateFields, ",")
+	return
 }
 
 func expandLoggingSinkBigqueryOptions(v interface{}) *logging.BigQueryOptions {

--- a/third_party/terraform/resources/resource_logging_sink.go
+++ b/third_party/terraform/resources/resource_logging_sink.go
@@ -71,6 +71,7 @@ func flattenResourceLoggingSink(d *schema.ResourceData, sink *logging.LogSink) {
 	d.Set("destination", sink.Destination)
 	d.Set("filter", sink.Filter)
 	d.Set("writer_identity", sink.WriterIdentity)
+	d.Set("bigquery_options", flattenLoggingSinkBigqueryOptions(sink.BigqueryOptions))
 }
 
 func expandResourceLoggingSinkForUpdate(d *schema.ResourceData) (sink *logging.LogSink, updateMask string) {
@@ -111,6 +112,16 @@ func expandLoggingSinkBigqueryOptions(v interface{}) *logging.BigQueryOptions {
 		bo.UsePartitionedTables = usePartitionedTables.(bool)
 	}
 	return bo
+}
+
+func flattenLoggingSinkBigqueryOptions(o *logging.BigQueryOptions) []map[string]interface{} {
+	if o == nil {
+		return nil
+	}
+	oMap := map[string]interface{}{
+		"use_partitioned_tables": o.UsePartitionedTables,
+	}
+	return []map[string]interface{}{oMap}
 }
 
 func resourceLoggingSinkImportState(sinkType string) schema.StateFunc {

--- a/third_party/terraform/resources/resource_logging_sink.go
+++ b/third_party/terraform/resources/resource_logging_sink.go
@@ -7,9 +7,6 @@ import (
 	"google.golang.org/api/logging/v2"
 )
 
-// Empty update masks will eventually cause updates to fail, currently empty masks default to this string
-const defaultLogSinkUpdateMask = "destination,filter,includeChildren"
-
 func resourceLoggingSinkSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"name": {

--- a/third_party/terraform/resources/resource_logging_sink.go
+++ b/third_party/terraform/resources/resource_logging_sink.go
@@ -73,7 +73,7 @@ func flattenResourceLoggingSink(d *schema.ResourceData, sink *logging.LogSink) {
 	d.Set("writer_identity", sink.WriterIdentity)
 }
 
-func expandResourceLoggingSinkForUpdate(d *schema.ResourceData) (*logging.LogSink, string) {
+func expandResourceLoggingSinkForUpdate(d *schema.ResourceData) (sink *logging.LogSink, updateMask string) {
 	// Can only update destination/filter right now. Despite the method below using 'Patch', the API requires both
 	// destination and filter (even if unchanged).
 	sink := logging.LogSink{
@@ -100,7 +100,11 @@ func expandLoggingSinkBigqueryOptions(v interface{}) *logging.BigQueryOptions {
 	if v == nil {
 		return nil
 	}
-	options := v.([]interface{})[0].(map[string]interface{})
+	optionsSlice := v.([]interface{})
+	if len(optionsSlice) == 0 || optionsSlice[0] == nil {
+		return nil
+	}
+	options := optionsSlice[0].(map[string]interface{})
 	bo := &logging.BigQueryOptions{}
 	if usePartitionedTables, ok := options["use_partitioned_tables"]; ok {
 		bo.UsePartitionedTables = usePartitionedTables.(bool)

--- a/third_party/terraform/tests/resource_logging_billing_account_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_billing_account_sink_test.go
@@ -84,6 +84,38 @@ func TestAccLoggingBillingAccountSink_update(t *testing.T) {
 	}
 }
 
+func TestAccLoggingBillingAccountSink_updateBigquerySink(t *testing.T) {
+	t.Parallel()
+
+	sinkName := "tf-test-sink-" + acctest.RandString(10)
+	bqDatasetID := "tf_test_sink_" + acctest.RandString(10)
+	billingAccount := getTestBillingAccountFromEnv(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLoggingBillingAccountSinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingBillingAccountSink_bigquery_before(sinkName, bqDatasetID, billingAccount),
+			},
+			{
+				ResourceName:      "google_logging_billing_account_sink.bigquery",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccLoggingBillingAccountSink_bigquery_after(sinkName, bqDatasetID, billingAccount),
+			},
+			{
+				ResourceName:      "google_logging_billing_account_sink.bigquery",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccLoggingBillingAccountSink_heredoc(t *testing.T) {
 	t.Parallel()
 
@@ -223,4 +255,40 @@ resource "google_storage_bucket" "log-bucket" {
   name = "%s"
 }
 `, name, billingAccount, getTestProjectFromEnv(), bucketName)
+}
+
+func testAccLoggingBillingAccountSink_bigquery_before(sinkName, bqDatasetID, billingAccount string) string {
+	return fmt.Sprintf(`
+resource "google_logging_billing_account_sink" "bigquery" {
+  name             = "%s"
+  billing_account  = "%s"
+  destination      = "bigquery.googleapis.com/projects/%s/datasets/${google_bigquery_dataset.logging_sink.dataset_id}"
+  filter           = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+  include_children = true
+
+  bigquery_options {
+    use_partitioned_tables = true
+  }
+}
+
+resource "google_bigquery_dataset" "logging_sink" {
+  dataset_id  = "%s"
+  description = "Log sink (generated during acc test of terraform-provider-google(-beta))."
+}`, sinkName, billingAccount, getTestProjectFromEnv(), getTestProjectFromEnv(), bqDatasetID)
+}
+
+func testAccLoggingBillingAccountSink_bigquery_after(sinkName, bqDatasetID, billingAccount string) string {
+	return fmt.Sprintf(`
+resource "google_logging_billing_account_sink" "bigquery" {
+  name             = "%s"
+  billing_account  = "%s"
+  destination      = "bigquery.googleapis.com/projects/%s/datasets/${google_bigquery_dataset.logging_sink.dataset_id}"
+  filter           = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=WARNING"
+  include_children = true
+}
+
+resource "google_bigquery_dataset" "logging_sink" {
+  dataset_id  = "%s"
+  description = "Log sink (generated during acc test of terraform-provider-google(-beta))."
+}`, sinkName, billingAccount, getTestProjectFromEnv(), getTestProjectFromEnv(), bqDatasetID)
 }

--- a/third_party/terraform/tests/resource_logging_billing_account_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_billing_account_sink_test.go
@@ -264,7 +264,6 @@ resource "google_logging_billing_account_sink" "bigquery" {
   billing_account  = "%s"
   destination      = "bigquery.googleapis.com/projects/%s/datasets/${google_bigquery_dataset.logging_sink.dataset_id}"
   filter           = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
-  include_children = true
 
   bigquery_options {
     use_partitioned_tables = true

--- a/third_party/terraform/tests/resource_logging_billing_account_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_billing_account_sink_test.go
@@ -283,7 +283,6 @@ resource "google_logging_billing_account_sink" "bigquery" {
   billing_account  = "%s"
   destination      = "bigquery.googleapis.com/projects/%s/datasets/${google_bigquery_dataset.logging_sink.dataset_id}"
   filter           = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=WARNING"
-  include_children = true
 }
 
 resource "google_bigquery_dataset" "logging_sink" {

--- a/third_party/terraform/tests/resource_logging_folder_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_folder_sink_test.go
@@ -152,6 +152,39 @@ func TestAccLoggingFolderSink_update(t *testing.T) {
 	}
 }
 
+func TestAccLoggingFolderSink_updateBigquerySink(t *testing.T) {
+	t.Parallel()
+
+	org := getTestOrgFromEnv(t)
+	sinkName := "tf-test-sink-" + acctest.RandString(10)
+	bqDatasetID := "tf_test_sink_" + acctest.RandString(10)
+	folderName := "tf-test-folder-" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLoggingFolderSinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingFolderSink_bigquery_before(sinkName, bqDatasetID, folderName, "organizations/"+org),
+			},
+			{
+				ResourceName:      "google_logging_folder_sink.bigquery",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccLoggingFolderSink_bigquery_after(sinkName, bqDatasetID, folderName, "organizations/"+org),
+			},
+			{
+				ResourceName:      "google_logging_folder_sink.bigquery",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccLoggingFolderSink_heredoc(t *testing.T) {
 	t.Parallel()
 
@@ -342,4 +375,50 @@ resource "google_folder" "my-folder" {
   parent       = "%s"
 }
 `, sinkName, getTestProjectFromEnv(), bucketName, folderName, folderParent)
+}
+
+func testAccLoggingFolderSink_bigquery_before(sinkName, bqDatasetID, folderName, folderParent string) string {
+	return fmt.Sprintf(`
+resource "google_logging_folder_sink" "bigquery" {
+  name             = "%s"
+  folder           = "${element(split("/", google_folder.my-folder.name), 1)}"
+  destination      = "bigquery.googleapis.com/projects/%s/datasets/${google_bigquery_dataset.logging_sink.dataset_id}"
+  filter           = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+  include_children = true
+
+  bigquery_options {
+    use_partitioned_tables = true
+  }
+}
+
+resource "google_bigquery_dataset" "logging_sink" {
+  dataset_id  = "%s"
+  description = "Log sink (generated during acc test of terraform-provider-google(-beta))."
+}
+
+resource "google_folder" "my-folder" {
+  display_name = "%s"
+  parent       = "%s"
+}`, sinkName, getTestProjectFromEnv(), getTestProjectFromEnv(), bqDatasetID, folderName, folderParent)
+}
+
+func testAccLoggingFolderSink_bigquery_after(sinkName, bqDatasetID, folderName, folderParent string) string {
+	return fmt.Sprintf(`
+resource "google_logging_folder_sink" "bigquery" {
+  name             = "%s"
+  folder           = "${element(split("/", google_folder.my-folder.name), 1)}"
+  destination      = "bigquery.googleapis.com/projects/%s/datasets/${google_bigquery_dataset.logging_sink.dataset_id}"
+  filter           = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=WARNING"
+  include_children = true
+}
+
+resource "google_bigquery_dataset" "logging_sink" {
+  dataset_id  = "%s"
+  description = "Log sink (generated during acc test of terraform-provider-google(-beta))."
+}
+
+resource "google_folder" "my-folder" {
+  display_name = "%s"
+  parent       = "%s"
+}`, sinkName, getTestProjectFromEnv(), getTestProjectFromEnv(), bqDatasetID, folderName, folderParent)
 }

--- a/third_party/terraform/tests/resource_logging_project_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_project_sink_test.go
@@ -64,6 +64,37 @@ func TestAccLoggingProjectSink_updatePreservesUniqueWriter(t *testing.T) {
 	})
 }
 
+func TestAccLoggingProjectSink_updateBigquerySink(t *testing.T) {
+	t.Parallel()
+
+	sinkName := "tf-test-sink-" + acctest.RandString(10)
+	bqDatasetID := "tf_test_sink_" + acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLoggingProjectSinkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingProjectSink_bigquery_before(sinkName, bqDatasetID),
+			},
+			{
+				ResourceName:      "google_logging_project_sink.bigquery",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccLoggingProjectSink_bigquery_after(sinkName, bqDatasetID),
+			},
+			{
+				ResourceName:      "google_logging_project_sink.bigquery",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccLoggingProjectSink_heredoc(t *testing.T) {
 	t.Parallel()
 
@@ -177,4 +208,42 @@ resource "google_storage_bucket" "log-bucket" {
   name = "%s"
 }
 `, name, project, project, bucketName)
+}
+
+func testAccLoggingProjectSink_bigquery_before(sinkName, bqDatasetID string) string {
+	return fmt.Sprintf(`
+resource "google_logging_project_sink" "bigquery" {
+  name        = "%s"
+  destination = "bigquery.googleapis.com/projects/%s/datasets/${google_bigquery_dataset.logging_sink.dataset_id}"
+  filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+
+  unique_writer_identity = true
+
+  bigquery_options {
+    use_partitioned_tables = true
+  }
+}
+
+resource "google_bigquery_dataset" "logging_sink" {
+  dataset_id  = "%s"
+  description = "Log sink (generated during acc test of terraform-provider-google(-beta))."
+}
+`, sinkName, getTestProjectFromEnv(), getTestProjectFromEnv(), bqDatasetID)
+}
+
+func testAccLoggingProjectSink_bigquery_after(sinkName, bqDatasetID string) string {
+	return fmt.Sprintf(`
+resource "google_logging_project_sink" "bigquery" {
+  name        = "%s"
+  destination = "bigquery.googleapis.com/projects/%s/datasets/${google_bigquery_dataset.logging_sink.dataset_id}"
+  filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=WARNING"
+
+  unique_writer_identity = false
+}
+
+resource "google_bigquery_dataset" "logging_sink" {
+  dataset_id  = "%s"
+  description = "Log sink (generated during acc test of terraform-provider-google(-beta))."
+}
+`, sinkName, getTestProjectFromEnv(), getTestProjectFromEnv(), bqDatasetID)
 }

--- a/third_party/terraform/website/docs/r/logging_billing_account_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_billing_account_sink.html.markdown
@@ -63,6 +63,15 @@ The following arguments are supported:
     See [Advanced Log Filters](https://cloud.google.com/logging/docs/view/advanced_filters) for information on how to
     write a filter.
 
+* `bigquery_options` - (Optional) Options that affect sinks exporting data to BigQuery. Structure documented below.
+
+The `bigquery_options` block supports:
+
+* `use_partitioned_tables` - (Required) Whether to use [BigQuery's partition tables](https://cloud.google.com/bigquery/docs/partitioned-tables).
+    By default, Logging creates dated tables based on the log entries' timestamps, e.g. syslog_20170523. With partitioned
+    tables the date suffix is no longer present and [special query syntax](https://cloud.google.com/bigquery/docs/querying-partitioned-tables)
+    has to be used instead. In both cases, tables are sharded based on UTC timezone.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are

--- a/third_party/terraform/website/docs/r/logging_folder_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_folder_sink.html.markdown
@@ -73,6 +73,15 @@ The following arguments are supported:
 * `include_children` - (Optional) Whether or not to include children folders in the sink export. If true, logs
     associated with child projects are also exported; otherwise only logs relating to the provided folder are included.
 
+* `bigquery_options` - (Optional) Options that affect sinks exporting data to BigQuery. Structure documented below.
+
+The `bigquery_options` block supports:
+
+* `use_partitioned_tables` - (Required) Whether to use [BigQuery's partition tables](https://cloud.google.com/bigquery/docs/partitioned-tables).
+    By default, Logging creates dated tables based on the log entries' timestamps, e.g. syslog_20170523. With partitioned
+    tables the date suffix is no longer present and [special query syntax](https://cloud.google.com/bigquery/docs/querying-partitioned-tables)
+    has to be used instead. In both cases, tables are sharded based on UTC timezone.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are

--- a/third_party/terraform/website/docs/r/logging_organization_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_organization_sink.html.markdown
@@ -65,6 +65,15 @@ The following arguments are supported:
 * `include_children` - (Optional) Whether or not to include children organizations in the sink export. If true, logs
     associated with child projects are also exported; otherwise only logs relating to the provided organization are included.
 
+* `bigquery_options` - (Optional) Options that affect sinks exporting data to BigQuery. Structure documented below.
+
+The `bigquery_options` block supports:
+
+* `use_partitioned_tables` - (Required) Whether to use [BigQuery's partition tables](https://cloud.google.com/bigquery/docs/partitioned-tables).
+    By default, Logging creates dated tables based on the log entries' timestamps, e.g. syslog_20170523. With partitioned
+    tables the date suffix is no longer present and [special query syntax](https://cloud.google.com/bigquery/docs/querying-partitioned-tables)
+    has to be used instead. In both cases, tables are sharded based on UTC timezone.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are

--- a/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -113,6 +113,15 @@ The following arguments are supported:
     then a unique service account is created and used for this sink. If you wish to publish logs across projects, you
     must set `unique_writer_identity` to true.
 
+* `bigquery_options` - (Optional) Options that affect sinks exporting data to BigQuery. Structure documented below.
+
+The `bigquery_options` block supports:
+
+* `use_partitioned_tables` - (Required) Whether to use [BigQuery's partition tables](https://cloud.google.com/bigquery/docs/partitioned-tables).
+    By default, Logging creates dated tables based on the log entries' timestamps, e.g. syslog_20170523. With partitioned
+    tables the date suffix is no longer present and [special query syntax](https://cloud.google.com/bigquery/docs/querying-partitioned-tables)
+    has to be used instead. In both cases, tables are sharded based on UTC timezone.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are


### PR DESCRIPTION
This PR fixes #2556 by adding `bigquery_options` field to logging_sink resources.

- Additional modification: 163eb0c logging_sink: use updateMask to specify updated fields rather than forceSendFields
    - When updating logging sink, it seems `destination` and `filter` fields must exist even if they didn't changed, so `ForceSendFields` should be used for this purpose. To specify which fields are updated, you should use `UpdateMask`

ref:

- https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks?hl=ja#LogSink.BigQueryOptions
- https://godoc.org/google.golang.org/api/logging/v2#BigQueryOptions

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
`google_logging_*_sink`: added support for `bigquery_options` to all logging_sink resources (project, organization, folder, billing_account).
```
