### PR TITLE
Remove encoder, can be done as send_empty_value on autoCreateSubnetworks

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -902,6 +902,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         exclude: true
       autoCreateSubnetworks: !ruby/object:Overrides::Terraform::PropertyOverride
         default_value: True
+        send_empty_value: true
         # autoCreateSubnetworks defaults to true, so we need to disable it explicitly
         conflicts: []
       routingConfig: !ruby/object:Overrides::Terraform::PropertyOverride
@@ -917,7 +918,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       post_create: templates/terraform/post_create/compute_network_delete_default_route.erb
-      encoder: templates/terraform/encoders/network.erb
       extra_schema_entry: templates/terraform/extra_schema_entry/network.erb
   NetworkEndpoint: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: "{{project}}/{{zone}}/{{network_endpoint_group}}/{{instance}}/{{ip_address}}/{{port}}"

--- a/templates/terraform/encoders/network.erb
+++ b/templates/terraform/encoders/network.erb
@@ -1,3 +1,0 @@
-obj["autoCreateSubnetworks"] = d.Get("auto_create_subnetworks")
-
-return obj, nil


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
