### PR TITLE
Subnet changes to logConfig for 3.0.0

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -8694,15 +8694,6 @@ objects:
           Only networks that are in the distributed mode can have subnetworks.
         input: true
         required: true
-      - !ruby/object:Api::Type::Boolean
-        name: 'enableFlowLogs'
-        description: |
-          Whether to enable flow logging for this subnetwork.
-        update_verb: :PATCH
-        update_url:  projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
-        update_id: 'enableFlowLogs'
-        fingerprint_name: 'fingerprint'
-        send_empty_value: true
       # TODO(rileykarson): Work with rambleraptor to remove this field from downstreams.
       - !ruby/object:Api::Type::Fingerprint
         name: 'fingerprint'
@@ -8786,11 +8777,18 @@ objects:
         input: true
       - !ruby/object:Api::Type::NestedObject
         name: 'logConfig'
+        update_verb: :PATCH
+        update_url:  projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
+        update_id: 'logConfig'
         description: |
           Denotes the logging options for the subnetwork flow logs. If logging is enabled
           logs will be exported to Stackdriver.
-        min_version: beta
         properties:
+          - !ruby/object:Api::Type::Boolean
+            name: enable
+            description: |
+              Enables flow logging to export logs to Stackdriver
+            default_value: false
           - !ruby/object:Api::Type::Enum
             name: 'aggregationInterval'
             description: |

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -8779,6 +8779,7 @@ objects:
         name: 'logConfig'
         update_verb: :PATCH
         update_url:  projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
+        fingerprint_name: 'fingerprint'
         update_id: 'logConfig'
         description: |
           Denotes the logging options for the subnetwork flow logs. If logging is enabled
@@ -8789,6 +8790,7 @@ objects:
             description: |
               Enables flow logging to export logs to Stackdriver
             default_value: false
+            send_empty_value: true
           - !ruby/object:Api::Type::Enum
             name: 'aggregationInterval'
             description: |
@@ -8805,7 +8807,7 @@ objects:
               - :INTERVAL_5_MIN
               - :INTERVAL_10_MIN
               - :INTERVAL_15_MIN
-            default_value: :INTERVAL_5_SEC
+            send_empty_value: true
           - !ruby/object:Api::Type::Double
             name: 'flowSampling'
             description: |
@@ -8814,7 +8816,7 @@ objects:
               flow logs within the subnetwork where 1.0 means all collected logs are
               reported and 0.0 means no logs are reported. Default is 0.5 which means
               half of all collected logs are reported.
-            default_value: 0.5
+            send_empty_value: true
           - !ruby/object:Api::Type::Enum
             name: 'metadata'
             description: |
@@ -8824,7 +8826,7 @@ objects:
             values:
               - :EXCLUDE_ALL_METADATA
               - :INCLUDE_ALL_METADATA
-            default_value: :INCLUDE_ALL_METADATA
+            send_empty_value: true
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Private Google Access':

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -242,8 +242,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         sensitive: true
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
-      logConfig: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
       portName: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       protocol: !ruby/object:Overrides::Terraform::PropertyOverride
@@ -1662,6 +1660,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           function: 'validateIpCidrRange'
       fingerprint: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: false
+      logConfig: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/subnetwork_log_config.go.erb'
+        custom_flatten: 'templates/terraform/custom_flatten/subnetwork_log_config.go.erb'
       ipCidrRange: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateIpCidrRange'

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1670,8 +1670,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         input: false
         default_from_api: true
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
-      logConfig: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
       purpose: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
@@ -1685,9 +1683,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           subnetwork_name: "test-subnetwork"
           network_name: "test-network"
       - !ruby/object:Provider::Terraform::Examples
-        name: "subnetwork_logging_config_beta"
+        name: "subnetwork_logging_config"
         primary_resource_id: "subnet-with-logging"
-        min_version: beta
         vars:
           subnetwork_name: "log-test-subnetwork"
           network_name: "log-test-network"

--- a/templates/terraform/constants/subnetwork.erb
+++ b/templates/terraform/constants/subnetwork.erb
@@ -17,11 +17,3 @@ func isShrinkageIpCidr(old, new, _ interface{}) bool {
 
 	return true
 }
-
-
-func splitSubnetID(id string) (region string, name string) {
-	parts := strings.Split(id, "/")
-	region = parts[0]
-	name = parts[1]
-	return
-}

--- a/templates/terraform/custom_expand/subnetwork_log_config.go.erb
+++ b/templates/terraform/custom_expand/subnetwork_log_config.go.erb
@@ -1,0 +1,30 @@
+<%- # the license inside this block applies to this file
+	# Copyright 2018 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+
+	if !original["enable"].(bool) {
+		transformed := make(map[string]interface{})
+		transformed["enable"] = original["enable"]
+		return transformed, nil
+	}
+
+	return original, nil
+}

--- a/templates/terraform/custom_flatten/subnetwork_log_config.go.erb
+++ b/templates/terraform/custom_flatten/subnetwork_log_config.go.erb
@@ -1,0 +1,29 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2019 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+	if !original["enable"].(bool) {
+		transformed := make(map[string]interface{})
+		transformed["enable"] = original["enable"]
+		return []interface{}{transformed}
+	}
+	return []interface{}{original}
+}

--- a/templates/terraform/custom_flatten/subnetwork_log_config.go.erb
+++ b/templates/terraform/custom_flatten/subnetwork_log_config.go.erb
@@ -20,10 +20,17 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
 	if len(original) == 0 {
 		return nil
 	}
-	if !original["enable"].(bool) {
-		transformed := make(map[string]interface{})
-		transformed["enable"] = original["enable"]
+	transformed := make(map[string]interface{})
+	transformed["enable"] = original["enable"]
+	if v, ok := original["enable"]; ok && !v.(bool) {
+		// enable is false, so the rest of the values should be unset
+		// the other values may be set on the response, but if we send them to the
+		// API on subsequent requests it will fail as enable is false
 		return []interface{}{transformed}
 	}
-	return []interface{}{original}
+
+	transformed["flow_sampling"] = original["flowSampling"]
+	transformed["aggregation_interval"] = original["aggregationInterval"]
+	transformed["metadata"] = original["metadata"]
+	return []interface{}{transformed}
 }

--- a/templates/terraform/examples/subnetwork_logging_config.tf.erb
+++ b/templates/terraform/examples/subnetwork_logging_config.tf.erb
@@ -1,11 +1,9 @@
 resource "google_compute_subnetwork" "subnet-with-logging" {
-  provider      = "google-beta" 
   name          = "<%= ctx[:vars]['subnetwork_name'] %>"
   ip_cidr_range = "10.2.0.0/16"
   region        = "us-central1"
   network       = "${google_compute_network.custom-test.self_link}"
 
-  enable_flow_logs = true
   log_config {
     aggregation_interval = "INTERVAL_10_MIN"
     flow_sampling = 0.5
@@ -14,12 +12,6 @@ resource "google_compute_subnetwork" "subnet-with-logging" {
 }
 
 resource "google_compute_network" "custom-test" {
-  provider                = "google-beta"
   name                    = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks = false
-}
-
-provider "google-beta"{
-  region = "us-central1"
-  zone   = "us-central1-a"
 }

--- a/templates/terraform/examples/subnetwork_logging_config.tf.erb
+++ b/templates/terraform/examples/subnetwork_logging_config.tf.erb
@@ -5,9 +5,10 @@ resource "google_compute_subnetwork" "subnet-with-logging" {
   network       = "${google_compute_network.custom-test.self_link}"
 
   log_config {
+    enable               = true
     aggregation_interval = "INTERVAL_10_MIN"
-    flow_sampling = 0.5
-    metadata = "INCLUDE_ALL_METADATA"
+    flow_sampling        = 0.5
+    metadata             = "INCLUDE_ALL_METADATA"
   }
 }
 

--- a/third_party/terraform/tests/resource_compute_subnetwork_test.go
+++ b/third_party/terraform/tests/resource_compute_subnetwork_test.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -266,7 +267,10 @@ func testAccCheckComputeSubnetworkExists(n string, subnetwork *compute.Subnetwor
 
 		config := testAccProvider.Meta().(*Config)
 
-		region, subnet_name := splitSubnetID(rs.Primary.ID)
+		splits := strings.Split(rs.Primary.ID, "/")
+		region := splits[len(splits)-3]
+		subnet_name := splits[len(splits)-1]
+
 		found, err := config.clientCompute.Subnetworks.Get(
 			config.Project, region, subnet_name).Do()
 		if err != nil {
@@ -487,7 +491,7 @@ func testAccComputeSubnetwork_flowLogs(cnName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "custom-test" {
 	name = "%s"
-	auto_create_subnetworks = true
+	auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "network-with-flow-logs" {

--- a/third_party/terraform/tests/resource_compute_subnetwork_test.go
+++ b/third_party/terraform/tests/resource_compute_subnetwork_test.go
@@ -523,7 +523,7 @@ resource "google_compute_subnetwork" "network-with-flow-logs" {
 	network = "${google_compute_network.custom-test.self_link}"
 	log_config {
 		enable               = true
-		aggregation_interval = "INTERVAL_10_SEC"
+		aggregation_interval = "INTERVAL_30_SEC"
 		flow_sampling        = 0.8
 		metadata             = "INCLUDE_ALL_METADATA"
 	}
@@ -543,6 +543,9 @@ resource "google_compute_subnetwork" "network-with-flow-logs" {
 	ip_cidr_range = "10.0.0.0/16"
 	region = "us-central1"
 	network = "${google_compute_network.custom-test.self_link}"
+	log_config {
+		enable               = false
+	}
 }
 `, cnName, subnetworkName)
 }

--- a/third_party/terraform/tests/resource_compute_subnetwork_test.go
+++ b/third_party/terraform/tests/resource_compute_subnetwork_test.go
@@ -544,7 +544,7 @@ resource "google_compute_subnetwork" "network-with-flow-logs" {
 	region = "us-central1"
 	network = "${google_compute_network.custom-test.self_link}"
 	log_config {
-		enable               = false
+		enable = false
 	}
 }
 `, cnName, subnetworkName)

--- a/third_party/terraform/tests/resource_compute_subnetwork_test.go
+++ b/third_party/terraform/tests/resource_compute_subnetwork_test.go
@@ -214,12 +214,10 @@ func TestAccComputeSubnetwork_flowLogs(t *testing.T) {
 		CheckDestroy: testAccCheckComputeSubnetworkDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeSubnetwork_flowLogs(cnName, subnetworkName, true),
+				Config: testAccComputeSubnetwork_flowLogs(cnName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeSubnetworkExists(
 						"google_compute_subnetwork.network-with-flow-logs", &subnetwork),
-					resource.TestCheckResourceAttr("google_compute_subnetwork.network-with-flow-logs",
-						"enable_flow_logs", "true"),
 				),
 			},
 			{
@@ -228,12 +226,22 @@ func TestAccComputeSubnetwork_flowLogs(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeSubnetwork_flowLogs(cnName, subnetworkName, false),
+				Config: testAccComputeSubnetwork_flowLogsUpdate(cnName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeSubnetworkExists(
 						"google_compute_subnetwork.network-with-flow-logs", &subnetwork),
-					resource.TestCheckResourceAttr("google_compute_subnetwork.network-with-flow-logs",
-						"enable_flow_logs", "false"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_subnetwork.network-with-flow-logs",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSubnetwork_flowLogsDelete(cnName, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSubnetworkExists(
+						"google_compute_subnetwork.network-with-flow-logs", &subnetwork),
 				),
 			},
 			{
@@ -382,7 +390,6 @@ resource "google_compute_subnetwork" "network-with-private-google-access" {
 	region = "us-central1"
 	network = "${google_compute_network.custom-test.self_link}"
 
-    enable_flow_logs = true
 	secondary_ip_range {
 		range_name = "tf-test-secondary-range-update"
 		ip_cidr_range = "192.168.10.0/24"
@@ -476,7 +483,29 @@ resource "google_compute_subnetwork" "network-with-private-secondary-ip-ranges" 
 `, cnName, subnetworkName)
 }
 
-func testAccComputeSubnetwork_flowLogs(cnName, subnetworkName string, enableLogs bool) string {
+func testAccComputeSubnetwork_flowLogs(cnName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "custom-test" {
+	name = "%s"
+	auto_create_subnetworks = true
+}
+
+resource "google_compute_subnetwork" "network-with-flow-logs" {
+	name = "%s"
+	ip_cidr_range = "10.0.0.0/16"
+	region = "us-central1"
+	network = "${google_compute_network.custom-test.self_link}"
+	log_config {
+		enable               = true
+		aggregation_interval = "INTERVAL_5_SEC"
+		flow_sampling        = 0.5
+		metadata             = "INCLUDE_ALL_METADATA"
+	}
+}
+`, cnName, subnetworkName)
+}
+
+func testAccComputeSubnetwork_flowLogsUpdate(cnName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "custom-test" {
 	name = "%s"
@@ -488,7 +517,28 @@ resource "google_compute_subnetwork" "network-with-flow-logs" {
 	ip_cidr_range = "10.0.0.0/16"
 	region = "us-central1"
 	network = "${google_compute_network.custom-test.self_link}"
-	enable_flow_logs = %v
+	log_config {
+		enable               = true
+		aggregation_interval = "INTERVAL_10_SEC"
+		flow_sampling        = 0.8
+		metadata             = "INCLUDE_ALL_METADATA"
+	}
 }
-`, cnName, subnetworkName, enableLogs)
+`, cnName, subnetworkName)
+}
+
+func testAccComputeSubnetwork_flowLogsDelete(cnName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "custom-test" {
+	name = "%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "network-with-flow-logs" {
+	name = "%s"
+	ip_cidr_range = "10.0.0.0/16"
+	region = "us-central1"
+	network = "${google_compute_network.custom-test.self_link}"
+}
+`, cnName, subnetworkName)
 }


### PR DESCRIPTION
Subnet changes to allow for logConfig to be patched after create.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
`compute`: moved `google_compute_subnetwork` `enable_flow_logs` to `log_config.enable` to support the move of `log_config` to GA
```
