### PR TITLE
Ansible - Logging Metrics

### DIFF
--- a/products/logging/ansible.yaml
+++ b/products/logging/ansible.yaml
@@ -1,0 +1,28 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Ansible::Config
+datasources: !ruby/object:Overrides::ResourceOverrides
+  Metric: !ruby/object:Overrides::Ansible::ResourceOverride
+    facts: !ruby/object:Provider::Ansible::FactsOverride
+      has_filters: false
+overrides: !ruby/object:Overrides::ResourceOverrides
+  OrganizationLogSink: !ruby/object:Overrides::Ansible::ResourceOverride
+    exclude: true
+  FolderExclusion: !ruby/object:Overrides::Ansible::ResourceOverride
+    exclude: true
+  FolderLogSink: !ruby/object:Overrides::Ansible::ResourceOverride
+    exclude: true
+files: !ruby/object:Provider::Config::Files
+  resource:
+<%= lines(indent(compile('provider/ansible/resource~compile.yaml'), 4)) -%>

--- a/products/logging/ansible_version_added.yaml
+++ b/products/logging/ansible_version_added.yaml
@@ -1,0 +1,55 @@
+---
+:facts:
+  :Metric:
+    :version_added: '2.10'
+:regular:
+  :Metric:
+    :version_added: '2.10'
+    :name:
+      :version_added: '2.10'
+    :description:
+      :version_added: '2.10'
+    :filter:
+      :version_added: '2.10'
+    :metricDescriptor:
+      :version_added: '2.10'
+      :unit:
+        :version_added: '2.10'
+      :valueType:
+        :version_added: '2.10'
+      :metricKind:
+        :version_added: '2.10'
+      :labels:
+        :version_added: '2.10'
+        :key:
+          :version_added: '2.10'
+        :description:
+          :version_added: '2.10'
+        :valueType:
+          :version_added: '2.10'
+    :labelExtractors:
+      :version_added: '2.10'
+    :valueExtractor:
+      :version_added: '2.10'
+    :bucketOptions:
+      :version_added: '2.10'
+      :linearBuckets:
+        :version_added: '2.10'
+        :numFiniteBuckets:
+          :version_added: '2.10'
+        :width:
+          :version_added: '2.10'
+        :offset:
+          :version_added: '2.10'
+      :exponentialBuckets:
+        :version_added: '2.10'
+        :numFiniteBuckets:
+          :version_added: '2.10'
+        :growthFactor:
+          :version_added: '2.10'
+        :scale:
+          :version_added: '2.10'
+      :explicitBuckets:
+        :version_added: '2.10'
+        :bounds:
+          :version_added: '2.10'

--- a/products/logging/api.yaml
+++ b/products/logging/api.yaml
@@ -28,6 +28,7 @@ objects:
   - !ruby/object:Api::Resource
     name: "Metric"
     base_url: projects/{{project}}/metrics
+    # The % in self_link indicates that the name value should be URL-encoded.
     self_link: "projects/{{project}}/metrics/{{%name}}"
     update_verb: :PUT
     description: |

--- a/products/logging/api.yaml
+++ b/products/logging/api.yaml
@@ -28,7 +28,7 @@ objects:
   - !ruby/object:Api::Resource
     name: "Metric"
     base_url: projects/{{project}}/metrics
-    self_link: "projects/{{project}}/metrics/{{name}}"
+    self_link: "projects/{{project}}/metrics/{{%name}}"
     update_verb: :PUT
     description: |
       Logs-based metric can also be used to extract values from logs and create a a distribution

--- a/products/logging/api.yaml
+++ b/products/logging/api.yaml
@@ -28,7 +28,7 @@ objects:
   - !ruby/object:Api::Resource
     name: "Metric"
     base_url: projects/{{project}}/metrics
-    self_link: "projects/{{project}}/metrics/{{%name}}"
+    self_link: "projects/{{project}}/metrics/{{name}}"
     update_verb: :PUT
     description: |
       Logs-based metric can also be used to extract values from logs and create a a distribution

--- a/products/logging/examples/ansible/metric.yaml
+++ b/products/logging/examples/ansible/metric.yaml
@@ -1,0 +1,35 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- !ruby/object:Provider::Ansible::Example
+task: !ruby/object:Provider::Ansible::Task
+  name: gcp_logging_metric
+  code:
+    name: "my-(custom)/metric"
+    filter: "resource.type=gae_app AND severity>=ERROR"
+    metric_descriptor:
+      metric_kind: "DELTA"
+      value_type: "DISTRIBUTION"
+      unit: "1"
+      labels:
+        - key: mass
+          value_type: "STRING"
+          description: "amount of matter"
+    value_extractor: "EXTRACT(jsonPayload.request)"
+    bucket_options:
+      linear_buckets:
+        num_finite_buckets: 3
+        width: 1
+        offset: 1
+    project: <%= ctx[:project] %>
+    auth_kind: <%= ctx[:auth_kind] %>
+    service_account_file: <%= ctx[:service_account_file] %>

--- a/products/logging/examples/ansible/metric.yaml
+++ b/products/logging/examples/ansible/metric.yaml
@@ -14,7 +14,7 @@
 task: !ruby/object:Provider::Ansible::Task
   name: gcp_logging_metric
   code:
-    name: "my-(custom)/metric"
+    name: <%= ctx[:name] %>
     filter: "resource.type=gae_app AND severity>=ERROR"
     metric_descriptor:
       metric_kind: "DELTA"
@@ -25,6 +25,8 @@ task: !ruby/object:Provider::Ansible::Task
           value_type: "STRING"
           description: "amount of matter"
     value_extractor: "EXTRACT(jsonPayload.request)"
+    label_extractors:
+      mass: "EXTRACT(jsonPayload.request)"
     bucket_options:
       linear_buckets:
         num_finite_buckets: 3

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -81,7 +81,10 @@ module Provider
       def build_url(url)
         # Return a quoted string, with single pairs of {} brackets and all
         # requested strings are underscored (as they come from the Ansible configs)
-        "\"#{url.gsub(/{{\w+}}/) { |param| "{#{param[2..-3].underscore}}" }}\""
+
+        # The % character indicates that the parameter should be url-encoded. `requests`
+        # does this by default, so the % character should be removed.
+        "\"#{url.gsub(/{{%?\w+}}/) { |param| "{#{param[2..-3].underscore.tr('%', '')}}" }}\""
       end
 
       # Returns the name of the module according to Ansible naming standards.

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -39,8 +39,7 @@ module Provider
         'Api::Type::Integer' => 'int',
         'Api::Type::KeyValuePairs' => 'dict',
         'Provider::Ansible::FilterProp' => 'list',
-        'Api::Type::Path' => 'path',
-        'Api::Type::KeyValuePairs' => 'dict'
+        'Api::Type::Path' => 'path'
       }.freeze
 
       include Provider::Ansible

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -39,7 +39,8 @@ module Provider
         'Api::Type::Integer' => 'int',
         'Api::Type::KeyValuePairs' => 'dict',
         'Provider::Ansible::FilterProp' => 'list',
-        'Api::Type::Path' => 'path'
+        'Api::Type::Path' => 'path',
+        'Api::Type::KeyValuePairs' => 'dict'
       }.freeze
 
       include Provider::Ansible
@@ -62,7 +63,7 @@ module Provider
       # Returns a string representation of the corresponding Python type
       # for a MM type.
       def python_type(prop)
-        prop = Module.const_get(prop).new('') unless prop.is_a?(Api::Type)
+        prop = Module.const_get(prop).new() unless prop.is_a?(Api::Type)
         # All ResourceRefs are dicts with properties.
         if prop.is_a? Api::Type::ResourceRef
           return 'str' if prop.resource_ref.readonly

--- a/provider/ansible.rb
+++ b/provider/ansible.rb
@@ -62,7 +62,7 @@ module Provider
       # Returns a string representation of the corresponding Python type
       # for a MM type.
       def python_type(prop)
-        prop = Module.const_get(prop).new() unless prop.is_a?(Api::Type)
+        prop = Module.const_get(prop).new unless prop.is_a?(Api::Type)
         # All ResourceRefs are dicts with properties.
         if prop.is_a? Api::Type::ResourceRef
           return 'str' if prop.resource_ref.readonly


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->
Logging Metrics on Ansible

This fixes two bugs: one in an incorrect self link in api.yaml and another in Ansible code.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
