### PR TITLE
Add InSpec support for cloud scheduler job

### DIFF
--- a/products/cloudscheduler/inspec.yaml
+++ b/products/cloudscheduler/inspec.yaml
@@ -1,0 +1,15 @@
+# Copyright 2019 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Inspec::Config
+overrides: !ruby/object:Overrides::ResourceOverrides

--- a/templates/inspec/examples/google_cloud_scheduler_job/google_cloud_scheduler_job.erb
+++ b/templates/inspec/examples/google_cloud_scheduler_job/google_cloud_scheduler_job.erb
@@ -1,0 +1,11 @@
+<% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
+<% scheduler_job = grab_attributes['scheduler_job'] -%>
+describe google_cloud_scheduler_job(project: <%= doc_generation ? "#{gcp_project_id}" : "gcp_project_id" -%>, region: <%= doc_generation ? "#{scheduler_job['region']}" : "scheduler_job['region']" -%>, name: <%= doc_generation ? "'#{scheduler_job['name']}'" : "scheduler_job['name']" -%>) do
+  it { should exist }
+
+  its('description') { should cmp <%= doc_generation ? "'#{scheduler_job['description']}'" : "scheduler_job['description']" -%> }
+  its('schedule') { should cmp <%= doc_generation ? "'#{scheduler_job['schedule']}'" : "scheduler_job['schedule']" -%> }
+  its('time_zone') { should cmp <%= doc_generation ? "'#{scheduler_job['time_zone']}'" : "scheduler_job['time_zone']" -%> }
+  its('http_target.http_method') { should cmp <%= doc_generation ? "'#{scheduler_job['http_method']}'" : "scheduler_job['http_method']" -%> }
+  its('http_target.uri') { should cmp <%= doc_generation ? "'#{scheduler_job['http_target_uri']}'" : "scheduler_job['http_target_uri']" -%> }
+end

--- a/templates/inspec/examples/google_cloud_scheduler_job/google_cloud_scheduler_job_attributes.erb
+++ b/templates/inspec/examples/google_cloud_scheduler_job/google_cloud_scheduler_job_attributes.erb
@@ -1,0 +1,2 @@
+gcp_project_id = attribute(:gcp_project_id, default: '<%= external_attribute('gcp_project_id') -%>', description: 'The GCP project identifier.')
+scheduler_job = attribute('scheduler_job', default: <%= JSON.pretty_generate(grab_attributes['scheduler_job']) -%>, description: 'Cloud Scheduler Job configuration')

--- a/templates/inspec/examples/google_cloud_scheduler_job/google_cloud_scheduler_jobs.erb
+++ b/templates/inspec/examples/google_cloud_scheduler_job/google_cloud_scheduler_jobs.erb
@@ -1,0 +1,13 @@
+<% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
+<% scheduler_job = grab_attributes['scheduler_job'] -%>
+google_cloud_scheduler_jobs(project: <%= doc_generation ? "#{gcp_project_id}" : "gcp_project_id" -%>, region: <%= doc_generation ? "#{scheduler_job['location']}" : "scheduler_job['location']" -%>).names.each do |name|
+  describe google_cloud_scheduler_job(project: <%= doc_generation ? "#{gcp_project_id}" : "gcp_project_id" -%>, region: <%= doc_generation ? "#{scheduler_job['region']}" : "scheduler_job['region']" -%>, name: name) do
+	  it { should exist }
+
+	  its('description') { should cmp <%= doc_generation ? "'#{scheduler_job['description']}'" : "scheduler_job['description']" -%> }
+	  its('schedule') { should cmp <%= doc_generation ? "'#{scheduler_job['schedule']}'" : "scheduler_job['schedule']" -%> }
+	  its('time_zone') { should cmp <%= doc_generation ? "'#{scheduler_job['time_zone']}'" : "scheduler_job['time_zone']" -%> }
+	  its('http_target.http_method') { should cmp <%= doc_generation ? "'#{scheduler_job['http_method']}'" : "scheduler_job['http_method']" -%> }
+	  its('http_target.uri') { should cmp <%= doc_generation ? "'#{scheduler_job['http_target_uri']}'" : "scheduler_job['http_target_uri']" -%> }
+	end
+end

--- a/templates/inspec/tests/integration/build/gcp-mm.tf
+++ b/templates/inspec/tests/integration/build/gcp-mm.tf
@@ -209,6 +209,10 @@ variable "spannerdatabase" {
   type = "map"
 }
 
+variable "scheduler_job" {
+  type = "map"
+}
+
 
 resource "google_compute_ssl_policy" "custom-ssl-policy" {
   name            = "${var.ssl_policy["name"]}"
@@ -892,4 +896,18 @@ resource "google_spanner_database" "database" {
   instance     = "${google_spanner_instance.spanner_instance.name}"
   name         = "${var.spannerdatabase["name"]}"
   ddl          = ["${var.spannerdatabase["ddl"]}"]
+}
+
+resource "google_cloud_scheduler_job" "job" {
+  project  = var.gcp_project_id
+  region   = var.scheduler_job["region"]
+  name     = var.scheduler_job["name"]
+  description = var.scheduler_job["description"]
+  schedule = var.scheduler_job["schedule"]
+  time_zone = var.scheduler_job["time_zone"]
+
+  http_target {
+    http_method = var.scheduler_job["http_method"]
+    uri = var.scheduler_job["http_target_uri"]
+  }
 }

--- a/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -342,3 +342,13 @@ spannerdatabase:
   name: spdatabase
   instance: spinstance
   ddl: "CREATE TABLE test (test STRING(MAX),) PRIMARY KEY (test)" 
+
+scheduler_job:
+  # region must match where the appengine instance is deployed
+  region: us-central1
+  name: job-name
+  description: A description
+  schedule: "*/8 * * * *"
+  time_zone: America/New_York
+  http_method: POST
+  http_target_uri: https://example.com/ping


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
