### PR TITLE
Terraform provider docs update

### DIFF
--- a/.ci/magic-modules/generate-terraform.sh
+++ b/.ci/magic-modules/generate-terraform.sh
@@ -32,7 +32,7 @@ if [ "$GITHUB_ORG" = "terraform-providers" ]; then
     # "-wholename": entire relative path - including directory names - matches following wildcard.
     # "-name": filename alone matches following string.  e.g. -name README.md matches ./README.md *and* ./foo/bar/README.md
     # "-exec": for each file found, execute the command following until the literal ';'
-    find . -type f -not -wholename "./.git*" -not -wholename "./vendor*" -not -name ".travis.yml" -not -name ".golangci.yml" -not -name "CHANGELOG.md" -not -name "GNUmakefile" -not -name "LICENSE" -not -name "README.md" -not -wholename "./examples*" -not -name "go.mod" -not -name "go.sum" -not -name "staticcheck.conf" -not -name ".go-version" -not -name ".hashibot.hcl" -not -name "tools.go"  -exec git rm {} \;
+    find . -type f -not -wholename "./.git*" -not -wholename "./vendor*" -not -name ".travis.yml" -not -name ".golangci.yml" -not -name "CHANGELOG.md" -not -name "GNUmakefile" -not -name "docscheck.sh" -not -name "LICENSE" -not -name "README.md" -not -wholename "./examples*" -not -name "go.mod" -not -name "go.sum" -not -name "staticcheck.conf" -not -name ".go-version" -not -name ".hashibot.hcl" -not -name "tools.go"  -exec git rm {} \;
 fi
 
 popd

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -35,8 +35,9 @@
     is generated from a ruby function, but skip it on anything that is
     directly inserted from YAML.
 -%>
-<% 
+<%
   tf_product = (@config.legacy_name || product_ns).underscore
+  tf_subcategory = (object.__product.display_name)
   terraform_name = object.legacy_name || "google_#{tf_product}_#{object.name.underscore}"
   properties = object.all_user_properties
   # In order of preference, use TF override,
@@ -47,6 +48,7 @@
 -%>
 ---
 <%= lines(autogen_notice :yaml) -%>
+subcategory: "<%= tf_subcategory -%>"
 layout: "google"
 page_title: "Google: <%= terraform_name -%>"
 sidebar_current: "docs-<%= terraform_name.gsub("_", "-") -%>"

--- a/templates/terraform/resource_iam.html.markdown.erb
+++ b/templates/terraform/resource_iam.html.markdown.erb
@@ -37,6 +37,7 @@
 -%>
 <%
   tf_product = (@config.legacy_name || product_ns).underscore
+  tf_subcategory = (object.__product.display_name)
   resource_ns = object.legacy_name || "google_#{tf_product}_#{object.name.underscore}"
   resource_ns_iam = "#{resource_ns}_iam"
   properties = object.all_user_properties
@@ -49,6 +50,7 @@
 -%>
 ---
 <%= lines(autogen_notice :yaml) -%>
+subcategory: "<%= tf_subcategory -%>"
 layout: "google"
 page_title: "Google: <%= resource_ns_iam -%>"
 sidebar_current: "docs-<%= resource_ns_iam.gsub("_", "-") -%>"

--- a/third_party/terraform/website/docs/d/datasource_client_config.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_client_config.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_client_config"
 sidebar_current: "docs-google-datasource-client-config"

--- a/third_party/terraform/website/docs/d/datasource_client_config.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_client_config.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_client_config"
 sidebar_current: "docs-google-datasource-client-config"

--- a/third_party/terraform/website/docs/d/datasource_cloudfunctions_function.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_cloudfunctions_function.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Functions"
+subcategory: "Cloud Functions"
 layout: "google"
 page_title: "Google: google_cloudfunctions_function"
 sidebar_current: "docs-google-datasource-cloudfunctions-function"

--- a/third_party/terraform/website/docs/d/datasource_cloudfunctions_function.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_cloudfunctions_function.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_cloudfunctions_function"
 sidebar_current: "docs-google-datasource-cloudfunctions-function"

--- a/third_party/terraform/website/docs/d/datasource_cloudfunctions_function.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_cloudfunctions_function.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Cloud Functions"
 layout: "google"
 page_title: "Google: google_cloudfunctions_function"
 sidebar_current: "docs-google-datasource-cloudfunctions-function"

--- a/third_party/terraform/website/docs/d/datasource_compute_address.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_address.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_address"
 sidebar_current: "docs-google-datasource-compute-address"

--- a/third_party/terraform/website/docs/d/datasource_compute_address.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_address.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_address"
 sidebar_current: "docs-google-datasource-compute-address"

--- a/third_party/terraform/website/docs/d/datasource_compute_address.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_address.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_address"
 sidebar_current: "docs-google-datasource-compute-address"

--- a/third_party/terraform/website/docs/d/datasource_compute_forwarding_rule.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_forwarding_rule.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_forwarding_rule"
 sidebar_current: "docs-google-datasource-compute-forwarding-rule"

--- a/third_party/terraform/website/docs/d/datasource_compute_forwarding_rule.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_forwarding_rule.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_forwarding_rule"
 sidebar_current: "docs-google-datasource-compute-forwarding-rule"

--- a/third_party/terraform/website/docs/d/datasource_compute_forwarding_rule.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_forwarding_rule.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_forwarding_rule"
 sidebar_current: "docs-google-datasource-compute-forwarding-rule"

--- a/third_party/terraform/website/docs/d/datasource_compute_global_address.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_global_address.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_global_address"
 sidebar_current: "docs-google-datasource-compute-global-address"

--- a/third_party/terraform/website/docs/d/datasource_compute_global_address.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_global_address.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_global_address"
 sidebar_current: "docs-google-datasource-compute-global-address"

--- a/third_party/terraform/website/docs/d/datasource_compute_global_address.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_global_address.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_global_address"
 sidebar_current: "docs-google-datasource-compute-global-address"

--- a/third_party/terraform/website/docs/d/datasource_compute_image.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_image.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_image"
 sidebar_current: "docs-google-datasource-compute-image"

--- a/third_party/terraform/website/docs/d/datasource_compute_image.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_image.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_image"
 sidebar_current: "docs-google-datasource-compute-image"

--- a/third_party/terraform/website/docs/d/datasource_compute_image.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_image.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_image"
 sidebar_current: "docs-google-datasource-compute-image"

--- a/third_party/terraform/website/docs/d/datasource_compute_instance.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_instance"
 sidebar_current: "docs-google-datasource-compute-instance-x"

--- a/third_party/terraform/website/docs/d/datasource_compute_instance.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_instance.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance"
 sidebar_current: "docs-google-datasource-compute-instance-x"

--- a/third_party/terraform/website/docs/d/datasource_compute_instance.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_instance.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance"
 sidebar_current: "docs-google-datasource-compute-instance-x"

--- a/third_party/terraform/website/docs/d/datasource_compute_lb_ip_ranges.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_lb_ip_ranges.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_lb_ip_ranges"
 sidebar_current: "docs-google-datasource-compute-lb-ip-ranges"

--- a/third_party/terraform/website/docs/d/datasource_compute_lb_ip_ranges.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_lb_ip_ranges.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_lb_ip_ranges"
 sidebar_current: "docs-google-datasource-compute-lb-ip-ranges"

--- a/third_party/terraform/website/docs/d/datasource_compute_network.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_network.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_network"
 sidebar_current: "docs-google-datasource-compute-network"

--- a/third_party/terraform/website/docs/d/datasource_compute_network.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_network.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_network"
 sidebar_current: "docs-google-datasource-compute-network"

--- a/third_party/terraform/website/docs/d/datasource_compute_network.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_network.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_network"
 sidebar_current: "docs-google-datasource-compute-network"

--- a/third_party/terraform/website/docs/d/datasource_compute_region_instance_group.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_region_instance_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_region_instance_group"
 sidebar_current: "docs-google-datasource-compute-region-instance-group"

--- a/third_party/terraform/website/docs/d/datasource_compute_region_instance_group.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_region_instance_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_region_instance_group"
 sidebar_current: "docs-google-datasource-compute-region-instance-group"

--- a/third_party/terraform/website/docs/d/datasource_compute_region_instance_group.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_region_instance_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_region_instance_group"
 sidebar_current: "docs-google-datasource-compute-region-instance-group"

--- a/third_party/terraform/website/docs/d/datasource_compute_router.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_router.html.markdown
@@ -1,5 +1,6 @@
 ---
 layout: "google"
+subcategory: "Google Compute Engine"
 page_title: "Google: google_compute_router"
 sidebar_current: "docs-google-datasource-compute-router"
 description: |-
@@ -27,7 +28,7 @@ The following arguments are supported:
 
 * `network` - (Required) The VPC network on which this router lives.
 
-* `project` - (Optional) The ID of the project in which the resource 
+* `project` - (Optional) The ID of the project in which the resource
     belongs. If it is not provided, the provider project is used.
 
 * `region` - (Optional) The region this router has been created in. If

--- a/third_party/terraform/website/docs/d/datasource_compute_router.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_router.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "google"
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 page_title: "Google: google_compute_router"
 sidebar_current: "docs-google-datasource-compute-router"
 description: |-

--- a/third_party/terraform/website/docs/d/datasource_compute_ssl_certificate.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_ssl_certificate.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_ssl_certificate"
 sidebar_current: "docs-google-datasource-compute-ssl-certificate"

--- a/third_party/terraform/website/docs/d/datasource_compute_ssl_certificate.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_ssl_certificate.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_ssl_certificate"
 sidebar_current: "docs-google-datasource-compute-ssl-certificate"

--- a/third_party/terraform/website/docs/d/datasource_compute_ssl_certificate.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_ssl_certificate.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_ssl_certificate"
 sidebar_current: "docs-google-datasource-compute-ssl-certificate"

--- a/third_party/terraform/website/docs/d/datasource_compute_ssl_policy.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_ssl_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_ssl_policy"
 sidebar_current: "docs-google-datasource-compute-ssl-policy"

--- a/third_party/terraform/website/docs/d/datasource_compute_ssl_policy.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_ssl_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_ssl_policy"
 sidebar_current: "docs-google-datasource-compute-ssl-policy"

--- a/third_party/terraform/website/docs/d/datasource_compute_ssl_policy.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_ssl_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_ssl_policy"
 sidebar_current: "docs-google-datasource-compute-ssl-policy"

--- a/third_party/terraform/website/docs/d/datasource_compute_subnetwork.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_subnetwork.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_subnetwork"
 sidebar_current: "docs-google-datasource-compute-subnetwork"

--- a/third_party/terraform/website/docs/d/datasource_compute_subnetwork.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_subnetwork.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_subnetwork"
 sidebar_current: "docs-google-datasource-compute-subnetwork"

--- a/third_party/terraform/website/docs/d/datasource_compute_subnetwork.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_subnetwork.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_subnetwork"
 sidebar_current: "docs-google-datasource-compute-subnetwork"

--- a/third_party/terraform/website/docs/d/datasource_compute_vpn_gateway.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_vpn_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_vpn_gateway"
 sidebar_current: "docs-google-datasource-compute-vpn-gateway"

--- a/third_party/terraform/website/docs/d/datasource_compute_vpn_gateway.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_vpn_gateway.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_vpn_gateway"
 sidebar_current: "docs-google-datasource-compute-vpn-gateway"

--- a/third_party/terraform/website/docs/d/datasource_compute_vpn_gateway.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_vpn_gateway.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_vpn_gateway"
 sidebar_current: "docs-google-datasource-compute-vpn-gateway"

--- a/third_party/terraform/website/docs/d/datasource_google_client_openid_userinfo.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_client_openid_userinfo.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_client_openid_userinfo"
 sidebar_current: "docs-google-datasource-client-openid-userinfo"

--- a/third_party/terraform/website/docs/d/datasource_google_client_openid_userinfo.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_client_openid_userinfo.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_client_openid_userinfo"
 sidebar_current: "docs-google-datasource-client-openid-userinfo"

--- a/third_party/terraform/website/docs/d/datasource_google_composer_image_versions.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_composer_image_versions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_composer_image_versions"
 sidebar_current: "docs-google-datasource-composer-image-versions"

--- a/third_party/terraform/website/docs/d/datasource_google_composer_image_versions.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_composer_image_versions.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Cloud Composer"
 layout: "google"
 page_title: "Google: google_composer_image_versions"
 sidebar_current: "docs-google-datasource-composer-image-versions"

--- a/third_party/terraform/website/docs/d/datasource_google_composer_image_versions.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_composer_image_versions.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Composer"
+subcategory: "Cloud Composer"
 layout: "google"
 page_title: "Google: google_composer_image_versions"
 sidebar_current: "docs-google-datasource-composer-image-versions"

--- a/third_party/terraform/website/docs/d/datasource_google_compute_backend_service.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_compute_backend_service.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_backend_service"
 sidebar_current: "docs-google-datasource-compute-backend-service"

--- a/third_party/terraform/website/docs/d/datasource_google_compute_backend_service.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_compute_backend_service.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_backend_service"
 sidebar_current: "docs-google-datasource-compute-backend-service"

--- a/third_party/terraform/website/docs/d/datasource_google_compute_backend_service.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_compute_backend_service.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_backend_service"
 sidebar_current: "docs-google-datasource-compute-backend-service"

--- a/third_party/terraform/website/docs/d/datasource_google_compute_network_endpoint_group.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_compute_network_endpoint_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_network_endpoint_group"
 sidebar_current: "docs-google-datasource-compute-network-endpoint-group"

--- a/third_party/terraform/website/docs/d/datasource_google_compute_network_endpoint_group.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_compute_network_endpoint_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_network_endpoint_group"
 sidebar_current: "docs-google-datasource-compute-network-endpoint-group"

--- a/third_party/terraform/website/docs/d/datasource_google_compute_network_endpoint_group.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_compute_network_endpoint_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_network_endpoint_group"
 sidebar_current: "docs-google-datasource-compute-network-endpoint-group"

--- a/third_party/terraform/website/docs/d/datasource_google_folder_organization_policy.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_folder_organization_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder_organization_policy"
 sidebar_current: "docs-google-datasource-folder-organization-policy"

--- a/third_party/terraform/website/docs/d/datasource_google_folder_organization_policy.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_folder_organization_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder_organization_policy"
 sidebar_current: "docs-google-datasource-folder-organization-policy"

--- a/third_party/terraform/website/docs/d/datasource_google_iam_role.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_iam_role.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_iam_role"
 sidebar_current: "docs-google-datasource-iam-role"

--- a/third_party/terraform/website/docs/d/datasource_google_iam_role.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_iam_role.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_iam_role"
 sidebar_current: "docs-google-datasource-iam-role"

--- a/third_party/terraform/website/docs/d/datasource_google_netblock_ip_ranges.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_netblock_ip_ranges.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_netblock_ip_ranges"
 sidebar_current: "docs-google-datasource-netblock-ip-ranges"

--- a/third_party/terraform/website/docs/d/datasource_google_netblock_ip_ranges.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_netblock_ip_ranges.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_netblock_ip_ranges"
 sidebar_current: "docs-google-datasource-netblock-ip-ranges"

--- a/third_party/terraform/website/docs/d/datasource_google_project_organization_policy.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_project_organization_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_organization_policy"
 sidebar_current: "docs-google-datasource-project-organization-policy"

--- a/third_party/terraform/website/docs/d/datasource_google_project_organization_policy.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_project_organization_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_organization_policy"
 sidebar_current: "docs-google-datasource-project-organization-policy"

--- a/third_party/terraform/website/docs/d/datasource_google_service_account.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_service_account.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_service_account"
 sidebar_current: "docs-google-datasource-service-account"

--- a/third_party/terraform/website/docs/d/datasource_google_service_account.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_service_account.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_service_account"
 sidebar_current: "docs-google-datasource-service-account"

--- a/third_party/terraform/website/docs/d/datasource_google_service_account_access_token.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_service_account_access_token.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_service_account_access_token"
 sidebar_current: "docs-google-service-account-access-token"

--- a/third_party/terraform/website/docs/d/datasource_google_service_account_access_token.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_service_account_access_token.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_service_account_access_token"
 sidebar_current: "docs-google-service-account-access-token"

--- a/third_party/terraform/website/docs/d/datasource_google_service_account_key.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_service_account_key.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_service_account_key"
 sidebar_current: "docs-google-datasource-service-account-key"

--- a/third_party/terraform/website/docs/d/datasource_google_service_account_key.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_service_account_key.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_service_account_key"
 sidebar_current: "docs-google-datasource-service-account-key"

--- a/third_party/terraform/website/docs/d/datasource_tpu_tensorflow_versions.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_tpu_tensorflow_versions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_tpu_tensorflow_versions"
 sidebar_current: "docs-google-datasource-tpu-tensorflow-versions"

--- a/third_party/terraform/website/docs/d/datasource_tpu_tensorflow_versions.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_tpu_tensorflow_versions.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_tpu_tensorflow_versions"
 sidebar_current: "docs-google-datasource-tpu-tensorflow-versions"

--- a/third_party/terraform/website/docs/d/dns_managed_zone.html.markdown
+++ b/third_party/terraform/website/docs/d/dns_managed_zone.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud DNS"
 layout: "google"
 page_title: "Google: google_dns_managed_zone"
 sidebar_current: "docs-google-datasource-dns-managed-zone"

--- a/third_party/terraform/website/docs/d/dns_managed_zone.html.markdown
+++ b/third_party/terraform/website/docs/d/dns_managed_zone.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_dns_managed_zone"
 sidebar_current: "docs-google-datasource-dns-managed-zone"

--- a/third_party/terraform/website/docs/d/google_active_folder.html.markdown
+++ b/third_party/terraform/website/docs/d/google_active_folder.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_active_folder"
 sidebar_current: "docs-google-datasource-active-folder"

--- a/third_party/terraform/website/docs/d/google_active_folder.html.markdown
+++ b/third_party/terraform/website/docs/d/google_active_folder.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_active_folder"
 sidebar_current: "docs-google-datasource-active-folder"

--- a/third_party/terraform/website/docs/d/google_billing_account.html.markdown
+++ b/third_party/terraform/website/docs/d/google_billing_account.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_billing_account"
 sidebar_current: "docs-google-datasource-billing-account"

--- a/third_party/terraform/website/docs/d/google_billing_account.html.markdown
+++ b/third_party/terraform/website/docs/d/google_billing_account.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_billing_account"
 sidebar_current: "docs-google-datasource-billing-account"

--- a/third_party/terraform/website/docs/d/google_compute_default_service_account.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_default_service_account.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_default_service_account"
 sidebar_current: "docs-google-datasource-compute-default-service-account"

--- a/third_party/terraform/website/docs/d/google_compute_default_service_account.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_default_service_account.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_default_service_account"
 sidebar_current: "docs-google-datasource-compute-default-service-account"

--- a/third_party/terraform/website/docs/d/google_compute_instance_group.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_instance_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_instance_group"
 sidebar_current: "docs-google-datasource-compute-instance-group"

--- a/third_party/terraform/website/docs/d/google_compute_instance_group.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_instance_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance_group"
 sidebar_current: "docs-google-datasource-compute-instance-group"

--- a/third_party/terraform/website/docs/d/google_compute_instance_group.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_instance_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance_group"
 sidebar_current: "docs-google-datasource-compute-instance-group"

--- a/third_party/terraform/website/docs/d/google_compute_node_types.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_node_types.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_node_types"
 sidebar_current: "docs-google-datasource-compute-node-types"

--- a/third_party/terraform/website/docs/d/google_compute_node_types.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_node_types.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_node_types"
 sidebar_current: "docs-google-datasource-compute-node-types"

--- a/third_party/terraform/website/docs/d/google_compute_node_types.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_node_types.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_node_types"
 sidebar_current: "docs-google-datasource-compute-node-types"

--- a/third_party/terraform/website/docs/d/google_compute_regions.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_regions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_regions"
 sidebar_current: "docs-google-datasource-compute-regions"

--- a/third_party/terraform/website/docs/d/google_compute_regions.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_regions.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_regions"
 sidebar_current: "docs-google-datasource-compute-regions"

--- a/third_party/terraform/website/docs/d/google_compute_regions.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_regions.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_regions"
 sidebar_current: "docs-google-datasource-compute-regions"

--- a/third_party/terraform/website/docs/d/google_compute_resource_policy.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_resource_policy.html.markdown
@@ -1,5 +1,6 @@
 ---
 layout: "google"
+subcategory: "Google Cloud Platform"
 page_title: "Google: google_compute_resource_policy"
 sidebar_current: "docs-google-datasource-compute-resource-policy"
 description: |-

--- a/third_party/terraform/website/docs/d/google_compute_resource_policy.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_resource_policy.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "google"
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 page_title: "Google: google_compute_resource_policy"
 sidebar_current: "docs-google-datasource-compute-resource-policy"
 description: |-

--- a/third_party/terraform/website/docs/d/google_compute_zones.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_zones.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_zones"
 sidebar_current: "docs-google-datasource-compute-zones"

--- a/third_party/terraform/website/docs/d/google_compute_zones.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_zones.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_zones"
 sidebar_current: "docs-google-datasource-compute-zones"

--- a/third_party/terraform/website/docs/d/google_compute_zones.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_zones.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_compute_zones"
 sidebar_current: "docs-google-datasource-compute-zones"

--- a/third_party/terraform/website/docs/d/google_container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/d/google_container_cluster.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_container_cluster"
 sidebar_current: "docs-google-datasource-container-cluster"

--- a/third_party/terraform/website/docs/d/google_container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/d/google_container_cluster.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Kubernetes (Container) Engine "
+subcategory: "Kubernetes (Container) Engine"
 layout: "google"
 page_title: "Google: google_container_cluster"
 sidebar_current: "docs-google-datasource-container-cluster"

--- a/third_party/terraform/website/docs/d/google_container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/d/google_container_cluster.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Kubernetes (Container) Engine "
 layout: "google"
 page_title: "Google: google_container_cluster"
 sidebar_current: "docs-google-datasource-container-cluster"

--- a/third_party/terraform/website/docs/d/google_container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/d/google_container_cluster.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Kubernetes (Container) Engine "
+subcategory: "Kubernetes (Container) Engine "
 layout: "google"
 page_title: "Google: google_container_cluster"
 sidebar_current: "docs-google-datasource-container-cluster"

--- a/third_party/terraform/website/docs/d/google_container_engine_versions.html.markdown
+++ b/third_party/terraform/website/docs/d/google_container_engine_versions.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Kubernetes (Container) Engine "
 layout: "google"
 page_title: "Google: google_container_engine_versions"
 sidebar_current: "docs-google-datasource-container-versions"

--- a/third_party/terraform/website/docs/d/google_container_engine_versions.html.markdown
+++ b/third_party/terraform/website/docs/d/google_container_engine_versions.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Kubernetes (Container) Engine "
+subcategory: "Kubernetes (Container) Engine "
 layout: "google"
 page_title: "Google: google_container_engine_versions"
 sidebar_current: "docs-google-datasource-container-versions"

--- a/third_party/terraform/website/docs/d/google_container_engine_versions.html.markdown
+++ b/third_party/terraform/website/docs/d/google_container_engine_versions.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Kubernetes (Container) Engine "
+subcategory: "Kubernetes (Container) Engine"
 layout: "google"
 page_title: "Google: google_container_engine_versions"
 sidebar_current: "docs-google-datasource-container-versions"

--- a/third_party/terraform/website/docs/d/google_container_engine_versions.html.markdown
+++ b/third_party/terraform/website/docs/d/google_container_engine_versions.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_container_engine_versions"
 sidebar_current: "docs-google-datasource-container-versions"

--- a/third_party/terraform/website/docs/d/google_container_registry_image.html.markdown
+++ b/third_party/terraform/website/docs/d/google_container_registry_image.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Container Registry"
 layout: "google"
 page_title: "Google: google_container_registry_image"
 sidebar_current: "docs-google-datasource-container-image"

--- a/third_party/terraform/website/docs/d/google_container_registry_image.html.markdown
+++ b/third_party/terraform/website/docs/d/google_container_registry_image.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_container_registry_image"
 sidebar_current: "docs-google-datasource-container-image"

--- a/third_party/terraform/website/docs/d/google_container_registry_image.html.markdown
+++ b/third_party/terraform/website/docs/d/google_container_registry_image.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Container Registry"
+subcategory: "Container Registry"
 layout: "google"
 page_title: "Google: google_container_registry_image"
 sidebar_current: "docs-google-datasource-container-image"

--- a/third_party/terraform/website/docs/d/google_container_registry_repository.html.markdown
+++ b/third_party/terraform/website/docs/d/google_container_registry_repository.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Container Registry"
 layout: "google"
 page_title: "Google: google_container_registry_repository"
 sidebar_current: "docs-google-datasource-container-repo"

--- a/third_party/terraform/website/docs/d/google_container_registry_repository.html.markdown
+++ b/third_party/terraform/website/docs/d/google_container_registry_repository.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Container Registry"
+subcategory: "Container Registry"
 layout: "google"
 page_title: "Google: google_container_registry_repository"
 sidebar_current: "docs-google-datasource-container-repo"

--- a/third_party/terraform/website/docs/d/google_container_registry_repository.html.markdown
+++ b/third_party/terraform/website/docs/d/google_container_registry_repository.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_container_registry_repository"
 sidebar_current: "docs-google-datasource-container-repo"

--- a/third_party/terraform/website/docs/d/google_folder.html.markdown
+++ b/third_party/terraform/website/docs/d/google_folder.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder"
 sidebar_current: "docs-google-datasource-folder"

--- a/third_party/terraform/website/docs/d/google_folder.html.markdown
+++ b/third_party/terraform/website/docs/d/google_folder.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder"
 sidebar_current: "docs-google-datasource-folder"

--- a/third_party/terraform/website/docs/d/google_iam_policy.html.markdown
+++ b/third_party/terraform/website/docs/d/google_iam_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_iam_policy"
 sidebar_current: "docs-google-datasource-iam-policy"

--- a/third_party/terraform/website/docs/d/google_iam_policy.html.markdown
+++ b/third_party/terraform/website/docs/d/google_iam_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_iam_policy"
 sidebar_current: "docs-google-datasource-iam-policy"

--- a/third_party/terraform/website/docs/d/google_kms_crypto_key.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_crypto_key.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Key Management Service"
+subcategory: "Cloud KMS"
 layout: "google"
 page_title: "Google: google_kms_crypto_key"
 sidebar_current: "docs-google-datasource-kms-crypto-key"

--- a/third_party/terraform/website/docs/d/google_kms_crypto_key.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_crypto_key.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Key Management Service"
+subcategory: "Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_crypto_key"
 sidebar_current: "docs-google-datasource-kms-crypto-key"

--- a/third_party/terraform/website/docs/d/google_kms_crypto_key.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_crypto_key.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_kms_crypto_key"
 sidebar_current: "docs-google-datasource-kms-crypto-key"

--- a/third_party/terraform/website/docs/d/google_kms_crypto_key.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_crypto_key.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_crypto_key"
 sidebar_current: "docs-google-datasource-kms-crypto-key"

--- a/third_party/terraform/website/docs/d/google_kms_crypto_key_version.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_crypto_key_version.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Key Management Service"
+subcategory: "Cloud KMS"
 layout: "google"
 page_title: "Google: google_kms_crypto_key_version"
 sidebar_current: "docs-google-datasource-kms-crypto-key-version"

--- a/third_party/terraform/website/docs/d/google_kms_crypto_key_version.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_crypto_key_version.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_kms_crypto_key_version"
 sidebar_current: "docs-google-datasource-kms-crypto-key-version"

--- a/third_party/terraform/website/docs/d/google_kms_crypto_key_version.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_crypto_key_version.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_crypto_key_version"
 sidebar_current: "docs-google-datasource-kms-crypto-key-version"

--- a/third_party/terraform/website/docs/d/google_kms_crypto_key_version.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_crypto_key_version.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Key Management Service"
+subcategory: "Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_crypto_key_version"
 sidebar_current: "docs-google-datasource-kms-crypto-key-version"

--- a/third_party/terraform/website/docs/d/google_kms_key_ring.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_key_ring.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Key Management Service"
+subcategory: "Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_key_ring"
 sidebar_current: "docs-google-datasource-kms-key-ring"

--- a/third_party/terraform/website/docs/d/google_kms_key_ring.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_key_ring.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_kms_key_ring"
 sidebar_current: "docs-google-datasource-kms-key-ring"

--- a/third_party/terraform/website/docs/d/google_kms_key_ring.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_key_ring.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_key_ring"
 sidebar_current: "docs-google-datasource-kms-key-ring"

--- a/third_party/terraform/website/docs/d/google_kms_key_ring.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_key_ring.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Key Management Service"
+subcategory: "Cloud KMS"
 layout: "google"
 page_title: "Google: google_kms_key_ring"
 sidebar_current: "docs-google-datasource-kms-key-ring"

--- a/third_party/terraform/website/docs/d/google_kms_secret.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_secret.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Key Management Service"
+subcategory: "Cloud KMS"
 layout: "google"
 page_title: "Google: google_kms_secret"
 sidebar_current: "docs-google-kms-secret"

--- a/third_party/terraform/website/docs/d/google_kms_secret.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_secret.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Key Management Service"
+subcategory: "Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_secret"
 sidebar_current: "docs-google-kms-secret"

--- a/third_party/terraform/website/docs/d/google_kms_secret.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_secret.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_kms_secret"
 sidebar_current: "docs-google-kms-secret"

--- a/third_party/terraform/website/docs/d/google_kms_secret.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_secret.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_secret"
 sidebar_current: "docs-google-kms-secret"

--- a/third_party/terraform/website/docs/d/google_kms_secret_ciphertext.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_secret_ciphertext.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_secret_ciphertext"
 sidebar_current: "docs-google-kms-secret-ciphertext"
@@ -62,7 +62,7 @@ resource "google_compute_instance" "instance" {
     access_config {
     }
   }
-  
+
   metadata = {
     password = "${data.google_kms_secret_ciphertext.my_password.ciphertext}"
   }

--- a/third_party/terraform/website/docs/d/google_kms_secret_ciphertext.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_secret_ciphertext.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Key Management Service"
+subcategory: "Cloud KMS"
 layout: "google"
 page_title: "Google: google_kms_secret_ciphertext"
 sidebar_current: "docs-google-kms-secret-ciphertext"

--- a/third_party/terraform/website/docs/d/google_kms_secret_ciphertext.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_secret_ciphertext.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_kms_secret_ciphertext"
 sidebar_current: "docs-google-kms-secret-ciphertext"

--- a/third_party/terraform/website/docs/d/google_kms_secret_ciphertext.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_secret_ciphertext.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Key Management Service"
+subcategory: "Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_secret_ciphertext"
 sidebar_current: "docs-google-kms-secret-ciphertext"

--- a/third_party/terraform/website/docs/d/google_organization.html.markdown
+++ b/third_party/terraform/website/docs/d/google_organization.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_organization"
 sidebar_current: "docs-google-datasource-organization"

--- a/third_party/terraform/website/docs/d/google_organization.html.markdown
+++ b/third_party/terraform/website/docs/d/google_organization.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_organization"
 sidebar_current: "docs-google-datasource-organization"

--- a/third_party/terraform/website/docs/d/google_project.html.markdown
+++ b/third_party/terraform/website/docs/d/google_project.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project"
 sidebar_current: "docs-google-datasource-project"

--- a/third_party/terraform/website/docs/d/google_project.html.markdown
+++ b/third_party/terraform/website/docs/d/google_project.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_project"
 sidebar_current: "docs-google-datasource-project"

--- a/third_party/terraform/website/docs/d/google_project.html.markdown
+++ b/third_party/terraform/website/docs/d/google_project.html.markdown
@@ -4,13 +4,13 @@ layout: "google"
 page_title: "Google: google_project"
 sidebar_current: "docs-google-datasource-project"
 description: |-
-  Retrieve project details   
+  Retrieve project details
 ---
 
 # google\_project
 
 Use this data source to get project details.
-For more information see 
+For more information see
 [API](https://cloud.google.com/resource-manager/reference/rest/v1/projects#Project)
 
 ## Example Usage
@@ -20,7 +20,7 @@ data "google_project" "project" {}
 
 output "project_number" {
   value = "${data.google_project.project.number}"
-} 
+}
 ```
 
 ## Argument Reference

--- a/third_party/terraform/website/docs/d/google_project_services.html.markdown
+++ b/third_party/terraform/website/docs/d/google_project_services.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_services"
 sidebar_current: "docs-google-datasource-project-services"

--- a/third_party/terraform/website/docs/d/google_project_services.html.markdown
+++ b/third_party/terraform/website/docs/d/google_project_services.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_services"
 sidebar_current: "docs-google-datasource-project-services"

--- a/third_party/terraform/website/docs/d/google_projects.html.markdown
+++ b/third_party/terraform/website/docs/d/google_projects.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_projects"
 sidebar_current: "docs-google-datasource-projects"

--- a/third_party/terraform/website/docs/d/google_projects.html.markdown
+++ b/third_party/terraform/website/docs/d/google_projects.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_projects"
 sidebar_current: "docs-google-datasource-projects"

--- a/third_party/terraform/website/docs/d/google_storage_project_service_account.html.markdown
+++ b/third_party/terraform/website/docs/d/google_storage_project_service_account.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_storage_project_service_account"
 sidebar_current: "docs-google-datasource-storage-project-service-account"

--- a/third_party/terraform/website/docs/d/google_storage_project_service_account.html.markdown
+++ b/third_party/terraform/website/docs/d/google_storage_project_service_account.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_storage_project_service_account"
 sidebar_current: "docs-google-datasource-storage-project-service-account"

--- a/third_party/terraform/website/docs/d/google_storage_transfer_project_service_account.html.markdown
+++ b/third_party/terraform/website/docs/d/google_storage_transfer_project_service_account.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_storage_transfer_project_service_account"
 sidebar_current: "docs-google-datasource-storage-transfer-project-service-account"

--- a/third_party/terraform/website/docs/d/google_storage_transfer_project_service_account.html.markdown
+++ b/third_party/terraform/website/docs/d/google_storage_transfer_project_service_account.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_storage_transfer_project_service_account"
 sidebar_current: "docs-google-datasource-storage-transfer-project-service-account"

--- a/third_party/terraform/website/docs/d/signed_url.html.markdown
+++ b/third_party/terraform/website/docs/d/signed_url.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Storage"
+subcategory: "Cloud Storage"
 layout: "google"
 page_title: "Google: google_storage_object_signed_url"
 sidebar_current: "docs-google-datasource-signed_url"

--- a/third_party/terraform/website/docs/d/signed_url.html.markdown
+++ b/third_party/terraform/website/docs/d/signed_url.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Storage"
 layout: "google"
 page_title: "Google: google_storage_object_signed_url"
 sidebar_current: "docs-google-datasource-signed_url"
@@ -23,7 +23,7 @@ data "google_storage_object_signed_url" "artifact" {
 
 resource "google_compute_instance" "vm" {
     name = "vm"
-    
+
     provisioner "remote-exec" {
         inline = [
                 "wget '${data.google_storage_object_signed_url.artifact.signed_url}' -O install_file.bin",
@@ -44,7 +44,7 @@ data "google_storage_object_signed_url" "get_url" {
   content_type = "text/plain"
   duration     = "2d"
   credentials  = "${file("path/to/credentials.json")}"
-  
+
   extension_headers = {
     x-goog-if-generation-match = 1
   }
@@ -58,20 +58,20 @@ The following arguments are supported:
 * `bucket` - (Required) The name of the bucket to read the object from
 * `path` - (Required) The full path to the object inside the bucket
 * `http_method` - (Optional) What HTTP Method will the signed URL allow (defaults to `GET`)
-* `duration` - (Optional) For how long shall the signed URL be valid (defaults to 1 hour - i.e. `1h`). 
+* `duration` - (Optional) For how long shall the signed URL be valid (defaults to 1 hour - i.e. `1h`).
      See [here](https://golang.org/pkg/time/#ParseDuration) for info on valid duration formats.
-* `credentials` - (Optional) What Google service account credentials json should be used to sign the URL. 
+* `credentials` - (Optional) What Google service account credentials json should be used to sign the URL.
      This data source checks the following locations for credentials, in order of preference: data source `credentials` attribute, provider `credentials` attribute and finally the GOOGLE_APPLICATION_CREDENTIALS environment variable.
-     
-    > **NOTE** the default google credentials configured by `gcloud` sdk or the service account associated with a compute instance cannot be used, because these do not include the private key required to sign the URL. A valid `json` service account credentials key file must be used, as generated via Google cloud console. 
-     
+
+    > **NOTE** the default google credentials configured by `gcloud` sdk or the service account associated with a compute instance cannot be used, because these do not include the private key required to sign the URL. A valid `json` service account credentials key file must be used, as generated via Google cloud console.
+
 * `content_type` - (Optional) If you specify this in the datasource, the client must provide the `Content-Type` HTTP header with the same value in its request.
 * `content_md5` - (Optional) The [MD5 digest](https://cloud.google.com/storage/docs/hashes-etags#_MD5) value in Base64.
      Typically retrieved from `google_storage_bucket_object.object.md5hash` attribute.
      If you provide this in the datasource, the client (e.g. browser, curl) must provide the `Content-MD5` HTTP header with this same value in its request.
-* `extension_headers` - (Optional) As needed. The server checks to make sure that the client provides matching values in requests using the signed URL. 
+* `extension_headers` - (Optional) As needed. The server checks to make sure that the client provides matching values in requests using the signed URL.
      Any header starting with `x-goog-` is accepted but see the [Google Docs](https://cloud.google.com/storage/docs/xml-api/reference-headers) for list of headers that are supported by Google.
-    
+
 
 ## Attributes Reference
 

--- a/third_party/terraform/website/docs/d/signed_url.html.markdown
+++ b/third_party/terraform/website/docs/d/signed_url.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_storage_object_signed_url"
 sidebar_current: "docs-google-datasource-signed_url"

--- a/third_party/terraform/website/docs/d/storage_bucket_object.html.markdown
+++ b/third_party/terraform/website/docs/d/storage_bucket_object.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Storage"
+subcategory: "Cloud Storage"
 layout: "google"
 page_title: "Google: google_storage_bucket_object"
 sidebar_current: "docs-google-datasource-storage-bucket-object"

--- a/third_party/terraform/website/docs/d/storage_bucket_object.html.markdown
+++ b/third_party/terraform/website/docs/d/storage_bucket_object.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Google Storage"
 layout: "google"
 page_title: "Google: google_storage_bucket_object"
 sidebar_current: "docs-google-datasource-storage-bucket-object"

--- a/third_party/terraform/website/docs/d/storage_bucket_object.html.markdown
+++ b/third_party/terraform/website/docs/d/storage_bucket_object.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_storage_bucket_object"
 sidebar_current: "docs-google-datasource-storage-bucket-object"

--- a/third_party/terraform/website/docs/r/app_engine_application.html.markdown
+++ b/third_party/terraform/website/docs/r/app_engine_application.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google App Engine"
+subcategory: "App Engine"
 layout: "google"
 page_title: "Google: google_app_engine_application"
 sidebar_current: "docs-google-app-engine-application"

--- a/third_party/terraform/website/docs/r/app_engine_application.html.markdown
+++ b/third_party/terraform/website/docs/r/app_engine_application.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google App Engine"
 layout: "google"
 page_title: "Google: google_app_engine_application"
 sidebar_current: "docs-google-app-engine-application"

--- a/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google BigQuery"
+subcategory: "BigQuery"
 layout: "google"
 page_title: "Google: google_bigquery_table"
 sidebar_current: "docs-google-bigquery-table"

--- a/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google BigQuery"
 layout: "google"
 page_title: "Google: google_bigquery_table"
 sidebar_current: "docs-google-bigquery-table"

--- a/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Bigtable"
+subcategory: "Bigtable"
 layout: "google"
 page_title: "Google: google_bigtable_gc_policy"
 sidebar_current: "docs-google-bigtable-gc-policy"

--- a/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Bigtable"
 layout: "google"
 page_title: "Google: google_bigtable_gc_policy"
 sidebar_current: "docs-google-bigtable-gc-policy"

--- a/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Bigtable"
 layout: "google"
 page_title: "Google: google_bigtable_instance"
 sidebar_current: "docs-google-bigtable-instance"

--- a/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Bigtable"
+subcategory: "Bigtable"
 layout: "google"
 page_title: "Google: google_bigtable_instance"
 sidebar_current: "docs-google-bigtable-instance"

--- a/third_party/terraform/website/docs/r/bigtable_instance_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_instance_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Bigtable"
 layout: "google"
 page_title: "Google: google_bigtable_instance_iam"
 sidebar_current: "docs-google-bigtable-instance-iam"

--- a/third_party/terraform/website/docs/r/bigtable_instance_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_instance_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Bigtable"
+subcategory: "Bigtable"
 layout: "google"
 page_title: "Google: google_bigtable_instance_iam"
 sidebar_current: "docs-google-bigtable-instance-iam"

--- a/third_party/terraform/website/docs/r/bigtable_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_table.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Bigtable"
 layout: "google"
 page_title: "Google: google_bigtable_table"
 sidebar_current: "docs-google-bigtable-table"

--- a/third_party/terraform/website/docs/r/bigtable_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_table.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Bigtable"
+subcategory: "Bigtable"
 layout: "google"
 page_title: "Google: google_bigtable_table"
 sidebar_current: "docs-google-bigtable-table"

--- a/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
+++ b/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Functions"
+subcategory: "Cloud Functions"
 layout: "google"
 page_title: "Google: google_cloudfunctions_function"
 sidebar_current: "docs-google-cloudfunctions-function"

--- a/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
+++ b/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Functions"
 layout: "google"
 page_title: "Google: google_cloudfunctions_function"
 sidebar_current: "docs-google-cloudfunctions-function"

--- a/third_party/terraform/website/docs/r/cloudiot_registry.html.markdown
+++ b/third_party/terraform/website/docs/r/cloudiot_registry.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud IoT Core"
 layout: "google"
 page_title: "Google: google_cloudiot_registry"
 sidebar_current: "docs-google-cloudiot-registry-x"

--- a/third_party/terraform/website/docs/r/cloudiot_registry.html.markdown
+++ b/third_party/terraform/website/docs/r/cloudiot_registry.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud IoT Core"
+subcategory: "Cloud IoT Core"
 layout: "google"
 page_title: "Google: google_cloudiot_registry"
 sidebar_current: "docs-google-cloudiot-registry-x"

--- a/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Composer"
 layout: "google"
 page_title: "Google: google_composer_environment"
 sidebar_current: "docs-google-composer-environment"

--- a/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Composer"
+subcategory: "Cloud Composer"
 layout: "google"
 page_title: "Google: google_composer_environment"
 sidebar_current: "docs-google-composer-environment"

--- a/third_party/terraform/website/docs/r/compute_attached_disk.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_attached_disk.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_attached_disk"
 sidebar_current: "docs-google-compute-attached-disk"

--- a/third_party/terraform/website/docs/r/compute_attached_disk.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_attached_disk.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_attached_disk"
 sidebar_current: "docs-google-compute-attached-disk"

--- a/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance"
 sidebar_current: "docs-google-compute-instance-x"

--- a/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance"
 sidebar_current: "docs-google-compute-instance-x"

--- a/third_party/terraform/website/docs/r/compute_instance_from_template.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance_from_template.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance_from_template"
 sidebar_current: "docs-google-compute-instance-from-template"

--- a/third_party/terraform/website/docs/r/compute_instance_from_template.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance_from_template.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance_from_template"
 sidebar_current: "docs-google-compute-instance-from-template"

--- a/third_party/terraform/website/docs/r/compute_instance_group.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance_group.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance_group"
 sidebar_current: "docs-google-compute-instance-group-x"

--- a/third_party/terraform/website/docs/r/compute_instance_group.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance_group.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance_group"
 sidebar_current: "docs-google-compute-instance-group-x"

--- a/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance_group_manager"
 sidebar_current: "docs-google-compute-instance-group-manager"

--- a/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance_group_manager"
 sidebar_current: "docs-google-compute-instance-group-manager"

--- a/third_party/terraform/website/docs/r/compute_instance_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance_iam"
 sidebar_current: "docs-google-compute-instance-iam"

--- a/third_party/terraform/website/docs/r/compute_instance_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance_iam"
 sidebar_current: "docs-google-compute-instance-iam"

--- a/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance_template"
 sidebar_current: "docs-google-compute-instance-template"

--- a/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_instance_template"
 sidebar_current: "docs-google-compute-instance-template"

--- a/third_party/terraform/website/docs/r/compute_network_peering.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_network_peering.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_network_peering"
 sidebar_current: "docs-google-compute-network-peering"

--- a/third_party/terraform/website/docs/r/compute_network_peering.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_network_peering.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_network_peering"
 sidebar_current: "docs-google-compute-network-peering"

--- a/third_party/terraform/website/docs/r/compute_project_default_network_tier.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_project_default_network_tier.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_project_default_network_tier"
 sidebar_current: "docs-google-compute-project-default-network-tier"

--- a/third_party/terraform/website/docs/r/compute_project_default_network_tier.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_project_default_network_tier.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_project_default_network_tier"
 sidebar_current: "docs-google-compute-project-default-network-tier"

--- a/third_party/terraform/website/docs/r/compute_project_metadata.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_project_metadata.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_project_metadata"
 sidebar_current: "docs-google-compute-project-metadata"

--- a/third_party/terraform/website/docs/r/compute_project_metadata.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_project_metadata.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_project_metadata"
 sidebar_current: "docs-google-compute-project-metadata"

--- a/third_party/terraform/website/docs/r/compute_project_metadata_item.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_project_metadata_item.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_project_metadata_item"
 sidebar_current: "docs-google-compute-project-metadata-item"

--- a/third_party/terraform/website/docs/r/compute_project_metadata_item.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_project_metadata_item.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_project_metadata_item"
 sidebar_current: "docs-google-compute-project-metadata-item"

--- a/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_region_instance_group_manager"
 sidebar_current: "docs-google-compute-region_instance-group-manager"

--- a/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_region_instance_group_manager"
 sidebar_current: "docs-google-compute-region_instance-group-manager"

--- a/third_party/terraform/website/docs/r/compute_router_interface.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_router_interface.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_router_interface"
 sidebar_current: "docs-google-compute-router-interface"

--- a/third_party/terraform/website/docs/r/compute_router_interface.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_router_interface.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_router_interface"
 sidebar_current: "docs-google-compute-router-interface"

--- a/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_router_peer"
 sidebar_current: "docs-google-compute-router-peer"

--- a/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_router_peer.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_router_peer"
 sidebar_current: "docs-google-compute-router-peer"

--- a/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_security_policy"
 sidebar_current: "docs-google-compute-security-policy"

--- a/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_security_policy"
 sidebar_current: "docs-google-compute-security-policy"

--- a/third_party/terraform/website/docs/r/compute_shared_vpc_host_project.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_shared_vpc_host_project.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_shared_vpc_host_project"
 sidebar_current: "docs-google-compute-shared-vpc-host-project"

--- a/third_party/terraform/website/docs/r/compute_shared_vpc_host_project.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_shared_vpc_host_project.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_shared_vpc_host_project"
 sidebar_current: "docs-google-compute-shared-vpc-host-project"

--- a/third_party/terraform/website/docs/r/compute_shared_vpc_service_project.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_shared_vpc_service_project.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_shared_vpc_service_project"
 sidebar_current: "docs-google-compute-shared-vpc-service-project"

--- a/third_party/terraform/website/docs/r/compute_shared_vpc_service_project.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_shared_vpc_service_project.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_shared_vpc_service_project"
 sidebar_current: "docs-google-compute-shared-vpc-service-project"

--- a/third_party/terraform/website/docs/r/compute_subnetwork_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_subnetwork_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_subnetwork_iam"
 sidebar_current: "docs-google-compute-subnetwork-iam"

--- a/third_party/terraform/website/docs/r/compute_subnetwork_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_subnetwork_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_subnetwork_iam"
 sidebar_current: "docs-google-compute-subnetwork-iam"

--- a/third_party/terraform/website/docs/r/compute_target_pool.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_target_pool.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_target_pool"
 sidebar_current: "docs-google-compute-target-pool"

--- a/third_party/terraform/website/docs/r/compute_target_pool.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_target_pool.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Compute Engine"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_target_pool"
 sidebar_current: "docs-google-compute-target-pool"

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Kubernetes (Container) Engine"
 layout: "google"
 page_title: "Google: google_container_cluster"
 sidebar_current: "docs-google-container-cluster"

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Kubernetes (Container) Engine"
+subcategory: "Kubernetes (Container) Engine"
 layout: "google"
 page_title: "Google: google_container_cluster"
 sidebar_current: "docs-google-container-cluster"

--- a/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Kubernetes (Container) Engine"
+subcategory: "Kubernetes (Container) Engine"
 layout: "google"
 page_title: "Google: google_container_node_pool"
 sidebar_current: "docs-google-container-node-pool"

--- a/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Kubernetes (Container) Engine"
 layout: "google"
 page_title: "Google: google_container_node_pool"
 sidebar_current: "docs-google-container-node-pool"

--- a/third_party/terraform/website/docs/r/dataflow_job.html.markdown
+++ b/third_party/terraform/website/docs/r/dataflow_job.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Dataflow"
+subcategory: "Dataflow"
 layout: "google"
 page_title: "Google: google_dataflow_job"
 sidebar_current: "docs-google-dataflow-job"

--- a/third_party/terraform/website/docs/r/dataflow_job.html.markdown
+++ b/third_party/terraform/website/docs/r/dataflow_job.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Dataflow"
 layout: "google"
 page_title: "Google: google_dataflow_job"
 sidebar_current: "docs-google-dataflow-job"

--- a/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Dataproc"
+subcategory: "Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_cluster"
 sidebar_current: "docs-google-dataproc-cluster"

--- a/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Dataproc"
+subcategory: "Cloud Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_cluster"
 sidebar_current: "docs-google-dataproc-cluster"

--- a/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_cluster"
 sidebar_current: "docs-google-dataproc-cluster"

--- a/third_party/terraform/website/docs/r/dataproc_cluster_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_cluster_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Dataproc"
+subcategory: "Cloud Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_cluster_iam"
 sidebar_current: "docs-google-dataproc-cluster-iam"

--- a/third_party/terraform/website/docs/r/dataproc_cluster_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_cluster_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Dataproc"
+subcategory: "Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_cluster_iam"
 sidebar_current: "docs-google-dataproc-cluster-iam"

--- a/third_party/terraform/website/docs/r/dataproc_cluster_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_cluster_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_cluster_iam"
 sidebar_current: "docs-google-dataproc-cluster-iam"

--- a/third_party/terraform/website/docs/r/dataproc_job.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_job.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Dataproc"
+subcategory: "Cloud Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_job"
 sidebar_current: "docs-google-dataproc-job"

--- a/third_party/terraform/website/docs/r/dataproc_job.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_job.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Dataproc"
+subcategory: "Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_job"
 sidebar_current: "docs-google-dataproc-job"

--- a/third_party/terraform/website/docs/r/dataproc_job.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_job.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_job"
 sidebar_current: "docs-google-dataproc-job"

--- a/third_party/terraform/website/docs/r/dataproc_job_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_job_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Dataproc"
+subcategory: "Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_job_iam"
 sidebar_current: "docs-google-dataproc-job-iam"

--- a/third_party/terraform/website/docs/r/dataproc_job_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_job_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_job_iam"
 sidebar_current: "docs-google-dataproc-job-iam"

--- a/third_party/terraform/website/docs/r/dataproc_job_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_job_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Dataproc"
+subcategory: "Cloud Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_job_iam"
 sidebar_current: "docs-google-dataproc-job-iam"

--- a/third_party/terraform/website/docs/r/dns_record_set.markdown
+++ b/third_party/terraform/website/docs/r/dns_record_set.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google DNS"
 layout: "google"
 page_title: "Google: google_dns_record_set"
 sidebar_current: "docs-google-dns-record-set"

--- a/third_party/terraform/website/docs/r/dns_record_set.markdown
+++ b/third_party/terraform/website/docs/r/dns_record_set.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google DNS"
+subcategory: "Cloud DNS"
 layout: "google"
 page_title: "Google: google_dns_record_set"
 sidebar_current: "docs-google-dns-record-set"

--- a/third_party/terraform/website/docs/r/endpoints_service.html.markdown
+++ b/third_party/terraform/website/docs/r/endpoints_service.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Endpoints"
+subcategory: "Cloud Endpoints"
 layout: "google"
 page_title: "Google: google_endpoints_service"
 sidebar_current: "docs-google-endpoints-service"

--- a/third_party/terraform/website/docs/r/endpoints_service.html.markdown
+++ b/third_party/terraform/website/docs/r/endpoints_service.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Endpoints"
+subcategory: "Endpoints"
 layout: "google"
 page_title: "Google: google_endpoints_service"
 sidebar_current: "docs-google-endpoints-service"

--- a/third_party/terraform/website/docs/r/endpoints_service.html.markdown
+++ b/third_party/terraform/website/docs/r/endpoints_service.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Endpoints"
 layout: "google"
 page_title: "Google: google_endpoints_service"
 sidebar_current: "docs-google-endpoints-service"

--- a/third_party/terraform/website/docs/r/google_billing_account_iam_binding.md
+++ b/third_party/terraform/website/docs/r/google_billing_account_iam_binding.md
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_billing_account_iam_binding"
 sidebar_current: "docs-google-billing-account-iam-binding"

--- a/third_party/terraform/website/docs/r/google_billing_account_iam_binding.md
+++ b/third_party/terraform/website/docs/r/google_billing_account_iam_binding.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_billing_account_iam_binding"
 sidebar_current: "docs-google-billing-account-iam-binding"

--- a/third_party/terraform/website/docs/r/google_billing_account_iam_member.md
+++ b/third_party/terraform/website/docs/r/google_billing_account_iam_member.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_billing_account_iam_member"
 sidebar_current: "docs-google-billing-account-iam-member"

--- a/third_party/terraform/website/docs/r/google_billing_account_iam_member.md
+++ b/third_party/terraform/website/docs/r/google_billing_account_iam_member.md
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_billing_account_iam_member"
 sidebar_current: "docs-google-billing-account-iam-member"

--- a/third_party/terraform/website/docs/r/google_billing_account_iam_policy.md
+++ b/third_party/terraform/website/docs/r/google_billing_account_iam_policy.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_billing_account_iam_policy"
 sidebar_current: "docs-google-billing-account-iam-policy"

--- a/third_party/terraform/website/docs/r/google_billing_account_iam_policy.md
+++ b/third_party/terraform/website/docs/r/google_billing_account_iam_policy.md
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_billing_account_iam_policy"
 sidebar_current: "docs-google-billing-account-iam-policy"

--- a/third_party/terraform/website/docs/r/google_folder.html.markdown
+++ b/third_party/terraform/website/docs/r/google_folder.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder"
 sidebar_current: "docs-google-folder-x"

--- a/third_party/terraform/website/docs/r/google_folder.html.markdown
+++ b/third_party/terraform/website/docs/r/google_folder.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder"
 sidebar_current: "docs-google-folder-x"

--- a/third_party/terraform/website/docs/r/google_folder_iam_binding.html.markdown
+++ b/third_party/terraform/website/docs/r/google_folder_iam_binding.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder_iam_binding"
 sidebar_current: "docs-google-folder-iam-binding"

--- a/third_party/terraform/website/docs/r/google_folder_iam_binding.html.markdown
+++ b/third_party/terraform/website/docs/r/google_folder_iam_binding.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder_iam_binding"
 sidebar_current: "docs-google-folder-iam-binding"

--- a/third_party/terraform/website/docs/r/google_folder_iam_member.html.markdown
+++ b/third_party/terraform/website/docs/r/google_folder_iam_member.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder_iam_member"
 sidebar_current: "docs-google-folder-iam-member"

--- a/third_party/terraform/website/docs/r/google_folder_iam_member.html.markdown
+++ b/third_party/terraform/website/docs/r/google_folder_iam_member.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder_iam_member"
 sidebar_current: "docs-google-folder-iam-member"

--- a/third_party/terraform/website/docs/r/google_folder_iam_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/google_folder_iam_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder_iam_policy"
 sidebar_current: "docs-google-folders-iam-policy"

--- a/third_party/terraform/website/docs/r/google_folder_iam_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/google_folder_iam_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder_iam_policy"
 sidebar_current: "docs-google-folders-iam-policy"

--- a/third_party/terraform/website/docs/r/google_folder_organization_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/google_folder_organization_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder_organization_policy"
 sidebar_current: "docs-google-folder-organization-policy"

--- a/third_party/terraform/website/docs/r/google_folder_organization_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/google_folder_organization_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_folder_organization_policy"
 sidebar_current: "docs-google-folder-organization-policy"

--- a/third_party/terraform/website/docs/r/google_kms_crypto_key_iam_binding.html.markdown
+++ b/third_party/terraform/website/docs/r/google_kms_crypto_key_iam_binding.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_crypto_key_iam_binding"
 sidebar_current: "docs-google-kms-crypto-key-iam-binding"

--- a/third_party/terraform/website/docs/r/google_kms_crypto_key_iam_binding.html.markdown
+++ b/third_party/terraform/website/docs/r/google_kms_crypto_key_iam_binding.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Key Management Service"
+subcategory: "Cloud KMS"
 layout: "google"
 page_title: "Google: google_kms_crypto_key_iam_binding"
 sidebar_current: "docs-google-kms-crypto-key-iam-binding"

--- a/third_party/terraform/website/docs/r/google_kms_crypto_key_iam_binding.html.markdown
+++ b/third_party/terraform/website/docs/r/google_kms_crypto_key_iam_binding.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Key Management Service"
+subcategory: "Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_crypto_key_iam_binding"
 sidebar_current: "docs-google-kms-crypto-key-iam-binding"

--- a/third_party/terraform/website/docs/r/google_kms_crypto_key_iam_member.html.markdown
+++ b/third_party/terraform/website/docs/r/google_kms_crypto_key_iam_member.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_crypto_key_iam_member"
 sidebar_current: "docs-google-kms-crypto-key-iam-member"

--- a/third_party/terraform/website/docs/r/google_kms_crypto_key_iam_member.html.markdown
+++ b/third_party/terraform/website/docs/r/google_kms_crypto_key_iam_member.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Key Management Service"
+subcategory: "Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_crypto_key_iam_member"
 sidebar_current: "docs-google-kms-crypto-key-iam-member"

--- a/third_party/terraform/website/docs/r/google_kms_crypto_key_iam_member.html.markdown
+++ b/third_party/terraform/website/docs/r/google_kms_crypto_key_iam_member.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Key Management Service"
+subcategory: "Cloud KMS"
 layout: "google"
 page_title: "Google: google_kms_crypto_key_iam_member"
 sidebar_current: "docs-google-kms-crypto-key-iam-member"

--- a/third_party/terraform/website/docs/r/google_kms_key_ring_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/google_kms_key_ring_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Key Management Service"
+subcategory: "Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_key_ring_iam"
 sidebar_current: "docs-google-kms-key-ring-iam"

--- a/third_party/terraform/website/docs/r/google_kms_key_ring_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/google_kms_key_ring_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_key_ring_iam"
 sidebar_current: "docs-google-kms-key-ring-iam"

--- a/third_party/terraform/website/docs/r/google_kms_key_ring_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/google_kms_key_ring_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Key Management Service"
+subcategory: "Cloud KMS"
 layout: "google"
 page_title: "Google: google_kms_key_ring_iam"
 sidebar_current: "docs-google-kms-key-ring-iam"

--- a/third_party/terraform/website/docs/r/google_organization_iam_binding.md
+++ b/third_party/terraform/website/docs/r/google_organization_iam_binding.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_organization_iam_binding"
 sidebar_current: "docs-google-organization-iam-binding"

--- a/third_party/terraform/website/docs/r/google_organization_iam_binding.md
+++ b/third_party/terraform/website/docs/r/google_organization_iam_binding.md
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_organization_iam_binding"
 sidebar_current: "docs-google-organization-iam-binding"

--- a/third_party/terraform/website/docs/r/google_organization_iam_custom_role.html.markdown
+++ b/third_party/terraform/website/docs/r/google_organization_iam_custom_role.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_organization_iam_custom_role"
 sidebar_current: "docs-google-organization-iam-custom-role"

--- a/third_party/terraform/website/docs/r/google_organization_iam_custom_role.html.markdown
+++ b/third_party/terraform/website/docs/r/google_organization_iam_custom_role.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_organization_iam_custom_role"
 sidebar_current: "docs-google-organization-iam-custom-role"

--- a/third_party/terraform/website/docs/r/google_organization_iam_member.md
+++ b/third_party/terraform/website/docs/r/google_organization_iam_member.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_organization_iam_member"
 sidebar_current: "docs-google-organization-iam-member"

--- a/third_party/terraform/website/docs/r/google_organization_iam_member.md
+++ b/third_party/terraform/website/docs/r/google_organization_iam_member.md
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_organization_iam_member"
 sidebar_current: "docs-google-organization-iam-member"

--- a/third_party/terraform/website/docs/r/google_organization_iam_policy.md
+++ b/third_party/terraform/website/docs/r/google_organization_iam_policy.md
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_organization_iam_policy"
 sidebar_current: "docs-google-organization-iam-policy"

--- a/third_party/terraform/website/docs/r/google_organization_iam_policy.md
+++ b/third_party/terraform/website/docs/r/google_organization_iam_policy.md
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_organization_iam_policy"
 sidebar_current: "docs-google-organization-iam-policy"

--- a/third_party/terraform/website/docs/r/google_organization_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/google_organization_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_organization_policy"
 sidebar_current: "docs-google-organization-policy"

--- a/third_party/terraform/website/docs/r/google_organization_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/google_organization_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_organization_policy"
 sidebar_current: "docs-google-organization-policy"

--- a/third_party/terraform/website/docs/r/google_project.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_project"
 sidebar_current: "docs-google-project-x"

--- a/third_party/terraform/website/docs/r/google_project.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project"
 sidebar_current: "docs-google-project-x"

--- a/third_party/terraform/website/docs/r/google_project_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_iam"
 sidebar_current: "docs-google-project-iam-x"

--- a/third_party/terraform/website/docs/r/google_project_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_iam"
 sidebar_current: "docs-google-project-iam-x"

--- a/third_party/terraform/website/docs/r/google_project_iam_custom_role.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_iam_custom_role.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_iam_custom_role"
 sidebar_current: "docs-google-project-iam-custom-role"

--- a/third_party/terraform/website/docs/r/google_project_iam_custom_role.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_iam_custom_role.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_iam_custom_role"
 sidebar_current: "docs-google-project-iam-custom-role"

--- a/third_party/terraform/website/docs/r/google_project_organization_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_organization_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_organization_policy"
 sidebar_current: "docs-google-project-organization-policy"

--- a/third_party/terraform/website/docs/r/google_project_organization_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_organization_policy.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_organization_policy"
 sidebar_current: "docs-google-project-organization-policy"

--- a/third_party/terraform/website/docs/r/google_project_service.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_service.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_service"
 sidebar_current: "docs-google-project-service-x"

--- a/third_party/terraform/website/docs/r/google_project_service.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_service.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_service"
 sidebar_current: "docs-google-project-service-x"

--- a/third_party/terraform/website/docs/r/google_project_services.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_services.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_services"
 sidebar_current: "docs-google-project-services"

--- a/third_party/terraform/website/docs/r/google_project_services.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_services.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_services"
 sidebar_current: "docs-google-project-services"

--- a/third_party/terraform/website/docs/r/google_service_account.html.markdown
+++ b/third_party/terraform/website/docs/r/google_service_account.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_service_account"
 sidebar_current: "docs-google-service-account-x"

--- a/third_party/terraform/website/docs/r/google_service_account.html.markdown
+++ b/third_party/terraform/website/docs/r/google_service_account.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_service_account"
 sidebar_current: "docs-google-service-account-x"

--- a/third_party/terraform/website/docs/r/google_service_account_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/google_service_account_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_service_account_iam"
 sidebar_current: "docs-google-service-account-iam"
@@ -193,3 +194,4 @@ With conditions:
 $ terraform import -provider=google-beta google_service_account_iam_binding.admin-account-iam "projects/{your-project-id}/serviceAccounts/{your-service-account-email} iam.serviceAccountUser expires_after_2019_12_31"
 
 $ terraform import -provider=google-beta google_service_account_iam_member.admin-account-iam "projects/{your-project-id}/serviceAccounts/{your-service-account-email} iam.serviceAccountUser user:foo@example.com expires_after_2019_12_31"
+```

--- a/third_party/terraform/website/docs/r/google_service_account_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/google_service_account_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_service_account_iam"
 sidebar_current: "docs-google-service-account-iam"

--- a/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
+++ b/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_service_account_key"
 sidebar_current: "docs-google-service-account-key"

--- a/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
+++ b/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_service_account_key"
 sidebar_current: "docs-google-service-account-key"

--- a/third_party/terraform/website/docs/r/logging_billing_account_exclusion.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_billing_account_exclusion.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Stackdriver Logging"
+subcategory: "Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_billing_account_exclusion"
 sidebar_current: "docs-google-logging-billing_account-exclusion"

--- a/third_party/terraform/website/docs/r/logging_billing_account_exclusion.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_billing_account_exclusion.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_billing_account_exclusion"
 sidebar_current: "docs-google-logging-billing_account-exclusion"

--- a/third_party/terraform/website/docs/r/logging_billing_account_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_billing_account_sink.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_billing_account_sink"
 sidebar_current: "docs-google-logging-billing-account-sink"

--- a/third_party/terraform/website/docs/r/logging_billing_account_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_billing_account_sink.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Stackdriver Logging"
+subcategory: "Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_billing_account_sink"
 sidebar_current: "docs-google-logging-billing-account-sink"

--- a/third_party/terraform/website/docs/r/logging_folder_exclusion.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_folder_exclusion.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_folder_exclusion"
 sidebar_current: "docs-google-logging-folder-exclusion"

--- a/third_party/terraform/website/docs/r/logging_folder_exclusion.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_folder_exclusion.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Stackdriver Logging"
+subcategory: "Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_folder_exclusion"
 sidebar_current: "docs-google-logging-folder-exclusion"

--- a/third_party/terraform/website/docs/r/logging_folder_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_folder_sink.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Stackdriver Logging"
+subcategory: "Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_folder_sink"
 sidebar_current: "docs-google-logging-folder-sink"

--- a/third_party/terraform/website/docs/r/logging_folder_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_folder_sink.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_folder_sink"
 sidebar_current: "docs-google-logging-folder-sink"

--- a/third_party/terraform/website/docs/r/logging_organization_exclusion.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_organization_exclusion.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_organization_exclusion"
 sidebar_current: "docs-google-logging-organization-exclusion"

--- a/third_party/terraform/website/docs/r/logging_organization_exclusion.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_organization_exclusion.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Stackdriver Logging"
+subcategory: "Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_organization_exclusion"
 sidebar_current: "docs-google-logging-organization-exclusion"

--- a/third_party/terraform/website/docs/r/logging_organization_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_organization_sink.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Stackdriver Logging"
+subcategory: "Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_organization_sink"
 sidebar_current: "docs-google-logging-organization-sink"

--- a/third_party/terraform/website/docs/r/logging_organization_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_organization_sink.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_organization_sink"
 sidebar_current: "docs-google-logging-organization-sink"

--- a/third_party/terraform/website/docs/r/logging_project_exclusion.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_project_exclusion.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Stackdriver Logging"
+subcategory: "Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_project_exclusion"
 sidebar_current: "docs-google-logging-project-exclusion"

--- a/third_party/terraform/website/docs/r/logging_project_exclusion.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_project_exclusion.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_project_exclusion"
 sidebar_current: "docs-google-logging-project-exclusion"

--- a/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Stackdriver Logging"
+subcategory: "Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_project_sink"
 sidebar_current: "docs-google-logging-project-sink"

--- a/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Stackdriver Logging"
 layout: "google"
 page_title: "Google: google_logging_project_sink"
 sidebar_current: "docs-google-logging-project-sink"

--- a/third_party/terraform/website/docs/r/pubsub_subscription_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/pubsub_subscription_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google PubSub"
 layout: "google"
 page_title: "Google: google_pubsub_subscription_iam"
 sidebar_current: "docs-google-pubsub-subscription-iam"

--- a/third_party/terraform/website/docs/r/pubsub_subscription_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/pubsub_subscription_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google PubSub"
+subcategory: "PubSub"
 layout: "google"
 page_title: "Google: google_pubsub_subscription_iam"
 sidebar_current: "docs-google-pubsub-subscription-iam"

--- a/third_party/terraform/website/docs/r/pubsub_subscription_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/pubsub_subscription_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "PubSub"
+subcategory: "Cloud Pub/Sub"
 layout: "google"
 page_title: "Google: google_pubsub_subscription_iam"
 sidebar_current: "docs-google-pubsub-subscription-iam"

--- a/third_party/terraform/website/docs/r/runtimeconfig_config.html.markdown
+++ b/third_party/terraform/website/docs/r/runtimeconfig_config.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google RuntimeConfig"
+subcategory: "RuntimeConfig"
 layout: "google"
 page_title: "Google: google_runtimeconfig_config"
 sidebar_current: "docs-google-runtimeconfig-config"

--- a/third_party/terraform/website/docs/r/runtimeconfig_config.html.markdown
+++ b/third_party/terraform/website/docs/r/runtimeconfig_config.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google RuntimeConfig"
 layout: "google"
 page_title: "Google: google_runtimeconfig_config"
 sidebar_current: "docs-google-runtimeconfig-config"

--- a/third_party/terraform/website/docs/r/runtimeconfig_config.html.markdown
+++ b/third_party/terraform/website/docs/r/runtimeconfig_config.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "RuntimeConfig"
+subcategory: "Cloud Runtime Configuration"
 layout: "google"
 page_title: "Google: google_runtimeconfig_config"
 sidebar_current: "docs-google-runtimeconfig-config"

--- a/third_party/terraform/website/docs/r/runtimeconfig_variable.html.markdown
+++ b/third_party/terraform/website/docs/r/runtimeconfig_variable.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google RuntimeConfig"
 layout: "google"
 page_title: "Google: google_runtimeconfig_variable"
 sidebar_current: "docs-google-runtimeconfig-variable"

--- a/third_party/terraform/website/docs/r/runtimeconfig_variable.html.markdown
+++ b/third_party/terraform/website/docs/r/runtimeconfig_variable.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google RuntimeConfig"
+subcategory: "RuntimeConfig"
 layout: "google"
 page_title: "Google: google_runtimeconfig_variable"
 sidebar_current: "docs-google-runtimeconfig-variable"

--- a/third_party/terraform/website/docs/r/runtimeconfig_variable.html.markdown
+++ b/third_party/terraform/website/docs/r/runtimeconfig_variable.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "RuntimeConfig"
+subcategory: "Cloud Runtime Configuration"
 layout: "google"
 page_title: "Google: google_runtimeconfig_variable"
 sidebar_current: "docs-google-runtimeconfig-variable"

--- a/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
+++ b/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Service Networking"
 layout: "google"
 page_title: "Google: google_service_networking_connection"
 sidebar_current: "docs-google-service-networking-connection"

--- a/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
+++ b/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Service Networking"
+subcategory: "Service Networking"
 layout: "google"
 page_title: "Google: google_service_networking_connection"
 sidebar_current: "docs-google-service-networking-connection"

--- a/third_party/terraform/website/docs/r/spanner_database_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/spanner_database_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Spanner"
 layout: "google"
 page_title: "Google: google_spanner_database_iam"
 sidebar_current: "docs-google-spanner-database-iam"

--- a/third_party/terraform/website/docs/r/spanner_database_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/spanner_database_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Spanner"
+subcategory: "Cloud Spanner"
 layout: "google"
 page_title: "Google: google_spanner_database_iam"
 sidebar_current: "docs-google-spanner-database-iam"

--- a/third_party/terraform/website/docs/r/spanner_database_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/spanner_database_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Spanner"
+subcategory: "Spanner"
 layout: "google"
 page_title: "Google: google_spanner_database_iam"
 sidebar_current: "docs-google-spanner-database-iam"

--- a/third_party/terraform/website/docs/r/spanner_instance_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/spanner_instance_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Spanner"
+subcategory: "Spanner"
 layout: "google"
 page_title: "Google: google_spanner_instance_iam"
 sidebar_current: "docs-google-spanner-instance-iam"

--- a/third_party/terraform/website/docs/r/spanner_instance_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/spanner_instance_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Spanner"
 layout: "google"
 page_title: "Google: google_spanner_instance_iam"
 sidebar_current: "docs-google-spanner-instance-iam"

--- a/third_party/terraform/website/docs/r/spanner_instance_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/spanner_instance_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Spanner"
+subcategory: "Cloud Spanner"
 layout: "google"
 page_title: "Google: google_spanner_instance_iam"
 sidebar_current: "docs-google-spanner-instance-iam"

--- a/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "SQL"
+subcategory: "Cloud SQL"
 layout: "google"
 page_title: "Google: google_sql_database_instance"
 sidebar_current: "docs-google-sql-database-instance"

--- a/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google SQL"
 layout: "google"
 page_title: "Google: google_sql_database_instance"
 sidebar_current: "docs-google-sql-database-instance"

--- a/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google SQL"
+subcategory: "SQL"
 layout: "google"
 page_title: "Google: google_sql_database_instance"
 sidebar_current: "docs-google-sql-database-instance"

--- a/third_party/terraform/website/docs/r/sql_ssl_cert.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_ssl_cert.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google SQL"
+subcategory: "SQL"
 layout: "google"
 page_title: "Google: google_sql_ssl_cert"
 sidebar_current: "docs-google-sql-ssl-cert"

--- a/third_party/terraform/website/docs/r/sql_ssl_cert.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_ssl_cert.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google SQL"
 layout: "google"
 page_title: "Google: google_sql_ssl_cert"
 sidebar_current: "docs-google-sql-ssl-cert"

--- a/third_party/terraform/website/docs/r/sql_ssl_cert.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_ssl_cert.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "SQL"
+subcategory: "Cloud SQL"
 layout: "google"
 page_title: "Google: google_sql_ssl_cert"
 sidebar_current: "docs-google-sql-ssl-cert"

--- a/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google SQL"
 layout: "google"
 page_title: "Google: google_sql_user"
 sidebar_current: "docs-google-sql-user"

--- a/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "SQL"
+subcategory: "Cloud SQL"
 layout: "google"
 page_title: "Google: google_sql_user"
 sidebar_current: "docs-google-sql-user"

--- a/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google SQL"
+subcategory: "SQL"
 layout: "google"
 page_title: "Google: google_sql_user"
 sidebar_current: "docs-google-sql-user"

--- a/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage"
 layout: "google"
 page_title: "Google: google_storage_bucket"
 sidebar_current: "docs-google-storage-bucket-x"

--- a/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Storage"
+subcategory: "Cloud Storage"
 layout: "google"
 page_title: "Google: google_storage_bucket"
 sidebar_current: "docs-google-storage-bucket-x"

--- a/third_party/terraform/website/docs/r/storage_bucket_acl.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_bucket_acl.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage"
 layout: "google"
 page_title: "Google: google_storage_bucket_acl"
 sidebar_current: "docs-google-storage-bucket-acl"

--- a/third_party/terraform/website/docs/r/storage_bucket_acl.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_bucket_acl.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Storage"
+subcategory: "Cloud Storage"
 layout: "google"
 page_title: "Google: google_storage_bucket_acl"
 sidebar_current: "docs-google-storage-bucket-acl"

--- a/third_party/terraform/website/docs/r/storage_bucket_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_bucket_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Storage"
+subcategory: "Cloud Storage"
 layout: "google"
 page_title: "Google: google_storage_bucket_iam"
 sidebar_current: "docs-google-storage-bucket-iam"

--- a/third_party/terraform/website/docs/r/storage_bucket_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_bucket_iam.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage"
 layout: "google"
 page_title: "Google: google_storage_bucket_iam"
 sidebar_current: "docs-google-storage-bucket-iam"

--- a/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage"
 layout: "google"
 page_title: "Google: google_storage_bucket_object"
 sidebar_current: "docs-google-storage-bucket-object"

--- a/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Storage"
+subcategory: "Cloud Storage"
 layout: "google"
 page_title: "Google: google_storage_bucket_object"
 sidebar_current: "docs-google-storage-bucket-object"

--- a/third_party/terraform/website/docs/r/storage_default_object_acl.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_default_object_acl.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Storage"
+subcategory: "Cloud Storage"
 layout: "google"
 page_title: "Google: google_storage_default_object_acl"
 sidebar_current: "docs-google-storage-default-object-acl"

--- a/third_party/terraform/website/docs/r/storage_default_object_acl.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_default_object_acl.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage"
 layout: "google"
 page_title: "Google: google_storage_default_object_acl"
 sidebar_current: "docs-google-storage-default-object-acl"

--- a/third_party/terraform/website/docs/r/storage_notification.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_notification.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Storage"
+subcategory: "Cloud Storage"
 layout: "google"
 page_title: "Google: google_storage_notification"
 sidebar_current: "docs-google-storage-notification"

--- a/third_party/terraform/website/docs/r/storage_notification.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_notification.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage"
 layout: "google"
 page_title: "Google: google_storage_notification"
 sidebar_current: "docs-google-storage-notification"

--- a/third_party/terraform/website/docs/r/storage_object_acl.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_object_acl.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage"
 layout: "google"
 page_title: "Google: google_storage_object_acl"
 sidebar_current: "docs-google-storage-object-acl"

--- a/third_party/terraform/website/docs/r/storage_object_acl.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_object_acl.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Storage"
+subcategory: "Cloud Storage"
 layout: "google"
 page_title: "Google: google_storage_object_acl"
 sidebar_current: "docs-google-storage-object-acl"

--- a/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Storage Transfer"
+subcategory: "Cloud Storage"
 layout: "google"
 page_title: "Google: google_storage_transfer_job"
 sidebar_current: "docs-google-storage-transfer-job-x"

--- a/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Storage Transfer"
+subcategory: "Cloud Storage Transfer"
 layout: "google"
 page_title: "Google: google_storage_transfer_job"
 sidebar_current: "docs-google-storage-transfer-job-x"

--- a/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Storage Transfer"
 layout: "google"
 page_title: "Google: google_storage_transfer_job"
 sidebar_current: "docs-google-storage-transfer-job-x"

--- a/third_party/terraform/website/docs/r/usage_export_bucket.html.markdown
+++ b/third_party/terraform/website/docs/r/usage_export_bucket.html.markdown
@@ -1,4 +1,5 @@
 ---
+subcategory: "Google Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_usage_export_bucket"
 sidebar_current: "docs-google-project-usage-export-bucket"

--- a/third_party/terraform/website/docs/r/usage_export_bucket.html.markdown
+++ b/third_party/terraform/website/docs/r/usage_export_bucket.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Google Cloud Platform"
+subcategory: "Cloud Platform"
 layout: "google"
 page_title: "Google: google_project_usage_export_bucket"
 sidebar_current: "docs-google-project-usage-export-bucket"


### PR DESCRIPTION
upstream changes from https://github.com/terraform-providers/terraform-provider-google/pull/4795

I upstreamed the PR from @findkim, then had to make some updates on top of that. Including changes to the templating to generate the docs and manually adding subcategories for datasources.

I updated the datasources to have categories that are the same as their Resource equivalents. I believe this will nest them in the appropriate place, but we can revert that commit if we want to keep all datasources together.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
