### PR TITLE
Update subnetwork to remove enable_flow_logs and depend on log_config

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -9093,18 +9093,6 @@ objects:
           Only networks that are in the distributed mode can have subnetworks.
         input: true
         required: true
-      - !ruby/object:Api::Type::Boolean
-        name: 'enableFlowLogs'
-        description: |
-          Whether to enable flow logging for this subnetwork.
-        update_verb: :PATCH
-        update_url:  projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
-        update_id: 'enableFlowLogs'
-        fingerprint_name: 'fingerprint'
-        send_empty_value: true
-        deprecation_message: >-
-          This field is being removed in favor of log_config. If log_config is present,
-          flow logs are enabled.
       # TODO(rileykarson): Work with rambleraptor to remove this field from downstreams.
       - !ruby/object:Api::Type::Fingerprint
         name: 'fingerprint'

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1680,10 +1680,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           function: 'validateIpCidrRange'
       fingerprint: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: false
-      enableFlowLogs: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
       logConfig: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
+        send_empty_value: true
         custom_expand: 'templates/terraform/custom_expand/subnetwork_log_config.go.erb'
         custom_flatten: 'templates/terraform/custom_flatten/subnetwork_log_config.go.erb'
       ipCidrRange: !ruby/object:Overrides::Terraform::PropertyOverride
@@ -1699,6 +1697,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/subnetwork.erb
       resource_definition: templates/terraform/resource_definition/subnetwork.erb
+      extra_schema_entry: templates/terraform/extra_schema_entry/subnetwork.erb
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "subnetwork_basic"

--- a/templates/terraform/constants/subnetwork.erb
+++ b/templates/terraform/constants/subnetwork.erb
@@ -17,11 +17,3 @@ func isShrinkageIpCidr(old, new, _ interface{}) bool {
 
 	return true
 }
-
-
-func splitSubnetID(id string) (region string, name string) {
-	parts := strings.Split(id, "/")
-	region = parts[0]
-	name = parts[1]
-	return
-}

--- a/templates/terraform/custom_expand/subnetwork_log_config.go.erb
+++ b/templates/terraform/custom_expand/subnetwork_log_config.go.erb
@@ -14,21 +14,20 @@
 -%>
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
 	l := v.([]interface{})
+	transformed := make(map[string]interface{})
 	if len(l) == 0 || l[0] == nil {
-		return nil, nil
+		// send enable = false to ensure logging is disabled if there is no config
+		transformed["enable"] = false
+		return transformed, nil
 	}
 	raw := l[0]
 	original := raw.(map[string]interface{})
 
-	v, ok := d.GetOkExists("enable_flow_logs")
-
-	transformed := make(map[string]interface{})
-	if !ok || v.(bool) {
-		transformed["enable"] = true
-		transformed["aggregationInterval"] = original["aggregation_interval"]
-		transformed["flowSampling"] = original["flow_sampling"]
-		transformed["metadata"] = original["metadata"]
-	}
+	// The log_config block is specified, so logging should be enabled
+	transformed["enable"] = true
+	transformed["aggregationInterval"] = original["aggregation_interval"]
+	transformed["flowSampling"] = original["flow_sampling"]
+	transformed["metadata"] = original["metadata"]
 
 	return transformed, nil
 }

--- a/templates/terraform/extra_schema_entry/subnetwork.erb
+++ b/templates/terraform/extra_schema_entry/subnetwork.erb
@@ -1,0 +1,20 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2019 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+"enable_flow_logs": {
+	Type:       schema.TypeBool,
+	Computed:   true,
+	Optional:   true,
+	Removed:    "This field is being removed in favor of log_config. If log_config is present, flow logs are enabled. Please remove this field",
+},

--- a/third_party/terraform/tests/resource_compute_subnetwork_test.go
+++ b/third_party/terraform/tests/resource_compute_subnetwork_test.go
@@ -318,8 +318,8 @@ func testAccCheckComputeSubnetworkExists(n string, subnetwork *compute.Subnetwor
 		}
 
 		config := testAccProvider.Meta().(*Config)
-
-		region, subnet_name := splitSubnetID(rs.Primary.ID)
+		region := rs.Primary.Attributes["region"]
+		subnet_name := rs.Primary.Attributes["name"]
 
 		found, err := config.clientCompute.Subnetworks.Get(
 			config.Project, region, subnet_name).Do()
@@ -549,7 +549,6 @@ resource "google_compute_subnetwork" "network-with-flow-logs" {
 	ip_cidr_range = "10.0.0.0/16"
 	region = "us-central1"
 	network = "${google_compute_network.custom-test.self_link}"
-	enable_flow_logs = true
 	log_config {
 		aggregation_interval = "INTERVAL_5_SEC"
 		flow_sampling        = 0.5
@@ -571,7 +570,6 @@ resource "google_compute_subnetwork" "network-with-flow-logs" {
 	ip_cidr_range = "10.0.0.0/16"
 	region = "us-central1"
 	network = "${google_compute_network.custom-test.self_link}"
-	enable_flow_logs = true
 	log_config {
 		aggregation_interval = "INTERVAL_30_SEC"
 		flow_sampling        = 0.8
@@ -593,7 +591,6 @@ resource "google_compute_subnetwork" "network-with-flow-logs" {
 	ip_cidr_range = "10.0.0.0/16"
 	region = "us-central1"
 	network = "${google_compute_network.custom-test.self_link}"
-	enable_flow_logs = false
 }
 `, cnName, subnetworkName)
 }
@@ -610,7 +607,6 @@ resource "google_compute_subnetwork" "network-with-flow-logs" {
 	ip_cidr_range = "10.0.0.0/16"
 	region = "us-central1"
 	network = "${google_compute_network.custom-test.self_link}"
-	enable_flow_logs = true
 	log_config {
 		aggregation_interval = "INTERVAL_30_SEC"
 		flow_sampling        = 0.6
@@ -653,7 +649,6 @@ resource "google_compute_subnetwork" "network-with-flow-logs" {
 	ip_cidr_range = "10.0.0.0/16"
 	region = "us-central1"
 	network = "${google_compute_network.custom-test.self_link}"
-	enable_flow_logs = true
 	log_config {
 		aggregation_interval = "INTERVAL_30_SEC"
 		flow_sampling        = 0.8


### PR DESCRIPTION
Finishes removal of `enable_flow_logs` and depends on the presence of `log_config` instead.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
`compute`: removed `enable_flow_logs` field from `google_compute_subnetwork`. This is now controlled by the presence of the `log_config` block
```
