### PR TITLE
Fix missing paren + bad var in resourcepolicy datasource 3.0.0

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_compute_resource_policy.go.erb
+++ b/third_party/terraform/data_sources/data_source_google_compute_resource_policy.go.erb
@@ -59,7 +59,7 @@ func dataSourceGoogleComputeResourcePolicyRead(d *schema.ResourceData, meta inte
 	}
 	d.Set("self_link", resourcePolicy.SelfLink)
 	d.Set("description", resourcePolicy.Description)
-	d.SetId(fmt.Sprintf("projects/%s/regions/%s/resourcePolicies/%s", project, regions, name)
+	d.SetId(fmt.Sprintf("projects/%s/regions/%s/resourcePolicies/%s", project, region, name))
 	return nil
 }
 <% end -%>


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
