### PR TITLE
Magician shouldn't delete handwritten Ansible module

### DIFF
--- a/.ci/magic-modules/generate-ansible.sh
+++ b/.ci/magic-modules/generate-ansible.sh
@@ -18,14 +18,15 @@ COMMIT_AUTHOR="$(git log --pretty="%an <%ae>" -n1 HEAD)"
 
 # Remove all modules so that old files are removed in process.
 rm build/ansible/plugins/modules/gcp_*
-# This module is handwritten. It's the only one.
-git checkout HEAD -- plugins/modules/gcp_storage_object.py
 
 bundle exec compiler -a -e ansible -o "build/ansible/"
 
 ANSIBLE_COMMIT_MSG="$(cat .git/title)"
 
 pushd "build/ansible"
+# This module is handwritten. It's the only one.
+# It was deleted earlier, so it needs to be undeleted.
+git checkout HEAD -- plugins/modules/gcp_storage_object.py
 
 # These config entries will set the "committer".
 git config --global user.email "magic-modules@google.com"

--- a/.ci/magic-modules/generate-ansible.sh
+++ b/.ci/magic-modules/generate-ansible.sh
@@ -18,6 +18,8 @@ COMMIT_AUTHOR="$(git log --pretty="%an <%ae>" -n1 HEAD)"
 
 # Remove all modules so that old files are removed in process.
 rm build/ansible/plugins/modules/gcp_*
+# This module is handwritten. It's the only one.
+git checkout HEAD -- plugins/modules/gcp_storage_object.py
 
 bundle exec compiler -a -e ansible -o "build/ansible/"
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->
There's now a lone handwritten Ansible module and the Magician keeps trying to delete it. Stop doing that!

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
