### PR TITLE
More integration test fixes

### DIFF
--- a/products/accesscontextmanager/terraform.yaml
+++ b/products/accesscontextmanager/terraform.yaml
@@ -19,6 +19,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       update_minutes: 6
       delete_minutes: 6
     autogen_async: true
+    id_format: "{{name}}"
     import_format: ["{{name}}"]
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/third_party/terraform/resources/resource_bigtable_table.go
+++ b/third_party/terraform/resources/resource_bigtable_table.go
@@ -107,7 +107,7 @@ func resourceBigtableTableCreate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
-	id, err := replaceVars(d, config, "projects/{{project}}/instances/{{instance_id}}/tables/{{name}}")
+	id, err := replaceVars(d, config, "projects/{{project}}/instances/{{instance_name}}/tables/{{name}}")
 	if err != nil {
 		return fmt.Errorf("Error constructing id: %s", err)
 	}
@@ -133,7 +133,7 @@ func resourceBigtableTableRead(d *schema.ResourceData, meta interface{}) error {
 
 	defer c.Close()
 
-	name := d.Id()
+	name := d.Get("name").(string)
 	table, err := c.TableInfo(ctx, name)
 	if err != nil {
 		log.Printf("[WARN] Removing %s because it's gone", name)

--- a/third_party/terraform/resources/resource_cloudiot_registry.go
+++ b/third_party/terraform/resources/resource_cloudiot_registry.go
@@ -404,6 +404,8 @@ func resourceCloudIoTRegistryRead(d *schema.ResourceData, meta interface{}) erro
 	}
 	d.Set("credentials", credentials)
 	d.Set("log_level", res.LogLevel)
+	// Removed Computed field must be set to nil to prevent spurious diffs
+	d.Set("event_notification_config", nil)
 
 	return nil
 }

--- a/third_party/terraform/tests/resource_compute_instance_template_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_template_test.go
@@ -1998,6 +1998,7 @@ resource "google_compute_instance_template" "foobar" {
 	}
 	disk {
 		auto_delete = true
+		disk_size_gb = 375
 		type = "SCRATCH"
 		disk_type = "local-ssd"
 	}

--- a/third_party/terraform/tests/resource_compute_target_pool_test.go
+++ b/third_party/terraform/tests/resource_compute_target_pool_test.go
@@ -139,7 +139,7 @@ func testAccCheckComputeTargetPoolHealthCheck(targetPool, healthCheck string) re
 
 		hcLink := healthCheckRes.Primary.Attributes["self_link"]
 		if targetPoolRes.Primary.Attributes["health_checks.0"] != hcLink {
-			return fmt.Errorf("Health check not set up. Expected %q", hcLink)
+			return fmt.Errorf("Health check not set up. Expected %q to equal %q", targetPoolRes.Primary.Attributes["health_checks.0"], hcLink)
 		}
 
 		return nil

--- a/third_party/terraform/tests/resource_compute_target_ssl_proxy_test.go
+++ b/third_party/terraform/tests/resource_compute_target_ssl_proxy_test.go
@@ -53,14 +53,15 @@ func testAccCheckComputeTargetSslProxy(n, proxyHeader, sslCert string) resource.
 		}
 
 		config := testAccProvider.Meta().(*Config)
+		name := rs.Primary.Attributes["name"]
 
 		found, err := config.clientCompute.TargetSslProxies.Get(
-			config.Project, rs.Primary.ID).Do()
+			config.Project, name).Do()
 		if err != nil {
 			return err
 		}
 
-		if found.Name != rs.Primary.ID {
+		if found.Name != name {
 			return fmt.Errorf("TargetSslProxy not found")
 		}
 

--- a/third_party/terraform/tests/resource_compute_target_tcp_proxy_test.go
+++ b/third_party/terraform/tests/resource_compute_target_tcp_proxy_test.go
@@ -51,14 +51,15 @@ func testAccCheckComputeTargetTcpProxyExists(n string) resource.TestCheckFunc {
 		}
 
 		config := testAccProvider.Meta().(*Config)
+		name := rs.Primary.Attributes["name"]
 
 		found, err := config.clientCompute.TargetTcpProxies.Get(
-			config.Project, rs.Primary.ID).Do()
+			config.Project, name).Do()
 		if err != nil {
 			return err
 		}
 
-		if found.Name != rs.Primary.ID {
+		if found.Name != name {
 			return fmt.Errorf("TargetTcpProxy not found")
 		}
 


### PR DESCRIPTION
Bigtable, proxy tests, target pool, instance groups
Cloud IOT set nil for removed field

Access context manager set specific id format for the only resource without one. ACM allows forward slashes for some resources, so avoiding migrating the resources
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
