### PR TITLE
Forwardingrule ip address

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -534,6 +534,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       IPAddress: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validateIpAddress'
         description: |
           The IP address that this forwarding rule is serving on behalf of.
 
@@ -554,15 +556,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           internal IP address will be automatically allocated from the IP range
           of the subnet or network configured for this forwarding rule.
 
-          ~> **NOTE** The address should be specified as a literal IP address,
-          e.g. `100.1.2.3` to avoid a permanent diff, as the server returns the
-          IP address regardless of the input value.
-
-          The server accepts a literal IP address or a URL reference to an existing
-          Address resource. The following examples are all valid but only the first
-          will prevent a permadiff. If you are using `google_compute_address` or
-          similar, interpolate using `.address` instead of `.self_link` or similar
-          to prevent a diff on re-apply.
+          An address must be specified by a literal IP address. ~> **NOTE**: While
+          the API allows you to specify various resource paths for an address resource
+          instead, Terraform requires this to specifically be an IP address to
+          avoid needing to fetching the IP address from resource paths on refresh
+          or unnecessary diffs.
       IPProtocol: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'caseDiffSuppress'
         default_from_api: true
@@ -637,6 +635,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         exclude: true
       IPAddress: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validateIpAddress'
         description: |
           The IP address that this forwarding rule is serving on behalf of.
 
@@ -657,15 +657,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           internal IP address will be automatically allocated from the IP range
           of the subnet or network configured for this forwarding rule.
 
-          ~> **NOTE** The address should be specified as a literal IP address,
-          e.g. `100.1.2.3` to avoid a permanent diff, as the server returns the
-          IP address regardless of the input value.
-
-          The server accepts a literal IP address or a URL reference to an existing
-          Address resource. The following examples are all valid but only the first
-          will prevent a permadiff. If you are using `google_compute_address` or
-          similar, interpolate using `.address` instead of `.self_link` or similar
-          to prevent a diff on re-apply.
+          An address must be specified by a literal IP address. ~> **NOTE**: While
+          the API allows you to specify various resource paths for an address resource
+          instead, Terraform requires this to specifically be an IP address to
+          avoid needing to fetching the IP address from resource paths on refresh
+          or unnecessary diffs.
       IPProtocol: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'caseDiffSuppress'
         default_from_api: true

--- a/third_party/terraform/utils/validation.go
+++ b/third_party/terraform/utils/validation.go
@@ -232,6 +232,14 @@ func validateNonNegativeDuration() schema.SchemaValidateFunc {
 	}
 }
 
+func validateIpAddress(i interface{}, val string) ([]string, []error) {
+	ip := net.ParseIP(i.(string))
+	if ip == nil {
+		return nil, []error{fmt.Errorf("could not parse %q to IP address", val)}
+	}
+	return nil, nil
+}
+
 // StringNotInSlice returns a SchemaValidateFunc which tests if the provided value
 // is of type string and that it matches none of the element in the invalid slice.
 // if ignorecase is true, case is ignored.


### PR DESCRIPTION
Restrict IP address in ForwardingRule and GlobalForwardingRule to disallow Address self links or paths.

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4461

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
`compute`: No longer allow selfLink or path style references as IP addresses for `google_compute_forwarding_rule` or `google_compute_global_forwarding_rule`
```
