### PR TITLE
Stop users from specifying bigquery-json in 3.0.0

### DIFF
--- a/third_party/terraform/resources/resource_google_project_service.go
+++ b/third_party/terraform/resources/resource_google_project_service.go
@@ -11,11 +11,14 @@ import (
 	"time"
 )
 
-var ignoredProjectServices = []string{"dataproc-control.googleapis.com", "source.googleapis.com", "stackdriverprovisioning.googleapis.com"}
-
 // These services can only be enabled as a side-effect of enabling other services,
 // so don't bother storing them in the config or using them for diffing.
+var ignoredProjectServices = []string{"dataproc-control.googleapis.com", "source.googleapis.com", "stackdriverprovisioning.googleapis.com"}
 var ignoredProjectServicesSet = golangSetFromStringSlice(ignoredProjectServices)
+
+// Services that can't be user-specified but are otherwise valid. Renamed
+// services should be added to this set during major releases.
+var bannedProjectServices = []string{"bigquery-json.googleapis.com"}
 
 // Service Renames
 // we expect when a service is renamed:
@@ -42,7 +45,7 @@ var ignoredProjectServicesSet = golangSetFromStringSlice(ignoredProjectServices)
 // upon removal, we should disallow the old name from being used even if it's
 // not gone from the underlying API yet
 var renamedServices = map[string]string{
-	"bigquery-json.googleapis.com": "bigquery.googleapis.com", // DEPRECATED FOR 3.0.0
+	"bigquery-json.googleapis.com": "bigquery.googleapis.com", // DEPRECATED FOR 4.0.0. Originally for 3.0.0, but the migration did not happen server-side yet.
 }
 
 // renamedServices in reverse (new -> old)
@@ -76,7 +79,7 @@ func resourceGoogleProjectService() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: StringNotInSlice(ignoredProjectServices, false),
+				ValidateFunc: StringNotInSlice(append(ignoredProjectServices, bannedProjectServices...), false),
 			},
 			"project": {
 				Type:     schema.TypeString,

--- a/third_party/terraform/tests/resource_google_project_service_test.go
+++ b/third_party/terraform/tests/resource_google_project_service_test.go
@@ -142,7 +142,7 @@ func TestAccProjectService_renamedService(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProjectService_single("bigquery-json.googleapis.com", pid, pname, org),
+				Config: testAccProjectService_single("bigquery.googleapis.com", pid, pname, org),
 			},
 			{
 				ResourceName:            "google_project_service.test",


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4624

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
`projectservices`: `bigquery-json.googleapis.com` can no longer be specified in `google_project_service`. Specify `biquery.googleapis.com` instead.
```
