### PR TITLE
Add docs for disallowing biquery-json service

### DIFF
--- a/third_party/terraform/website/docs/guides/version_3_upgrade.html.markdown
+++ b/third_party/terraform/website/docs/guides/version_3_upgrade.html.markdown
@@ -51,6 +51,7 @@ so Terraform knows to manage them.
 
 <!-- TOC depthFrom:2 depthTo:2 -->
 - [Resource: `google_container_cluster`](#resource-google_container_cluster)
+- [Resource: `google_project_service`](#resource-google_project_service)
 - [Resource: `google_project_services`](#resource-google_project_services)
 
 <!-- /TOC -->
@@ -237,6 +238,14 @@ of this change, the JSON/state representation of the field has changed,
 introducing an incompatibility for users who specify config in JSON instead of
 HCL or who use `dynamic` blocks. See more details in the [Attributes as Blocks](https://www.terraform.io/docs/configuration/attr-as-blocks.html)
 documentation.
+
+## Resource: `google_project_service`
+
+### `bigquery-json.googleapis.com` service can no longer be specified
+
+`bigquery-json.googleapis.com` is being renamed to `bigquery.googleapis.com` in
+the upstream API. As a result, `bigquery-json.googleapis.com` has been
+disallowed.
 
 ## Resource: `google_project_services`
 


### PR DESCRIPTION
Docs for https://github.com/GoogleCloudPlatform/magic-modules/pull/2626

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
