### PR TITLE
Add import support to google_bigtable_table

### DIFF
--- a/third_party/terraform/tests/resource_bigtable_table_test.go
+++ b/third_party/terraform/tests/resource_bigtable_table_test.go
@@ -23,10 +23,13 @@ func TestAccBigtableTable_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBigtableTable(instanceName, tableName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccBigtableTableExists(
-						"google_bigtable_table.table"),
-				),
+			},
+			{
+				ResourceName:      "google_bigtable_table.table",
+				ImportState:       true,
+				ImportStateVerify: true,
+				//TODO(rileykarson): Remove ImportStateId when id format is fixed in 3.0.0
+				ImportStateId: fmt.Sprintf("%s/%s", instanceName, tableName),
 			},
 		},
 	})
@@ -45,10 +48,13 @@ func TestAccBigtableTable_splitKeys(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBigtableTable_splitKeys(instanceName, tableName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccBigtableTableExists(
-						"google_bigtable_table.table"),
-				),
+			},
+			{
+				ResourceName:            "google_bigtable_table.table",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"split_keys"},
+				ImportStateId:           fmt.Sprintf("%s/%s", instanceName, tableName),
 			},
 		},
 	})
@@ -68,10 +74,12 @@ func TestAccBigtableTable_family(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBigtableTable_family(instanceName, tableName, family),
-				Check: resource.ComposeTestCheckFunc(
-					testAccBigtableTableExists(
-						"google_bigtable_table.table"),
-				),
+			},
+			{
+				ResourceName:      "google_bigtable_table.table",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     fmt.Sprintf("%s/%s", instanceName, tableName),
 			},
 		},
 	})
@@ -91,10 +99,12 @@ func TestAccBigtableTable_familyMany(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBigtableTable_familyMany(instanceName, tableName, family),
-				Check: resource.ComposeTestCheckFunc(
-					testAccBigtableTableExists(
-						"google_bigtable_table.table"),
-				),
+			},
+			{
+				ResourceName:      "google_bigtable_table.table",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     fmt.Sprintf("%s/%s", instanceName, tableName),
 			},
 		},
 	})
@@ -123,34 +133,6 @@ func testAccCheckBigtableTableDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccBigtableTableExists(n string) resource.TestCheckFunc {
-	var ctx = context.Background()
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not found: %s", n)
-		}
-
-		if rs.Primary.ID == "" {
-			return fmt.Errorf("No ID is set")
-		}
-		config := testAccProvider.Meta().(*Config)
-		c, err := config.bigtableClientFactory.NewAdminClient(config.Project, rs.Primary.Attributes["instance_name"])
-		if err != nil {
-			return fmt.Errorf("Error starting admin client. %s", err)
-		}
-
-		_, err = c.TableInfo(ctx, rs.Primary.Attributes["name"])
-		if err != nil {
-			return fmt.Errorf("Error retrieving table. Could not find %s in %s.", rs.Primary.Attributes["name"], rs.Primary.Attributes["instance_name"])
-		}
-
-		c.Close()
-
-		return nil
-	}
 }
 
 func testAccBigtableTable(instanceName, tableName string) string {

--- a/third_party/terraform/website/docs/r/bigtable_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_table.html.markdown
@@ -56,3 +56,17 @@ The following arguments are supported:
 ## Attributes Reference
 
 Only the arguments listed above are exposed as attributes.
+
+## Import
+
+Bigtable Tables can be imported using any of these accepted formats:
+
+```
+$ terraform import google_bigtable_table.default projects/{{project}}/instances/{{instance_name}}/tables/{{name}}
+$ terraform import google_bigtable_table.default {{project}}/{{instance_name}}/{{name}}
+$ terraform import google_bigtable_table.default {{instance_name}}/{{name}}
+```
+
+The following fields can't be read and will show diffs if set in config when imported:
+
+- `split_keys`


### PR DESCRIPTION
Part of https://github.com/terraform-providers/terraform-provider-google/issues/932

I've kept the id compatible with `2.X`, I'll need to x-merge this with `3.0.0`.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
`bigtable`: added import support to `google_bigtable_table`
```
