### PR TITLE
Send null logConfig if subnetwork is L7ILB

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -9182,7 +9182,8 @@ objects:
         update_id: 'logConfig'
         description: |
           Denotes the logging options for the subnetwork flow logs. If logging is enabled
-          logs will be exported to Stackdriver.
+          logs will be exported to Stackdriver. This field cannot be set if the `purpose` of this
+          subnetwork is `INTERNAL_HTTPS_LOAD_BALANCER`
         properties:
           - !ruby/object:Api::Type::Enum
             name: 'aggregationInterval'

--- a/templates/terraform/custom_expand/subnetwork_log_config.go.erb
+++ b/templates/terraform/custom_expand/subnetwork_log_config.go.erb
@@ -13,6 +13,13 @@
 	# limitations under the License.
 -%>
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	purpose, ok := d.GetOkExists("purpose")
+
+	if ok && purpose.(string) == "INTERNAL_HTTPS_LOAD_BALANCER" {
+		// Subnetworks for L7ILB do not accept any values for logConfig
+		return nil, nil
+	}
+
 	l := v.([]interface{})
 	transformed := make(map[string]interface{})
 	if len(l) == 0 || l[0] == nil {
@@ -20,6 +27,7 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d T
 		transformed["enable"] = false
 		return transformed, nil
 	}
+
 	raw := l[0]
 	original := raw.(map[string]interface{})
 

--- a/templates/terraform/custom_expand/subnetwork_log_config.go.erb
+++ b/templates/terraform/custom_expand/subnetwork_log_config.go.erb
@@ -13,16 +13,15 @@
 	# limitations under the License.
 -%>
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
-	purpose, ok := d.GetOkExists("purpose")
-
-	if ok && purpose.(string) == "INTERNAL_HTTPS_LOAD_BALANCER" {
-		// Subnetworks for L7ILB do not accept any values for logConfig
-		return nil, nil
-	}
-
 	l := v.([]interface{})
 	transformed := make(map[string]interface{})
 	if len(l) == 0 || l[0] == nil {
+		purpose, ok := d.GetOkExists("purpose")
+
+		if ok && purpose.(string) == "INTERNAL_HTTPS_LOAD_BALANCER" {
+			// Subnetworks for L7ILB do not accept any values for logConfig
+			return nil, nil
+		}
 		// send enable = false to ensure logging is disabled if there is no config
 		transformed["enable"] = false
 		return transformed, nil


### PR DESCRIPTION
The API rejects requests that contain any values for `logConfig` (including enable:false) if the purpose of the subnetwork is INTERNAL_HTTPS_LOAD_BALANCER.

Check the purpose and set `logConfig` as nil accordingly

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
