### PR TITLE
All handwritten resource call computeSharedOperationWaitTime

### DIFF
--- a/templates/terraform/custom_delete/appversion_delete.go.erb
+++ b/templates/terraform/custom_delete/appversion_delete.go.erb
@@ -2,7 +2,7 @@
 if d.Get("noop_on_destroy") == true {
 	log.Printf("[DEBUG] Keeping the StandardAppVersion %q", d.Id())
 	return nil
-} 
+}
 config := meta.(*Config)
 
 project, err := getProject(d, config)
@@ -28,13 +28,8 @@ if d.Get("delete_service_on_destroy") == true {
 	if err != nil {
 		return handleNotFoundError(err, d, "Service")
 	}
-	op := &appengine.Operation{}
-	err = Convert(res, op)
-	if err != nil {
-		return err
-	}
 	err = appEngineOperationWaitTime(
-		config.clientAppEngine, op, project, "Deleting Service",
+		config, res, project, "Deleting Service",
 		int(d.Timeout(schema.TimeoutDelete).Minutes()))
 
 	if err != nil {
@@ -42,7 +37,7 @@ if d.Get("delete_service_on_destroy") == true {
 	}
 	log.Printf("[DEBUG] Finished deleting Service %q: %#v", d.Id(), res)
 	return nil
-} else {	
+} else {
 	url, err := replaceVars(d, config, "{{AppEngineBasePath}}apps/{{project}}/services/{{service}}/versions/{{version_id}}")
 	if err != nil {
 		return err
@@ -53,13 +48,8 @@ if d.Get("delete_service_on_destroy") == true {
 	if err != nil {
 		return handleNotFoundError(err, d, "StandardAppVersion")
 	}
-	op := &appengine.Operation{}
-	err = Convert(res, op)
-	if err != nil {
-		return err
-	}
 	err = appEngineOperationWaitTime(
-		config.clientAppEngine, op, project, "Deleting StandardAppVersion",
+		config, res, project, "Deleting StandardAppVersion",
 		int(d.Timeout(schema.TimeoutDelete).Minutes()))
 
 	if err != nil {

--- a/templates/terraform/post_create/compute_backend_service_security_policy.go.erb
+++ b/templates/terraform/post_create/compute_backend_service_security_policy.go.erb
@@ -11,7 +11,7 @@ if o, n := d.GetChange("security_policy"); o.(string) != n.(string) {
   if err != nil {
     return errwrap.Wrapf("Error setting Backend Service security policy: {{err}}", err)
   }
-  waitErr := computeSharedOperationWait(config, op, project, "Setting Backend Service Security Policy")
+  waitErr := computeOperationWait(config, op, project, "Setting Backend Service Security Policy")
   if waitErr != nil {
     return waitErr
   }

--- a/templates/terraform/post_create/compute_backend_service_security_policy.go.erb
+++ b/templates/terraform/post_create/compute_backend_service_security_policy.go.erb
@@ -11,7 +11,7 @@ if o, n := d.GetChange("security_policy"); o.(string) != n.(string) {
   if err != nil {
     return errwrap.Wrapf("Error setting Backend Service security policy: {{err}}", err)
   }
-  waitErr := computeSharedOperationWait(config.clientCompute, op, project, "Setting Backend Service Security Policy")
+  waitErr := computeSharedOperationWait(config, op, project, "Setting Backend Service Security Policy")
   if waitErr != nil {
     return waitErr
   }

--- a/templates/terraform/post_create/compute_network_delete_default_route.erb
+++ b/templates/terraform/post_create/compute_network_delete_default_route.erb
@@ -16,7 +16,7 @@ if d.Get("delete_default_routes_on_create").(bool) {
 			if err != nil {
 				return fmt.Errorf("Error deleting route: %s", err)
 			}
-			err = computeSharedOperationWait(config.clientCompute, op, project, "Deleting Route")
+			err = computeSharedOperationWait(config, op, project, "Deleting Route")
 			if err != nil {
 				return err
 			}

--- a/templates/terraform/post_create/compute_network_delete_default_route.erb
+++ b/templates/terraform/post_create/compute_network_delete_default_route.erb
@@ -16,7 +16,7 @@ if d.Get("delete_default_routes_on_create").(bool) {
 			if err != nil {
 				return fmt.Errorf("Error deleting route: %s", err)
 			}
-			err = computeSharedOperationWait(config, op, project, "Deleting Route")
+			err = computeOperationWait(config, op, project, "Deleting Route")
 			if err != nil {
 				return err
 			}

--- a/templates/terraform/post_create/labels.erb
+++ b/templates/terraform/post_create/labels.erb
@@ -25,13 +25,8 @@ if v, ok := d.GetOkExists("labels"); !isEmptyValue(reflect.ValueOf(v)) && (ok ||
       return fmt.Errorf("Error adding labels to <%= resource_name -%> %q: %s", d.Id(), err)
     }
 
-    err = Convert(res, op)
-    if err != nil {
-        return err
-    }
-
     err = computeOperationWaitTime(
-        config.clientCompute, op, project, "Updating <%= resource_name -%> Labels",
+        config, res, project, "Updating <%= resource_name -%> Labels",
         int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 
     if err != nil {

--- a/templates/terraform/pre_delete/detach_disk.erb
+++ b/templates/terraform/pre_delete/detach_disk.erb
@@ -41,7 +41,7 @@ if v, ok := readRes["users"].([]interface{}); ok {
 			return fmt.Errorf("Error detaching disk %s from instance %s/%s/%s: %s", call.deviceName, call.project,
 				call.zone, call.instance, err.Error())
 		}
-		err = computeOperationWait(config.clientCompute, op, call.project,
+		err = computeOperationWait(config, op, call.project,
 			fmt.Sprintf("Detaching disk from %s/%s/%s", call.project, call.zone, call.instance))
 		if err != nil {
 			if opErr, ok := err.(ComputeOperationError); ok && len(opErr.Errors) == 1 && opErr.Errors[0].Code == "RESOURCE_NOT_FOUND" {

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -489,22 +489,10 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
     }
 
 <%  if !object.async.nil? && object.async.allow?('update') -%>
-<% if object.autogen_async && object.async.allow?('update') -%>
 
     err = <%= client_name_camel -%>OperationWaitTime(
     config, res, <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
     int(d.Timeout(schema.TimeoutUpdate).Minutes()))
-<% else -%>
-    op := &<%= client_name_lower -%>.Operation{}
-    err = Convert(res, op)
-    if err != nil {
-        return err
-    }
-
-    err = <%= client_name_camel -%>OperationWaitTime(
-    config.client<%= client_name_pascal -%>, op, <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
-    int(d.Timeout(schema.TimeoutUpdate).Minutes()))
-<% end -%>
 
     if err != nil {
         return err
@@ -562,22 +550,10 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
     }
 
 <%  if !object.async.nil? && object.async.allow?('delete') -%>
-<% if object.autogen_async && object.async.allow?('delete') -%>
 
     err = <%= client_name_camel -%>OperationWaitTime(
         config, res, <% if has_project -%> project, <% end -%> "Deleting <%= object.name -%>",
         int(d.Timeout(schema.TimeoutDelete).Minutes()))
-<% else -%>
-    op := &<%= client_name_lower -%>.Operation{}
-    err = Convert(res, op)
-    if err != nil {
-        return err
-    }
-
-    err = <%= client_name_camel -%>OperationWaitTime(
-        config.client<%= client_name_pascal -%>, op, <% if has_project -%> project, <% end -%> "Deleting <%= object.name -%>",
-        int(d.Timeout(schema.TimeoutDelete).Minutes()))
-<% end -%>
 
     if err != nil {
         return err

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -198,21 +198,9 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     d.SetId(id)
 
 <%  if !object.async.nil? && object.async.allow?('create') -%>
-<% if object.autogen_async -%>
     waitErr := <%= client_name_camel -%>OperationWaitTime(
     config, res,<% if has_project -%> project, <% end -%> "Creating <%= object.name -%>",
         int(d.Timeout(schema.TimeoutCreate).Minutes()))
-<% else -%>
-    op := &<%= client_name_lower -%>.Operation{}
-    err = Convert(res, op)
-    if err != nil {
-        return err
-    }
-
-    waitErr := <%= client_name_camel -%>OperationWaitTime(
-    config.client<%= client_name_pascal -%>, op,<% if has_project -%> project, <% end -%> "Creating <%= object.name -%>",
-        int(d.Timeout(schema.TimeoutCreate).Minutes()))
-<% end -%>
 
     if waitErr != nil {
         // The resource didn't actually create
@@ -419,24 +407,10 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
         }
 
 <%      if !object.async.nil? && object.async.allow?('update') -%>
-<%        if object.autogen_async -%>
 
         err = <%= client_name_camel -%>OperationWaitTime(
             config, res, <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
             int(d.Timeout(schema.TimeoutUpdate).Minutes()))
-
-<%        else -%>
-        op := &<%= client_name_lower -%>.Operation{}
-        err = Convert(res, op)
-        if err != nil {
-            return err
-        }
-
-        err = <%= client_name_camel -%>OperationWaitTime(
-            config.client<%= client_name_pascal -%>, op, <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
-            int(d.Timeout(schema.TimeoutUpdate).Minutes()))
-
-<%        end -%>
         if err != nil {
             return err
         }

--- a/third_party/terraform/resources/resource_app_engine_application.go
+++ b/third_party/terraform/resources/resource_app_engine_application.go
@@ -151,7 +151,7 @@ func resourceAppEngineApplicationCreate(d *schema.ResourceData, meta interface{}
 	d.SetId(project)
 
 	// Wait for the operation to complete
-	waitErr := appEngineOperationWait(config.clientAppEngine, op, project, "App Engine app to create")
+	waitErr := appEngineOperationWait(config, op, project, "App Engine app to create")
 	if waitErr != nil {
 		d.SetId("")
 		return waitErr
@@ -212,7 +212,7 @@ func resourceAppEngineApplicationUpdate(d *schema.ResourceData, meta interface{}
 	}
 
 	// Wait for the operation to complete
-	waitErr := appEngineOperationWait(config.clientAppEngine, op, pid, "App Engine app to update")
+	waitErr := appEngineOperationWait(config, op, pid, "App Engine app to update")
 	if waitErr != nil {
 		return waitErr
 	}

--- a/third_party/terraform/resources/resource_compute_attached_disk.go
+++ b/third_party/terraform/resources/resource_compute_attached_disk.go
@@ -103,7 +103,7 @@ func resourceAttachedDiskCreate(d *schema.ResourceData, meta interface{}) error 
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s/%s", zv.Project, zv.Zone, zv.Name, diskName))
 
 	waitErr := computeSharedOperationWaitTime(config.clientCompute, op, zv.Project,
-		int(d.Timeout(schema.TimeoutCreate).Minutes()), "disk to attach")
+		"disk to attach", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if waitErr != nil {
 		d.SetId("")
 		return waitErr
@@ -184,7 +184,7 @@ func resourceAttachedDiskDelete(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	waitErr := computeSharedOperationWaitTime(config.clientCompute, op, zv.Project,
-		int(d.Timeout(schema.TimeoutDelete).Minutes()), fmt.Sprintf("Detaching disk from %s", zv.Name))
+		fmt.Sprintf("Detaching disk from %s", zv.Name), int(d.Timeout(schema.TimeoutDelete).Minutes()))
 	if waitErr != nil {
 		return waitErr
 	}

--- a/third_party/terraform/resources/resource_compute_attached_disk.go
+++ b/third_party/terraform/resources/resource_compute_attached_disk.go
@@ -102,7 +102,7 @@ func resourceAttachedDiskCreate(d *schema.ResourceData, meta interface{}) error 
 
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s/%s", zv.Project, zv.Zone, zv.Name, diskName))
 
-	waitErr := computeSharedOperationWaitTime(config, op, zv.Project,
+	waitErr := computeOperationWaitTime(config, op, zv.Project,
 		"disk to attach", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if waitErr != nil {
 		d.SetId("")
@@ -183,7 +183,7 @@ func resourceAttachedDiskDelete(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	waitErr := computeSharedOperationWaitTime(config, op, zv.Project,
+	waitErr := computeOperationWaitTime(config, op, zv.Project,
 		fmt.Sprintf("Detaching disk from %s", zv.Name), int(d.Timeout(schema.TimeoutDelete).Minutes()))
 	if waitErr != nil {
 		return waitErr

--- a/third_party/terraform/resources/resource_compute_attached_disk.go
+++ b/third_party/terraform/resources/resource_compute_attached_disk.go
@@ -102,7 +102,7 @@ func resourceAttachedDiskCreate(d *schema.ResourceData, meta interface{}) error 
 
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s/%s", zv.Project, zv.Zone, zv.Name, diskName))
 
-	waitErr := computeSharedOperationWaitTime(config.clientCompute, op, zv.Project,
+	waitErr := computeSharedOperationWaitTime(config, op, zv.Project,
 		"disk to attach", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if waitErr != nil {
 		d.SetId("")
@@ -183,7 +183,7 @@ func resourceAttachedDiskDelete(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	waitErr := computeSharedOperationWaitTime(config.clientCompute, op, zv.Project,
+	waitErr := computeSharedOperationWaitTime(config, op, zv.Project,
 		fmt.Sprintf("Detaching disk from %s", zv.Name), int(d.Timeout(schema.TimeoutDelete).Minutes()))
 	if waitErr != nil {
 		return waitErr

--- a/third_party/terraform/resources/resource_compute_instance.go
+++ b/third_party/terraform/resources/resource_compute_instance.go
@@ -748,7 +748,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, z, instance.Name))
 
 	// Wait for the operation to complete
-	waitErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "instance to create", createTimeout)
+	waitErr := computeSharedOperationWaitTime(config, op, project, "instance to create", createTimeout)
 	if waitErr != nil {
 		// The resource didn't actually create
 		d.SetId("")
@@ -996,7 +996,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 					return fmt.Errorf("Error updating metadata: %s", err)
 				}
 
-				opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "metadata to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeSharedOperationWaitTime(config, op, project, "metadata to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 				if opErr != nil {
 					return opErr
 				}
@@ -1024,7 +1024,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating tags: %s", err)
 		}
 
-		opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "tags to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+		opErr := computeSharedOperationWaitTime(config, op, project, "tags to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr
 		}
@@ -1042,7 +1042,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating labels: %s", err)
 		}
 
-		opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "labels to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+		opErr := computeSharedOperationWaitTime(config, op, project, "labels to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr
 		}
@@ -1102,7 +1102,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return fmt.Errorf("Error deleting old access_config: %s", err)
 				}
-				opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "old access_config to delete", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeSharedOperationWaitTime(config, op, project, "old access_config to delete", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 				if opErr != nil {
 					return opErr
 				}
@@ -1127,7 +1127,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return fmt.Errorf("Error adding new access_config: %s", err)
 				}
-				opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "new access_config to add", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeSharedOperationWaitTime(config, op, project, "new access_config to add", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 				if opErr != nil {
 					return opErr
 				}
@@ -1147,7 +1147,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return errwrap.Wrapf("Error removing alias_ip_range: {{err}}", err)
 				}
-				opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "updating alias ip ranges", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeSharedOperationWaitTime(config, op, project, "updating alias ip ranges", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 				if opErr != nil {
 					return opErr
 				}
@@ -1171,7 +1171,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return errwrap.Wrapf("Error adding alias_ip_range: {{err}}", err)
 				}
-				opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "updating alias ip ranges", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeSharedOperationWaitTime(config, op, project, "updating alias ip ranges", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 				if opErr != nil {
 					return opErr
 				}
@@ -1249,7 +1249,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 					return errwrap.Wrapf("Error detaching disk: %s", err)
 				}
 
-				opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "detaching disk", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeSharedOperationWaitTime(config, op, project, "detaching disk", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 				if opErr != nil {
 					return opErr
 				}
@@ -1264,7 +1264,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				return errwrap.Wrapf("Error attaching disk : {{err}}", err)
 			}
 
-			opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "attaching disk", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeSharedOperationWaitTime(config, op, project, "attaching disk", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 			if opErr != nil {
 				return opErr
 			}
@@ -1298,7 +1298,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating deletion protection flag: %s", err)
 		}
 
-		opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "deletion protection to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+		opErr := computeSharedOperationWaitTime(config, op, project, "deletion protection to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr
 		}
@@ -1317,7 +1317,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return errwrap.Wrapf("Error stopping instance: {{err}}", err)
 		}
 
-		opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "stopping instance", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+		opErr := computeSharedOperationWaitTime(config, op, project, "stopping instance", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr
 		}
@@ -1334,7 +1334,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return err
 			}
-			opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "updating machinetype", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeSharedOperationWaitTime(config, op, project, "updating machinetype", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 			if opErr != nil {
 				return opErr
 			}
@@ -1356,7 +1356,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return err
 			}
-			opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "updating min cpu platform", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeSharedOperationWaitTime(config, op, project, "updating min cpu platform", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 			if opErr != nil {
 				return opErr
 			}
@@ -1375,7 +1375,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return err
 			}
-			opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "updating service account", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeSharedOperationWaitTime(config, op, project, "updating service account", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 			if opErr != nil {
 				return opErr
 			}
@@ -1391,7 +1391,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error updating display device: %s", err)
 			}
-			opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "updating display device", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeSharedOperationWaitTime(config, op, project, "updating display device", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 			if opErr != nil {
 				return opErr
 			}
@@ -1403,7 +1403,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return errwrap.Wrapf("Error starting instance: {{err}}", err)
 		}
 
-		opErr = computeSharedOperationWaitTime(config.clientCompute, op, project,
+		opErr = computeSharedOperationWaitTime(config, op, project,
 			"starting instance", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr
@@ -1418,7 +1418,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating shielded vm config: %s", err)
 		}
 
-		opErr := computeSharedOperationWaitTime(config.clientCompute, op, project,
+		opErr := computeSharedOperationWaitTime(config, op, project,
 			"shielded vm config update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr
@@ -1579,7 +1579,7 @@ func resourceComputeInstanceDelete(d *schema.ResourceData, meta interface{}) err
 		}
 
 		// Wait for the operation to complete
-		opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "instance to delete", int(d.Timeout(schema.TimeoutDelete).Minutes()))
+		opErr := computeSharedOperationWaitTime(config, op, project, "instance to delete", int(d.Timeout(schema.TimeoutDelete).Minutes()))
 		if opErr != nil {
 			return opErr
 		}

--- a/third_party/terraform/resources/resource_compute_instance.go
+++ b/third_party/terraform/resources/resource_compute_instance.go
@@ -1063,7 +1063,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 
 		opErr := computeSharedOperationWaitTime(
-			config.clientCompute, op, project, "scheduling policy update",
+			config, op, project, "scheduling policy update",
 			int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr

--- a/third_party/terraform/resources/resource_compute_instance.go
+++ b/third_party/terraform/resources/resource_compute_instance.go
@@ -748,7 +748,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, z, instance.Name))
 
 	// Wait for the operation to complete
-	waitErr := computeSharedOperationWaitTime(config.clientCompute, op, project, createTimeout, "instance to create")
+	waitErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "instance to create", createTimeout)
 	if waitErr != nil {
 		// The resource didn't actually create
 		d.SetId("")
@@ -996,7 +996,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 					return fmt.Errorf("Error updating metadata: %s", err)
 				}
 
-				opErr := computeOperationWaitTime(config.clientCompute, op, project, "metadata to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "metadata to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 				if opErr != nil {
 					return opErr
 				}
@@ -1024,7 +1024,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating tags: %s", err)
 		}
 
-		opErr := computeOperationWaitTime(config.clientCompute, op, project, "tags to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+		opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "tags to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr
 		}
@@ -1042,7 +1042,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating labels: %s", err)
 		}
 
-		opErr := computeOperationWaitTime(config.clientCompute, op, project, "labels to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+		opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "labels to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr
 		}
@@ -1062,7 +1062,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating scheduling policy: %s", err)
 		}
 
-		opErr := computeBetaOperationWaitTime(
+		opErr := computeSharedOperationWaitTime(
 			config.clientCompute, op, project, "scheduling policy update",
 			int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
@@ -1102,7 +1102,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return fmt.Errorf("Error deleting old access_config: %s", err)
 				}
-				opErr := computeOperationWaitTime(config.clientCompute, op, project, "old access_config to delete", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "old access_config to delete", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 				if opErr != nil {
 					return opErr
 				}
@@ -1127,7 +1127,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return fmt.Errorf("Error adding new access_config: %s", err)
 				}
-				opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, int(d.Timeout(schema.TimeoutUpdate).Minutes()), "new access_config to add")
+				opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "new access_config to add", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 				if opErr != nil {
 					return opErr
 				}
@@ -1147,7 +1147,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return errwrap.Wrapf("Error removing alias_ip_range: {{err}}", err)
 				}
-				opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, int(d.Timeout(schema.TimeoutUpdate).Minutes()), "updating alias ip ranges")
+				opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "updating alias ip ranges", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 				if opErr != nil {
 					return opErr
 				}
@@ -1171,7 +1171,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return errwrap.Wrapf("Error adding alias_ip_range: {{err}}", err)
 				}
-				opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, int(d.Timeout(schema.TimeoutUpdate).Minutes()), "updating alias ip ranges")
+				opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "updating alias ip ranges", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 				if opErr != nil {
 					return opErr
 				}
@@ -1249,7 +1249,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 					return errwrap.Wrapf("Error detaching disk: %s", err)
 				}
 
-				opErr := computeOperationWaitTime(config.clientCompute, op, project, "detaching disk", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "detaching disk", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 				if opErr != nil {
 					return opErr
 				}
@@ -1264,7 +1264,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				return errwrap.Wrapf("Error attaching disk : {{err}}", err)
 			}
 
-			opErr := computeOperationWaitTime(config.clientCompute, op, project, "attaching disk", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "attaching disk", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 			if opErr != nil {
 				return opErr
 			}
@@ -1298,7 +1298,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating deletion protection flag: %s", err)
 		}
 
-		opErr := computeOperationWaitTime(config.clientCompute, op, project, "deletion protection to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+		opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "deletion protection to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr
 		}
@@ -1317,7 +1317,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return errwrap.Wrapf("Error stopping instance: {{err}}", err)
 		}
 
-		opErr := computeOperationWaitTime(config.clientCompute, op, project, "stopping instance", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+		opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "stopping instance", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr
 		}
@@ -1334,7 +1334,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return err
 			}
-			opErr := computeOperationWaitTime(config.clientCompute, op, project, "updating machinetype", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "updating machinetype", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 			if opErr != nil {
 				return opErr
 			}
@@ -1356,7 +1356,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return err
 			}
-			opErr := computeOperationWaitTime(config.clientCompute, op, project, "updating min cpu platform", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "updating min cpu platform", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 			if opErr != nil {
 				return opErr
 			}
@@ -1375,7 +1375,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return err
 			}
-			opErr := computeOperationWaitTime(config.clientCompute, op, project, "updating service account", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "updating service account", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 			if opErr != nil {
 				return opErr
 			}
@@ -1391,7 +1391,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error updating display device: %s", err)
 			}
-			opErr := computeOperationWaitTime(config.clientCompute, op, project, "updating display device", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "updating display device", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 			if opErr != nil {
 				return opErr
 			}
@@ -1403,7 +1403,8 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return errwrap.Wrapf("Error starting instance: {{err}}", err)
 		}
 
-		opErr = computeOperationWaitTime(config.clientCompute, op, project, "starting instance", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+		opErr = computeSharedOperationWaitTime(config.clientCompute, op, project,
+			"starting instance", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr
 		}
@@ -1417,7 +1418,8 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating shielded vm config: %s", err)
 		}
 
-		opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, int(d.Timeout(schema.TimeoutUpdate).Minutes()), "shielded vm config update")
+		opErr := computeSharedOperationWaitTime(config.clientCompute, op, project,
+			"shielded vm config update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr
 		}
@@ -1577,7 +1579,7 @@ func resourceComputeInstanceDelete(d *schema.ResourceData, meta interface{}) err
 		}
 
 		// Wait for the operation to complete
-		opErr := computeOperationWaitTime(config.clientCompute, op, project, "instance to delete", int(d.Timeout(schema.TimeoutDelete).Minutes()))
+		opErr := computeSharedOperationWaitTime(config.clientCompute, op, project, "instance to delete", int(d.Timeout(schema.TimeoutDelete).Minutes()))
 		if opErr != nil {
 			return opErr
 		}

--- a/third_party/terraform/resources/resource_compute_instance.go
+++ b/third_party/terraform/resources/resource_compute_instance.go
@@ -748,7 +748,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, z, instance.Name))
 
 	// Wait for the operation to complete
-	waitErr := computeSharedOperationWaitTime(config, op, project, "instance to create", createTimeout)
+	waitErr := computeOperationWaitTime(config, op, project, "instance to create", createTimeout)
 	if waitErr != nil {
 		// The resource didn't actually create
 		d.SetId("")
@@ -996,7 +996,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 					return fmt.Errorf("Error updating metadata: %s", err)
 				}
 
-				opErr := computeSharedOperationWaitTime(config, op, project, "metadata to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeOperationWaitTime(config, op, project, "metadata to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 				if opErr != nil {
 					return opErr
 				}
@@ -1024,7 +1024,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating tags: %s", err)
 		}
 
-		opErr := computeSharedOperationWaitTime(config, op, project, "tags to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+		opErr := computeOperationWaitTime(config, op, project, "tags to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr
 		}
@@ -1042,7 +1042,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating labels: %s", err)
 		}
 
-		opErr := computeSharedOperationWaitTime(config, op, project, "labels to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+		opErr := computeOperationWaitTime(config, op, project, "labels to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr
 		}
@@ -1062,7 +1062,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating scheduling policy: %s", err)
 		}
 
-		opErr := computeSharedOperationWaitTime(
+		opErr := computeOperationWaitTime(
 			config, op, project, "scheduling policy update",
 			int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
@@ -1102,7 +1102,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return fmt.Errorf("Error deleting old access_config: %s", err)
 				}
-				opErr := computeSharedOperationWaitTime(config, op, project, "old access_config to delete", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeOperationWaitTime(config, op, project, "old access_config to delete", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 				if opErr != nil {
 					return opErr
 				}
@@ -1127,7 +1127,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return fmt.Errorf("Error adding new access_config: %s", err)
 				}
-				opErr := computeSharedOperationWaitTime(config, op, project, "new access_config to add", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeOperationWaitTime(config, op, project, "new access_config to add", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 				if opErr != nil {
 					return opErr
 				}
@@ -1147,7 +1147,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return errwrap.Wrapf("Error removing alias_ip_range: {{err}}", err)
 				}
-				opErr := computeSharedOperationWaitTime(config, op, project, "updating alias ip ranges", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeOperationWaitTime(config, op, project, "updating alias ip ranges", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 				if opErr != nil {
 					return opErr
 				}
@@ -1171,7 +1171,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return errwrap.Wrapf("Error adding alias_ip_range: {{err}}", err)
 				}
-				opErr := computeSharedOperationWaitTime(config, op, project, "updating alias ip ranges", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeOperationWaitTime(config, op, project, "updating alias ip ranges", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 				if opErr != nil {
 					return opErr
 				}
@@ -1249,7 +1249,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 					return errwrap.Wrapf("Error detaching disk: %s", err)
 				}
 
-				opErr := computeSharedOperationWaitTime(config, op, project, "detaching disk", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeOperationWaitTime(config, op, project, "detaching disk", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 				if opErr != nil {
 					return opErr
 				}
@@ -1264,7 +1264,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				return errwrap.Wrapf("Error attaching disk : {{err}}", err)
 			}
 
-			opErr := computeSharedOperationWaitTime(config, op, project, "attaching disk", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeOperationWaitTime(config, op, project, "attaching disk", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 			if opErr != nil {
 				return opErr
 			}
@@ -1298,7 +1298,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating deletion protection flag: %s", err)
 		}
 
-		opErr := computeSharedOperationWaitTime(config, op, project, "deletion protection to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+		opErr := computeOperationWaitTime(config, op, project, "deletion protection to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr
 		}
@@ -1317,7 +1317,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return errwrap.Wrapf("Error stopping instance: {{err}}", err)
 		}
 
-		opErr := computeSharedOperationWaitTime(config, op, project, "stopping instance", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+		opErr := computeOperationWaitTime(config, op, project, "stopping instance", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr
 		}
@@ -1334,7 +1334,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return err
 			}
-			opErr := computeSharedOperationWaitTime(config, op, project, "updating machinetype", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeOperationWaitTime(config, op, project, "updating machinetype", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 			if opErr != nil {
 				return opErr
 			}
@@ -1356,7 +1356,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return err
 			}
-			opErr := computeSharedOperationWaitTime(config, op, project, "updating min cpu platform", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeOperationWaitTime(config, op, project, "updating min cpu platform", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 			if opErr != nil {
 				return opErr
 			}
@@ -1375,7 +1375,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return err
 			}
-			opErr := computeSharedOperationWaitTime(config, op, project, "updating service account", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeOperationWaitTime(config, op, project, "updating service account", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 			if opErr != nil {
 				return opErr
 			}
@@ -1391,7 +1391,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error updating display device: %s", err)
 			}
-			opErr := computeSharedOperationWaitTime(config, op, project, "updating display device", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeOperationWaitTime(config, op, project, "updating display device", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 			if opErr != nil {
 				return opErr
 			}
@@ -1403,7 +1403,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return errwrap.Wrapf("Error starting instance: {{err}}", err)
 		}
 
-		opErr = computeSharedOperationWaitTime(config, op, project,
+		opErr = computeOperationWaitTime(config, op, project,
 			"starting instance", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr
@@ -1418,7 +1418,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating shielded vm config: %s", err)
 		}
 
-		opErr := computeSharedOperationWaitTime(config, op, project,
+		opErr := computeOperationWaitTime(config, op, project,
 			"shielded vm config update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if opErr != nil {
 			return opErr
@@ -1579,7 +1579,7 @@ func resourceComputeInstanceDelete(d *schema.ResourceData, meta interface{}) err
 		}
 
 		// Wait for the operation to complete
-		opErr := computeSharedOperationWaitTime(config, op, project, "instance to delete", int(d.Timeout(schema.TimeoutDelete).Minutes()))
+		opErr := computeOperationWaitTime(config, op, project, "instance to delete", int(d.Timeout(schema.TimeoutDelete).Minutes()))
 		if opErr != nil {
 			return opErr
 		}

--- a/third_party/terraform/resources/resource_compute_instance_from_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_from_template.go
@@ -156,7 +156,8 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, z, instance.Name))
 
 	// Wait for the operation to complete
-	waitErr := computeSharedOperationWaitTime(config.clientCompute, op, project, int(d.Timeout(schema.TimeoutCreate).Minutes()), "instance to create")
+	waitErr := computeSharedOperationWaitTime(config.clientCompute, op, project,
+		"instance to create", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if waitErr != nil {
 		// The resource didn't actually create
 		d.SetId("")

--- a/third_party/terraform/resources/resource_compute_instance_from_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_from_template.go
@@ -156,7 +156,7 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, z, instance.Name))
 
 	// Wait for the operation to complete
-	waitErr := computeSharedOperationWaitTime(config, op, project,
+	waitErr := computeOperationWaitTime(config, op, project,
 		"instance to create", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if waitErr != nil {
 		// The resource didn't actually create

--- a/third_party/terraform/resources/resource_compute_instance_from_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_from_template.go
@@ -156,7 +156,7 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, z, instance.Name))
 
 	// Wait for the operation to complete
-	waitErr := computeSharedOperationWaitTime(config.clientCompute, op, project,
+	waitErr := computeSharedOperationWaitTime(config, op, project,
 		"instance to create", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if waitErr != nil {
 		// The resource didn't actually create

--- a/third_party/terraform/resources/resource_compute_instance_group.go
+++ b/third_party/terraform/resources/resource_compute_instance_group.go
@@ -159,7 +159,7 @@ func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instanceGroups/%s", project, zone, name))
 
 	// Wait for the operation to complete
-	err = computeOperationWait(config.clientCompute, op, project, "Creating InstanceGroup")
+	err = computeOperationWait(config, op, project, "Creating InstanceGroup")
 	if err != nil {
 		d.SetId("")
 		return err
@@ -183,7 +183,7 @@ func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}
 		}
 
 		// Wait for the operation to complete
-		err = computeOperationWait(config.clientCompute, op, project, "Adding instances to InstanceGroup")
+		err = computeOperationWait(config, op, project, "Adding instances to InstanceGroup")
 		if err != nil {
 			return err
 		}
@@ -295,7 +295,7 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 				}
 			} else {
 				// Wait for the operation to complete
-				err = computeOperationWait(config.clientCompute, removeOp, project, "Updating InstanceGroup")
+				err = computeOperationWait(config, removeOp, project, "Updating InstanceGroup")
 				if err != nil {
 					return err
 				}
@@ -316,7 +316,7 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 			}
 
 			// Wait for the operation to complete
-			err = computeOperationWait(config.clientCompute, addOp, project, "Updating InstanceGroup")
+			err = computeOperationWait(config, addOp, project, "Updating InstanceGroup")
 			if err != nil {
 				return err
 			}
@@ -339,7 +339,7 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 			return fmt.Errorf("Error updating named ports for InstanceGroup: %s", err)
 		}
 
-		err = computeOperationWait(config.clientCompute, op, project, "Updating InstanceGroup")
+		err = computeOperationWait(config, op, project, "Updating InstanceGroup")
 		if err != nil {
 			return err
 		}
@@ -369,7 +369,7 @@ func resourceComputeInstanceGroupDelete(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error deleting InstanceGroup: %s", err)
 	}
 
-	err = computeOperationWait(config.clientCompute, op, project, "Deleting InstanceGroup")
+	err = computeOperationWait(config, op, project, "Deleting InstanceGroup")
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_compute_instance_group_manager.go
+++ b/third_party/terraform/resources/resource_compute_instance_group_manager.go
@@ -320,7 +320,7 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 
 	// Wait for the operation to complete
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-	err = computeSharedOperationWaitTime(config.clientCompute, op, project, timeoutInMinutes, "Creating InstanceGroupManager")
+	err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Creating InstanceGroupManager", timeoutInMinutes)
 	if err != nil {
 		return err
 	}
@@ -497,7 +497,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		}
 
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, timeoutInMinutes, "Updating managed group instances")
+		err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Updating managed group instances", timeoutInMinutes)
 		if err != nil {
 			return err
 		}
@@ -524,7 +524,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 
 		// Wait for the operation to complete:
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, timeoutInMinutes, "Updating InstanceGroupManager")
+		err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Updating InstanceGroupManager", timeoutInMinutes)
 		if err != nil {
 			return err
 		}
@@ -545,7 +545,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 
 		// Wait for the operation to complete
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, timeoutInMinutes, "Updating InstanceGroupManager")
+		err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Updating InstanceGroupManager", timeoutInMinutes)
 		if err != nil {
 			return err
 		}
@@ -584,7 +584,7 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 
 	// Wait for the operation to complete
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
-	err = computeSharedOperationWaitTime(config.clientCompute, op, project, timeoutInMinutes, "Deleting InstanceGroupManager")
+	err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Deleting InstanceGroupManager", timeoutInMinutes)
 
 	for err != nil && currentSize > 0 {
 		if !strings.Contains(err.Error(), "timeout") {
@@ -606,7 +606,7 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 		log.Printf("[INFO] timeout occurred, but instance group is shrinking (%d < %d)", instanceGroupSize, currentSize)
 		currentSize = instanceGroupSize
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, timeoutInMinutes, "Deleting InstanceGroupManager")
+		err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Deleting InstanceGroupManager", timeoutInMinutes)
 	}
 
 	d.SetId("")

--- a/third_party/terraform/resources/resource_compute_instance_group_manager.go
+++ b/third_party/terraform/resources/resource_compute_instance_group_manager.go
@@ -320,7 +320,7 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 
 	// Wait for the operation to complete
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-	err = computeSharedOperationWaitTime(config, op, project, "Creating InstanceGroupManager", timeoutInMinutes)
+	err = computeOperationWaitTime(config, op, project, "Creating InstanceGroupManager", timeoutInMinutes)
 	if err != nil {
 		return err
 	}
@@ -497,7 +497,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		}
 
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeSharedOperationWaitTime(config, op, project, "Updating managed group instances", timeoutInMinutes)
+		err = computeOperationWaitTime(config, op, project, "Updating managed group instances", timeoutInMinutes)
 		if err != nil {
 			return err
 		}
@@ -524,7 +524,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 
 		// Wait for the operation to complete:
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeSharedOperationWaitTime(config, op, project, "Updating InstanceGroupManager", timeoutInMinutes)
+		err = computeOperationWaitTime(config, op, project, "Updating InstanceGroupManager", timeoutInMinutes)
 		if err != nil {
 			return err
 		}
@@ -545,7 +545,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 
 		// Wait for the operation to complete
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeSharedOperationWaitTime(config, op, project, "Updating InstanceGroupManager", timeoutInMinutes)
+		err = computeOperationWaitTime(config, op, project, "Updating InstanceGroupManager", timeoutInMinutes)
 		if err != nil {
 			return err
 		}
@@ -584,7 +584,7 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 
 	// Wait for the operation to complete
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
-	err = computeSharedOperationWaitTime(config, op, project, "Deleting InstanceGroupManager", timeoutInMinutes)
+	err = computeOperationWaitTime(config, op, project, "Deleting InstanceGroupManager", timeoutInMinutes)
 
 	for err != nil && currentSize > 0 {
 		if !strings.Contains(err.Error(), "timeout") {
@@ -606,7 +606,7 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 		log.Printf("[INFO] timeout occurred, but instance group is shrinking (%d < %d)", instanceGroupSize, currentSize)
 		currentSize = instanceGroupSize
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
-		err = computeSharedOperationWaitTime(config, op, project, "Deleting InstanceGroupManager", timeoutInMinutes)
+		err = computeOperationWaitTime(config, op, project, "Deleting InstanceGroupManager", timeoutInMinutes)
 	}
 
 	d.SetId("")

--- a/third_party/terraform/resources/resource_compute_instance_group_manager.go
+++ b/third_party/terraform/resources/resource_compute_instance_group_manager.go
@@ -320,7 +320,7 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 
 	// Wait for the operation to complete
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-	err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Creating InstanceGroupManager", timeoutInMinutes)
+	err = computeSharedOperationWaitTime(config, op, project, "Creating InstanceGroupManager", timeoutInMinutes)
 	if err != nil {
 		return err
 	}
@@ -497,7 +497,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		}
 
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Updating managed group instances", timeoutInMinutes)
+		err = computeSharedOperationWaitTime(config, op, project, "Updating managed group instances", timeoutInMinutes)
 		if err != nil {
 			return err
 		}
@@ -524,7 +524,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 
 		// Wait for the operation to complete:
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Updating InstanceGroupManager", timeoutInMinutes)
+		err = computeSharedOperationWaitTime(config, op, project, "Updating InstanceGroupManager", timeoutInMinutes)
 		if err != nil {
 			return err
 		}
@@ -545,7 +545,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 
 		// Wait for the operation to complete
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Updating InstanceGroupManager", timeoutInMinutes)
+		err = computeSharedOperationWaitTime(config, op, project, "Updating InstanceGroupManager", timeoutInMinutes)
 		if err != nil {
 			return err
 		}
@@ -584,7 +584,7 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 
 	// Wait for the operation to complete
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
-	err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Deleting InstanceGroupManager", timeoutInMinutes)
+	err = computeSharedOperationWaitTime(config, op, project, "Deleting InstanceGroupManager", timeoutInMinutes)
 
 	for err != nil && currentSize > 0 {
 		if !strings.Contains(err.Error(), "timeout") {
@@ -606,7 +606,7 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 		log.Printf("[INFO] timeout occurred, but instance group is shrinking (%d < %d)", instanceGroupSize, currentSize)
 		currentSize = instanceGroupSize
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Deleting InstanceGroupManager", timeoutInMinutes)
+		err = computeSharedOperationWaitTime(config, op, project, "Deleting InstanceGroupManager", timeoutInMinutes)
 	}
 
 	d.SetId("")

--- a/third_party/terraform/resources/resource_compute_instance_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_template.go
@@ -769,7 +769,7 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 	// Store the ID now
 	d.SetId(fmt.Sprintf("projects/%s/global/instanceTemplates/%s", project, instanceTemplate.Name))
 
-	err = computeSharedOperationWait(config, op, project, "Creating Instance Template")
+	err = computeOperationWait(config, op, project, "Creating Instance Template")
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_compute_instance_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_template.go
@@ -769,7 +769,7 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 	// Store the ID now
 	d.SetId(fmt.Sprintf("projects/%s/global/instanceTemplates/%s", project, instanceTemplate.Name))
 
-	err = computeSharedOperationWait(config.clientCompute, op, project, "Creating Instance Template")
+	err = computeSharedOperationWait(config, op, project, "Creating Instance Template")
 	if err != nil {
 		return err
 	}
@@ -1130,7 +1130,7 @@ func resourceComputeInstanceTemplateDelete(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error deleting instance template: %s", err)
 	}
 
-	err = computeOperationWait(config.clientCompute, op, project, "Deleting Instance Template")
+	err = computeOperationWait(config, op, project, "Deleting Instance Template")
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_compute_network_peering.go.erb
+++ b/third_party/terraform/resources/resource_compute_network_peering.go.erb
@@ -90,7 +90,7 @@ func resourceComputeNetworkPeeringCreate(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error adding network peering: %s", err)
 	}
 
-	err = computeSharedOperationWait(config, addOp, networkFieldValue.Project, "Adding Network Peering")
+	err = computeOperationWait(config, addOp, networkFieldValue.Project, "Adding Network Peering")
 	if err != nil {
 		return err
 	}
@@ -164,7 +164,7 @@ func resourceComputeNetworkPeeringDelete(d *schema.ResourceData, meta interface{
 			return fmt.Errorf("Error removing peering `%s` from network `%s`: %s", name, networkFieldValue.Name, err)
 		}
 	} else {
-		err = computeSharedOperationWait(config, removeOp, networkFieldValue.Project, "Removing Network Peering")
+		err = computeOperationWait(config, removeOp, networkFieldValue.Project, "Removing Network Peering")
 		if err != nil {
 			return err
 		}

--- a/third_party/terraform/resources/resource_compute_network_peering.go.erb
+++ b/third_party/terraform/resources/resource_compute_network_peering.go.erb
@@ -90,7 +90,7 @@ func resourceComputeNetworkPeeringCreate(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error adding network peering: %s", err)
 	}
 
-	err = computeSharedOperationWait(config.clientCompute, addOp, networkFieldValue.Project, "Adding Network Peering")
+	err = computeSharedOperationWait(config, addOp, networkFieldValue.Project, "Adding Network Peering")
 	if err != nil {
 		return err
 	}
@@ -164,7 +164,7 @@ func resourceComputeNetworkPeeringDelete(d *schema.ResourceData, meta interface{
 			return fmt.Errorf("Error removing peering `%s` from network `%s`: %s", name, networkFieldValue.Name, err)
 		}
 	} else {
-		err = computeSharedOperationWait(config.clientCompute, removeOp, networkFieldValue.Project, "Removing Network Peering")
+		err = computeSharedOperationWait(config, removeOp, networkFieldValue.Project, "Removing Network Peering")
 		if err != nil {
 			return err
 		}

--- a/third_party/terraform/resources/resource_compute_project_default_network_tier.go
+++ b/third_party/terraform/resources/resource_compute_project_default_network_tier.go
@@ -55,7 +55,7 @@ func resourceComputeProjectDefaultNetworkTierCreateOrUpdate(d *schema.ResourceDa
 	}
 
 	log.Printf("[DEBUG] SetDefaultNetworkTier: %d (%s)", op.Id, op.SelfLink)
-	err = computeOperationWait(config.clientCompute, op, projectID, "SetDefaultNetworkTier")
+	err = computeOperationWait(config, op, projectID, "SetDefaultNetworkTier")
 	if err != nil {
 		return fmt.Errorf("SetDefaultNetworkTier failed: %s", err)
 	}

--- a/third_party/terraform/resources/resource_compute_project_metadata.go
+++ b/third_party/terraform/resources/resource_compute_project_metadata.go
@@ -120,7 +120,7 @@ func resourceComputeProjectMetadataSet(projectID string, config *Config, md *com
 		}
 
 		log.Printf("[DEBUG] SetCommonMetadata: %d (%s)", op.Id, op.SelfLink)
-		return computeOperationWait(config.clientCompute, op, project.Name, "SetCommonMetadata")
+		return computeOperationWait(config, op, project.Name, "SetCommonMetadata")
 	}
 
 	err := MetadataRetryWrapper(createMD)

--- a/third_party/terraform/resources/resource_compute_project_metadata_item.go
+++ b/third_party/terraform/resources/resource_compute_project_metadata_item.go
@@ -180,7 +180,7 @@ func updateComputeCommonInstanceMetadata(config *Config, projectID string, key s
 
 		log.Printf("[DEBUG] SetCommonInstanceMetadata: %d (%s)", op.Id, op.SelfLink)
 
-		return computeSharedOperationWaitTime(config, op, project.Name, "SetCommonInstanceMetadata", timeout)
+		return computeOperationWaitTime(config, op, project.Name, "SetCommonInstanceMetadata", timeout)
 	}
 
 	return MetadataRetryWrapper(updateMD)

--- a/third_party/terraform/resources/resource_compute_project_metadata_item.go
+++ b/third_party/terraform/resources/resource_compute_project_metadata_item.go
@@ -180,7 +180,7 @@ func updateComputeCommonInstanceMetadata(config *Config, projectID string, key s
 
 		log.Printf("[DEBUG] SetCommonInstanceMetadata: %d (%s)", op.Id, op.SelfLink)
 
-		return computeSharedOperationWaitTime(config.clientCompute, op, project.Name, "SetCommonInstanceMetadata", timeout)
+		return computeSharedOperationWaitTime(config, op, project.Name, "SetCommonInstanceMetadata", timeout)
 	}
 
 	return MetadataRetryWrapper(updateMD)

--- a/third_party/terraform/resources/resource_compute_project_metadata_item.go
+++ b/third_party/terraform/resources/resource_compute_project_metadata_item.go
@@ -180,7 +180,7 @@ func updateComputeCommonInstanceMetadata(config *Config, projectID string, key s
 
 		log.Printf("[DEBUG] SetCommonInstanceMetadata: %d (%s)", op.Id, op.SelfLink)
 
-		return computeOperationWaitTime(config.clientCompute, op, project.Name, "SetCommonInstanceMetadata", timeout)
+		return computeSharedOperationWaitTime(config.clientCompute, op, project.Name, "SetCommonInstanceMetadata", timeout)
 	}
 
 	return MetadataRetryWrapper(updateMD)

--- a/third_party/terraform/resources/resource_compute_region_instance_group_manager.go
+++ b/third_party/terraform/resources/resource_compute_region_instance_group_manager.go
@@ -308,7 +308,7 @@ func resourceComputeRegionInstanceGroupManagerCreate(d *schema.ResourceData, met
 
 	// Wait for the operation to complete
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutCreate).Minutes())
-	err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Creating InstanceGroupManager", timeoutInMinutes)
+	err = computeSharedOperationWaitTime(config, op, project, "Creating InstanceGroupManager", timeoutInMinutes)
 	if err != nil {
 		return err
 	}
@@ -462,7 +462,7 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 		}
 
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Updating region managed group instances", timeoutInMinutes)
+		err = computeSharedOperationWaitTime(config, op, project, "Updating region managed group instances", timeoutInMinutes)
 		if err != nil {
 			return err
 		}
@@ -485,7 +485,7 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 		}
 
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Updating RegionInstanceGroupManager", timeoutInMinutes)
+		err = computeSharedOperationWaitTime(config, op, project, "Updating RegionInstanceGroupManager", timeoutInMinutes)
 		if err != nil {
 			return err
 		}
@@ -504,7 +504,7 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 		}
 
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Resizing RegionInstanceGroupManager", timeoutInMinutes)
+		err = computeSharedOperationWaitTime(config, op, project, "Resizing RegionInstanceGroupManager", timeoutInMinutes)
 		if err != nil {
 			return err
 		}
@@ -539,7 +539,7 @@ func resourceComputeRegionInstanceGroupManagerDelete(d *schema.ResourceData, met
 
 	// Wait for the operation to complete
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
-	err = computeSharedOperationWaitTime(config.clientCompute, op, regionalID.Project, "Deleting RegionInstanceGroupManager", timeoutInMinutes)
+	err = computeSharedOperationWaitTime(config, op, regionalID.Project, "Deleting RegionInstanceGroupManager", timeoutInMinutes)
 	if err != nil {
 		return fmt.Errorf("Error waiting for delete to complete: %s", err)
 	}

--- a/third_party/terraform/resources/resource_compute_region_instance_group_manager.go
+++ b/third_party/terraform/resources/resource_compute_region_instance_group_manager.go
@@ -308,7 +308,7 @@ func resourceComputeRegionInstanceGroupManagerCreate(d *schema.ResourceData, met
 
 	// Wait for the operation to complete
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutCreate).Minutes())
-	err = computeSharedOperationWaitTime(config, op, project, "Creating InstanceGroupManager", timeoutInMinutes)
+	err = computeOperationWaitTime(config, op, project, "Creating InstanceGroupManager", timeoutInMinutes)
 	if err != nil {
 		return err
 	}
@@ -462,7 +462,7 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 		}
 
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeSharedOperationWaitTime(config, op, project, "Updating region managed group instances", timeoutInMinutes)
+		err = computeOperationWaitTime(config, op, project, "Updating region managed group instances", timeoutInMinutes)
 		if err != nil {
 			return err
 		}
@@ -485,7 +485,7 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 		}
 
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeSharedOperationWaitTime(config, op, project, "Updating RegionInstanceGroupManager", timeoutInMinutes)
+		err = computeOperationWaitTime(config, op, project, "Updating RegionInstanceGroupManager", timeoutInMinutes)
 		if err != nil {
 			return err
 		}
@@ -504,7 +504,7 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 		}
 
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeSharedOperationWaitTime(config, op, project, "Resizing RegionInstanceGroupManager", timeoutInMinutes)
+		err = computeOperationWaitTime(config, op, project, "Resizing RegionInstanceGroupManager", timeoutInMinutes)
 		if err != nil {
 			return err
 		}
@@ -539,7 +539,7 @@ func resourceComputeRegionInstanceGroupManagerDelete(d *schema.ResourceData, met
 
 	// Wait for the operation to complete
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
-	err = computeSharedOperationWaitTime(config, op, regionalID.Project, "Deleting RegionInstanceGroupManager", timeoutInMinutes)
+	err = computeOperationWaitTime(config, op, project, "Deleting RegionInstanceGroupManager", timeoutInMinutes)
 	if err != nil {
 		return fmt.Errorf("Error waiting for delete to complete: %s", err)
 	}

--- a/third_party/terraform/resources/resource_compute_region_instance_group_manager.go
+++ b/third_party/terraform/resources/resource_compute_region_instance_group_manager.go
@@ -308,7 +308,7 @@ func resourceComputeRegionInstanceGroupManagerCreate(d *schema.ResourceData, met
 
 	// Wait for the operation to complete
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutCreate).Minutes())
-	err = computeSharedOperationWaitTime(config.clientCompute, op, project, timeoutInMinutes, "Creating InstanceGroupManager")
+	err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Creating InstanceGroupManager", timeoutInMinutes)
 	if err != nil {
 		return err
 	}
@@ -462,7 +462,7 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 		}
 
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, timeoutInMinutes, "Updating region managed group instances")
+		err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Updating region managed group instances", timeoutInMinutes)
 		if err != nil {
 			return err
 		}
@@ -485,7 +485,7 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 		}
 
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, timeoutInMinutes, "Updating RegionInstanceGroupManager")
+		err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Updating RegionInstanceGroupManager", timeoutInMinutes)
 		if err != nil {
 			return err
 		}
@@ -504,7 +504,7 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 		}
 
 		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, timeoutInMinutes, "Resizing RegionInstanceGroupManager")
+		err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Resizing RegionInstanceGroupManager", timeoutInMinutes)
 		if err != nil {
 			return err
 		}
@@ -539,7 +539,7 @@ func resourceComputeRegionInstanceGroupManagerDelete(d *schema.ResourceData, met
 
 	// Wait for the operation to complete
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
-	err = computeSharedOperationWaitTime(config.clientCompute, op, project, timeoutInMinutes, "Deleting RegionInstanceGroupManager")
+	err = computeSharedOperationWaitTime(config.clientCompute, op, regionalID.Project, "Deleting RegionInstanceGroupManager", timeoutInMinutes)
 	if err != nil {
 		return fmt.Errorf("Error waiting for delete to complete: %s", err)
 	}

--- a/third_party/terraform/resources/resource_compute_router_interface.go
+++ b/third_party/terraform/resources/resource_compute_router_interface.go
@@ -145,7 +145,7 @@ func resourceComputeRouterInterfaceCreate(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error patching router %s/%s: %s", region, routerName, err)
 	}
 	d.SetId(fmt.Sprintf("%s/%s/%s", region, routerName, ifaceName))
-	err = computeOperationWait(config.clientCompute, op, project, "Patching router")
+	err = computeOperationWait(config, op, project, "Patching router")
 	if err != nil {
 		d.SetId("")
 		return fmt.Errorf("Error waiting to patch router %s/%s: %s", region, routerName, err)
@@ -270,7 +270,7 @@ func resourceComputeRouterInterfaceDelete(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Error patching router %s/%s: %s", region, routerName, err)
 	}
 
-	err = computeOperationWait(config.clientCompute, op, project, "Patching router")
+	err = computeOperationWait(config, op, project, "Patching router")
 	if err != nil {
 		return fmt.Errorf("Error waiting to patch router %s/%s: %s", region, routerName, err)
 	}

--- a/third_party/terraform/resources/resource_compute_router_peer.go
+++ b/third_party/terraform/resources/resource_compute_router_peer.go
@@ -196,7 +196,7 @@ func resourceComputeRouterPeerCreate(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error patching router %s/%s: %s", region, routerName, err)
 	}
 	d.SetId(fmt.Sprintf("%s/%s/%s", region, routerName, peerName))
-	err = computeOperationWait(config.clientCompute, op, project, "Patching router")
+	err = computeOperationWait(config, op, project, "Patching router")
 	if err != nil {
 		d.SetId("")
 		return fmt.Errorf("Error waiting to patch router %s/%s: %s", region, routerName, err)
@@ -322,7 +322,7 @@ func resourceComputeRouterPeerDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error patching router %s/%s: %s", region, routerName, err)
 	}
 
-	err = computeOperationWait(config.clientCompute, op, project, "Patching router")
+	err = computeOperationWait(config, op, project, "Patching router")
 	if err != nil {
 		return fmt.Errorf("Error waiting to patch router %s/%s: %s", region, routerName, err)
 	}

--- a/third_party/terraform/resources/resource_compute_security_policy.go
+++ b/third_party/terraform/resources/resource_compute_security_policy.go
@@ -154,7 +154,7 @@ func resourceComputeSecurityPolicyCreate(d *schema.ResourceData, meta interface{
 	}
 	d.SetId(id)
 
-	err = computeSharedOperationWaitTime(config, op, project, fmt.Sprintf("Creating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Creating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 			return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 		}
 
-		err = computeSharedOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
+		err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
 		if err != nil {
 			return err
 		}
@@ -238,7 +238,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 					return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 				}
 
-				err = computeSharedOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
+				err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
 				if err != nil {
 					return err
 				}
@@ -250,7 +250,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 					return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 				}
 
-				err = computeSharedOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
+				err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
 				if err != nil {
 					return err
 				}
@@ -267,7 +267,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 					return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 				}
 
-				err = computeSharedOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
+				err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
 				if err != nil {
 					return err
 				}
@@ -292,7 +292,7 @@ func resourceComputeSecurityPolicyDelete(d *schema.ResourceData, meta interface{
 		return errwrap.Wrapf("Error deleting SecurityPolicy: {{err}}", err)
 	}
 
-	err = computeSharedOperationWaitTime(config, op, project, "Deleting SecurityPolicy", int(d.Timeout(schema.TimeoutDelete).Minutes()))
+	err = computeOperationWaitTime(config, op, project, "Deleting SecurityPolicy", int(d.Timeout(schema.TimeoutDelete).Minutes()))
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_compute_security_policy.go
+++ b/third_party/terraform/resources/resource_compute_security_policy.go
@@ -154,7 +154,7 @@ func resourceComputeSecurityPolicyCreate(d *schema.ResourceData, meta interface{
 	}
 	d.SetId(id)
 
-	err = computeSharedOperationWaitTime(config.clientCompute, op, project, int(d.Timeout(schema.TimeoutCreate).Minutes()), fmt.Sprintf("Creating SecurityPolicy %q", sp))
+	err = computeSharedOperationWaitTime(config.clientCompute, op, project, fmt.Sprintf("Creating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 			return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 		}
 
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, int(d.Timeout(schema.TimeoutCreate).Minutes()), fmt.Sprintf("Updating SecurityPolicy %q", sp))
+		err = computeSharedOperationWaitTime(config.clientCompute, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
 		if err != nil {
 			return err
 		}
@@ -238,7 +238,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 					return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 				}
 
-				err = computeSharedOperationWaitTime(config.clientCompute, op, project, int(d.Timeout(schema.TimeoutCreate).Minutes()), fmt.Sprintf("Updating SecurityPolicy %q", sp))
+				err = computeSharedOperationWaitTime(config.clientCompute, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
 				if err != nil {
 					return err
 				}
@@ -250,7 +250,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 					return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 				}
 
-				err = computeSharedOperationWaitTime(config.clientCompute, op, project, int(d.Timeout(schema.TimeoutCreate).Minutes()), fmt.Sprintf("Updating SecurityPolicy %q", sp))
+				err = computeSharedOperationWaitTime(config.clientCompute, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
 				if err != nil {
 					return err
 				}
@@ -267,7 +267,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 					return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 				}
 
-				err = computeSharedOperationWaitTime(config.clientCompute, op, project, int(d.Timeout(schema.TimeoutCreate).Minutes()), fmt.Sprintf("Updating SecurityPolicy %q", sp))
+				err = computeSharedOperationWaitTime(config.clientCompute, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
 				if err != nil {
 					return err
 				}
@@ -292,7 +292,7 @@ func resourceComputeSecurityPolicyDelete(d *schema.ResourceData, meta interface{
 		return errwrap.Wrapf("Error deleting SecurityPolicy: {{err}}", err)
 	}
 
-	err = computeSharedOperationWaitTime(config.clientCompute, op, project, int(d.Timeout(schema.TimeoutDelete).Minutes()), "Deleting SecurityPolicy")
+	err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Deleting SecurityPolicy", int(d.Timeout(schema.TimeoutDelete).Minutes()))
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_compute_security_policy.go
+++ b/third_party/terraform/resources/resource_compute_security_policy.go
@@ -154,7 +154,7 @@ func resourceComputeSecurityPolicyCreate(d *schema.ResourceData, meta interface{
 	}
 	d.SetId(id)
 
-	err = computeSharedOperationWaitTime(config.clientCompute, op, project, fmt.Sprintf("Creating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeSharedOperationWaitTime(config, op, project, fmt.Sprintf("Creating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 			return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 		}
 
-		err = computeSharedOperationWaitTime(config.clientCompute, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
+		err = computeSharedOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
 		if err != nil {
 			return err
 		}
@@ -238,7 +238,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 					return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 				}
 
-				err = computeSharedOperationWaitTime(config.clientCompute, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
+				err = computeSharedOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
 				if err != nil {
 					return err
 				}
@@ -250,7 +250,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 					return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 				}
 
-				err = computeSharedOperationWaitTime(config.clientCompute, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
+				err = computeSharedOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
 				if err != nil {
 					return err
 				}
@@ -267,7 +267,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 					return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 				}
 
-				err = computeSharedOperationWaitTime(config.clientCompute, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
+				err = computeSharedOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
 				if err != nil {
 					return err
 				}
@@ -292,7 +292,7 @@ func resourceComputeSecurityPolicyDelete(d *schema.ResourceData, meta interface{
 		return errwrap.Wrapf("Error deleting SecurityPolicy: {{err}}", err)
 	}
 
-	err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Deleting SecurityPolicy", int(d.Timeout(schema.TimeoutDelete).Minutes()))
+	err = computeSharedOperationWaitTime(config, op, project, "Deleting SecurityPolicy", int(d.Timeout(schema.TimeoutDelete).Minutes()))
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_compute_shared_vpc_host_project.go
+++ b/third_party/terraform/resources/resource_compute_shared_vpc_host_project.go
@@ -37,7 +37,7 @@ func resourceComputeSharedVpcHostProjectCreate(d *schema.ResourceData, meta inte
 
 	d.SetId(hostProject)
 
-	err = computeBetaOperationWaitTime(config.clientCompute, op, hostProject, "Enabling Shared VPC Host", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeSharedOperationWaitTime(config.clientCompute, op, hostProject, "Enabling Shared VPC Host", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if err != nil {
 		d.SetId("")
 		return err
@@ -75,7 +75,7 @@ func resourceComputeSharedVpcHostProjectDelete(d *schema.ResourceData, meta inte
 		return fmt.Errorf("Error disabling Shared VPC Host %q: %s", hostProject, err)
 	}
 
-	err = computeBetaOperationWaitTime(config.clientCompute, op, hostProject, "Disabling Shared VPC Host", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeSharedOperationWaitTime(config.clientCompute, op, hostProject, "Disabling Shared VPC Host", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_compute_shared_vpc_host_project.go
+++ b/third_party/terraform/resources/resource_compute_shared_vpc_host_project.go
@@ -37,7 +37,7 @@ func resourceComputeSharedVpcHostProjectCreate(d *schema.ResourceData, meta inte
 
 	d.SetId(hostProject)
 
-	err = computeSharedOperationWaitTime(config, op, hostProject, "Enabling Shared VPC Host", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeOperationWaitTime(config, op, hostProject, "Enabling Shared VPC Host", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if err != nil {
 		d.SetId("")
 		return err
@@ -75,7 +75,7 @@ func resourceComputeSharedVpcHostProjectDelete(d *schema.ResourceData, meta inte
 		return fmt.Errorf("Error disabling Shared VPC Host %q: %s", hostProject, err)
 	}
 
-	err = computeSharedOperationWaitTime(config, op, hostProject, "Disabling Shared VPC Host", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeOperationWaitTime(config, op, hostProject, "Disabling Shared VPC Host", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_compute_shared_vpc_host_project.go
+++ b/third_party/terraform/resources/resource_compute_shared_vpc_host_project.go
@@ -37,7 +37,7 @@ func resourceComputeSharedVpcHostProjectCreate(d *schema.ResourceData, meta inte
 
 	d.SetId(hostProject)
 
-	err = computeSharedOperationWaitTime(config.clientCompute, op, hostProject, "Enabling Shared VPC Host", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeSharedOperationWaitTime(config, op, hostProject, "Enabling Shared VPC Host", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if err != nil {
 		d.SetId("")
 		return err
@@ -75,7 +75,7 @@ func resourceComputeSharedVpcHostProjectDelete(d *schema.ResourceData, meta inte
 		return fmt.Errorf("Error disabling Shared VPC Host %q: %s", hostProject, err)
 	}
 
-	err = computeSharedOperationWaitTime(config.clientCompute, op, hostProject, "Disabling Shared VPC Host", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeSharedOperationWaitTime(config, op, hostProject, "Disabling Shared VPC Host", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_compute_shared_vpc_service_project.go
+++ b/third_party/terraform/resources/resource_compute_shared_vpc_service_project.go
@@ -52,7 +52,7 @@ func resourceComputeSharedVpcServiceProjectCreate(d *schema.ResourceData, meta i
 	if err != nil {
 		return err
 	}
-	err = computeSharedOperationWaitTime(config.clientCompute, op, hostProject, "Enabling Shared VPC Resource", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeSharedOperationWaitTime(config, op, hostProject, "Enabling Shared VPC Resource", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func disableXpnResource(d *schema.ResourceData, config *Config, hostProject, pro
 	if err != nil {
 		return err
 	}
-	err = computeSharedOperationWaitTime(config.clientCompute, op, hostProject, "Disabling Shared VPC Resource", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeSharedOperationWaitTime(config, op, hostProject, "Disabling Shared VPC Resource", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_compute_shared_vpc_service_project.go
+++ b/third_party/terraform/resources/resource_compute_shared_vpc_service_project.go
@@ -52,7 +52,7 @@ func resourceComputeSharedVpcServiceProjectCreate(d *schema.ResourceData, meta i
 	if err != nil {
 		return err
 	}
-	err = computeSharedOperationWaitTime(config, op, hostProject, "Enabling Shared VPC Resource", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeOperationWaitTime(config, op, hostProject, "Enabling Shared VPC Resource", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func disableXpnResource(d *schema.ResourceData, config *Config, hostProject, pro
 	if err != nil {
 		return err
 	}
-	err = computeSharedOperationWaitTime(config, op, hostProject, "Disabling Shared VPC Resource", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeOperationWaitTime(config, op, hostProject, "Disabling Shared VPC Resource", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_compute_shared_vpc_service_project.go
+++ b/third_party/terraform/resources/resource_compute_shared_vpc_service_project.go
@@ -52,7 +52,7 @@ func resourceComputeSharedVpcServiceProjectCreate(d *schema.ResourceData, meta i
 	if err != nil {
 		return err
 	}
-	err = computeBetaOperationWaitTime(config.clientCompute, op, hostProject, "Enabling Shared VPC Resource", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeSharedOperationWaitTime(config.clientCompute, op, hostProject, "Enabling Shared VPC Resource", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func disableXpnResource(d *schema.ResourceData, config *Config, hostProject, pro
 	if err != nil {
 		return err
 	}
-	err = computeBetaOperationWaitTime(config.clientCompute, op, hostProject, "Disabling Shared VPC Resource", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeSharedOperationWaitTime(config.clientCompute, op, hostProject, "Disabling Shared VPC Resource", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_compute_target_pool.go
+++ b/third_party/terraform/resources/resource_compute_target_pool.go
@@ -213,7 +213,7 @@ func resourceComputeTargetPoolCreate(d *schema.ResourceData, meta interface{}) e
 	}
 	d.SetId(id)
 
-	err = computeOperationWait(config.clientCompute, op, project, "Creating Target Pool")
+	err = computeOperationWait(config, op, project, "Creating Target Pool")
 	if err != nil {
 		return err
 	}
@@ -262,7 +262,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("Error updating health_check: %s", err)
 		}
 
-		err = computeOperationWait(config.clientCompute, op, project, "Updating Target Pool")
+		err = computeOperationWait(config, op, project, "Updating Target Pool")
 		if err != nil {
 			return err
 		}
@@ -278,7 +278,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("Error updating health_check: %s", err)
 		}
 
-		err = computeOperationWait(config.clientCompute, op, project, "Updating Target Pool")
+		err = computeOperationWait(config, op, project, "Updating Target Pool")
 		if err != nil {
 			return err
 		}
@@ -312,7 +312,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("Error updating instances: %s", err)
 		}
 
-		err = computeOperationWait(config.clientCompute, op, project, "Updating Target Pool")
+		err = computeOperationWait(config, op, project, "Updating Target Pool")
 		if err != nil {
 			return err
 		}
@@ -327,7 +327,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 		if err != nil {
 			return fmt.Errorf("Error updating instances: %s", err)
 		}
-		err = computeOperationWait(config.clientCompute, op, project, "Updating Target Pool")
+		err = computeOperationWait(config, op, project, "Updating Target Pool")
 		if err != nil {
 			return err
 		}
@@ -345,7 +345,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 			return fmt.Errorf("Error updating backup_pool: %s", err)
 		}
 
-		err = computeOperationWait(config.clientCompute, op, project, "Updating Target Pool")
+		err = computeOperationWait(config, op, project, "Updating Target Pool")
 		if err != nil {
 			return err
 		}
@@ -423,7 +423,7 @@ func resourceComputeTargetPoolDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error deleting TargetPool: %s", err)
 	}
 
-	err = computeOperationWait(config.clientCompute, op, project, "Deleting Target Pool")
+	err = computeOperationWait(config, op, project, "Deleting Target Pool")
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -407,7 +407,7 @@ func forceDeleteComputeNetwork(d *schema.ResourceData, config *Config, projectId
 			if err != nil {
 				return fmt.Errorf("Error deleting firewall: %s", err)
 			}
-			err = computeSharedOperationWait(config, op, projectId, "Deleting Firewall")
+			err = computeOperationWait(config, op, projectId, "Deleting Firewall")
 			if err != nil {
 				return err
 			}
@@ -459,7 +459,7 @@ func deleteComputeNetwork(project, network string, config *Config) error {
 		return fmt.Errorf("Error deleting network: %s", err)
 	}
 
-	err = computeSharedOperationWaitTime(config, op, project, "Deleting Network", 10)
+	err = computeOperationWaitTime(config, op, project, "Deleting Network", 10)
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -459,7 +459,7 @@ func deleteComputeNetwork(project, network string, config *Config) error {
 		return fmt.Errorf("Error deleting network: %s", err)
 	}
 
-	err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Deleting Network", 10)
+	err = computeSharedOperationWaitTime(config, op, project, "Deleting Network", 10)
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -459,7 +459,7 @@ func deleteComputeNetwork(project, network string, config *Config) error {
 		return fmt.Errorf("Error deleting network: %s", err)
 	}
 
-	err = computeOperationWaitTime(config.clientCompute, op, project, "Deleting Network", 10)
+	err = computeSharedOperationWaitTime(config.clientCompute, op, project, "Deleting Network", 10)
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -407,7 +407,7 @@ func forceDeleteComputeNetwork(d *schema.ResourceData, config *Config, projectId
 			if err != nil {
 				return fmt.Errorf("Error deleting firewall: %s", err)
 			}
-			err = computeSharedOperationWait(config.clientCompute, op, projectId, "Deleting Firewall")
+			err = computeSharedOperationWait(config, op, projectId, "Deleting Firewall")
 			if err != nil {
 				return err
 			}

--- a/third_party/terraform/resources/resource_service_networking_connection.go
+++ b/third_party/terraform/resources/resource_service_networking_connection.go
@@ -195,7 +195,7 @@ func resourceServiceNetworkingConnectionDelete(d *schema.ResourceData, meta inte
 	}
 
 	err = computeSharedOperationWaitTime(
-		config.clientCompute, op, project, "Updating Network",
+		config, op, project, "Updating Network",
 		int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 	if err != nil {
 		return err

--- a/third_party/terraform/resources/resource_service_networking_connection.go
+++ b/third_party/terraform/resources/resource_service_networking_connection.go
@@ -194,7 +194,7 @@ func resourceServiceNetworkingConnectionDelete(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	err = computeSharedOperationWaitTime(
+	err = computeOperationWaitTime(
 		config, op, project, "Updating Network",
 		int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 	if err != nil {

--- a/third_party/terraform/resources/resource_service_networking_connection.go
+++ b/third_party/terraform/resources/resource_service_networking_connection.go
@@ -194,7 +194,7 @@ func resourceServiceNetworkingConnectionDelete(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	err = computeOperationWaitTime(
+	err = computeSharedOperationWaitTime(
 		config.clientCompute, op, project, "Updating Network",
 		int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 	if err != nil {

--- a/third_party/terraform/resources/resource_sql_database_instance.go
+++ b/third_party/terraform/resources/resource_sql_database_instance.go
@@ -582,7 +582,7 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 	}
 	d.SetId(id)
 
-	err = sqlAdminOperationWaitTime(config.clientSqlAdmin, op, project, "Create Instance", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = sqlAdminOperationWaitTime(config, op, project, "Create Instance", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if err != nil {
 		d.SetId("")
 		return err
@@ -609,7 +609,7 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 				err = retry(func() error {
 					op, err = config.clientSqlAdmin.Users.Delete(project, instance.Name, u.Host, u.Name).Do()
 					if err == nil {
-						err = sqlAdminOperationWaitTime(config.clientSqlAdmin, op, project, "Delete default root User", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+						err = sqlAdminOperationWaitTime(config, op, project, "Delete default root User", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 					}
 					return err
 				})
@@ -870,7 +870,7 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error, failed to update instance settings for %s: %s", instance.Name, err)
 	}
 
-	err = sqlAdminOperationWaitTime(config.clientSqlAdmin, op, project, "Update Instance", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+	err = sqlAdminOperationWaitTime(config, op, project, "Update Instance", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 	if err != nil {
 		return err
 	}
@@ -902,7 +902,7 @@ func resourceSqlDatabaseInstanceDelete(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error, failed to delete instance %s: %s", d.Get("name").(string), err)
 	}
 
-	err = sqlAdminOperationWaitTime(config.clientSqlAdmin, op, project, "Delete Instance", int(d.Timeout(schema.TimeoutDelete).Minutes()))
+	err = sqlAdminOperationWaitTime(config, op, project, "Delete Instance", int(d.Timeout(schema.TimeoutDelete).Minutes()))
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_sql_ssl_cert.go
+++ b/third_party/terraform/resources/resource_sql_ssl_cert.go
@@ -98,7 +98,7 @@ func resourceSqlSslCertCreate(d *schema.ResourceData, meta interface{}) error {
 			"ssl cert %s into instance %s: %s", commonName, instance, err)
 	}
 
-	err = sqlAdminOperationWait(config.clientSqlAdmin, resp.Operation, project, "Create Ssl Cert")
+	err = sqlAdminOperationWait(config, resp.Operation, project, "Create Ssl Cert")
 	if err != nil {
 		return fmt.Errorf("Error, failure waiting for creation of %q "+
 			"in %q: %s", commonName, instance, err)
@@ -174,7 +174,7 @@ func resourceSqlSslCertDelete(d *schema.ResourceData, meta interface{}) error {
 			instance, err)
 	}
 
-	err = sqlAdminOperationWait(config.clientSqlAdmin, op, project, "Delete Ssl Cert")
+	err = sqlAdminOperationWait(config, op, project, "Delete Ssl Cert")
 
 	if err != nil {
 		return fmt.Errorf("Error, failure waiting for deletion of ssl cert %q "+

--- a/third_party/terraform/resources/resource_sql_user.go
+++ b/third_party/terraform/resources/resource_sql_user.go
@@ -91,7 +91,7 @@ func resourceSqlUserCreate(d *schema.ResourceData, meta interface{}) error {
 	// for which user.Host is an empty string.  That's okay.
 	d.SetId(fmt.Sprintf("%s/%s/%s", user.Name, user.Host, user.Instance))
 
-	err = sqlAdminOperationWait(config.clientSqlAdmin, op, project, "Insert User")
+	err = sqlAdminOperationWait(config, op, project, "Insert User")
 
 	if err != nil {
 		return fmt.Errorf("Error, failure waiting for insertion of %s "+
@@ -180,7 +180,7 @@ func resourceSqlUserUpdate(d *schema.ResourceData, meta interface{}) error {
 				"user %s into user %s: %s", name, instance, err)
 		}
 
-		err = sqlAdminOperationWait(config.clientSqlAdmin, op, project, "Insert User")
+		err = sqlAdminOperationWait(config, op, project, "Insert User")
 
 		if err != nil {
 			return fmt.Errorf("Error, failure waiting for update of %s "+
@@ -220,7 +220,7 @@ func resourceSqlUserDelete(d *schema.ResourceData, meta interface{}) error {
 			instance, err)
 	}
 
-	err = sqlAdminOperationWait(config.clientSqlAdmin, op, project, "Delete User")
+	err = sqlAdminOperationWait(config, op, project, "Delete User")
 
 	if err != nil {
 		return fmt.Errorf("Error, failure waiting for deletion of %s "+

--- a/third_party/terraform/resources/resource_usage_export_bucket.go
+++ b/third_party/terraform/resources/resource_usage_export_bucket.go
@@ -78,7 +78,7 @@ func resourceProjectUsageBucketCreate(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 	d.SetId(project)
-	err = computeOperationWait(config.clientCompute, op, project, "Setting usage export bucket.")
+	err = computeOperationWait(config, op, project, "Setting usage export bucket.")
 	if err != nil {
 		d.SetId("")
 		return err
@@ -102,7 +102,7 @@ func resourceProjectUsageBucketDelete(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	err = computeOperationWait(config.clientCompute, op, project,
+	err = computeOperationWait(config, op, project,
 		"Setting usage export bucket to nil, automatically disabling usage export.")
 	if err != nil {
 		return err

--- a/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -710,7 +710,7 @@ func testAccCheckClearComposerEnvironmentFirewalls(networkName string) resource.
 				continue
 			}
 
-			waitErr := computeSharedOperationWaitTime(config, op, config.Project,
+			waitErr := computeOperationWaitTime(config, op, config.Project,
 				"Sweeping test composer environment firewalls", 10)
 			if waitErr != nil {
 				allErrors = multierror.Append(allErrors,

--- a/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -710,7 +710,7 @@ func testAccCheckClearComposerEnvironmentFirewalls(networkName string) resource.
 				continue
 			}
 
-			waitErr := computeOperationWaitTime(config.clientCompute, op, config.Project,
+			waitErr := computeSharedOperationWaitTime(config.clientCompute, op, config.Project,
 				"Sweeping test composer environment firewalls", 10)
 			if waitErr != nil {
 				allErrors = multierror.Append(allErrors,

--- a/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -710,7 +710,7 @@ func testAccCheckClearComposerEnvironmentFirewalls(networkName string) resource.
 				continue
 			}
 
-			waitErr := computeSharedOperationWaitTime(config.clientCompute, op, config.Project,
+			waitErr := computeSharedOperationWaitTime(config, op, config.Project,
 				"Sweeping test composer environment firewalls", 10)
 			if waitErr != nil {
 				allErrors = multierror.Append(allErrors,

--- a/third_party/terraform/tests/resource_compute_instance_migrate_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_migrate_test.go
@@ -107,7 +107,7 @@ func TestAccComputeInstanceMigrateState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config, op, config.Project, "instance to create")
+	waitErr := computeOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -180,7 +180,7 @@ func TestAccComputeInstanceMigrateState_bootDisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config, op, config.Project, "instance to create")
+	waitErr := computeOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -248,7 +248,7 @@ func TestAccComputeInstanceMigrateState_v4FixBootDisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config, op, config.Project, "instance to create")
+	waitErr := computeOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -301,7 +301,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating disk: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config, op, config.Project, "disk to create")
+	waitErr := computeOperationWait(config, op, config.Project, "disk to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -333,7 +333,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr = computeSharedOperationWait(config, op, config.Project, "instance to create")
+	waitErr = computeOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -382,7 +382,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromSource(t *testing.T
 	if err != nil {
 		t.Fatalf("Error creating disk: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config, op, config.Project, "disk to create")
+	waitErr := computeOperationWait(config, op, config.Project, "disk to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -414,7 +414,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromSource(t *testing.T
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr = computeSharedOperationWait(config, op, config.Project, "instance to create")
+	waitErr = computeOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -483,7 +483,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromEncryptionKey(t *testing
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config, op, config.Project, "instance to create")
+	waitErr := computeOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -552,7 +552,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromEncryptionKey(t *te
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config, op, config.Project, "instance to create")
+	waitErr := computeOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -623,7 +623,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromAutoDeleteAndImage(t *te
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config, op, config.Project, "instance to create")
+	waitErr := computeOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -696,7 +696,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromAutoDeleteAndImage(
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config, op, config.Project, "instance to create")
+	waitErr := computeOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -764,7 +764,7 @@ func TestAccComputeInstanceMigrateState_scratchDisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config, op, config.Project, "instance to create")
+	waitErr := computeOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -829,7 +829,7 @@ func TestAccComputeInstanceMigrateState_v4FixScratchDisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config, op, config.Project, "instance to create")
+	waitErr := computeOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}

--- a/third_party/terraform/tests/resource_compute_instance_migrate_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_migrate_test.go
@@ -107,7 +107,7 @@ func TestAccComputeInstanceMigrateState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config.clientCompute, op, config.Project, "instance to create")
+	waitErr := computeSharedOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -180,7 +180,7 @@ func TestAccComputeInstanceMigrateState_bootDisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config.clientCompute, op, config.Project, "instance to create")
+	waitErr := computeSharedOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -248,7 +248,7 @@ func TestAccComputeInstanceMigrateState_v4FixBootDisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config.clientCompute, op, config.Project, "instance to create")
+	waitErr := computeSharedOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -301,7 +301,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating disk: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config.clientCompute, op, config.Project, "disk to create")
+	waitErr := computeSharedOperationWait(config, op, config.Project, "disk to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -333,7 +333,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr = computeSharedOperationWait(config.clientCompute, op, config.Project, "instance to create")
+	waitErr = computeSharedOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -382,7 +382,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromSource(t *testing.T
 	if err != nil {
 		t.Fatalf("Error creating disk: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config.clientCompute, op, config.Project, "disk to create")
+	waitErr := computeSharedOperationWait(config, op, config.Project, "disk to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -414,7 +414,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromSource(t *testing.T
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr = computeSharedOperationWait(config.clientCompute, op, config.Project, "instance to create")
+	waitErr = computeSharedOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -483,7 +483,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromEncryptionKey(t *testing
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config.clientCompute, op, config.Project, "instance to create")
+	waitErr := computeSharedOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -552,7 +552,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromEncryptionKey(t *te
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config.clientCompute, op, config.Project, "instance to create")
+	waitErr := computeSharedOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -623,7 +623,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromAutoDeleteAndImage(t *te
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config.clientCompute, op, config.Project, "instance to create")
+	waitErr := computeSharedOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -696,7 +696,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromAutoDeleteAndImage(
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config.clientCompute, op, config.Project, "instance to create")
+	waitErr := computeSharedOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -764,7 +764,7 @@ func TestAccComputeInstanceMigrateState_scratchDisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config.clientCompute, op, config.Project, "instance to create")
+	waitErr := computeSharedOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -829,7 +829,7 @@ func TestAccComputeInstanceMigrateState_v4FixScratchDisk(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
-	waitErr := computeSharedOperationWait(config.clientCompute, op, config.Project, "instance to create")
+	waitErr := computeSharedOperationWait(config, op, config.Project, "instance to create")
 	if waitErr != nil {
 		t.Fatal(waitErr)
 	}
@@ -908,7 +908,7 @@ func cleanUpInstance(config *Config, instanceName, zone string) {
 	}
 
 	// Wait for the operation to complete
-	opErr := computeOperationWait(config.clientCompute, op, config.Project, "instance to delete")
+	opErr := computeOperationWait(config, op, config.Project, "instance to delete")
 	if opErr != nil {
 		log.Printf("[WARNING] Error deleting instance %q, dangling resources may exist: %s", instanceName, opErr)
 	}
@@ -922,7 +922,7 @@ func cleanUpDisk(config *Config, diskName, zone string) {
 	}
 
 	// Wait for the operation to complete
-	opErr := computeOperationWait(config.clientCompute, op, config.Project, "disk to delete")
+	opErr := computeOperationWait(config, op, config.Project, "disk to delete")
 	if opErr != nil {
 		log.Printf("[WARNING] Error deleting disk %q, dangling resources may exist: %s", diskName, opErr)
 	}

--- a/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_test.go
@@ -1240,7 +1240,7 @@ func testAccCheckComputeInstanceUpdateMachineType(n string) resource.TestCheckFu
 		if err != nil {
 			return fmt.Errorf("Could not stop instance: %s", err)
 		}
-		err = computeSharedOperationWaitTime(config, op, config.Project, "Waiting on stop", 20)
+		err = computeOperationWaitTime(config, op, config.Project, "Waiting on stop", 20)
 		if err != nil {
 			return fmt.Errorf("Could not stop instance: %s", err)
 		}
@@ -1254,7 +1254,7 @@ func testAccCheckComputeInstanceUpdateMachineType(n string) resource.TestCheckFu
 		if err != nil {
 			return fmt.Errorf("Could not change machine type: %s", err)
 		}
-		err = computeSharedOperationWaitTime(config, op, config.Project, "Waiting machine type change", 20)
+		err = computeOperationWaitTime(config, op, config.Project, "Waiting machine type change", 20)
 		if err != nil {
 			return fmt.Errorf("Could not change machine type: %s", err)
 		}

--- a/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_test.go
@@ -1240,7 +1240,7 @@ func testAccCheckComputeInstanceUpdateMachineType(n string) resource.TestCheckFu
 		if err != nil {
 			return fmt.Errorf("Could not stop instance: %s", err)
 		}
-		err = computeSharedOperationWaitTime(config.clientCompute, op, config.Project, "Waiting on stop", 20)
+		err = computeSharedOperationWaitTime(config, op, config.Project, "Waiting on stop", 20)
 		if err != nil {
 			return fmt.Errorf("Could not stop instance: %s", err)
 		}
@@ -1254,7 +1254,7 @@ func testAccCheckComputeInstanceUpdateMachineType(n string) resource.TestCheckFu
 		if err != nil {
 			return fmt.Errorf("Could not change machine type: %s", err)
 		}
-		err = computeSharedOperationWaitTime(config.clientCompute, op, config.Project, "Waiting machine type change", 20)
+		err = computeSharedOperationWaitTime(config, op, config.Project, "Waiting machine type change", 20)
 		if err != nil {
 			return fmt.Errorf("Could not change machine type: %s", err)
 		}

--- a/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_test.go
@@ -1240,7 +1240,7 @@ func testAccCheckComputeInstanceUpdateMachineType(n string) resource.TestCheckFu
 		if err != nil {
 			return fmt.Errorf("Could not stop instance: %s", err)
 		}
-		err = computeOperationWaitTime(config.clientCompute, op, config.Project, "Waiting on stop", 20)
+		err = computeSharedOperationWaitTime(config.clientCompute, op, config.Project, "Waiting on stop", 20)
 		if err != nil {
 			return fmt.Errorf("Could not stop instance: %s", err)
 		}
@@ -1254,7 +1254,7 @@ func testAccCheckComputeInstanceUpdateMachineType(n string) resource.TestCheckFu
 		if err != nil {
 			return fmt.Errorf("Could not change machine type: %s", err)
 		}
-		err = computeOperationWaitTime(config.clientCompute, op, config.Project, "Waiting machine type change", 20)
+		err = computeSharedOperationWaitTime(config.clientCompute, op, config.Project, "Waiting machine type change", 20)
 		if err != nil {
 			return fmt.Errorf("Could not change machine type: %s", err)
 		}

--- a/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -103,7 +103,7 @@ func testSweepDatabases(region string) error {
 				return fmt.Errorf("error, failed to stop replica instance (%s) for instance (%s): %s", replicaName, d.Name, err)
 			}
 
-			err = sqlAdminOperationWait(config.clientSqlAdmin, op, config.Project, "Stop Replica")
+			err = sqlAdminOperationWait(config, op, config.Project, "Stop Replica")
 			if err != nil {
 				if strings.Contains(err.Error(), "does not exist") {
 					log.Printf("Replication operation not found")
@@ -133,7 +133,7 @@ func testSweepDatabases(region string) error {
 				return fmt.Errorf("Error, failed to delete instance %s: %s", db, err)
 			}
 
-			err = sqlAdminOperationWait(config.clientSqlAdmin, op, config.Project, "Delete Instance")
+			err = sqlAdminOperationWait(config, op, config.Project, "Delete Instance")
 			if err != nil {
 				if strings.Contains(err.Error(), "does not exist") {
 					log.Printf("SQL instance not found")
@@ -263,7 +263,7 @@ func TestAccSqlDatabaseInstance_dontDeleteDefaultUserOnReplica(t *testing.T) {
 						t.Errorf("Error while inserting root@%% user: %s", err)
 						return
 					}
-					err = sqlAdminOperationWait(config.clientSqlAdmin, op, config.Project, "Waiting for user to insert")
+					err = sqlAdminOperationWait(config, op, config.Project, "Waiting for user to insert")
 					if err != nil {
 						t.Errorf("Error while waiting for user insert operation to complete: %s", err.Error())
 					}

--- a/third_party/terraform/utils/appengine_operation.go
+++ b/third_party/terraform/utils/appengine_operation.go
@@ -28,11 +28,17 @@ func (w *AppEngineOperationWaiter) QueryOp() (interface{}, error) {
 	return w.Service.Apps.Operations.Get(w.AppId, matches[1]).Do()
 }
 
-func appEngineOperationWait(config *Config, op *appengine.Operation, appId, activity string) error {
-	return appEngineOperationWaitTime(client, op, appId, activity, 4)
+func appEngineOperationWait(config *Config, res interface{}, appId, activity string) error {
+	return appEngineOperationWaitTime(config, res, appId, activity, 4)
 }
 
-func appEngineOperationWaitTime(config *Config, op *appengine.Operation, appId, activity string, timeoutMinutes int) error {
+func appEngineOperationWaitTime(config *Config, res interface{}, appId, activity string, timeoutMinutes int) error {
+	op := &appengine.Operation{}
+	err := Convert(res, op)
+	if err != nil {
+		return err
+	}
+
 	w := &AppEngineOperationWaiter{
 		Service: config.clientAppEngine,
 		AppId:   appId,

--- a/third_party/terraform/utils/appengine_operation.go
+++ b/third_party/terraform/utils/appengine_operation.go
@@ -28,13 +28,13 @@ func (w *AppEngineOperationWaiter) QueryOp() (interface{}, error) {
 	return w.Service.Apps.Operations.Get(w.AppId, matches[1]).Do()
 }
 
-func appEngineOperationWait(client *appengine.APIService, op *appengine.Operation, appId, activity string) error {
+func appEngineOperationWait(config *Config, op *appengine.Operation, appId, activity string) error {
 	return appEngineOperationWaitTime(client, op, appId, activity, 4)
 }
 
-func appEngineOperationWaitTime(client *appengine.APIService, op *appengine.Operation, appId, activity string, timeoutMinutes int) error {
+func appEngineOperationWaitTime(config *Config, op *appengine.Operation, appId, activity string, timeoutMinutes int) error {
 	w := &AppEngineOperationWaiter{
-		Service: client,
+		Service: config.clientAppEngine,
 		AppId:   appId,
 	}
 

--- a/third_party/terraform/utils/compute_operation.go
+++ b/third_party/terraform/utils/compute_operation.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 
-	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -83,7 +82,13 @@ func computeOperationWait(client *compute.Service, op *compute.Operation, projec
 	return computeOperationWaitTime(client, op, project, activity, 4)
 }
 
-func computeOperationWaitTime(client *compute.Service, op *compute.Operation, project, activity string, timeoutMinutes int) error {
+func computeOperationWaitTime(client *compute.Service, res interface{}, project, activity string, timeoutMinutes int) error {
+	op := &compute.Operation{}
+	err := Convert(res, op)
+	if err != nil {
+		return err
+	}
+
 	w := &ComputeOperationWaiter{
 		Service: client,
 		Op:      op,
@@ -94,16 +99,6 @@ func computeOperationWaitTime(client *compute.Service, op *compute.Operation, pr
 		return err
 	}
 	return OperationWait(w, activity, timeoutMinutes)
-}
-
-func computeBetaOperationWaitTime(client *compute.Service, op *computeBeta.Operation, project, activity string, timeoutMin int) error {
-	opV1 := &compute.Operation{}
-	err := Convert(op, opV1)
-	if err != nil {
-		return err
-	}
-
-	return computeOperationWaitTime(client, opV1, project, activity, timeoutMin)
 }
 
 // ComputeOperationError wraps compute.OperationError and implements the

--- a/third_party/terraform/utils/compute_operation.go
+++ b/third_party/terraform/utils/compute_operation.go
@@ -78,11 +78,11 @@ func (w *ComputeOperationWaiter) TargetStates() []string {
 	return []string{"DONE"}
 }
 
-func computeOperationWait(client *compute.Service, op *compute.Operation, project, activity string) error {
-	return computeOperationWaitTime(client, op, project, activity, 4)
+func computeOperationWait(config *Config, op *compute.Operation, project, activity string) error {
+	return computeOperationWaitTime(config, op, project, activity, 4)
 }
 
-func computeOperationWaitTime(client *compute.Service, res interface{}, project, activity string, timeoutMinutes int) error {
+func computeOperationWaitTime(config *Config, res interface{}, project, activity string, timeoutMinutes int) error {
 	op := &compute.Operation{}
 	err := Convert(res, op)
 	if err != nil {
@@ -90,7 +90,7 @@ func computeOperationWaitTime(client *compute.Service, res interface{}, project,
 	}
 
 	w := &ComputeOperationWaiter{
-		Service: client,
+		Service: config.clientCompute,
 		Op:      op,
 		Project: project,
 	}

--- a/third_party/terraform/utils/compute_operation.go
+++ b/third_party/terraform/utils/compute_operation.go
@@ -78,8 +78,8 @@ func (w *ComputeOperationWaiter) TargetStates() []string {
 	return []string{"DONE"}
 }
 
-func computeOperationWait(config *Config, op *compute.Operation, project, activity string) error {
-	return computeOperationWaitTime(config, op, project, activity, 4)
+func computeOperationWait(config *Config, res interface{}, project, activity string) error {
+	return computeOperationWaitTime(config, res, project, activity, 4)
 }
 
 func computeOperationWaitTime(config *Config, res interface{}, project, activity string, timeoutMinutes int) error {

--- a/third_party/terraform/utils/compute_shared_operation.go
+++ b/third_party/terraform/utils/compute_shared_operation.go
@@ -1,16 +1,4 @@
 package google
 
-func computeSharedOperationWait(config *Config, op interface{}, project, activity string) error {
-	return computeSharedOperationWaitTime(config, op, project, activity, 4)
-}
-
-// This is a shell around computeOperationWaitTime. It was originall meant to type switch between Beta and GA wait
-// operations but it now serves to differentiate handwritten resource calls to computeWait from generated. This method
-// should be eventually removed when the distinction is no longer needed.
-func computeSharedOperationWaitTime(config *Config, op interface{}, project, activity string, minutes int) error {
-	if op == nil {
-		panic("Attempted to wait on an Operation that was nil.")
-	}
-
-	return computeOperationWaitTime(config, op, project, activity, minutes)
-}
+// Empty file so that the build will run tests on terraform-conversion mapper.
+// File should be removed once the PR has been merged.

--- a/third_party/terraform/utils/compute_shared_operation.go
+++ b/third_party/terraform/utils/compute_shared_operation.go
@@ -4,17 +4,17 @@ import (
 	"google.golang.org/api/compute/v1"
 )
 
-func computeSharedOperationWait(client *compute.Service, op interface{}, project, activity string) error {
-	return computeSharedOperationWaitTime(client, op, project, activity, 4)
+func computeSharedOperationWait(config *Config, op interface{}, project, activity string) error {
+	return computeSharedOperationWaitTime(config, op, project, activity, 4)
 }
 
 // This is a shell around computeOperationWaitTime. It was originall meant to type switch between Beta and GA wait
 // operations but it now serves to differentiate handwritten resource calls to computeWait from generated. This method
 // should be eventually removed when the distinction is no longer needed.
-func computeSharedOperationWaitTime(client *compute.Service, op interface{}, project, activity string, minutes int) error {
+func computeSharedOperationWaitTime(config *Config, op interface{}, project, activity string, minutes int) error {
 	if op == nil {
 		panic("Attempted to wait on an Operation that was nil.")
 	}
 
-	return computeOperationWaitTime(client, op, project, activity, minutes)
+	return computeOperationWaitTime(config, op, project, activity, minutes)
 }

--- a/third_party/terraform/utils/compute_shared_operation.go
+++ b/third_party/terraform/utils/compute_shared_operation.go
@@ -1,7 +1,6 @@
 package google
 
 import (
-	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 )
 
@@ -9,17 +8,13 @@ func computeSharedOperationWait(client *compute.Service, op interface{}, project
 	return computeSharedOperationWaitTime(client, op, project, activity, 4)
 }
 
+// This is a shell around computeOperationWaitTime. It was originall meant to type switch between Beta and GA wait
+// operations but it now serves to differentiate handwritten resource calls to computeWait from generated. This method
+// should be eventually removed when the distinction is no longer needed.
 func computeSharedOperationWaitTime(client *compute.Service, op interface{}, project, activity string, minutes int) error {
 	if op == nil {
 		panic("Attempted to wait on an Operation that was nil.")
 	}
 
-	switch op.(type) {
-	case *compute.Operation:
-		return computeOperationWaitTime(client, op.(*compute.Operation), project, activity, minutes)
-	case *computeBeta.Operation:
-		return computeBetaOperationWaitTime(client, op.(*computeBeta.Operation), project, activity, minutes)
-	default:
-		panic("Attempted to wait on an Operation of unknown type.")
-	}
+	return computeOperationWaitTime(client, op, project, activity, minutes)
 }

--- a/third_party/terraform/utils/compute_shared_operation.go
+++ b/third_party/terraform/utils/compute_shared_operation.go
@@ -1,9 +1,5 @@
 package google
 
-import (
-	"google.golang.org/api/compute/v1"
-)
-
 func computeSharedOperationWait(config *Config, op interface{}, project, activity string) error {
 	return computeSharedOperationWaitTime(config, op, project, activity, 4)
 }

--- a/third_party/terraform/utils/compute_shared_operation.go
+++ b/third_party/terraform/utils/compute_shared_operation.go
@@ -5,11 +5,11 @@ import (
 	"google.golang.org/api/compute/v1"
 )
 
-func computeSharedOperationWait(client *compute.Service, op interface{}, project string, activity string) error {
-	return computeSharedOperationWaitTime(client, op, project, 4, activity)
+func computeSharedOperationWait(client *compute.Service, op interface{}, project, activity string) error {
+	return computeSharedOperationWaitTime(client, op, project, activity, 4)
 }
 
-func computeSharedOperationWaitTime(client *compute.Service, op interface{}, project string, minutes int, activity string) error {
+func computeSharedOperationWaitTime(client *compute.Service, op interface{}, project, activity string, minutes int) error {
 	if op == nil {
 		panic("Attempted to wait on an Operation that was nil.")
 	}

--- a/third_party/terraform/utils/sqladmin_operation.go
+++ b/third_party/terraform/utils/sqladmin_operation.go
@@ -9,7 +9,7 @@ import (
 )
 
 type SqlAdminOperationWaiter struct {
-	config  *Config
+	Service *sqladmin.Service
 	Op      *sqladmin.Operation
 	Project string
 }
@@ -99,11 +99,17 @@ func (w *SqlAdminOperationWaiter) TargetStates() []string {
 	return []string{"DONE"}
 }
 
-func sqlAdminOperationWait(config *Config, op *sqladmin.Operation, project, activity string) error {
-	return sqlAdminOperationWaitTime(service, op, project, activity, 10)
+func sqlAdminOperationWait(config *Config, res interface{}, project, activity string) error {
+	return sqlAdminOperationWaitTime(config, res, project, activity, 10)
 }
 
-func sqlAdminOperationWaitTime(config *Config, op *sqladmin.Operation, project, activity string, timeoutMinutes int) error {
+func sqlAdminOperationWaitTime(config *Config, res interface{}, project, activity string, timeoutMinutes int) error {
+	op := &sqladmin.Operation{}
+	err := Convert(res, op)
+	if err != nil {
+		return err
+	}
+
 	w := &SqlAdminOperationWaiter{
 		Service: config.clientSqlAdmin,
 		Op:      op,

--- a/third_party/terraform/utils/sqladmin_operation.go
+++ b/third_party/terraform/utils/sqladmin_operation.go
@@ -9,7 +9,7 @@ import (
 )
 
 type SqlAdminOperationWaiter struct {
-	Service *sqladmin.Service
+	config  *Config
 	Op      *sqladmin.Operation
 	Project string
 }
@@ -99,13 +99,13 @@ func (w *SqlAdminOperationWaiter) TargetStates() []string {
 	return []string{"DONE"}
 }
 
-func sqlAdminOperationWait(service *sqladmin.Service, op *sqladmin.Operation, project, activity string) error {
+func sqlAdminOperationWait(config *Config, op *sqladmin.Operation, project, activity string) error {
 	return sqlAdminOperationWaitTime(service, op, project, activity, 10)
 }
 
-func sqlAdminOperationWaitTime(service *sqladmin.Service, op *sqladmin.Operation, project, activity string, timeoutMinutes int) error {
+func sqlAdminOperationWaitTime(config *Config, op *sqladmin.Operation, project, activity string, timeoutMinutes int) error {
 	w := &SqlAdminOperationWaiter{
-		Service: service,
+		Service: config.clientSqlAdmin,
 		Op:      op,
 		Project: project,
 	}


### PR DESCRIPTION
 This is pre-work to being able to refactor the `computeOperationWaitTime` method signature so that it's more similar to generated operation methods.

Changes are best viewed commit by commit and include:
- [x]  Changing `computeSharedOperationWaitTime` to list timeouts last to be consistent with other methods.
- [x]  Updating all `third_party` resources to call into `computeSharedOperationWaitTime` instead of directly to `computeOperationWaitTime` so that method signatures can be refactored more easily.
- [x]  Pulling out any awareness of the beta operation as it gets converted to v1 anyway.
- [x] Updating other handwritten operation code to use interfaces instead of Operations so that they can be called the same as `autogen` Operations.
- [x] Changing generated code to no longer distinguish between `autogen_async` and normal async.
- [x] Update sql and app engine operations to also be generic signatures
- [x] Removing `computeSharedOperationWait`