### PR TITLE
Convert old import formats (using non-/) to use /.

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_folder_organization_policy.go
+++ b/third_party/terraform/data_sources/data_source_google_folder_organization_policy.go
@@ -21,7 +21,7 @@ func dataSourceGoogleFolderOrganizationPolicy() *schema.Resource {
 
 func datasourceGoogleFolderOrganizationPolicyRead(d *schema.ResourceData, meta interface{}) error {
 
-	d.SetId(fmt.Sprintf("%s:%s", d.Get("folder"), d.Get("constraint")))
+	d.SetId(fmt.Sprintf("%s/%s", d.Get("folder"), d.Get("constraint")))
 
 	return resourceGoogleFolderOrganizationPolicyRead(d, meta)
 }

--- a/third_party/terraform/resources/resource_google_folder_organization_policy.go
+++ b/third_party/terraform/resources/resource_google_folder_organization_policy.go
@@ -59,7 +59,7 @@ func resourceFolderOrgPolicyImporter(d *schema.ResourceData, meta interface{}) (
 }
 
 func resourceGoogleFolderOrganizationPolicyCreate(d *schema.ResourceData, meta interface{}) error {
-	d.SetId(fmt.Sprintf("%s:%s", d.Get("folder"), d.Get("constraint")))
+	d.SetId(fmt.Sprintf("%s/%s", d.Get("folder"), d.Get("constraint")))
 
 	if isOrganizationPolicyUnset(d) {
 		return resourceGoogleFolderOrganizationPolicyDelete(d, meta)

--- a/third_party/terraform/resources/resource_google_folder_organization_policy.go
+++ b/third_party/terraform/resources/resource_google_folder_organization_policy.go
@@ -43,8 +43,8 @@ func resourceFolderOrgPolicyImporter(d *schema.ResourceData, meta interface{}) (
 	config := meta.(*Config)
 
 	if err := parseImportId([]string{
-		"folders/(?P<folder>[^/]+):constraints/(?P<constraint>[^/]+)",
-		"(?P<folder>[^/]+):(?P<constraint>[^/]+)"},
+		"folders/(?P<folder>[^/]+)/constraints/(?P<constraint>[^/]+)",
+		"(?P<folder>[^/]+)/(?P<constraint>[^/]+)"},
 		d, config); err != nil {
 		return nil, err
 	}

--- a/third_party/terraform/resources/resource_google_organization_policy.go
+++ b/third_party/terraform/resources/resource_google_organization_policy.go
@@ -155,7 +155,7 @@ func resourceGoogleOrganizationPolicy() *schema.Resource {
 }
 
 func resourceGoogleOrganizationPolicyCreate(d *schema.ResourceData, meta interface{}) error {
-	d.SetId(fmt.Sprintf("%s:%s", d.Get("org_id"), d.Get("constraint").(string)))
+	d.SetId(fmt.Sprintf("%s/%s", d.Get("org_id"), d.Get("constraint").(string)))
 
 	if isOrganizationPolicyUnset(d) {
 		return resourceGoogleOrganizationPolicyDelete(d, meta)

--- a/third_party/terraform/resources/resource_google_organization_policy.go
+++ b/third_party/terraform/resources/resource_google_organization_policy.go
@@ -224,9 +224,9 @@ func resourceGoogleOrganizationPolicyDelete(d *schema.ResourceData, meta interfa
 }
 
 func resourceGoogleOrganizationPolicyImportState(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	parts := strings.Split(d.Id(), ":")
+	parts := strings.SplitN(d.Id(), "/", 2)
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("Invalid id format. Expecting {org_id}:{constraint}, got '%s' instead.", d.Id())
+		return nil, fmt.Errorf("Invalid id format. Expecting {org_id}/{constraint}, got '%s' instead.", d.Id())
 	}
 
 	d.Set("org_id", parts[0])

--- a/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -244,5 +244,5 @@ exported:
 BigQuery tables can be imported using the `project`, `dataset_id`, and `table_id`, e.g.
 
 ```
-$ terraform import google_bigquery_table.default gcp-project:foo.bar
+$ terraform import google_bigquery_table.default gcp-project/foo/bar
 ```

--- a/third_party/terraform/website/docs/r/google_folder_organization_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/google_folder_organization_policy.html.markdown
@@ -137,6 +137,6 @@ exported:
 Folder organization policies can be imported using any of the follow formats:
 
 ```
-$ terraform import google_folder_organization_policy.policy folders/folder-1234:constraints/serviceuser.services
-$ terraform import google_folder_organization_policy.policy folder-1234:serviceuser.services
+$ terraform import google_folder_organization_policy.policy folders/folder-1234/constraints/serviceuser.services
+$ terraform import google_folder_organization_policy.policy folder-1234/serviceuser.services
 ```

--- a/third_party/terraform/website/docs/r/google_organization_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/google_organization_policy.html.markdown
@@ -135,4 +135,7 @@ exported:
 Organization Policies can be imported using the `org_id` and the `constraint`, e.g.
 
 ```
-$ terraform import google_organization_policy.services_policy 123456789:constraints/serviceuser.services
+$ terraform import google_organization_policy.services_policy 123456789/constraints/serviceuser.services
+```
+
+It is all right if the constraint contains a slash, as in the example above.


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
Convert `google_folder_organization_policy` and `google_organization_policy` import format to use slashes instead of colons.
```
