### PR TITLE
Make master_authorized_networks_config.cidr_blocks Optional in GKE

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -24,7 +24,7 @@ var (
 		Schema: map[string]*schema.Schema{
 			"cidr_blocks": {
 				Type:     schema.TypeSet,
-				Required: true,
+				Optional: true,
 				Elem:     cidrBlockConfig,
 			},
 		},

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -24,6 +24,9 @@ var (
 		Schema: map[string]*schema.Schema{
 			"cidr_blocks": {
 				Type:     schema.TypeSet,
+				// Despite being the only entry in a nested block, this should be kept
+				// Optional. Expressing the parent with no entries and omitting the
+				// parent entirely are semantically different.
 				Optional: true,
 				Elem:     cidrBlockConfig,
 			},


### PR DESCRIPTION
Sorry, this is a special case that I'd forgotten about before. The field not being defined is considered a list with no entries by Terraform- and we don't have another way to represent the behaviour.


```

```

means "I have no master authorized networks and the feature isn't on", leaving a GKE cluster master accessible.

```
master_authorized_networks_config {}
```

means "I have no master authorized networks and the feature is on", leaving the cluster master inaccessible.

```
master_authorized_networks_config {
  cidr_blocks {
    cidr_block = "10.0.0.0/8"
  }
}
```

enables the feature and supplies an IP range from which the cluster is accessible.


---

If keeping this `Required` is important, we could enable `SchemaConfigModeAttr` and do the following, although it's a bit of an abuse of `SchemaConfigModeAttr` as it was intended as a hack for O+C fields:

```
master_authorized_networks_config {
  cidr_blocks = []
}
```

this is equivalent to

```
master_authorized_networks_config {}
```

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
