### PR TITLE
add exactly_one_of to magic modules

### DIFF
--- a/api/type.rb
+++ b/api/type.rb
@@ -231,7 +231,7 @@ module Api
       return if @exactly_one_of.empty?
     end
 
-    # Returns list of properties that needs at least one of their fields set.
+    # Returns list of properties that needs exactly one of their fields set.
     def exactly_one_of_list
       return [] unless @__resource
 

--- a/api/type.rb
+++ b/api/type.rb
@@ -73,6 +73,9 @@ module Api
       # A list of properties that at least one of must be set.
       attr_reader :at_least_one_of
 
+      # A list of properties that exactly one of must be set.
+      attr_reader :exactly_one_of
+
       # Can only be overridden - we should never set this ourselves.
       attr_reader :new_type
 
@@ -113,6 +116,7 @@ module Api
       check_default_value_property
       check_conflicts
       check_at_least_one_of
+      check_exactly_one_of
     end
 
     def to_s
@@ -141,6 +145,8 @@ module Api
           # ignore empty conflict arrays
         elsif v == :@at_least_one_of && instance_variable_get(v).empty?
           # ignore empty at_least_one_of arrays
+        elsif v == :@exactly_one_of && instance_variable_get(v).empty?
+          # ignore empty exactly_one_of arrays
         elsif instance_variable_get(v) == false || instance_variable_get(v).nil?
           # ignore false booleans as non-existence indicates falsey
         elsif !ignored_fields.include? v
@@ -214,6 +220,22 @@ module Api
       return [] unless @__resource
 
       @at_least_one_of
+    end
+
+    # Checks that all properties that needs exactly one of their fields actually exist.
+    # This currently just returns if empty, because we don't want to do the check, since
+    # this list will have a full path for nested attributes.
+    def check_exactly_one_of
+      check :exactly_one_of, type: ::Array, default: [], item_type: ::String
+
+      return if @exactly_one_of.empty?
+    end
+
+    # Returns list of properties that needs at least one of their fields set.
+    def exactly_one_of_list
+      return [] unless @__resource
+
+      @exactly_one_of
     end
 
     def type
@@ -312,6 +334,7 @@ module Api
       def validate
         @conflicts ||= []
         @at_least_one_of ||= []
+        @exactly_one_of ||= []
       end
 
       def api_name

--- a/overrides/terraform/property_override.rb
+++ b/overrides/terraform/property_override.rb
@@ -72,6 +72,9 @@ module Overrides
           # Names of attributes that at least one of must be set
           :at_least_one_of,
 
+          # Names of attributes that exactly one of must be set
+          :exactly_one_of,
+
           # Names of fields that should be included in the updateMask.
           :update_mask_fields,
 

--- a/products/cloudbuild/api.yaml
+++ b/products/cloudbuild/api.yaml
@@ -138,15 +138,27 @@ objects:
             description: |
               Name of the branch to build. Exactly one a of branch name, tag, or commit SHA must be provided.
               This field is a regular expression.
+            exactly_one_of:
+              - trigger_template.0.branch_name
+              - trigger_template.0.tag_name
+              - trigger_template.0.commit_sha
           - !ruby/object:Api::Type::String
             name: 'tagName'
             description: |
               Name of the tag to build. Exactly one of a branch name, tag, or commit SHA must be provided.
               This field is a regular expression.
+            exactly_one_of:
+              - trigger_template.0.branch_name
+              - trigger_template.0.tag_name
+              - trigger_template.0.commit_sha
           - !ruby/object:Api::Type::String
             name: 'commitSha'
             description: |
               Explicit commit SHA to build. Exactly one of a branch name, tag, or commit SHA must be provided.
+            exactly_one_of:
+              - trigger_template.0.branch_name
+              - trigger_template.0.tag_name
+              - trigger_template.0.commit_sha
       - !ruby/object:Api::Type::NestedObject
         name: 'github'
         description: |
@@ -167,6 +179,9 @@ objects:
             name: 'pullRequest'
             description: |
                 filter to match changes in pull requests.  Specify only one of pullRequest or push.
+            exactly_one_of:
+              - github.0.pull_request
+              - github.0.push
             properties:
               - !ruby/object:Api::Type::String
                 name: 'branch'
@@ -184,15 +199,24 @@ objects:
             name: 'push'
             description: |
                 filter to match changes in refs, like branches or tags.  Specify only one of pullRequest or push.
+            exactly_one_of:
+              - github.0.pull_request
+              - github.0.push
             properties:
               - !ruby/object:Api::Type::String
                 name: 'branch'
                 description: |
                     Regex of branches to match.  Specify only one of branch or tag.
+                exactly_one_of:
+                  - github.0.push.0.branch
+                  - github.0.push.0.tag
               - !ruby/object:Api::Type::String
                 name: 'tag'
                 description: |
                     Regex of tags to match.  Specify only one of branch or tag.
+                exactly_one_of:
+                  - github.0.push.0.branch
+                  - github.0.push.0.tag
       - !ruby/object:Api::Type::NestedObject
         name: 'build'
         description: |

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -8658,6 +8658,10 @@ objects:
                 name: 'hourlySchedule'
                 description: |
                   The policy will execute every nth hour starting at the specified time.
+                exactly_one_of:
+                  - snapshot_schedule_policy.0.schedule.0.hourly_schedule
+                  - snapshot_schedule_policy.0.schedule.0.daily_schedule
+                  - snapshot_schedule_policy.0.schedule.0.weekly_schedule
                 properties:
                   - !ruby/object:Api::Type::Integer
                     name: 'hoursInCycle'
@@ -8675,6 +8679,10 @@ objects:
                 name: 'dailySchedule'
                 description: |
                   The policy will execute every nth day at the specified time.
+                exactly_one_of:
+                  - snapshot_schedule_policy.0.schedule.0.hourly_schedule
+                  - snapshot_schedule_policy.0.schedule.0.daily_schedule
+                  - snapshot_schedule_policy.0.schedule.0.weekly_schedule
                 properties:
                   - !ruby/object:Api::Type::Integer
                     name: 'daysInCycle'
@@ -8692,6 +8700,10 @@ objects:
                 name: 'weeklySchedule'
                 description: |
                   Allows specifying a snapshot time for each day of the week.
+                exactly_one_of:
+                  - snapshot_schedule_policy.0.schedule.0.hourly_schedule
+                  - snapshot_schedule_policy.0.schedule.0.daily_schedule
+                  - snapshot_schedule_policy.0.schedule.0.weekly_schedule
                 properties:
                   - !ruby/object:Api::Type::Array
                     name: 'dayOfWeeks'
@@ -8800,7 +8812,8 @@ objects:
       sending virtual machine's routing table will be dropped.
 
       A Route resource must have exactly one specification of either
-      nextHopGateway, nextHopInstance, nextHopIp, or nextHopVpnTunnel.
+      nextHopGateway, nextHopInstance, nextHopIp, nextHopVpnTunnel, or
+      nextHopIlb.
 
     references: !ruby/object:Api::Resource::ReferenceLinks
           guides:
@@ -8873,6 +8886,12 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'nextHopGateway'
         input: true
+        exactly_one_of:
+          - next_hop_gateway
+          - next_hop_instance
+          - next_hop_ip
+          - next_hop_vpn_tunnel
+          - next_hop_ilb
         description: |
           URL to a gateway that should handle matching packets.
 
@@ -8888,6 +8907,12 @@ objects:
         resource: 'Instance'
         imports: 'selfLink'
         input: true
+        exactly_one_of:
+          - next_hop_gateway
+          - next_hop_instance
+          - next_hop_ip
+          - next_hop_vpn_tunnel
+          - next_hop_ilb
         description: |
           URL to an instance that should handle matching packets.
           You can specify this as a full or partial URL. For example:
@@ -8901,11 +8926,23 @@ objects:
         description: |
           Network IP address of an instance that should handle matching packets.
         input: true
+        exactly_one_of:
+          - next_hop_gateway
+          - next_hop_instance
+          - next_hop_ip
+          - next_hop_vpn_tunnel
+          - next_hop_ilb
       - !ruby/object:Api::Type::ResourceRef
         name: 'nextHopVpnTunnel'
         resource: 'VpnTunnel'
         imports: 'selfLink'
         input: true
+        exactly_one_of:
+          - next_hop_gateway
+          - next_hop_instance
+          - next_hop_ip
+          - next_hop_vpn_tunnel
+          - next_hop_ilb
         description: |
           URL to a VpnTunnel that should handle matching packets.
       - !ruby/object:Api::Type::String
@@ -8924,6 +8961,12 @@ objects:
           regions/region/forwardingRules/forwardingRule
           Note that this can only be used when the destinationRange is a public (non-RFC 1918) IP CIDR range.
         input: true
+        exactly_one_of:
+          - next_hop_gateway
+          - next_hop_instance
+          - next_hop_ip
+          - next_hop_vpn_tunnel
+          - next_hop_ilb
         min_version: beta
   - !ruby/object:Api::Resource
     name: 'Router'

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -147,6 +147,9 @@
 <% unless property.at_least_one_of_list().empty? -%>
     AtLeastOneOf: <%= go_literal(property.at_least_one_of_list) -%>,
 <% end -%>
+<% unless property.exactly_one_of_list().empty? -%>
+    ExactlyOneOf: <%= go_literal(property.exactly_one_of_list) -%>,
+<% end -%>
 },
 <% else -%>
   // TODO: Property '<%= property.name -%>' of type <%= property.class -%> is not supported


### PR DESCRIPTION
The only other one I questioned, but couldn't find specifically anywhere was `google_compute_health_check`.  Should the different health check blocks be `ExactlyOneOf`?
`http_health_check`, `https_health_check`, `tcp_health_check`, `ssl_health_check`, `http2_health_check` 

Will update docs in a separate (but related) PR, when all nested objects changes have been finalized.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
`cloudbuild`: required exactly one of `branch_name`, `tag_name` or `commit_sha` on `google_cloudbuild_trigger.trigger_template`.
```

```release-note:breaking-change
`cloudbuild`: required exactly one of `pull_request` or `push` on `google_cloudbuild_trigger.github`.
```

```release-note:breaking-change
`cloudbuild`: required exactly one of `branch` or `tag_name` on `google_cloudbuild_trigger.github.push`.
```

```release-note:breaking-change
`compute`: required exactly one of `hourly_schedule`, `daily_schedule` or `weekly_schedule` on `google_compute_resource_policy.snapshot_schedule_policy.schedule`.
```

```release-note:breaking-change
`compute`: required exactly one of `next_hop_gateway`, `next_hop_instance`, `next_hop_ip`, `next_hop_vpn_tunnel` or `next_hop_ilb` on `google_compute_route`.
```