### PR TITLE
Update bigtable import & tests to 3.0

### DIFF
--- a/third_party/terraform/resources/resource_bigtable_table.go
+++ b/third_party/terraform/resources/resource_bigtable_table.go
@@ -203,7 +203,7 @@ func resourceBigtableTableImport(d *schema.ResourceData, meta interface{}) ([]*s
 	}
 
 	// Replace import id for the resource id
-	id, err := replaceVars(d, config, "{{name}}")
+	id, err := replaceVars(d, config, "projects/{{project}}/instances/{{instance_name}}/tables/{{name}}")
 	if err != nil {
 		return nil, fmt.Errorf("Error constructing id: %s", err)
 	}

--- a/third_party/terraform/tests/resource_bigtable_table_test.go
+++ b/third_party/terraform/tests/resource_bigtable_table_test.go
@@ -28,8 +28,6 @@ func TestAccBigtableTable_basic(t *testing.T) {
 				ResourceName:      "google_bigtable_table.table",
 				ImportState:       true,
 				ImportStateVerify: true,
-				//TODO(rileykarson): Remove ImportStateId when id format is fixed in 3.0.0
-				ImportStateId: fmt.Sprintf("%s/%s", instanceName, tableName),
 			},
 		},
 	})
@@ -54,7 +52,6 @@ func TestAccBigtableTable_splitKeys(t *testing.T) {
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"split_keys"},
-				ImportStateId:           fmt.Sprintf("%s/%s", instanceName, tableName),
 			},
 		},
 	})
@@ -79,7 +76,6 @@ func TestAccBigtableTable_family(t *testing.T) {
 				ResourceName:      "google_bigtable_table.table",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateId:     fmt.Sprintf("%s/%s", instanceName, tableName),
 			},
 		},
 	})
@@ -104,7 +100,6 @@ func TestAccBigtableTable_familyMany(t *testing.T) {
 				ResourceName:      "google_bigtable_table.table",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateId:     fmt.Sprintf("%s/%s", instanceName, tableName),
 			},
 		},
 	})


### PR DESCRIPTION
Bigtable import was added recently, and needs to be migrated to the 3.0.0 id style

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
