### PR TITLE
Fix Ansible spurious diffs

### DIFF
--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -41,7 +41,7 @@ module Provider
             'default' => (
               if prop.default_value&.is_a?(::Hash)
                 prop.default_value
-              elsif !prop.default_value&.zero?
+              elsif prop.default_value.to_s != '0'
                 prop.default_value&.to_s
               end),
             'type' => python_type(prop),

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -41,7 +41,7 @@ module Provider
             'default' => (
               if prop.default_value&.is_a?(::Hash)
                 prop.default_value
-              elsif !prop.default_value.zero?
+              elsif !prop.default_value&.zero?
                 prop.default_value&.to_s
               end),
             'type' => python_type(prop),

--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -23,6 +23,8 @@ module Provider
     module Documentation
       # Builds out the DOCUMENTATION for a property.
       # This will eventually be converted to YAML
+      #
+      # TODO(alexstephen): Ansible docs don't like defaults of 0, because 0 == null
       def documentation_for_property(prop)
         required = prop.required && !prop.default_value ? true : false
         {
@@ -39,7 +41,7 @@ module Provider
             'default' => (
               if prop.default_value&.is_a?(::Hash)
                 prop.default_value
-              else
+              elsif !prop.default_value.zero?
                 prop.default_value&.to_s
               end),
             'type' => python_type(prop),

--- a/provider/ansible/gcp_utils.py
+++ b/provider/ansible/gcp_utils.py
@@ -1,6 +1,8 @@
 # Copyright (c), Google Inc, 2017
 # Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
 
+from __future__ import (absolute_import, division, print_function)
+
 try:
     import requests
     HAS_REQUESTS = True

--- a/provider/ansible/gcp_utils.py
+++ b/provider/ansible/gcp_utils.py
@@ -3,7 +3,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-__metaclass__ == type
+__metaclass__ = type
 
 try:
     import requests

--- a/provider/ansible/gcp_utils.py
+++ b/provider/ansible/gcp_utils.py
@@ -3,6 +3,8 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+__metaclass__ == type
+
 try:
     import requests
     HAS_REQUESTS = True


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->
Ansible has some spurious diffs. Let's fix them.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
