### PR TITLE
remove TestAccContainerCluster_withReleaseChannelDefault as it no longer tests a valid config

### DIFF
--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -338,27 +338,6 @@ func TestAccContainerCluster_withReleaseChannelEnabled(t *testing.T) {
 	})
 }
 
-func TestAccContainerCluster_withReleaseChannelDefault(t *testing.T) {
-	t.Parallel()
-	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckContainerClusterDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccContainerCluster_withReleaseChannelDefault(clusterName),
-			},
-			{
-				ResourceName:        "google_container_cluster.with_default_release_channel",
-				ImportStateIdPrefix: "us-central1-a/",
-				ImportState:         true,
-				ImportStateVerify:   true,
-			},
-		},
-	})
-}
-
 func TestAccContainerCluster_withInvalidReleaseChannel(t *testing.T) {
 	t.Parallel()
 	clusterName := fmt.Sprintf("cluster-test-%s", acctest.RandString(10))
@@ -1905,16 +1884,6 @@ resource "google_container_cluster" "with_release_channel" {
 	channel = "%s"
   }
 }`, clusterName, channel)
-}
-
-func testAccContainerCluster_withReleaseChannelDefault(clusterName string) string {
-	return fmt.Sprintf(`
-resource "google_container_cluster" "with_default_release_channel" {
-	name               = "%s"
-	location           = "us-central1-a"
-	initial_node_count = 1
-	release_channel {}
-}`, clusterName)
 }
 <% end -%>
 


### PR DESCRIPTION

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
