### PR TITLE
Filter lists of TF schema paths for included properties

### DIFF
--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -108,9 +108,11 @@ module Provider
 
       schema_path.split('.').each_with_index do |pname, i|
         next if i.odd?
+
         pname = pname.camelize(:lower)
         prop = nested_props.find { |p| p.name == pname }
         break if prop.nil?
+
         nested_props = prop.nested_properties || []
       end
       prop

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -99,6 +99,23 @@ module Provider
                              force_new?(property.parent, resource))))
     end
 
+    # Returns the property for a given Terraform field path (e.g.
+    # 'a_field', 'parent_field.0.child_name'). Returns nil if the property
+    # is not included in the resource's properties.
+    def property_for_schema_path(schema_path, resource)
+      nested_props = resource.properties
+      prop = nil
+
+      schema_path.split('.').each_with_index do |pname, i|
+        next if i.odd?
+        pname = pname.camelize(:lower)
+        prop = nested_props.find { |p| p.name == pname }
+        break if prop.nil?
+        nested_props = prop.nested_properties || []
+      end
+      prop
+    end
+
     # Transforms a format string with field markers to a regex string with
     # capture groups.
     #

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -143,13 +143,13 @@
 <% end -%>
 <% unless property.conflicting().empty? -%>
 <% conflicting_props = property.conflicting().map(&:name).map(&:underscore) -%>
-    ConflictsWith: <%= go_literal(conflicting_props) -%>,
+    ConflictsWith: <%= go_literal(conflicting_props.reject {|sp| property_for_schema_path(sp, object).nil? }) -%>,
 <% end -%>
 <% unless property.at_least_one_of_list().empty? -%>
-    AtLeastOneOf: <%= go_literal(property.at_least_one_of_list) -%>,
+    AtLeastOneOf: <%= go_literal(property.at_least_one_of_list.reject {|sp| property_for_schema_path(sp, object).nil? }) -%>,
 <% end -%>
 <% unless property.exactly_one_of_list().empty? -%>
-    ExactlyOneOf: <%= go_literal(property.exactly_one_of_list) -%>,
+    ExactlyOneOf: <%= go_literal(property.exactly_one_of_list.reject {|sp| property_for_schema_path(sp, object).nil? }) -%>,
 <% end -%>
 },
 <% else -%>


### PR DESCRIPTION
Fix GA provider post 3.0.0 merge
Omitting changelog for TF since the initial bug has not been released yet (was part of 3.0.0 work)

Helper returns the property and not a bool as I could see this being useful for future nested field work for TF