### PR TITLE
Use project_id rather than id on project

### DIFF
--- a/third_party/terraform/tests/resource_google_project_iam_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_google_project_iam_policy_test.go.erb
@@ -242,7 +242,7 @@ resource "google_project" "acceptance" {
 }
 
 resource "google_project_iam_policy" "acceptance" {
-    project = "${google_project.acceptance.id}"
+    project = "${google_project.acceptance.project_id}"
     policy_data = "${data.google_iam_policy.admin.policy_data}"
 }
 
@@ -273,7 +273,7 @@ resource "google_project" "acceptance" {
 }
 
 resource "google_project_iam_policy" "acceptance" {
-    project = "${google_project.acceptance.id}"
+    project = "${google_project.acceptance.project_id}"
     policy_data = "${data.google_iam_policy.admin.policy_data}"
 }
 
@@ -335,7 +335,7 @@ resource "google_project" "acceptance" {
 }
 
 resource "google_project_iam_policy" "acceptance" {
-    project = "${google_project.acceptance.id}"
+    project = "${google_project.acceptance.project_id}"
     policy_data = "${data.google_iam_policy.expanded.policy_data}"
 }
 
@@ -355,7 +355,7 @@ resource "google_project" "acceptance" {
     org_id = "%s"
 }
 resource "google_project_iam_policy" "acceptance" {
-    project = "${google_project.acceptance.id}"
+    project = "${google_project.acceptance.project_id}"
     policy_data = "${data.google_iam_policy.expanded.policy_data}"
 }
 
@@ -384,7 +384,7 @@ resource "google_project" "acceptance" {
     org_id = "%s"
 }
 resource "google_project_iam_policy" "acceptance" {
-    project = "${google_project.acceptance.id}"
+    project = "${google_project.acceptance.project_id}"
     policy_data = "${data.google_iam_policy.expanded.policy_data}"
 }
 
@@ -437,7 +437,7 @@ resource "google_project" "acceptance" {
 }
 
 resource "google_project_iam_policy" "acceptance" {
-    project = "${google_project.acceptance.id}"
+    project = "${google_project.acceptance.project_id}"
     policy_data = "${data.google_iam_policy.admin.policy_data}"
 }
 


### PR DESCRIPTION
This fixes the test failures, but doesn't allow the use of `projects/project-id` for `google_project_iam_policy`

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
