### PR TITLE
Add GKE Resource Consumption Metering, promote resource export to GA

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -869,7 +869,7 @@ func resourceContainerCluster() *schema.Resource {
 					},
 				},
 			},
-
+<% end -%>
 			"resource_usage_export_config": {
 					Type:       schema.TypeList,
 					MaxItems:   1,
@@ -881,6 +881,20 @@ func resourceContainerCluster() *schema.Resource {
 											Optional: true,
 											Default:  false,
 									},
+									"enable_resource_consumption_metering": {
+							                Type:     schema.TypeList,
+							                MaxItems: 1,
+							                Optional: true,
+							                Elem: &schema.Resource{
+								                    Schema: map[string]*schema.Schema{
+									                        "enabled": {
+										                            Type:     schema.TypeBool,
+										                            Optional: true,
+										                            Default:  true,
+									                        },
+								                    },
+							                },
+						            },
 									"bigquery_destination": {
 											Type:       schema.TypeList,
 											MaxItems:   1,
@@ -897,7 +911,6 @@ func resourceContainerCluster() *schema.Resource {
 							},
 					},
 			},
-<% end -%>
 
 			"enable_intranode_visibility": {
 				Type:     schema.TypeBool,
@@ -2454,7 +2467,6 @@ func expandDefaultMaxPodsConstraint(v interface{}) *containerBeta.MaxPodsConstra
 	}
 }
 
-<% unless version == 'ga' -%>
 func expandResourceUsageExportConfig(configured interface{}) *containerBeta.ResourceUsageExportConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
@@ -2477,9 +2489,18 @@ func expandResourceUsageExportConfig(configured interface{}) *containerBeta.Reso
 					}
 			}
 	}
+	if _, ok := resourceUsageConfig["enable_resource_consumption_metering"]; ok {
+		    if len(resourceUsageConfig["enable_resource_consumption_metering"].([]interface{})) > 0 {
+			        consumptionMeteringConfig := resourceUsageConfig["enable_resource_consumption_metering"].([]interface{})[0].(map[string]interface{})
+			        if _, ok := consumptionMeteringConfig["enabled"]; ok {
+				            result.ConsumptionMeteringConfig = &containerBeta.ConsumptionMeteringConfig{
+					                Enabled: consumptionMeteringConfig["enabled"].(bool),
+				            }
+			        }
+		    }
+	}
 	return result
 }
-<% end -%>
 
 func flattenNetworkPolicy(c *containerBeta.NetworkPolicy) []map[string]interface{} {
 	result := []map[string]interface{}{}
@@ -2757,6 +2778,7 @@ func flattenPodSecurityPolicyConfig(c *containerBeta.PodSecurityPolicyConfig) []
 		},
 	}
 }
+<% end -%>
 
 func flattenResourceUsageExportConfig(c *containerBeta.ResourceUsageExportConfig) []map[string]interface{} {
 		if c == nil {
@@ -2765,13 +2787,15 @@ func flattenResourceUsageExportConfig(c *containerBeta.ResourceUsageExportConfig
 		return []map[string]interface{}{
 				{
 						"enable_network_egress_metering": c.EnableNetworkEgressMetering,
+						"enable_resource_consumption_metering": []map[string]interface{}{
+				                {"enabled": c.ConsumptionMeteringConfig.Enabled},
+			            },
 						"bigquery_destination": []map[string]interface{}{
 								{"dataset_id": c.BigqueryDestination.DatasetId},
 						},
 				},
 		}
 }
-<% end -%>
 
 <% unless version == 'ga' -%>
 func flattenDatabaseEncryption(c *containerBeta.DatabaseEncryption) []map[string]interface{} {

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2867,13 +2867,15 @@ resource "google_container_cluster" "with_ip_allocation_policy" {
 }`, cluster, cluster)
 }
 
-<% unless version == 'ga' -%>
 func testAccContainerCluster_withResourceUsageExportConfig(clusterName, datasetId string, resourceUsage bool) string {
 	resourceUsageConfig := ""
 	if resourceUsage {
 		resourceUsageConfig = `
 		resource_usage_export_config {
 			enable_network_egress_metering = true
+			enable_resource_consumption_metering {
+			    enabled = false
+			}
 
 			bigquery_destination {
 				dataset_id = "${google_bigquery_dataset.default.dataset_id}"
@@ -2896,7 +2898,6 @@ func testAccContainerCluster_withResourceUsageExportConfig(clusterName, datasetI
 	}`, datasetId, clusterName, resourceUsageConfig)
 	return config
 }
-<% end -%>
 
 func testAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(clusterName string) string {
 	return fmt.Sprintf(`

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -626,6 +626,12 @@ The `resource_usage_export_config` block supports:
 * `enable_network_egress_metering` (Optional) - Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created
     in the cluster to meter network egress traffic.
 
+* `enable_resource_consumption_metering` (Optional) - Parameters for managing resource consumption metering.
+    
+* `enable_resource_consumption_metering.enabled` (Optional) - Whether to enable resource consumption metering on this cluster. When enabled, a table will be created 
+    in the resource export BigQuery dataset to store resource consumption data. The resulting table can be joined with the resource usage table or with BigQuery billing export.
+    Defaults to `true` if `resource_usage_export_config` block is present.
+
 * `bigquery_destination` (Required) - Parameters for using BigQuery as the destination of resource usage export.
 
 * `bigquery_destination.dataset_id` (Required) - The ID of a BigQuery Dataset. For Example:
@@ -633,6 +639,10 @@ The `resource_usage_export_config` block supports:
 ```hcl
 resource_usage_export_config {
   enable_network_egress_metering = false
+
+  enable_resource_consumption_metering {
+    enabled = false
+  }
 
   bigquery_destination {
     dataset_id = "cluster_resource_usage"


### PR DESCRIPTION
Add GKE Resource Consumption Metering, promote resource export block to GA
Should resolve https://github.com/terraform-providers/terraform-provider-google/issues/4634
Relates to https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/316

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**
```release-note:enhancement
```
