### PR TITLE
Use name, not id to fetch dns managed zone datasource

### DIFF
--- a/third_party/terraform/data_sources/data_source_dns_managed_zone.go
+++ b/third_party/terraform/data_sources/data_source_dns_managed_zone.go
@@ -52,10 +52,11 @@ func dataSourceDnsManagedZoneRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	d.SetId(fmt.Sprintf("projects/%s/managedZones/%s", project, d.Get("name").(string)))
+	name := d.Get("name").(string)
+	d.SetId(fmt.Sprintf("projects/%s/managedZones/%s", project, name))
 
 	zone, err := config.clientDns.ManagedZones.Get(
-		project, d.Id()).Do()
+		project, name).Do()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
`dns`: Fixed bug causing `google_dns_managed_zone` datasource to always return a 404
```
