### PR TITLE
Default min instances to 0 for secondary worker config

### DIFF
--- a/products/dataproc/api.yaml
+++ b/products/dataproc/api.yaml
@@ -101,7 +101,7 @@ objects:
               - secondary_worker_config.0.min_instances
               - secondary_worker_config.0.max_instances
               - secondary_worker_config.0.weight
-            default_value: 2
+            default_value: 0
             description: |
               Minimum number of instances for this group. Bounds: [0, maxInstances]. Defaults to 0.
           - !ruby/object:Api::Type::Integer


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4944

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
`dataproc`: Changed default for `google_dataproc_autoscaling_policy` `secondary_worker_config.min_instances` from 2 to 0.
```
