### PR TITLE
Refactor async class to support kubernetes objects

### DIFF
--- a/google/yaml_validator.rb
+++ b/google/yaml_validator.rb
@@ -100,7 +100,8 @@ module Google
       elsif type.is_a? ::Array
         return if type.find_index(:boolean) && [TrueClass, FalseClass].find_index(object.class)
         return unless type.find_index(object.class).nil?
-      elsif object.is_a?(type)
+      # check if class is or inherits from type
+      elsif object.class <= type
         return
       end
       raise "Property '#{name}' is '#{object.class}' instead of '#{type}'"

--- a/products/accesscontextmanager/api.yaml
+++ b/products/accesscontextmanager/api.yaml
@@ -20,21 +20,21 @@ versions:
     base_url: https://accesscontextmanager.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
-async: !ruby/object:Api::Async
-  operation: !ruby/object:Api::Async::Operation
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
     path: 'name'
     base_url: '{{op_id}}'
     wait_ms: 1000
-  result: !ruby/object:Api::Async::Result
+  result: !ruby/object:Api::OpAsync::Result
     path: 'response'
     resource_inside_response: true
-  status: !ruby/object:Api::Async::Status
+  status: !ruby/object:Api::OpAsync::Status
     path: 'done'
     complete: true
     allowed:
       - true
       - false
-  error: !ruby/object:Api::Async::Error
+  error: !ruby/object:Api::OpAsync::Error
     path: 'error'
     message: 'message'
 objects:

--- a/products/appengine/api.yaml
+++ b/products/appengine/api.yaml
@@ -38,21 +38,21 @@ objects:
         'Official Documentation':
           'https://cloud.google.com/appengine/docs/standard/python/mapping-custom-domains'
       api: 'https://cloud.google.com/appengine/docs/admin-api/reference/rest/v1/apps.domainMappings'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         path: 'name'
         base_url: '{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'response'
         resource_inside_response: true
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'done'
         complete: True
         allowed:
           - True
           - False
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error'
         message: 'message'
     parameters:
@@ -226,22 +226,22 @@ objects:
         'Official Documentation':
           'https://cloud.google.com/appengine/docs/admin-api/deploying-overview'
       api: 'https://cloud.google.com/appengine/docs/admin-api/reference/rest/v1/apps.services.versions'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'appengine#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -472,21 +472,21 @@ objects:
     update_verb: :PATCH
     references: !ruby/object:Api::Resource::ReferenceLinks
       api: 'https://cloud.google.com/appengine/docs/admin-api/reference/rest/v1/apps#UrlDispatchRule'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         path: 'name'
         base_url: '{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'response'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:

--- a/products/cloudfunctions/api.yaml
+++ b/products/cloudfunctions/api.yaml
@@ -33,21 +33,21 @@ objects:
       A Cloud Function that contains user computation executed in response to an event.
     collection_url_key: 'functions'
     update_mask: true
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         path: 'name'
         base_url: '{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'response'
         resource_inside_response: true
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'done'
         complete: True
         allowed:
           - True
           - False
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error'
         message: 'message'
     parameters:

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -56,22 +56,22 @@ objects:
         'Reserving a Static External IP Address': 'https://cloud.google.com/compute/docs/instances-and-network'
         'Reserving a Static Internal IP Address': 'https://cloud.google.com/compute/docs/ip-addresses/reserve-static-internal-ip-address'
       api: 'https://cloud.google.com/compute/docs/reference/beta/addresses'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -188,22 +188,22 @@ objects:
       guides:
         'Autoscaling Groups of Instances': 'https://cloud.google.com/compute/docs/autoscaler/'
       api: 'https://cloud.google.com/compute/docs/reference/rest/v1/autoscalers'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/zones/{{zone}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -432,22 +432,22 @@ objects:
       guides:
         'Using a Cloud Storage bucket as a load balancer backend': 'https://cloud.google.com/compute/docs/load-balancing/http/backend-bucket'
       api: 'https://cloud.google.com/compute/docs/reference/v1/backendBuckets'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -522,22 +522,22 @@ objects:
       guides:
         'Using Signed URLs': 'https://cloud.google.com/cdn/docs/using-signed-urls/'
       api: 'https://cloud.google.com/compute/docs/reference/rest/v1/backendBuckets'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -581,22 +581,22 @@ objects:
       guides:
         'Official Documentation': 'https://cloud.google.com/compute/docs/load-balancing/http/backend-service'
       api: 'https://cloud.google.com/compute/docs/reference/v1/backendServices'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -1477,22 +1477,22 @@ objects:
       guides:
         'Internal TCP/UDP Load Balancing': 'https://cloud.google.com/compute/docs/load-balancing/internal/'
       api: 'https://cloud.google.com/compute/docs/reference/latest/regionBackendServices'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -2296,22 +2296,22 @@ objects:
       guides:
         'Using Signed URLs': 'https://cloud.google.com/cdn/docs/using-signed-urls/'
       api: 'https://cloud.google.com/compute/docs/reference/rest/v1/backendServices'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -2451,8 +2451,8 @@ objects:
     description: |
       Disk resource policies define a schedule for taking snapshots and a
       retention period for these snapshots.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/zones/{{zone}}/operations/{{op_id}}'
@@ -2460,16 +2460,16 @@ objects:
         timeouts: !ruby/object:Api::Timeouts
           insert_minutes: 4
           delete_minutes: 4
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -2527,8 +2527,8 @@ objects:
         'Adding a persistent disk':
           'https://cloud.google.com/compute/docs/disks/add-persistent-disk'
       api: 'https://cloud.google.com/compute/docs/reference/v1/disks'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/zones/{{zone}}/operations/{{op_id}}'
@@ -2537,16 +2537,16 @@ objects:
         # https://github.com/terraform-providers/terraform-provider-google/issues/703
         timeouts: !ruby/object:Api::Timeouts
           insert_minutes: 5
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -2819,22 +2819,22 @@ objects:
       outgoing traffic and a default "deny" for incoming traffic. For all
       networks except the default network, you must create any firewall rules
       you need.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -3079,22 +3079,22 @@ objects:
           'https://cloud.google.com/compute/docs/load-balancing/network/forwarding-rules'
       api: 'https://cloud.google.com/compute/docs/reference/v1/forwardingRule'
     input: true
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -3347,22 +3347,22 @@ objects:
           'https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address'
       api: 'https://cloud.google.com/compute/docs/reference/v1/globalAddresses'
     input: true
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -3483,22 +3483,22 @@ objects:
 
       For more information, see
       https://cloud.google.com/compute/docs/load-balancing/http/
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -3728,22 +3728,22 @@ objects:
       guides:
         'Adding Health Checks': 'https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks'
       api: 'https://cloud.google.com/compute/docs/reference/v1/httpHealthChecks'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -3825,22 +3825,22 @@ objects:
       guides:
         'Adding Health Checks': 'https://cloud.google.com/compute/docs/load-balancing/health-checks#legacy_health_checks'
       api: 'https://cloud.google.com/compute/docs/reference/v1/httpsHealthChecks'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -3930,22 +3930,22 @@ objects:
       continue to poll unhealthy instances. If an instance later responds
       successfully to some number of consecutive probes, it is marked
       healthy again and can receive new connections.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -4608,22 +4608,22 @@ objects:
 
       Tip: Disks should be set to autoDelete=true
       so that leftover disks are not left behind on machine deletion.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -5148,8 +5148,8 @@ objects:
       images are available only to your project. You can create a custom image
       from root persistent disks and other images. Then, use the custom image
       to create an instance.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
@@ -5158,16 +5158,16 @@ objects:
           insert_minutes: 6
           update_minutes: 6
           delete_minutes: 6
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -5406,8 +5406,8 @@ objects:
     has_self_link: true
     description: |
        An instance is a virtual machine (VM) hosted on Google's infrastructure.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/zones/{{zone}}/operations/{{op_id}}'
@@ -5418,16 +5418,16 @@ objects:
           insert_minutes: 6
           update_minutes: 6
           delete_minutes: 6
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -5980,22 +5980,22 @@ objects:
       and can contain identical or different instances. Instance groups do not
       use an instance template. Unlike managed instance groups, you must create
       and add instances to an instance group manually.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/zones/{{zone}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     input: true
@@ -6098,22 +6098,22 @@ objects:
       verify the status of the individual instances.
 
       A managed instance group can have up to 1000 VM instances per group.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/zones/{{zone}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -6292,22 +6292,22 @@ objects:
     description: |
       Represents an InterconnectAttachment (VLAN attachment) resource. For more
       information, see Creating VLAN Attachments.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -6605,22 +6605,22 @@ objects:
       api: 'https://cloud.google.com/compute/docs/reference/rest/v1/networks'
     description: |
       Manages a VPC network or legacy network resource on GCP.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -6725,8 +6725,8 @@ objects:
       guides:
         'Official Documentation': 'https://cloud.google.com/load-balancing/docs/negs/'
       api: 'https://cloud.google.com/compute/docs/reference/rest/beta/networkEndpointGroups'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/zones/{{zone}}/operations/{{op_id}}'
@@ -6735,16 +6735,16 @@ objects:
           insert_minutes: 6
           update_minutes: 6
           delete_minutes: 6
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -6808,22 +6808,22 @@ objects:
       backend with internal load balancers. Because NEG backends allow you to
       specify IP addresses and ports, you can distribute traffic in a granular
       fashion among applications or containers running within VM instances.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/zones/{{zone}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -6900,22 +6900,22 @@ objects:
         'Sole-Tenant Nodes': 'https://cloud.google.com/compute/docs/nodes/'
       api: 'https://cloud.google.com/compute/docs/reference/rest/v1/nodeGroups'
     collection_url_key: 'items'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/zones/{{zone}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -6969,22 +6969,22 @@ objects:
       guides:
         'Sole-Tenant Nodes': 'https://cloud.google.com/compute/docs/nodes/'
       api: 'https://cloud.google.com/compute/docs/reference/rest/v1/nodeTemplates'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     collection_url_key: 'items'
@@ -7196,22 +7196,22 @@ objects:
       guides:
         'Autoscaling Groups of Instances': 'https://cloud.google.com/compute/docs/autoscaler/'
       api: 'https://cloud.google.com/compute/docs/reference/rest/v1/regionAutoscalers'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -7539,24 +7539,24 @@ objects:
         'Adding or Resizing Regional Persistent Disks':
           'https://cloud.google.com/compute/docs/disks/regional-persistent-disk'
       api: 'https://cloud.google.com/compute/docs/reference/rest/beta/regionDisks'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
         timeouts: !ruby/object:Api::Timeouts
           insert_minutes: 5
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -7759,22 +7759,22 @@ objects:
     description: |
       UrlMaps are used to route requests to a backend service based on rules
       that you define for the host and path of an incoming URL.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -7942,22 +7942,22 @@ objects:
       continue to poll unhealthy instances. If an instance later responds
       successfully to some number of consecutive probes, it is marked
       healthy again and can receive new connections.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -8619,22 +8619,22 @@ objects:
     has_self_link: true
     description: |
       A policy that can be attached to a resource to specify or schedule actions on that resource.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -8833,22 +8833,22 @@ objects:
           guides:
             'Using Routes': 'https://cloud.google.com/vpc/docs/using-routes'
           api: 'https://cloud.google.com/compute/docs/reference/rest/v1/routes'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -8998,22 +8998,22 @@ objects:
           guides:
             'Google Cloud Router': 'https://cloud.google.com/router/docs/'
           api: 'https://cloud.google.com/compute/docs/reference/rest/v1/routers'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -9146,8 +9146,8 @@ objects:
       guides:
         'Google Cloud Router': 'https://cloud.google.com/router/docs/'
       api: 'https://cloud.google.com/compute/docs/reference/rest/v1/routers'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{regions}}/operations/{{op_id}}'
@@ -9156,16 +9156,16 @@ objects:
           insert_minutes: 10
           update_minutes: 10
           delete_minutes: 10
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -9354,8 +9354,8 @@ objects:
     # 'createSnapshot' is a zonal operation while 'snapshot.delete' is a global
     # operation. we'll leave the object as global operation and use the disk's
     # zonal operation for the create action.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         full_url: 'selfLink'
@@ -9364,16 +9364,16 @@ objects:
           insert_minutes: 5
           update_minutes: 5
           delete_minutes: 5
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -9518,22 +9518,22 @@ objects:
       An SslCertificate resource, used for HTTPS load balancing. This resource
       provides a mechanism to upload an SSL key and certificate to
       the load balancer to serve secure connections from the user.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -9588,8 +9588,8 @@ objects:
       An SslCertificate resource, used for HTTPS load balancing.  This resource
       represents a certificate for which the certificate secrets are created and
       managed by Google.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
@@ -9600,16 +9600,16 @@ objects:
           # Deletes can take 20-30 minutes to complete, since they depend
           # on the provisioning process either succeeding or failing completely.
           delete_minutes: 30
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -9683,22 +9683,22 @@ objects:
       A RegionSslCertificate resource, used for HTTPS load balancing. This resource
       provides a mechanism to upload an SSL key and certificate to
       the load balancer to serve secure connections from the user.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -9763,22 +9763,22 @@ objects:
       guides:
         'Reserving zonal resources': 'https://cloud.google.com/compute/docs/instances/reserving-zonal-resources'
       api: 'https://cloud.google.com/compute/docs/reference/rest/v1/reservations'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/zones/{{zone}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -9926,22 +9926,22 @@ objects:
           guides:
             'Using SSL Policies': 'https://cloud.google.com/compute/docs/load-balancing/ssl-policies'
           api: 'https://cloud.google.com/compute/docs/reference/rest/v1/sslPolicies'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -10057,8 +10057,8 @@ objects:
       instances in all other subnets of the same VPC network, regardless of
       region, using their RFC1918 private IP addresses. You can isolate portions
       of the network, even entire subnets, using firewall rules.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
@@ -10069,16 +10069,16 @@ objects:
           insert_minutes: 6
           update_minutes: 6
           delete_minutes: 6
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -10294,22 +10294,22 @@ objects:
         'Official Documentation':
           'https://cloud.google.com/compute/docs/load-balancing/http/target-proxies'
       api: 'https://cloud.google.com/compute/docs/reference/v1/targetHttpProxies'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -10359,22 +10359,22 @@ objects:
       guides:
         'Official Documentation': 'https://cloud.google.com/compute/docs/load-balancing/http/target-proxies'
       api: 'https://cloud.google.com/compute/docs/reference/v1/targetHttpsProxies'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -10470,22 +10470,22 @@ objects:
         'Official Documentation':
           'https://cloud.google.com/compute/docs/load-balancing/http/target-proxies'
       api: 'https://cloud.google.com/compute/docs/reference/rest/beta/regionTargetHttpProxies'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -10545,22 +10545,22 @@ objects:
       guides:
         'Official Documentation': 'https://cloud.google.com/compute/docs/load-balancing/http/target-proxies'
       api: 'https://cloud.google.com/compute/docs/reference/rest/beta/regionTargetHttpsProxies'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -10673,22 +10673,22 @@ objects:
       guides:
         'Using Protocol Forwarding': 'https://cloud.google.com/compute/docs/protocol-forwarding'
       api: 'https://cloud.google.com/compute/docs/reference/v1/targetInstances'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/zones/{{zone}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -10751,22 +10751,22 @@ objects:
         'Official Documentation':
           'https://cloud.google.com/compute/docs/load-balancing/network/target-pools'
       api: 'https://cloud.google.com/compute/docs/reference/rest/v1/targetPools'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -10891,22 +10891,22 @@ objects:
       guides:
         'Setting Up SSL proxy for Google Cloud Load Balancing': 'https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/'
       api: 'https://cloud.google.com/compute/docs/reference/v1/targetSslProxies'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -10995,22 +10995,22 @@ objects:
         'Setting Up TCP proxy for Google Cloud Load Balancing':
           'https://cloud.google.com/compute/docs/load-balancing/tcp-ssl/tcp-proxy'
       api: 'https://cloud.google.com/compute/docs/reference/v1/targetTcpProxies'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -11069,22 +11069,22 @@ objects:
       by Google, but used only by you.
     references: !ruby/object:Api::Resource::ReferenceLinks
       api: https://cloud.google.com/compute/docs/reference/rest/v1/targetVpnGateways
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -11169,22 +11169,22 @@ objects:
         'Choosing a VPN': https://cloud.google.com/vpn/docs/how-to/choosing-a-vpn
         'Cloud VPN Overview': 'https://cloud.google.com/vpn/docs/concepts/overview'
       api: https://cloud.google.com/compute/docs/reference/rest/beta/vpnGateways
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:
@@ -11253,22 +11253,22 @@ objects:
       Represents a VPN gateway managed outside of GCP.
     references: !ruby/object:Api::Resource::ReferenceLinks
       api: https://cloud.google.com/compute/docs/reference/rest/beta/externalVpnGateways
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -11325,22 +11325,22 @@ objects:
     description: |
       UrlMaps are used to route requests to a backend service based on rules
       that you define for the host and path of an incoming URL.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/global/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     properties:
@@ -11491,22 +11491,22 @@ objects:
         'Cloud VPN Overview': 'https://cloud.google.com/vpn/docs/concepts/overview'
         'Networks and Tunnel Routing': 'https://cloud.google.com/vpn/docs/concepts/choosing-networks-routing'
       api: 'https://cloud.google.com/compute/docs/reference/rest/v1/vpnTunnels'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
         path: 'name'
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'targetLink'
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'status'
         complete: 'DONE'
         allowed:
           - 'PENDING'
           - 'RUNNING'
           - 'DONE'
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error/errors'
         message: 'message'
     parameters:

--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -27,15 +27,15 @@ apis_required:
   - !ruby/object:Api::Product::ApiReference
     name: Kubernetes Engine API
     url: https://console.cloud.google.com/apis/library/container.googleapis.com/
-async: !ruby/object:Api::Async
-  operation: !ruby/object:Api::Async::Operation
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
     kind: 'container#operation'
     path: 'name'
     base_url: 'projects/{{project}}/locations/{{location}}/operations/{{op_id}}'
     wait_ms: 1000
-  result: !ruby/object:Api::Async::Result
+  result: !ruby/object:Api::OpAsync::Result
     path: 'targetLink'
-  status: !ruby/object:Api::Async::Status
+  status: !ruby/object:Api::OpAsync::Status
     path: 'status'
     complete: 'DONE'
     allowed:
@@ -43,7 +43,7 @@ async: !ruby/object:Api::Async
       - 'RUNNING'
       - 'DONE'
       - 'ABORTING'
-  error: !ruby/object:Api::Async::Error
+  error: !ruby/object:Api::OpAsync::Error
     path: 'error/errors'
     message: 'message'
 objects:

--- a/products/datafusion/api.yaml
+++ b/products/datafusion/api.yaml
@@ -20,21 +20,21 @@ versions:
     base_url: https://datafusion.googleapis.com/v1beta1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
-async: !ruby/object:Api::Async
-  operation: !ruby/object:Api::Async::Operation
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
     path: 'name'
     base_url: '{{op_id}}'
     wait_ms: 1000
-  result: !ruby/object:Api::Async::Result
+  result: !ruby/object:Api::OpAsync::Result
     path: 'response'
     resource_inside_response: true
-  status: !ruby/object:Api::Async::Status
+  status: !ruby/object:Api::OpAsync::Status
     path: 'done'
     complete: true
     allowed:
       - true
       - false
-  error: !ruby/object:Api::Async::Error
+  error: !ruby/object:Api::OpAsync::Error
     path: 'error'
     message: 'message'
 apis_required:

--- a/products/filestore/api.yaml
+++ b/products/filestore/api.yaml
@@ -26,21 +26,21 @@ versions:
     base_url: https://file.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
-async: !ruby/object:Api::Async
-  operation: !ruby/object:Api::Async::Operation
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
     path: 'name'
     base_url: '{{op_id}}'
     wait_ms: 1000
-  result: !ruby/object:Api::Async::Result
+  result: !ruby/object:Api::OpAsync::Result
     path: 'response'
     resource_inside_response: true
-  status: !ruby/object:Api::Async::Status
+  status: !ruby/object:Api::OpAsync::Status
     path: 'done'
     complete: True
     allowed:
       - True
       - False
-  error: !ruby/object:Api::Async::Error
+  error: !ruby/object:Api::OpAsync::Error
     path: 'error'
     message: 'message'
 objects:

--- a/products/firestore/api.yaml
+++ b/products/firestore/api.yaml
@@ -20,21 +20,21 @@ versions:
     base_url: https://firestore.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
-async: !ruby/object:Api::Async
-  operation: !ruby/object:Api::Async::Operation
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
     path: 'name'
     base_url: '{{op_id}}'
     wait_ms: 1000
-  result: !ruby/object:Api::Async::Result
+  result: !ruby/object:Api::OpAsync::Result
     path: 'response'
     resource_inside_response: true
-  status: !ruby/object:Api::Async::Status
+  status: !ruby/object:Api::OpAsync::Status
     path: 'done'
     complete: true
     allowed:
       - true
       - false
-  error: !ruby/object:Api::Async::Error
+  error: !ruby/object:Api::OpAsync::Error
     path: 'error'
     message: 'message'
 objects:

--- a/products/mlengine/api.yaml
+++ b/products/mlengine/api.yaml
@@ -31,22 +31,22 @@ objects:
     self_link: projects/{{project}}/models/{{name}}
     # This resources is not updatable (outside of versions, which is a version-level method)
     input: true
-    async: !ruby/object:Api::Async
+    async: !ruby/object:Api::OpAsync
       actions: ['delete']
-      operation: !ruby/object:Api::Async::Operation
+      operation: !ruby/object:Api::OpAsync::Operation
         path: 'name'
         base_url: '{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'response'
         resource_inside_response: true
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'done'
         complete: True
         allowed:
           - True
           - False
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error'
         message: 'message'
     description: |
@@ -100,21 +100,21 @@ objects:
     description: |
       Each version is a trained model deployed in the cloud, ready to handle
       prediction requests. A model can have multiple versions
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         path: 'name'
         base_url: '{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'response'
         resource_inside_response: true
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'done'
         complete: True
         allowed:
           - True
           - False
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error'
         message: 'message'
     parameters:

--- a/products/redis/api.yaml
+++ b/products/redis/api.yaml
@@ -23,21 +23,21 @@ versions:
     base_url: https://redis.googleapis.com/v1beta1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
-async: !ruby/object:Api::Async
-  operation: !ruby/object:Api::Async::Operation
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
     path: 'name'
     base_url: '{{op_id}}'
     wait_ms: 1000
-  result: !ruby/object:Api::Async::Result
+  result: !ruby/object:Api::OpAsync::Result
     path: 'response'
     resource_inside_response: true
-  status: !ruby/object:Api::Async::Status
+  status: !ruby/object:Api::OpAsync::Status
     path: 'done'
     complete: true
     allowed:
       - true
       - false
-  error: !ruby/object:Api::Async::Error
+  error: !ruby/object:Api::OpAsync::Error
     path: 'error'
     message: 'message'
 objects:
@@ -125,7 +125,7 @@ objects:
       - !ruby/object:Api::Type::String
         name: name
         description: |
-          The ID of the instance or a fully qualified identifier for the instance. 
+          The ID of the instance or a fully qualified identifier for the instance.
         required: true
         input: true
       - !ruby/object:Api::Type::Integer

--- a/products/resourcemanager/api.yaml
+++ b/products/resourcemanager/api.yaml
@@ -33,21 +33,21 @@ objects:
     description: |
       Represents a GCP Project. A project is a container for ACLs, APIs, App
       Engine Apps, VMs, and other Google Cloud Platform resources.
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         kind: 'notinuse'
         path: 'name'
         base_url: '{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         resource_inside_response: true
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'done'
         complete: true
         allowed:
           - True
           - False
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error'
         message: 'message'
     parameters:

--- a/products/serviceusage/api.yaml
+++ b/products/serviceusage/api.yaml
@@ -36,21 +36,21 @@ objects:
         'Getting Started': 'https://cloud.google.com/service-usage/docs/getting-started'
     description: |
       A service that is available for use
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         path: 'name'
         base_url: '{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'response'
         resource_inside_response: true
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'done'
         complete: True
         allowed:
           - True
           - False
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error'
         message: 'message'
     properties:

--- a/products/spanner/api.yaml
+++ b/products/spanner/api.yaml
@@ -54,22 +54,22 @@ objects:
       guides:
         'Official Documentation': 'https://cloud.google.com/spanner/'
       api: 'https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances'
-    async: !ruby/object:Api::Async
+    async: !ruby/object:Api::OpAsync
       actions: ['create', 'update']
-      operation: !ruby/object:Api::Async::Operation
+      operation: !ruby/object:Api::OpAsync::Operation
         path: 'name'
         base_url: '{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'response'
         resource_inside_response: true
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'done'
         complete: True
         allowed:
           - True
           - False
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error'
         message: 'message'
     properties:
@@ -129,22 +129,22 @@ objects:
       guides:
         'Official Documentation': 'https://cloud.google.com/spanner/'
       api: 'https://cloud.google.com/spanner/docs/reference/rest/v1/projects.instances.databases'
-    async: !ruby/object:Api::Async
+    async: !ruby/object:Api::OpAsync
       actions: ['create', 'update']
-      operation: !ruby/object:Api::Async::Operation
+      operation: !ruby/object:Api::OpAsync::Operation
         path: 'name'
         base_url: '{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'response'
         resource_inside_response: true
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'done'
         complete: True
         allowed:
           - True
           - False
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error'
         message: 'message'
     parameters:

--- a/products/sql/api.yaml
+++ b/products/sql/api.yaml
@@ -24,22 +24,22 @@ apis_required:
   - !ruby/object:Api::Product::ApiReference
     name: Cloud SQL Admin API
     url: https://console.cloud.google.com/apis/library/sqladmin.googleapis.com/
-async: !ruby/object:Api::Async
-  operation: !ruby/object:Api::Async::Operation
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
     kind: 'sql#operation'
     path: 'name'
     base_url: 'projects/{{project}}/operations/{{op_id}}'
     wait_ms: 1000
-  result: !ruby/object:Api::Async::Result
+  result: !ruby/object:Api::OpAsync::Result
     path: 'targetLink'
-  status: !ruby/object:Api::Async::Status
+  status: !ruby/object:Api::OpAsync::Status
     path: 'status'
     complete: 'DONE'
     allowed:
       - 'PENDING'
       - 'RUNNING'
       - 'DONE'
-  error: !ruby/object:Api::Async::Error
+  error: !ruby/object:Api::OpAsync::Error
     path: 'error/errors'
     message: 'message'
 objects:

--- a/products/tpu/api.yaml
+++ b/products/tpu/api.yaml
@@ -20,21 +20,21 @@ versions:
     base_url: https://tpu.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
-async: !ruby/object:Api::Async
-  operation: !ruby/object:Api::Async::Operation
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
     path: 'name'
     base_url: '{{op_id}}'
     wait_ms: 1000
-  result: !ruby/object:Api::Async::Result
+  result: !ruby/object:Api::OpAsync::Result
     path: 'response'
     resource_inside_response: true
-  status: !ruby/object:Api::Async::Status
+  status: !ruby/object:Api::OpAsync::Status
     path: 'done'
     complete: true
     allowed:
       - true
       - false
-  error: !ruby/object:Api::Async::Error
+  error: !ruby/object:Api::OpAsync::Error
     path: 'error'
     message: 'message'
 objects:

--- a/products/vpcaccess/api.yaml
+++ b/products/vpcaccess/api.yaml
@@ -37,21 +37,21 @@ objects:
       guides:
         'Configuring Serverless VPC Access': 'https://cloud.google.com/vpc/docs/configure-serverless-vpc-access'
       api: 'https://cloud.google.com/vpc/docs/reference/vpcaccess/rest/v1beta1/projects.locations.connectors'
-    async: !ruby/object:Api::Async
-      operation: !ruby/object:Api::Async::Operation
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
         path: 'name'
         base_url: '{{op_id}}'
         wait_ms: 1000
-      result: !ruby/object:Api::Async::Result
+      result: !ruby/object:Api::OpAsync::Result
         path: 'response'
         resource_inside_response: true
-      status: !ruby/object:Api::Async::Status
+      status: !ruby/object:Api::OpAsync::Status
         path: 'done'
         complete: True
         allowed:
           - True
           - False
-      error: !ruby/object:Api::Async::Error
+      error: !ruby/object:Api::OpAsync::Error
         path: 'error'
         message: 'message'
     parameters:


### PR DESCRIPTION
Splitting the Async class into 2 classes that inherit from the same base so
that we can type sniff later in code to determine which type of async
functionality should be used.

