### PR TITLE
Mark DiskEncryptionKey.rawKey as sensitive for Terraform

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -401,6 +401,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           [google_compute_image data source](/docs/providers/google/d/datasource_compute_image.html).
           For instance, the image `centos-6-v20180104` includes its family name `centos-6`.
           These images can be referred by family name here.
+      diskEncryptionKey.rawKey: !ruby/object:Overrides::Terraform::PropertyOverride
+        sensitive: true
       diskEncryptionKey.kmsKeyName: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'compareSelfLinkRelativePaths'
         name: "kmsKeySelfLink"


### PR DESCRIPTION
This PR marks the raw disk encryption key in Terraform as sensitive and therefore doesn't output it to the console log. 

Inspired by: https://github.com/GoogleCloudPlatform/magic-modules/blob/b67500f4cd54cff23fb29dd9bcf1f59a5026ac43/products/compute/terraform.yaml#L1445-L1452

I'm not 100% sure if changes to at other points are required or not. 

Changes need to end in the end in the [terraform-provider-google resource_compute_disk](https://github.com/terraform-providers/terraform-provider-google/blob/25921448f16c97ad313bdc3ed01286ad266a8dcc/google/resource_compute_disk.go#L294-L300).

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: `google_compute_disk` `disk_encryption_key.raw_key` is now sensitive
```
