### PR TITLE
non-NIC0 ILB support

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2273,6 +2273,14 @@ objects:
               the field must be in [0, 1]. This configures the sampling rate of requests to the load balancer
               where 1.0 means all logged requests are reported and 0.0 means no logged requests are reported.
               The default value is 1.0.
+      - !ruby/object:Api::Type::ResourceRef
+        resource: 'Network'
+        name: 'network'
+        imports: 'selfLink'
+        description: |
+          The URL of the network to which this backend service belongs.
+          This field can only be specified when the load balancing scheme is set to INTERNAL.
+        min_version: beta
   - !ruby/object:Api::Resource
     name: 'BackendServiceSignedUrlKey'
     kind: 'compute#BackendServiceSignedUrlKey'

--- a/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
@@ -103,6 +103,35 @@ func TestAccComputeRegionBackendService_withBackendAndUpdate(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
+func TestAccComputeRegionBackendService_withBackendMultiNic(t *testing.T) {
+        t.Parallel()
+
+        serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+        net1Name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+        net2Name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+        igName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+        itName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+        checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+        resource.Test(t, resource.TestCase{
+                PreCheck:     func() { testAccPreCheck(t) },
+                Providers:    testAccProviders,
+                CheckDestroy: testAccCheckComputeRegionBackendServiceDestroy,
+                Steps: []resource.TestStep{
+                        resource.TestStep{
+                                Config: testAccComputeRegionBackendService_withBackendMultiNic(
+                                        serviceName, net1Name, net2Name, igName, itName, checkName, 10),
+                        },
+                        {
+                                ResourceName:      "google_compute_region_backend_service.lipsum",
+                                ImportState:       true,
+                                ImportStateVerify: true,
+                        },
+                },
+        })
+}
+<% end -%>
+
 func TestAccComputeRegionBackendService_withConnectionDrainingAndUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -518,6 +547,107 @@ resource "google_compute_health_check" "default" {
 }
 `, serviceName, timeout, igName, itName, checkName)
 }
+
+<% unless version == 'ga' -%>
+func testAccComputeRegionBackendService_withBackendMultiNic(
+        serviceName, net1Name, net2Name, igName, itName, checkName string, timeout int64) string {
+        return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_region_backend_service" "lipsum" {
+  name        = "%s"
+  description = "Hello World 1234"
+  protocol    = "TCP"
+  region      = "us-central1"
+  timeout_sec = %v
+
+  backend {
+    group = google_compute_instance_group_manager.foobar.instance_group
+    failover = true
+  }
+
+  failover_policy {
+    disable_connection_drain_on_failover = true
+    drop_traffic_if_unhealthy = true
+    failover_ratio = 0.4
+  }
+
+  network = google_compute_network.network2.self_link
+
+  health_checks = [google_compute_health_check.default.self_link]
+}
+
+resource "google_compute_network" "network1" {
+  name                            = "%s"
+  auto_create_subnetworks         = false
+}
+
+resource "google_compute_subnetwork" "subnet1" {
+  name                     = "%s"
+  ip_cidr_range            = "10.0.1.0/24"
+  region                   = "us-central1"
+  private_ip_google_access = true
+  network                  = google_compute_network.network1.self_link
+}
+
+resource "google_compute_network" "network2" {
+  name                            = "%s"
+  auto_create_subnetworks         = false
+}
+
+resource "google_compute_subnetwork" "subnet2" {
+  name                     = "%s"
+  ip_cidr_range            = "10.0.2.0/24"
+  region                   = "us-central1"
+  private_ip_google_access = true
+  network                  = google_compute_network.network2.self_link
+}
+
+resource "google_compute_instance_group_manager" "foobar" {
+  name               = "%s"
+  version {
+    instance_template  = google_compute_instance_template.foobar.self_link
+    name               = "primary"
+  }
+  base_instance_name = "foobar"
+  zone               = "us-central1-f"
+  target_size        = 1
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "%s"
+  machine_type = "n1-standard-1"
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.subnet1.self_link
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.subnet2.self_link
+  }
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+}
+
+resource "google_compute_health_check" "default" {
+  name               = "%s"
+  check_interval_sec = 1
+  timeout_sec        = 1
+
+  tcp_health_check {
+    port = 443
+  }
+}
+`, serviceName, timeout, net1Name, net1Name, net2Name, net2Name, igName, itName, checkName)
+}
+<% end -%>
 
 func testAccComputeRegionBackendService_withConnectionDraining(serviceName, checkName string, drainingTimeout int64) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
`compute`: field `network` can now be specified on `google_compute_region_backend_service`, which allows internal load balancers to target the non-primary interface of an instance.
```
