### PR TITLE
Dataproc autoscaling ga

### DIFF
--- a/products/dataproc/api.yaml
+++ b/products/dataproc/api.yaml
@@ -32,7 +32,6 @@ objects:
     name: 'AutoscalingPolicy'
     base_url: "projects/{{project}}/locations/{{location}}/autoscalingPolicies"
     self_link: "projects/{{project}}/locations/{{location}}/autoscalingPolicies/{{id}}"
-    min_version: beta
     description: |
       Describes an autoscaling policy for Dataproc cluster autoscaler.
     parameters:

--- a/products/dataproc/terraform.yaml
+++ b/products/dataproc/terraform.yaml
@@ -21,7 +21,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "dataproc_autoscaling_policy"
         primary_resource_id: "asp"
-        min_version: beta
         vars:
           name: "tf-dataproc-test-"
     properties:

--- a/templates/terraform/examples/dataproc_autoscaling_policy.tf.erb
+++ b/templates/terraform/examples/dataproc_autoscaling_policy.tf.erb
@@ -1,8 +1,4 @@
-provider "google-beta" {
-}
-
 resource "google_dataproc_cluster" "basic" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['name'] %>"
   region   = "us-central1"
 
@@ -14,7 +10,6 @@ resource "google_dataproc_cluster" "basic" {
 }
 
 resource "google_dataproc_autoscaling_policy" "<%= ctx[:primary_resource_id] %>" {
-  provider  = google-beta
   policy_id = "<%= ctx[:vars]['name'] %>"
   location  = "us-central1"
 

--- a/third_party/terraform/resources/resource_dataproc_cluster.go.erb
+++ b/third_party/terraform/resources/resource_dataproc_cluster.go.erb
@@ -51,9 +51,7 @@ var (
 		"cluster_config.0.software_config",
 		"cluster_config.0.initialization_action",
 		"cluster_config.0.encryption_config",
-<% unless version == 'ga' -%>
 		"cluster_config.0.autoscaling_config",
-<% end -%>
 	}
 )
 
@@ -398,7 +396,6 @@ func resourceDataprocCluster() *schema.Resource {
 								},
 							},
 						},
-<% unless version == 'ga' -%>
 						"autoscaling_config": {
 							Type:         schema.TypeList,
 							Optional:     true,
@@ -413,7 +410,6 @@ func resourceDataprocCluster() *schema.Resource {
 								},
 							},
 						},
-<% end -%>
 					},
 				},
 			},
@@ -651,11 +647,9 @@ func expandClusterConfig(d *schema.ResourceData, config *Config) (*dataproc.Clus
 		conf.EncryptionConfig = expandEncryptionConfig(cfg)
 	}
 
-<% unless version == 'ga' -%>
 	if cfg, ok := configOptions(d, "cluster_config.0.autoscaling_config"); ok {
 		conf.AutoscalingConfig = expandAutoscalingConfig(cfg)
 	}
-<% end -%>
 
 	if cfg, ok := configOptions(d, "cluster_config.0.master_config"); ok {
 		log.Println("[INFO] got master_config")
@@ -759,7 +753,6 @@ func expandEncryptionConfig(cfg map[string]interface{}) *dataproc.EncryptionConf
 	return conf
 }
 
-<% unless version == 'ga' -%>
 func expandAutoscalingConfig(cfg map[string]interface{}) *dataproc.AutoscalingConfig {
 	conf := &dataproc.AutoscalingConfig{}
 	if v, ok := cfg["policy_uri"]; ok {
@@ -767,7 +760,6 @@ func expandAutoscalingConfig(cfg map[string]interface{}) *dataproc.AutoscalingCo
 	}
 	return conf
 }
-<% end -%>
 
 func expandInitializationActions(v interface{}) []*dataproc.NodeInitializationAction {
 	actionList := v.([]interface{})
@@ -983,9 +975,7 @@ func flattenClusterConfig(d *schema.ResourceData, cfg *dataproc.ClusterConfig) (
 		"worker_config":             flattenInstanceGroupConfig(d, cfg.WorkerConfig),
 		"preemptible_worker_config": flattenPreemptibleInstanceGroupConfig(d, cfg.SecondaryWorkerConfig),
 		"encryption_config":         flattenEncryptionConfig(d, cfg.EncryptionConfig),
-	<% unless version == 'ga' -%>
 		"autoscaling_config":        flattenAutoscalingConfig(d, cfg.AutoscalingConfig),
-	<% end -%>
 	}
 
 	if len(cfg.InitializationActions) > 0 {
@@ -1021,7 +1011,6 @@ func flattenEncryptionConfig(d *schema.ResourceData, ec *dataproc.EncryptionConf
 	return []map[string]interface{}{data}
 }
 
-<% unless version == 'ga' -%>
 func flattenAutoscalingConfig(d *schema.ResourceData, ec *dataproc.AutoscalingConfig) []map[string]interface{} {
 	if ec == nil {
 		return nil
@@ -1033,7 +1022,6 @@ func flattenAutoscalingConfig(d *schema.ResourceData, ec *dataproc.AutoscalingCo
 
 	return []map[string]interface{}{data}
 }
-<% end -%>
 
 func flattenAccelerators(accelerators []*dataproc.AcceleratorConfig) interface{} {
 	acceleratorsTypeSet := schema.NewSet(schema.HashResource(acceleratorsSchema()), []interface{}{})

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -842,12 +842,10 @@
     <li<%%= sidebar_current("docs-google-dataproc") %>>
         <a href="#">Google Dataproc Resources</a>
         <ul class="nav nav-visible">
-<% unless version == 'ga' %>
           <li<%%= sidebar_current("docs-google-dataproc-autoscaling-policy") %>>
           <a href="/docs/providers/google/r/dataproc_autoscaling_policy.html">google_dataproc_autoscaling_policy</a>
           </li>
 
-<% end -%>
           <li<%%= sidebar_current("docs-google-dataproc-cluster") %>>
           <a href="/docs/providers/google/r/dataproc_cluster.html">google_dataproc_cluster</a>
           </li>


### PR DESCRIPTION
Move autoscaling policy to GA, autoscaling config in cluster to GA as well

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
`dataproc`: `google_dataproc_autoscaling_policy` is now GA. `google_dataproc_cluster.autoscaling_config` is also available in GA
```
