### PR TITLE
Don't rely on bigquery table id anymore

### DIFF
--- a/third_party/terraform/resources/resource_bigquery_table.go.erb
+++ b/third_party/terraform/resources/resource_bigquery_table.go.erb
@@ -501,6 +501,7 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		return handleNotFoundError(err, d, fmt.Sprintf("BigQuery table %q", tableID))
 	}
 
+	d.Set("project", project)
 	d.Set("description", res.Description)
 	d.Set("expiration_time", res.ExpirationTime)
 	d.Set("friendly_name", res.FriendlyName)

--- a/third_party/terraform/resources/resource_bigquery_table.go.erb
+++ b/third_party/terraform/resources/resource_bigquery_table.go.erb
@@ -21,7 +21,7 @@ func resourceBigQueryTable() *schema.Resource {
 		Delete: resourceBigQueryTableDelete,
 		Update: resourceBigQueryTableUpdate,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceBigQueryTableImport,
 		},
 		Schema: map[string]*schema.Schema{
 			// TableId: [Required] The ID of the table. The ID must contain only
@@ -488,17 +488,19 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[INFO] Reading BigQuery table: %s", d.Id())
 
-	id, err := parseBigQueryTableId(d.Id())
+	project, err := getProject(d, config)
 	if err != nil {
 		return err
 	}
 
-	res, err := config.clientBigQuery.Tables.Get(id.Project, id.DatasetId, id.TableId).Do()
+	datasetID := d.Get("dataset_id").(string)
+	tableID := d.Get("table_id").(string)
+
+	res, err := config.clientBigQuery.Tables.Get(project, datasetID, tableID).Do()
 	if err != nil {
-		return handleNotFoundError(err, d, fmt.Sprintf("BigQuery table %q", id.TableId))
+		return handleNotFoundError(err, d, fmt.Sprintf("BigQuery table %q", tableID))
 	}
 
-	d.Set("project", id.Project)
 	d.Set("description", res.Description)
 	d.Set("expiration_time", res.ExpirationTime)
 	d.Set("friendly_name", res.FriendlyName)
@@ -561,12 +563,15 @@ func resourceBigQueryTableUpdate(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[INFO] Updating BigQuery table: %s", d.Id())
 
-	id, err := parseBigQueryTableId(d.Id())
+	project, err := getProject(d, config)
 	if err != nil {
 		return err
 	}
 
-	if _, err = config.clientBigQuery.Tables.Update(id.Project, id.DatasetId, id.TableId, table).Do(); err != nil {
+	datasetID := d.Get("dataset_id").(string)
+	tableID := d.Get("table_id").(string)
+
+	if _, err = config.clientBigQuery.Tables.Update(project, datasetID, tableID, table).Do(); err != nil {
 		return err
 	}
 
@@ -578,12 +583,15 @@ func resourceBigQueryTableDelete(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[INFO] Deleting BigQuery table: %s", d.Id())
 
-	id, err := parseBigQueryTableId(d.Id())
+	project, err := getProject(d, config)
 	if err != nil {
 		return err
 	}
 
-	if err := config.clientBigQuery.Tables.Delete(id.Project, id.DatasetId, id.TableId).Do(); err != nil {
+	datasetID := d.Get("dataset_id").(string)
+	tableID := d.Get("table_id").(string)
+
+	if err := config.clientBigQuery.Tables.Delete(project, datasetID, tableID).Do(); err != nil {
 		return err
 	}
 
@@ -841,20 +849,22 @@ func flattenView(vd *bigquery.ViewDefinition) []map[string]interface{} {
 	return []map[string]interface{}{result}
 }
 
-type bigQueryTableId struct {
-	Project, DatasetId, TableId string
-}
-
-func parseBigQueryTableId(id string) (*bigQueryTableId, error) {
-	// Expected format is "projects/{{project}}/datasets/{{dataset}}/tables/{{table}}"
-	matchRegex := regexp.MustCompile("^projects/(.+)/datasets/(.+)/tables/(.+)$")
-	subMatches := matchRegex.FindStringSubmatch(id)
-	if subMatches == nil {
-		return nil, fmt.Errorf("Invalid BigQuery table specifier. Expecting projects/{{project}}/datasets/{{dataset}}/tables/{{table}}, got %s", id)
+func resourceBigQueryTableImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	config := meta.(*Config)
+	if err := parseImportId([]string{
+		"projects/(?P<project>[^/]+)/datasets/(?P<dataset_id>[^/]+)/tables/(?P<table_id>[^/]+)",
+		"(?P<project>[^/]+)/(?P<dataset_id>[^/]+)/(?P<table_id>[^/]+)",
+		"(?P<dataset_id>[^/]+)/(?P<table_id>[^/]+)",
+	}, d, config); err != nil {
+		return nil, err
 	}
-	return &bigQueryTableId{
-		Project:   subMatches[1],
-		DatasetId: subMatches[2],
-		TableId:   subMatches[3],
-	}, nil
+
+	// Replace import id for the resource id
+	id, err := replaceVars(d, config, "projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}")
+	if err != nil {
+		return nil, fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4919

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
`bigquery`: fixed an issue where bigquery table id formats from the `2.X` series caused an error at plan time
```
