### PR TITLE
add encryption_configuration to google_bigquery_table resource

### DIFF
--- a/third_party/terraform/resources/resource_bigquery_table.go.erb
+++ b/third_party/terraform/resources/resource_bigquery_table.go.erb
@@ -312,6 +312,26 @@ func resourceBigQueryTable() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
+			// EncryptionConfiguration: [Optional] Custom encryption configuration (e.g., Cloud KMS keys).
+			"encryption_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// KmsKeyName: [Optional] Describes the Cloud KMS encryption key that
+						// will be used to protect destination BigQuery table. The BigQuery
+						// Service Account associated with your project requires access to this
+						// encryption key.
+						"kms_key_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+
 			// CreationTime: [Output-only] The time when this table was created, in
 			// milliseconds since the epoch.
 			"creation_time": {
@@ -451,6 +471,10 @@ func resourceTable(d *schema.ResourceData, meta interface{}) (*bigquery.Table, e
 		}
 	}
 
+	if v, ok := d.GetOk("encryption_configuration"); ok {
+		table.EncryptionConfiguration = expandEncryptionConfiguration(v)
+	}
+
 	return table, nil
 }
 
@@ -532,6 +556,12 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 
 	if res.Clustering != nil {
 		d.Set("clustering", res.Clustering.Fields)
+	}
+
+	if res.EncryptionConfiguration != nil {
+		if err := d.Set("encryption_configuration", flattenEncryptionConfiguration(res.EncryptionConfiguration)); err != nil {
+			return err
+		}
 	}
 
 	if res.Schema != nil {
@@ -837,6 +867,19 @@ func expandView(configured interface{}) *bigquery.ViewDefinition {
 func flattenView(vd *bigquery.ViewDefinition) []map[string]interface{} {
 	result := map[string]interface{}{"query": vd.Query}
 	result["use_legacy_sql"] = vd.UseLegacySql
+
+	return []map[string]interface{}{result}
+}
+
+func expandEncryptionConfiguration(configured interface{}) *bigquery.EncryptionConfiguration {
+	raw := configured.([]interface{})[0].(map[string]interface{})
+	ec := &bigquery.EncryptionConfiguration{KmsKeyName: raw["kms_key_name"].(string)}
+
+	return ec
+}
+
+func flattenEncryptionConfiguration(ec *bigquery.EncryptionConfiguration) []map[string]interface{} {
+	result := map[string]interface{}{"kms_key_name": ec.KmsKeyName}
 
 	return []map[string]interface{}{result}
 }


### PR DESCRIPTION
- fixes terraform-providers/terraform-provider-google#2014

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
