### PR TITLE
Add `expr` to `google_compute_security_policy.rule.match`

### DIFF
--- a/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -106,7 +106,7 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 													Type:     schema.TypeString,
 													Required: true,
 												},
-												// These fields are not yet supported (Issue #4497: mbang)
+												// These fields are not yet supported (Issue terraform-providers/terraform-provider-google#4497: mbang)
 												// "title": {
 												// 	Type:     schema.TypeString,
 												// 	Optional: true,
@@ -386,7 +386,7 @@ func expandSecurityPolicyMatchExpr(expr []interface{}) *compute.Expr {
 	data := expr[0].(map[string]interface{})
 	return &compute.Expr{
 		Expression: data["expression"].(string),
-		// These fields are not yet supported  (Issue #4497: mbang)
+		// These fields are not yet supported  (Issue terraform-providers/terraform-provider-google#4497: mbang)
 		// Title:       data["title"].(string),
 		// Description: data["description"].(string),
 		// Location:    data["location"].(string),
@@ -402,20 +402,28 @@ func flattenSecurityPolicyRules(rules []*compute.SecurityPolicyRule) []map[strin
 			"priority":    rule.Priority,
 			"action":      rule.Action,
 			"preview":     rule.Preview,
-			"match": []map[string]interface{}{
-				{
-					"versioned_expr": rule.Match.VersionedExpr,
-					"config":         flattenMatchConfig(rule.Match.Config),
-<% unless version == 'ga' -%>
-					"expr":           flattenMatchExpr(rule.Match),
-<% end -%>
-				},
-			},
+			"match":       flattenMatch(rule.Match),
 		}
 
 		rulesSchema = append(rulesSchema, data)
 	}
 	return rulesSchema
+}
+
+func flattenMatch(match *compute.SecurityPolicyRuleMatcher) []map[string]interface{} {
+	if match == nil {
+		return nil
+	}
+
+	data := map[string]interface{}{
+		"versioned_expr": match.VersionedExpr,
+		"config":         flattenMatchConfig(match.Config),
+<% unless version == 'ga' -%>
+		"expr":           flattenMatchExpr(match),
+<% end -%>
+	}
+
+	return []map[string]interface{}{data}
 }
 
 func flattenMatchConfig(conf *compute.SecurityPolicyRuleMatcherConfig) []map[string]interface{} {
@@ -438,7 +446,7 @@ func flattenMatchExpr(match *compute.SecurityPolicyRuleMatcher) []map[string]int
 
 	data := map[string]interface{}{
 		"expression": match.Expr.Expression,
-		// These fields are not yet supported (Issue #4497: mbang)
+		// These fields are not yet supported (Issue terraform-providers/terraform-provider-google#4497: mbang)
 		// "title":       match.Expr.Title,
 		// "description": match.Expr.Description,
 		// "location":    match.Expr.Location,

--- a/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package google
 
 import (
@@ -94,6 +95,7 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 										ValidateFunc: validation.StringInSlice([]string{"SRC_IPS_V1"}, false),
 									},
 
+<% unless version == 'ga' -%>
 									"expr": {
 										Type:     schema.TypeList,
 										Optional: true,
@@ -120,6 +122,7 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 											},
 										},
 									},
+<% end -%>
 								},
 							},
 						},
@@ -357,7 +360,9 @@ func expandSecurityPolicyMatch(configured []interface{}) *compute.SecurityPolicy
 	return &compute.SecurityPolicyRuleMatcher{
 		VersionedExpr: data["versioned_expr"].(string),
 		Config:        expandSecurityPolicyMatchConfig(data["config"].([]interface{})),
+<% unless version == 'ga' -%>
 		Expr:          expandSecurityPolicyMatchExpr(data["expr"].([]interface{})),
+<% end -%>
 	}
 }
 
@@ -372,6 +377,7 @@ func expandSecurityPolicyMatchConfig(configured []interface{}) *compute.Security
 	}
 }
 
+<% unless version == 'ga' -%>
 func expandSecurityPolicyMatchExpr(expr []interface{}) *compute.Expr {
 	if len(expr) == 0 || expr[0] == nil {
 		return nil
@@ -386,6 +392,7 @@ func expandSecurityPolicyMatchExpr(expr []interface{}) *compute.Expr {
 		// Location:    data["location"].(string),
 	}
 }
+<% end -%>
 
 func flattenSecurityPolicyRules(rules []*compute.SecurityPolicyRule) []map[string]interface{} {
 	rulesSchema := make([]map[string]interface{}, 0, len(rules))
@@ -399,7 +406,9 @@ func flattenSecurityPolicyRules(rules []*compute.SecurityPolicyRule) []map[strin
 				{
 					"versioned_expr": rule.Match.VersionedExpr,
 					"config":         flattenMatchConfig(rule.Match.Config),
+<% unless version == 'ga' -%>
 					"expr":           flattenMatchExpr(rule.Match),
+<% end -%>
 				},
 			},
 		}
@@ -421,6 +430,7 @@ func flattenMatchConfig(conf *compute.SecurityPolicyRuleMatcherConfig) []map[str
 	return []map[string]interface{}{data}
 }
 
+<% unless version == 'ga' -%>
 func flattenMatchExpr(match *compute.SecurityPolicyRuleMatcher) []map[string]interface{} {
 	if match.Expr == nil {
 		return nil
@@ -436,6 +446,7 @@ func flattenMatchExpr(match *compute.SecurityPolicyRuleMatcher) []map[string]int
 
 	return []map[string]interface{}{data}
 }
+<% end -%>
 
 func resourceSecurityPolicyStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)

--- a/third_party/terraform/tests/resource_compute_security_policy_test.go
+++ b/third_party/terraform/tests/resource_compute_security_policy_test.go
@@ -196,15 +196,11 @@ resource "google_compute_security_policy" "policy" {
 		action   = "allow"
 		priority = "2000"
 		match {
-			versioned_expr = "SRC_IPS_V1"
-			config {
-				src_ip_ranges = ["10.0.0.0/24"]
-			}
-
 			expr {
-				title = "Has User"
-				description = "Determines whether the request has a user account"
-				expression = "size(request.user) > 0"
+				// These fields are not yet supported (Issue #4497: mbang)
+				// title = "Has User"
+				// description = "Determines whether the request has a user account"
+				expression = "evaluatePreconfiguredExpr('xss-canary')"
 			}
 		}
 		preview = true

--- a/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -249,7 +249,7 @@ resource "google_compute_security_policy" "policy" {
 		priority = "2000"
 		match {
 			expr {
-				// These fields are not yet supported (Issue #4497: mbang)
+				// These fields are not yet supported (Issue terraform-providers/terraform-provider-google#4497: mbang)
 				// title = "Has User"
 				// description = "Determines whether the request has a user account"
 				expression = "evaluatePreconfiguredExpr('xss-canary')"

--- a/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package google
 
 import (
@@ -53,6 +54,7 @@ func TestAccComputeSecurityPolicy_withRule(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
 func TestAccComputeSecurityPolicy_withRuleExpr(t *testing.T) {
 	t.Parallel()
 
@@ -74,6 +76,7 @@ func TestAccComputeSecurityPolicy_withRuleExpr(t *testing.T) {
 		},
 	})
 }
+<% end -%>
 
 func TestAccComputeSecurityPolicy_update(t *testing.T) {
 	t.Parallel()
@@ -175,40 +178,6 @@ resource "google_compute_security_policy" "policy" {
 `, spName)
 }
 
-func testAccComputeSecurityPolicy_withRuleExpr(spName string) string {
-	return fmt.Sprintf(`
-resource "google_compute_security_policy" "policy" {
-	name = "%s"
-
-	rule {
-		action   = "allow"
-		priority = "2147483647"
-		match {
-			versioned_expr = "SRC_IPS_V1"
-			config {
-				src_ip_ranges = ["*"]
-			}
-		}
-		description = "default rule"
-	}
-
-	rule {
-		action   = "allow"
-		priority = "2000"
-		match {
-			expr {
-				// These fields are not yet supported (Issue #4497: mbang)
-				// title = "Has User"
-				// description = "Determines whether the request has a user account"
-				expression = "evaluatePreconfiguredExpr('xss-canary')"
-			}
-		}
-		preview = true
-	}
-}
-`, spName)
-}
-
 func testAccComputeSecurityPolicy_update(spName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_security_policy" "policy" {
@@ -256,3 +225,39 @@ resource "google_compute_security_policy" "policy" {
 }
 `, spName)
 }
+
+<% unless version == 'ga' -%>
+func testAccComputeSecurityPolicy_withRuleExpr(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+	name = "%s"
+
+	rule {
+		action   = "allow"
+		priority = "2147483647"
+		match {
+			versioned_expr = "SRC_IPS_V1"
+			config {
+				src_ip_ranges = ["*"]
+			}
+		}
+		description = "default rule"
+	}
+
+	rule {
+		action   = "allow"
+		priority = "2000"
+		match {
+			expr {
+				// These fields are not yet supported (Issue #4497: mbang)
+				// title = "Has User"
+				// description = "Determines whether the request has a user account"
+				expression = "evaluatePreconfiguredExpr('xss-canary')"
+			}
+		}
+		preview = true
+	}
+}
+`, spName)
+}
+<% end -%>

--- a/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -83,17 +83,28 @@ The `rule` block supports:
 
 The `match` block supports:
 
-* `config` - (Required) The configuration options available when specifying `versioned_expr`.
+* `config` - (Optional) The configuration options available when specifying `versioned_expr`.
+    This field must be specified if `versioned_expr` is specified and cannot be specified if `versioned_expr` is not specified.
     Structure is documented below.
 
-* `versioned_expr` - (Required) Predefined rule expression. Available options:
+* `versioned_expr` - (Optional) Predefined rule expression. If this field is specified, `config` must also be specified.
+    Available options:
     * SRC_IPS_V1: Must specify the corresponding `src_ip_ranges` field in `config`.
+
+* `expr` - (Optional) User defined CEVAL expression. A CEVAL expression is used to specify match criteria
+    such as origin.ip, source.region_code and contents in the request header.
+    Structure is documented below.
 
 The `config` block supports:
 
 * `src_ip_ranges` - (Required) Set of IP addresses or ranges (IPV4 or IPV6) in CIDR notation
     to match against inbound traffic. There is a limit of 5 IP ranges per rule. A value of '\*' matches all IPs
     (can be used to override the default behavior).
+
+The `expr` block supports:
+
+* `expression` - (Required) Textual representation of an expression in Common Expression Language syntax.
+    The application context of the containing message determines which well-known feature set of CEL is supported.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4497
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4994

Add `expr` to `google_compute_security_policy.rule.match`
Note the `title`, `description` and `location` fields are not yet supported.  I left them commented out to add them back in easily, but can remove them if that's preferred to keep the codebase clean.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
`compute`: added support for `expr` to `google_compute_security_policy.rule.match`
```
