### PR TITLE
Update RELEASE_NOTES_GUIDE.md

### DIFF
--- a/.ci/RELEASE_NOTES_GUIDE.md
+++ b/.ci/RELEASE_NOTES_GUIDE.md
@@ -171,7 +171,7 @@ compute: Fix permadiff on description for `google_compute_instance`
 ```
 ~~~
 
-This doesn't use the past tense. Readers of teh changelog will be reading what _happened_ in a release,
+This doesn't use the past tense. Readers of the changelog will be reading what _happened_ in a release,
 so the language should be that of describing what happened. Imagine you're answering the question
 "what changed since the last version?"
 

--- a/.ci/RELEASE_NOTES_GUIDE.md
+++ b/.ci/RELEASE_NOTES_GUIDE.md
@@ -48,6 +48,29 @@ container: Added general field `location` to `google_container_cluster`
 Do not indent the block and make sure to leave newlines, so you don't confuse
 the Markdown parser.
 
+## Headings
+
+Release notes should be formatted with one of the following headings:
+- `release-note:enhancement`
+- `release-note:bug`
+- `release-note:note`
+- `release-note:new-resource`
+- `release-note:new-datasource`
+- `release-note:deprecation`
+- `release-note:breaking-change`
+- `release-note:none`
+
+However, any note with a language heading starting with ```release-note:... will get copied.
+
+## Non-User-Facing PRs
+
+Any PR that should not have any impact on users (test fixes, code generation, website updates,
+CI changes, etc.) should use a `release-note:none` block. It can be left empty, or can be
+optionally filled with an explanation of why the PR is not user-facing.
+
+By including this block explicitly, it lets whoever is generating the changelog know that
+a release note was explicitly omitted, not just forgotten. It'll also let your PR pass any
+future automation around release note correctness checking.
 
 ## Release Note Style Guide (Terraform-specific)
 
@@ -58,6 +81,10 @@ Notes SHOULD:
   changes, deprecations, or new behavior.
 - Impersonal third person (no “I”, “you”, etc.)
 - Start with {{service}} if changing an existing resource (see below)
+
+Notes, breaking changes, and features are exceptions. These are more free-form and left to
+the discretion of the PR author and reviewer. The overarching goal should be a good user
+experience when reading the changelog.
 
 See examples below for good release notes.
 
@@ -109,51 +136,126 @@ container: deprecated `region` and `zone` on `google_container_unicorn`. Use `lo
 ```
 ~~~
 
-Notes: General tag for things that don’t have changes in provider but may be important to users. Syntax is slightly more flexible here. 
+**Notes:** General tag for things that don’t have changes in provider but may be important to users. Syntax is slightly more flexible here. 
 
 ```release-note:note
 Starting on Nov 1, 2019, Cloud Functions API will be private by default. Add appropriate bindings through `google_cloud_function_iam_*` resources to manage privileges for `google_cloud_function` resources created by Terraform.
 ```
+### Counter-examples:
 
-Don’t write notes like:
-- Add compute_instance resource
-  - not past tense
-  - no \`\` around resource
-  - doesn't start with service
-- Fix bug
-  - not past tense
-  - no indication of impact to users
-  - doesn't start with service
-- fixed a bug in google_compute_network
-  - no \`\` around resource
-  - doesn't start with service
-  - unclear impact to users
-- `google_project` now supports `blah`
-  - not past tense
-  - doesn't start with service
-- You can now create google_sql_instances in us-central1
-  - not past tense
-  - second person voice
-  - no \`\` around resource
-  - doesn't start with service
-- Adds support for `google_source_repo_repository`’s `url` field
-  - not past tense
-  - doesn't start with service
-- Users should now use location instead of zone/region on `google_container_unicorn`
-  - prescriptive instead of descriptive
-  - not past tense
-  - doesn't start with service
-  - would be fine after a "container: deprecated `location` field on `google_container_unicorn`."
+The following changelog entries are not ideal.
 
-## Headings
+#### No Type
 
-Release notes should be formatted with one of the following headings:
-- `release-note:enhancement`
-- `release-note:bug`
-- `release-note:note`
-- `release-note:new-resource`
-- `release-note:new-datasource`
-- `release-note:deprecation`
-- `release-note:breaking-change`
+~~~
+```release-note:REPLACEME
+compute: fixed permadiff on description for `google_compute_instance`
+```
+~~~
 
-However, any note with a language heading starting with ```release-note:... will get copied.
+This doesn't update the type of release note, which means it will need to be corrected at generation time.
+
+Better:
+
+~~~
+```release-note:bug
+compute: fixed permadiff on description for `google_compute_instance`
+```
+~~~
+
+### Not Past Tense
+
+~~~
+```release-note:bug
+compute: Fix permadiff on description for `google_compute_instance`
+```
+~~~
+
+This doesn't use the past tense. Readers of teh changelog will be reading what _happened_ in a release,
+so the language should be that of describing what happened. Imagine you're answering the question
+"what changed since the last version?"
+
+Better:
+
+~~~
+```release-note:bug
+compute: Fixed permadiff for `google_compute_instance`
+```
+~~~
+
+### No Service
+
+~~~
+```release-note:bug
+Fixed permadiff on description for `google_compute_instance`
+```
+~~~
+
+This doesn't start with a service name. By convention, we prefix all our bug and enhancement changelog
+entries with service names, and the other entries when it makes sense and seems beneficial. This helps
+sort the changelog and group related changes together, and helps users scan for the services they use.
+
+Better:
+
+~~~
+```release-note:bug
+compute: Fixed permadiff for `google_compute_instance`
+```
+~~~
+
+### Not User-Centric
+
+~~~
+```release-note:bug
+compute: made description Computed for `google_compute_instance`
+```
+~~~
+
+This isn't written for the right audience; our users don't all, or even mostly, know what Computed
+means, and shouldn't have to. Instead, describe the impact that this will have on them.
+
+Better:
+
+~~~
+```release-note:bug
+compute: fixed permadiff on description for `google_compute_instance`
+```
+~~~
+
+### Resource Instead of Service
+
+~~~
+```release-note:bug
+compute_instance: Fixed permadiff on description for `google_compute_instance`
+```
+~~~
+
+This uses the resource instead of the service as a prefix. 
+
+### Unticked Resource Names
+
+~~~
+```release-note:bug
+compute: Fixed permadiff on description for google_compute_instance
+```
+~~~
+
+This doesn't have \`\` marks around the resource name, which by convention we do. This sets the resource
+name apart, making it easer to notice.
+
+Better:
+
+~~~
+```release-note:bug
+compute: Fixed permadiff on description for `google_compute_instance`
+```
+~~~
+
+Choosing the right service name is a bit of an art. A good rule of thumb is if there's something
+besides the resource name after `google_`, use that. For example, `compute` is a good choice from
+`google_compute_instance`. Not every resource has that, however; for `google_project`, the service
+is not part of the resource address. In these cases, falling back on the name of the package the
+resource's APIs is implemented in (`resourcemanager`, for `google_project`) is a good call.
+
+Not every change applies only to one resource. Judgment is best here. When in doubt, `provider` is
+a good way to indicate sweeping changes that are likely to impact most users.

--- a/.ci/RELEASE_NOTES_GUIDE.md
+++ b/.ci/RELEASE_NOTES_GUIDE.md
@@ -23,7 +23,7 @@ PR Description
 ...
 
 ```release-note:enhancement
-`compute`: Fixed permadiff for `bar` in `google_compute_foo`
+compute: Fixed permadiff for `bar` in `google_compute_foo`
 ```
 ~~~
 
@@ -36,11 +36,11 @@ PR Description
 ...
 
 ```release-note:deprecation
-Deprecated `region` for `google_container_cluster` - use location instead.
+container: Deprecated `region` for `google_container_cluster` - use location instead.
 ```
 
 ```release-note:enhancement
-`container`: Added general field `location` to `google_container_cluster`
+container: Added general field `location` to `google_container_cluster`
 ```
 ~~~
 
@@ -57,7 +57,7 @@ Notes SHOULD:
 - Only use present tense to suggest future behavior, i.e. for breaking
   changes, deprecations, or new behavior.
 - Impersonal third person (no “I”, “you”, etc.)
-- Start with `{{service}}` if changing an existing resource (see below)
+- Start with {{service}} if changing an existing resource (see below)
 
 See examples below for good release notes.
 
@@ -67,14 +67,14 @@ See examples below for good release notes.
 
 ~~~
 ```release-note:enhancement
-`compute`: added `foo_bar` field to `google_compute_foo` resource
+compute: added `foo_bar` field to `google_compute_foo` resource
 ```
 ~~~
 **Bugs:** fixing existing resources
 
 ~~~
 ```release-note:bug
-`container`: fixed perma-diff in `google_container_cluster`
+container: fixed perma-diff in `google_container_cluster`
 ```
 ~~~
 
@@ -82,7 +82,7 @@ See examples below for good release notes.
 
 ~~~
 ```release-note:breaking-change
-`project`: made `iam_policy` authoritative
+project: made `iam_policy` authoritative
 ```
 ~~~
 
@@ -90,7 +90,7 @@ See examples below for good release notes.
 
 ~~~
 ``` release-note:deprecation
-`container`: deprecated `region` and `zone` on `google_container_unicorn`. Use `location` instead.
+container: deprecated `region` and `zone` on `google_container_unicorn`. Use `location` instead.
 ```
 ~~~
 
@@ -117,12 +117,33 @@ Starting on Nov 1, 2019, Cloud Functions API will be private by default. Add app
 
 Don’t write notes like:
 - Add compute_instance resource
+  - not past tense
+  - no \`\` around resource
+  - doesn't start with service
 - Fix bug
+  - not past tense
+  - no indication of impact to users
+  - doesn't start with service
 - fixed a bug in google_compute_network
+  - no \`\` around resource
+  - doesn't start with service
+  - unclear impact to users
 - `google_project` now supports `blah`
+  - not past tense
+  - doesn't start with service
 - You can now create google_sql_instances in us-central1
+  - not past tense
+  - second person voice
+  - no \`\` around resource
+  - doesn't start with service
 - Adds support for `google_source_repo_repository`’s `url` field
+  - not past tense
+  - doesn't start with service
 - Users should now use location instead of zone/region on `google_container_unicorn`
+  - prescriptive instead of descriptive
+  - not past tense
+  - doesn't start with service
+  - would be fine after a "container: deprecated `location` field on `google_container_unicorn`."
 
 ## Headings
 

--- a/.ci/RELEASE_NOTES_GUIDE.md
+++ b/.ci/RELEASE_NOTES_GUIDE.md
@@ -232,6 +232,23 @@ compute_instance: Fixed permadiff on description for `google_compute_instance`
 
 This uses the resource instead of the service as a prefix. 
 
+Better:
+
+~~~
+```release-note:bug
+compute: Fixed permadiff on description for `google_compute_instance`
+```
+~~~
+
+Choosing the right service name is a bit of an art. A good rule of thumb is if there's something
+besides the resource name after `google_`, use that. For example, `compute` is a good choice from
+`google_compute_instance`. Not every resource has that, however; for `google_project`, the service
+is not part of the resource address. In these cases, falling back on the name of the package the
+resource's APIs is implemented in (`resourcemanager`, for `google_project`) is a good call.
+
+Not every change applies only to one resource. Judgment is best here. When in doubt, `provider` is
+a good way to indicate sweeping changes that are likely to impact most users.
+
 ### Unticked Resource Names
 
 ~~~
@@ -250,12 +267,3 @@ Better:
 compute: Fixed permadiff on description for `google_compute_instance`
 ```
 ~~~
-
-Choosing the right service name is a bit of an art. A good rule of thumb is if there's something
-besides the resource name after `google_`, use that. For example, `compute` is a good choice from
-`google_compute_instance`. Not every resource has that, however; for `google_project`, the service
-is not part of the resource address. In these cases, falling back on the name of the package the
-resource's APIs is implemented in (`resourcemanager`, for `google_project`) is a good call.
-
-Not every change applies only to one resource. Judgment is best here. When in doubt, `provider` is
-a good way to indicate sweeping changes that are likely to impact most users.

--- a/.ci/RELEASE_NOTES_GUIDE.md
+++ b/.ci/RELEASE_NOTES_GUIDE.md
@@ -199,7 +199,7 @@ Better:
 
 ~~~
 ```release-note:bug
-compute: Fixed permadiff for `google_compute_instance`
+compute: Fixed permadiff on description for `google_compute_instance`
 ```
 ~~~
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

I took a spin through our CHANGELOG authoring guidelines. There are basically two changes here that I made:

* I removed the \`\` around the service names at the start. This is almost certainly my fault, I probably suggested this when creating the style guide, but it looks like I just confused myself. Historically, we have almost always done service names _without_ \`\`, except for a brief period where I confused myself. I think aligning with the vast majority of our CHANGELOG here is probably the right move, so I updated to reflect it.
* I added notes on _why_ the counter-examples are counter-examples, to help explain what's wrong with them.
