### PR TITLE
DNS managed zone DS test ignores for beta-only fields

### DIFF
--- a/third_party/terraform/tests/data_source_dns_managed_zone_test.go
+++ b/third_party/terraform/tests/data_source_dns_managed_zone_test.go
@@ -24,6 +24,8 @@ func TestAccDataSourceDnsManagedZone_basic(t *testing.T) {
 					map[string]struct{}{
 						"dnssec_config.#":             {},
 						"private_visibility_config.#": {},
+						"peering_config.#":            {},
+						"forwarding_config.#":         {},
 					},
 				),
 			},

--- a/third_party/terraform/tests/data_source_dns_managed_zone_test.go.erb
+++ b/third_party/terraform/tests/data_source_dns_managed_zone_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package google
 
 import (
@@ -24,8 +25,10 @@ func TestAccDataSourceDnsManagedZone_basic(t *testing.T) {
 					map[string]struct{}{
 						"dnssec_config.#":             {},
 						"private_visibility_config.#": {},
+<% unless version == "ga" -%>
 						"peering_config.#":            {},
 						"forwarding_config.#":         {},
+<% end -%>
 					},
 				),
 			},


### PR DESCRIPTION
Fixes TestAccDataSourceDnsManagedZone_basic in beta which gets extra fields in the response

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

