### PR TITLE
Remove more url map path matching files with long names

### DIFF
--- a/products/compute/inspec.yaml
+++ b/products/compute/inspec.yaml
@@ -99,6 +99,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       pathMatchers.routeRules: !ruby/object:Overrides::Inspec::PropertyOverride
         exclude: true
+      pathMatchers.pathRules: !ruby/object:Overrides::Inspec::PropertyOverride
+        exclude: true
   VpnTunnel: !ruby/object:Overrides::Inspec::ResourceOverride
     exclude: true
   Zone: !ruby/object:Overrides::Inspec::ResourceOverride


### PR DESCRIPTION
Long names in generated files are causing issues with the ruby tar extractor, so we are excluding these until we can find a workaround

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
