### PR TITLE
Allow for no-release-note to be used in relesenote block

### DIFF
--- a/.ci/changelog.tmpl
+++ b/.ci/changelog.tmpl
@@ -18,6 +18,7 @@
 		{{$improvements = append $improvements (renderReleaseNote .) -}}
 	{{ else if eq "bug" .Type -}}
 		{{$bugs = append $bugs (renderReleaseNote .) -}}
+	{{ else if eq "none" .Type -}}
 	{{ else -}}
 		{{$unknown = append $unknown (renderReleaseNote .) -}}
 	{{end -}}

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,7 @@ For Terraform PRs, we use the following "release-note:" headings
     - release-note:new-datasource
     - release-note:deprecation
     - release-note:breaking-change
+    - release-note:none
 -->
 
 **Release Note Template for Downstream PRs (will be copied)**


### PR DESCRIPTION
fixes https://github.com/GoogleCloudPlatform/magic-modules/issues/2792

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:no-release-note
No release note is needed for this change. This is just here to add context. 
For example this change doesn't affect the terraform provider
```
