### PR TITLE
Promote region health check to GA

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -9003,7 +9003,6 @@ objects:
                 should be mapped to.
   - !ruby/object:Api::Resource
     name: 'RegionHealthCheck'
-    min_version: beta
     kind: 'compute#healthCheck'
     base_url: projects/{{project}}/regions/{{region}}/healthChecks
     collection_url_key: 'items'

--- a/templates/terraform/examples/region_health_check_http.tf.erb
+++ b/templates/terraform/examples/region_health_check_http.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_region_health_check" "http-region-health-check" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['health_check_name'] %>"
 
   timeout_sec        = 1

--- a/templates/terraform/examples/region_health_check_http2.tf.erb
+++ b/templates/terraform/examples/region_health_check_http2.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_region_health_check" "http2-region-health-check" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['health_check_name'] %>"
 
   timeout_sec        = 1

--- a/templates/terraform/examples/region_health_check_http2_full.tf.erb
+++ b/templates/terraform/examples/region_health_check_http2_full.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_region_health_check" "http2-region-health-check" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['health_check_name'] %>"
   description = "Health check via http2"
 

--- a/templates/terraform/examples/region_health_check_http_full.tf.erb
+++ b/templates/terraform/examples/region_health_check_http_full.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_region_health_check" "http-region-health-check" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['health_check_name'] %>"
   description = "Health check via http"
 

--- a/templates/terraform/examples/region_health_check_https.tf.erb
+++ b/templates/terraform/examples/region_health_check_https.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_region_health_check" "https-region-health-check" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['health_check_name'] %>"
 
   timeout_sec        = 1

--- a/templates/terraform/examples/region_health_check_https_full.tf.erb
+++ b/templates/terraform/examples/region_health_check_https_full.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_region_health_check" "https-region-health-check" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['health_check_name'] %>"
   description = "Health check via https"
 

--- a/templates/terraform/examples/region_health_check_ssl.tf.erb
+++ b/templates/terraform/examples/region_health_check_ssl.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_region_health_check" "ssl-region-health-check" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['health_check_name'] %>"
 
   timeout_sec        = 1

--- a/templates/terraform/examples/region_health_check_ssl_full.tf.erb
+++ b/templates/terraform/examples/region_health_check_ssl_full.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_region_health_check" "ssl-region-health-check" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['health_check_name'] %>"
   description = "Health check via ssl"
 

--- a/templates/terraform/examples/region_health_check_tcp.tf.erb
+++ b/templates/terraform/examples/region_health_check_tcp.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_region_health_check" "tcp-region-health-check" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['health_check_name'] %>"
 
   timeout_sec        = 1

--- a/templates/terraform/examples/region_health_check_tcp_full.tf.erb
+++ b/templates/terraform/examples/region_health_check_tcp_full.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_region_health_check" "tcp-region-health-check" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['health_check_name'] %>"
   description = "Health check via tcp"
 

--- a/third_party/terraform/tests/resource_compute_region_health_check_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_health_check_test.go.erb
@@ -1,7 +1,6 @@
 <% autogen_exception -%>
 package google
 
-<% unless version == 'ga' -%>
 import (
 	"fmt"
 	"regexp"
@@ -343,4 +342,3 @@ resource "google_compute_region_health_check" "foobar" {
 }
 `, hckName)
 }
-<% end -%>


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_compute_region_health_check` has been promoted to GA.
```
