### PR TITLE
Changing Ansible Repo on Concourse

### DIFF
--- a/.ci/acceptance-tests/ansible-integration.sh
+++ b/.ci/acceptance-tests/ansible-integration.sh
@@ -17,7 +17,7 @@ popd
 
 # Clone ansible_collections_google because submodules
 # break collections
-git clone https://github.com/ansible/ansible_collections_google.git
+git clone https://github.com/ansible-collections/ansible_collections_google.git
 
 # Build newest modules
 pushd magic-modules-gcp

--- a/.ci/ci.yml.tmpl
+++ b/.ci/ci.yml.tmpl
@@ -455,7 +455,7 @@ jobs:
                 GITHUB_TOKEN: ((github-account.password))
                 # This is what tells us which terraform repo to write PRs against - this
                 # is what you change if you want to test this in a non-live environment.
-                ANSIBLE_REPO_USER: ansible
+                ANSIBLE_REPO_USER: ansible-collections
                 INSPEC_REPO_USER: modular-magician
                 TERRAFORM_VERSIONS: "{{','.join(vars.terraform_properties_serialized)}}"
             on_failure:


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->
Ansible changed the downstream repo to https://github.com/ansible-collections/ansible_collections_google.git

Everything was copied over by GitHub (including forks), so we should be good to go.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
