### PR TITLE
add support for source repositories with forward slashes in their names

### DIFF
--- a/api/resource/iam_policy.rb
+++ b/api/resource/iam_policy.rb
@@ -90,6 +90,12 @@ module Api
       # variables that are outside of the base_url qualifiers.
       attr_reader :import_format
 
+      # This code replaces the portion of code that manipulates the import format after getting
+      # the import id qualifiers.  It's useful in checking the the qualifiers were parsed correctly
+      # in cases that they may not have been (for example, if the name of the resource has a forward
+      # slash in it)
+      attr_reader :custom_import
+
       def validate
         super
 

--- a/products/sourcerepo/terraform.yaml
+++ b/products/sourcerepo/terraform.yaml
@@ -19,6 +19,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       exclude: false
       method_name_separator: ':'
       parent_resource_attribute: 'repository'
+      custom_import: templates/terraform/custom_import/source_repo_name_from_self_link_iam.go.erb
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "sourcerepo_repository_basic"
@@ -43,6 +44,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       pubsubConfigs.serviceAccountEmail: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
+      custom_import: templates/terraform/custom_import/source_repo_name_from_self_link.go.erb
       update_encoder: templates/terraform/update_encoder/source_repo_repository.erb
       post_create: templates/terraform/post_create/source_repo_repository_update.go.erb
 # This is for copying files over

--- a/products/sourcerepo/terraform.yaml
+++ b/products/sourcerepo/terraform.yaml
@@ -24,9 +24,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "sourcerepo_repository_basic"
         primary_resource_id: "my-repo"
-        primary_resource_name: "fmt.Sprintf(\"my-repository%s\", context[\"random_suffix\"])"
+        primary_resource_name: "fmt.Sprintf(\"my-repository/%s\", context[\"random_suffix\"])"
         vars:
-          repository_name: "my-repository"
+          repository_name: "my-repository/"
       - !ruby/object:Provider::Terraform::Examples
         name: "sourcerepo_repository_full"
         primary_resource_id: "my-repo"

--- a/templates/terraform/custom_import/source_repo_name_from_self_link.go.erb
+++ b/templates/terraform/custom_import/source_repo_name_from_self_link.go.erb
@@ -1,0 +1,20 @@
+
+	config := meta.(*Config)
+
+	// current import_formats can't import fields with forward slashes in their value
+	if err := parseImportId([]string{"(?P<name>.+)"}, d, config); err != nil {
+		return nil, err
+	}
+
+	stringParts := strings.SplitN(d.Get("name").(string), "/", 4)
+	if len(stringParts) != 4 {
+		return nil, fmt.Errorf(
+				"Saw %s when the name is expected to have shape %s",
+				d.Get("name"),
+				"projects/{{project}}/repos/{{repository}}",
+			)
+	}
+
+	d.Set("project", stringParts[1])
+	d.Set("name", stringParts[3])
+	return []*schema.ResourceData{d}, nil

--- a/templates/terraform/custom_import/source_repo_name_from_self_link_iam.go.erb
+++ b/templates/terraform/custom_import/source_repo_name_from_self_link_iam.go.erb
@@ -1,0 +1,10 @@
+
+	repo := values["repository"]
+	if repo == "" {
+		repo = d.Id()
+	}
+
+	stringParts := strings.SplitN(repo, "/", 4)
+	if len(stringParts) == 4 {
+		values["repository"] = stringParts[3]
+	}

--- a/templates/terraform/iam_policy.go.erb
+++ b/templates/terraform/iam_policy.go.erb
@@ -87,6 +87,9 @@ func <%= resource_name -%>IamUpdaterProducer(d *schema.ResourceData, config *Con
 
 <% end # if provider_default_values.include? -%>
 <% end # resource_params.each -%>
+<% if object.custom_code.custom_import -%>
+<%= lines(compile(object.iam_policy.custom_import)) -%>
+<% else -%>
 <% import_format = object.iam_policy.import_format || object.import_format -%>
 
 	// We may have gotten either a long or short name, so attempt to parse long name if possible
@@ -98,6 +101,7 @@ func <%= resource_name -%>IamUpdaterProducer(d *schema.ResourceData, config *Con
 	for k, v := range m {
 		values[k] = v
 	}
+<% end -%>
 
 	u := &<%= resource_name -%>IamUpdater{
 <% resource_params.each do |param| -%>
@@ -138,6 +142,9 @@ func <%= resource_name -%>IdParseFunc(d *schema.ResourceData, config *Config) er
 <% end # if provider_default_values.include? -%>
 <% end # resource_params.each -%>
 
+<% if object.custom_code.custom_import -%>
+<%= lines(compile(object.iam_policy.custom_import)) -%>
+<% else -%>
 	m, err := getImportIdQualifiers([]string{"<%= import_id_formats(import_format, object.identity, object.base_url).map{|s| format2regex s}.map{|s| s.gsub('<name>', "<#{parent_resource_name}>")}.join('","') -%>"}, d, config, d.Id())
 	if err != nil {
 		return err
@@ -146,6 +153,7 @@ func <%= resource_name -%>IdParseFunc(d *schema.ResourceData, config *Config) er
 	for k, v := range m {
     values[k] = v
 	}
+<% end -%>
 
 	u := &<%= resource_name -%>IamUpdater{
 <% resource_params.each do |param| -%>


### PR DESCRIPTION
add support for source repositories with forward slashes in their names

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME
sourcerepo: added support for source repositories with forward slashes in their names.
```
