### PR TITLE
Managed certificates support 100 domains, not 1

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -10903,8 +10903,8 @@ objects:
             name: 'domains'
             description: |
               Domains for which a managed SSL certificate will be valid.  Currently,
-              there can only be one domain in this list.
-            max_size: 1
+              there can be up to 100 domains in this list.
+            max_size: 100
             item_type: Api::Type::String
             required: true
       - !ruby/object:Api::Type::Enum


### PR DESCRIPTION
Per https://cloud.google.com/load-balancing/docs/ssl-certificates#certificate-types:
> Google-managed SSL certificates are certificates that Google Cloud obtains and manages for your domains, renewing them automatically. This type can only be Domain Validation (DV) certificates. They do not demonstrate the identity of an organization or individual associated with the certificate, and they do not support wildcard common names. Multiple subject alternate names are supported, in beta; each Google-managed SSL certificate supports **up to 100 domain names**. One certificate for multiple domains is issued per Google-managed certificate entity.

Emphasis mine.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
