### PR TITLE
update node pool workload metada config attribute

### DIFF
--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -857,6 +857,38 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 			d.SetPartial("upgrade_settings")
 		}
 	}
+
+	if d.HasChange(prefix + "workload_metadata_config") {
+		workloadMetadata := &containerBeta.WorkloadMetadataConfig{}
+		if v, ok := d.GetOk(prefix + "workload_metadata_config"); ok {
+			workloadMetadataConfig := v.([]interface{})[0].(map[string]interface{})
+			workloadMetadata.NodeMetadata = string(workloadMetadataConfig["node_metadata"].(string))
+		}
+		req := &containerBeta.UpdateNodePoolRequest{
+			WorkloadMetadataConfig: workloadMetadata,
+		}
+		updateF := func() error {
+			op, err := config.clientContainerBeta.Projects.Locations.Clusters.NodePools.Update(nodePoolInfo.fullyQualifiedName(name), req).Do()
+
+			if err != nil {
+				return err
+			}
+
+			// Wait until it's updated
+			return containerOperationWait(config, op, nodePoolInfo.project, nodePoolInfo.location, "updating GKE node pool workload metadata config", timeoutInMinutes)
+		}
+
+		// Call update serially.
+		if err := lockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] Updated workload metadata config in Node Pool %s", name)
+
+		if prefix == "" {
+			d.SetPartial("workload_metadata_config")
+		}
+	}
 <% end -%>
 
 	return nil

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -178,7 +178,7 @@ func TestAccContainerNodePool_withWorkloadMetadataConfig(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerNodePool_withWorkloadMetadataConfig(cluster, np),
+				Config: testAccContainerNodePool_withWorkloadMetadataConfig(cluster, np, "SECURE"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_container_node_pool.with_workload_metadata_config",
 						"node_config.0.workload_metadata_config.0.node_metadata", "SECURE"),
@@ -193,6 +193,13 @@ func TestAccContainerNodePool_withWorkloadMetadataConfig(t *testing.T) {
 					"node_config.0.workload_metadata_config.#",
 					"node_config.0.workload_metadata_config.0.node_metadata",
 				},
+			},
+			{
+				Config: testAccContainerNodePool_withWorkloadMetadataConfig(cluster, np, "EXPOSE"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_container_node_pool.with_workload_metadata_config",
+						"node_config.0.workload_metadata_config.0.node_metadata", "EXPOSE"),
+				),
 			},
 		},
 	})
@@ -1149,7 +1156,7 @@ resource "google_container_node_pool" "np_with_node_config" {
 }
 
 <% unless version.nil? || version == 'ga' -%>
-func testAccContainerNodePool_withWorkloadMetadataConfig(cluster, np string) string {
+func testAccContainerNodePool_withWorkloadMetadataConfig(cluster, np, nm string) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
   location = "us-central1-a"
@@ -1174,11 +1181,11 @@ resource "google_container_node_pool" "with_workload_metadata_config" {
     ]
 
     workload_metadata_config {
-      node_metadata = "SECURE"
+      node_metadata = "%s"
     }
   }
 }
-`, cluster, np)
+`, cluster, np, nm)
 }
 
 func testAccContainerNodePool_withWorkloadMetadataConfig_gkeMetadataServer(projectID, cluster, np string) string {

--- a/third_party/terraform/utils/node_config.go.erb
+++ b/third_party/terraform/utils/node_config.go.erb
@@ -210,14 +210,12 @@ var schemaNodeConfig = &schema.Schema{
 <% end -%>
 				Type:       schema.TypeList,
 				Optional:   true,
-				ForceNew:   true,
 				MaxItems:   1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"node_metadata": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ForceNew:     true,
 							ValidateFunc: validation.StringInSlice([]string{"UNSPECIFIED", "SECURE", "EXPOSE", "GKE_METADATA_SERVER"}, false),
 						},
 					},


### PR DESCRIPTION
Hello.

First, thank you for magic-modules.

I'm trying to fix https://github.com/terraform-providers/terraform-provider-google/issues/4041 but I'm struggling where I should make the change and how can I test the effects.

I can see the tests for `workload_metadata_config` were stripped out when the field moved from `google` to `google-beta` (https://github.com/GoogleCloudPlatform/magic-modules/pull/1008). The beta provider doesn't has any tests?

Where can I find an example to help me with the issue?

I'd appreciate you share your comments on this. Thank you!