### PR TITLE
Fixes discovered in testing GCB/GH differ.

### DIFF
--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -64,16 +64,12 @@ fi
 
 if [ "$REPO" == "terraform" ]; then
     pushd $LOCAL_PATH
-    go get -v
     find . -type f -not -wholename "./.git*" -not -wholename "./vendor*" -not -name ".travis.yml" -not -name ".golangci.yml" -not -name "CHANGELOG.md" -not -name "GNUmakefile" -not -name "docscheck.sh" -not -name "LICENSE" -not -name "README.md" -not -wholename "./examples*" -not -name "go.mod" -not -name "go.sum" -not -name "staticcheck.conf" -not -name ".go-version" -not -name ".hashibot.hcl" -not -name "tools.go"  -exec git rm {} \;
-    popd
-elif [ "$REPO" == "tf-conversion" ]; then
-    pushd $LOCAL_PATH
-    go get -v ./google
     popd
 fi
 
 if [ "$REPO" == "tf-conversion" ]; then
+    # Special case - use terraform generator with validator overrides.
     bundle exec compiler -a -e terraform -f validator -o $LOCAL_PATH -v $VERSION
 else
     bundle exec compiler -a -e $REPO -o $LOCAL_PATH -v $VERSION

--- a/.ci/containers/github-differ/Dockerfile
+++ b/.ci/containers/github-differ/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine/git
 
 RUN apk add --no-cache curl
+RUN apk add --no-cache curl-dev
 RUN apk add --no-cache bash
 ADD generate_comment.sh /generate_comment.sh
 ENTRYPOINT ["/generate_comment.sh"]

--- a/.ci/containers/github-differ/generate_comment.sh
+++ b/.ci/containers/github-differ/generate_comment.sh
@@ -85,6 +85,6 @@ else
     DIFFS="Hi!  I'm the modular magician.  Your PR generated some diffs in downstreams - here they are.$NEWLINE# Diff report:$NEWLINE$NEWLINE$DIFFS"
 fi
 
-curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
-     -X POST -d "{\"body\": \"$DIFFS\"}" \
+curl -H "Authorization: token ${GITHUB_TOKEN}" \
+     -d "{\"body\": \"$DIFFS\"}" \
       "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}/comments"

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -1,8 +1,44 @@
 ---
 steps:
+    - name: 'alpine'
+      args:
+          - sh
+          - -c
+          - rm -rfv ./* ./.* || true
+    - name: 'alpine'
+      args:
+          - ls
+          - -lash
+    - name: 'gcr.io/cloud-builders/git'
+      args:
+          - clone
+          - https://github.com/GoogleCloudPlatform/magic-modules
+          - .
+    - name: 'gcr.io/cloud-builders/git'
+      args:
+          - config
+          - --global
+          - user.email
+          - magic-modules+differ@google.com
+    - name: 'gcr.io/cloud-builders/git'
+      args:
+          - config
+          - --global
+          - user.name
+          - "Modular Magician Diff Process"
+    - name: 'gcr.io/cloud-builders/git'
+      args:
+          - checkout
+          - $_HEAD_BRANCH
+    - name: 'gcr.io/cloud-builders/git'
+      id: merged
+      args:
+          - merge
+          - origin/$_BASE_BRANCH
+
     - name: 'gcr.io/graphite-docker-images/downstream-builder'
       secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["-"]
+      waitFor: ["merged"]
       args:
           - 'head'
           - 'terraform'
@@ -11,7 +47,7 @@ steps:
 
     - name: 'gcr.io/graphite-docker-images/downstream-builder'
       secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["-"]
+      waitFor: ["merged"]
       args:
           - 'base'
           - 'terraform'
@@ -20,7 +56,7 @@ steps:
 
     - name: 'gcr.io/graphite-docker-images/downstream-builder'
       secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["-"]
+      waitFor: ["merged"]
       args:
           - 'head'
           - 'terraform'
@@ -29,7 +65,7 @@ steps:
 
     - name: 'gcr.io/graphite-docker-images/downstream-builder'
       secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["-"]
+      waitFor: ["merged"]
       args:
           - 'base'
           - 'terraform'
@@ -38,7 +74,7 @@ steps:
 
     - name: 'gcr.io/graphite-docker-images/downstream-builder'
       secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["-"]
+      waitFor: ["merged"]
       args:
           - 'head'
           - 'ansible'
@@ -47,7 +83,7 @@ steps:
 
     - name: 'gcr.io/graphite-docker-images/downstream-builder'
       secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["-"]
+      waitFor: ["merged"]
       args:
           - 'base'
           - 'ansible'
@@ -56,7 +92,7 @@ steps:
 
     - name: 'gcr.io/graphite-docker-images/downstream-builder'
       secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["-"]
+      waitFor: ["merged"]
       args:
           - 'head'
           - 'inspec'
@@ -65,7 +101,7 @@ steps:
 
     - name: 'gcr.io/graphite-docker-images/downstream-builder'
       secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["-"]
+      waitFor: ["merged"]
       args:
           - 'base'
           - 'inspec'
@@ -74,7 +110,7 @@ steps:
 
     - name: 'gcr.io/graphite-docker-images/downstream-builder'
       secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["-"]
+      waitFor: ["merged"]
       args:
           - 'head'
           - 'tf-conversion'
@@ -83,7 +119,7 @@ steps:
 
     - name: 'gcr.io/graphite-docker-images/downstream-builder'
       secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["-"]
+      waitFor: ["merged"]
       args:
           - 'base'
           - 'tf-conversion'
@@ -94,6 +130,9 @@ steps:
       secretEnv: ["GITHUB_TOKEN"]
       args:
           - $_PR_NUMBER
+
+options:
+    machineType: 'N1_HIGHCPU_8'
 
 secrets:
     - kmsKeyName: projects/graphite-docker-images/locations/global/keyRings/token-keyring/cryptoKeys/github-token

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -1,19 +1,24 @@
 ---
 steps:
+    # The GCB / GH integration doesn't satisfy our use case perfectly.
+    # It doesn't check out the merge commit, and it doesn't check out the repo
+    # itself - it only gives us the actual code, not the repo. So we need
+    # to handle that access ourselves - which means deleting the code
+    # and cloning the repo to the present directory.  We need to use
+    # 'sh' to evaluate the '*' arguments, which otherwise would be
+    # passed literally to 'rm'.
     - name: 'alpine'
       args:
           - sh
           - -c
-          - rm -rfv ./* ./.* || true
-    - name: 'alpine'
-      args:
-          - ls
-          - -lash
+          - rm -rf ./* ./.* || true
     - name: 'gcr.io/cloud-builders/git'
       args:
           - clone
           - https://github.com/GoogleCloudPlatform/magic-modules
           - .
+    # We need to configure git since creating the merge commit is
+    # technically a commit.
     - name: 'gcr.io/cloud-builders/git'
       args:
           - config
@@ -26,6 +31,9 @@ steps:
           - --global
           - user.name
           - "Modular Magician Diff Process"
+    # Then we check out the branch provided, and merge it into
+    # the base branch provided.  This matches the behavior
+    # we're used to from Concourse.
     - name: 'gcr.io/cloud-builders/git'
       args:
           - checkout


### PR DESCRIPTION
The GCB / GH integration doesn't satisfy our use case perfectly.
It doesn't check out the merge commit, and it doesn't check out the repo
itself - it only gives us the actual *code*, not the repo.  So we need
to handle that access ourselves in the beginning.  We also need a
beefier machine to make this work in a reasonable amount of time.

Finally, we are apparently okay to skip `go get` in this version.