### PR TITLE
Inspec beta flag on resources

### DIFF
--- a/.ci/acceptance-tests/inspec-post-approve.sh
+++ b/.ci/acceptance-tests/inspec-post-approve.sh
@@ -37,7 +37,7 @@ export VCR_MODE=all
 # Running other controls may cause caching issues due to underlying clients caching responses
 rm build/inspec/test/integration/verify/controls/*
 bundle install
-bundle exec compiler -a -e inspec -o "build/inspec/"
+bundle exec compiler -a -e inspec -o "build/inspec/" -v beta
 cp templates/inspec/vcr_config.rb build/inspec
 
 pushd build/inspec

--- a/.ci/acceptance-tests/inspec-post-merge.sh
+++ b/.ci/acceptance-tests/inspec-post-merge.sh
@@ -36,7 +36,7 @@ export VCR_MODE=all
 # Running other controls may cause caching issues due to underlying clients caching responses
 rm build/inspec/test/integration/verify/controls/*
 bundle install
-bundle exec compiler -a -e inspec -o "build/inspec/"
+bundle exec compiler -a -e inspec -o "build/inspec/" -v beta
 cp templates/inspec/vcr_config.rb build/inspec
 
 pushd build/inspec

--- a/.ci/acceptance-tests/inspec-vcr.sh
+++ b/.ci/acceptance-tests/inspec-vcr.sh
@@ -26,7 +26,7 @@ export VCR_MODE=all
 # Running other controls may cause caching issues due to underlying clients caching responses
 rm build/inspec/test/integration/verify/controls/*
 bundle install
-bundle exec compiler -a -e inspec -o "build/inspec/"
+bundle exec compiler -a -e inspec -o "build/inspec/" -v beta
 cp templates/inspec/vcr_config.rb build/inspec
 
 pushd build/inspec

--- a/.ci/magic-modules/generate-inspec.sh
+++ b/.ci/magic-modules/generate-inspec.sh
@@ -16,7 +16,7 @@ pushd magic-modules-branched
 # use their GH noreply email which isn't compatible with CLAs.
 COMMIT_AUTHOR="$(git log --pretty="%an <%ae>" -n1 HEAD)"
 
-bundle exec compiler -a -e inspec -o "build/inspec/"
+bundle exec compiler -a -e inspec -o "build/inspec/" -v beta
 
 INSPEC_COMMIT_MSG="$(cat .git/title)"
 

--- a/.ci/unit-tests/inspec.sh
+++ b/.ci/unit-tests/inspec.sh
@@ -24,7 +24,7 @@ pushd magic-modules
 rm build/inspec/test/integration/verify/controls/*
 export VCR_MODE=none
 bundle install
-bundle exec compiler -a -e inspec -o "build/inspec/"
+bundle exec compiler -a -e inspec -o "build/inspec/" -v beta
 
 cp templates/inspec/vcr_config.rb build/inspec
 

--- a/products/compute/inspec.yaml
+++ b/products/compute/inspec.yaml
@@ -76,6 +76,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     exclude: true
   MachineType: !ruby/object:Overrides::Inspec::ResourceOverride
     exclude: true
+  ManagedSslCertificate: !ruby/object:Overrides::Inspec::ResourceOverride
+    exclude: true
   Network: !ruby/object:Overrides::Inspec::ResourceOverride
     additional_functions: third_party/inspec/custom_functions/google_compute_network.erb
     singular_extra_examples: 'third_party/inspec/documentation/network_examples.md'
@@ -149,6 +151,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         exclude: true
       pathMatchers.pathRules: !ruby/object:Overrides::Inspec::PropertyOverride
         exclude: true
+  VpnGateway: !ruby/object:Overrides::Inspec::ResourceOverride
+    exclude: true
   VpnTunnel: !ruby/object:Overrides::Inspec::ResourceOverride
     properties:
       name: !ruby/object:Overrides::Inspec::PropertyOverride

--- a/products/dns/inspec.yaml
+++ b/products/dns/inspec.yaml
@@ -20,4 +20,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     base_url: projects/{{project}}/managedZones/{{managed_zone}}/rrsets
   Project: !ruby/object:Overrides::Inspec::ResourceOverride
     exclude: true
+  Policy: !ruby/object:Overrides::Inspec::ResourceOverride
+    exclude: true
 

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -51,8 +51,6 @@ module Provider
       # If this is a privileged resource, which will make integration tests unusable
       # unless the user is an admin of the GCP organization
       attr_accessor :privileged
-
-      attr_accessor :ga_version
     end
 
     # Subclass of ProductFileTemplate with InSpec specific fields
@@ -66,7 +64,6 @@ module Provider
     def generate_resource(data)
       target_folder = File.join(data.output_folder, 'libraries')
       name = data.object.name.underscore
-      data.ga_version = data.product.version_obj_or_closest('ga')
 
       data.generate(
         'templates/inspec/singular_resource.erb',

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -51,6 +51,8 @@ module Provider
       # If this is a privileged resource, which will make integration tests unusable
       # unless the user is an admin of the GCP organization
       attr_accessor :privileged
+
+      attr_accessor :ga_version
     end
 
     # Subclass of ProductFileTemplate with InSpec specific fields
@@ -64,6 +66,7 @@ module Provider
     def generate_resource(data)
       target_folder = File.join(data.output_folder, 'libraries')
       name = data.object.name.underscore
+      data.ga_version = data.product.version_obj_or_closest('ga')
 
       data.generate(
         'templates/inspec/singular_resource.erb',

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -294,11 +294,9 @@ module Provider
     # Recursively calls itself on any arrays or nested objects within this property, indenting
     # further for each call
     def markdown_format(property, indent = 1)
-      beta_description = ''
-      if property.min_version.name == 'beta'
-        beta_description = '(Beta only) '
-      end
-      prop_description = "`#{property.out_name}`: #{beta_description}#{property.description.split("\n").join(' ')}"
+      beta_description = property.min_version.name == 'beta' ? '(Beta only) ' : ''
+      desc = "#{beta_description}#{property.description.split("\n").join(' ')}"
+      prop_description = "`#{property.out_name}`: #{desc}"
       description = "#{'  ' * indent}* #{prop_description}"
       if nested_object?(property)
         description_arr = [description]

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -294,7 +294,11 @@ module Provider
     # Recursively calls itself on any arrays or nested objects within this property, indenting
     # further for each call
     def markdown_format(property, indent = 1)
-      prop_description = "`#{property.out_name}`: #{property.description.split("\n").join(' ')}"
+      beta_description = ''
+      if property.min_version.name == 'beta'
+        beta_description = '(Beta only) '
+      end
+      prop_description = "`#{property.out_name}`: #{beta_description}#{property.description.split("\n").join(' ')}"
       description = "#{'  ' * indent}* #{prop_description}"
       if nested_object?(property)
         description_arr = [description]

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -370,7 +370,7 @@ module Provider
       property_list.any? { |sub_property| time?(sub_property) }
     end
 
-    def has_beta(object)
+    def beta?(object)
       beta_api_url(object) != ga_api_url(object)
     end
 

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -372,5 +372,18 @@ module Provider
     def time_prop?(property_list = [])
       property_list.any? { |sub_property| time?(sub_property) }
     end
+
+    def has_beta(object)
+      beta_api_url(object) != ga_api_url(object)
+    end
+
+    def beta_api_url(object)
+      object.product_url || object.__product.base_url
+    end
+
+    def ga_api_url(object)
+      ga_version = object.__product.version_obj_or_closest('ga')
+      object.product_url || ga_version.base_url
+    end
   end
 end

--- a/templates/inspec/doc_template.md.erb
+++ b/templates/inspec/doc_template.md.erb
@@ -22,6 +22,12 @@ platform: gcp
 ## Syntax
 A `<%= resource_underscored_name -%>` is used to test a Google <%= object.name -%> resource
 
+<% if has_beta(object) -%>
+
+## Beta Resource
+This resource has beta fields available. To retrieve these fields, include `beta: true` in the constructor for the resource
+
+<% end -%>
 ## Examples
 ```
 <%= compile("templates/inspec/examples/#{resource_name(object, product)}/#{resource_underscored_name}.erb") -%>

--- a/templates/inspec/doc_template.md.erb
+++ b/templates/inspec/doc_template.md.erb
@@ -39,7 +39,7 @@ Properties that can be accessed from the `<%= resource_underscored_name -%>` res
 <% if plural -%>
 See <%= "[#{resource_name(object, product)}.md](#{resource_name(object, product)}.md)" -%> for more detailed information
 <% object.all_user_properties.reject(&:exclude_plural).each do |prop| -%>
-  * `<%= "#{(prop.override_name || prop.out_name).pluralize}" -%>`: an array of `<%= resource_name(object, product) -%>` <%= "#{prop.out_name}" -%>
+  * `<%= "#{(prop.override_name || prop.out_name).pluralize}" -%>`: <% if prop.min_version.name == 'beta' -%><%= '(Beta only) ' -%><% end -%>an array of `<%= resource_name(object, product) -%>` <%= "#{prop.out_name}" -%>
 
 <% end -%>
 

--- a/templates/inspec/doc_template.md.erb
+++ b/templates/inspec/doc_template.md.erb
@@ -22,7 +22,7 @@ platform: gcp
 ## Syntax
 A `<%= resource_underscored_name -%>` is used to test a Google <%= object.name -%> resource
 
-<% if has_beta(object) -%>
+<% if beta?(object) -%>
 
 ## Beta Resource
 This resource has beta fields available. To retrieve these fields, include `beta: true` in the constructor for the resource

--- a/templates/inspec/plural_resource.erb
+++ b/templates/inspec/plural_resource.erb
@@ -96,20 +96,7 @@ link_query_items = object&.nested_query&.keys&.first || object.collection_url_ke
 
   private
 
-<% ga_api_url = object.product_url || ga_version.base_url -%>
-<% beta_api_url = object.product_url || object.__product.base_url -%>
-<% unless ga_api_url == beta_api_url -%>
-  def product_url(beta = false)
-    if beta
-      '<%= object.product_url || object.__product.base_url %>'
-    else
-      '<%= object.product_url || ga_version.base_url %>'
-    end
-<% else -%>
-  def product_url(_)
-    '<%= ga_api_url %>'
-<% end -%>
-  end
+<%= compile('templates/inspec/product_url.erb') -%>
 
   def resource_base_url
     '<%= object.base_url %>'

--- a/templates/inspec/plural_resource.erb
+++ b/templates/inspec/plural_resource.erb
@@ -96,8 +96,18 @@ link_query_items = object&.nested_query&.keys&.first || object.collection_url_ke
 
   private
 
-  def product_url
-    '<%= object.product_url || object.__product.base_url %>'
+<% ga_api_url = object.product_url || ga_version.base_url -%>
+<% beta_api_url = object.product_url || object.__product.base_url -%>
+  def product_url(beta = false)
+<% unless ga_api_url == beta_api_url -%>
+    if beta
+      '<%= object.product_url || object.__product.base_url %>'
+    else
+      '<%= object.product_url || ga_version.base_url %>'
+    end
+<% else -%>
+    '<%= ga_api_url %>'
+<% end -%>
   end
 
   def resource_base_url

--- a/templates/inspec/plural_resource.erb
+++ b/templates/inspec/plural_resource.erb
@@ -98,14 +98,15 @@ link_query_items = object&.nested_query&.keys&.first || object.collection_url_ke
 
 <% ga_api_url = object.product_url || ga_version.base_url -%>
 <% beta_api_url = object.product_url || object.__product.base_url -%>
-  def product_url(beta = false)
 <% unless ga_api_url == beta_api_url -%>
+  def product_url(beta = false)
     if beta
       '<%= object.product_url || object.__product.base_url %>'
     else
       '<%= object.product_url || ga_version.base_url %>'
     end
 <% else -%>
+  def product_url(_)
     '<%= ga_api_url %>'
 <% end -%>
   end

--- a/templates/inspec/product_url.erb
+++ b/templates/inspec/product_url.erb
@@ -1,14 +1,12 @@
-<% ga_api_url = object.product_url || ga_version.base_url -%>
-<% beta_api_url = object.product_url || object.__product.base_url -%>
-<% unless ga_api_url == beta_api_url -%>
+<% if has_beta(object) -%>
   def product_url(beta = false)
     if beta
-      '<%= object.product_url || object.__product.base_url %>'
+      '<%= beta_api_url(object) %>'
     else
-      '<%= object.product_url || ga_version.base_url %>'
+      '<%= ga_api_url(object) %>'
     end
 <% else -%>
   def product_url(_)
-    '<%= ga_api_url %>'
+    '<%= ga_api_url(object) %>'
 <% end -%>
   end

--- a/templates/inspec/product_url.erb
+++ b/templates/inspec/product_url.erb
@@ -1,4 +1,4 @@
-<% if has_beta(object) -%>
+<% if beta?(object) -%>
   def product_url(beta = false)
     if beta
       '<%= beta_api_url(object) %>'

--- a/templates/inspec/product_url.erb
+++ b/templates/inspec/product_url.erb
@@ -6,7 +6,7 @@
       '<%= ga_api_url(object) %>'
     end
 <% else -%>
-  def product_url(_)
+  def product_url(_ = nil)
     '<%= ga_api_url(object) %>'
 <% end -%>
   end

--- a/templates/inspec/product_url.erb
+++ b/templates/inspec/product_url.erb
@@ -1,0 +1,14 @@
+<% ga_api_url = object.product_url || ga_version.base_url -%>
+<% beta_api_url = object.product_url || object.__product.base_url -%>
+<% unless ga_api_url == beta_api_url -%>
+  def product_url(beta = false)
+    if beta
+      '<%= object.product_url || object.__product.base_url %>'
+    else
+      '<%= object.product_url || ga_version.base_url %>'
+    end
+<% else -%>
+  def product_url(_)
+    '<%= ga_api_url %>'
+<% end -%>
+  end

--- a/templates/inspec/singular_resource.erb
+++ b/templates/inspec/singular_resource.erb
@@ -102,20 +102,7 @@ best_guess_identifier = extract_identifiers(individual_url).last
 
   private
 
-<% ga_api_url = object.product_url || ga_version.base_url -%>
-<% beta_api_url = object.product_url || object.__product.base_url -%>
-<% unless ga_api_url == beta_api_url -%>
-  def product_url(beta = false)
-    if beta
-      '<%= object.product_url || object.__product.base_url %>'
-    else
-      '<%= object.product_url || ga_version.base_url %>'
-    end
-<% else -%>
-  def product_url(_)
-    '<%= ga_api_url %>'
-<% end -%>
-  end
+<%= compile('templates/inspec/product_url.erb') -%>
 
 <% url = object.self_link || object.base_url + '/{{name}}' -%>
 <% url_params = extract_identifiers(individual_url) -%>

--- a/templates/inspec/singular_resource.erb
+++ b/templates/inspec/singular_resource.erb
@@ -104,14 +104,15 @@ best_guess_identifier = extract_identifiers(individual_url).last
 
 <% ga_api_url = object.product_url || ga_version.base_url -%>
 <% beta_api_url = object.product_url || object.__product.base_url -%>
-  def product_url(beta = false)
 <% unless ga_api_url == beta_api_url -%>
+  def product_url(beta = false)
     if beta
       '<%= object.product_url || object.__product.base_url %>'
     else
       '<%= object.product_url || ga_version.base_url %>'
     end
 <% else -%>
+  def product_url(_)
     '<%= ga_api_url %>'
 <% end -%>
   end

--- a/templates/inspec/singular_resource.erb
+++ b/templates/inspec/singular_resource.erb
@@ -42,14 +42,14 @@ class <%= object.__product.name.camelize(:upper) -%><%= object.name -%> < GcpRes
   def initialize(params)
     super(params.merge({ use_http_transport: true }))
     @params = params
-    @fetched = @connection.fetch(product_url, resource_base_url, params, 'Get')
+    @fetched = @connection.fetch(product_url(params[:beta]), resource_base_url, params, 'Get')
     parse unless @fetched.nil?
   end
 <% else # object.nested_query.nil? -%>
   def initialize(params)
     super(params.merge({ use_http_transport: true }))
     @params = params
-    fetched = @connection.fetch(product_url, resource_base_url, params, 'Get')
+    fetched = @connection.fetch(product_url(params[:beta]), resource_base_url, params, 'Get')
     @fetched = unwrap(fetched, params)
     parse unless @fetched.nil?
   end
@@ -102,8 +102,18 @@ best_guess_identifier = extract_identifiers(individual_url).last
 
   private
 
-  def product_url
-    '<%= object.product_url || object.__product.base_url -%>'
+<% ga_api_url = object.product_url || ga_version.base_url -%>
+<% beta_api_url = object.product_url || object.__product.base_url -%>
+  def product_url(beta = false)
+<% unless ga_api_url == beta_api_url -%>
+    if beta
+      '<%= object.product_url || object.__product.base_url %>'
+    else
+      '<%= object.product_url || ga_version.base_url %>'
+    end
+<% else -%>
+    '<%= ga_api_url %>'
+<% end -%>
   end
 
 <% url = object.self_link || object.base_url + '/{{name}}' -%>


### PR DESCRIPTION
Generate InSpec resources at beta.

Switch on endpoint due to flag given in resource constructor. No flag means use GA endpoint, `:beta = true` means use the beta endpoint

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
