### PR TITLE
Add Downstream pusher on Google Cloud Build

### DIFF
--- a/.ci/containers/downstream-builder/Dockerfile
+++ b/.ci/containers/downstream-builder/Dockerfile
@@ -3,6 +3,7 @@ from golang:1.13-stretch as resource
 SHELL ["/bin/bash", "-c"]
 
 RUN go get golang.org/x/tools/cmd/goimports
+RUN go get github.com/github/hub
 
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts
@@ -38,7 +39,7 @@ RUN apt-get install -y git build-essential libbz2-dev libssl-dev libreadline-dev
                         libffi-dev libsqlite3-dev tk-dev libpng-dev libfreetype6-dev \
                         make build-essential libssl-dev zlib1g-dev libbz2-dev \
                         libreadline-dev libsqlite3-dev curl llvm libncurses5-dev libncursesw5-dev \
-                        xz-utils tk-dev libffi-dev liblzma-dev python-openssl
+                        xz-utils tk-dev libffi-dev liblzma-dev python-openssl jq
 
 RUN wget https://raw.githubusercontent.com/GoogleCloudPlatform/magic-modules/master/Gemfile
 RUN wget https://raw.githubusercontent.com/GoogleCloudPlatform/magic-modules/master/Gemfile.lock

--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -116,7 +116,7 @@ if [ "$COMMITTED" == "true" ] && [ "$COMMAND" == "downstream" ]; then
         "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/$PR_NUMBER" | \
         jq -r .title)
 
-    NEW_PR_URL=$(hub pull-request -b $UPSTREAM_OWNER:master -h $SCRATCH_OWNER:$BRANCH -m "$PR_TITLE" -m "$PR_BODY")
+    NEW_PR_URL=$(hub pull-request -b $UPSTREAM_OWNER:downstream-master -h $SCRATCH_OWNER:$BRANCH -m "$PR_TITLE" -m "$PR_BODY")
     if [ $? != 0 ]; then
         exit $?
     fi

--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -3,41 +3,45 @@
 set -e
 
 function clone_repo() {
+    SCRATCH_OWNER=modular-magician
     if [ "$REPO" == "terraform" ]; then
         if [ "$VERSION" == "ga" ]; then
-            GITHUB_PATH=https://modular-magician:$GITHUB_TOKEN@github.com/terraform-providers/terraform-provider-google
-            SCRATCH_PATH=https://modular-magician:$GITHUB_TOKEN@github.com/modular-magician/terraform-provider-google
+            UPSTREAM_OWNER=terraform-providers
+            GH_REPO=terraform-provider-google
             LOCAL_PATH=$GOPATH/src/github.com/terraform-providers/terraform-provider-google
         elif [ "$VERSION" == "beta" ]; then
-            GITHUB_PATH=https://modular-magician:$GITHUB_TOKEN@github.com/terraform-providers/terraform-provider-google-beta
-            SCRATCH_PATH=https://modular-magician:$GITHUB_TOKEN@github.com/modular-magician/terraform-provider-google-beta
+            UPSTREAM_OWNER=terraform-providers
+            GH_REPO=terraform-provider-google-beta
             LOCAL_PATH=$GOPATH/src/github.com/terraform-providers/terraform-provider-google-beta
         else
             echo "Unrecognized version $VERSION"
             exit 1
         fi
     elif [ "$REPO" == "tf-conversion" ]; then
-        GITHUB_PATH=https://modular-magician:$GITHUB_TOKEN@github.com/GoogleCloudPlatform/terraform-google-conversion
-        SCRATCH_PATH=https://modular-magician:$GITHUB_TOKEN@github.com/modular-magician/terraform-google-conversion
+        UPSTREAM_OWNER=GoogleCloudPlatform
+        GH_REPO=terraform-google-conversion
         LOCAL_PATH=$GOPATH/src/github.com/GoogleCloudPlatform/terraform-google-conversion
     elif [ "$REPO" == "ansible" ]; then
-        GITHUB_PATH=https://modular-magician:$GITHUB_TOKEN@github.com/ansible-collections/ansible_collections_google
-        SCRATCH_PATH=https://modular-magician:$GITHUB_TOKEN@github.com/modular-magician/ansible_collections_google
+        UPSTREAM_OWNER=ansible-collections
+        GH_REPO=ansible_collections_google
         LOCAL_PATH=$PWD/../ansible
     elif [ "$REPO" == "inspec" ]; then
-        GITHUB_PATH=https://modular-magician:$GITHUB_TOKEN@github.com/modular-magician/inspec-gcp
-        SCRATCH_PATH=$GITHUB_PATH
+        UPSTREAM_OWNER=modular-magician
+        GH_REPO=inspec-gcp
         LOCAL_PATH=$PWD/../inspec
     else
         echo "Unrecognized repo $REPO"
         exit 1
     fi
+
+    GITHUB_PATH=https://modular-magician:$GITHUB_TOKEN@github.com/$UPSTREAM_OWNER/$GH_REPO
+    SCRATCH_PATH=https://modular-magician:$GITHUB_TOKEN@github.com/$SCRATCH_OWNER/$GH_REPO
     mkdir -p "$(dirname $LOCAL_PATH)"
     git clone $GITHUB_PATH $LOCAL_PATH
 }
 
 if [ $# -lt 4 ]; then
-    echo "Usage: $0 (build|diff) (terraform|tf-conversion|ansible|inspec) (ga|beta) (pr number)"
+    echo "Usage: $0 (build|diff|downstream) (terraform|tf-conversion|ansible|inspec) (ga|beta) (pr number|sha)"
     exit 1
 fi
 if [ -z "$GITHUB_TOKEN" ]; then
@@ -48,7 +52,7 @@ fi
 COMMAND=$1
 REPO=$2
 VERSION=$3
-PR_NUMBER=$4
+REFERENCE=$4
 
 clone_repo
 
@@ -56,10 +60,15 @@ git config --global user.name "Modular Magician"
 git config --global user.email "magic-modules@google.com"
 
 if [ "$COMMAND" == "head" ]; then
-    BRANCH=auto-pr-$PR_NUMBER
+    BRANCH=auto-pr-$REFERENCE
+    COMMIT_MESSAGE="New generated code for MM PR $REFERENCE."
 elif [ "$COMMAND" == "base" ]; then
     git checkout HEAD~
-    BRANCH=auto-pr-$PR_NUMBER-old
+    BRANCH=auto-pr-$REFERENCE-old
+    COMMIT_MESSAGE="Old generated code for MM PR $REFERENCE."
+elif [ "$COMMAND" == "downstream" ]; then
+    BRANCH=downstream-pr-$REFERENCE
+    COMMIT_MESSAGE="$(git log -1 --pretty=%B "$REFERENCE")"
 fi
 
 if [ "$REPO" == "terraform" ]; then
@@ -75,10 +84,50 @@ else
     bundle exec compiler -a -e $REPO -o $LOCAL_PATH -v $VERSION
 fi
 
-
 pushd $LOCAL_PATH
 git add .
 git checkout -b $BRANCH
-git commit -m "New generated code for PR $PR_NUMBER." || true
+
+COMMITTED=true
+git commit -m "$COMMIT_MESSAGE" || COMMITTED=false
+
+if [ "$COMMITTED" == "true" ] && [ "$COMMAND" == "downstream" ]; then
+    # Add the changelog entry!
+    PR_NUMBER=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
+        "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls?state=closed&base=master&sort=updated&direction=desc" | \
+        jq -r ".[] | if .merge_commit_sha == \"$REFERENCE\" then .number else empty end")
+    mkdir -p .changelog/
+    curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
+        "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/$PR_NUMBER" | \
+        jq -r .body | \
+        sed -e '/```release-note/,/```/!d' \
+        > .changelog/$PR_NUMBER.txt
+    git add .changelog
+    git commit --amend --no-edit
+fi
+
 git push $SCRATCH_PATH $BRANCH -f
+
+if [ "$COMMITTED" == "true" ] && [ "$COMMAND" == "downstream" ]; then
+    PR_BODY=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
+        "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/$PR_NUMBER" | \
+        jq -r .body)
+    PR_TITLE=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
+        "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/$PR_NUMBER" | \
+        jq -r .title)
+
+    NEW_PR_URL=$(hub pull-request -b $UPSTREAM_OWNER:master -h $SCRATCH_OWNER:$BRANCH -m "$PR_TITLE" -m "$PR_BODY")
+    if [ $? != 0 ]; then
+        exit $?
+    fi
+    NEW_PR_NUMBER=$(echo $NEW_PR_URL | awk -F '/' '{print $NF}')
+
+    # Wait a few seconds, then merge the PR.
+    sleep 5
+    curl -H "Authorization: token ${GITHUB_TOKEN}" \
+        -X PUT \
+        -d '{"merge_method": "squash"}' \
+        "https://api.github.com/repos/$UPSTREAM_OWNER/$GH_REPO/pulls/$NEW_PR_NUMBER/merge"
+fi
+
 popd

--- a/.ci/containers/downstream-waiter/Dockerfile
+++ b/.ci/containers/downstream-waiter/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine/git
+
+RUN apk add --no-cache bash
+ADD wait_for_commit.sh /wait_for_commit.sh
+ENTRYPOINT ["/wait_for_commit.sh"]

--- a/.ci/containers/downstream-waiter/wait_for_commit.sh
+++ b/.ci/containers/downstream-waiter/wait_for_commit.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+if [ $# -lt 3 ]; then
+    echo "Usage: $0 (sync-branch) (base-branch) (sha)"
+    exit 1
+fi
+
+SYNC_BRANCH=$1
+BASE_BRANCH=$2
+SHA=$3
+
+if git merge-base --is-ancestor $SHA origin/$SYNC_BRANCH; then
+    echo "Found $SHA in history of $SYNC_BRANCH - dying to avoid double-generating that commit."
+    exit 1
+fi
+
+while true; do
+    commits="$(git log --pretty=%H origin/$SYNC_BRANCH..origin/$BASE_BRANCH | tail -n 1)"
+    if [ "$commits" == "$SHA" ]; then
+        break
+    else
+        echo "git log says waiting on: $commits"
+        echo "command says waiting on $SHA"
+        git fetch origin $SYNC_BRANCH
+    fi
+    sleep 5
+done

--- a/.ci/gcb-push-downstream.yml
+++ b/.ci/gcb-push-downstream.yml
@@ -1,0 +1,85 @@
+---
+steps:
+    # The GCB / GH integration doesn't satisfy our use case perfectly.
+    # It doesn't check out the repo itself - it only gives us the actual code.
+    # So we need to handle that access ourselves - which means deleting the code
+    # and cloning the repo to the present directory.  We need to use
+    # 'sh' to evaluate the '*' arguments, which otherwise would be
+    # passed literally to 'rm'.
+    - name: 'alpine'
+      args:
+          - sh
+          - -c
+          - rm -rf ./* ./.* || true
+    - name: 'gcr.io/cloud-builders/git'
+      id: clone
+      args:
+          - clone
+          - https://github.com/GoogleCloudPlatform/magic-modules
+          - .
+
+    - name: 'gcr.io/cloud-builders/git'
+      id: checkout
+      args:
+          - checkout
+          - $COMMIT_SHA
+
+    - name: 'gcr.io/graphite-docker-images/downstream-waiter'
+      id: tpg-sync
+      secretEnv: ["GITHUB_TOKEN"]
+      waitFor: ["checkout"]
+      args:
+          - 'tpg-sync'
+          - $BRANCH_NAME
+          - $COMMIT_SHA
+
+    - name: 'gcr.io/graphite-docker-images/downstream-builder'
+      secretEnv: ["GITHUB_TOKEN"]
+      id: tpg-push
+      waitFor: ["tpg-sync"]
+      args:
+          - 'downstream'
+          - 'terraform'
+          - 'ga'
+          - $COMMIT_SHA
+
+    - name: 'gcr.io/cloud-builders/git'
+      waitFor: ["tpg-push"]
+      secretEnv: ["GITHUB_TOKEN"]
+      entrypoint: 'bash'
+      args:
+          - -c
+          - git push https://modular-magician:$$GITHUB_TOKEN@github.com/GoogleCloudPlatform/magic-modules $COMMIT_SHA:tpg-sync
+
+    - name: 'gcr.io/graphite-docker-images/downstream-waiter'
+      id: tpgb-sync
+      secretEnv: ["GITHUB_TOKEN"]
+      waitFor: ["checkout"]
+      args:
+          - 'tpgb-sync'
+          - $BRANCH_NAME
+          - $COMMIT_SHA
+
+    - name: 'gcr.io/graphite-docker-images/downstream-builder'
+      secretEnv: ["GITHUB_TOKEN"]
+      id: tpgb-push
+      waitFor: ["tpgb-sync"]
+      args:
+          - 'downstream'
+          - 'terraform'
+          - 'beta'
+          - $COMMIT_SHA
+
+    - name: 'gcr.io/cloud-builders/git'
+      waitFor: ["tpgb-push"]
+      secretEnv: ["GITHUB_TOKEN"]
+      entrypoint: 'bash'
+      args:
+          - -c
+          - git push https://modular-magician:$$GITHUB_TOKEN@github.com/GoogleCloudPlatform/magic-modules $COMMIT_SHA:tpgb-sync
+
+
+secrets:
+    - kmsKeyName: projects/graphite-docker-images/locations/global/keyRings/token-keyring/cryptoKeys/github-token
+      secretEnv:
+          GITHUB_TOKEN: CiQADkR4NnCVXo1OLSWFuPX7eSiifaOfQVzSYmKi2jZdVbKlfYMSUQBfF82vNAgpvSVyhzM8JsQaP6Oky0SAdoR5fPED5cU3qxsCB9wArmdGcgQoRzP7S6jEWHRcvxv/xauznjkJQMWCORzcbUbk6T7k80bdo2mpqw==

--- a/.ci/gcb-push-downstream.yml
+++ b/.ci/gcb-push-downstream.yml
@@ -24,6 +24,7 @@ steps:
           - checkout
           - $COMMIT_SHA
 
+    # TPG
     - name: 'gcr.io/graphite-docker-images/downstream-waiter'
       id: tpg-sync
       secretEnv: ["GITHUB_TOKEN"]
@@ -51,6 +52,7 @@ steps:
           - -c
           - git push https://modular-magician:$$GITHUB_TOKEN@github.com/GoogleCloudPlatform/magic-modules $COMMIT_SHA:tpg-sync
 
+    # TPGB
     - name: 'gcr.io/graphite-docker-images/downstream-waiter'
       id: tpgb-sync
       secretEnv: ["GITHUB_TOKEN"]
@@ -78,6 +80,89 @@ steps:
           - -c
           - git push https://modular-magician:$$GITHUB_TOKEN@github.com/GoogleCloudPlatform/magic-modules $COMMIT_SHA:tpgb-sync
 
+    # TF-CONV
+    - name: 'gcr.io/graphite-docker-images/downstream-waiter'
+      id: tf-conv-sync
+      secretEnv: ["GITHUB_TOKEN"]
+      waitFor: ["checkout"]
+      args:
+          - 'tf-conv-sync'
+          - $BRANCH_NAME
+          - $COMMIT_SHA
+
+    - name: 'gcr.io/graphite-docker-images/downstream-builder'
+      secretEnv: ["GITHUB_TOKEN"]
+      id: tf-conv-push
+      waitFor: ["tf-conv-sync"]
+      args:
+          - 'downstream'
+          - 'tf-conversion'
+          - 'ga'
+          - $COMMIT_SHA
+
+    - name: 'gcr.io/cloud-builders/git'
+      waitFor: ["tf-conv-push"]
+      secretEnv: ["GITHUB_TOKEN"]
+      entrypoint: 'bash'
+      args:
+          - -c
+          - git push https://modular-magician:$$GITHUB_TOKEN@github.com/GoogleCloudPlatform/magic-modules $COMMIT_SHA:tf-conv-sync
+
+    # Ansible
+    - name: 'gcr.io/graphite-docker-images/downstream-waiter'
+      id: ansible-sync
+      secretEnv: ["GITHUB_TOKEN"]
+      waitFor: ["checkout"]
+      args:
+          - 'ansible-sync'
+          - $BRANCH_NAME
+          - $COMMIT_SHA
+
+    - name: 'gcr.io/graphite-docker-images/downstream-builder'
+      secretEnv: ["GITHUB_TOKEN"]
+      id: ansible-push
+      waitFor: ["ansible-sync"]
+      args:
+          - 'downstream'
+          - 'ansible'
+          - 'ga'
+          - $COMMIT_SHA
+
+    - name: 'gcr.io/cloud-builders/git'
+      waitFor: ["ansible-push"]
+      secretEnv: ["GITHUB_TOKEN"]
+      entrypoint: 'bash'
+      args:
+          - -c
+          - git push https://modular-magician:$$GITHUB_TOKEN@github.com/GoogleCloudPlatform/magic-modules $COMMIT_SHA:ansible-sync
+
+    # Inspec
+    - name: 'gcr.io/graphite-docker-images/downstream-waiter'
+      id: inspec-sync
+      secretEnv: ["GITHUB_TOKEN"]
+      waitFor: ["checkout"]
+      args:
+          - 'inspec-sync'
+          - $BRANCH_NAME
+          - $COMMIT_SHA
+
+    - name: 'gcr.io/graphite-docker-images/downstream-builder'
+      secretEnv: ["GITHUB_TOKEN"]
+      id: inspec-push
+      waitFor: ["inspec-sync"]
+      args:
+          - 'downstream'
+          - 'inspec'
+          - 'ga'
+          - $COMMIT_SHA
+
+    - name: 'gcr.io/cloud-builders/git'
+      waitFor: ["inspec-push"]
+      secretEnv: ["GITHUB_TOKEN"]
+      entrypoint: 'bash'
+      args:
+          - -c
+          - git push https://modular-magician:$$GITHUB_TOKEN@github.com/GoogleCloudPlatform/magic-modules $COMMIT_SHA:inspec-sync
 
 secrets:
     - kmsKeyName: projects/graphite-docker-images/locations/global/keyRings/token-keyring/cryptoKeys/github-token


### PR DESCRIPTION
This relies on using fundamentally the same code to push the downstreams as to generate the diffs.  This will reduce our container / script count.  :)

It should be _moderately_ readable?  Please complain about any parts of it that suck.