### PR TITLE
Retry reads of organization datasource

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_organization.go
+++ b/third_party/terraform/data_sources/data_source_google_organization.go
@@ -54,9 +54,13 @@ func dataSourceOrganizationRead(d *schema.ResourceData, meta interface{}) error 
 	var organization *cloudresourcemanager.Organization
 	if v, ok := d.GetOk("domain"); ok {
 		filter := fmt.Sprintf("domain=%s", v.(string))
-		resp, err := config.clientResourceManager.Organizations.Search(&cloudresourcemanager.SearchOrganizationsRequest{
-			Filter: filter,
-		}).Do()
+		var resp *cloudresourcemanager.SearchOrganizationsResponse
+		err := retryTimeDuration(func() (err error) {
+			resp, err = config.clientResourceManager.Organizations.Search(&cloudresourcemanager.SearchOrganizationsRequest{
+				Filter: filter,
+			}).Do()
+			return err
+		}, d.Timeout(schema.TimeoutRead))
 		if err != nil {
 			return fmt.Errorf("Error reading organization: %s", err)
 		}
@@ -64,13 +68,18 @@ func dataSourceOrganizationRead(d *schema.ResourceData, meta interface{}) error 
 		if len(resp.Organizations) == 0 {
 			return fmt.Errorf("Organization not found: %s", v)
 		}
+
 		if len(resp.Organizations) > 1 {
 			return fmt.Errorf("More than one matching organization found")
 		}
 
 		organization = resp.Organizations[0]
 	} else if v, ok := d.GetOk("organization"); ok {
-		resp, err := config.clientResourceManager.Organizations.Get(canonicalOrganizationName(v.(string))).Do()
+		var resp *cloudresourcemanager.Organization
+		err := retryTimeDuration(func() (err error) {
+			resp, err = config.clientResourceManager.Organizations.Get(canonicalOrganizationName(v.(string))).Do()
+			return err
+		}, d.Timeout(schema.TimeoutRead))
 		if err != nil {
 			return handleNotFoundError(err, d, fmt.Sprintf("Organization Not Found : %s", v))
 		}


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4941

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
resourcemanager: added retries for `data.google_organization`
```
