### PR TITLE
fix google_bigquery_table encryption_configuration modifications

### DIFF
--- a/third_party/terraform/resources/resource_bigquery_table.go.erb
+++ b/third_party/terraform/resources/resource_bigquery_table.go.erb
@@ -314,6 +314,7 @@ func resourceBigQueryTable() *schema.Resource {
 			"encryption_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
+				ForceNew: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
- changing to/from CMEK requires recreating the table (see [Change a table from default encryption to Cloud KMS protection](https://cloud.google.com/bigquery/docs/customer-managed-encryption#change_to_kms))
- the BQ API appears to support the default -> kms transition (no API error), but tables don't appear to get encrypted according to the UI/CLI
- see terraform-providers/terraform-provider-google#5241 and https://github.com/GoogleCloudPlatform/magic-modules/pull/2763#issuecomment-567148378 for more info

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
