### PR TITLE
Add support for range partitioning in BigQuery

### DIFF
--- a/third_party/terraform/resources/resource_bigquery_table.go.erb
+++ b/third_party/terraform/resources/resource_bigquery_table.go.erb
@@ -4,6 +4,7 @@ package google
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"regexp"
@@ -302,6 +303,55 @@ func resourceBigQueryTable() *schema.Resource {
 				},
 			},
 
+			<% unless version == 'ga' -%>
+			// RangePartitioning: [Optional] If specified, configures range-based
+			// partitioning for this table.
+			"range_partitioning": &schema.Schema{
+				Type: schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						// Field: [Required] The field used to determine how to create a range-based
+						// partition.
+						"field": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+
+						// Range: [Required] Information required to partition based on ranges.
+						"range": &schema.Schema{
+							Type: schema.TypeList,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									// Start: [Required] Start of the range partitioning, inclusive.
+									"start": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+
+									// End: [Required] End of the range partitioning, exclusive.
+									"end": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+
+									// Interval: [Required] The width of each range within the partition.
+									"interval": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			<% end -%>
+
 			// Clustering: [Optional] Specifies column names to use for data clustering.  Up to four
 			// top-level columns are allowed, and should be specified in descending priority order.
 			"clustering": &schema.Schema{
@@ -464,6 +514,17 @@ func resourceTable(d *schema.ResourceData, meta interface{}) (*bigquery.Table, e
 		table.TimePartitioning = expandTimePartitioning(v)
 	}
 
+	<% unless version == 'ga' -%>
+	if v, ok := d.GetOk("range_partitioning"); ok {
+		rangePartitioning, err := expandRangePartitioning(v)
+		if err != nil {
+			return nil, err
+		}
+
+		table.RangePartitioning = rangePartitioning
+	}
+	<% end -%>
+
 	if v, ok := d.GetOk("clustering"); ok {
 		table.Clustering = &bigquery.Clustering{
 			Fields:          convertStringArr(v.([]interface{})),
@@ -552,6 +613,14 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 	}
+
+	<% unless version == 'ga' -%>
+	if res.RangePartitioning != nil {
+		if err := d.Set("range_partitioning", flattenRangePartitioning(res.RangePartitioning)); err != nil {
+			return err
+		}
+	}
+	<% end -%>
 
 	if res.Clustering != nil {
 		d.Set("clustering", res.Clustering.Fields)
@@ -838,6 +907,41 @@ func expandTimePartitioning(configured interface{}) *bigquery.TimePartitioning {
 	return tp
 }
 
+<% unless version == 'ga' -%>
+func expandRangePartitioning(configured interface{}) (*bigquery.RangePartitioning, error) {
+	if configured == nil {
+		return nil, nil
+	}
+
+	rpJson := configured.([]interface{})
+	if len(rpJson) == 0 || rpJson[0] == nil {
+		return nil, errors.New("Error casting range partitioning interface to expected structure")
+	}
+
+	rpRaw := rpJson[0].([]map[string]interface{})
+	rprRaw := rpRaw["range"].(map[string]interface{})
+	rp := &bigquery.RangePartitioning{
+		Field: rpRaw["field"].(string),
+	}
+
+	if v, ok := rpRaw["range"]; ok && v != nil {
+		rangeLs := v.([]interface{})
+		if len(rangeLs) != 1 || rangeLs[0] == nil {
+			return nil, errors.New("Non-empty range must be given for range partitioning")
+		}
+
+		rangeJson := rangeLs[0].(map[string]interface{})
+		rp.Range = &bigquery.RangePartitioningRange{
+			Start:    int64(rangeJson["start"].(int)),
+			End:      int64(rangeJson["end"].(int)),
+			Interval: int64(rangeJson["interval"].(int)),
+		}
+	}
+
+	return rp, nil
+}
+<% end -%>
+
 func flattenEncryptionConfiguration(ec *bigquery.EncryptionConfiguration) []map[string]interface{} {
 	return []map[string]interface{}{{"kms_key_name": ec.KmsKeyName}}
 }
@@ -859,6 +963,23 @@ func flattenTimePartitioning(tp *bigquery.TimePartitioning) []map[string]interfa
 
 	return []map[string]interface{}{result}
 }
+
+<% unless version == 'ga' -%>
+func flattenRangePartitioning(rp *bigquery.RangePartitioning) []map[string]interface{} {
+	result := map[string]interface{}{
+		"field": rp.Field,
+		"range": []map[string]interface{}{
+			{
+				"start":    rp.Range.Start,
+				"end":      rp.Range.End,
+				"interval": rp.Range.Interval,
+			},
+		},
+	}
+
+	return []map[string]interface{}{result}
+}
+<% end -%>
 
 func expandView(configured interface{}) *bigquery.ViewDefinition {
 	raw := configured.([]interface{})[0].(map[string]interface{})

--- a/third_party/terraform/resources/resource_bigquery_table.go.erb
+++ b/third_party/terraform/resources/resource_bigquery_table.go.erb
@@ -913,18 +913,17 @@ func expandRangePartitioning(configured interface{}) (*bigquery.RangePartitionin
 		return nil, nil
 	}
 
-	rpJson := configured.([]interface{})
-	if len(rpJson) == 0 || rpJson[0] == nil {
+	rpList := configured.([]interface{})
+	if len(rpList) == 0 || rpList[0] == nil {
 		return nil, errors.New("Error casting range partitioning interface to expected structure")
 	}
 
-	rpRaw := rpJson[0].([]map[string]interface{})
-	rprRaw := rpRaw["range"].(map[string]interface{})
+	rangePartJson := rpList[0].(map[string]interface{})
 	rp := &bigquery.RangePartitioning{
-		Field: rpRaw["field"].(string),
+		Field: rangePartJson["field"].(string),
 	}
 
-	if v, ok := rpRaw["range"]; ok && v != nil {
+	if v, ok := rangePartJson["range"]; ok && v != nil {
 		rangeLs := v.([]interface{})
 		if len(rangeLs) != 1 || rangeLs[0] == nil {
 			return nil, errors.New("Non-empty range must be given for range partitioning")

--- a/third_party/terraform/tests/resource_bigquery_table_test.go.erb
+++ b/third_party/terraform/tests/resource_bigquery_table_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package google
 
 import (
@@ -64,6 +65,31 @@ func TestAccBigQueryTable_Kms(t *testing.T) {
 		},
 	})
 }
+
+<% unless version == 'ga' -%>
+func TestAccBigQueryTable_RangePartitioning(t *testing.T) {
+	t.Parallel()
+	resourceName := "google_bigquery_table.test"
+	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
+	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBigQueryTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTableRangePartitioning(datasetID, tableID),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+<% end -%>
 
 func TestAccBigQueryTable_View(t *testing.T) {
 	t.Parallel()
@@ -267,7 +293,7 @@ resource "google_bigquery_table" "test" {
 
 	time_partitioning {
 		type = "DAY"
-		field = "ts"	
+		field = "ts"
 	}
 
 	encryption_configuration {
@@ -305,6 +331,60 @@ EOH
 }
 `, datasetID, cryptoKeyName, tableID)
 }
+
+<% unless version == 'ga' -%>
+func testAccBigQueryTableRangePartitioning(datasetID, tableID string) string {
+	return fmt.Sprintf(`
+	resource "google_bigquery_dataset" "test" {
+		dataset_id = "%s"
+	}
+
+	resource "google_bigquery_table" "test" {
+		provider   = google-beta
+		table_id   = "%s"
+		dataset_id = google_bigquery_dataset.test.dataset_id
+
+		range_partitioning {
+			field = "id"
+			range {
+				start    = 1
+				end      = 10000
+				interval = 100
+			}
+		}
+
+		schema = <<EOH
+[
+	{
+		"name": "ts",
+		"type": "TIMESTAMP"
+	},
+	{
+		"name": "id",
+		"type": "INTEGER"
+	},
+	{
+		"name": "city",
+		"type": "RECORD",
+		"fields": [
+	{
+		"name": "coord",
+		"type": "RECORD",
+		"fields": [
+		{
+		"name": "lon",
+		"type": "FLOAT"
+		}
+		]
+	}
+		]
+	}
+]
+EOH
+}
+	`, datasetID, tableID)
+}
+<% end -%>
 
 func testAccBigQueryTableWithView(datasetID, tableID string) string {
 	return fmt.Sprintf(`

--- a/third_party/terraform/tests/resource_bigquery_table_test.go.erb
+++ b/third_party/terraform/tests/resource_bigquery_table_test.go.erb
@@ -362,22 +362,6 @@ func testAccBigQueryTableRangePartitioning(datasetID, tableID string) string {
 	{
 		"name": "id",
 		"type": "INTEGER"
-	},
-	{
-		"name": "city",
-		"type": "RECORD",
-		"fields": [
-	{
-		"name": "coord",
-		"type": "RECORD",
-		"fields": [
-		{
-		"name": "lon",
-		"type": "FLOAT"
-		}
-		]
-	}
-		]
 	}
 ]
 EOH

--- a/third_party/terraform/tests/resource_bigquery_table_test.go.erb
+++ b/third_party/terraform/tests/resource_bigquery_table_test.go.erb
@@ -340,7 +340,6 @@ func testAccBigQueryTableRangePartitioning(datasetID, tableID string) string {
 	}
 
 	resource "google_bigquery_table" "test" {
-		provider   = google-beta
 		table_id   = "%s"
 		dataset_id = google_bigquery_dataset.test.dataset_id
 

--- a/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -127,6 +127,9 @@ The following arguments are supported:
 * `time_partitioning` - (Optional) If specified, configures time-based
     partitioning for this table. Structure is documented below.
 
+* `range_partitioning` - (Optional, Beta) If specified, configures range-based
+    partitioning for this table. Structure is documented below.
+
 * `clustering` - (Optional) Specifies column names to use for data clustering.
     Up to four top-level columns are allowed, and should be specified in
     descending priority order.
@@ -176,7 +179,7 @@ The `csv_options` block supports:
     characters, you must also set the `allow_quoted_newlines` property to true.
     The API-side default is `"`, specified in Terraform escaped as `\"`. Due to
     limitations with Terraform default values, this value is required to be
-    explicitly set. 
+    explicitly set.
 
 * `allow_jagged_rows` (Optional) - Indicates if BigQuery should accept rows
     that are missing trailing optional columns.
@@ -219,6 +222,22 @@ The `time_partitioning` block supports:
 * `require_partition_filter` - (Optional) If set to true, queries over this table
     require a partition filter that can be used for partition elimination to be
     specified.
+
+The `range_partitioning` block supports:
+
+* `field` - (Required) The field used to determine how to create a range-based
+    partition.
+
+* `range` - (Required) Information required to partition based on ranges.
+    Structure is documented below.
+
+The `range` block supports:
+
+* `start` - (Required) Start of the range partitioning, inclusive.
+
+* `end` - (Required) End of the range partitioning, exclusive.
+
+* `interval` - (Required) The width of each range within the partition.
 
 The `view` block supports:
 


### PR DESCRIPTION
Currently only time partitioning is supported.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

https://github.com/terraform-providers/terraform-provider-google/issues/5239

```release-note:enhancement
Support for range-based partitioning in BigQuery tables has landed. Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5239.
```
