### PR TITLE
update isEmptyValue function

### DIFF
--- a/templates/terraform/custom_expand/bigtable_app_profile_routing.erb
+++ b/templates/terraform/custom_expand/bigtable_app_profile_routing.erb
@@ -17,5 +17,5 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d T
         return nil, nil
     }
 
-	return map[string]interface{}{}, nil
+	return bigtableadmin.MultiClusterRoutingUseAny{}, nil
 }

--- a/templates/terraform/custom_expand/bigtable_app_profile_routing.erb
+++ b/templates/terraform/custom_expand/bigtable_app_profile_routing.erb
@@ -17,5 +17,5 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d T
         return nil, nil
     }
 
-	return bigtableadmin.MultiClusterRoutingUseAny{}, nil
+	return map[string]interface{}{}, nil
 }

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -539,10 +539,12 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
             `NullFields` is a special case of `send_empty_value` where the empty value
             in question is go's literal nil.
 -%>
-<%          unless prop.send_empty_value -%>
-        } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
-<%          else -%>
+<%          if prop.send_empty_value -%>
         } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop) {
+<%          elsif prop.flatten_object -%>
+        } else if !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) {
+<%          else -%>
+        } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
 <%          end -%>
             obj["<%= prop.api_name -%>"] = <%= prop.api_name -%>Prop
         }
@@ -611,10 +613,12 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
     <%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(<%= schemaPrefix -%>, d, config)
     if err != nil {
         return err
-<%      unless prop.send_empty_value -%>
-    } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
-<%      else -%>
+<%      if prop.send_empty_value -%>
     } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop) {
+<%      elsif prop.flatten_object -%>
+    } else if !isEmptyValue(reflect.ValueOf(<%= prop.api_name -%>Prop)) {
+<%      else -%>
+    } else if v, ok := d.GetOkExists("<%= prop.name.underscore -%>"); !isEmptyValue(reflect.ValueOf(v)) && (ok || !reflect.DeepEqual(v, <%= prop.api_name -%>Prop)) {
 <%      end -%>
         obj["<%= prop.api_name -%>"] = <%= prop.api_name -%>Prop
     }

--- a/third_party/terraform/utils/transport.go
+++ b/third_party/terraform/utils/transport.go
@@ -18,21 +18,7 @@ import (
 var DefaultRequestTimeout = 5 * time.Minute
 
 func isEmptyValue(v reflect.Value) bool {
-	switch v.Kind() {
-	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
-		return v.Len() == 0
-	case reflect.Bool:
-		return !v.Bool()
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return v.Int() == 0
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
-		return v.Uint() == 0
-	case reflect.Float32, reflect.Float64:
-		return v.Float() == 0
-	case reflect.Interface, reflect.Ptr:
-		return v.IsNil()
-	}
-	return false
+	return !v.IsValid() || v.IsZero()
 }
 
 func sendRequest(config *Config, method, project, rawurl string, body map[string]interface{}, errorRetryPredicates ...RetryErrorPredicateFunc) (map[string]interface{}, error) {

--- a/third_party/terraform/utils/transport.go
+++ b/third_party/terraform/utils/transport.go
@@ -18,7 +18,25 @@ import (
 var DefaultRequestTimeout = 5 * time.Minute
 
 func isEmptyValue(v reflect.Value) bool {
-	return !v.IsValid() || v.IsZero()
+	if !v.IsValid() {
+		return true
+	}
+
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
 }
 
 func sendRequest(config *Config, method, project, rawurl string, body map[string]interface{}, errorRetryPredicates ...RetryErrorPredicateFunc) (map[string]interface{}, error) {


### PR DESCRIPTION
Added IsValid check, which handles nil objects ~, and updated our zero-checking logic to use the one built into go in 1.13~. This fixes an issue where we were sending null to the API for all nested objects instead of omitting them from the request if they were unset.

~The logic is slightly different than in our version, and the only way to really find out if it breaks anything is by running tests- I caught one already and I'll catch any others post-submit in our CI run. Conveniently, this affects fields that _aren't_ set, so the only way we wouldn't notice it for a given resource would be if all of its tests set an Optional block (which is rare; usually we have at least one test that only sets Required fields)~

@drebes fyi

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
all: fixed issue where nested objects were getting sent as null values to GCP on create instead of being omitted from requests
```
