### PR TITLE
mark vpc_access_connector.network as required

### DIFF
--- a/products/vpcaccess/api.yaml
+++ b/products/vpcaccess/api.yaml
@@ -72,6 +72,7 @@ objects:
         name: network
         description: |
           Name of a VPC network.
+        required: true
       - !ruby/object:Api::Type::String
         name: ipCidrRange
         description: |


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5233

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
vpcaccess: marked `network` field as required in order to fail invalid configs at plan-time instead of at apply-time
```
