### PR TITLE
Allow domain mapping to succeed if DNS is pending

### DIFF
--- a/third_party/terraform/utils/cloudrun_polling.go
+++ b/third_party/terraform/utils/cloudrun_polling.go
@@ -59,6 +59,11 @@ func (s KnativeStatus) LatestMessage() string {
 func (s KnativeStatus) State(res interface{}) string {
 	for _, condition := range s.Status.Conditions {
 		if condition.Type == "Ready" {
+			// DomainMapping can enter a 'terminal' state of waiting for external verification
+			// of DNS records.
+			if condition.Reason != "" && condition.Reason == "CertificatePending" {
+				return "Ready:CertificatePending"
+			}
 			return fmt.Sprintf("%s:%s", condition.Type, condition.Status)
 		}
 	}
@@ -76,7 +81,7 @@ func (p *CloudRunPolling) PendingStates() []string {
 	return []string{"Ready:Unknown", "Empty"}
 }
 func (p *CloudRunPolling) TargetStates() []string {
-	return []string{"Ready:True"}
+	return []string{"Ready:True", "Ready:CertificatePending"}
 }
 func (p *CloudRunPolling) ErrorStates() []string {
 	return []string{"Ready:False"}


### PR DESCRIPTION
This now mimics the gcloud behavior where the resource creation "succeeds" even though it's still in a ready:unknown state.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
`cloudrun`: Stopped returning an error when a `cloud_run_domain_mapping` was waiting on DNS verification.
```
