### PR TITLE
Add sidebar entry for google_sql_ca_certs

### DIFF
--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -187,6 +187,9 @@
       <li<%%= sidebar_current("docs-google-datasource-service-account-key") %>>
         <a href="/docs/providers/google/d/datasource_google_service_account_key.html">google_service_account_key</a>
       </li>
+      <li<%%= sidebar_current("docs-google-datasource-sql-ca-certs") %>>
+        <a href="/docs/providers/google/d/datasource_google_sql_ca_certs.html">google_sql_ca_certs</a>
+      </li>
       <li<%%= sidebar_current("docs-google-datasource-storage-bucket-object") %>>
         <a href="/docs/providers/google/d/storage_bucket_object.html">google_storage_bucket_object</a>
       </li>


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->
Add missing sidebar entry for google_sql_ca_certs data source (PR: https://github.com/GoogleCloudPlatform/magic-modules/pull/2901)

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
