### PR TITLE
set master_authorized_networks_config.enabled=true ...

### DIFF
--- a/third_party/validator/container.go
+++ b/third_party/validator/container.go
@@ -1,13 +1,13 @@
-// This file is written manually and is not based from terraform-provider-google. 
-// There is a huge potential for drift. The longer term plan is to have this 
-// file generated from the logic in terraform-provider-google. Please 
-// see https://github.com/GoogleCloudPlatform/magic-modules/pull/2485#issuecomment-545680059 
+// This file is written manually and is not based from terraform-provider-google.
+// There is a huge potential for drift. The longer term plan is to have this
+// file generated from the logic in terraform-provider-google. Please
+// see https://github.com/GoogleCloudPlatform/magic-modules/pull/2485#issuecomment-545680059
 // for the discussion.
 
 package google
 
 import (
-  "fmt"
+	"fmt"
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -1100,12 +1100,9 @@ func expandContainerClusterMasterAuthorizedNetworksConfig(v interface{}, d Terra
 	original := raw.(map[string]interface{})
 	transformed := make(map[string]interface{})
 
-	transformedEnabled, err := expandContainerClusterMasterAuthorizedNetworksConfigEnabled(original["enabled"], d, config)
-	if err != nil {
-		return nil, err
-	} else if val := reflect.ValueOf(transformedEnabled); val.IsValid() && !isEmptyValue(val) {
-		transformed["enabled"] = transformedEnabled
-	}
+	// enabled is always true as long as there is a master_authorized_networks_config config block.
+	// There is no option in Terraform to disable that when master_authorized_networks_config is seen.
+	transformed["enabled"] = true
 
 	transformedCidrBlocks, err := expandContainerClusterMasterAuthorizedNetworksConfigCidrBlocks(original["cidr_blocks"], d, config)
 	if err != nil {
@@ -1115,10 +1112,6 @@ func expandContainerClusterMasterAuthorizedNetworksConfig(v interface{}, d Terra
 	}
 
 	return transformed, nil
-}
-
-func expandContainerClusterMasterAuthorizedNetworksConfigEnabled(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
-	return v, nil
 }
 
 func expandContainerClusterMasterAuthorizedNetworksConfigCidrBlocks(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {


### PR DESCRIPTION
…when there is a master_authorized_networks_config block in terraform-google-conversion. This aligns with how terraform-google-provider handles master_authorized_networks_config block. https://github.com/GoogleCloudPlatform/magic-modules/blob/435551bdd45b3d70d145125edae1c6a0dac3517b/third_party/terraform/resources/resource_container_cluster.go.erb#L2400-L2407

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME
terraform-google-conversion only: set master_authorized_networks_config.enabled to true when there is a master_authorized_networks_config block in Terraform configuration.
```
