### PR TITLE
Change max dispatches from int to double

### DIFF
--- a/products/cloudtasks/api.yaml
+++ b/products/cloudtasks/api.yaml
@@ -86,7 +86,7 @@ objects:
       - !ruby/object:Api::Type::NestedObject
         name: 'rateLimits'
         description: |
-          Rate limits for task dispatches. 
+          Rate limits for task dispatches.
 
           The queue's actual dispatch rate is the result of:
 
@@ -96,7 +96,7 @@ objects:
             Unavailable) responses from the worker, high error rates, or to
             smooth sudden large traffic spikes.
         properties:
-          - !ruby/object:Api::Type::Integer
+          - !ruby/object:Api::Type::Double
             name: 'maxDispatchesPerSecond'
             description: |
               The maximum rate at which tasks are dispatched from this queue.


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5341

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
`cloudtasks`: Changed `max_dispatches_per_second` to a double instead of an integer.
```
