### PR TITLE
Adding various test fixes, extra logic for special cases

### DIFF
--- a/overrides/inspec/resource_override.rb
+++ b/overrides/inspec/resource_override.rb
@@ -27,6 +27,7 @@ module Overrides
           singular_only
           singular_extra_examples
           plural_custom_logic
+          plural_custom_attr_readers
         ]
       end
 
@@ -46,6 +47,10 @@ module Overrides
         # Custom logic injected into plural resource's parse method.
         # Allows for multiple interpretations of a single field within an API response
         check :plural_custom_logic, type: String
+
+        # Attribute readers to add to plural resource to access fields added via
+        # plural_custom_logic
+        check :plural_custom_attr_readers, type: ::Array, default: [], item_type: String
       end
     end
   end

--- a/products/kms/inspec.yaml
+++ b/products/kms/inspec.yaml
@@ -17,6 +17,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     privileged: true
     additional_functions: third_party/inspec/custom_functions/kms_key_ring.erb
     plural_custom_logic: third_party/inspec/custom_functions/kms_key_ring_name.erb
+    plural_custom_attr_readers: 
+      - key_ring_name
     properties:
       name: !ruby/object:Overrides::Inspec::PropertyOverride
         # This is added back via custom methods

--- a/products/storage/inspec.yaml
+++ b/products/storage/inspec.yaml
@@ -54,7 +54,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     name: BucketObject
     singular_only: true
     privileged: true
-    additional_functions: third_party/inspec/custom_functions/bucket_name_from_params.erb
+    additional_functions: third_party/inspec/custom_functions/bucket_object.erb
     properties:
       bucket: !ruby/object:Overrides::Inspec::PropertyOverride
         exclude: true

--- a/templates/inspec/plural_resource.erb
+++ b/templates/inspec/plural_resource.erb
@@ -31,6 +31,10 @@ name = resource_name(object, product)
 
   <%= "filter_table_config.add(:#{(prop.override_name || prop.out_name).pluralize}, field: :#{prop.override_name || prop.out_name})" -%>
 <% end # object.all_user_properties.each do -%>
+<% object.plural_custom_attr_readers.each do |custom_attr_reader| -%>
+
+  <%= "filter_table_config.add(:#{custom_attr_reader.pluralize}, field: :#{custom_attr_reader})" -%>
+<% end -%>
 
 
   filter_table_config.connect(self, :table)

--- a/third_party/inspec/custom_functions/bucket_object.erb
+++ b/third_party/inspec/custom_functions/bucket_object.erb
@@ -1,0 +1,9 @@
+def bucket
+  @params[:bucket]
+end
+
+# rubocop:disable Lint/DuplicateMethods
+def size
+  @size&.to_i
+end
+# rubocop:enable Lint/DuplicateMethods


### PR DESCRIPTION
Special case for bucket size which is a long coming back as a string. Fix allows us to preserve existing method signature.

Special case for using the same field in the key ring resource for two separate output values, key ring url which is the long name and key ring name which is the short name.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
