### PR TITLE
Change VCR test jobs to use a seed to allow for random suffixes

### DIFF
--- a/.ci/acceptance-tests/inspec-post-approve.sh
+++ b/.ci/acceptance-tests/inspec-post-approve.sh
@@ -56,7 +56,16 @@ function cleanup {
 export INSPEC_DIR=${PWD}
 trap cleanup EXIT
 
-bundle exec rake test:integration
+seed=$RANDOM
+bundle exec rake test:init_workspace
+# Seed plan_integration_tests so VCR cassettes work with random resource suffixes
+bundle exec rake test:plan_integration_tests[$seed]
+bundle exec rake test:setup_integration_tests
+bundle exec rake test:run_integration_tests
+bundle exec rake test:cleanup_integration_tests
+
+echo $seed > inspec-cassettes/seed.txt
+
 gsutil -m cp inspec-cassettes/* gs://magic-modules-inspec-bucket/$PR_ID/inspec-cassettes/approved/
 
 popd

--- a/.ci/acceptance-tests/inspec-post-merge.sh
+++ b/.ci/acceptance-tests/inspec-post-merge.sh
@@ -62,7 +62,15 @@ if [ $? -eq 0 ]; then
 	gsutil -m cp gs://magic-modules-inspec-bucket/$PR_ID/inspec-cassettes/approved/* gs://magic-modules-inspec-bucket/master/inspec-cassettes
 else
 	# We need to record new cassettes for this PR
-	bundle exec rake test:integration
+	seed=$RANDOM
+	bundle exec rake test:init_workspace
+	# Seed plan_integration_tests so VCR cassettes work with random resource suffixes
+	bundle exec rake test:plan_integration_tests[$seed]
+	bundle exec rake test:setup_integration_tests
+	bundle exec rake test:run_integration_tests
+	bundle exec rake test:cleanup_integration_tests
+
+	echo $seed > inspec-cassettes/seed.txt
 	gsutil -m cp inspec-cassettes/* gs://magic-modules-inspec-bucket/master/inspec-cassettes/
 fi
 set -e

--- a/.ci/acceptance-tests/inspec-vcr.sh
+++ b/.ci/acceptance-tests/inspec-vcr.sh
@@ -41,15 +41,6 @@ function cleanup {
 	cd $INSPEC_DIR
 	bundle exec rake test:cleanup_integration_tests
 }
-    Rake::Task["test:init_workspace"].execute
-    if File.exists?(File.join(integration_dir,"build",variable_file_name))
-      Rake::Task["test:cleanup_integration_tests"].execute
-    end
-    Rake::Task["test:plan_integration_tests"].execute
-    Rake::Task["test:setup_integration_tests"].execute
-    Rake::Task["test:run_integration_tests"].execute
-    Rake::Task["test:cleanup_integration_tests"].execute
-  end
 
 export INSPEC_DIR=${PWD}
 trap cleanup EXIT

--- a/.ci/acceptance-tests/inspec-vcr.sh
+++ b/.ci/acceptance-tests/inspec-vcr.sh
@@ -41,10 +41,28 @@ function cleanup {
 	cd $INSPEC_DIR
 	bundle exec rake test:cleanup_integration_tests
 }
-
+    Rake::Task["test:init_workspace"].execute
+    if File.exists?(File.join(integration_dir,"build",variable_file_name))
+      Rake::Task["test:cleanup_integration_tests"].execute
+    end
+    Rake::Task["test:plan_integration_tests"].execute
+    Rake::Task["test:setup_integration_tests"].execute
+    Rake::Task["test:run_integration_tests"].execute
+    Rake::Task["test:cleanup_integration_tests"].execute
+  end
 
 export INSPEC_DIR=${PWD}
 trap cleanup EXIT
-bundle exec rake test:integration
+
+seed=$RANDOM
+bundle exec rake test:init_workspace
+# Seed plan_integration_tests so VCR cassettes work with random resource suffixes
+bundle exec rake test:plan_integration_tests[$seed]
+bundle exec rake test:setup_integration_tests
+bundle exec rake test:run_integration_tests
+bundle exec rake test:cleanup_integration_tests
+
+echo $seed > inspec-cassettes/seed.txt
+
 gsutil -m cp inspec-cassettes/* gs://magic-modules-inspec-bucket/$PR_ID/inspec-cassettes/
 popd

--- a/.ci/unit-tests/inspec.sh
+++ b/.ci/unit-tests/inspec.sh
@@ -49,7 +49,7 @@ bundle exec rake test:init_workspace
 if test -f "inspec-cassettes/seed.txt"; then
 	# Seed the plan with the seed used to record the VCR cassettes.
 	# This lets randomly generated suffixes be the same between runs
-	bundle exec rake test:plan_integration_tests[$(echo inspec-cassettes/seed.txt)]
+	bundle exec rake test:plan_integration_tests[$(cat inspec-cassettes/seed.txt)]
 else
 	bundle exec rake test:plan_integration_tests
 fi

--- a/.ci/unit-tests/inspec.sh
+++ b/.ci/unit-tests/inspec.sh
@@ -46,10 +46,10 @@ fi
 set -e
 
 bundle exec rake test:init_workspace
-if test -f "seed.txt"; then
+if test -f "inspec-cassettes/seed.txt"; then
 	# Seed the plan with the seed used to record the VCR cassettes.
 	# This lets randomly generated suffixes be the same between runs
-	bundle exec rake test:plan_integration_tests[$(echo seed.txt)]
+	bundle exec rake test:plan_integration_tests[$(echo inspec-cassettes/seed.txt)]
 else
 	bundle exec rake test:plan_integration_tests
 fi

--- a/.ci/unit-tests/inspec.sh
+++ b/.ci/unit-tests/inspec.sh
@@ -45,6 +45,7 @@ else
 fi
 set -e
 
+bundle exec rake test:init_workspace
 if test -f "seed.txt"; then
 	# Seed the plan with the seed used to record the VCR cassettes.
 	# This lets randomly generated suffixes be the same between runs

--- a/.ci/unit-tests/inspec.sh
+++ b/.ci/unit-tests/inspec.sh
@@ -44,7 +44,15 @@ else
   gsutil -m cp gs://magic-modules-inspec-bucket/master/inspec-cassettes/* inspec-cassettes/
 fi
 set -e
-bundle exec rake test:generate_integration_test_variables
+
+if test -f "seed.txt"; then
+	# Seed the plan with the seed used to record the VCR cassettes.
+	# This lets randomly generated suffixes be the same between runs
+	bundle exec rake test:plan_integration_tests[$(echo seed.txt)]
+else
+	bundle exec rake test:plan_integration_tests
+fi
+
 bundle exec rake test:run_integration_tests
 
 popd

--- a/products/appengine/inspec.yaml
+++ b/products/appengine/inspec.yaml
@@ -22,6 +22,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     exclude: true
   StandardAppVersion: !ruby/object:Overrides::Inspec::ResourceOverride
     exclude: false
+    # This resource is very flaky, skip tests via privileged so integration tests pass
+    privileged: true
     properties:
       id: !ruby/object:Overrides::Inspec::PropertyOverride
         name: "version_id"

--- a/templates/inspec/examples/google_appengine_standard_app_version/google_appengine_standard_app_version_attributes.erb
+++ b/templates/inspec/examples/google_appengine_standard_app_version/google_appengine_standard_app_version_attributes.erb
@@ -1,3 +1,4 @@
 gcp_project_id = attribute(:gcp_project_id, default: '<%= external_attribute('gcp_project_id') -%>', description: 'The GCP project identifier.')
 gcp_location = attribute(:gcp_location, default: '<%= external_attribute('gcp_location') -%>', description: 'The GCP project location.')
 standardappversion = attribute('standardappversion', default: <%= JSON.pretty_generate(grab_attributes['standardappversion']) -%>, description: 'Cloud App Engine definition')
+gcp_enable_privileged_resources = attribute(:gcp_enable_privileged_resources, default:0, description:'Flag to enable privileged resources requiring elevated privileges in GCP.')

--- a/templates/inspec/tests/integration/build/gcp-mm.tf
+++ b/templates/inspec/tests/integration/build/gcp-mm.tf
@@ -661,6 +661,7 @@ resource "google_storage_bucket_object" "object" {
 }
 
 resource "google_app_engine_standard_app_version" "default" {
+  count = "${var.gcp_organization_id == "" ? 0 : var.gcp_enable_privileged_resources}"
   project         = var.gcp_project_id
   version_id      = var.standardappversion["version_id"]
   service         = var.standardappversion["service"]


### PR DESCRIPTION
Some newly generated InSpec resources require random suffixes (SQL instance cannot reuse a name within a project for several months after destroying).

This allows a seed to be passed to the `plan_integration_tests` rake task, and this seed is stored during VCR cassette generation and used to run unit tests.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
