### PR TITLE
Fix TestAccContainerCluster_misc, add alpha cluster test

### DIFF
--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1643,6 +1643,29 @@ func TestAccContainerCluster_withMasterAuthorizedNetworksDisabled(t *testing.T) 
 	})
 }
 
+func TestAccContainerCluster_withEnableKubernetesAlpha(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(10))
+	npName := fmt.Sprintf("tf-test-np-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withEnableKubernetesAlpha(clusterName, npName),
+			},
+			{
+				ResourceName:      "google_container_cluster.primary",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccContainerCluster_masterAuthorizedNetworksDisabled(resource_name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resource_name]
@@ -1801,7 +1824,6 @@ resource "google_container_cluster" "primary" {
     "us-central1-c",
   ]
 
-  enable_kubernetes_alpha = true
   enable_legacy_abac      = true
 
   logging_service    = "logging.googleapis.com"
@@ -1837,7 +1859,6 @@ resource "google_container_cluster" "primary" {
     "us-central1-c",
   ]
 
-  enable_kubernetes_alpha = true # Not updatable
   enable_legacy_abac      = false
 
   logging_service    = "none"
@@ -3566,4 +3587,23 @@ resource "google_container_cluster" "with_private_cluster" {
   }
 }
 `, containerNetName, clusterName)
+}
+
+func testAccContainerCluster_withEnableKubernetesAlpha(cluster, np string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  enable_kubernetes_alpha = true
+
+  node_pool {
+    name = "%s"
+	initial_node_count = 1
+	management {
+		auto_repair = false
+		auto_upgrade = false
+	}
+  }
+}
+`, cluster, np)
 }


### PR DESCRIPTION
TestAccContainerCluster_misc is failing with:

```
Auto_upgrade and auto_repair are not supported for clusters with enable_kubernetes_alpha = true., badRequest
```

Given `enable_kubernetes_alpha` creates an alpha cluster, we should probably create a new test for just alpha clusters/features