### PR TITLE
Mark network peering routes fields GA

### DIFF
--- a/third_party/terraform/resources/resource_compute_network_peering.go.erb
+++ b/third_party/terraform/resources/resource_compute_network_peering.go.erb
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
-	computeBeta "google.golang.org/api/compute/v0.beta"
 )
 
 const peerNetworkLinkRegex = "projects/(" + ProjectRegex + ")/global/networks/((?:[a-z](?:[-a-z0-9]*[a-z0-9])?))$"
@@ -47,7 +46,6 @@ func resourceComputeNetworkPeering() *schema.Resource {
 				DiffSuppressFunc: compareSelfLinkRelativePaths,
 			},
 
-			<% unless version == 'ga' -%>
 			"export_custom_routes": {
 				Type:     schema.TypeBool,
 				ForceNew: true,
@@ -61,7 +59,6 @@ func resourceComputeNetworkPeering() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
-			<% end -%>
 
 			"state": {
 				Type:             schema.TypeString,
@@ -94,7 +91,7 @@ func resourceComputeNetworkPeeringCreate(d *schema.ResourceData, meta interface{
 		return err
 	}
 
-	request := &computeBeta.NetworksAddPeeringRequest{}
+	request := &compute.NetworksAddPeeringRequest{}
 	request.NetworkPeering = expandNetworkPeering(d)
 
 	// Only one peering operation at a time can be performed for a given network.
@@ -105,7 +102,7 @@ func resourceComputeNetworkPeeringCreate(d *schema.ResourceData, meta interface{
 		defer mutexKV.Unlock(kn)
 	}
 
-	addOp, err := config.clientComputeBeta.Networks.AddPeering(networkFieldValue.Project, networkFieldValue.Name, request).Do()
+	addOp, err := config.clientCompute.Networks.AddPeering(networkFieldValue.Project, networkFieldValue.Name, request).Do()
 	if err != nil {
 		return fmt.Errorf("Error adding network peering: %s", err)
 	}
@@ -129,7 +126,7 @@ func resourceComputeNetworkPeeringRead(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	network, err := config.clientComputeBeta.Networks.Get(networkFieldValue.Project, networkFieldValue.Name).Do()
+	network, err := config.clientCompute.Networks.Get(networkFieldValue.Project, networkFieldValue.Name).Do()
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("Network %q", networkFieldValue.Name))
 	}
@@ -143,10 +140,8 @@ func resourceComputeNetworkPeeringRead(d *schema.ResourceData, meta interface{})
 
 	d.Set("peer_network", peering.Network)
 	d.Set("name", peering.Name)
-	<% unless version == 'ga' -%>
 	d.Set("import_custom_routes", peering.ImportCustomRoutes)
 	d.Set("export_custom_routes", peering.ExportCustomRoutes)
-	<% end -%>
 	d.Set("state", peering.State)
 	d.Set("state_details", peering.StateDetails)
 
@@ -196,7 +191,7 @@ func resourceComputeNetworkPeeringDelete(d *schema.ResourceData, meta interface{
 	return nil
 }
 
-func findPeeringFromNetwork(network *computeBeta.Network, peeringName string) *computeBeta.NetworkPeering {
+func findPeeringFromNetwork(network *compute.Network, peeringName string) *compute.NetworkPeering {
 	for _, p := range network.Peerings {
 		if p.Name == peeringName {
 			return p
@@ -204,15 +199,13 @@ func findPeeringFromNetwork(network *computeBeta.Network, peeringName string) *c
 	}
 	return nil
 }
-func expandNetworkPeering(d *schema.ResourceData) *computeBeta.NetworkPeering {
-	return &computeBeta.NetworkPeering{
+func expandNetworkPeering(d *schema.ResourceData) *compute.NetworkPeering {
+	return &compute.NetworkPeering{
 		ExchangeSubnetRoutes: true,
 		Name:	                d.Get("name").(string),
 		Network:              d.Get("peer_network").(string),
-<% unless version == 'ga' -%>
 		ExportCustomRoutes:   d.Get("export_custom_routes").(bool),
 		ImportCustomRoutes:   d.Get("import_custom_routes").(bool),
-<% end -%>
 	}
 }
 

--- a/third_party/terraform/tests/resource_compute_network_peering_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_network_peering_test.go.erb
@@ -9,12 +9,11 @@ import (
 	"strings"
 	"testing"
 	"google.golang.org/api/compute/v1"
-	computeBeta "google.golang.org/api/compute/v0.beta"
 )
 
 func TestAccComputeNetworkPeering_basic(t *testing.T) {
 	t.Parallel()
-	var peering_beta computeBeta.NetworkPeering
+	var peering_beta compute.NetworkPeering
 
 	primaryNetworkName := acctest.RandomWithPrefix("network-test-1")
 	peeringName := acctest.RandomWithPrefix("peering-test-1")
@@ -28,18 +27,17 @@ func TestAccComputeNetworkPeering_basic(t *testing.T) {
 			{
 				Config: testAccComputeNetworkPeering_basic(primaryNetworkName, peeringName),
 				Check: resource.ComposeTestCheckFunc(
+					// network foo
 					testAccCheckComputeNetworkPeeringExist("google_compute_network_peering.foo", &peering_beta),
 					testAccCheckComputeNetworkPeeringAutoCreateRoutes(true, &peering_beta),
-					<% unless version == 'ga' -%>
 					testAccCheckComputeNetworkPeeringImportCustomRoutes(false, &peering_beta),
 					testAccCheckComputeNetworkPeeringExportCustomRoutes(false, &peering_beta),
-					<% end -%>
+
+					// network bar
 					testAccCheckComputeNetworkPeeringExist("google_compute_network_peering.bar", &peering_beta),
 					testAccCheckComputeNetworkPeeringAutoCreateRoutes(true, &peering_beta),
-					<% unless version == 'ga' -%>
 					testAccCheckComputeNetworkPeeringImportCustomRoutes(true, &peering_beta),
 					testAccCheckComputeNetworkPeeringExportCustomRoutes(true, &peering_beta),
-					<% end -%>
 				),
 			},
 			{
@@ -61,7 +59,7 @@ func testAccComputeNetworkPeeringDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := config.clientComputeBeta.Networks.Get(
+		_, err := config.clientCompute.Networks.Get(
 			config.Project, rs.Primary.ID).Do()
 		if err == nil {
 			return fmt.Errorf("Network peering still exists")
@@ -71,7 +69,7 @@ func testAccComputeNetworkPeeringDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckComputeNetworkPeeringExist(n string, peering *computeBeta.NetworkPeering) resource.TestCheckFunc {
+func testAccCheckComputeNetworkPeeringExist(n string, peering *compute.NetworkPeering) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -91,7 +89,7 @@ func testAccCheckComputeNetworkPeeringExist(n string, peering *computeBeta.Netwo
 
 		networkName, peeringName := parts[0], parts[1]
 
-		network, err := config.clientComputeBeta.Networks.Get(config.Project, networkName).Do()
+		network, err := config.clientCompute.Networks.Get(config.Project, networkName).Do()
 		if err != nil {
 			return err
 		}
@@ -106,7 +104,7 @@ func testAccCheckComputeNetworkPeeringExist(n string, peering *computeBeta.Netwo
 	}
 }
 
-func testAccCheckComputeNetworkPeeringAutoCreateRoutes(v bool, peering *computeBeta.NetworkPeering) resource.TestCheckFunc {
+func testAccCheckComputeNetworkPeeringAutoCreateRoutes(v bool, peering *compute.NetworkPeering) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if peering.ExchangeSubnetRoutes != v {
@@ -116,8 +114,7 @@ func testAccCheckComputeNetworkPeeringAutoCreateRoutes(v bool, peering *computeB
 	}
 }
 
-<% unless version == 'ga' -%>
-func testAccCheckComputeNetworkPeeringImportCustomRoutes(v bool, peering *computeBeta.NetworkPeering) resource.TestCheckFunc {
+func testAccCheckComputeNetworkPeeringImportCustomRoutes(v bool, peering *compute.NetworkPeering) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if peering.ImportCustomRoutes != v {
 			return fmt.Errorf("should ImportCustomRoutes set to %t", v)
@@ -127,7 +124,7 @@ func testAccCheckComputeNetworkPeeringImportCustomRoutes(v bool, peering *comput
 	}
 }
 
-func testAccCheckComputeNetworkPeeringExportCustomRoutes(v bool, peering *computeBeta.NetworkPeering) resource.TestCheckFunc {
+func testAccCheckComputeNetworkPeeringExportCustomRoutes(v bool, peering *compute.NetworkPeering) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if peering.ExportCustomRoutes != v {
 			return fmt.Errorf("should ExportCustomRoutes set to %t", v)
@@ -136,7 +133,6 @@ func testAccCheckComputeNetworkPeeringExportCustomRoutes(v bool, peering *comput
 		return nil
 	}
 }
-<% end -%>
 
 func testAccComputeNetworkPeering_basic(primaryNetworkName, peeringName string) string {
 	s := `
@@ -162,12 +158,10 @@ resource "google_compute_network_peering" "bar" {
   name         = "peering-test-2-%s"
 `
 
-	<% unless version == 'ga' -%>
 	s = s +
 	   `import_custom_routes = true
 		export_custom_routes = true
 		`
-	<% end -%>
 	s = s + `}`
 	return fmt.Sprintf(s, primaryNetworkName, peeringName, acctest.RandString(10), acctest.RandString(10))
 }

--- a/third_party/terraform/website/docs/r/compute_network_peering.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_network_peering.html.markdown
@@ -56,10 +56,10 @@ The following arguments are supported:
 * `peer_network` - (Required) The peer network in the peering. The peer network
 may belong to a different project.
 
-* `export_custom_routes` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+* `export_custom_routes` - (Optional)
 Whether to export the custom routes to the peer network. Defaults to `false`.
 
-* `import_custom_routes` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+* `import_custom_routes` - (Optional)
 Whether to export the custom routes from the peer network. Defaults to `false`.
 
 ## Attributes Reference


### PR DESCRIPTION
Pre-work for https://github.com/terraform-providers/terraform-provider-google/issues/5007 so I don't need version guards for my test

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: made the `google_compute_network_peering` routes fields available in GA
```
