### PR TITLE
Inspec alert policy

### DIFF
--- a/overrides/inspec/resource_override.rb
+++ b/overrides/inspec/resource_override.rb
@@ -26,6 +26,7 @@ module Overrides
           privileged
           singular_only
           singular_extra_examples
+          plural_extra_examples
           plural_custom_logic
           plural_custom_attr_readers
         ]
@@ -44,6 +45,8 @@ module Overrides
         check :singular_only, type: :boolean, default: false
         # Points to a markdown file with extra examples to include in documentation
         check :singular_extra_examples, type: String
+        # Points to a markdown file with extra examples to include in plural documentation
+        check :plural_extra_examples, type: String
         # Custom logic injected into plural resource's parse method.
         # Allows for multiple interpretations of a single field within an API response
         check :plural_custom_logic, type: String

--- a/products/monitoring/inspec.yaml
+++ b/products/monitoring/inspec.yaml
@@ -15,10 +15,12 @@
 legacy_name: project
 overrides: !ruby/object:Overrides::ResourceOverrides
   AlertPolicy: !ruby/object:Overrides::Inspec::ResourceOverride
+    additional_functions: third_party/inspec/custom_functions/alert_policy.erb
+    singular_extra_examples: third_party/inspec/documentation/alert_policy_examples.md
+    plural_extra_examples: third_party/inspec/documentation/alert_policies.md
     self_link: projects/{{project}}/alertPolicies/{{name}}
     properties:
       name: !ruby/object:Overrides::Inspec::PropertyOverride
-        name_from_self_link: true
         override_name: policy_names
       displayName: !ruby/object:Overrides::Inspec::PropertyOverride
         override_name: policy_display_names

--- a/products/monitoring/inspec.yaml
+++ b/products/monitoring/inspec.yaml
@@ -1,0 +1,24 @@
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Inspec::Config
+legacy_name: project
+overrides: !ruby/object:Overrides::ResourceOverrides
+  AlertPolicy: !ruby/object:Overrides::Inspec::ResourceOverride
+    self_link: projects/{{project}}/alertPolicies/{{name}}
+  Group: !ruby/object:Overrides::Inspec::ResourceOverride
+    exclude: true
+  NotificationChannel: !ruby/object:Overrides::Inspec::ResourceOverride
+    exclude: true
+  UptimeCheckConfig: !ruby/object:Overrides::Inspec::ResourceOverride
+    exclude: true

--- a/products/monitoring/inspec.yaml
+++ b/products/monitoring/inspec.yaml
@@ -16,6 +16,14 @@ legacy_name: project
 overrides: !ruby/object:Overrides::ResourceOverrides
   AlertPolicy: !ruby/object:Overrides::Inspec::ResourceOverride
     self_link: projects/{{project}}/alertPolicies/{{name}}
+    properties:
+      name: !ruby/object:Overrides::Inspec::PropertyOverride
+        name_from_self_link: true
+        override_name: policy_names
+      displayName: !ruby/object:Overrides::Inspec::PropertyOverride
+        override_name: policy_display_names
+      enabled: !ruby/object:Overrides::Inspec::PropertyOverride
+        override_name: policy_enabled_state
   Group: !ruby/object:Overrides::Inspec::ResourceOverride
     exclude: true
   NotificationChannel: !ruby/object:Overrides::Inspec::ResourceOverride

--- a/templates/inspec/doc_template.md.erb
+++ b/templates/inspec/doc_template.md.erb
@@ -32,6 +32,11 @@ A `<%= resource_underscored_name -%>` is used to test a Google <%= object.name -
 <%= compile(object.singular_extra_examples) -%>
 
 <% end -%>
+<% if object.plural_extra_examples && plural -%>
+
+<%= compile(object.plural_extra_examples) -%>
+
+<% end -%>
 
 ## Properties
 Properties that can be accessed from the `<%= resource_underscored_name -%>` resource:

--- a/templates/inspec/examples/google_project_alert_policy/google_project_alert_policies.erb
+++ b/templates/inspec/examples/google_project_alert_policy/google_project_alert_policies.erb
@@ -1,0 +1,7 @@
+<% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
+<% alert_policy = grab_attributes['alert_policy'] -%>
+describe google_project_alert_policies(project: <%= gcp_project_id -%>) do
+  it { should exist }
+  its('policy_display_names') { should include <%= doc_generation ? "'#{alert_policy['display_name']}'" : "alert_policy['display_name']" -%>}
+  its('combiners') { should include <%= doc_generation ? "'#{alert_policy['combiner']}'" : "alert_policy['combiner']" -%>}
+end

--- a/templates/inspec/examples/google_project_alert_policy/google_project_alert_policy.erb
+++ b/templates/inspec/examples/google_project_alert_policy/google_project_alert_policy.erb
@@ -1,0 +1,11 @@
+<% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
+<% alert_policy = grab_attributes['alert_policy'] -%>
+describe.one do
+  google_project_alert_policies(project: <%= gcp_project_id -%>).policy_names do |policy_name|
+    describe google_project_alert_policy(project: <%= gcp_project_id -%>, name: policy_name) do
+      it { should exist }
+      its('display_name') { should cmp <%= doc_generation ? "'#{alert_policy['display_name']}'" : "alert_policy['display_name']" -%>}
+      its('combiner') { should cmp <%= doc_generation ? "'#{alert_policy['combiner']}'" : "alert_policy['combiner']" -%>}
+    end
+  end
+end

--- a/templates/inspec/examples/google_project_alert_policy/google_project_alert_policy.erb
+++ b/templates/inspec/examples/google_project_alert_policy/google_project_alert_policy.erb
@@ -6,6 +6,7 @@ describe.one do
       it { should exist }
       its('display_name') { should cmp <%= doc_generation ? "'#{alert_policy['display_name']}'" : "alert_policy['display_name']" -%>}
       its('combiner') { should cmp <%= doc_generation ? "'#{alert_policy['combiner']}'" : "alert_policy['combiner']" -%>}
+      it { should be_enabled }
     end
   end
 end

--- a/templates/inspec/examples/google_project_alert_policy/google_project_alert_policy_attributes.erb
+++ b/templates/inspec/examples/google_project_alert_policy/google_project_alert_policy_attributes.erb
@@ -1,0 +1,2 @@
+gcp_project_id = attribute(:gcp_project_id, default: '<%= external_attribute('gcp_project_id') -%>', description: 'The GCP project identifier.')
+alert_policy = attribute('alert_policy', default: <%= JSON.pretty_generate(grab_attributes['alert_policy']) -%>, description: 'Alert Policy description')

--- a/templates/inspec/tests/integration/build/gcp-mm.tf
+++ b/templates/inspec/tests/integration/build/gcp-mm.tf
@@ -1125,3 +1125,25 @@ resource "google_compute_vpn_tunnel" "tunnel1" {
     google_compute_forwarding_rule.inspec-gcp-fr-udp4500,
   ]
 }
+
+variable "alert_policy" {
+  type = any
+}
+
+resource "google_monitoring_alert_policy" "alert_policy" {
+  project      = var.gcp_project_id
+  display_name = var.alert_policy["display_name"]
+  combiner     = var.alert_policy["combiner"]
+  conditions {
+    display_name = var.alert_policy["condition_display_name"]
+    condition_threshold {
+      filter     = var.alert_policy["condition_filter"]
+      duration   = var.alert_policy["condition_duration"]
+      comparison = var.alert_policy["condition_comparison"]
+      aggregations {
+        alignment_period   = "60s"
+        per_series_aligner = "ALIGN_RATE"
+      }
+    }
+  }
+}

--- a/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -413,3 +413,11 @@ project_exclusion:
   name: inspec-project-exclusion
   description: My project exclusion description
   filter: resource.type = gce_instance AND severity <= DEBUG
+
+alert_policy:
+  display_name: Display
+  combiner: OR
+  condition_display_name: condition
+  condition_filter: "metric.type=\"compute.googleapis.com/instance/disk/write_bytes_count\" AND resource.type=\"gce_instance\""
+  condition_duration: 60s
+  condition_comparison: COMPARISON_GT

--- a/third_party/inspec/custom_functions/alert_policy.erb
+++ b/third_party/inspec/custom_functions/alert_policy.erb
@@ -1,0 +1,3 @@
+def enabled?
+  @enabled
+end

--- a/third_party/inspec/documentation/alert_policies.md
+++ b/third_party/inspec/documentation/alert_policies.md
@@ -1,0 +1,27 @@
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that there are no more than a specified number of project alert policies available for the project
+
+    describe google_project_alert_policies(project: 'chef-inspec-gcp') do
+      its('count') { should be <= 100}
+    end
+
+### Test that an expected policy name is available for the project
+
+    describe google_project_alert_policies(project: 'chef-inspec-gcp') do
+      its('policy_names') { should include 'projects/spaterson-project/alertPolicies/9271751234503117449' }
+    end
+
+### Test whether any expected policy display name is available for the project
+
+    describe google_project_alert_policies(project: 'chef-inspec-gcp') do
+      its('policy_display_names') { should_not include 'banned policy' }
+    end
+
+### Ensure no existing policies are inactive
+
+    describe google_project_alert_policies(project: 'chef-inspec-gcp') do
+      its('policy_enabled_states') { should_not include false }
+    end

--- a/third_party/inspec/documentation/alert_policies.md
+++ b/third_party/inspec/documentation/alert_policies.md
@@ -1,7 +1,3 @@
-## Examples
-
-The following examples show how to use this InSpec audit resource.
-
 ### Test that there are no more than a specified number of project alert policies available for the project
 
     describe google_project_alert_policies(project: 'chef-inspec-gcp') do

--- a/third_party/inspec/documentation/alert_policy_examples.md
+++ b/third_party/inspec/documentation/alert_policy_examples.md
@@ -1,0 +1,15 @@
+## Examples
+
+The following examples show how to use this InSpec audit resource.
+
+### Test that a GCP alert policy is enabled 
+
+    describe google_project_alert_policy(policy: 'spaterson', name: '9271751234503117449') do
+      it { should be_enabled }
+    end
+
+### Test that a GCP compute alert policy display name is correct
+
+    describe google_project_alert_policy(policy: 'spaterson-project', name: '9271751234503117449') do
+      its('display_name') { should eq 'policy name' }
+    end

--- a/third_party/inspec/documentation/alert_policy_examples.md
+++ b/third_party/inspec/documentation/alert_policy_examples.md
@@ -1,7 +1,3 @@
-## Examples
-
-The following examples show how to use this InSpec audit resource.
-
 ### Test that a GCP alert policy is enabled 
 
     describe google_project_alert_policy(policy: 'spaterson', name: '9271751234503117449') do


### PR DESCRIPTION
Add support for monitoring alert policy. Use legacy_name to conform with old resources

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
