### PR TITLE
Expand boot disk name to full name during instance from template creation

### DIFF
--- a/third_party/terraform/resources/resource_compute_instance_from_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_from_template.go
@@ -181,6 +181,13 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *Config, it 
 		// boot disk was not overridden, so use the one from the instance template
 		for _, disk := range it.Properties.Disks {
 			if disk.Boot {
+				if disk.Source != "" {
+					source, err := ParseDiskFieldValue(disk.Source, d, config)
+					if err != nil {
+						return nil, err
+					}
+					disk.Source = source.RelativeLink()
+				}
 				if disk.InitializeParams != nil {
 					if dt := disk.InitializeParams.DiskType; dt != "" {
 						// Instances need a URL for the disk type, but instance templates

--- a/third_party/terraform/resources/resource_compute_instance_from_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_from_template.go
@@ -182,6 +182,7 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *Config, it 
 		for _, disk := range it.Properties.Disks {
 			if disk.Boot {
 				if disk.Source != "" {
+					// Instances need a URL for the disk, but instance templates only have the name
 					source, err := ParseDiskFieldValue(disk.Source, d, config)
 					if err != nil {
 						return nil, err

--- a/third_party/terraform/resources/resource_compute_instance_from_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_from_template.go
@@ -183,11 +183,7 @@ func adjustInstanceFromTemplateDisks(d *schema.ResourceData, config *Config, it 
 			if disk.Boot {
 				if disk.Source != "" {
 					// Instances need a URL for the disk, but instance templates only have the name
-					source, err := ParseDiskFieldValue(disk.Source, d, config)
-					if err != nil {
-						return nil, err
-					}
-					disk.Source = source.RelativeLink()
+					disk.Source = fmt.Sprintf("projects/%s/zones/%s/disks/%s", project, zone.Name, disk.Source)
 				}
 				if disk.InitializeParams != nil {
 					if dt := disk.InitializeParams.DiskType; dt != "" {

--- a/third_party/terraform/tests/resource_compute_instance_from_template_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_from_template_test.go
@@ -230,16 +230,9 @@ resource "google_compute_instance_template" "foobar" {
   machine_type = "n1-standard-1"
 
   disk {
-    source_image = data.google_compute_image.my_image.self_link
-    auto_delete  = true
-    disk_size_gb = 100
-    boot         = true
-  }
-
-  disk {
     source      = google_compute_disk.foobar.name
     auto_delete = false
-    boot        = false
+    boot        = true
   }
 
   disk {
@@ -247,6 +240,15 @@ resource "google_compute_instance_template" "foobar" {
     type         = "SCRATCH"
     interface    = "NVME"
     disk_size_gb = 375
+  }
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    disk_size_gb = 100
+    boot         = false
+    disk_type    = "pd-ssd"
+    type         = "PERSISTENT"
   }
 
   network_interface {


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/5413

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: Fixed `google_compute_instance_from_template` with existing boot disks
```
