### PR TITLE
Output data fusion instance service account

### DIFF
--- a/products/datafusion/api.yaml
+++ b/products/datafusion/api.yaml
@@ -150,6 +150,11 @@ objects:
         output: true
         description: |
           Current version of the Data Fusion.
+      - !ruby/object:Api::Type::String
+        name: 'serviceAccount'
+        output: true
+        description: |
+          Service account which will be used to access resources in the customer project.
       - !ruby/object:Api::Type::Boolean
         name: 'privateInstance'
         description: |


### PR DESCRIPTION
Fix https://github.com/terraform-providers/terraform-provider-google/issues/5454

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
`google_data_fusion_instance`: Added `service_account` field
```
