### PR TITLE
Add error if boot disk specified on non-first disk in instance template

### DIFF
--- a/third_party/terraform/resources/resource_compute_instance_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_template.go
@@ -598,6 +598,9 @@ func buildDisks(d *schema.ResourceData, config *Config) ([]*computeBeta.Attached
 		disk.AutoDelete = d.Get(prefix + ".auto_delete").(bool)
 
 		if v, ok := d.GetOk(prefix + ".boot"); ok {
+			if v.(bool) && i != 0 {
+				return nil, fmt.Errorf("Only the first disk specified in instance_template can be a boot disk")
+			}
 			disk.Boot = v.(bool)
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/5428

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: `google_compute_instance_template` add plan time check for any disks marked `boot` outside of the first disk
```
