### PR TITLE
ensure InstanceGroup URLs returned for x_node_pool

### DIFF
--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -557,6 +557,10 @@ func flattenNodePool(d *schema.ResourceData, config *Config, np *containerBeta.N
 		}
 		size += int(igm.TargetSize)
 	}
+	instanceGroupUrls, err := getInstanceGroupUrlsFromManagerUrls(config, np.InstanceGroupUrls)
+	if err != nil {
+		return nil, err
+	}
 	nodePool := map[string]interface{}{
 		"name":                np.Name,
 		"name_prefix":         d.Get(prefix + "name_prefix"),
@@ -566,7 +570,7 @@ func flattenNodePool(d *schema.ResourceData, config *Config, np *containerBeta.N
 <% end -%>
 		"node_count":          size / len(np.InstanceGroupUrls),
 		"node_config":         flattenNodeConfig(np.Config),
-		"instance_group_urls": np.InstanceGroupUrls,
+		"instance_group_urls": instanceGroupUrls,
 		"version":             np.Version,
 	}
 


### PR DESCRIPTION
Upstreams https://github.com/terraform-providers/terraform-provider-google/pull/5465

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: `google_container_node_pool` `instance_group_urls` are now correctly the URLS of instance groups, not instance group managers
```
