### PR TITLE
bugfix for occasional generation failure.

### DIFF
--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -67,7 +67,10 @@ if [ "$COMMAND" == "head" ]; then
     BRANCH=auto-pr-$REFERENCE
     COMMIT_MESSAGE="New generated code for MM PR $REFERENCE."
 elif [ "$COMMAND" == "base" ]; then
-    git checkout HEAD^2
+    # In this case, there is guaranteed to be a merge commit,
+    # and the *left* side of it is the old master branch.
+    # the *right* side of it is the code to be merged.
+    git checkout HEAD~
     BRANCH=auto-pr-$REFERENCE-old
     COMMIT_MESSAGE="Old generated code for MM PR $REFERENCE."
 elif [ "$COMMAND" == "downstream" ]; then

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -50,12 +50,12 @@ steps:
     - name: 'gcr.io/cloud-builders/git'
       args:
           - checkout
-          - head/$_HEAD_BRANCH
+          - origin/$_BASE_BRANCH
     - name: 'gcr.io/cloud-builders/git'
       id: merged
       args:
           - merge
-          - origin/$_BASE_BRANCH
+          - head/$_HEAD_BRANCH
 
     - name: 'gcr.io/graphite-docker-images/downstream-builder'
       secretEnv: ["GITHUB_TOKEN"]


### PR DESCRIPTION
It was formerly possible for a commit which did not generate a merge commit merging *into* master to fail to generate.  This will prevent that by merging the head branch *into* master, which will always produce a merge commit.


<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```