### PR TITLE
read/write iam policies at version 3 in GA provider

### DIFF
--- a/templates/terraform/iam_policy.go.erb
+++ b/templates/terraform/iam_policy.go.erb
@@ -178,19 +178,17 @@ func (u *<%= resource_name -%>IamUpdater) GetResourceIamPolicy() (*cloudresource
 	}
 <% end -%>
 	var obj map[string]interface{}
-<% unless version == 'ga' -%>
-<%   if object.iam_policy.iam_conditions_request_type == :QUERY_PARAM -%>
+<% if object.iam_policy.iam_conditions_request_type == :QUERY_PARAM -%>
 	url, err = addQueryParams(url, map[string]string{"optionsRequestedPolicyVersion": fmt.Sprintf("%d", iamPolicyVersion)})
 	if err != nil {
 		return nil, err
 	}
-<%   elsif object.iam_policy.iam_conditions_request_type == :REQUEST_BODY -%>
+<% elsif object.iam_policy.iam_conditions_request_type == :REQUEST_BODY -%>
 	obj = map[string]interface{}{
 		"options": map[string]interface{}{
 			"requestedPolicyVersion": iamPolicyVersion,
 		},
 	}
-<%    end  -%>
 <%  end -%>
 
 	policy, err := sendRequest(u.Config, "<%= object.iam_policy.fetch_iam_policy_verb.to_s.upcase -%>", <% if resource_params.include?('project')  %>project<% else %>""<% end %>, url, obj<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)

--- a/third_party/terraform/resources/resource_google_project_iam_policy.go.erb
+++ b/third_party/terraform/resources/resource_google_project_iam_policy.go.erb
@@ -142,10 +142,8 @@ func resourceGoogleProjectIamPolicyImport(d *schema.ResourceData, meta interface
 }
 
 func setProjectIamPolicy(policy *cloudresourcemanager.Policy, config *Config, pid string) error {
-<% unless version == 'ga' -%>
 	policy.Version = iamPolicyVersion
 
-<% end -%>
 	// Apply the policy
 	pbytes, _ := json.Marshal(policy)
 	log.Printf("[DEBUG] Setting policy %#v for project: %s", string(pbytes), pid)
@@ -171,17 +169,12 @@ func getResourceIamPolicy(d *schema.ResourceData) (*cloudresourcemanager.Policy,
 
 // Retrieve the existing IAM Policy for a Project
 func getProjectIamPolicy(project string, config *Config) (*cloudresourcemanager.Policy, error) {
-<% if version == 'ga' -%>
-	p, err := config.clientResourceManager.Projects.GetIamPolicy(project,
-		&cloudresourcemanager.GetIamPolicyRequest{}).Do()
-<% else -%>
 	p, err := config.clientResourceManager.Projects.GetIamPolicy(project,
 		&cloudresourcemanager.GetIamPolicyRequest{
 			Options: &cloudresourcemanager.GetPolicyOptions{
 				RequestedPolicyVersion: iamPolicyVersion,
 			},
 		}).Do()
-<% end -%>
 
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving IAM policy for project %q: %s", project, err)

--- a/third_party/terraform/resources/resource_iam_binding.go.erb
+++ b/third_party/terraform/resources/resource_iam_binding.go.erb
@@ -94,9 +94,7 @@ func resourceIamBindingCreateUpdate(newUpdaterFunc newResourceIamUpdaterFunc, en
 		modifyF := func(ep *cloudresourcemanager.Policy) error {
 			cleaned := filterBindingsWithRoleAndCondition(ep.Bindings, binding.Role, binding.Condition)
 			ep.Bindings = append(cleaned, binding)
-<% unless version == 'ga' -%>
 			ep.Version = iamPolicyVersion
-<% end -%>
 			return nil
 		}
 

--- a/third_party/terraform/resources/resource_iam_member.go.erb
+++ b/third_party/terraform/resources/resource_iam_member.go.erb
@@ -185,9 +185,7 @@ func resourceIamMemberCreate(newUpdaterFunc newResourceIamUpdaterFunc, enableBat
 		modifyF := func(ep *cloudresourcemanager.Policy) error {
 			// Merge the bindings together
 			ep.Bindings = mergeBindings(append(ep.Bindings, memberBind))
-<% unless version == 'ga' -%>
 			ep.Version = iamPolicyVersion
-<% end -%>
 			return nil
 		}
 		if enableBatching {

--- a/third_party/terraform/resources/resource_iam_policy.go.erb
+++ b/third_party/terraform/resources/resource_iam_policy.go.erb
@@ -120,9 +120,7 @@ func ResourceIamPolicyDelete(newUpdaterFunc newResourceIamUpdaterFunc) schema.De
 		if v, ok := d.GetOk("etag"); ok {
 			pol.Etag = v.(string)
 		}
-<% unless version == 'ga' -%>
 		pol.Version = iamPolicyVersion
-<% end -%>
 		err = updater.SetResourceIamPolicy(pol)
 		if err != nil {
 			return err
@@ -137,9 +135,7 @@ func setIamPolicyData(d *schema.ResourceData, updater ResourceIamUpdater) error 
 	if err != nil {
 		return fmt.Errorf("'policy_data' is not valid for %s: %s", updater.DescribeResource(), err)
 	}
-<% unless version == 'ga' -%>
 	policy.Version = iamPolicyVersion
-<% end -%>
 
 	err = updater.SetResourceIamPolicy(policy)
 	if err != nil {

--- a/third_party/terraform/tests/resource_google_service_account_iam_test.go.erb
+++ b/third_party/terraform/tests/resource_google_service_account_iam_test.go.erb
@@ -224,11 +224,7 @@ func TestAccServiceAccountIamPolicy_withCondition(t *testing.T) {
 func testAccCheckGoogleServiceAccountIam(account string, numBindings int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
-<% if version == 'ga' -%>
-		p, err := config.clientIAM.Projects.ServiceAccounts.GetIamPolicy(serviceAccountCanonicalId(account)).Do()
-<% else -%>
 		p, err := config.clientIAM.Projects.ServiceAccounts.GetIamPolicy(serviceAccountCanonicalId(account)).OptionsRequestedPolicyVersion(iamPolicyVersion).Do()
-<% end -%>
 		if err != nil {
 			return err
 		}

--- a/third_party/terraform/utils/iam.go.erb
+++ b/third_party/terraform/utils/iam.go.erb
@@ -16,9 +16,7 @@ import (
 )
 
 const maxBackoffSeconds = 30
-<% unless version == 'ga' -%>
 const iamPolicyVersion = 3
-<% end -%>
 
 // These types are implemented per GCP resource type and specify how to do per-resource IAM operations.
 // They are used in the generic Terraform IAM resource definitions
@@ -276,7 +274,6 @@ func listFromIamBindingMap(bm map[iamBindingKey]map[string]struct{}) []*cloudres
 			Role:    key.Role,
 			Members: stringSliceFromGolangSet(members),
 		}
-<% unless version == 'ga' -%>
 		if !key.Condition.Empty() {
 			b.Condition = &cloudresourcemanager.Expr{
 				Description: key.Condition.Description,
@@ -284,7 +281,6 @@ func listFromIamBindingMap(bm map[iamBindingKey]map[string]struct{}) []*cloudres
 				Title:       key.Condition.Title,
 			}
 		}
-<% end -%>
 		rb = append(rb, b)
 	}
 	return rb

--- a/third_party/terraform/utils/iam_kms_crypto_key.go.erb
+++ b/third_party/terraform/utils/iam_kms_crypto_key.go.erb
@@ -48,11 +48,7 @@ func CryptoIdParseFunc(d *schema.ResourceData, config *Config) error {
 }
 
 func (u *KmsCryptoKeyIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Policy, error) {
-<% if version == 'ga' -%>
-	p, err := u.Config.clientKms.Projects.Locations.KeyRings.CryptoKeys.GetIamPolicy(u.resourceId).Do()
-<% else -%>
 	p, err := u.Config.clientKms.Projects.Locations.KeyRings.CryptoKeys.GetIamPolicy(u.resourceId).OptionsRequestedPolicyVersion(iamPolicyVersion).Do()
-<% end -%>
 
 	if err != nil {
 		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{err}}", u.DescribeResource()), err)

--- a/third_party/terraform/utils/iam_kms_key_ring.go.erb
+++ b/third_party/terraform/utils/iam_kms_key_ring.go.erb
@@ -49,11 +49,7 @@ func KeyRingIdParseFunc(d *schema.ResourceData, config *Config) error {
 }
 
 func (u *KmsKeyRingIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Policy, error) {
-<% if version == 'ga' -%>
-	p, err := u.Config.clientKms.Projects.Locations.KeyRings.GetIamPolicy(u.resourceId).Do()
-<% else -%>
 	p, err := u.Config.clientKms.Projects.Locations.KeyRings.GetIamPolicy(u.resourceId).OptionsRequestedPolicyVersion(iamPolicyVersion).Do()
-<% end -%>
 
 	if err != nil {
 		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{err}}", u.DescribeResource()), err)

--- a/third_party/terraform/utils/iam_project.go.erb
+++ b/third_party/terraform/utils/iam_project.go.erb
@@ -43,17 +43,12 @@ func ProjectIdParseFunc(d *schema.ResourceData, _ *Config) error {
 }
 
 func (u *ProjectIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Policy, error) {
-<% if version == 'ga' -%>
-	p, err := u.Config.clientResourceManager.Projects.GetIamPolicy(u.resourceId,
-		&cloudresourcemanager.GetIamPolicyRequest{}).Do()
-<% else -%>
 	p, err := u.Config.clientResourceManager.Projects.GetIamPolicy(u.resourceId,
 		&cloudresourcemanager.GetIamPolicyRequest{
 			Options: &cloudresourcemanager.GetPolicyOptions{
 				RequestedPolicyVersion: iamPolicyVersion,
 			},
 		}).Do()
-<% end -%>
 
 	if err != nil {
 		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{err}}", u.DescribeResource()), err)

--- a/third_party/terraform/utils/iam_service_account.go.erb
+++ b/third_party/terraform/utils/iam_service_account.go.erb
@@ -37,11 +37,7 @@ func ServiceAccountIdParseFunc(d *schema.ResourceData, _ *Config) error {
 }
 
 func (u *ServiceAccountIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Policy, error) {
-<% if version == 'ga' -%>
-	p, err := u.Config.clientIAM.Projects.ServiceAccounts.GetIamPolicy(u.serviceAccountId).Do()
-<% else -%>
 	p, err := u.Config.clientIAM.Projects.ServiceAccounts.GetIamPolicy(u.serviceAccountId).OptionsRequestedPolicyVersion(iamPolicyVersion).Do()
-<% end -%>
 
 	if err != nil {
 		return nil, errwrap.Wrapf(fmt.Sprintf("Error retrieving IAM policy for %s: {{err}}", u.DescribeResource()), err)


### PR DESCRIPTION
Conditions will still only be able to be set in the beta provider, but this way we don't end up in situations where people are stuck because they're only managing part of their IAM in terraform, and the part that doesn't has a condition, so the policy version is 3 but we're reading at 1. Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5218, which explains the problem a bit better.

This also makes sure that the changes outlined in b/147505583 won't affect us.

Tested by adding a member with a condition to a role in the console, and then using Terraform to add another member to the same role, but with no condition.

Technically this would break users that have an IAM binding resource defined in their config, have modified it out of band to have a condition on it, upgrade to the version with this change, and then modify the member list. Since those users should be using the beta provider and defining the condition in their config anyway, I'm not too worried about it.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
iam: starts reading/writing IAM policies at version 3 in the GA provider. If you have an IAM resource defined in your config that has a condition on it created outside of Terraform, you should start using the beta provider and defining the condition in your config to avoid unexpected behavior.
```
```release-note:bug
iam: fixes issue where users of the GA provider who used IAM conditions outside of Terraform were getting an error
```
