### PR TITLE
Allow Version and Scopes to use overrides

### DIFF
--- a/api/object.rb
+++ b/api/object.rb
@@ -26,7 +26,19 @@ module Api
         attr_reader :name
       end
 
+      def string_array?(arr)
+        types = arr.map(&:class).uniq
+        types.size == 1 && types[0] == String
+      end
+
       def deep_merge(arr1, arr2)
+        # Scopes is an array of standard strings. In which case return the
+        # version in the overrides. This allows scopes to be removed rather
+        # than allowing for a merge of the two arrays
+        if string_array?(arr1)
+          return arr2.nil? ? arr1 : arr2
+        end
+
         # Merge any elements that exist in both
         result = arr1.map do |el1|
           other = arr2.select { |el2| el1.name == el2.name }.first

--- a/api/product/version.rb
+++ b/api/product/version.rb
@@ -19,7 +19,7 @@ module Api
     # In GCP, different product versions are generally ordered where alpha is
     # a superset of beta, and beta a superset of GA. Each version will have a
     # different version url.
-    class Version < Api::Object
+    class Version < Api::Object::Named
       include Comparable
 
       attr_reader :base_url


### PR DESCRIPTION
Version was not a Named type even though it has a `name` field. Changing its
type allows it to inherit the merge logic defined in Named
Scopes is defined as an Array of type String which the merge logic will now
take the entire contents of the string array defined in the overrides.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
This change should not have any downstreams.
```
