### PR TITLE
Add support for google_compute_project_info to inspec to migrate

### DIFF
--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -33,6 +33,8 @@ datasources: !ruby/object:Overrides::ResourceOverrides
     exclude: true
   NetworkEndpoint: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
+  ProjectInfo: !ruby/object:Overrides::Ansible::ResourceOverride
+    exclude: true
   Region: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
   RegionDiskType: !ruby/object:Overrides::Ansible::ResourceOverride
@@ -320,6 +322,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   NetworkEndpoint: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
   NetworkPeeringRoutesConfig: !ruby/object:Overrides::Ansible::ResourceOverride
+    exclude: true
+  ProjectInfo: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
   Region: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -7453,6 +7453,68 @@ objects:
               - :RESTART_NODE_ON_ANY_SERVER
               - :RESTART_NODE_ON_MINIMAL_SERVERS
   - !ruby/object:Api::Resource
+    name: 'ProjectInfo'
+    base_url: projects
+    self_link: projects/{{project}}
+    readonly: true
+    description: |
+      Information about the project specifically for compute.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: name
+        description: The name of this project
+      - !ruby/object:Api::Type::NestedObject
+        name: 'commonInstanceMetadata'
+        description: 'Metadata shared for all instances in this project'
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: 'items'
+            description: |
+              Array of key/values
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'key'
+                  description: 'Key of the metadata key/value pair'
+                - !ruby/object:Api::Type::String
+                  name: 'value'
+                  description: 'Value of the metadata key/value pair'
+      - !ruby/object:Api::Type::Array
+        name: 'enabledFeatures'
+        description: |
+          Restricted features enabled for use on this project
+        item_type: Api::Type::String
+      - !ruby/object:Api::Type::String
+        name: defaultServiceAccount
+        description: Default service account used by VMs in this project
+      - !ruby/object:Api::Type::String
+        name: xpnProjectStatus
+        description: The role this project has in a shared VPC configuration.
+      - !ruby/object:Api::Type::String
+        name: defaultNetworkTier
+        description: The default network tier used for configuring resources in this project
+      - !ruby/object:Api::Type::Array
+        name: 'quotas'
+        description: |
+          Quotas applied to this project
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'metric'
+              description: 'Name of the quota metric'
+            - !ruby/object:Api::Type::String
+              name: 'limit'
+              description: 'Quota limit for this metric'
+            - !ruby/object:Api::Type::String
+              name: 'usage'
+              description: 'Current usage of this metric'
+            - !ruby/object:Api::Type::String
+              name: 'owner'
+              description: Owning resource. This is the resource on which this quota is applied.
+      - !ruby/object:Api::Type::Time
+        name: 'creationTimestamp'
+        description: 'Creation timestamp in RFC3339 text format.'
+  - !ruby/object:Api::Resource
     name: 'Region'
     kind: 'compute#region'
     base_url: projects/{{project}}/regions

--- a/products/compute/inspec.yaml
+++ b/products/compute/inspec.yaml
@@ -90,6 +90,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     exclude: true
   NetworkPeeringRoutesConfig: !ruby/object:Overrides::Inspec::ResourceOverride
     exclude: true
+  ProjectInfo:  !ruby/object:Overrides::Inspec::ResourceOverride
+    singular_only: true
+    additional_functions: third_party/inspec/custom_functions/google_compute_project_info.erb
   Region: !ruby/object:Overrides::Inspec::ResourceOverride
     additional_functions: third_party/inspec/custom_functions/google_compute_region.erb
     properties:

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1120,6 +1120,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           If it is not provided, the provider region is used.
       serverBinding: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+  ProjectInfo: !ruby/object:Overrides::Terraform::ResourceOverride
+    exclude: true
   Region: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true
   RegionAutoscaler: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/templates/inspec/examples/google_compute_project_info/google_compute_project_info.erb
+++ b/templates/inspec/examples/google_compute_project_info/google_compute_project_info.erb
@@ -1,0 +1,6 @@
+<% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
+describe google_compute_project_info(project: <%= gcp_project_id -%>) do
+	it { should exist }
+	its('default_service_account') { should match "developer.gserviceaccount.com" }
+	it { should_not be_has_enabled_oslogin }
+end

--- a/templates/inspec/examples/google_compute_project_info/google_compute_project_info_attributes.erb
+++ b/templates/inspec/examples/google_compute_project_info/google_compute_project_info_attributes.erb
@@ -1,0 +1,1 @@
+gcp_project_id = attribute(:gcp_project_id, default: '<%= external_attribute('gcp_project_id') -%>', description: 'The GCP project identifier.')

--- a/third_party/inspec/custom_functions/google_compute_project_info.erb
+++ b/third_party/inspec/custom_functions/google_compute_project_info.erb
@@ -1,0 +1,6 @@
+def has_enabled_oslogin?
+  @common_instance_metadata&.items&.each do |element|
+    return true if element.key=='enable-oslogin' and element.value.casecmp('true').zero?
+  end
+  false
+end


### PR DESCRIPTION
Migrate handwritten resource.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
