### PR TITLE
Add Dialogflow Agent resource

### DIFF
--- a/products/dialogflow/api.yaml
+++ b/products/dialogflow/api.yaml
@@ -31,7 +31,10 @@ objects:
     self_link: "projects/{{project}}/agent"
     update_verb: :POST
     description: |
-      Represents a Dialogflow agent.
+      A Dialogflow agent is a virtual agent that handles conversations with your end-users. It is a natural language
+      understanding module that understands the nuances of human language. Dialogflow translates end-user text or audio
+      during a conversation to structured data that your apps and services can understand. You design and build a Dialogflow
+      agent to handle the types of conversations required for your system.
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Official Documentation':
@@ -41,14 +44,13 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'displayName'
         required: true
-        input: true
         description: |
           The name of this agent.
       - !ruby/object:Api::Type::String
         name: 'defaultLanguageCode'
         description: |
-         The default language of the agent as a language tag. [See Language Support](https://cloud.google.com/dialogflow/docs/reference/language) for a 
-         list of the currently supported language codes. This field cannot be updated after creation.
+         The default language of the agent as a language tag. [See Language Support](https://cloud.google.com/dialogflow/docs/reference/language) 
+         for a list of the currently supported language codes. This field cannot be updated after creation.
         input: true
         required: true
       - !ruby/object:Api::Type::Array
@@ -59,7 +61,8 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'timeZone'
         description: |
-         The time zone of this agent from the [time zone database](https://www.iana.org/time-zones), e.g., America/New_York, Europe/Paris.
+         The time zone of this agent from the [time zone database](https://www.iana.org/time-zones), e.g., America/New_York,
+         Europe/Paris.
         required: true
       - !ruby/object:Api::Type::String
         name: 'description'
@@ -68,8 +71,8 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'avatarUri'
         description: |
-         The URI of the agent's avatar, which are used throughout the Dialogflow console. When an image URL is entered 
-         into this field, the Dialogflow will save the image in the backend. The address of the backend image returned 
+         The URI of the agent's avatar, which are used throughout the Dialogflow console. When an image URL is entered
+         into this field, the Dialogflow will save the image in the backend. The address of the backend image returned
          from the API will be shown in the [avatarUriBackend] field.
       - !ruby/object:Api::Type::String
         name: 'avatarUriBackend'
@@ -85,22 +88,27 @@ objects:
         name: 'matchMode'
         description: |
           Determines how intents are detected from user queries.
-          * MATCH_MODE_HYBRID: Best for agents with a small number of examples in intents and/or wide use of templates syntax and composite entities.
-          * MATCH_MODE_ML_ONLY: Can be used for agents with a large number of examples in intents, especially the ones using @sys.any or very large developer entities.
+          * MATCH_MODE_HYBRID: Best for agents with a small number of examples in intents and/or wide use of templates
+          syntax and composite entities.
+          * MATCH_MODE_ML_ONLY: Can be used for agents with a large number of examples in intents, especially the ones
+          using @sys.any or very large developer entities.
         values:
           - :MATCH_MODE_HYBRID
           - :MATCH_MODE_ML_ONLY
       - !ruby/object:Api::Type::Double
         name: 'classificationThreshold'
         description: |
-         To filter out false positive results and still get variety in matched natural language inputs for your agent, you can tune the machine learning classification threshold. 
-         If the returned score value is less than the threshold value, then a fallback intent will be triggered or, if there are no fallback intents defined, no intent will be 
-         triggered. The score values range from 0.0 (completely uncertain) to 1.0 (completely certain). If set to 0.0, the default of 0.3 is used.
+         To filter out false positive results and still get variety in matched natural language inputs for your agent,
+         you can tune the machine learning classification threshold. If the returned score value is less than the threshold
+         value, then a fallback intent will be triggered or, if there are no fallback intents defined, no intent will be 
+         triggered. The score values range from 0.0 (completely uncertain) to 1.0 (completely certain). If set to 0.0, the 
+         default of 0.3 is used.
       - !ruby/object:Api::Type::Enum
         name: 'apiVersion'
         description: |
-          API version displayed in Dialogflow console. If not specified, V2 API is assumed. Clients are free to query different service endpoints for different API versions. 
-          However, bots connectors and webhook calls will follow the specified API version.
+          API version displayed in Dialogflow console. If not specified, V2 API is assumed. Clients are free to query
+          different service endpoints for different API versions. However, bots connectors and webhook calls will follow 
+          the specified API version.
           * API_VERSION_V1: Legacy V1 API.
           * API_VERSION_V2: V2 API.
           * API_VERSION_V2_BETA_1: V2beta1 API.
@@ -115,8 +123,9 @@ objects:
           * TIER_STANDARD: Standard tier.
           * TIER_ENTERPRISE: Enterprise tier (Essentials).
           * TIER_ENTERPRISE_PLUS: Enterprise tier (Plus).
-          NOTE: This field seems to have eventual consistency in the API. Updating this field to a new value, or even creating a new agent with a tier that is different from a previous agent 
-          in the same project will take some time to propogate. The provider will wait for the API to show consistency, which can lead to longer apply times.
+          NOTE: This field seems to have eventual consistency in the API. Updating this field to a new value, or even 
+          creating a new agent with a tier that is different from a previous agent in the same project will take some
+          time to propagate. The provider will wait for the API to show consistency, which can lead to longer apply times.
         values:
           - :TIER_STANDARD
           - :TIER_ENTERPRISE

--- a/products/dialogflow/api.yaml
+++ b/products/dialogflow/api.yaml
@@ -1,0 +1,123 @@
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: Dialogflow
+display_name: Dialogflow
+versions:
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://dialogflow.googleapis.com/v2/
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: Dialogflow API
+    url: https://console.cloud.google.com/apis/library/dialogflow.googleapis.com
+objects:
+  - !ruby/object:Api::Resource
+    name: 'Agent'
+    base_url: "projects/{{project}}/agent"
+    self_link: "projects/{{project}}/agent"
+    update_verb: :POST
+    description: |
+      Represents a Dialogflow agent.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+          'https://cloud.google.com/dialogflow/docs/'
+      api: 'https://cloud.google.com/dialogflow/docs/reference/rest/v2/projects/agent'
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'displayName'
+        required: true
+        input: true
+        description: |
+          The name of this agent.
+      - !ruby/object:Api::Type::String
+        name: 'defaultLanguageCode'
+        description: |
+         The default language of the agent as a language tag. [See Language Support](https://cloud.google.com/dialogflow/docs/reference/language) for a 
+         list of the currently supported language codes. This field cannot be updated after creation.
+        input: true
+        required: true
+      - !ruby/object:Api::Type::Array
+        name: 'supportedLanguageCodes'
+        item_type: Api::Type::String
+        description: |
+         The list of all languages supported by this agent (except for the defaultLanguageCode).
+      - !ruby/object:Api::Type::String
+        name: 'timeZone'
+        description: |
+         The time zone of this agent from the [time zone database](https://www.iana.org/time-zones), e.g., America/New_York, Europe/Paris.
+        required: true
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+         The description of this agent. The maximum length is 500 characters. If exceeded, the request is rejected.
+      - !ruby/object:Api::Type::String
+        name: 'avatarUri'
+        description: |
+         The URI of the agent's avatar, which are used throughout the Dialogflow console. When an image URL is entered 
+         into this field, the Dialogflow will save the image in the backend. The address of the backend image returned 
+         from the API will be shown in the [avatarUriBackend] field.
+      - !ruby/object:Api::Type::String
+        name: 'avatarUriBackend'
+        description: |
+         The URI of the agent's avatar as returned from the API. Output only. To provide an image URL for the agent avatar,
+         the [avatarUri] field can be used.
+        output: true
+      - !ruby/object:Api::Type::Boolean
+        name: 'enableLogging'
+        description: |
+         Determines whether this agent should log conversation queries.
+      - !ruby/object:Api::Type::Enum
+        name: 'matchMode'
+        description: |
+          Determines how intents are detected from user queries.
+          * MATCH_MODE_HYBRID: Best for agents with a small number of examples in intents and/or wide use of templates syntax and composite entities.
+          * MATCH_MODE_ML_ONLY: Can be used for agents with a large number of examples in intents, especially the ones using @sys.any or very large developer entities.
+        values:
+          - :MATCH_MODE_HYBRID
+          - :MATCH_MODE_ML_ONLY
+      - !ruby/object:Api::Type::Double
+        name: 'classificationThreshold'
+        description: |
+         To filter out false positive results and still get variety in matched natural language inputs for your agent, you can tune the machine learning classification threshold. 
+         If the returned score value is less than the threshold value, then a fallback intent will be triggered or, if there are no fallback intents defined, no intent will be 
+         triggered. The score values range from 0.0 (completely uncertain) to 1.0 (completely certain). If set to 0.0, the default of 0.3 is used.
+      - !ruby/object:Api::Type::Enum
+        name: 'apiVersion'
+        description: |
+          API version displayed in Dialogflow console. If not specified, V2 API is assumed. Clients are free to query different service endpoints for different API versions. 
+          However, bots connectors and webhook calls will follow the specified API version.
+          * API_VERSION_V1: Legacy V1 API.
+          * API_VERSION_V2: V2 API.
+          * API_VERSION_V2_BETA_1: V2beta1 API.
+        values:
+          - :API_VERSION_V1
+          - :API_VERSION_V2
+          - :API_VERSION_V2_BETA_1
+      - !ruby/object:Api::Type::Enum
+        name: 'tier'
+        description: |
+          The agent tier. If not specified, TIER_STANDARD is assumed.
+          * TIER_STANDARD: Standard tier.
+          * TIER_ENTERPRISE: Enterprise tier (Essentials).
+          * TIER_ENTERPRISE_PLUS: Enterprise tier (Plus).
+          NOTE: This field seems to have eventual consistency in the API. Updating this field to a new value, or even creating a new agent with a tier that is different from a previous agent 
+          in the same project will take some time to propogate. The provider will wait for the API to show consistency, which can lead to longer apply times.
+        values:
+          - :TIER_STANDARD
+          - :TIER_ENTERPRISE
+          - :TIER_ENTERPRISE_PLUS

--- a/products/dialogflow/terraform.yaml
+++ b/products/dialogflow/terraform.yaml
@@ -20,6 +20,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "full_agent"
         vars:
           agent_name: "tf-test-full-agent"
+    # Only one agent per project, API does not have an agent ID
     id_format: "{{project}}"
     import_format: ["{{project}}"]
     # Skip sweeper gen due to non-standard urls.

--- a/products/dialogflow/terraform.yaml
+++ b/products/dialogflow/terraform.yaml
@@ -1,0 +1,50 @@
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Terraform::Config
+overrides: !ruby/object:Overrides::ResourceOverrides
+  Agent: !ruby/object:Overrides::Terraform::ResourceOverride
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "dialogflow_agent_full"
+        primary_resource_id: "full_agent"
+        vars:
+          agent_name: "tf-test-full-agent"
+    id_format: "{{project}}"
+    import_format: ["{{project}}"]
+    # Skip sweeper gen due to non-standard urls.
+    skip_sweeper: true
+    properties:
+      description: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.StringLenBetween(0, 500)'
+      avatarUri: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
+      avatarUriBackend: !ruby/object:Overrides::Terraform::PropertyOverride
+        api_name: avatarUri
+      apiVersion: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      matchMode: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      tier: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      post_update: 'templates/terraform/post_create/dialogflow_agent_tier.go.erb'
+      post_create: 'templates/terraform/post_create/dialogflow_agent_tier.go.erb'
+
+# This is for copying files over
+files: !ruby/object:Provider::Config::Files
+  # These files have templating (ERB) code that will be run.
+  # This is usually to add licensing info, autogeneration notices, etc.
+  compile:
+<%= lines(indent(compile('provider/terraform/product~compile.yaml'), 4)) -%>

--- a/products/dialogflow/terraform.yaml
+++ b/products/dialogflow/terraform.yaml
@@ -14,6 +14,9 @@
 --- !ruby/object:Provider::Terraform::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
   Agent: !ruby/object:Overrides::Terraform::ResourceOverride
+    timeouts: !ruby/object:Api::Timeouts
+      insert_minutes: 40
+      update_minutes: 40
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "dialogflow_agent_full"

--- a/templates/terraform/examples/dialogflow_agent_full.tf.erb
+++ b/templates/terraform/examples/dialogflow_agent_full.tf.erb
@@ -1,0 +1,13 @@
+resource "google_dialogflow_agent" "<%= ctx[:primary_resource_id] %>" {
+  display_name = "<%= ctx[:vars]["agent_name"] %>"
+  default_language_code = "en"
+  supported_language_codes = ["fr","de","es"]
+  time_zone = "America/New_York"
+  description = "Example description."
+  avatar_uri = "https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/super_cloud.png"
+  enable_logging = true
+  match_mode = "MATCH_MODE_ML_ONLY"
+  classification_threshold = 0.3
+  api_version = "API_VERSION_V2_BETA_1"
+  tier = "TIER_STANDARD"
+}

--- a/templates/terraform/post_create/dialogflow_agent_tier.go.erb
+++ b/templates/terraform/post_create/dialogflow_agent_tier.go.erb
@@ -2,30 +2,24 @@
 // The tier field is eventually consistent, we need to test for consistency before moving on.
 // Otherwise, the user will see diffs on the field.
 if d.HasChange("tier") {
+	old, new := d.GetChange("tier")
 	readUrl, err := replaceVars(d, config, "{{DialogflowBasePath}}projects/{{project}}/agent")
-	if err != nil {
-		return err
-	}
-
-	incorrect_attempts := 0
-	consistent_threshold := 8
-	for correct_in_row := 0; correct_in_row < consistent_threshold; {
-		log.Printf("[INFO] Failed attempts: %d, correct in row: %d out of %d ", incorrect_attempts, correct_in_row, consistent_threshold)
-		res, err := sendRequest(config, "GET", project, readUrl, nil)
-		if err != nil {
-			return handleNotFoundError(err, d, fmt.Sprintf("DialogflowAgent %q", d.Id()))
-		}
-
-		if res["tier"] == d.Get("tier") {
-			correct_in_row++
-		} else {
-			if incorrect_attempts >= 20 {
-				return fmt.Errorf("Timed out waiting for agent tier to return correct value.  Waiting for %s, got %s.",
-				d.Get("tier"), res["tier"])
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{old.(string)},
+		Target:  []string{new.(string)},
+		Refresh: func() (interface{}, string, error) {
+			res, err := sendRequest(config, "GET", project, readUrl, nil)
+			if err != nil {
+				return 0, "", err
 			}
-			correct_in_row = 0
-			incorrect_attempts++
-			time.Sleep(2 * time.Minute)
-		}
+			return res, res["tier"].(string), nil
+		},
+		Timeout:                   40 * time.Minute,
+		MinTimeout:                10 * time.Second,
+		ContinuousTargetOccurence: 10,
+	}
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Timed out waiting for agent tier to return correct value.  Waiting for %s, got %s.", new, old)
 	}
 }

--- a/templates/terraform/post_create/dialogflow_agent_tier.go.erb
+++ b/templates/terraform/post_create/dialogflow_agent_tier.go.erb
@@ -1,0 +1,31 @@
+
+// The tier field is eventually consistent, we need to test for consistency before moving on.
+// Otherwise, the user will see diffs on the field.
+if d.HasChange("tier") {
+	readUrl, err := replaceVars(d, config, "{{DialogflowBasePath}}projects/{{project}}/agent")
+	if err != nil {
+		return err
+	}
+
+	incorrect_attempts := 0
+	consistent_threshold := 8
+	for correct_in_row := 0; correct_in_row < consistent_threshold; {
+		log.Printf("[INFO] Failed attempts: %d, correct in row: %d out of %d ", incorrect_attempts, correct_in_row, consistent_threshold)
+		res, err := sendRequest(config, "GET", project, readUrl, nil)
+		if err != nil {
+			return handleNotFoundError(err, d, fmt.Sprintf("DialogflowAgent %q", d.Id()))
+		}
+
+		if res["tier"] == d.Get("tier") {
+			correct_in_row++
+		} else {
+			if incorrect_attempts >= 20 {
+				return fmt.Errorf("Timed out waiting for agent tier to return correct value.  Waiting for %s, got %s.",
+				d.Get("tier"), res["tier"])
+			}
+			correct_in_row = 0
+			incorrect_attempts++
+			time.Sleep(2 * time.Minute)
+		}
+	}
+}

--- a/third_party/terraform/tests/resource_dialogflow_agent_test.go.erb
+++ b/third_party/terraform/tests/resource_dialogflow_agent_test.go.erb
@@ -14,6 +14,7 @@ func TestAccDialogflowAgent_update(t *testing.T) {
 	t.Parallel()
 
 	agentName := acctest.RandomWithPrefix("tf-test")
+	agentNameUpdate := acctest.RandomWithPrefix("tf-test")
 	projectID := acctest.RandomWithPrefix("tf-test")
 	orgID := getTestOrgFromEnv(t)
 
@@ -31,7 +32,7 @@ func TestAccDialogflowAgent_update(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"avatar_uri"},
 			},
 			{
-				Config: testAccDialogflowAgent_full2(projectID, orgID, agentName),
+				Config: testAccDialogflowAgent_full2(projectID, orgID, agentNameUpdate),
 			},
 			{
 				ResourceName:      "google_dialogflow_agent.foobar",

--- a/third_party/terraform/tests/resource_dialogflow_agent_test.go.erb
+++ b/third_party/terraform/tests/resource_dialogflow_agent_test.go.erb
@@ -1,0 +1,120 @@
+<% autogen_exception -%>
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDialogflowAgent_update(t *testing.T) {
+	t.Parallel()
+
+	agentName := acctest.RandomWithPrefix("tf-test")
+	projectID := acctest.RandomWithPrefix("tf-test")
+	orgID := getTestOrgFromEnv(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDialogflowAgent_full1(projectID, orgID, agentName),
+			},
+			{
+				ResourceName:      "google_dialogflow_agent.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"avatar_uri"},
+			},
+			{
+				Config: testAccDialogflowAgent_full2(projectID, orgID, agentName),
+			},
+			{
+				ResourceName:      "google_dialogflow_agent.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"avatar_uri"},
+			},
+		},
+	})
+}
+
+func testAccDialogflowAgent_full1(projectID string, orgID string, agentName string) string {
+	return fmt.Sprintf(`
+	resource "google_project" "agent_project" {
+		project_id = "%s"
+		name       = "%s"
+		org_id     = "%s"
+	  }
+
+	resource "google_project_service" "agent_project" {
+		project = google_project.agent_project.project_id
+		service = "dialogflow.googleapis.com"
+	  }
+	  
+	resource "google_project_iam_member" "agent_create" {
+		project = google_project_service.agent_project.project
+		role    = "roles/dialogflow.admin"
+		member  = "serviceAccount:service-${google_project.agent_project.number}@gcp-sa-dialogflow.iam.gserviceaccount.com"
+		depends_on = [google_project_service.agent_project]
+	  }
+
+	resource "google_dialogflow_agent" "foobar" {
+		project = "%s"
+		display_name = "%s"
+		default_language_code = "en"
+		supported_language_codes = ["fr","de","es"]
+		time_zone = "America/New_York"
+		description = "Description 1."
+		avatar_uri = "https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/super_cloud.png"
+		enable_logging = true
+		match_mode = "MATCH_MODE_ML_ONLY"
+		classification_threshold = 0.3
+		api_version = "API_VERSION_V2_BETA_1"
+		tier = "TIER_STANDARD"
+		depends_on = [google_project_iam_member.agent_create]
+	  }
+	`, projectID, projectID, orgID, projectID, agentName)
+}
+
+func testAccDialogflowAgent_full2(projectID string, orgID string, agentName string) string {
+	return fmt.Sprintf(`
+	resource "google_project" "agent_project" {
+		project_id = "%s"
+		name       = "%s"
+		org_id     = "%s"
+	  }
+
+	  resource "google_project_service" "agent_project" {
+		project = google_project.agent_project.project_id
+		service = "dialogflow.googleapis.com"
+	  }
+	  
+	resource "google_project_iam_member" "agent_create" {
+		project = google_project_service.agent_project.project
+		role    = "roles/dialogflow.admin"
+		member  = "serviceAccount:service-${google_project.agent_project.number}@gcp-sa-dialogflow.iam.gserviceaccount.com"
+		depends_on = [google_project_service.agent_project]
+	  }
+
+	resource "google_dialogflow_agent" "foobar" {
+		project = "%s"
+		display_name = "%s"
+		default_language_code = "en"
+		supported_language_codes = ["no"]
+		time_zone = "Europe/London"
+		description = "Description 2!"
+		avatar_uri = "https://storage.googleapis.com/gweb-cloudblog-publish/images/f4xvje.max-200x200.PNG"
+		enable_logging = false
+		match_mode = "MATCH_MODE_HYBRID"
+		classification_threshold = 0.7
+		api_version = "API_VERSION_V2"
+		tier = "TIER_ENTERPRISE"
+		depends_on = [google_project_iam_member.agent_create]
+	  }
+	  `, projectID, projectID, orgID, projectID, agentName)
+}


### PR DESCRIPTION
1 / 3 resources needed for [Dialogflow support](https://github.com/terraform-providers/terraform-provider-google/issues/3487)
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5511
Note:
The agent.tier field is eventually consistent. Updates to the field seem to take 20+ minutes to propagate. Due to this, I added a retry loop to check for consistency. Meanwhile, I submitted a bug internally to see what's up.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
google_dialogflow_agent
```
