### PR TITLE
Migrate organizations. Need support for POST verb in MM plural resources

### DIFF
--- a/overrides/inspec/resource_override.rb
+++ b/overrides/inspec/resource_override.rb
@@ -31,6 +31,7 @@ module Overrides
           plural_custom_attr_readers
           resource_name
           singular_custom_constructor
+          plural_fetch_verb
         ]
       end
 
@@ -64,6 +65,8 @@ module Overrides
         # Compute image checks two different endpoints to see if one returns a success.
         # This is strange, but preserves existing functionality
         check :singular_custom_constructor, type: String
+        # Some resources (organizations) use Post instead of Get for fetching their plural version
+        check :plural_fetch_verb, type: Symbol, default: :GET, allowed: %i[POST GET]
       end
     end
   end

--- a/products/resourcemanager/inspec.yaml
+++ b/products/resourcemanager/inspec.yaml
@@ -34,7 +34,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       method_name_separator: ':'
       fetch_iam_policy_verb: :POST
   Organization: !ruby/object:Overrides::Inspec::ResourceOverride
-    exclude: true
+    privileged: true
+    # Name should be organizations/123456
+    self_link: '{{name}}'
+    base_url: organizations:search
+    resource_name: google_organization
+    plural_fetch_verb: :POST
   Folder: !ruby/object:Overrides::Inspec::ResourceOverride
     product_url: https://cloudresourcemanager.googleapis.com/v2/
     # Creating and viewing folders requires organization level privileges

--- a/templates/inspec/examples/google_organization/google_organization.erb
+++ b/templates/inspec/examples/google_organization/google_organization.erb
@@ -1,0 +1,6 @@
+<% gcp_organization_id = "#{external_attribute('gcp_organization_id', doc_generation)}" -%>
+
+describe google_organization(name: "organizations/<%= doc_generation ? '123456' : "\#{gcp_organization_id}" -%>") do
+  its('name') { should eq "organizations/<%= doc_generation ? '123456' : "\#{gcp_organization_id}" -%>" }
+  its('lifecycle_state') { should cmp 'ACTIVE' }
+end

--- a/templates/inspec/examples/google_organization/google_organization_attributes.erb
+++ b/templates/inspec/examples/google_organization/google_organization_attributes.erb
@@ -1,0 +1,2 @@
+gcp_organization_id = attribute(:gcp_organization_id, default: <%= external_attribute('gcp_organization_id') -%>, description: 'The identifier of the organization that is the parent of this folder')
+gcp_enable_privileged_resources = attribute(:gcp_enable_privileged_resources, default:0, description:'Flag to enable privileged resources requiring elevated privileges in GCP.')

--- a/templates/inspec/examples/google_organization/google_organizations.erb
+++ b/templates/inspec/examples/google_organization/google_organizations.erb
@@ -1,0 +1,6 @@
+<% gcp_organization_id = "#{external_attribute('gcp_organization_id', doc_generation)}" -%>
+<% gcp_organization_display_name = "#{external_attribute('gcp_organization_display_name', doc_generation)}" -%>
+
+describe google_organizations do
+  its('names') { should include "organizations/<%= doc_generation ? '123456' : "\#{gcp_organization_id}" -%>" }
+end

--- a/templates/inspec/plural_resource.erb
+++ b/templates/inspec/plural_resource.erb
@@ -50,7 +50,7 @@ link_query_items = object&.nested_query&.keys&.first || object.collection_url_ke
 
   def fetch_wrapped_resource(wrap_path)
     # fetch_resource returns an array of responses (to handle pagination)
-    result = @connection.fetch_all(product_url, resource_base_url, @params, 'Get')
+    result = @connection.fetch_all(product_url, resource_base_url, @params, '<%= object.plural_fetch_verb.capitalize -%>')
     return if result.nil?
 
     # Conversion of string -> object hash to symbol -> object hash that InSpec needs


### PR DESCRIPTION
Almost there!

Organizations `search` which lists organizations is called with a POST to `organizations:search` which caused some issues with current implementations. Needed custom verb for plural resource

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
