### PR TITLE
Magician signoff on commits

### DIFF
--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -96,7 +96,7 @@ git add .
 git checkout -b $BRANCH
 
 COMMITTED=true
-git commit -m "$COMMIT_MESSAGE" || COMMITTED=false
+git commit --signoff -m "$COMMIT_MESSAGE" || COMMITTED=false
 
 if [ "$COMMITTED" == "true" ] && [ "$COMMAND" == "downstream" ]; then
     # Add the changelog entry!
@@ -110,7 +110,7 @@ if [ "$COMMITTED" == "true" ] && [ "$COMMAND" == "downstream" ]; then
         sed -e '/```release-note/,/```/!d' \
         > .changelog/$PR_NUMBER.txt
     git add .changelog
-    git commit --amend --no-edit
+    git commit --signoff --amend --no-edit
 fi
 
 git push $SCRATCH_PATH $BRANCH -f


### PR DESCRIPTION
InSpec commits need to be signed off for the DCO to pass. It feels safe to do this for all repos, but I could limit it to just the inspec-gcp repo if necessary

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
