### PR TITLE
Add support for new beta non-rfc fields in dns managed zone

### DIFF
--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -224,6 +224,15 @@ objects:
                   name: 'ipv4Address'
                   required: true
                   description: 'IPv4 address of a target name server.'
+                - !ruby/object:Api::Type::Enum
+                  name: 'forwardingPath'
+                  description: |
+                    Forwarding path for this TargetNameServer. If unset or `default` Cloud DNS will make forwarding
+                    decision based on address ranges, i.e. RFC1918 addresses go to the VPC, Non-RFC1918 addresses go
+                    to the Internet. When set to `private`, Cloud DNS will always send queries through VPC for this target
+                  values:
+                  - :default
+                  - :private
         min_version: beta
       - !ruby/object:Api::Type::NestedObject
         min_version: beta
@@ -248,6 +257,14 @@ objects:
                   The fully qualified URL of the VPC network to forward queries to.
                   This should be formatted like
                   `https://www.googleapis.com/compute/v1/projects/{project}/global/networks/{network}`
+      - !ruby/object:Api::Type::Boolean
+        name: 'reverseLookup'
+        api_name: reverseLookupConfig
+        min_version: beta
+        description: |
+          Specifies if this is a managed reverse lookup zone. If true, Cloud DNS will resolve reverse
+          lookup queries using automatically configured records for VPC resources. This only applies
+          to networks listed under `private_visibility_config`.
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Managing Zones':

--- a/products/dns/terraform.yaml
+++ b/products/dns/terraform.yaml
@@ -97,6 +97,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       visibility: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'caseDiffSuppress'
         custom_flatten: templates/terraform/custom_flatten/default_if_empty.erb
+      reverseLookup: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_flatten: templates/terraform/custom_flatten/object_to_bool.go.erb
+        custom_expand: templates/terraform/custom_expand/bool_to_object.go.erb
   Policy: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: 'projects/{{project}}/policies/{{name}}'
     examples:

--- a/templates/terraform/custom_expand/bool_to_object.go.erb
+++ b/templates/terraform/custom_expand/bool_to_object.go.erb
@@ -1,0 +1,21 @@
+<%- # the license inside this block applies to this file
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	if v == nil || !v.(bool) {
+        return nil, nil
+    }
+
+	return struct{}{}, nil
+}

--- a/templates/terraform/custom_flatten/object_to_bool.go.erb
+++ b/templates/terraform/custom_flatten/object_to_bool.go.erb
@@ -1,0 +1,17 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData) interface{} {
+	return v != nil
+}

--- a/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
+++ b/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
@@ -145,6 +145,30 @@ func TestAccDNSManagedZone_privateForwardingUpdate(t *testing.T) {
 }
 <% end -%>
 
+<% unless version.nil? || version == 'ga' -%>
+func TestAccDNSManagedZone_reverseLookup(t *testing.T) {
+	t.Parallel()
+
+	zoneSuffix := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSManagedZoneDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDnsManagedZone_reverseLookup(zoneSuffix),
+			},
+			resource.TestStep{
+				ResourceName:      "google_dns_managed_zone.reverse",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+<% end -%>
+
 func testAccDnsManagedZone_basic(suffix, description string) string {
 	return fmt.Sprintf(`
 resource "google_dns_managed_zone" "foobar" {
@@ -247,9 +271,11 @@ resource "google_dns_managed_zone" "private" {
   forwarding_config {
     target_name_servers {
       ipv4_address = "%s"
+      forwarding_path = "default"
     }
     target_name_servers {
       ipv4_address = "%s"
+      forwarding_path = "private"
     }
   }
 }
@@ -259,6 +285,26 @@ resource "google_compute_network" "network-1" {
   auto_create_subnetworks = false
 }
 `, suffix, first_nameserver, second_nameserver, suffix)
+}
+<% end -%>
+
+<% unless version.nil? || version == 'ga' -%>
+func testAccDnsManagedZone_reverseLookup(suffix string) string {
+	return fmt.Sprintf(`
+resource "google_dns_managed_zone" "reverse" {
+  name        = "reverse-zone-%s"
+  dns_name    = "1.0.168.192.in-addr.arpa."
+  visibility  = "private"
+  description = "Example private DNS zone"
+
+  reverse_lookup = true
+}
+
+resource "google_compute_network" "network-1" {
+  name                    = "network-1-%s"
+  auto_create_subnetworks = false
+}
+`, suffix, suffix)
 }
 <% end -%>
 

--- a/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
+++ b/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
@@ -304,7 +304,7 @@ resource "google_compute_network" "network-1" {
   name                    = "network-1-%s"
   auto_create_subnetworks = false
 }
-`, suffix)
+`, suffix, suffix)
 }
 <% end -%>
 

--- a/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
+++ b/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
@@ -125,7 +125,7 @@ func TestAccDNSManagedZone_privateForwardingUpdate(t *testing.T) {
 		CheckDestroy: testAccCheckDNSManagedZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDnsManagedZone_privateForwardingUpdate(zoneSuffix, "172.16.1.10", "172.16.1.20"),
+				Config: testAccDnsManagedZone_privateForwardingUpdate(zoneSuffix, "172.16.1.10", "172.16.1.20", "default", "private"),
 			},
 			resource.TestStep{
 				ResourceName:      "google_dns_managed_zone.private",
@@ -133,7 +133,7 @@ func TestAccDNSManagedZone_privateForwardingUpdate(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			resource.TestStep{
-				Config: testAccDnsManagedZone_privateForwardingUpdate(zoneSuffix, "172.16.1.10", "192.168.1.1"),
+				Config: testAccDnsManagedZone_privateForwardingUpdate(zoneSuffix, "172.16.1.10", "192.168.1.1", "private", "default"),
 			},
 			resource.TestStep{
 				ResourceName:      "google_dns_managed_zone.private",
@@ -255,7 +255,7 @@ resource "google_compute_network" "network-3" {
 }
 
 <% unless version.nil? || version == 'ga' -%>
-func testAccDnsManagedZone_privateForwardingUpdate(suffix, first_nameserver, second_nameserver string) string {
+func testAccDnsManagedZone_privateForwardingUpdate(suffix, first_nameserver, second_nameserver, first_forwarding_path, second_forwarding_path string) string {
 	return fmt.Sprintf(`
 resource "google_dns_managed_zone" "private" {
   name        = "private-zone-%s"
@@ -271,11 +271,11 @@ resource "google_dns_managed_zone" "private" {
   forwarding_config {
     target_name_servers {
       ipv4_address = "%s"
-      forwarding_path = "default"
+      forwarding_path = "%s"
     }
     target_name_servers {
       ipv4_address = "%s"
-      forwarding_path = "private"
+      forwarding_path = "%s"
     }
   }
 }
@@ -284,7 +284,7 @@ resource "google_compute_network" "network-1" {
   name                    = "network-1-%s"
   auto_create_subnetworks = false
 }
-`, suffix, first_nameserver, second_nameserver, suffix)
+`, suffix, first_nameserver, first_forwarding_path, second_nameserver, second_forwarding_path, suffix)
 }
 <% end -%>
 
@@ -304,7 +304,7 @@ resource "google_compute_network" "network-1" {
   name                    = "network-1-%s"
   auto_create_subnetworks = false
 }
-`, suffix, suffix)
+`, suffix, reverseLookup)
 }
 <% end -%>
 

--- a/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
+++ b/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
@@ -304,7 +304,7 @@ resource "google_compute_network" "network-1" {
   name                    = "network-1-%s"
   auto_create_subnetworks = false
 }
-`, suffix, reverseLookup)
+`, suffix)
 }
 <% end -%>
 


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/5062

I cribbed the object_to_bool and bool_to_object code from: https://github.com/GoogleCloudPlatform/magic-modules/pull/3007 as this will likely make it in before that.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dns: `google_dns_managed_zone` added support for Non-RFC1918 fields for reverse lookup and fowarding paths.
```
