### PR TITLE
Move expr to GA

### DIFF
--- a/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -95,7 +95,6 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 										ValidateFunc: validation.StringInSlice([]string{"SRC_IPS_V1"}, false),
 									},
 
-<% unless version == 'ga' -%>
 									"expr": {
 										Type:     schema.TypeList,
 										Optional: true,
@@ -122,7 +121,6 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 											},
 										},
 									},
-<% end -%>
 								},
 							},
 						},
@@ -360,9 +358,7 @@ func expandSecurityPolicyMatch(configured []interface{}) *compute.SecurityPolicy
 	return &compute.SecurityPolicyRuleMatcher{
 		VersionedExpr: data["versioned_expr"].(string),
 		Config:        expandSecurityPolicyMatchConfig(data["config"].([]interface{})),
-<% unless version == 'ga' -%>
 		Expr:          expandSecurityPolicyMatchExpr(data["expr"].([]interface{})),
-<% end -%>
 	}
 }
 
@@ -377,7 +373,6 @@ func expandSecurityPolicyMatchConfig(configured []interface{}) *compute.Security
 	}
 }
 
-<% unless version == 'ga' -%>
 func expandSecurityPolicyMatchExpr(expr []interface{}) *compute.Expr {
 	if len(expr) == 0 || expr[0] == nil {
 		return nil
@@ -392,7 +387,6 @@ func expandSecurityPolicyMatchExpr(expr []interface{}) *compute.Expr {
 		// Location:    data["location"].(string),
 	}
 }
-<% end -%>
 
 func flattenSecurityPolicyRules(rules []*compute.SecurityPolicyRule) []map[string]interface{} {
 	rulesSchema := make([]map[string]interface{}, 0, len(rules))
@@ -418,9 +412,7 @@ func flattenMatch(match *compute.SecurityPolicyRuleMatcher) []map[string]interfa
 	data := map[string]interface{}{
 		"versioned_expr": match.VersionedExpr,
 		"config":         flattenMatchConfig(match.Config),
-<% unless version == 'ga' -%>
 		"expr":           flattenMatchExpr(match),
-<% end -%>
 	}
 
 	return []map[string]interface{}{data}
@@ -438,7 +430,6 @@ func flattenMatchConfig(conf *compute.SecurityPolicyRuleMatcherConfig) []map[str
 	return []map[string]interface{}{data}
 }
 
-<% unless version == 'ga' -%>
 func flattenMatchExpr(match *compute.SecurityPolicyRuleMatcher) []map[string]interface{} {
 	if match.Expr == nil {
 		return nil
@@ -454,7 +445,6 @@ func flattenMatchExpr(match *compute.SecurityPolicyRuleMatcher) []map[string]int
 
 	return []map[string]interface{}{data}
 }
-<% end -%>
 
 func resourceSecurityPolicyStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)


### PR DESCRIPTION
Looks like this field is GA based on: https://cloud.google.com/compute/docs/reference/rest/v1/securityPolicies

Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/5502

Upstream solution to https://github.com/terraform-providers/terraform-provider-google/pull/5504

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: `google_compute_security_policy` `rule.match.expr` field is now GA
```
