### PR TITLE
Ignore reverse_lookup in managed zone datasource test

### DIFF
--- a/third_party/terraform/tests/data_source_dns_managed_zone_test.go.erb
+++ b/third_party/terraform/tests/data_source_dns_managed_zone_test.go.erb
@@ -28,6 +28,7 @@ func TestAccDataSourceDnsManagedZone_basic(t *testing.T) {
 <% unless version == "ga" -%>
 						"peering_config.#":            {},
 						"forwarding_config.#":         {},
+						"reverse_lookup":         {},
 <% end -%>
 					},
 				),


### PR DESCRIPTION
No user facing changes. Could also add `reverse_lookup` to the datasource, but it doesn't seem like a valuable field for users?

Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/5507

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->
