### PR TITLE
updated expiration_time in tests to use year < 2038, undeprecated it

### DIFF
--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -24,7 +24,6 @@ var sqlDatabaseAuthorizedNetWorkSchemaElem *schema.Resource = &schema.Resource{
 		"expiration_time": {
 			Type:     schema.TypeString,
 			Optional: true,
-			Deprecated: "This property is only applicable to First Generation instances, and First Generation instances are now deprecated.",
 		},
 		"name": {
 			Type:     schema.TypeString,

--- a/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -790,6 +790,7 @@ resource "google_sql_database_instance" "instance" {
       authorized_networks {
         value           = "108.12.12.12"
         name            = "misc"
+        expiration_time = "2037-11-15T16:19:00.094Z"
       }
     }
 
@@ -952,6 +953,7 @@ resource "google_sql_database_instance" "instance" {
       authorized_networks {
         value           = "108.12.12.12"
         name            = "misc"
+        expiration_time = "2037-11-15T16:19:00.094Z"
       }
     }
   }

--- a/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -27,7 +27,6 @@ the above documentation:
 * `tier`  
 Remove any fields that are not applicable to Second-generation instances:
 * `settings.crash_safe_replication`
-* `settings.ip_configuration.authorized_networks.expiration_time`
 * `settings.replication_type`
 * `settings.authorized_gae_applications`
 And change values to appropriate values for Second-generation instances for:


### PR DESCRIPTION
When changing the code to upgrade to support second-generation-only instances, the authorized_networks tests failed to create instances because of the `expiration_time`.  I assumed it had to do with the upgrade, so I deprecated the field, however, we later found out it is a limitation on the value of the year, so now I have updated the tests to use a year < 2038, and they pass on second generation instances.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
sql: undeprecated `settings.ip_configuration.authorized_networks.expiration_time`
```
