### PR TITLE
update bigquery_options to be O+C

### DIFF
--- a/third_party/terraform/resources/resource_logging_sink.go
+++ b/third_party/terraform/resources/resource_logging_sink.go
@@ -34,6 +34,7 @@ func resourceLoggingSinkSchema() map[string]*schema.Schema {
 		"bigquery_options": {
 			Type:     schema.TypeList,
 			Optional: true,
+			Computed: true,
 			MaxItems: 1,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5501

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
logging: updated `bigquery_options` so the default value from the api will be set in state.
```
