### PR TITLE
Exclude various generation types from OiCS repo

### DIFF
--- a/provider/terraform_oics.rb
+++ b/provider/terraform_oics.rb
@@ -65,7 +65,10 @@ module Provider
 
     # We don't want to generate anything but the resource.
     def generate_resource_tests(data) end
-
     def generate_resource_sweepers(data) end
+    def compile_common_files(output_folder, products, common_compile_file) end
+    def copy_common_files(output_folder) end
+    def generate_iam_policy(data) end
+
   end
 end

--- a/provider/terraform_oics.rb
+++ b/provider/terraform_oics.rb
@@ -65,10 +65,13 @@ module Provider
 
     # We don't want to generate anything but the resource.
     def generate_resource_tests(data) end
-    def generate_resource_sweepers(data) end
-    def compile_common_files(output_folder, products, common_compile_file) end
-    def copy_common_files(output_folder) end
-    def generate_iam_policy(data) end
 
+    def generate_resource_sweepers(data) end
+
+    def compile_common_files(output_folder, products, common_compile_file) end
+
+    def copy_common_files(output_folder) end
+
+    def generate_iam_policy(data) end
   end
 end


### PR DESCRIPTION
The OiCS provider over-copied a few things, I was deleting them manually since they were all contained in a couple folders. Get rid of them so the Magician can sync the repo.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
