### PR TITLE
Bootstrap network for redis tests

### DIFF
--- a/products/cloudfunctions/terraform.yaml
+++ b/products/cloudfunctions/terraform.yaml
@@ -28,7 +28,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           function_name: "my-function"
           bucket_name: "tf-cloudfunctions-function-example-bucket"
-        test_custom_context:
+          zip_path: "path/to/index.zip"
+        test_vars_overrides:
           zip_path: 'createZIPArchiveForCloudFunctionSource(t, testHTTPTriggerPath)'
     properties:
       location: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/products/redis/terraform.yaml
+++ b/products/redis/terraform.yaml
@@ -32,7 +32,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "cache"
         vars:
           instance_name: "ha-memory-cache"
-          network_name: "authorized-network"
+          network_name: "redis-test-network"
+        test_vars_overrides:
+          network_name: 'BootstrapSharedTestNetwork(t, "redis-full")'
     properties:
       alternativeLocationId: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true

--- a/provider/terraform/examples.rb
+++ b/provider/terraform/examples.rb
@@ -63,6 +63,22 @@ module Provider
       attr_reader :test_env_vars
 
       # Hash to provider custom override values for generating test config
+      # If field my-var is set in this hash, it will replace vars[my-var] in
+      # tests. i.e. if vars["network"] = "my-vpc", without override:
+      #   - doc config will have `network = "my-vpc"`
+      #   - tests config will have `"network = my-vpc%{random_suffix}"`
+      #     with context
+      #       map[string]interface{}{
+      #         "random_suffix": randString()
+      #       }
+      #
+      # If test_vars_overrides["network"] = "nameOfVpc()"
+      #   - doc config will have `network = "my-vpc"`
+      #   - tests will replace with `"network = %{network}"` with context
+      #       map[string]interface{}{
+      #         "network": nameOfVpc
+      #         ...
+      #       }
       attr_reader :test_vars_overrides
 
       # The version name of of the example's version if it's different than the

--- a/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/templates/terraform/examples/base_configs/test_file.go.erb
@@ -44,9 +44,9 @@ func TestAcc<%= test_slug -%>(t *testing.T) {
 
 	context := map[string]interface{} {
 <%= lines(indent(compile('templates/terraform/env_var_context.go.erb'), 4)) -%>
-	<% unless example.test_custom_context.nil? -%>
-	<% example.test_custom_context.each do |var_name, custom_val| -%>
-			"<%= var_name %>": <%= custom_val %>,
+	<% unless example.test_var_overrides.nil? -%>
+	<% example.test_var_overrides.each do |var_name, override| -%>
+			"<%= var_name %>": <%= override %>,
 	<% end -%>
 	<% end -%>
 			"random_suffix": acctest.RandString(10),

--- a/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/templates/terraform/examples/base_configs/test_file.go.erb
@@ -44,8 +44,8 @@ func TestAcc<%= test_slug -%>(t *testing.T) {
 
 	context := map[string]interface{} {
 <%= lines(indent(compile('templates/terraform/env_var_context.go.erb'), 4)) -%>
-	<% unless example.test_var_overrides.nil? -%>
-	<% example.test_var_overrides.each do |var_name, override| -%>
+	<% unless example.test_vars_overrides.nil? -%>
+	<% example.test_vars_overrides.each do |var_name, override| -%>
 			"<%= var_name %>": <%= override %>,
 	<% end -%>
 	<% end -%>

--- a/templates/terraform/examples/cloudfunctions_cloud_function.tf.erb
+++ b/templates/terraform/examples/cloudfunctions_cloud_function.tf.erb
@@ -5,7 +5,7 @@ resource "google_storage_bucket" "bucket" {
 resource "google_storage_bucket_object" "archive" {
   name   = "index.zip"
   bucket = google_storage_bucket.bucket.name
-  source = "path/to/index.zip"
+  source = "<%= ctx[:vars]['zip_path'] %>"
 }
 
 resource "google_cloudfunctions_function" "<%= ctx[:primary_resource_id] %>" {

--- a/templates/terraform/examples/redis_instance_full.tf.erb
+++ b/templates/terraform/examples/redis_instance_full.tf.erb
@@ -1,5 +1,5 @@
 resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
-  name           = "<%= ctx[:vars]["instance_name"] %>"
+  name           = "<%= ctx[:vars]['instance_name'] %>"
   tier           = "STANDARD_HA"
   memory_size_gb = 1
 
@@ -24,8 +24,8 @@ resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
 // network (authorized_network) is deleted, so this prevents issues
 // with tenant network quota.
 // If this network hasn't been created and you are using this example in your
-// config, add an additional `google_compute_network` resource or change
-// this from a data source to a network.
+// config, add an additional network resource or change
+// this from "data"to "resource"
 data "google_compute_network" "redis-network" {
-  name = "<%= ctx[:vars]["network_name"] %>"
+  name = "<%= ctx[:vars]['network_name'] %>"
 }

--- a/templates/terraform/examples/redis_instance_full.tf.erb
+++ b/templates/terraform/examples/redis_instance_full.tf.erb
@@ -6,7 +6,7 @@ resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
   location_id             = "us-central1-a"
   alternative_location_id = "us-central1-f"
 
-  authorized_network = google_compute_network.auto-network.self_link
+  authorized_network = data.google_compute_network.redis-network.self_link
 
   redis_version     = "REDIS_3_2"
   display_name      = "Terraform Test Instance"
@@ -18,6 +18,14 @@ resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
   }
 }
 
-resource "google_compute_network" "auto-network" {
+// This example assumes this network already exists.
+// The API creates a tenant network per network authorized for a
+// Redis instance and that network is not deleted when the user-created
+// network (authorized_network) is deleted, so this prevents issues
+// with tenant network quota.
+// If this network hasn't been created and you are using this example in your
+// config, add an additional `google_compute_network` resource or change
+// this from a data source to a network.
+data "google_compute_network" "redis-network" {
   name = "<%= ctx[:vars]["network_name"] %>"
 }

--- a/templates/terraform/iam/iam_context.go.erb
+++ b/templates/terraform/iam/iam_context.go.erb
@@ -8,9 +8,9 @@ context := map[string]interface{}{
 	"project_id" : fmt.Sprintf("<%= object.iam_policy.test_project_name -%>%s", acctest.RandString(10)),
 <% end -%>
 <%= lines(compile('templates/terraform/env_var_context.go.erb')) -%>
-<% unless example.test_custom_context.nil? -%>
-<% example.test_custom_context.each do |var_name, custom_val| -%>
-	"<%= var_name %>": <%= custom_val %>,
+<% unless example.test_vars_overrides.nil? -%>
+<% example.test_vars_overrides.each do |var_name, override| -%>
+	"<%= var_name %>": <%= override %>,
 <% end -%>
 <% end -%>
 <% unless version == 'ga' || object.iam_policy.iam_conditions_request_type.nil? -%>

--- a/third_party/terraform/tests/resource_service_networking_connection_test.go
+++ b/third_party/terraform/tests/resource_service_networking_connection_test.go
@@ -12,7 +12,7 @@ import (
 func TestAccServiceNetworkingConnection_create(t *testing.T) {
 	t.Parallel()
 
-	network := BootstrapSharedServiceNetworkingConsumerNetwork(t, "service-networking-connection-create")
+	network := BootstrapSharedTestNetwork(t, "service-networking-connection-create")
 	addr := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	service := "servicenetworking.googleapis.com"
 
@@ -36,7 +36,7 @@ func TestAccServiceNetworkingConnection_create(t *testing.T) {
 func TestAccServiceNetworkingConnection_update(t *testing.T) {
 	t.Parallel()
 
-	network := BootstrapSharedServiceNetworkingConsumerNetwork(t, "service-networking-connection-update")
+	network := BootstrapSharedTestNetwork(t, "service-networking-connection-update")
 	addr1 := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	addr2 := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	service := "servicenetworking.googleapis.com"

--- a/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -593,7 +593,7 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork(t *testing.T) {
 
 	databaseName := "tf-test-" + acctest.RandString(10)
 	addressName := "tf-test-" + acctest.RandString(10)
-	networkName := BootstrapSharedServiceNetworkingConsumerNetwork(t, "sql-instance-private")
+	networkName := BootstrapSharedTestNetwork(t, "sql-instance-private")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/third_party/terraform/utils/bootstrap_utils_test.go
+++ b/third_party/terraform/utils/bootstrap_utils_test.go
@@ -234,13 +234,11 @@ func BootstrapServiceAccount(t *testing.T, project, testRunner string) string {
 
 const SharedTestNetworkPrefix = "tf-bootstrap-net-"
 
-// BootstrapSharedServiceNetworkingConsumerNetwork will return a shared compute network
-// for service networking test to prevent hitting limits on tenancy projects.
-//
-// This will either return an existing network or create one if it hasn't been created
-// in the project yet. One consumer network/tenant project we don't own is created
-// per producer network (i.e. network created by test), with a hard limit set.
-func BootstrapSharedServiceNetworkingConsumerNetwork(t *testing.T, testId string) string {
+// BootstrapSharedTestNetwork will return a shared compute network
+// for tests that create tenant network resources. This prevents hitting limits on
+// tenancy projects and resources that we don't control.
+// Returns the name of an network, creating it if hasn't been created in the test projcet.
+func BootstrapSharedTestNetwork(t *testing.T, testId string) string {
 	if v := os.Getenv("TF_ACC"); v == "" {
 		log.Println("Acceptance tests and bootstrapping skipped unless env 'TF_ACC' set")
 		// If not running acceptance tests, return an empty string

--- a/third_party/terraform/utils/bootstrap_utils_test.go
+++ b/third_party/terraform/utils/bootstrap_utils_test.go
@@ -235,8 +235,12 @@ func BootstrapServiceAccount(t *testing.T, project, testRunner string) string {
 const SharedTestNetworkPrefix = "tf-bootstrap-net-"
 
 // BootstrapSharedTestNetwork will return a shared compute network
-// for tests that create tenant network resources. This prevents hitting limits on
-// tenancy projects and resources that we don't control.
+// for a test or set of tests. Often resources create complementing
+// tenant network resources, which we don't control and which don't get cleaned
+// up after our owned resource is deleted in test. These tenant resources
+// have quotas, so creating a shared test network prevents hitting these limits.
+//
+// testId specifies the test/suite for which a shared network is used/initialized.
 // Returns the name of an network, creating it if hasn't been created in the test projcet.
 func BootstrapSharedTestNetwork(t *testing.T, testId string) string {
 	if v := os.Getenv("TF_ACC"); v == "" {


### PR DESCRIPTION
Also, change test_custom_context to just override vars - this prevents the need for custom path replacement like "path/to/index.zip" --> %{zip_path}

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5509

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
