### PR TITLE
Add docs for the id field

### DIFF
--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -144,7 +144,6 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are exported:
 
 * `id` - an identifier for the resource with format `<%= id_format(object) %>`
-
 <% object.root_properties.select(&:output).each do |prop| -%>
 <%= lines(build_property_documentation(prop)) -%>
 <% end -%>

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -139,10 +139,11 @@ The following arguments are supported:
 <%= lines(build_nested_property_documentation(prop)) -%>
 <% end -%>
 
-<% unless properties.select(&:output).empty? && object.docs.attributes.nil? -%>
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are exported:
+
+* `id` - an identifier for the resource with format "<%= id_format(object) %>>
 
 <% object.root_properties.select(&:output).each do |prop| -%>
 <%= lines(build_property_documentation(prop)) -%>
@@ -156,7 +157,6 @@ In addition to the arguments listed above, the following computed attributes are
 <% end -%>
 <%- unless object.docs.attributes.nil? -%>
 <%= "\n" + object.docs.attributes -%>
-<% end -%>
 <% end -%>
 
 ## Timeouts

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -143,7 +143,7 @@ The following arguments are supported:
 
 In addition to the arguments listed above, the following computed attributes are exported:
 
-* `id` - an identifier for the resource with format "<%= id_format(object) %>>
+* `id` - an identifier for the resource with format `<%= id_format(object) %>`
 
 <% object.root_properties.select(&:output).each do |prop| -%>
 <%= lines(build_property_documentation(prop)) -%>


### PR DESCRIPTION
Part of https://github.com/terraform-providers/terraform-provider-google/issues/5542

We never actually documented the `id` field during `3.0.0`, and according to https://github.com/terraform-providers/terraform-provider-google/wiki/Developer-Best-Practices#self-links-names-and-ids we expect users to use it. Add it to generated resources. Also filed the issue above for handwritten ones too since they're not like a 3 line change.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
provider: added documentation for the `id` field for many resources, including format
```
