### PR TITLE
added boot_disk_kms_key to node_config

### DIFF
--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -627,7 +627,7 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 		for _, u := range users.Items {
 			if u.Name == "root" && u.Host == "%" {
 				err = retry(func() error {
-					op, err = config.clientSqlAdmin.Users.Delete(project, instance.Name, u.Host, u.Name).Do()
+					op, err = config.clientSqlAdmin.Users.Delete(project, instance.Name).Do()
 					if err == nil {
 						err = sqlAdminOperationWaitTime(config, op, project, "Delete default root User", int(d.Timeout(schema.TimeoutCreate).Minutes()))
 					}
@@ -673,7 +673,7 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, secondGen bool)
 	// 1st Generation instances don't support the disk_autoresize parameter
 	// and it defaults to true - so we shouldn't set it if this is first gen
 	if secondGen {
-		settings.StorageAutoResize = googleapi.Bool(_settings["disk_autoresize"].(bool))
+		settings.StorageAutoResize = _settings["disk_autoresize"].(bool)
 	}
 
 	return settings
@@ -984,9 +984,7 @@ func flattenSettings(settings *sqladmin.Settings) []map[string]interface{} {
 		data["maintenance_window"] = flattenMaintenanceWindow(settings.MaintenanceWindow)
 	}
 
-	if settings.StorageAutoResize != nil {
-		data["disk_autoresize"] = *settings.StorageAutoResize
-	}
+	data["disk_autoresize"] = settings.StorageAutoResize
 
 	if settings.UserLabels != nil {
 		data["user_labels"] = settings.UserLabels

--- a/third_party/terraform/resources/resource_sql_user.go
+++ b/third_party/terraform/resources/resource_sql_user.go
@@ -179,7 +179,7 @@ func resourceSqlUserUpdate(d *schema.ResourceData, meta interface{}) error {
 		defer mutexKV.Unlock(instanceMutexKey(project, instance))
 		var op *sqladmin.Operation
 		updateFunc := func() error {
-			op, err = config.clientSqlAdmin.Users.Update(project, instance, name,
+			op, err = config.clientSqlAdmin.Users.Update(project, instance,
 				user).Host(host).Do()
 			return err
 		}
@@ -213,14 +213,13 @@ func resourceSqlUserDelete(d *schema.ResourceData, meta interface{}) error {
 
 	name := d.Get("name").(string)
 	instance := d.Get("instance").(string)
-	host := d.Get("host").(string)
 
 	mutexKV.Lock(instanceMutexKey(project, instance))
 	defer mutexKV.Unlock(instanceMutexKey(project, instance))
 
 	var op *sqladmin.Operation
 	err = retryTimeDuration(func() error {
-		op, err = config.clientSqlAdmin.Users.Delete(project, instance, host, name).Do()
+		op, err = config.clientSqlAdmin.Users.Delete(project, instance).Do()
 		return err
 	}, d.Timeout(schema.TimeoutDelete))
 

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -831,6 +831,29 @@ func TestAccContainerCluster_withSandboxConfig(t *testing.T) {
 		},
 	})
 }
+
+func TestAccContainerCluster_withBootDiskKmsKey(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:	  func() { testAccPreCheck(t) },
+		Providers:	  testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withBootDiskKmsKey(getTestProjectFromEnv(), clusterName),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_cmek",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
+		},
+	})
+}
 <% end -%>
 
 func TestAccContainerCluster_network(t *testing.T) {
@@ -2584,6 +2607,53 @@ resource "google_container_cluster" "with_sandbox_config" {
   }
 }
 `, clusterName)
+}
+
+func testAccContainerCluster_withBootDiskKmsKey(project, clusterName string) string {
+	return fmt.Sprintf(`
+data "google_container_engine_versions" "central1a" {
+  location = "us-central1-a"
+}
+
+data "google_project" "project" {
+  project_id = "%s"
+}
+
+resource "google_project_iam_member" "kms-project-binding" {
+  project = data.google_project.project.project_id
+  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member  = "serviceAccount:service-${data.google_project.project.number}@compute-system.iam.gserviceaccount.com"
+}
+
+resource "google_kms_key_ring" "keyring" {
+  name     = "%s-kms-key-ring"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "example-key" {
+  name            = "%s-kms-key"
+  key_ring        = google_kms_key_ring.keyring.self_link
+  rotation_period = "100000s"
+}
+
+resource "google_container_cluster" "with_boot_disk_kms_key" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+
+  node_config {
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+
+    image_type = "COS_CONTAINERD"
+
+    boot_disk_kms_key = google_kms_key_ring.example-key.self_link
+  }
+}
+`, project, clusterName, clusterName, clusterName)
 }
 <% end -%>
 

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -846,7 +846,7 @@ func TestAccContainerCluster_withBootDiskKmsKey(t *testing.T) {
 				Config: testAccContainerCluster_withBootDiskKmsKey(getTestProjectFromEnv(), clusterName),
 			},
 			{
-				ResourceName:            "google_container_cluster.with_cmek",
+				ResourceName:            "google_container_cluster.with_boot_disk_kms_key",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"min_master_version"},
@@ -2650,7 +2650,7 @@ resource "google_container_cluster" "with_boot_disk_kms_key" {
 
     image_type = "COS_CONTAINERD"
 
-    boot_disk_kms_key = google_kms_key_ring.example-key.self_link
+    boot_disk_kms_key = google_kms_crypto_key.example-key.self_link
   }
 }
 `, project, clusterName, clusterName, clusterName)

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -253,6 +253,29 @@ func TestAccContainerNodePool_withSandboxConfig(t *testing.T) {
 	})
 }
 
+func TestAccContainerNodePool_withBootDiskKmsKey(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(10))
+	np := fmt.Sprintf("tf-test-np-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_withBootDiskKmsKey(getTestProjectFromEnv(), cluster, np),
+			},
+			{
+				ResourceName:      "google_container_node_pool.with_boot_disk_kms_key",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccContainerNodePool_withUpgradeSettings(t *testing.T) {
 	t.Parallel()
 
@@ -1252,6 +1275,58 @@ resource "google_container_node_pool" "with_sandbox_config" {
   }
 }
 `, cluster, np)
+}
+
+func testAccContainerNodePool_withBootDiskKmsKey(project, cluster, np string) string {
+	return fmt.Sprintf(`
+data "google_container_engine_versions" "central1a" {
+  location = "us-central1-a"
+}
+
+data "google_project" "project" {
+  project_id = "%s"
+}
+
+resource "google_project_iam_member" "kms-project-binding" {
+  project = data.google_project.project.project_id
+  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member  = "serviceAccount:service-${data.google_project.project.number}@compute-system.iam.gserviceaccount.com"
+}
+
+resource "google_kms_key_ring" "keyring" {
+  name     = "%s-kms-key-ring"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "example-key" {
+  name            = "%s-kms-key"
+  key_ring        = google_kms_key_ring.keyring.self_link
+  rotation_period = "100000s"
+}
+
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+}
+
+resource "google_container_node_pool" "with_boot_disk_kms_key" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 1
+
+  node_config {
+    image_type = "COS_CONTAINERD"
+    boot_disk_kms_key = google_kms_crypto_key.example-key.self_link
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+}
+`, project, cluster, cluster, cluster, np)
 }
 
 func testAccContainerNodePool_withUpgradeSettings(clusterName string, nodePoolName string, maxSurge int, maxUnavailable int) string {

--- a/third_party/terraform/utils/node_config.go.erb
+++ b/third_party/terraform/utils/node_config.go.erb
@@ -244,6 +244,16 @@ var schemaNodeConfig = &schema.Schema{
 					},
 				},
 			},
+
+			"boot_disk_kms_key": {
+<% if version.nil? || version == 'ga' -%>
+				Removed: "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/guides/provider_versions.html for more details.",
+				Computed: true,
+<% end -%>
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+			},
 		},
 	},
 }
@@ -381,6 +391,10 @@ func expandNodeConfig(v interface{}) *containerBeta.NodeConfig {
 			SandboxType: conf["sandbox_type"].(string),
 		}
 	}
+
+	if v, ok := nodeConfig["boot_disk_kms_key"]; ok {
+		nc.BootDiskKmsKey = v.(string)
+	}
 <% end -%>
 
 	return nc
@@ -411,6 +425,7 @@ func flattenNodeConfig(c *containerBeta.NodeConfig) []map[string]interface{} {
 <% unless version == 'ga' -%>
 		"workload_metadata_config": flattenWorkloadMetadataConfig(c.WorkloadMetadataConfig),
 		"sandbox_config": 			flattenSandboxConfig(c.SandboxConfig),
+		"boot_disk_kms_key": 		c.BootDiskKmsKey,
 <% end -%>
 	})
 

--- a/third_party/terraform/utils/node_config.go.erb
+++ b/third_party/terraform/utils/node_config.go.erb
@@ -244,16 +244,15 @@ var schemaNodeConfig = &schema.Schema{
 					},
 				},
 			},
-
+<% unless version == 'ga' -%>
 			"boot_disk_kms_key": {
-<% if version.nil? || version == 'ga' -%>
 				Removed: "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/guides/provider_versions.html for more details.",
 				Computed: true,
-<% end -%>
 				Type:       schema.TypeString,
 				Optional:   true,
 				ForceNew:   true,
 			},
+<% end -%>
 		},
 	},
 }

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -553,6 +553,8 @@ The `node_config` block supports:
 * `sandbox_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) [GKE Sandbox](https://cloud.google.com/kubernetes-engine/docs/how-to/sandbox-pods) configuration. When enabling this feature you must specify `image_type = "COS_CONTAINERD"` and `node_version = "1.12.7-gke.17"` or later to use it.
     Structure is documented below.
 
+* `boot_disk_kms_key` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) The Customer Managed Encryption Key used to encrypt the boot disk attached to each node in the node pool. This should be of the form projects/[KEY_PROJECT_ID]/locations/[LOCATION]/keyRings/[RING_NAME]/cryptoKeys/[KEY_NAME]. For more information about protecting resources with Cloud KMS Keys please see: https://cloud.google.com/compute/docs/disks/customer-managed-encryption
+
 * `service_account` - (Optional) The service account to be used by the Node VMs.
     If not specified, the "default" service account is used.
     In order to use the configured `oauth_scopes` for logging and monitoring, the service account being used needs the


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5478

Added `boot_disk_kms_key` to `node_config` block.

This will require us to update the vendor package `google.golang.org/api/container/v1beta1`, but the attribute we need hasn't been released yet, and the hash I updated it to for testing, broke another resource.  Do I wait for it to be released?  Or manually revert the broken package?  Or try to find a different hash to update to?

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `boot_disk_kms_key` to `node_config` block.
```
