### PR TITLE
add fine-grained resource for service perimeter resource

### DIFF
--- a/products/accesscontextmanager/api.yaml
+++ b/products/accesscontextmanager/api.yaml
@@ -423,3 +423,52 @@ objects:
               - status.0.access_levels
               - status.0.restricted_services
             item_type: Api::Type::String
+  - !ruby/object:Api::Resource
+    name: 'ServicePerimeterResource'
+    create_url: "{{perimeter_name}}"
+    base_url: ""
+    self_link: "{{perimeter_name}}"
+    create_verb: :PATCH
+    delete_verb: :PATCH
+    input: true
+    update_mask: true
+    identity:
+      - resource
+    nested_query: !ruby/object:Api::Resource::NestedQuery
+      modify_by_patch: true
+      is_list_of_ids: true
+      keys:
+        - status
+        - resources
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Service Perimeter Quickstart': 'https://cloud.google.com/vpc-service-controls/docs/quickstart'
+      api: 'https://cloud.google.com/access-context-manager/docs/reference/rest/v1/accessPolicies.servicePerimeters'
+    description: |
+      Allows configuring a single GCP resource that should be inside of a service perimeter.
+      This resource is intended to be used in cases where it is not possible to compile a full list
+      of projects to include in a `google_access_context_manager_service_perimeter` resource,
+      to enable them to be added separately.
+
+      ~> **Note:** If this resource is used alongside a `google_access_context_manager_service_perimeter` resource,
+      the service perimeter resource must have a `lifecycle` block with `ignore_changes = [status[0].resources]` so
+      they don't fight over which resources should be in the policy.
+    parameters:
+      - !ruby/object:Api::Type::ResourceRef
+        name: 'perimeterName'
+        resource: 'ServicePerimeter'
+        imports: 'name'
+        description: |
+          The name of the Service Perimeter to add this resource to.
+        required: true
+        input: true
+        url_param_only: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'resource'
+        description: |
+              A GCP resource that is inside of the service perimeter.
+              Currently only projects are allowed.
+              Format: projects/{project_number}
+        required: true
+        input: true

--- a/products/accesscontextmanager/inspec.yaml
+++ b/products/accesscontextmanager/inspec.yaml
@@ -29,3 +29,5 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       name: !ruby/object:Overrides::Inspec::PropertyOverride
         name_from_self_link: true
+  ServicePerimeterResource: !ruby/object:Overrides::Inspec::ResourceOverride
+    exclude: true

--- a/products/accesscontextmanager/terraform.yaml
+++ b/products/accesscontextmanager/terraform.yaml
@@ -70,6 +70,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     skip_sweeper: true
     id_format: "{{name}}"
     import_format: ["{{name}}"]
+    mutex: "{{name}}"
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "access_context_manager_service_perimeter_basic"
@@ -87,6 +88,23 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       encoder: templates/terraform/encoders/access_level_never_send_parent.go.erb
       custom_import: templates/terraform/custom_import/set_access_policy_parent_from_self_link.go.erb
+  ServicePerimeterResource: !ruby/object:Overrides::Terraform::ResourceOverride
+    autogen_async: true
+    exclude_validator: true
+    # Skipping the sweeper due to the non-standard base_url and because this is fine-grained under ServicePerimeter
+    skip_sweeper: true
+    id_format: "{{perimeter_name}}/{{resource}}"
+    import_format: ["{{perimeter_name}}/{{resource}}"]
+    mutex: "{{perimeter_name}}"
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "access_context_manager_service_perimeter_resource_basic"
+        skip_test: true
+        primary_resource_id: "service-perimeter-resource"
+        vars:
+          service_perimeter_name: "restrict_all"
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      custom_import: templates/terraform/custom_import/access_context_manager_service_perimeter_resource.go.erb
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.

--- a/templates/terraform/custom_import/access_context_manager_service_perimeter_resource.go.erb
+++ b/templates/terraform/custom_import/access_context_manager_service_perimeter_resource.go.erb
@@ -1,0 +1,25 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+	config := meta.(*Config)
+
+	// current import_formats can't import fields with forward slashes in their value
+	parts, err := getImportIdQualifiers([]string{"accessPolicies/(?P<accessPolicy>[^/]+)/servicePerimeters/(?P<perimeter>[^/]+)/(?P<resource>.+)"}, d, config, d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	d.Set("perimeter_name", fmt.Sprintf("accessPolicies/%s/servicePerimeters/%s", parts["accessPolicy"], parts["perimeter"]))
+	d.Set("resource", parts["resource"])
+	return []*schema.ResourceData{d}, nil

--- a/templates/terraform/examples/access_context_manager_service_perimeter_resource_basic.tf.erb
+++ b/templates/terraform/examples/access_context_manager_service_perimeter_resource_basic.tf.erb
@@ -1,0 +1,22 @@
+resource "google_access_context_manager_service_perimeter_resource" "<%= ctx[:primary_resource_id] %>" {
+  perimiter_name = google_access_context_manager_service_perimeter.<%= ctx[:primary_resource_id] %>.name
+  resource = "projects/987654321"
+}
+
+resource "google_access_context_manager_service_perimeter" "<%= ctx[:primary_resource_id] %>" {
+  parent = "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}"
+  name   = "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}/servicePerimeters/<%= ctx[:vars]['service_perimeter_name'] %>"
+  title  = "<%= ctx[:vars]['service_perimeter_name'] %>"
+  status {
+    restricted_services = ["storage.googleapis.com"]
+  }
+
+  lifecycle {
+    ignore_changes = [status[0].resources]
+  }
+}
+
+resource "google_access_context_manager_access_policy" "access-policy" {
+  parent = "organizations/123456789"
+  title  = "my policy"
+}

--- a/templates/terraform/nested_query.go.erb
+++ b/templates/terraform/nested_query.go.erb
@@ -112,11 +112,31 @@ func resource<%= resource_name -%>PatchCreateEncoder(d *schema.ResourceData, met
     "<%= list_key %>": append(currItems, obj),
   }
   <% end -%>
-  <% object.nested_query.keys.reverse[1..-1].each do |k| -%>
-  newRes := map[string]interface{}{}
-  newRes["<%= k %>"] = res
-  res = newRes
+  <%#
+  Reconstruct the full nested object. For example, if nested_query.keys is:
+  - nested_item
+  - more_nested_item
+  Then the code above will build:
+  {
+    "more_nested_item": [...]
+  }
+  Add back the other keys so we get:
+  {
+    "nested_item": {
+      "more_nested_item": [...]
+    }
+  }
+  Note that this assumes that we can safely have "more_nested_item" be the only element
+  in the "nested_item" map, which only works if the patch request takes an update mask
+  (or if the rest of the map would have been empty anyway).
+  -%>
+  <% object.nested_query.keys[0..-2].reverse_each do |k| -%>
+  wrapped := map[string]interface{}{
+    "<%= k %>": res,
+  }
+  res = wrapped
   <% end -%>
+
   return res, nil
 }
 
@@ -145,9 +165,18 @@ func resource<%= resource_name -%>PatchUpdateEncoder(d *schema.ResourceData, met
   items[idx] = item
 
   // Return list with new item added
-  return map[string]interface{}{
+  res := map[string]interface{}{
     "<%= list_key %>": items,
-  }, nil
+  }
+  <%# see comments in PatchCreateEncoder for details -%>
+  <% object.nested_query.keys[0..-2].reverse_each do |k| -%>
+  wrapped := map[string]interface{}{
+    "<%= k %>": res,
+  }
+  res = wrapped
+  <% end -%>
+
+  return res, nil
 }
 
 // PatchDeleteEncoder handles creating request data to PATCH parent resource
@@ -174,10 +203,12 @@ func resource<%= resource_name -%>PatchDeleteEncoder(d *schema.ResourceData, met
   res := map[string]interface{}{
     "<%= list_key %>": updatedItems,
   }
-  <% object.nested_query.keys.reverse[1..-1].each do |k| -%>
-  newRes := map[string]interface{}{}
-  newRes["<%= k %>"] = res
-  res = newRes
+  <%# see comments in PatchCreateEncoder for details -%>
+  <% object.nested_query.keys[0..-2].reverse_each do |k| -%>
+  wrapped := map[string]interface{}{
+    "<%= k %>": res,
+  }
+  res = wrapped
   <% end -%>
 
   return res, nil

--- a/templates/terraform/nested_query.go.erb
+++ b/templates/terraform/nested_query.go.erb
@@ -103,9 +103,21 @@ func resource<%= resource_name -%>PatchCreateEncoder(d *schema.ResourceData, met
   }
 
   // Return list with the resource to create appended
-  return map[string]interface{}{
+  <% if object.nested_query.is_list_of_ids -%>
+  res := map[string]interface{}{
+    "<%= list_key %>": append(currItems, obj["<%= object.identity.first.api_name %>"]),
+  }
+  <% else -%>
+  res := map[string]interface{}{
     "<%= list_key %>": append(currItems, obj),
-  }, nil
+  }
+  <% end -%>
+  <% object.nested_query.keys.reverse[1..-1].each do |k| -%>
+  newRes := map[string]interface{}{}
+  newRes["<%= k %>"] = res
+  res = newRes
+  <% end -%>
+  return res, nil
 }
 
 // PatchUpdateEncoder handles creating request data to PATCH parent resource
@@ -159,9 +171,16 @@ func resource<%= resource_name -%>PatchDeleteEncoder(d *schema.ResourceData, met
   }
 
   updatedItems := append(currItems[:idx], currItems[idx+1:]...)
-  return map[string]interface{}{
+  res := map[string]interface{}{
     "<%= list_key %>": updatedItems,
-  }, nil
+  }
+  <% object.nested_query.keys.reverse[1..-1].each do |k| -%>
+  newRes := map[string]interface{}{}
+  newRes["<%= k %>"] = res
+  res = newRes
+  <% end -%>
+
+  return res, nil
 }
 
 // ListForPatch handles making API request to get parent resource and 
@@ -190,6 +209,8 @@ func resource<%= resource_name -%>ListForPatch(d *schema.ResourceData, meta inte
     return nil, err
   }
 
+  var v interface{}
+  var ok bool
   <% object.nested_query.keys[0...-1].each do |k| -%>
   if v, ok = res["<%=k-%>"]; ok && v != nil {
     res = v.(map[string]interface{})    
@@ -198,7 +219,7 @@ func resource<%= resource_name -%>ListForPatch(d *schema.ResourceData, meta inte
   }
   <% end -%>
   
-  v, ok := res["<%=object.nested_query.keys[-1]-%>"]
+  v, ok = res["<%=object.nested_query.keys[-1]-%>"]
   if ok && v != nil {
     ls, lsOk := v.([]interface{})
     if !lsOk {

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -178,6 +178,12 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     if err != nil {
         return err
     }
+<%    if object.update_mask -%>
+    url, err = addQueryParams(url, map[string]string{"updateMask": "<%= object.nested_query.keys.join('.') -%>"})
+    if err != nil {
+        return err
+    }
+<%    end -%>
 <%  end -%>
 <%  if has_project -%>
     project, err := getProject(d, config)
@@ -621,6 +627,12 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
     if err != nil {
         return handleNotFoundError(err, d, "<%= object.name -%>")
     }
+<%    if object.update_mask -%>
+    url, err = addQueryParams(url, map[string]string{"updateMask": "<%= object.nested_query.keys.join('.') -%>"})
+    if err != nil {
+        return err
+    }
+<%    end -%>
 <%  end -%>
 <%  if object.supports_indirect_user_project_override -%>
     var project string

--- a/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
@@ -75,11 +75,12 @@ func testSweepAccessContextManagerPolicies(region string) error {
 // can exist, they need to be ran serially
 func TestAccAccessContextManager(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
-		"access_policy":            testAccAccessContextManagerAccessPolicy_basicTest,
-		"service_perimeter":        testAccAccessContextManagerServicePerimeter_basicTest,
-		"service_perimeter_update": testAccAccessContextManagerServicePerimeter_updateTest,
-		"access_level":             testAccAccessContextManagerAccessLevel_basicTest,
-		"access_level_full":        testAccAccessContextManagerAccessLevel_fullTest,
+		"access_policy":              testAccAccessContextManagerAccessPolicy_basicTest,
+		"service_perimeter":          testAccAccessContextManagerServicePerimeter_basicTest,
+		"service_perimeter_update":   testAccAccessContextManagerServicePerimeter_updateTest,
+		"service_perimeter_resource": testAccAccessContextManagerServicePerimeterResource_basicTest,
+		"access_level":               testAccAccessContextManagerAccessLevel_basicTest,
+		"access_level_full":          testAccAccessContextManagerAccessLevel_fullTest,
 	}
 
 	for name, tc := range testCases {

--- a/third_party/terraform/tests/resource_access_context_manager_service_perimeter_resource_test.go
+++ b/third_party/terraform/tests/resource_access_context_manager_service_perimeter_resource_test.go
@@ -1,0 +1,123 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+// Since each test here is acting on the same organization and only one AccessPolicy
+// can exist, they need to be ran serially. See AccessPolicy for the test runner.
+
+func testAccAccessContextManagerServicePerimeterResource_basicTest(t *testing.T) {
+	org := getTestOrgFromEnv(t)
+	projects := BootstrapServicePerimeterProjects(t, 2)
+	policyTitle := "my policy"
+	perimeterTitle := "perimeter"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccessContextManagerServicePerimeterResource_basic(org, policyTitle, perimeterTitle, projects[0].ProjectNumber, projects[1].ProjectNumber),
+			},
+			{
+				ResourceName:      "google_access_context_manager_service_perimeter_resource.test-access1",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "google_access_context_manager_service_perimeter_resource.test-access2",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Use a separate TestStep rather than a CheckDestroy because we need the service perimeter to still exist
+			{
+				Config: testAccAccessContextManagerServicePerimeterResource_destroy(org, policyTitle, perimeterTitle),
+				Check:  testAccCheckAccessContextManagerServicePerimeterResourceDestroy,
+			},
+		},
+	})
+}
+
+func testAccCheckAccessContextManagerServicePerimeterResourceDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "google_access_context_manager_service_perimeter_resource" {
+			continue
+		}
+
+		config := testAccProvider.Meta().(*Config)
+
+		url, err := replaceVarsForTest(config, rs, "{{AccessContextManagerBasePath}}{{perimeter_name}}")
+		if err != nil {
+			return err
+		}
+
+		res, err := sendRequest(config, "GET", "", url, nil)
+		if err != nil {
+			return err
+		}
+
+		v, ok := res["status"]
+		if !ok || v == nil {
+			return nil
+		}
+
+		res = v.(map[string]interface{})
+		v, ok = res["resources"]
+		if !ok || v == nil {
+			return nil
+		}
+
+		resources := v.([]interface{})
+		if len(resources) == 0 {
+			return nil
+		}
+
+		return fmt.Errorf("expected 0 resources in perimeter, found %d: %v", len(resources), resources)
+	}
+
+	return nil
+}
+
+func testAccAccessContextManagerServicePerimeterResource_basic(org, policyTitle, perimeterTitleName string, projectNumber1, projectNumber2 int64) string {
+	return fmt.Sprintf(`
+%s
+
+resource "google_access_context_manager_service_perimeter_resource" "test-access1" {
+  perimeter_name = google_access_context_manager_service_perimeter.test-access.name
+  resource = "projects/%d"
+}
+
+resource "google_access_context_manager_service_perimeter_resource" "test-access2" {
+  perimeter_name = google_access_context_manager_service_perimeter.test-access.name
+  resource = "projects/%d"
+}
+`, testAccAccessContextManagerServicePerimeterResource_destroy(org, policyTitle, perimeterTitleName), projectNumber1, projectNumber2)
+}
+
+func testAccAccessContextManagerServicePerimeterResource_destroy(org, policyTitle, perimeterTitleName string) string {
+	return fmt.Sprintf(`
+resource "google_access_context_manager_access_policy" "test-access" {
+  parent = "organizations/%s"
+  title  = "%s"
+}
+
+resource "google_access_context_manager_service_perimeter" "test-access" {
+  parent         = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}"
+  name           = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}/servicePerimeters/%s"
+  title          = "%s"
+  perimeter_type = "PERIMETER_TYPE_REGULAR"
+  status {
+    restricted_services = ["storage.googleapis.com"]
+  }
+
+  lifecycle {
+  	ignore_changes = [status[0].resources]
+  }
+}
+`, org, policyTitle, perimeterTitleName, perimeterTitleName)
+}

--- a/third_party/terraform/utils/bootstrap_utils_test.go
+++ b/third_party/terraform/utils/bootstrap_utils_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"google.golang.org/api/cloudkms/v1"
 	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
 	"google.golang.org/api/iam/v1"

--- a/third_party/terraform/utils/bootstrap_utils_test.go
+++ b/third_party/terraform/utils/bootstrap_utils_test.go
@@ -319,7 +319,8 @@ func BootstrapServicePerimeterProjects(t *testing.T, desiredProjects int) []*clo
 	// The filter endpoint works differently if you provide both the parent id and parent type, and
 	// doesn't seem to allow for prefix matching. Don't change this to include the parent type unless
 	// that API behavior changes.
-	res, err := config.clientResourceManager.Projects.List().Filter(fmt.Sprintf("id:%s* parent.id:%s", SharedServicePerimeterProjectPrefix, org)).Do()
+	prefixFilter := fmt.Sprintf("id:%s* parent.id:%s", SharedServicePerimeterProjectPrefix, org)
+	res, err := config.clientResourceManager.Projects.List().Filter(prefixFilter).Do()
 	if err != nil {
 		t.Errorf("Error getting shared test projects: %s", err)
 	}

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -222,6 +222,9 @@
       <li<%%= sidebar_current("docs-google-access-context-manager-service-perimeter") %>>
       <a href="/docs/providers/google/r/access_context_manager_service_perimeter.html">google_access_context_manager_service_perimeter</a>
       </li>
+      <li<%%= sidebar_current("docs-google-access-context-manager-service-perimeter-resource") %>>
+      <a href="/docs/providers/google/r/access_context_manager_service_perimeter_resource.html">google_access_context_manager_service_perimeter_resource</a>
+      </li>
     </ul>
     </li>
 <% end -%>


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4509.

In order to do this I had to make some changes to nested_query to allow it to add/remove an element of an array which is part of a nested object. I got it to work in this case by wrapping the object down the chain, so the patch request in this case would look like:
```
{
  "status": {
    "resources": [...]
  }
}
```

Notably, this doesn't merge the `resources` block into the `status` object that was returned from the API, but instead just wraps it. This works fine in this case because this API uses an update mask, so it can modify `resources` without changing anything else within status, but isn't future-proof if a similarly nested resource comes along that doesn't use an update mask.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_access_context_manager_service_perimeter_resource`
```
