### PR TITLE
VPC serverless access update version from beta to GA

### DIFF
--- a/products/vpcaccess/api.yaml
+++ b/products/vpcaccess/api.yaml
@@ -16,9 +16,6 @@ name: VPCAccess
 display_name: Serverless VPC Access
 versions:
   - !ruby/object:Api::Product::Version
-    name: beta
-    base_url: https://vpcaccess.googleapis.com/v1beta1/
-  - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://vpcaccess.googleapis.com/v1/
 scopes:
@@ -32,14 +29,13 @@ objects:
     name: 'Connector'
     kind: 'vpcaccess#Connector'
     description: 'Serverless VPC Access connector resource.'
-    min_version: beta
     input: true
     base_url: projects/{{project}}/locations/{{region}}/connectors
     create_url: projects/{{project}}/locations/{{region}}/connectors?connectorId={{name}}
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Configuring Serverless VPC Access': 'https://cloud.google.com/vpc/docs/configure-serverless-vpc-access'
-      api: 'https://cloud.google.com/vpc/docs/reference/vpcaccess/rest/v1beta1/projects.locations.connectors'
+      api: 'https://cloud.google.com/vpc/docs/reference/vpcaccess/rest/v1/projects.locations.connectors'
     async: !ruby/object:Api::OpAsync
       operation: !ruby/object:Api::OpAsync::Operation
         path: 'name'

--- a/products/vpcaccess/api.yaml
+++ b/products/vpcaccess/api.yaml
@@ -16,8 +16,8 @@ name: VPCAccess
 display_name: Serverless VPC Access
 versions:
   - !ruby/object:Api::Product::Version
-    name: beta
-    base_url: https://vpcaccess.googleapis.com/v1beta1/
+    name: ga
+    base_url: https://vpcaccess.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 apis_required:

--- a/products/vpcaccess/api.yaml
+++ b/products/vpcaccess/api.yaml
@@ -16,6 +16,9 @@ name: VPCAccess
 display_name: Serverless VPC Access
 versions:
   - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://vpcaccess.googleapis.com/v1beta1/
+  - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://vpcaccess.googleapis.com/v1/
 scopes:

--- a/products/vpcaccess/terraform.yaml
+++ b/products/vpcaccess/terraform.yaml
@@ -22,7 +22,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "vpc_access_connector"
-        min_version: beta
         primary_resource_id: "connector"
         vars:
           name: "my-connector"

--- a/templates/terraform/examples/vpc_access_connector.tf.erb
+++ b/templates/terraform/examples/vpc_access_connector.tf.erb
@@ -3,7 +3,6 @@ provider "google-beta" {
 
 resource "google_vpc_access_connector" "connector" {
   name          = "<%= ctx[:vars]['name'] %>"
-  provider      = google-beta
   region        = "us-central1"
   ip_cidr_range = "10.8.0.0/28"
   network       = "default"

--- a/templates/terraform/examples/vpc_access_connector.tf.erb
+++ b/templates/terraform/examples/vpc_access_connector.tf.erb
@@ -1,6 +1,3 @@
-provider "google-beta" {
-}
-
 resource "google_vpc_access_connector" "connector" {
   name          = "<%= ctx[:vars]['name'] %>"
   region        = "us-central1"

--- a/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
+++ b/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
@@ -778,8 +778,6 @@ resource "google_compute_network" "vpc" {
 }
 
 resource "google_vpc_access_connector" "connector" {
-  provider      = "google-beta"
-
   name          = "%s"
   region        = "us-central1"
   ip_cidr_range = "10.10.0.0/28"


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

vpc access connector is now GA

https://cloud.google.com/functions/docs/release-notes#December_11_2019

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_vpc_access_connector` (GA provider)
```
