### PR TITLE
Capture subshell output for OiCS

### DIFF
--- a/.ci/containers/github-differ/generate_comment.sh
+++ b/.ci/containers/github-differ/generate_comment.sh
@@ -75,19 +75,22 @@ popd
 # don't generate OiCS. This should be safe to remove after Feb 18th or so.
 set +e
 # Use a subshell to run commands serially and fail when one fails
-bash -e <<TRY
+OICSDIFFS=$(bash -e <<TRY
     # TF OICS
     mkdir -p $TFOICS_LOCAL_PATH
     git clone -b $NEW_BRANCH $TFOICS_SCRATCH_PATH $TFOICS_LOCAL_PATH
     pushd $TFOICS_LOCAL_PATH
     git fetch origin $OLD_BRANCH
     if ! git diff --exit-code origin/$NEW_BRANCH origin/$OLD_BRANCH; then
-        DIFFS="${DIFFS}${NEWLINE}TF OiCS: [Diff](https://github.com/modular-magician/docs-examples/compare/$OLD_BRANCH..$NEW_BRANCH)"
+        echo "TF OiCS: [Diff](https://github.com/modular-magician/docs-examples/compare/$OLD_BRANCH..$NEW_BRANCH)"
     fi
     popd
 TRY
+)
 if [ $? -ne 0 ]; then
   echo failed to generate OiCS
+else
+  DIFFS="${DIFFS}${NEWLINE}${OICSDIFFS}"
 fi
 set -e
 

--- a/.ci/containers/github-differ/generate_comment.sh
+++ b/.ci/containers/github-differ/generate_comment.sh
@@ -81,7 +81,7 @@ OICSDIFFS=$(bash -e <<TRY
     git clone -b $NEW_BRANCH $TFOICS_SCRATCH_PATH $TFOICS_LOCAL_PATH
     pushd $TFOICS_LOCAL_PATH
     git fetch origin $OLD_BRANCH
-    if ! git diff --exit-code origin/$NEW_BRANCH origin/$OLD_BRANCH; then
+    if ! git diff --exit-code --quiet origin/$NEW_BRANCH origin/$OLD_BRANCH; then
         echo "TF OiCS: [Diff](https://github.com/modular-magician/docs-examples/compare/$OLD_BRANCH..$NEW_BRANCH)"
     fi
     popd

--- a/.ci/containers/github-differ/generate_comment.sh
+++ b/.ci/containers/github-differ/generate_comment.sh
@@ -79,12 +79,12 @@ OICSDIFFS=$(bash -e <<TRY
     # TF OICS
     mkdir -p $TFOICS_LOCAL_PATH
     git clone -b $NEW_BRANCH $TFOICS_SCRATCH_PATH $TFOICS_LOCAL_PATH
-    pushd $TFOICS_LOCAL_PATH
+    pushd $TFOICS_LOCAL_PATH > /dev/null
     git fetch origin $OLD_BRANCH
     if ! git diff --exit-code --quiet origin/$NEW_BRANCH origin/$OLD_BRANCH; then
         echo "TF OiCS: [Diff](https://github.com/modular-magician/docs-examples/compare/$OLD_BRANCH..$NEW_BRANCH)"
     fi
-    popd
+    popd > /dev/null
 TRY
 )
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
I'd tested feeding variables in & error cases, but not actually the output. Editing them inside the subshell doesn't make it's way back to the parent. Capture the output from the subshell.

I get the output `Diffs: TF OiCS: [Diff](https://github.com/modular-magician/docs-examples/compare/auto-pr-3050-old..auto-pr-3050)` from the test script below:

```sh
set -e

PR_NUMBER=3050
NEW_BRANCH=auto-pr-$PR_NUMBER
OLD_BRANCH=auto-pr-$PR_NUMBER-old
TFOICS_SCRATCH_PATH=https://modular-magician:$GITHUB_TOKEN@github.com/modular-magician/docs-examples
TFOICS_LOCAL_PATH=$PWD/../tfoics

set +e
DIFFS="Diffs: "
VAR=$(bash -e <<TRY
    # TF OICS
    mkdir -p $TFOICS_LOCAL_PATH
    git clone -b $NEW_BRANCH $TFOICS_SCRATCH_PATH $TFOICS_LOCAL_PATH
    pushd $TFOICS_LOCAL_PATH > /dev/null
    git fetch origin $OLD_BRANCH
    if ! git diff --exit-code --quiet origin/$NEW_BRANCH origin/$OLD_BRANCH; then
        echo "TF OiCS: [Diff](https://github.com/modular-magician/docs-examples/compare/$OLD_BRANCH..$NEW_BRANCH)"
    fi
    popd > /dev/null
TRY
)
if [ $? -ne 0 ]; then
  echo caught exception
else
DIFFS="$DIFFS $VAR"
fi
set -e
echo $DIFFS
```

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
