### PR TITLE
Forcing ASN validation to int64

### DIFF
--- a/third_party/terraform/tests/resource_compute_router_test.go
+++ b/third_party/terraform/tests/resource_compute_router_test.go
@@ -168,7 +168,7 @@ resource "google_compute_router" "foobar" {
   region  = google_compute_subnetwork.foobar.region
   network = google_compute_network.foobar.name
   bgp {
-    asn = 64514
+    asn = 4294967294
   }
 }
 `, testId, testId, resourceRegion, testId)

--- a/third_party/terraform/utils/validation.go
+++ b/third_party/terraform/utils/validation.go
@@ -64,11 +64,12 @@ var (
 
 	// Valid range for Cloud Router ASN values as per RFC6996
 	// https://tools.ietf.org/html/rfc6996
-	Rfc6996Asn16BitMin  = 64512
-	Rfc6996Asn16BitMax  = 65534
-	Rfc6996Asn32BitMin  = 4200000000
-	Rfc6996Asn32BitMax  = 4294967294
-	GcpRouterPartnerAsn = 16550
+	// Must be explicitly int64 to avoid overflow when building Terraform for 32bit architectures
+	Rfc6996Asn16BitMin  = int64(64512)
+	Rfc6996Asn16BitMax  = int64(65534)
+	Rfc6996Asn32BitMin  = int64(4200000000)
+	Rfc6996Asn32BitMax  = int64(4294967294)
+	GcpRouterPartnerAsn = int64(16550)
 )
 
 var rfc1918Networks = []string{
@@ -84,7 +85,7 @@ func validateGCPName(v interface{}, k string) (ws []string, errors []error) {
 
 // Ensure that the BGP ASN value of Cloud Router is a valid value as per RFC6996 or a value of 16550
 func validateRFC6996Asn(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(int)
+	value := int64(v.(int))
 	if !(value >= Rfc6996Asn16BitMin && value <= Rfc6996Asn16BitMax) &&
 		!(value >= Rfc6996Asn32BitMin && value <= Rfc6996Asn32BitMax) &&
 		value != GcpRouterPartnerAsn {


### PR DESCRIPTION
This code works as is for 64 bit architechture but we compile Terraform to 32
bit architecture binaries where this would have overflowed.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
No release note needed as this is a follow up to https://github.com/GoogleCloudPlatform/magic-modules/pull/3045
```
