### PR TITLE
handle case where bigtable development instances have one node

### DIFF
--- a/third_party/terraform/resources/resource_bigtable_instance.go
+++ b/third_party/terraform/resources/resource_bigtable_instance.go
@@ -50,8 +50,11 @@ func resourceBigtableInstance() *schema.Resource {
 							Required: true,
 						},
 						"num_nodes": {
-							Type:         schema.TypeInt,
-							Optional:     true,
+							Type:     schema.TypeInt,
+							Optional: true,
+							// DEVELOPMENT instances could get returned with either zero or one node,
+							// so mark as computed.
+							Computed:     true,
 							ValidateFunc: validation.IntAtLeast(3),
 						},
 						"storage_type": {
@@ -311,7 +314,7 @@ func resourceBigtableInstanceValidateDevelopment(diff *schema.ResourceDiff, meta
 	if diff.Get("cluster.#").(int) != 1 {
 		return fmt.Errorf("config is invalid: instance with instance_type=\"DEVELOPMENT\" should have exactly one \"cluster\" block")
 	}
-	if diff.Get("cluster.0.num_nodes").(int) != 0 {
+	if diff.Get("cluster.0.num_nodes").(int) > 1 {
 		return fmt.Errorf("config is invalid: num_nodes cannot be set for instance_type=\"DEVELOPMENT\"")
 	}
 	return nil


### PR DESCRIPTION
The API still doesn't permit setting the node count for development instances, but if we send it as empty it might return 0 or 1 back. Unfortunately, customizediff can't tell that the field isn't set in the config if it is set in state (regardless of whether it's set to computed), so we have to have it allow 1 as a value for num_nodes even though it'll fail at apply-time. 

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5492.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigtable: fixed diff for DEVELOPMENT instances that are returned from the API with one node
```
