### PR TITLE
Balance diff summary braces

### DIFF
--- a/.ci/containers/github-differ/generate_comment.sh
+++ b/.ci/containers/github-differ/generate_comment.sh
@@ -37,7 +37,7 @@ pushd $TPG_LOCAL_PATH
 git fetch origin $OLD_BRANCH
 if ! git diff --exit-code origin/$NEW_BRANCH origin/$OLD_BRANCH; then
     SUMMARY=`git diff origin/$NEW_BRANCH origin/$OLD_BRANCH --shortstat`
-    DIFFS="${DIFFS}${NEWLINE}Terraform GA: [Diff](https://github.com/modular-magician/terraform-provider-google/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY)"
+    DIFFS="${DIFFS}${NEWLINE}Terraform GA: [Diff](https://github.com/modular-magician/terraform-provider-google/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY )"
 fi
 popd
 
@@ -48,7 +48,7 @@ pushd $TPGB_LOCAL_PATH
 git fetch origin $OLD_BRANCH
 if ! git diff --exit-code origin/$NEW_BRANCH origin/$OLD_BRANCH; then
     SUMMARY=`git diff origin/$NEW_BRANCH origin/$OLD_BRANCH --shortstat`
-    DIFFS="${DIFFS}${NEWLINE}Terraform Beta: [Diff](https://github.com/modular-magician/terraform-provider-google-beta/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY)"
+    DIFFS="${DIFFS}${NEWLINE}Terraform Beta: [Diff](https://github.com/modular-magician/terraform-provider-google-beta/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY )"
 fi
 popd
 
@@ -59,7 +59,7 @@ pushd $ANSIBLE_LOCAL_PATH
 git fetch origin $OLD_BRANCH
 if ! git diff --exit-code origin/$NEW_BRANCH origin/$OLD_BRANCH; then
     SUMMARY=`git diff origin/$NEW_BRANCH origin/$OLD_BRANCH --shortstat`
-    DIFFS="${DIFFS}${NEWLINE}Ansible: [Diff](https://github.com/modular-magician/ansible_collections_google/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY)"
+    DIFFS="${DIFFS}${NEWLINE}Ansible: [Diff](https://github.com/modular-magician/ansible_collections_google/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY )"
 fi
 popd
 
@@ -70,7 +70,7 @@ pushd $TFC_LOCAL_PATH
 git fetch origin $OLD_BRANCH
 if ! git diff --exit-code origin/$NEW_BRANCH origin/$OLD_BRANCH; then
     SUMMARY=`git diff origin/$NEW_BRANCH origin/$OLD_BRANCH --shortstat`
-    DIFFS="${DIFFS}${NEWLINE}TF Conversion: [Diff](https://github.com/modular-magician/terraform-google-conversion/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY)"
+    DIFFS="${DIFFS}${NEWLINE}TF Conversion: [Diff](https://github.com/modular-magician/terraform-google-conversion/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY )"
 fi
 popd
 
@@ -87,7 +87,7 @@ OICSDIFFS=$(bash -e <<TRY
     git fetch origin $OLD_BRANCH
     if ! git diff --exit-code --quiet origin/$NEW_BRANCH origin/$OLD_BRANCH; then
         SUMMARY=`git diff origin/$NEW_BRANCH origin/$OLD_BRANCH --shortstat`
-        echo "TF OiCS: [Diff](https://github.com/modular-magician/docs-examples/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY)"
+        echo "TF OiCS: [Diff](https://github.com/modular-magician/docs-examples/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY )"
     fi
     popd > /dev/null
 TRY
@@ -106,7 +106,7 @@ pushd $INSPEC_LOCAL_PATH
 git fetch origin $OLD_BRANCH
 if ! git diff --exit-code origin/$NEW_BRANCH origin/$OLD_BRANCH; then
     SUMMARY=`git diff origin/$NEW_BRANCH origin/$OLD_BRANCH --shortstat`
-    DIFFS="${DIFFS}${NEWLINE}Inspec: [Diff](https://github.com/modular-magician/inspec-gcp/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY)"
+    DIFFS="${DIFFS}${NEWLINE}Inspec: [Diff](https://github.com/modular-magician/inspec-gcp/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY )"
 fi
 popd
 


### PR DESCRIPTION
the output comes with a space for free, so add one afterwards as well. See https://github.com/GoogleCloudPlatform/magic-modules/pull/3059#issuecomment-580887210

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
