### PR TITLE
update tests that are still using first gen sql instances

### DIFF
--- a/templates/terraform/examples/cloud_run_service_sql.tf.erb
+++ b/templates/terraform/examples/cloud_run_service_sql.tf.erb
@@ -23,6 +23,6 @@ resource "google_sql_database_instance" "instance" {
   name   = "<%= ctx[:vars]['cloud_run_sql_name'] %>"
   region = "us-east1"
   settings {
-    tier = "D0"
+    tier = "db-f1-micro"
   }
 }

--- a/templates/terraform/examples/sql_database_basic.tf.erb
+++ b/templates/terraform/examples/sql_database_basic.tf.erb
@@ -5,8 +5,8 @@ resource "google_sql_database" "<%= ctx[:primary_resource_id] %>" {
 
 resource "google_sql_database_instance" "instance" {
   name   = "<%= ctx[:vars]['database_instance_name'] %>"
-  region = "us-central"
+  region = "us-central1"
   settings {
-    tier = "D0"
+    tier = "db-f1-micro"
   }
 }

--- a/third_party/terraform/resources/resource_sql_ssl_cert_test.go
+++ b/third_party/terraform/resources/resource_sql_ssl_cert_test.go
@@ -98,9 +98,9 @@ func testGoogleSqlClientCert_mysql(instance string) string {
 	return fmt.Sprintf(`
 	resource "google_sql_database_instance" "instance" {
 		name = "%s"
-		region = "us-central"
+		region = "us-central1"
 		settings {
-			tier = "D0"
+			tier = "db-f1-micro"
 		}
 	}
 

--- a/third_party/terraform/tests/resource_sql_database_test.go
+++ b/third_party/terraform/tests/resource_sql_database_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 
-	"google.golang.org/api/sqladmin/v1beta4"
+	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
 func TestAccSqlDatabase_basic(t *testing.T) {
@@ -183,9 +183,9 @@ func testAccSqlDatabaseDestroy(s *terraform.State) error {
 var testGoogleSqlDatabase_basic = `
 resource "google_sql_database_instance" "instance" {
   name   = "%s"
-  region = "us-central"
+  region = "us-central1"
   settings {
-    tier = "D0"
+    tier = "db-f1-micro"
   }
 }
 
@@ -197,9 +197,9 @@ resource "google_sql_database" "database" {
 var testGoogleSqlDatabase_latin1 = `
 resource "google_sql_database_instance" "instance" {
   name   = "%s"
-  region = "us-central"
+  region = "us-central1"
   settings {
-    tier = "D0"
+    tier = "db-f1-micro"
   }
 }
 

--- a/third_party/terraform/tests/resource_sql_user_test.go
+++ b/third_party/terraform/tests/resource_sql_user_test.go
@@ -134,9 +134,9 @@ func testGoogleSqlUser_mysql(instance, password string) string {
 	return fmt.Sprintf(`
 resource "google_sql_database_instance" "instance" {
   name   = "%s"
-  region = "us-central"
+  region = "us-central1"
   settings {
-    tier = "D0"
+    tier = "db-f1-micro"
   }
 }
 

--- a/third_party/terraform/website/docs/d/google_kms_secret.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_secret.html.markdown
@@ -68,7 +68,7 @@ resource "google_sql_database_instance" "master" {
   name = "master-instance-${random_id.db_name_suffix.hex}"
 
   settings {
-    tier = "D0"
+    tier = "db-f1-micro"
   }
 }
 

--- a/third_party/terraform/website/docs/r/sql_ssl_cert.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_ssl_cert.html.markdown
@@ -27,7 +27,7 @@ resource "google_sql_database_instance" "master" {
   name = "master-instance-${random_id.db_name_suffix.hex}"
 
   settings {
-    tier = "D0"
+    tier = "db-f1-micro"
   }
 }
 

--- a/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -28,7 +28,7 @@ resource "google_sql_database_instance" "master" {
   name = "master-instance-${random_id.db_name_suffix.hex}"
 
   settings {
-    tier = "D0"
+    tier = "db-f1-micro"
   }
 }
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
