### PR TITLE
Remove notes about base-64 encoding of secret data in markdown

### DIFF
--- a/products/secretmanager/api.yaml
+++ b/products/secretmanager/api.yaml
@@ -161,4 +161,4 @@ objects:
         properties:
           - !ruby/object:Api::Type::String
             name: data
-            description: The secret data. Must be no larger than 64KiB. A base64-encoded string.
+            description: The secret data. Must be no larger than 64KiB.

--- a/third_party/terraform/data_sources/data_source_secret_manager_secret_version.go.erb
+++ b/third_party/terraform/data_sources/data_source_secret_manager_secret_version.go.erb
@@ -116,7 +116,11 @@ func dataSourceSecretManagerSecretVersionRead(d *schema.ResourceData, meta inter
 	d.Set("enabled", true)
 
 	data := resp["payload"].(map[string]interface{})
-	d.Set("secret_data", data["data"].(string))
+	secretData, err := base64.StdEncoding.DecodeString(data["data"].(string))
+	if err != nil {
+		return fmt.Errorf("Error decoding secret manager secret version data: %s", err.Error())
+	}
+	d.Set("secret_data", string(secretData))
 
 	d.SetId(time.Now().UTC().String())
 	return nil

--- a/third_party/terraform/website/docs/d/datasource_google_secret_manager_secret_version.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_secret_manager_secret_version.html.markdown
@@ -37,7 +37,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
-* `secret_data` - The secret data. No larger than 64KiB. A base64-encoded string.
+* `secret_data` - The secret data. No larger than 64KiB.
 
 * `name` - The resource name of the SecretVersion. Format:
   `projects/{{project}}/secrets/{{secret_id}}/versions/{{version}}`


### PR DESCRIPTION
Decode secret data in secret manager version datasource to match secret version resource.

Remove notes from docs about base 64 encoding

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->
