### PR TITLE
no changelog on ansible or inspec

### DIFF
--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -106,7 +106,12 @@ git checkout -b $BRANCH
 COMMITTED=true
 git commit --signoff -m "$COMMIT_MESSAGE" || COMMITTED=false
 
-if [ "$COMMITTED" == "true" ] && [ "$COMMAND" == "downstream" ]; then
+CHANGELOG=false
+if ["$REPO" == "terraform"]; then
+  CHANGELOG=true
+fi
+
+if [ "$COMMITTED" == "true" ] && [ "$COMMAND" == "downstream" ] && ["$CHANGELOG" == "true"]; then
     # Add the changelog entry!
     PR_NUMBER=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
         "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls?state=closed&base=master&sort=updated&direction=desc" | \
@@ -123,12 +128,7 @@ fi
 
 git push $SCRATCH_PATH $BRANCH -f
 
-CHANGELOG=true
-if ["$REPO" == "ansible"] || ["$REPO" == "inspec"]; then
-  CHANGELOG=false
-fi
-
-if [ "$COMMITTED" == "true" ] && [ "$COMMAND" == "downstream" ] && ["$CHANGELOG" == "true"]; then
+if [ "$COMMITTED" == "true" ] && [ "$COMMAND" == "downstream" ]; then
     PR_BODY=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
         "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/$PR_NUMBER" | \
         jq -r .body)

--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -53,6 +53,7 @@ if [ -z "$GITHUB_TOKEN" ]; then
     exit 1
 fi
 
+
 COMMAND=$1
 REPO=$2
 VERSION=$3
@@ -122,7 +123,12 @@ fi
 
 git push $SCRATCH_PATH $BRANCH -f
 
-if [ "$COMMITTED" == "true" ] && [ "$COMMAND" == "downstream" ]; then
+CHANGELOG=true
+if ["$REPO" == "ansible"] || ["$REPO" == "inspec"]; then
+  CHANGELOG=false
+fi
+
+if [ "$COMMITTED" == "true" ] && [ "$COMMAND" == "downstream" ] && ["$CHANGELOG" == "true"]; then
     PR_BODY=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
         "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/$PR_NUMBER" | \
         jq -r .body)


### PR DESCRIPTION
Does InSpec want the changelog generated? I'm going back and forth on Ansible's changelog, but I'm not sure if I want it in the TF format.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
