### PR TITLE
Add custom_create custom code attachement.

### DIFF
--- a/provider/terraform/custom_code.rb
+++ b/provider/terraform/custom_code.rb
@@ -82,6 +82,10 @@ module Provider
       # returned. It's placed in the Create function directly without
       # modification.
       attr_reader :post_create_failure
+      # This code replaces the entire contents of the Create call. It
+      # should be used for resources that don't have normal creation
+      # semantics that cannot be supported well by other MM features.
+      attr_reader :custom_create
       # This code is run before the Update call happens.  It's placed
       # in the Update function, just after the encoder call, before
       # the Update call.  Just like the encoder, it is only used if
@@ -123,6 +127,7 @@ module Provider
         check :decoder, type: String
         check :constants, type: String
         check :post_create, type: String
+        check :custom_create, type: String
         check :pre_update, type: String
         check :post_update, type: String
         check :pre_delete, type: String

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -131,6 +131,9 @@ func resource<%= resource_name -%><%= prop.name.camelize(:upper) -%>SetStyleDiff
 <% end -%>
 
 func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{}) error {
+<%  if object.custom_code.custom_create -%>
+    <%= lines(compile(object.custom_code.custom_create))  -%>
+<%  else  -%>
     config := meta.(*Config)
 
     obj := make(map[string]interface{})
@@ -245,6 +248,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <%= lines(compile(object.custom_code.post_create)) if object.custom_code.post_create -%>
 
     return resource<%= resource_name -%>Read(d, meta)
+<%  end # if custom_create  -%>
 }
 
 func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
This PR doesn't include any downstream changes as this will be used in an up coming resource. The intent for the consuming resource will be to allow bypassing the Create method and call straight through to Update and set the id if successful. 

It could also be used for any other resource that doesn't have a traditional 'Create' that can be handled with other existing custom code.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
mm compiler only change
```
