### PR TITLE
Add note about Postgres requiring user passwords

### DIFF
--- a/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -50,8 +50,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the user. Changing this forces a new resource
     to be created.
 
-* `password` - (Optional) The password for the user, for Postgres instances this
-    field is Required. Can be updated.
+* `password` - (Optional) The password for the user. Can be updated. For Postgres
+    instances this is a Required field.
 
 - - -
 

--- a/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -50,7 +50,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the user. Changing this forces a new resource
     to be created.
 
-* `password` - (Optional) The password for the user. Can be updated.
+* `password` - (Optional) The password for the user, for Postgres instances this
+    field is Required. Can be updated.
 
 - - -
 


### PR DESCRIPTION
Upstreams https://github.com/terraform-providers/terraform-provider-google/pull/5569

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
