### PR TITLE
Always diff $OLD $NEW instead of $NEW $OLD

### DIFF
--- a/.ci/containers/github-differ/generate_comment.sh
+++ b/.ci/containers/github-differ/generate_comment.sh
@@ -35,8 +35,8 @@ mkdir -p $TPG_LOCAL_PATH
 git clone -b $NEW_BRANCH $TPG_SCRATCH_PATH $TPG_LOCAL_PATH
 pushd $TPG_LOCAL_PATH
 git fetch origin $OLD_BRANCH
-if ! git diff --exit-code origin/$NEW_BRANCH origin/$OLD_BRANCH; then
-    SUMMARY=`git diff origin/$NEW_BRANCH origin/$OLD_BRANCH --shortstat`
+if ! git diff --exit-code origin/$OLD_BRANCH origin/$NEW_BRANCH; then
+    SUMMARY=`git diff origin/$OLD_BRANCH origin/$NEW_BRANCH --shortstat`
     DIFFS="${DIFFS}${NEWLINE}Terraform GA: [Diff](https://github.com/modular-magician/terraform-provider-google/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY)"
 fi
 popd
@@ -46,8 +46,8 @@ mkdir -p $TPGB_LOCAL_PATH
 git clone -b $NEW_BRANCH $TPGB_SCRATCH_PATH $TPGB_LOCAL_PATH
 pushd $TPGB_LOCAL_PATH
 git fetch origin $OLD_BRANCH
-if ! git diff --exit-code origin/$NEW_BRANCH origin/$OLD_BRANCH; then
-    SUMMARY=`git diff origin/$NEW_BRANCH origin/$OLD_BRANCH --shortstat`
+if ! git diff --exit-code origin/$OLD_BRANCH origin/$NEW_BRANCH; then
+    SUMMARY=`git diff origin/$OLD_BRANCH origin/$NEW_BRANCH --shortstat`
     DIFFS="${DIFFS}${NEWLINE}Terraform Beta: [Diff](https://github.com/modular-magician/terraform-provider-google-beta/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY)"
 fi
 popd
@@ -57,8 +57,8 @@ mkdir -p $ANSIBLE_LOCAL_PATH
 git clone -b $NEW_BRANCH $ANSIBLE_SCRATCH_PATH $ANSIBLE_LOCAL_PATH
 pushd $ANSIBLE_LOCAL_PATH
 git fetch origin $OLD_BRANCH
-if ! git diff --exit-code origin/$NEW_BRANCH origin/$OLD_BRANCH; then
-    SUMMARY=`git diff origin/$NEW_BRANCH origin/$OLD_BRANCH --shortstat`
+if ! git diff --exit-code origin/$OLD_BRANCH origin/$NEW_BRANCH; then
+    SUMMARY=`git diff origin/$OLD_BRANCH origin/$NEW_BRANCH --shortstat`
     DIFFS="${DIFFS}${NEWLINE}Ansible: [Diff](https://github.com/modular-magician/ansible_collections_google/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY)"
 fi
 popd
@@ -68,8 +68,8 @@ mkdir -p $TFC_LOCAL_PATH
 git clone -b $NEW_BRANCH $TFC_SCRATCH_PATH $TFC_LOCAL_PATH
 pushd $TFC_LOCAL_PATH
 git fetch origin $OLD_BRANCH
-if ! git diff --exit-code origin/$NEW_BRANCH origin/$OLD_BRANCH; then
-    SUMMARY=`git diff origin/$NEW_BRANCH origin/$OLD_BRANCH --shortstat`
+if ! git diff --exit-code origin/$OLD_BRANCH origin/$NEW_BRANCH; then
+    SUMMARY=`git diff origin/$OLD_BRANCH origin/$NEW_BRANCH --shortstat`
     DIFFS="${DIFFS}${NEWLINE}TF Conversion: [Diff](https://github.com/modular-magician/terraform-google-conversion/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY)"
 fi
 popd
@@ -85,8 +85,8 @@ OICSDIFFS=$(bash -e <<TRY
     git clone -b $NEW_BRANCH $TFOICS_SCRATCH_PATH $TFOICS_LOCAL_PATH
     pushd $TFOICS_LOCAL_PATH > /dev/null
     git fetch origin $OLD_BRANCH
-    if ! git diff --exit-code --quiet origin/$NEW_BRANCH origin/$OLD_BRANCH; then
-        SUMMARY=`git diff origin/$NEW_BRANCH origin/$OLD_BRANCH --shortstat`
+    if ! git diff --exit-code --quiet origin/$OLD_BRANCH origin/$NEW_BRANCH; then
+        SUMMARY=`git diff origin/$OLD_BRANCH origin/$NEW_BRANCH --shortstat`
         echo "TF OiCS: [Diff](https://github.com/modular-magician/docs-examples/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY)"
     fi
     popd > /dev/null
@@ -104,8 +104,8 @@ mkdir -p $INSPEC_LOCAL_PATH
 git clone -b $NEW_BRANCH $INSPEC_SCRATCH_PATH $INSPEC_LOCAL_PATH
 pushd $INSPEC_LOCAL_PATH
 git fetch origin $OLD_BRANCH
-if ! git diff --exit-code origin/$NEW_BRANCH origin/$OLD_BRANCH; then
-    SUMMARY=`git diff origin/$NEW_BRANCH origin/$OLD_BRANCH --shortstat`
+if ! git diff --exit-code origin/$OLD_BRANCH origin/$NEW_BRANCH; then
+    SUMMARY=`git diff origin/$OLD_BRANCH origin/$NEW_BRANCH --shortstat`
     DIFFS="${DIFFS}${NEWLINE}Inspec: [Diff](https://github.com/modular-magician/inspec-gcp/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY)"
 fi
 popd


### PR DESCRIPTION
Magician summaries are currently swapping additions/deletions (see https://github.com/GoogleCloudPlatform/magic-modules/pull/3052#issuecomment-581638891 for an example)
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
