### PR TITLE
only include PatchUpdateEncoder if the resource is updatable

### DIFF
--- a/templates/terraform/nested_query.go.erb
+++ b/templates/terraform/nested_query.go.erb
@@ -140,6 +140,7 @@ func resource<%= resource_name -%>PatchCreateEncoder(d *schema.ResourceData, met
   return res, nil
 }
 
+<% if updatable?(object, object.root_properties) -%>
 // PatchUpdateEncoder handles creating request data to PATCH parent resource
 // with list including updated object.
 func resource<%= resource_name -%>PatchUpdateEncoder(d *schema.ResourceData, meta interface{}, obj map[string]interface{}) (map[string]interface{}, error) {
@@ -178,6 +179,7 @@ func resource<%= resource_name -%>PatchUpdateEncoder(d *schema.ResourceData, met
 
   return res, nil
 }
+<% end -%>
 
 // PatchDeleteEncoder handles creating request data to PATCH parent resource
 // with list excluding object to delete.


### PR DESCRIPTION
Follow up to https://github.com/GoogleCloudPlatform/magic-modules/pull/3052 to fix lint issues.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
