### PR TITLE
Split up TF utils.go.erb

### DIFF
--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -125,7 +125,9 @@ module Provider
                        ['google/kms_utils.go',
                         'third_party/terraform/utils/kms_utils.go'],
                        ['google/batcher.go',
-                        'third_party/terraform/utils/batcher.go']
+                        'third_party/terraform/utils/batcher.go'],
+                       ['google/retry_utils.go',
+                        'third_party/terraform/utils/retry_utils.go']
                      ])
     end
 

--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -127,7 +127,9 @@ module Provider
                        ['google/batcher.go',
                         'third_party/terraform/utils/batcher.go'],
                        ['google/retry_utils.go',
-                        'third_party/terraform/utils/retry_utils.go']
+                        'third_party/terraform/utils/retry_utils.go'],
+                       ['google/error_retry_predicates.go',
+                        'third_party/terraform/utils/error_retry_predicates.go']
                      ])
     end
 

--- a/third_party/terraform/utils/common_diff_suppress.go.erb
+++ b/third_party/terraform/utils/common_diff_suppress.go.erb
@@ -1,0 +1,105 @@
+<% autogen_exception -%>
+// Contains common diff suppress functions.
+
+package google
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func optionalPrefixSuppress(prefix string) schema.SchemaDiffSuppressFunc {
+	return func(k, old, new string, d *schema.ResourceData) bool {
+		return prefix+old == new || prefix+new == old
+	}
+}
+
+func optionalSurroundingSpacesSuppress(k, old, new string, d *schema.ResourceData) bool {
+	return strings.TrimSpace(old) == strings.TrimSpace(new)
+}
+
+func emptyOrDefaultStringSuppress(defaultVal string) schema.SchemaDiffSuppressFunc {
+	return func(k, old, new string, d *schema.ResourceData) bool {
+		return (old == "" && new == defaultVal) || (new == "" && old == defaultVal)
+	}
+}
+
+func ipCidrRangeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	// The range may be a:
+	// A) single IP address (e.g. 10.2.3.4)
+	// B) CIDR format string (e.g. 10.1.2.0/24)
+	// C) netmask (e.g. /24)
+	//
+	// For A) and B), no diff to suppress, they have to match completely.
+	// For C), The API picks a network IP address and this creates a diff of the form:
+	// network_interface.0.alias_ip_range.0.ip_cidr_range: "10.128.1.0/24" => "/24"
+	// We should only compare the mask portion for this case.
+	if len(new) > 0 && new[0] == '/' {
+		oldNetmaskStartPos := strings.LastIndex(old, "/")
+
+		if oldNetmaskStartPos != -1 {
+			oldNetmask := old[strings.LastIndex(old, "/"):]
+			if oldNetmask == new {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// sha256DiffSuppress
+// if old is the hex-encoded sha256 sum of new, treat them as equal
+func sha256DiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
+	return hex.EncodeToString(sha256.New().Sum([]byte(old))) == new
+}
+
+func caseDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
+	return strings.ToUpper(old) == strings.ToUpper(new)
+}
+
+// Port range '80' and '80-80' is equivalent.
+// `old` is read from the server and always has the full range format (e.g. '80-80', '1024-2048').
+// `new` can be either a single port or a port range.
+func portRangeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	return old == new+"-"+new
+}
+
+// Single-digit hour is equivalent to hour with leading zero e.g. suppress diff 1:00 => 01:00.
+// Assume either value could be in either format.
+func rfc3339TimeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	if (len(old) == 4 && "0"+old == new) || (len(new) == 4 && "0"+new == old) {
+		return true
+	}
+	return false
+}
+
+<% unless version == 'ga' -%>
+// For managed SSL certs, if new is an absolute FQDN (trailing '.') but old isn't, treat them as equals.
+func absoluteDomainSuppress(k, old, new string, _ *schema.ResourceData) bool {
+	if k == "managed.0.domains.0" {
+		return old == strings.TrimRight(new, ".")
+	}
+	return old == new
+}
+
+func timestampDiffSuppress(format string) schema.SchemaDiffSuppressFunc {
+	return func(_, old, new string, _ *schema.ResourceData) bool {
+		oldT, err := time.Parse(format, old)
+		if err != nil {
+			return false
+		}
+
+		newT, err := time.Parse(format, new)
+		if err != nil {
+			return false
+		}
+
+		return oldT == newT
+	}
+}
+<% end -%>

--- a/third_party/terraform/utils/error_retry_predicates.go
+++ b/third_party/terraform/utils/error_retry_predicates.go
@@ -6,6 +6,20 @@ import (
 	"strings"
 )
 
+var FINGERPRINT_FAIL_ERRORS = []string{"Invalid fingerprint.", "Supplied fingerprint does not match current metadata fingerprint."}
+
+// We've encountered a few common fingerprint-related strings; if this is one of
+// them, we're confident this is an error due to fingerprints.
+func isFingerprintError(err error) bool {
+	for _, msg := range FINGERPRINT_FAIL_ERRORS {
+		if strings.Contains(err.Error(), msg) {
+			return true
+		}
+	}
+
+	return false
+}
+
 // If a permission necessary to provision a resource is created in the same config
 // as the resource itself, the permission may not have propagated by the time terraform
 // attempts to create the resource. This allows those errors to be retried until the timeout expires

--- a/third_party/terraform/utils/retry_utils.go
+++ b/third_party/terraform/utils/retry_utils.go
@@ -1,0 +1,85 @@
+package google
+
+import (
+	"log"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"google.golang.org/api/googleapi"
+)
+
+func retry(retryFunc func() error) error {
+	return retryTime(retryFunc, 1)
+}
+
+func retryTime(retryFunc func() error, minutes int) error {
+	return retryTimeDuration(retryFunc, time.Duration(minutes)*time.Minute)
+}
+
+func retryTimeDuration(retryFunc func() error, duration time.Duration, errorRetryPredicates ...func(e error) (bool, string)) error {
+	return resource.Retry(duration, func() *resource.RetryError {
+		err := retryFunc()
+		if err == nil {
+			return nil
+		}
+		for _, e := range getAllTypes(err, &googleapi.Error{}, &url.Error{}) {
+			if isRetryableError(e, errorRetryPredicates) {
+				return resource.RetryableError(e)
+			}
+		}
+		return resource.NonRetryableError(err)
+	})
+}
+
+func getAllTypes(err error, args ...interface{}) []error {
+	var result []error
+	for _, v := range args {
+		subResult := errwrap.GetAllType(err, v)
+		if subResult != nil {
+			result = append(result, subResult...)
+		}
+	}
+	return result
+}
+
+func isRetryableError(err error, retryPredicates []func(e error) (bool, string)) bool {
+	// These operations are always hitting googleapis.com - they should rarely
+	// time out, and if they do, that timeout is retryable.
+	if urlerr, ok := err.(*url.Error); ok && urlerr.Timeout() {
+		log.Printf("[DEBUG] Dismissed an error as retryable based on googleapis.com target: %s", err)
+		return true
+	}
+
+	if gerr, ok := err.(*googleapi.Error); ok {
+		if gerr.Code == 429 || gerr.Code == 500 || gerr.Code == 502 || gerr.Code == 503 {
+			log.Printf("[DEBUG] Dismissed an error as retryable based on error code: %s", err)
+			return true
+		}
+
+		if gerr.Code == 409 && strings.Contains(gerr.Body, "operationInProgress") {
+			// 409's are retried because cloud sql throws a 409 when concurrent calls are made.
+			// The only way right now to determine it is a SQL 409 due to concurrent calls is to
+			// look at the contents of the error message.
+			// See https://github.com/terraform-providers/terraform-provider-google/issues/3279
+			log.Printf("[DEBUG] Dismissed an error as retryable based on error code 409 and error reason 'operationInProgress': %s", err)
+			return true
+		}
+
+		if gerr.Code == 412 && isFingerprintError(err) {
+			log.Printf("[DEBUG] Dismissed an error as retryable as a fingerprint mismatch: %s", err)
+			return true
+		}
+
+	}
+	for _, pred := range retryPredicates {
+		if retry, reason := (pred(err)); retry {
+			log.Printf("[DEBUG] Dismissed an error as retryable. %s - %s", reason, err)
+			return true
+		}
+	}
+
+	return false
+}

--- a/third_party/terraform/utils/utils.go.erb
+++ b/third_party/terraform/utils/utils.go.erb
@@ -132,20 +132,6 @@ func isFailedPreconditionError(err error) bool {
 	return false
 }
 
-var FINGERPRINT_FAIL_ERRORS = []string{"Invalid fingerprint.", "Supplied fingerprint does not match current metadata fingerprint."}
-
-// We've encountered a few common fingerprint-related strings; if this is one of
-// them, we're confident this is an error due to fingerprints.
-func isFingerprintError(err error) bool {
-	for _, msg := range FINGERPRINT_FAIL_ERRORS {
-		if strings.Contains(err.Error(), msg) {
-			return true
-		}
-	}
-
-	return false
-}
-
 func isConflictError(err error) bool {
 	if e, ok := err.(*googleapi.Error); ok && e.Code == 409 {
 		return true
@@ -154,72 +140,6 @@ func isConflictError(err error) bool {
 		if e.Code == 409 {
 			return true
 		}
-	}
-	return false
-}
-
-func optionalPrefixSuppress(prefix string) schema.SchemaDiffSuppressFunc {
-	return func(k, old, new string, d *schema.ResourceData) bool {
-		return prefix+old == new || prefix+new == old
-	}
-}
-
-func optionalSurroundingSpacesSuppress(k, old, new string, d *schema.ResourceData) bool {
-	return strings.TrimSpace(old) == strings.TrimSpace(new)
-}
-
-func emptyOrDefaultStringSuppress(defaultVal string) schema.SchemaDiffSuppressFunc {
-	return func(k, old, new string, d *schema.ResourceData) bool {
-		return (old == "" && new == defaultVal) || (new == "" && old == defaultVal)
-	}
-}
-
-func ipCidrRangeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	// The range may be a:
-	// A) single IP address (e.g. 10.2.3.4)
-	// B) CIDR format string (e.g. 10.1.2.0/24)
-	// C) netmask (e.g. /24)
-	//
-	// For A) and B), no diff to suppress, they have to match completely.
-	// For C), The API picks a network IP address and this creates a diff of the form:
-	// network_interface.0.alias_ip_range.0.ip_cidr_range: "10.128.1.0/24" => "/24"
-	// We should only compare the mask portion for this case.
-	if len(new) > 0 && new[0] == '/' {
-		oldNetmaskStartPos := strings.LastIndex(old, "/")
-
-		if oldNetmaskStartPos != -1 {
-			oldNetmask := old[strings.LastIndex(old, "/"):]
-			if oldNetmask == new {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
-// sha256DiffSuppress
-// if old is the hex-encoded sha256 sum of new, treat them as equal
-func sha256DiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
-	return hex.EncodeToString(sha256.New().Sum([]byte(old))) == new
-}
-
-func caseDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
-	return strings.ToUpper(old) == strings.ToUpper(new)
-}
-
-// Port range '80' and '80-80' is equivalent.
-// `old` is read from the server and always has the full range format (e.g. '80-80', '1024-2048').
-// `new` can be either a single port or a port range.
-func portRangeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	return old == new+"-"+new
-}
-
-// Single-digit hour is equivalent to hour with leading zero e.g. suppress diff 1:00 => 01:00.
-// Assume either value could be in either format.
-func rfc3339TimeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	if (len(old) == 4 && "0"+old == new) || (len(new) == 4 && "0"+new == old) {
-		return true
 	}
 	return false
 }
@@ -368,80 +288,6 @@ func mergeResourceMaps(ms ...map[string]*schema.Resource) (map[string]*schema.Re
 	return merged, err
 }
 
-func retry(retryFunc func() error) error {
-	return retryTime(retryFunc, 1)
-}
-
-func retryTime(retryFunc func() error, minutes int) error {
-	return retryTimeDuration(retryFunc, time.Duration(minutes)*time.Minute)
-}
-
-func retryTimeDuration(retryFunc func() error, duration time.Duration, errorRetryPredicates ...func(e error) (bool, string)) error {
-	return resource.Retry(duration, func() *resource.RetryError {
-		err := retryFunc()
-		if err == nil {
-			return nil
-		}
-		for _, e := range getAllTypes(err, &googleapi.Error{}, &url.Error{}) {
-			if isRetryableError(e, errorRetryPredicates) {
-				return resource.RetryableError(e)
-			}
-		}
-		return resource.NonRetryableError(err)
-	})
-}
-
-func getAllTypes(err error, args ...interface{}) []error {
-	var result []error
-	for _, v := range args {
-		subResult := errwrap.GetAllType(err, v)
-		if subResult != nil {
-			result = append(result, subResult...)
-		}
-	}
-	return result
-}
-
-func isRetryableError(err error, retryPredicates []func(e error) (bool, string)) bool {
-
-	// These operations are always hitting googleapis.com - they should rarely
-	// time out, and if they do, that timeout is retryable.
-	if urlerr, ok := err.(*url.Error); ok && urlerr.Timeout() {
-		log.Printf("[DEBUG] Dismissed an error as retryable based on googleapis.com target: %s", err)
-		return true
-	}
-
-	if gerr, ok := err.(*googleapi.Error); ok {
-		if (gerr.Code == 429 || gerr.Code == 500 || gerr.Code == 502 || gerr.Code == 503) {
-			log.Printf("[DEBUG] Dismissed an error as retryable based on error code: %s", err)
-			return true
-		}
-
-		if (gerr.Code == 409 && strings.Contains(gerr.Body, "operationInProgress")) {
-			// 409's are retried because cloud sql throws a 409 when concurrent calls are made.
-			// The only way right now to determine it is a SQL 409 due to concurrent calls is to
-			// look at the contents of the error message.
-			// See https://github.com/terraform-providers/terraform-provider-google/issues/3279
-			log.Printf("[DEBUG] Dismissed an error as retryable based on error code 409 and error reason 'operationInProgress': %s", err)
-			return true
-		}
-
-		if (gerr.Code == 412 && isFingerprintError(err)) {
-			log.Printf("[DEBUG] Dismissed an error as retryable as a fingerprint mismatch: %s", err)
-			return true
-		}
-
-	}
-	for _, pred := range retryPredicates {
-		if retry, reason := (pred(err)); retry {
-			log.Printf("[DEBUG] Dismissed an error as retryable. %s - %s", reason, err)
-			return true
-		}
-	}
-
-	return false
-}
-
 func extractFirstMapConfig(m []interface{}) map[string]interface{} {
 	if len(m) == 0 {
 		return map[string]interface{}{}
@@ -518,16 +364,6 @@ func paginatedListRequest(project, baseUrl string, config *Config, flattener fun
 	return ls, nil
 }
 
-<% unless version == 'ga' -%>
-// For managed SSL certs, if new is an absolute FQDN (trailing '.') but old isn't, treat them as equals.
-func absoluteDomainSuppress(k, old, new string, _ *schema.ResourceData) bool {
-	if k == "managed.0.domains.0" {
-		return old == strings.TrimRight(new, ".")
-	}
-	return old == new
-}
-<% end -%>
-
 func getInterconnectAttachmentLink(config *Config, project, region, ic string) (string, error) {
 	if !strings.Contains(ic, "/") {
 		icData, err := config.clientCompute.InterconnectAttachments.Get(
@@ -583,24 +419,6 @@ func stringInSlice(arr []string, str string) bool {
 
 	return false
 }
-<% unless version == 'ga' -%>
-
-func timestampDiffSuppress(format string) schema.SchemaDiffSuppressFunc {
-	return func(_, old, new string, _ *schema.ResourceData) bool {
-		oldT, err := time.Parse(format, old)
-		if err != nil {
-			return false
-		}
-
-		newT, err := time.Parse(format, new)
-		if err != nil {
-			return false
-		}
-
-		return oldT == newT
-	}
-}
-<% end -%>
 
 func migrateStateNoop(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
 		return is, nil


### PR DESCRIPTION
As a precursor to implementing eventual-consistency polling and retries everywhere, I would like to clean up utils.go.erb

Summary of changes:

- Moved error retry predicate `isFingerprintError()` into existing util file (`error_retry_predicates.go`)
- Moved general utils for retrying requests into `retry_utils.go` (TODO: combine with transport.go.erb maybe)
- Moved diff suppress utils into `common_diff_suppress.go.erb`

Because conversion doesnt use the schema, I didn't add `common_diff_suppress.go.erb` to the copied-files list.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
