### PR TITLE
Gcr resource

### DIFF
--- a/third_party/terraform/resources/resource_container_registry.go
+++ b/third_party/terraform/resources/resource_container_registry.go
@@ -17,7 +17,6 @@ func resourceContainerRegistry() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"location": {
 				Type:     schema.TypeString,
-				Default:  "US",
 				Optional: true,
 				ForceNew: true,
 				StateFunc: func(s interface{}) string {
@@ -32,12 +31,7 @@ func resourceContainerRegistry() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"self_link": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"url": {
+			"bucket_self_link": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -96,8 +90,8 @@ func resourceContainerRegistryRead(d *schema.ResourceData, meta interface{}) err
 	}
 	log.Printf("[DEBUG] Read bucket %v at location %v\n\n", res.Name, res.SelfLink)
 
-	// Update the bucket ID according to the resource ID
-	d.Set("self_link", res.SelfLink)
+	// Update the ID according to the bucket ID
+	d.Set("bucket_self_link", res.SelfLink)
 
 	d.SetId(res.Id)
 	return nil

--- a/third_party/terraform/resources/resource_container_registry.go
+++ b/third_party/terraform/resources/resource_container_registry.go
@@ -1,0 +1,111 @@
+package google
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+	"google.golang.org/api/storage/v1"
+)
+
+func resourceContainerRegistry() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceContainerRegistryCreate,
+		Read:   resourceContainerRegistryRead,
+		Delete: resourceContainerRegistryDelete,
+
+		Schema: map[string]*schema.Schema{
+			"location": {
+				Type:     schema.TypeString,
+				Default:  "US",
+				Optional: true,
+				ForceNew: true,
+				StateFunc: func(s interface{}) string {
+					return strings.ToUpper(s.(string))
+				},
+			},
+
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"self_link": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceContainerRegistryCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] Project: %s", project)
+
+	location := d.Get("location").(string)
+	log.Printf("[DEBUG] location: %s", location)
+	urlBase := "https://gcr.io/v2/token"
+	if location != "" {
+		urlBase = fmt.Sprintf("https://%s.gcr.io/v2/token", strings.ToLower(location))
+	}
+
+	// Performing a token handshake with the GCR API causes the backing bucket to create if it hasn't already.
+	url, err := replaceVars(d, config, fmt.Sprintf("%s?service=gcr.io&scope=repository:{{project}}/my-repo:push,pull", urlBase))
+	if err != nil {
+		return err
+	}
+
+	_, err = sendRequestWithTimeout(config, "GET", project, url, nil, d.Timeout(schema.TimeoutCreate))
+
+	if err != nil {
+		return err
+	}
+	return resourceContainerRegistryRead(d, meta)
+}
+
+func resourceContainerRegistryRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	name := ""
+	location := d.Get("location").(string)
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+	if location != "" {
+		name = fmt.Sprintf("%s.artifacts.%s.appspot.com", strings.ToLower(location), project)
+	} else {
+		name = fmt.Sprintf("artifacts.%s.appspot.com", project) 
+	}
+
+	res, err := config.clientStorage.Buckets.Get(name).Do()
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("Container Registry Storage Bucket %q", name))
+	}
+	log.Printf("[DEBUG] Read bucket %v at location %v\n\n", res.Name, res.SelfLink)
+
+	// Update the bucket ID according to the resource ID
+	d.Set("self_link", res.SelfLink)
+
+	d.SetId(res.Id)
+	return nil
+}
+
+func resourceContainerRegistryDelete(d *schema.ResourceData, meta interface{}) error {
+	// TODO do we want to do this?
+	return nil
+}

--- a/third_party/terraform/resources/resource_container_registry.go
+++ b/third_party/terraform/resources/resource_container_registry.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-
-	"google.golang.org/api/storage/v1"
 )
 
 func resourceContainerRegistry() *schema.Resource {
@@ -80,16 +78,16 @@ func resourceContainerRegistryCreate(d *schema.ResourceData, meta interface{}) e
 func resourceContainerRegistryRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	name := ""
 	location := d.Get("location").(string)
 	project, err := getProject(d, config)
 	if err != nil {
 		return err
 	}
+	name := ""
 	if location != "" {
 		name = fmt.Sprintf("%s.artifacts.%s.appspot.com", strings.ToLower(location), project)
 	} else {
-		name = fmt.Sprintf("artifacts.%s.appspot.com", project) 
+		name = fmt.Sprintf("artifacts.%s.appspot.com", project)
 	}
 
 	res, err := config.clientStorage.Buckets.Get(name).Do()
@@ -106,6 +104,6 @@ func resourceContainerRegistryRead(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourceContainerRegistryDelete(d *schema.ResourceData, meta interface{}) error {
-	// TODO do we want to do this?
+	// Don't delete the backing bucket as this is not a supported GCR action
 	return nil
 }

--- a/third_party/terraform/tests/resource_container_registry_test.go
+++ b/third_party/terraform/tests/resource_container_registry_test.go
@@ -1,0 +1,65 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccContainerRegistry_basic(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerRegistry_basic(),
+			},
+		},
+	})
+}
+
+func TestAccContainerRegistry_iam(t *testing.T) {
+	t.Parallel()
+	account := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerRegistry_iam(account),
+			},
+		},
+	})
+}
+
+func testAccContainerRegistry_basic() string {
+	return `
+resource "google_container_registry" "foobar" {
+  location = "EU"
+}
+`
+}
+
+func testAccContainerRegistry_iam(account string) string {
+	return fmt.Sprintf(`
+resource "google_container_registry" "foobar" {
+  location = "EU"
+}
+
+resource "google_service_account" "test-account-1" {
+  account_id   = "acct-%s-1"
+  display_name = "Container Registry Iam Testing Account"
+}
+
+resource "google_storage_bucket_iam_member" "viewer" {
+  bucket = google_container_registry.foobar.id
+  role = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.test-account-1.email}"
+}
+`, account)
+}

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -311,6 +311,7 @@ end     # products.each do
 				"google_compute_target_pool":                   resourceComputeTargetPool(),
 				"google_container_cluster":                     resourceContainerCluster(),
 				"google_container_node_pool":                   resourceContainerNodePool(),
+				"google_container_registry":                    resourceContainerRegistry(),
 				"google_dataflow_job":                          resourceDataflowJob(),
 				"google_dataproc_cluster":                      resourceDataprocCluster(),
 				"google_dataproc_cluster_iam_binding":          ResourceIamBinding(IamDataprocClusterSchema, NewDataprocClusterUpdater, DataprocClusterIdParseFunc),

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -849,6 +849,15 @@
     </ul>
     </li>
 
+    <li<%%= sidebar_current("docs-google-container-registry") %>>
+    <a href="#">Google Container Registry Resources</a>
+    <ul class="nav nav-visible">
+      <li<%%= sidebar_current("docs-google-container-registry") %>>
+      <a href="/docs/providers/google/r/container_registry.html">google_container_registry</a>
+      </li>
+    </ul>
+    </li>
+
     <li<%%= sidebar_current("docs-google-container") %>>
     <a href="#">Google Kubernetes (Container) Engine Resources</a>
     <ul class="nav nav-visible">

--- a/third_party/terraform/website/docs/r/container_registry.html.markdown
+++ b/third_party/terraform/website/docs/r/container_registry.html.markdown
@@ -1,0 +1,57 @@
+---
+subcategory: "Container Registry"
+layout: "google"
+page_title: "Google: google_container_registry"
+sidebar_current: "docs-google-container-registry"
+description: |-
+  Ensures the GCS bucket backing Google Container Registry exists.
+---
+
+# google_container_registry
+
+Ensures that the Google Cloud Storage bucket that backs Google Container Registry exists. Creating this resource will create the backing bucket if it does not exist, or do nothing if the bucket already exists. Destroying this resource does *NOT* destroy the backing bucket. For more information see [the official documentation](https://cloud.google.com/container-registry/docs/overview)
+
+This resource can be used to ensure that the GCS bucket exists prior to assigning permissions. For more information see the [access control page](https://cloud.google.com/container-registry/docs/access-control) for GCR.
+
+
+## Example Usage
+
+```hcl
+resource "google_container_registry" "registry" {
+  project  = "my-project"
+  location = "EU"
+}
+```
+
+The `id` field of the `google_container_registry` is the identifier of the storage bucket that backs GCR and can be used to assign permissions to the bucket.
+
+```hcl
+resource "google_container_registry" "registry" {
+  project  = "my-project"
+  location = "EU"
+}
+
+resource "google_storage_bucket_iam_member" "viewer" {
+  bucket = google_container_registry.registry.id
+  role = "roles/storage.objectViewer"
+  member = "user:jane@example.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `location` - (Optional) The location of the registry. One of `ASIA`, `EU`, `US` or not specified. See [the official documentation](https://cloud.google.com/container-registry/docs/pushing-and-pulling#pushing_an_image_to_a_registry) for more information on registry locations.
+
+* `project` - (Optional) The ID of the project in which the resource belongs. If it is not provided, the provider project is used.
+
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `self_link` - The URI of the created resource.
+
+* `id` - The name of the bucket that supports the Container Registry.

--- a/third_party/terraform/website/docs/r/container_registry.html.markdown
+++ b/third_party/terraform/website/docs/r/container_registry.html.markdown
@@ -52,6 +52,6 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
-* `self_link` - The URI of the created resource.
+* `bucket_self_link` - The URI of the created resource.
 
-* `id` - The name of the bucket that supports the Container Registry.
+* `id` - The name of the bucket that supports the Container Registry. In the form of `artifacts.{project}.appspot.com` or `{location}.artifacts.{project}.appspot.com` if location is specified.


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/4184

Add support for a GCR resource that ensures the backing bucket for a project/location combination exists. This allows for terraform to ensure the bucket exists prior to setting permissions on it. 

Normally the registry is created when the first image is pushed to it, but we cannot push images via Terraform. Performing the auth token handshake on the correct domain is enough to ensure that the bucket gets created by GCR.

Delete does not function on this resource so that we don't delete the bucket containing container images. This is not a function allowed via GCR, but can be done manually by deleting the bucket, so I decided to not include it.

This resource does a create or acquire on create, so import is not needed.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_container_registry`
```
