### PR TITLE
Add encryption_key_name to google_sql_database_instance.

### DIFF
--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -329,6 +329,17 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 				ForceNew: true,
 			},
 
+            <% unless version == 'ga' -%>
+            "encryption_key_name": {
+                Type:     schema.TypeString,
+                Optional: true,
+                // Property only valid for second-gen.
+                Computed: true,
+                ForceNew: true,
+            },
+            <% end -%>
+
+
 			<% unless version == 'ga' -%>
 			"root_password": {
 				Type:      schema.TypeString,
@@ -586,6 +597,13 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 		mutexKV.Lock(instanceMutexKey(project, instance.MasterInstanceName))
 		defer mutexKV.Unlock(instanceMutexKey(project, instance.MasterInstanceName))
 	}
+    <% unless version == 'ga' -%>
+    if k, ok := d.GetOk("encryption_key_name"); ok {
+        instance.DiskEncryptionConfiguration = &sqladmin.DiskEncryptionConfiguration{
+            KmsKeyName: k.(string),
+        }
+    }
+    <% end -%>
 
 	var op *sqladmin.Operation
 	err = retryTimeDuration(func() (operr error) {
@@ -821,6 +839,11 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 	if err := d.Set("settings", flattenSettings(instance.Settings)); err != nil {
 		log.Printf("[WARN] Failed to set SQL Database Instance Settings")
 	}
+    <% unless version == 'ga' -%>
+    if instance.DiskEncryptionConfiguration != nil {
+        d.Set("encryption_key_name", instance.DiskEncryptionConfiguration.KmsKeyName)
+    }
+    <% end -%>
 
 	if err := d.Set("replica_configuration", flattenReplicaConfiguration(instance.ReplicaConfiguration, d)); err != nil {
 		log.Printf("[WARN] Failed to set SQL Database Instance Replica Configuration")

--- a/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -216,6 +216,16 @@ includes an up-to-date reference of supported versions.
     
 * `root_password` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Initial root password. Required for MS SQL Server, ignored by MySQL and PostgreSQL.
 
+* `encryption_key_name` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+    The full path to the encryption key used for the CMEK disk encryption.  Setting
+    up disk encryption currently requires manual steps outside of Terraform.
+    The provided key must be in the same region as the SQL instance.  In order
+    to use this feature, a special kind of service account must be created and
+    granted permission on this key.  This step can currently only be done
+    manually, please see [this step](https://cloud.google.com/sql/docs/mysql/configure-cmek#service-account).
+    That service account needs the `Cloud KMS > Cloud KMS CryptoKey Encrypter/Decrypter` role on your
+    key - please see [this step](https://cloud.google.com/sql/docs/mysql/configure-cmek#grantkey).
+
 The required `settings` block supports:
 
 * `tier` - (Required) The machine type to use. See [tiers](https://cloud.google.com/sql/docs/admin-api/v1beta4/tiers)


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5434.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
sql: add CMEK support to google_sql_database_instance.
```

This does require a little manual work - according to the docs this is unavoidable.
> You need to create a service account for each project that requires customer-managed encryption keys. Currently, you can only use gcloud command-line tool commands to create the type of service account you need for customer-managed encryption keys.

Because of that, I've only been able to test this by hand.  It does seem to produce exactly the same result as gcloud, though.