### PR TITLE
Implement new-style resource state handling for GKE cluster

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1225,9 +1225,15 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	if err := waitForContainerClusterReady(config, project, location, clusterName, d.Timeout(schema.TimeoutCreate)); err != nil {
+	state, stateType, err := containerClusterAwaitRestingState(config, project, location, clusterName, d.Timeout(schema.TimeoutCreate))
+	if err != nil {
 		return err
 	}
+
+	if stateType == ErrorState {
+		return fmt.Errorf("Cluster %s was created in the error state %q", clusterName, state)
+	}
+
 	return nil
 }
 
@@ -1397,7 +1403,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	clusterName := d.Get("name").(string)
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
 
-	if err := waitForContainerClusterReady(config, project, location, clusterName, d.Timeout(schema.TimeoutUpdate)); err != nil {
+	if _, _, err := containerClusterAwaitRestingState(config, project, location, clusterName, d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return err
 	}
 
@@ -2012,6 +2018,10 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 <% end -%>
 	d.Partial(false)
 
+	if _, _, err := containerClusterAwaitRestingState(config, project, location, clusterName, d.Timeout(schema.TimeoutDelete)); err != nil {
+		return err
+	}
+
 	return resourceContainerClusterRead(d, meta)
 }
 
@@ -2031,7 +2041,7 @@ func resourceContainerClusterDelete(d *schema.ResourceData, meta interface{}) er
 	clusterName := d.Get("name").(string)
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
 
-	if err := waitForContainerClusterReady(config, project, location, clusterName, d.Timeout(schema.TimeoutDelete)); err != nil {
+	if _, _, err := containerClusterAwaitRestingState(config, project, location, clusterName, d.Timeout(schema.TimeoutDelete)); err != nil {
 		return err
 	}
 
@@ -2113,22 +2123,38 @@ func cleanFailedContainerCluster(d *schema.ResourceData, meta interface{}) error
 	return nil
 }
 
-func waitForContainerClusterReady(config *Config, project, location, clusterName string, timeout time.Duration) error {
-	return resource.Retry(timeout, func() *resource.RetryError {
+var containerClusterRestingStates = RestingStates{
+	"RUNNING":  ReadyState,
+	"DEGRADED": ErrorState,
+	"ERROR":    ErrorState,
+}
+
+func containerClusterAwaitRestingState(config *Config, project, location, clusterName string, timeout time.Duration) (state string, stateType StateType, err error) {
+	err = resource.Retry(timeout, func() *resource.RetryError {
 		name := containerClusterFullName(project, location, clusterName)
 		cluster, err := config.clientContainerBeta.Projects.Locations.Clusters.Get(name).Do()
 		if err != nil {
 			return resource.NonRetryableError(err)
 		}
-		if cluster.Status == "PROVISIONING" || cluster.Status == "RECONCILING" || cluster.Status == "STOPPING" {
-			return resource.RetryableError(fmt.Errorf("Cluster %q has status %q with message %q", clusterName, cluster.Status, cluster.StatusMessage))
-		} else if cluster.Status == "RUNNING" {
-			log.Printf("Cluster %q has status 'RUNNING'.", clusterName)
+
+		state = cluster.Status
+		stateType = containerClusterRestingStates[cluster.Status]
+
+		if stateType == ReadyState {
+			log.Printf("Cluster %q has status %q.", clusterName, state)
 			return nil
+		} else if stateType == ErrorState {
+			return resource.NonRetryableError(fmt.Errorf("Cluster %q has terminal state %q with message %q.", clusterName, state, cluster.StatusMessage))
 		} else {
-			return resource.NonRetryableError(fmt.Errorf("Cluster %q has terminal state %q with message %q.", clusterName, cluster.Status, cluster.StatusMessage))
+			return resource.RetryableError(fmt.Errorf("Cluster %q has status %q with message %q", clusterName, state, cluster.StatusMessage))
 		}
 	})
+
+	if _, ok := containerClusterRestingStates[state]; ok {
+		return state, stateType, nil
+	} else {
+		return "", UndefinedState, err
+	}
 }
 
 // container engine's API returns the instance group manager's URL instead of the instance
@@ -2877,7 +2903,7 @@ func resourceContainerClusterStateImporter(d *schema.ResourceData, meta interfac
 	clusterName := d.Get("name").(string)
 
 	d.Set("location", location)
-	if err := waitForContainerClusterReady(config, project, location, clusterName, d.Timeout(schema.TimeoutCreate)); err != nil {
+	if _, _, err := containerClusterAwaitRestingState(config, project, location, clusterName, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return nil, err
 	}
 

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1225,12 +1225,12 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	state, stateType, err := containerClusterAwaitRestingState(config, project, location, clusterName, d.Timeout(schema.TimeoutCreate))
+	state, err := containerClusterAwaitRestingState(config, project, location, clusterName, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return err
 	}
 
-	if stateType == ErrorState {
+	if containerClusterRestingStates[state] == ErrorState {
 		return fmt.Errorf("Cluster %s was created in the error state %q", clusterName, state)
 	}
 
@@ -1403,7 +1403,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	clusterName := d.Get("name").(string)
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
 
-	if _, _, err := containerClusterAwaitRestingState(config, project, location, clusterName, d.Timeout(schema.TimeoutUpdate)); err != nil {
+	if _, err := containerClusterAwaitRestingState(config, project, location, clusterName, d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return err
 	}
 
@@ -2018,7 +2018,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 <% end -%>
 	d.Partial(false)
 
-	if _, _, err := containerClusterAwaitRestingState(config, project, location, clusterName, d.Timeout(schema.TimeoutDelete)); err != nil {
+	if _, err := containerClusterAwaitRestingState(config, project, location, clusterName, d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return err
 	}
 
@@ -2041,7 +2041,7 @@ func resourceContainerClusterDelete(d *schema.ResourceData, meta interface{}) er
 	clusterName := d.Get("name").(string)
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
 
-	if _, _, err := containerClusterAwaitRestingState(config, project, location, clusterName, d.Timeout(schema.TimeoutDelete)); err != nil {
+	if _, err := containerClusterAwaitRestingState(config, project, location, clusterName, d.Timeout(schema.TimeoutDelete)); err != nil {
 		return err
 	}
 
@@ -2129,32 +2129,30 @@ var containerClusterRestingStates = RestingStates{
 	"ERROR":    ErrorState,
 }
 
-func containerClusterAwaitRestingState(config *Config, project, location, clusterName string, timeout time.Duration) (state string, stateType StateType, err error) {
+// returns a state with no error if the state is a resting state, and the last state with an error otherwise
+func containerClusterAwaitRestingState(config *Config, project, location, clusterName string, timeout time.Duration) (state string, err error) {
 	err = resource.Retry(timeout, func() *resource.RetryError {
 		name := containerClusterFullName(project, location, clusterName)
-		cluster, err := config.clientContainerBeta.Projects.Locations.Clusters.Get(name).Do()
-		if err != nil {
-			return resource.NonRetryableError(err)
+		cluster, gErr := config.clientContainerBeta.Projects.Locations.Clusters.Get(name).Do()
+		if gErr != nil {
+			return resource.NonRetryableError(gErr)
 		}
 
 		state = cluster.Status
-		stateType = containerClusterRestingStates[cluster.Status]
 
-		if stateType == ReadyState {
-			log.Printf("Cluster %q has status %q.", clusterName, state)
+		switch stateType := containerClusterRestingStates[cluster.Status]; stateType {
+		case ReadyState:
+			log.Printf("[DEBUG] Cluster %q has status %q with message %q.", clusterName, state, cluster.StatusMessage)
 			return nil
-		} else if stateType == ErrorState {
-			return resource.NonRetryableError(fmt.Errorf("Cluster %q has terminal state %q with message %q.", clusterName, state, cluster.StatusMessage))
-		} else {
-			return resource.RetryableError(fmt.Errorf("Cluster %q has status %q with message %q", clusterName, state, cluster.StatusMessage))
+		case ErrorState:
+			log.Printf("[DEBUG] Cluster %q has error state %q with message %q.", clusterName, state, cluster.StatusMessage)
+			return nil
+		default:
+			return resource.RetryableError(fmt.Errorf("Cluster %q has state %q with message %q", clusterName, state, cluster.StatusMessage))
 		}
 	})
 
-	if _, ok := containerClusterRestingStates[state]; ok {
-		return state, stateType, nil
-	} else {
-		return "", UndefinedState, err
-	}
+	return state, err
 }
 
 // container engine's API returns the instance group manager's URL instead of the instance
@@ -2903,7 +2901,7 @@ func resourceContainerClusterStateImporter(d *schema.ResourceData, meta interfac
 	clusterName := d.Get("name").(string)
 
 	d.Set("location", location)
-	if _, _, err := containerClusterAwaitRestingState(config, project, location, clusterName, d.Timeout(schema.TimeoutCreate)); err != nil {
+	if _, err := containerClusterAwaitRestingState(config, project, location, clusterName, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return nil, err
 	}
 

--- a/third_party/terraform/utils/state_util.go
+++ b/third_party/terraform/utils/state_util.go
@@ -1,0 +1,19 @@
+package google
+
+// A StateType represents the specific type of resting state that a state value
+// is.
+type StateType int
+
+const (
+	UndefinedState StateType = iota
+	// A special resting state, that generally requires special consideration
+	// Interactive states like PENDING_PARTNER in interconnects are an example
+	RestingState
+	// An error state is a state that indicates that a resource is not working
+	// correctly. If this is Create, it should be tainted by returning an error
+	ErrorState
+	// A ready resource is fully provisioned, and ready to accept traffic/work
+	ReadyState
+)
+
+type RestingStates map[string]StateType


### PR DESCRIPTION
Implements go/tpg-resource-state-handling, pre-work for https://github.com/terraform-providers/terraform-provider-google/issues/3304

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: `google_container_cluster` will allow importing / updating / deleting clusters in error states and will wait for a stable state after updates.
```
