### PR TITLE
Dont return error if we cant find a default value in IAM parse import id

### DIFF
--- a/templates/terraform/iam_policy.go.erb
+++ b/templates/terraform/iam_policy.go.erb
@@ -74,9 +74,9 @@ func <%= resource_name -%>IamUpdaterProducer(d *schema.ResourceData, config *Con
 
 <% resource_params.each do |param| -%>
 <% if provider_default_values.include?(param) -%>
-	<%= param -%>, err := get<%= param.capitalize -%>(d, config)
-	if err != nil {
-		return nil, err
+	<%= param -%>, _ := get<%= param.capitalize -%>(d, config)
+	if <%= param -%> != "" {
+		values["<%= param -%>"] = <%= param -%>
 	}
 	values["<%= param -%>"] = <%= param -%>
 
@@ -129,11 +129,10 @@ func <%= resource_name -%>IdParseFunc(d *schema.ResourceData, config *Config) er
 
 <% resource_params.each do |param| -%>
 <% if provider_default_values.include?(param) -%>
-	<%= param -%>, err := get<%= param.capitalize -%>(d, config)
-	if err != nil {
-		return err
+	<%= param -%>, _ := get<%= param.capitalize -%>(d, config)
+	if <%= param -%> != "" {
+		values["<%= param -%>"] = <%= param -%>
 	}
-	values["<%= param -%>"] = <%= param -%>
 
 <% end # if provider_default_values.include? -%>
 <% end # resource_params.each -%>

--- a/third_party/terraform/utils/import.go
+++ b/third_party/terraform/utils/import.go
@@ -133,6 +133,10 @@ func getImportIdQualifiers(idRegexes []string, d TerraformResourceData, config *
 
 			for k, v := range defaults {
 				if _, ok := result[k]; !ok {
+					if v == "" {
+						// No default was found and no value was specified in the import ID
+						return nil, fmt.Errorf("No value was found for %s during import", k)
+					}
 					// Set any fields that are defaultable and not specified in import ID
 					result[k] = v
 				}
@@ -149,24 +153,15 @@ func getImportIdQualifiers(idRegexes []string, d TerraformResourceData, config *
 func getDefaultValues(idRegex string, d TerraformResourceData, config *Config) (map[string]string, error) {
 	result := make(map[string]string)
 	if _, ok := d.GetOk("project"); !ok && strings.Contains(idRegex, "?P<project>") {
-		project, err := getProject(d, config)
-		if err != nil {
-			return nil, err
-		}
+		project, _ := getProject(d, config)
 		result["project"] = project
 	}
 	if _, ok := d.GetOk("region"); !ok && strings.Contains(idRegex, "?P<region>") {
-		region, err := getRegion(d, config)
-		if err != nil {
-			return nil, err
-		}
+		region, _ := getRegion(d, config)
 		result["region"] = region
 	}
 	if _, ok := d.GetOk("zone"); !ok && strings.Contains(idRegex, "?P<zone>") {
-		zone, err := getZone(d, config)
-		if err != nil {
-			return nil, err
-		}
+		zone, _ := getZone(d, config)
 		result["zone"] = zone
 	}
 	return result, nil


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/5550

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
iam: Fixed an erroneous error during import of IAM resources when a provider default project/zone/region is not defined.
```
