### PR TITLE
Ansible: Bigtable Instances and Clusters

### DIFF
--- a/products/bigtable/ansible.yaml
+++ b/products/bigtable/ansible.yaml
@@ -1,0 +1,32 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Ansible::Config
+datasources: !ruby/object:Overrides::ResourceOverrides
+  Instance: !ruby/object:Overrides::Ansible::ResourceOverride
+    facts: !ruby/object:Provider::Ansible::FactsOverride
+      has_filters: false
+overrides: !ruby/object:Overrides::ResourceOverrides
+  Instance: !ruby/object:Overrides::Ansible::ResourceOverride
+    transport: !ruby/object:Overrides::Ansible::Transport
+      encoder: encode_request
+      decoder: decode_response
+    custom_code: !ruby/object:Provider::Ansible::CustomCode
+      custom_create_resource: true
+    provider_helpers:
+      - 'products/bigtable/helpers/ansible/instance.py'
+  AppProfile: !ruby/object:Overrides::Ansible::ResourceOverride
+    exclude: true
+files: !ruby/object:Provider::Config::Files
+  resource:
+<%= lines(indent(compile('provider/ansible/resource~compile.yaml'), 4)) -%>

--- a/products/bigtable/ansible.yaml
+++ b/products/bigtable/ansible.yaml
@@ -23,6 +23,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       decoder: decode_response
     custom_code: !ruby/object:Provider::Ansible::CustomCode
       custom_create_resource: true
+      custom_async_function: bigtable_async_url
     provider_helpers:
       - 'products/bigtable/helpers/ansible/instance.py'
   AppProfile: !ruby/object:Overrides::Ansible::ResourceOverride

--- a/products/bigtable/ansible.yaml
+++ b/products/bigtable/ansible.yaml
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc.
+# Copyright 2020 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/products/bigtable/ansible_version_added.yaml
+++ b/products/bigtable/ansible_version_added.yaml
@@ -13,3 +13,13 @@
       :version_added: '2.10'
     :labels:
       :version_added: '2.10'
+    :clusters:
+      :version_added: '2.10'
+      :name:
+        :version_added: '2.10'
+      :serveNodes:
+        :version_added: '2.10'
+      :defaultStorageType:
+        :version_added: '2.10'
+      :location:
+        :version_added: '2.10'

--- a/products/bigtable/ansible_version_added.yaml
+++ b/products/bigtable/ansible_version_added.yaml
@@ -1,0 +1,15 @@
+---
+:facts:
+  :Instance:
+    :version_added: '2.10'
+:regular:
+  :Instance:
+    :version_added: '2.10'
+    :name:
+      :version_added: '2.10'
+    :displayName:
+      :version_added: '2.10'
+    :type:
+      :version_added: '2.10'
+    :labels:
+      :version_added: '2.10'

--- a/products/bigtable/api.yaml
+++ b/products/bigtable/api.yaml
@@ -19,7 +19,7 @@ versions:
     name: ga
     base_url: https://bigtableadmin.googleapis.com/v2/
 scopes:
-  - https://www.googleapis.com/auth/bigtable.admin
+  - https://www.googleapis.com/auth/bigtable
 apis_required:
   - !ruby/object:Api::Product::ApiReference
     name: Bigtable API

--- a/products/bigtable/api.yaml
+++ b/products/bigtable/api.yaml
@@ -91,3 +91,41 @@ objects:
               description: |
                 If true, CheckAndMutateRow and ReadModifyWriteRow requests are allowed by this app profile.
                 It is unsafe to send these requests to the same table/row/column in multiple clusters.
+  - !ruby/object:Api::Resource
+    name: Instance
+    base_url:
+    description: |
+      A collection of Bigtable Tables and the resources that serve them.  All
+      tables in an instance are served from all Clusters in the instance.
+    properties:
+    - !ruby/object:Api::Type::Enum
+      name: state
+      description: The current state of the instance.
+      values:
+      - :STATE_NOT_KNOWN
+      - :READY
+      - :CREATING
+      output: true
+    - !ruby/object:Api::Type::String
+      name: name
+      description: The unique name of the instance.
+    - !ruby/object:Api::Type::String
+      name: displayName
+      description: |
+        The descriptive name for this instance as it appears in UIs.
+        Can be changed at any time, but should be kept globally unique
+        to avoid confusion.
+    - !ruby/object:Api::Type::Enum
+      name: type
+      description: The type of the instance. Defaults to `PRODUCTION`.
+      values:
+      - :TYPE_UNSPECIFIED
+      - :PRODUCTION
+      - :DEVELOPMENT
+    - !ruby/object:Api::Type::KeyValuePairs
+      name: labels
+      description: |
+        Labels are a flexible and lightweight mechanism for organizing cloud
+        resources into groups that reflect a customer's organizational needs and
+        deployment strategies. They can be used to filter resources and aggregate
+        metrics.

--- a/products/bigtable/api.yaml
+++ b/products/bigtable/api.yaml
@@ -97,6 +97,26 @@ objects:
     description: |
       A collection of Bigtable Tables and the resources that serve them.  All
       tables in an instance are served from all Clusters in the instance.
+    async: !ruby/object:Api::OpAsync
+      actions: ['create']
+      operation: !ruby/object:Api::OpAsync::Operation
+        path: 'name'
+        # TODO: change this to be less Pythonic.
+        # Only Ansible uses this, so it's alright for now.
+        base_url: "operations/{module.params['clusters'][0]['location']}/{{op_id}}"
+        wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+        path: 'response'
+        resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: True
+        allowed:
+          - True
+          - False
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error'
+        message: 'message'
     properties:
     - !ruby/object:Api::Type::Enum
       name: state
@@ -129,3 +149,42 @@ objects:
         resources into groups that reflect a customer's organizational needs and
         deployment strategies. They can be used to filter resources and aggregate
         metrics.
+    - !ruby/object:Api::Type::Array
+      name: clusters
+      description: An array of clusters. Maximum 4.
+      item_type: !ruby/object:Api::Type::NestedObject
+        properties:
+        - !ruby/object:Api::Type::String
+          name: name
+          description: The unique name of the cluster.
+        - !ruby/object:Api::Type::Integer
+          name: serveNodes
+          description: |
+            The number of nodes allocated to this cluster. More nodes enable higher
+            throughput and more consistent performance.
+        - !ruby/object:Api::Type::Enum
+          name: defaultStorageType
+          description: |
+            The type of storage used by this cluster to serve its
+            parent instance's tables, unless explicitly overridden.
+          values:
+          - :STORAGE_TYPE_UNSPECIFIED
+          - :SSD
+          - :HDD
+        - !ruby/object:Api::Type::String
+          name: location
+          description: |
+            The location where this cluster's nodes and storage reside. For best
+            performance, clients should be located as close as possible to this
+            cluster. Currently only zones are supported, so values should be of the
+            form `projects/<project>/locations/<zone>`.
+        - !ruby/object:Api::Type::Enum
+          name: state
+          description: The current state of the cluster.
+          values:
+          - :STATE_NOT_KNOWN
+          - :READY
+          - :CREATING
+          - :RESIZING
+          - :DISABLED
+          output: true

--- a/products/bigtable/api.yaml
+++ b/products/bigtable/api.yaml
@@ -93,7 +93,7 @@ objects:
                 It is unsafe to send these requests to the same table/row/column in multiple clusters.
   - !ruby/object:Api::Resource
     name: Instance
-    base_url:
+    base_url: projects/{{project}}/instances
     description: |
       A collection of Bigtable Tables and the resources that serve them.  All
       tables in an instance are served from all Clusters in the instance.

--- a/products/bigtable/api.yaml
+++ b/products/bigtable/api.yaml
@@ -19,7 +19,7 @@ versions:
     name: ga
     base_url: https://bigtableadmin.googleapis.com/v2/
 scopes:
-  - https://www.googleapis.com/auth/bigtable
+  - https://www.googleapis.com/auth/bigtable.admin
 apis_required:
   - !ruby/object:Api::Product::ApiReference
     name: Bigtable API

--- a/products/bigtable/examples/ansible/instance.yaml
+++ b/products/bigtable/examples/ansible/instance.yaml
@@ -1,0 +1,21 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- !ruby/object:Provider::Ansible::Example
+task: !ruby/object:Provider::Ansible::Task
+  name: gcp_bigtable_instance
+  code:
+    name: <%= ctx[:name] %>
+    display_name: My Test Cluster
+    project: <%= ctx[:project] %>
+    auth_kind: <%= ctx[:auth_kind] %>
+    service_account_file: <%= ctx[:service_account_file] %>

--- a/products/bigtable/examples/ansible/instance.yaml
+++ b/products/bigtable/examples/ansible/instance.yaml
@@ -16,6 +16,10 @@ task: !ruby/object:Provider::Ansible::Task
   code:
     name: 'my-instance'
     display_name: My Test Cluster
+    clusters:
+      - name: mycluster
+        location: "projects/<%= ctx[:project] -%>/locations/us-central1-a"
+        serve_nodes: 1
     project: <%= ctx[:project] %>
     auth_kind: <%= ctx[:auth_kind] %>
     service_account_file: <%= ctx[:service_account_file] %>

--- a/products/bigtable/examples/ansible/instance.yaml
+++ b/products/bigtable/examples/ansible/instance.yaml
@@ -14,7 +14,7 @@
 task: !ruby/object:Provider::Ansible::Task
   name: gcp_bigtable_instance
   code:
-    name: <%= ctx[:name] %>
+    name: 'my-instance'
     display_name: My Test Cluster
     project: <%= ctx[:project] %>
     auth_kind: <%= ctx[:auth_kind] %>

--- a/products/bigtable/helpers/ansible/instance.py
+++ b/products/bigtable/helpers/ansible/instance.py
@@ -1,7 +1,10 @@
 def resource_to_create(module):
     instance = resource_to_request(module)
+    if 'name' in instance:
+        del instance['name']
+
     return {
-        'instanceId': module.params['name'],
+        'instanceId': module.params['name'].split('/')[-1],
         'instance': instance
     }
 

--- a/products/bigtable/helpers/ansible/instance.py
+++ b/products/bigtable/helpers/ansible/instance.py
@@ -1,0 +1,14 @@
+def resource_to_create(module):
+    instance = resource_to_request(module)
+    return {
+        'instanceId': module.params['name'],
+        'instance': instance
+    }
+
+def encode_request(request, module):
+    del request['name']
+    return request
+
+def decode_response(response, module):
+    response['name'] = response['name'].split('/')[-1]
+    return response

--- a/products/bigtable/helpers/ansible/instance.py
+++ b/products/bigtable/helpers/ansible/instance.py
@@ -49,8 +49,8 @@ def bigtable_async_url(module, extra_data=None):
         extra_data = {}
     location_name = module.params['clusters'][0]['location'].split('/')[-1]
 
-    url = "https://bigtableadmin.googleapis.com/v2/operations/projects/" + \
-            module.params['project'] + '/instances/' + module.params['name'] + \
-            '/locations/' + location_name + '/operations/{op_id}'
+    url = ('https://bigtableadmin.googleapis.com/v2/operations/projects/%s'
+       '/instances/%s/locations/%s/operations/{op_id}' %
+       (module.params['project'], module.params['name'], location_name))
 
     return url.format(**extra_data)

--- a/products/bigtable/helpers/ansible/instance.py
+++ b/products/bigtable/helpers/ansible/instance.py
@@ -39,8 +39,8 @@ def convert_clusters_to_map(clusters):
 
 def convert_map_to_clusters(clusters):
     carray = []
-    for cluster in clusters:
-        cluster['name'] = cluster['name'].split('/')[-1]
+    for key, cluster in clusters.items():
+        cluster['name'] = key.split('/')[-1]
         carray.append(cluster)
     return carray
 

--- a/products/bigtable/helpers/ansible/instance.py
+++ b/products/bigtable/helpers/ansible/instance.py
@@ -3,15 +3,54 @@ def resource_to_create(module):
     if 'name' in instance:
         del instance['name']
 
+    clusters = []
+    if 'clusters' in instance:
+        clusters = instance['clusters']
+        del instance['clusters']
+
     return {
         'instanceId': module.params['name'].split('/')[-1],
-        'instance': instance
+        'instance': instance,
+        'clusters': clusters
     }
 
 def encode_request(request, module):
-    del request['name']
+    if 'name' in request:
+        del request['name']
+
+    if 'clusters' in request:
+        request['clusters'] = convert_clusters_to_map(request['clusters'])
     return request
 
 def decode_response(response, module):
-    response['name'] = response['name'].split('/')[-1]
+    if 'name' in response:
+        response['name'] = response['name'].split('/')[-1]
+
+    if 'clusters' in response:
+        response['clusters'] = convert_map_to_clusters(response['clusters'])
     return response
+
+def convert_clusters_to_map(clusters):
+    cmap = {}
+    for cluster in clusters:
+        cmap[cluster['name']] = cluster
+        del cmap[cluster['name']]['name']
+    return cmap
+
+def convert_map_to_clusters(clusters):
+    carray = []
+    for cluster in clusters:
+        cluster['name'] = cluster['name'].split('/')[-1]
+        carray.append(cluster)
+    return carray
+
+def bigtable_async_url(module, extra_data=None):
+    if extra_data is None:
+        extra_data = {}
+    location_name = module.params['clusters'][0]['location'].split('/')[-1]
+
+    url = "https://bigtableadmin.googleapis.com/v2/operations/projects/" + \
+            module.params['project'] + '/instances/' + module.params['name'] + \
+            '/locations/' + location_name + '/operations/{op_id}'
+
+    return url.format(**extra_data)

--- a/products/bigtable/terraform.yaml
+++ b/products/bigtable/terraform.yaml
@@ -14,7 +14,7 @@
 --- !ruby/object:Provider::Terraform::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
   Instance: !ruby/object:Overrides::Terraform::ResourceOverride
-    exclude: true
+    exclude_resource: true
   AppProfile: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: "projects/{{project}}/instances/{{instance}}/appProfiles/{{app_profile_id}}"
     import_format: ["projects/{{project}}/instances/{{instance}}/appProfiles/{{app_profile_id}}"]

--- a/products/bigtable/terraform.yaml
+++ b/products/bigtable/terraform.yaml
@@ -15,6 +15,7 @@
 overrides: !ruby/object:Overrides::ResourceOverrides
   Instance: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude_resource: true
+    exclude: true
   AppProfile: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: "projects/{{project}}/instances/{{instance}}/appProfiles/{{app_profile_id}}"
     import_format: ["projects/{{project}}/instances/{{instance}}/appProfiles/{{app_profile_id}}"]

--- a/products/bigtable/terraform.yaml
+++ b/products/bigtable/terraform.yaml
@@ -13,6 +13,8 @@
 
 --- !ruby/object:Provider::Terraform::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
+  Instance: !ruby/object:Overrides::Terraform::ResourceOverride
+    exclude: true
   AppProfile: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: "projects/{{project}}/instances/{{instance}}/appProfiles/{{app_profile_id}}"
     import_format: ["projects/{{project}}/instances/{{instance}}/appProfiles/{{app_profile_id}}"]

--- a/provider/ansible/custom_code.rb
+++ b/provider/ansible/custom_code.rb
@@ -43,6 +43,9 @@ module Provider
       # Says if different resource_to_request body sent for update calls.
       attr_reader :custom_update_resource
 
+      # Custom function to get async url.
+      attr_reader :custom_async_function
+
       def validate
         check :create, type: String
         check :custom_create_resource, type: :boolean
@@ -54,6 +57,7 @@ module Provider
         check :return_if_object, type: String
         check :update, type: String
         check :unwrap_resource, type: :boolean
+        check :custom_async_function, type: String
       end
     end
   end

--- a/templates/ansible/async.erb
+++ b/templates/ansible/async.erb
@@ -55,6 +55,8 @@ def wait_for_completion(status, op_result, module):
     op_id = navigate_hash(op_result, <%= op_path -%>)
 <% if object.async.operation&.full_url -%>
     op_uri = navigate_hash(op_result, <%= python_literal(object.async.operation.full_url.split('/')) -%>)
+<% elsif object&.custom_code&.custom_async_function -%>
+    op_uri = <%= object&.custom_code&.custom_async_function -%>(module, {'op_id': op_id})
 <% else -%>
     op_uri = async_op_url(module, {'op_id': op_id})
 <% end -%>


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->
Ansible Bigtable Instances + Clusters. Clusters are built through the Instance API (unlike GKE, you can't have a Instance with no clusters).

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
