### PR TITLE
Update `secondary_ip_range` docs for sending an empty array

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -11905,9 +11905,6 @@ objects:
           contained in this subnetwork. The primary IP of such VM must belong
           to the primary ipCidrRange of the subnetwork. The alias IPs may belong
           to either primary or secondary ranges.
-          **Note**: This field will default to the API if empty. In order to explicitly
-          remove any secondary IP ranges, set this to an empty array. 
-          For example: `secondary_ip_range=[]`
         update_verb: :PATCH
         update_url:  projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
         update_id: 'secondaryIpRanges'

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -11905,6 +11905,9 @@ objects:
           contained in this subnetwork. The primary IP of such VM must belong
           to the primary ipCidrRange of the subnetwork. The alias IPs may belong
           to either primary or secondary ranges.
+          **Note**: This field will default to the API if empty. In order to explicitly
+          remove any secondary IP ranges, set this to an empty array. 
+          For example: `secondary_ip_range=[]`
         update_verb: :PATCH
         update_url:  projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
         update_id: 'secondaryIpRanges'

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1843,9 +1843,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         schema_config_mode_attr: true
         send_empty_value: true
         description: |
-          {{description}}This field uses attr-as-block mode to avoid breaking
-          users during the 0.12 upgrade. See [the Attr-as-Block page](https://www.terraform.io/docs/configuration/attr-as-blocks.html)
-          for more details.
+          {{description}}
+          **Note**: This field uses [attr-as-block mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html) to avoid
+          breaking users during the 0.12 upgrade. To explicitly send a list
+          of zero objects you must use the following syntax:
+          `example=[]`
+          For more details about this behavior, see [this section](https://www.terraform.io/docs/configuration/attr-as-blocks.html#defining-a-fixed-object-collection-value).
       secondaryIpRanges.rangeName: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateGCPName'

--- a/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -101,6 +101,11 @@ The following arguments are supported:
 
 * `guest_accelerator` - (Optional) List of the type and count of accelerator cards attached to the instance. Structure documented below.
     **Note:** GPU accelerators can only be used with [`on_host_maintenance`](#on_host_maintenance) option set to TERMINATE.
+    **Note**: This field uses [attr-as-block mode](https://www.terraform.io/docs/configuration/attr-as-blocks.html) to avoid
+    breaking users during the 0.12 upgrade. To explicitly send a list
+    of zero objects you must use the following syntax:
+    `example=[]`
+    For more details about this behavior, see [this section](https://www.terraform.io/docs/configuration/attr-as-blocks.html#defining-a-fixed-object-collection-value).
 
 * `labels` - (Optional) A map of key/value label pairs to assign to the instance.
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5568
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
