### PR TITLE
Build datastore index resource.

### DIFF
--- a/api/resource.rb
+++ b/api/resource.rb
@@ -314,6 +314,8 @@ module Api
       if @self_link.nil?
         [@base_url, '{{name}}'].join('/')
       else
+        # If the terms in this are not snake-cased, this will require
+        # an override in Terraform.
         @self_link
       end
     end

--- a/products/datastore/api.yaml
+++ b/products/datastore/api.yaml
@@ -1,0 +1,81 @@
+--- !ruby/object:Api::Product
+name: Datastore
+display_name: Cloud Datastore
+versions:
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://datastore.googleapis.com/v1/
+scopes:
+  - https://www.googleapis.com/auth/datastore
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: Cloud Datastore APU
+    url: https://console.cloud.google.com/apis/library/datastore.googleapis.com
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
+    path: 'name'
+    base_url: '{{op_id}}'
+    wait_ms: 1000
+  result: !ruby/object:Api::OpAsync::Result
+    path: 'response'
+    resource_inside_response: true
+  status: !ruby/object:Api::OpAsync::Status
+    path: 'done'
+    complete: true
+    allowed:
+      - true
+      - false
+  error: !ruby/object:Api::OpAsync::Error
+    path: 'error'
+    message: 'message'
+
+objects:
+  - !ruby/object:Api::Resource
+    name: 'Index'
+    base_url: "projects/{{project}}/indexes"
+    self_link: "projects/{{project}}/indexes/{{indexId}}"
+    input: true
+    identity:
+      - indexId
+    description: |
+      Describes a composite index for Cloud Datastore.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'indexId'
+        output: true
+        description: |
+          The index id. Output only.
+      - !ruby/object:Api::Type::String
+        name: 'kind'
+        required: true
+        description: |
+          The entity kind which the index applies to.
+      - !ruby/object:Api::Type::Enum
+        name: 'ancestor'
+        default_value: :NONE
+        values:
+          - :NONE
+          - :ALL_ANCESTORS
+        description: |
+            Policy for including ancestors in the index.  Either all ancestors or none will
+            be included, the default is none.
+      - !ruby/object:Api::Type::Array
+        name: 'properties'
+        description: |
+            An ordered list of properties to index on.
+        min_size: 1
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'name'
+              required: true
+              description: |
+                  The property name to index.
+            - !ruby/object:Api::Type::Enum
+              name: 'direction'
+              required: true
+              values:
+                - :ASCENDING
+                - :DESCENDING
+              description: |
+                 Which direction should the index optimize for sorting?

--- a/products/datastore/api.yaml
+++ b/products/datastore/api.yaml
@@ -40,7 +40,7 @@ async: !ruby/object:Api::OpAsync
       - false
   error: !ruby/object:Api::OpAsync::Error
     path: 'error'
-    message: 'message' 
+    message: 'message'
 objects:
   - !ruby/object:Api::Resource
     name: 'Index'

--- a/products/datastore/api.yaml
+++ b/products/datastore/api.yaml
@@ -1,3 +1,16 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 --- !ruby/object:Api::Product
 name: Datastore
 display_name: Cloud Datastore

--- a/products/datastore/api.yaml
+++ b/products/datastore/api.yaml
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc.
+# Copyright 2020 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -22,7 +22,7 @@ scopes:
   - https://www.googleapis.com/auth/datastore
 apis_required:
   - !ruby/object:Api::Product::ApiReference
-    name: Cloud Datastore APU
+    name: Cloud Datastore API
     url: https://console.cloud.google.com/apis/library/datastore.googleapis.com
 async: !ruby/object:Api::OpAsync
   operation: !ruby/object:Api::OpAsync::Operation
@@ -40,14 +40,18 @@ async: !ruby/object:Api::OpAsync
       - false
   error: !ruby/object:Api::OpAsync::Error
     path: 'error'
-    message: 'message'
-
+    message: 'message' 
 objects:
   - !ruby/object:Api::Resource
     name: 'Index'
     base_url: "projects/{{project}}/indexes"
     self_link: "projects/{{project}}/indexes/{{indexId}}"
     input: true
+    collection_url_key: indexes
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation': 'https://cloud.google.com/datastore/docs/concepts/indexes'
+      api: 'https://cloud.google.com/datastore/docs/reference/admin/rest/v1/projects.indexes'
     identity:
       - indexId
     description: |
@@ -57,7 +61,7 @@ objects:
         name: 'indexId'
         output: true
         description: |
-          The index id. Output only.
+          The index id.
       - !ruby/object:Api::Type::String
         name: 'kind'
         required: true
@@ -70,8 +74,8 @@ objects:
           - :NONE
           - :ALL_ANCESTORS
         description: |
-            Policy for including ancestors in the index.  Either all ancestors or none will
-            be included, the default is none.
+            Policy for including ancestors in the index.  Either `ALL_ANCESTORS` or `NONE`,
+            the default is `NONE`.
       - !ruby/object:Api::Type::Array
         name: 'properties'
         description: |
@@ -91,4 +95,4 @@ objects:
                 - :ASCENDING
                 - :DESCENDING
               description: |
-                 Which direction should the index optimize for sorting?
+                 The direction the index should optimize for sorting. Possible values are ASCENDING and DESCENDING.

--- a/products/datastore/terraform.yaml
+++ b/products/datastore/terraform.yaml
@@ -1,3 +1,16 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 --- !ruby/object:Provider::Terraform::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
   Index: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/products/datastore/terraform.yaml
+++ b/products/datastore/terraform.yaml
@@ -19,4 +19,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     import_format: ["projects/{{project}}/indexes/{{index_id}}"]
     autogen_async: true
     timeouts: !ruby/object:Api::Timeouts
-      insert_minutes: 15
+      insert_minutes: 10
+      delete_minutes: 10
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "datastore_index"
+        primary_resource_id: "default"
+        vars:
+          property_name_1: "property_a"
+          property_name_2: "property_b"

--- a/products/datastore/terraform.yaml
+++ b/products/datastore/terraform.yaml
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc.
+# Copyright 2020 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -18,6 +18,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     self_link: "projects/{{project}}/indexes/{{index_id}}"
     import_format: ["projects/{{project}}/indexes/{{index_id}}"]
     autogen_async: true
+    # TODO(ndmckinley): This resource doesn't have a name, so the current
+    # sweeper won't ever sweep it - might as well not have one for now,
+    # but we'll add it in when we change the sweeper to account for
+    # identity.
+    skip_sweeper: true
     timeouts: !ruby/object:Api::Timeouts
       insert_minutes: 10
       delete_minutes: 10

--- a/products/datastore/terraform.yaml
+++ b/products/datastore/terraform.yaml
@@ -16,7 +16,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   Index: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: "projects/{{project}}/indexes/{{index_id}}"
     self_link: "projects/{{project}}/indexes/{{index_id}}"
-    import_format: ["projects/{{project}}/indexes/{{index_id}}"]
     autogen_async: true
     # TODO(ndmckinley): This resource doesn't have a name, so the current
     # sweeper won't ever sweep it - might as well not have one for now,

--- a/products/datastore/terraform.yaml
+++ b/products/datastore/terraform.yaml
@@ -1,0 +1,9 @@
+--- !ruby/object:Provider::Terraform::Config
+overrides: !ruby/object:Overrides::ResourceOverrides
+  Index: !ruby/object:Overrides::Terraform::ResourceOverride
+    id_format: "projects/{{project}}/indexes/{{index_id}}"
+    self_link: "projects/{{project}}/indexes/{{index_id}}"
+    import_format: ["projects/{{project}}/indexes/{{index_id}}"]
+    autogen_async: true
+    timeouts: !ruby/object:Api::Timeouts
+      insert_minutes: 15

--- a/templates/terraform/examples/datastore_index.tf.erb
+++ b/templates/terraform/examples/datastore_index.tf.erb
@@ -1,0 +1,11 @@
+resource "google_datastore_index" "<%= ctx[:primary_resource_id] %>" {
+  kind = "foo"
+  properties {
+    name = "<%= ctx[:vars]['property_name_1'] %>"
+    direction = "ASCENDING"
+  }
+  properties {
+    name = "<%= ctx[:vars]['property_name_2'] %>"
+    direction = "ASCENDING"
+  }
+}

--- a/templates/terraform/operation.go.erb
+++ b/templates/terraform/operation.go.erb
@@ -26,7 +26,7 @@ func (w *<%= product_name -%>OperationWaiter) QueryOp() (interface{}, error) {
   return sendRequest(w.Config, "GET", <% if has_project %>w.Project<% else %>""<% end %>, url, nil<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
 }
 
-func <%= product_name.camelize(:lower) -%>OperationWaitTime(config *Config, op map[string]interface{},<% if has_project -%> project,<% end -%> activity string, timeoutMinutes int) error {
+func <%= product_name.camelize(:lower) -%>OperationWaitTime(config *Config, op map[string]interface{},<% if async.result.resource_inside_response -%> response *map[string]interface{},<% end -%> <% if has_project -%> project,<% end -%> activity string, timeoutMinutes int) error {
   if val, ok := op["name"]; !ok || val == "" {
     // This was a synchronous call - there is no operation to wait for.
     return nil
@@ -40,5 +40,12 @@ func <%= product_name.camelize(:lower) -%>OperationWaitTime(config *Config, op m
   if err := w.CommonOperationWaiter.SetOp(op); err != nil {
     return err
   }
+  <% if async.result.resource_inside_response -%> 
+  if err := OperationWait(w, activity, timeoutMinutes); err != nil {
+      return err
+  }
+  return json.Unmarshal([]byte(w.CommonOperationWaiter.Op.Response), response)
+  <% else -%>
   return OperationWait(w, activity, timeoutMinutes)
+  <% end -%>
 }

--- a/templates/terraform/operation.go.erb
+++ b/templates/terraform/operation.go.erb
@@ -44,6 +44,11 @@ func create<%= product_name %>Waiter(config *Config, op map[string]interface{}, 
 }
 
 <% if async.result.resource_inside_response -%>
+<%# Not all APIs will need a WithResponse operation, but it's hard to check whether
+    they will or not since it involves iterating over all resources.
+    Might as well just nolint it so we can pass the linter checks.
+-%>
+// nolint: deadcode,unused
 func <%= product_name.camelize(:lower) -%>OperationWaitTimeWithResponse(config *Config, op map[string]interface{}, response *map[string]interface{},<% if has_project -%> project,<% end -%> activity string, timeoutMinutes int) error {
   w, err := create<%= product_name %>Waiter(config, op, <% if has_project -%> project, <%end-%> activity)
   if err != nil || w == nil {

--- a/templates/terraform/operation.go.erb
+++ b/templates/terraform/operation.go.erb
@@ -26,10 +26,10 @@ func (w *<%= product_name -%>OperationWaiter) QueryOp() (interface{}, error) {
   return sendRequest(w.Config, "GET", <% if has_project %>w.Project<% else %>""<% end %>, url, nil<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
 }
 
-func <%= product_name.camelize(:lower) -%>OperationWaitTime(config *Config, op map[string]interface{},<% if async.result.resource_inside_response -%> response *map[string]interface{},<% end -%> <% if has_project -%> project,<% end -%> activity string, timeoutMinutes int) error {
+func create<%= product_name %>Waiter(config *Config, op map[string]interface{}, <% if has_project -%> project, <% end -%> activity string) (*<%=product_name%>OperationWaiter, error) {
   if val, ok := op["name"]; !ok || val == "" {
     // This was a synchronous call - there is no operation to wait for.
-    return nil
+    return nil, nil
   }
   w := &<%= product_name -%>OperationWaiter{
     Config: config,
@@ -38,14 +38,30 @@ func <%= product_name.camelize(:lower) -%>OperationWaitTime(config *Config, op m
 <% end -%>
   }
   if err := w.CommonOperationWaiter.SetOp(op); err != nil {
-    return err
+    return nil, err
   }
-  <% if async.result.resource_inside_response -%> 
+  return w, nil
+}
+
+<% if async.result.resource_inside_response -%>
+func <%= product_name.camelize(:lower) -%>OperationWaitTimeWithResponse(config *Config, op map[string]interface{}, response *map[string]interface{},<% if has_project -%> project,<% end -%> activity string, timeoutMinutes int) error {
+  w, err := create<%= product_name %>Waiter(config, op, <% if has_project -%> project, <%end-%> activity)
+  if err != nil || w == nil {
+      // If w is nil, the op was synchronous.
+      return err
+  }
   if err := OperationWait(w, activity, timeoutMinutes); err != nil {
       return err
   }
   return json.Unmarshal([]byte(w.CommonOperationWaiter.Op.Response), response)
-  <% else -%>
+}
+<% end -%>
+
+func <%= product_name.camelize(:lower) -%>OperationWaitTime(config *Config, op map[string]interface{}, <% if has_project -%> project,<% end -%> activity string, timeoutMinutes int) error {
+  w, err := create<%= product_name %>Waiter(config, op, <% if has_project -%> project, <%end-%> activity)
+  if err != nil || w == nil {
+      // If w is nil, the op was synchronous.
+      return err
+  }
   return OperationWait(w, activity, timeoutMinutes)
-  <% end -%>
 }

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -234,11 +234,10 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     }
 <%    end -%>
 <%    if object.async.is_a? Api::OpAsync -%>
-    <% if object.async.result.resource_inside_response -%>
+    <% if object.async.result.resource_inside_response and not object.identity.empty? -%>
     var response map[string]interface{}
-    <% end -%>
-    err = <%= client_name_camel -%>OperationWaitTime(
-    config, res,<% if object.async.result.resource_inside_response -%> &response,<% end -%> <% if has_project -%> project, <% end -%> "Creating <%= object.name -%>",
+    err = <%= client_name_camel -%>OperationWaitTimeWithResponse(
+    config, res, &response, <% if has_project -%> project, <% end -%> "Creating <%= object.name -%>",
         int(d.Timeout(schema.TimeoutCreate).Minutes()))
 
     if err != nil {
@@ -249,7 +248,6 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
         d.SetId("")
         return fmt.Errorf("Error waiting to create <%= object.name -%>: %s", err)
     }
-    <% if object.async.result.resource_inside_response -%>
     <% object.gettable_properties.each do |prop| -%>
     <% if object.identity.include?(prop) -%>
     if err := d.Set("<%= prop.name.underscore -%>", flatten<%= resource_name -%><%= titlelize_property(prop) -%>(response["<%= prop.api_name -%>"], d, config)); err != nil {
@@ -258,10 +256,30 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 
     <% end -%>
     <% end -%>
-    <% end -%>
 
+    // This may have caused the ID to update - update it if so.
+    id, err = replaceVars(d, config, "<%= id_format(object) -%>")
+    if err != nil {
+        return fmt.Errorf("Error constructing id: %s", err)
+    }
+    d.SetId(id)
+
+    <% else -%>
+    err = <%= client_name_camel -%>OperationWaitTime(
+    config, res, <% if has_project -%> project, <% end -%> "Creating <%= object.name -%>",
+        int(d.Timeout(schema.TimeoutCreate).Minutes()))
+
+    if err != nil {
+<%      if object.custom_code.post_create_failure -%>
+        resource<%= resource_name -%>PostCreateFailure(d, meta)
+<%      end -%>
+        // The resource didn't actually create
+        d.SetId("")
+        return fmt.Errorf("Error waiting to create <%= object.name -%>: %s", err)
+    }
 
 <%    end -%>
+<%  end -%>
 <%  end -%>
 
     log.Printf("[DEBUG] Finished creating <%= object.name -%> %q: %#v", d.Id(), res)
@@ -492,11 +510,8 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
         }
 <%        end -%>
 <%        if object.async.is_a? Api::OpAsync -%>
-    <% if object.async.result.resource_inside_response -%>
-    var response map[string]interface{}
-    <% end -%>
         err = <%= client_name_camel -%>OperationWaitTime(
-            config, res,<% if object.async.result.resource_inside_response -%> &response,<% end -%> <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
+            config, res, <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
             int(d.Timeout(schema.TimeoutUpdate).Minutes()))
         if err != nil {
             return err
@@ -597,11 +612,8 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
     }
 <%    end -%>
 <%    if object.async.is_a? Api::OpAsync -%>
-    <% if object.async.result.resource_inside_response -%>
-    var response map[string]interface{}
-    <% end -%>
     err = <%= client_name_camel -%>OperationWaitTime(
-        config, res,<% if object.async.result.resource_inside_response -%> &response,<% end -%> <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
+        config, res, <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
         int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 
     if err != nil {
@@ -673,11 +685,8 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
     }
 
 <%  if !object.async.nil? && object.async.allow?('delete') -%>
-    <% if object.async.result.resource_inside_response -%>
-    var response map[string]interface{}
-    <% end -%>
     err = <%= client_name_camel -%>OperationWaitTime(
-        config, res,<% if object.async.result.resource_inside_response -%> &response,<% end -%> <% if has_project -%> project, <% end -%> "Deleting <%= object.name -%>",
+        config, res, <% if has_project -%> project, <% end -%> "Deleting <%= object.name -%>",
         int(d.Timeout(schema.TimeoutDelete).Minutes()))
 
     if err != nil {

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -234,8 +234,11 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     }
 <%    end -%>
 <%    if object.async.is_a? Api::OpAsync -%>
+    <% if object.async.result.resource_inside_response -%>
+    var response map[string]interface{}
+    <% end -%>
     err = <%= client_name_camel -%>OperationWaitTime(
-    config, res,<% if has_project -%> project, <% end -%> "Creating <%= object.name -%>",
+    config, res,<% if object.async.result.resource_inside_response -%> &response,<% end -%> <% if has_project -%> project, <% end -%> "Creating <%= object.name -%>",
         int(d.Timeout(schema.TimeoutCreate).Minutes()))
 
     if err != nil {
@@ -246,6 +249,18 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
         d.SetId("")
         return fmt.Errorf("Error waiting to create <%= object.name -%>: %s", err)
     }
+    <% if object.async.result.resource_inside_response -%>
+    <% object.gettable_properties.each do |prop| -%>
+    <% if object.identity.include?(prop) -%>
+    if err := d.Set("<%= prop.name.underscore -%>", flatten<%= resource_name -%><%= titlelize_property(prop) -%>(response["<%= prop.api_name -%>"], d, config)); err != nil {
+        return err
+    }
+
+    <% end -%>
+    <% end -%>
+    <% end -%>
+
+
 <%    end -%>
 <%  end -%>
 
@@ -477,8 +492,11 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
         }
 <%        end -%>
 <%        if object.async.is_a? Api::OpAsync -%>
+    <% if object.async.result.resource_inside_response -%>
+    var response map[string]interface{}
+    <% end -%>
         err = <%= client_name_camel -%>OperationWaitTime(
-            config, res, <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
+            config, res,<% if object.async.result.resource_inside_response -%> &response,<% end -%> <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
             int(d.Timeout(schema.TimeoutUpdate).Minutes()))
         if err != nil {
             return err
@@ -579,8 +597,11 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
     }
 <%    end -%>
 <%    if object.async.is_a? Api::OpAsync -%>
+    <% if object.async.result.resource_inside_response -%>
+    var response map[string]interface{}
+    <% end -%>
     err = <%= client_name_camel -%>OperationWaitTime(
-        config, res, <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
+        config, res,<% if object.async.result.resource_inside_response -%> &response,<% end -%> <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
         int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 
     if err != nil {
@@ -652,14 +673,17 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
     }
 
 <%  if !object.async.nil? && object.async.allow?('delete') -%>
-
+    <% if object.async.result.resource_inside_response -%>
+    var response map[string]interface{}
+    <% end -%>
     err = <%= client_name_camel -%>OperationWaitTime(
-        config, res, <% if has_project -%> project, <% end -%> "Deleting <%= object.name -%>",
+        config, res,<% if object.async.result.resource_inside_response -%> &response,<% end -%> <% if has_project -%> project, <% end -%> "Deleting <%= object.name -%>",
         int(d.Timeout(schema.TimeoutDelete).Minutes()))
 
     if err != nil {
         return err
     }
+
 <%  end -%>
 
     log.Printf("[DEBUG] Finished deleting <%= object.name -%> %q: %#v", d.Id(), res)

--- a/third_party/terraform/utils/appengine_operation.go
+++ b/third_party/terraform/utils/appengine_operation.go
@@ -1,6 +1,7 @@
 package google
 
 import (
+	"encoding/json"
 	"fmt"
 	"regexp"
 
@@ -30,6 +31,27 @@ func (w *AppEngineOperationWaiter) QueryOp() (interface{}, error) {
 
 func appEngineOperationWait(config *Config, res interface{}, appId, activity string) error {
 	return appEngineOperationWaitTime(config, res, appId, activity, 4)
+}
+
+func appEngineOperationWaitTimeWithResponse(config *Config, res interface{}, response *map[string]interface{}, appId, activity string, timeoutMinutes int) error {
+	op := &appengine.Operation{}
+	err := Convert(res, op)
+	if err != nil {
+		return err
+	}
+
+	w := &AppEngineOperationWaiter{
+		Service: config.clientAppEngine,
+		AppId:   appId,
+	}
+
+	if err := w.SetOp(op); err != nil {
+		return err
+	}
+	if err := OperationWait(w, activity, timeoutMinutes); err != nil {
+		return err
+	}
+	return json.Unmarshal([]byte(w.CommonOperationWaiter.Op.Response), response)
 }
 
 func appEngineOperationWaitTime(config *Config, res interface{}, appId, activity string, timeoutMinutes int) error {

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -894,6 +894,15 @@
     </ul>
     </li>
 
+    <li<%%= sidebar_current("docs-google-datastore") %>>
+    <a href="#">Google Datastore Resources</a>
+    <ul class="nav nav-visible">
+      <li<%%= sidebar_current("docs-google-datastore-index") %>>
+          <a href="/docs/providers/google/r/datastore_index.html">google_datastore_index</a>
+      </li>
+    </ul>
+    </li>
+
     <li<%%= sidebar_current("docs-google-dataproc") %>>
         <a href="#">Google Dataproc Resources</a>
         <ul class="nav nav-visible">


### PR DESCRIPTION
Add datastore/ product
Add ability for fetching resources from operations
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/60

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
google_datastore_index

```