### PR TITLE
Added utils for polling for existance post creation, before final read into state

### DIFF
--- a/overrides/terraform/resource_override.rb
+++ b/overrides/terraform/resource_override.rb
@@ -70,7 +70,10 @@ module Overrides
 
           # This enables resources that get their project via a reference to a different resource
           # instead of a project field to use User Project Overrides
-          :supports_indirect_user_project_override
+          :supports_indirect_user_project_override,
+
+          # If true, adds code post-create to poll for resource existence
+          :poll_for_existence
         ]
       end
 
@@ -102,6 +105,7 @@ module Overrides
         check :schema_version, type: Integer
         check :skip_sweeper, type: :boolean, default: false
         check :supports_indirect_user_project_override, type: :boolean, default: false
+        check :poll_for_existence, type: :boolean, default: false
       end
 
       def apply(resource)

--- a/products/pubsub/terraform.yaml
+++ b/products/pubsub/terraform.yaml
@@ -15,6 +15,7 @@
 overrides: !ruby/object:Overrides::ResourceOverrides
   Topic: !ruby/object:Overrides::Terraform::ResourceOverride
     error_retry_predicates: ["pubsubTopicProjectNotReady"]
+    poll_for_existence: true
     iam_policy: !ruby/object:Api::Resource::IamPolicy
       parent_resource_attribute: 'topic'
       method_name_separator: ':'
@@ -49,6 +50,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       encoder: templates/terraform/encoders/no_send_name.go.erb
       update_encoder: templates/terraform/update_encoder/pubsub_topic.erb
   Subscription: !ruby/object:Overrides::Terraform::ResourceOverride
+    poll_for_existence: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "pubsub_subscription_push"

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -251,11 +251,52 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 
     log.Printf("[DEBUG] Finished creating <%= object.name -%> %q: %#v", d.Id(), res)
 
+<% if object.poll_for_existence -%>
+    log.Printf("[DEBUG] Making sure eventually consistent <%= object.name -%> %q is ready", d.Id())
+    tryPollForResourceExistence(d, meta, resource<%= resource_name -%>ExistenceCheck)
+<% end -%>
 <%= lines(compile(object.custom_code.post_create)) if object.custom_code.post_create -%>
 
     return resource<%= resource_name -%>Read(d, meta)
 <%  end # if custom_create  -%>
 }
+
+<% if object.poll_for_existence -%>
+// Checks if a resource exists. If the response is successful (200s),
+// this function returns true with no error. If response is 404, returns false
+// with no error. All other error responses are returned as is.
+func resource<%= resource_name -%>ExistenceCheck(d *schema.ResourceData, meta interface{}) (bool, error) {
+    log.Printf("[DEBUG] Check for existence of <%= object.name -%> %q", d.Id())
+
+    config := meta.(*Config)
+
+    url, err := replaceVars(d, config, "<%= "{{#{object.__product.name}BasePath}}#{object.self_link_uri}" -%>")
+    if err != nil {
+        return false, err
+    }
+
+<%  if has_project -%>
+    project, err := getProject(d, config)
+    if err != nil {
+        return false, err
+    }
+<%  end -%>
+<%  if object.supports_indirect_user_project_override -%>
+    var project string
+    if parts := regexp.MustCompile(`projects\/([^\/]+)\/`).FindStringSubmatch(url); parts != nil {
+        project = parts[1]
+    }
+<%  end -%>
+    _, err = sendRequest(config, "<%= object.read_verb.to_s.upcase -%>", <% if has_project || object.supports_indirect_user_project_override %>project<% else %>""<% end %>, url, nil<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
+    if err != nil {
+        if isGoogleApiErrorWithCode(err, 404) {
+            return false, nil
+        }
+        return false, err
+    }
+    return true, nil
+}
+<% end -%>
 
 func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{}) error {
     config := meta.(*Config)
@@ -666,7 +707,6 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
     return nil
 <% end -%>
 }
-
 <% unless object.exclude_import -%>
 func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 <% if object.custom_code.custom_import -%>


### PR DESCRIPTION
- Added new MM TF override flag `poll_for_existence`
- Added hook in resource template so TF polls for non-404 response post-create
- Supported in PubSub with test

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
pubsub: Added short poll for existance after creation to prevent a previously negative-cached result in read-after-create  
```

Part of https://github.com/terraform-providers/terraform-provider-google/issues/4993