### PR TITLE
Set `public_key` to computed

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_kms_crypto_key_version.go
+++ b/third_party/terraform/data_sources/data_source_google_kms_crypto_key_version.go
@@ -37,7 +37,7 @@ func dataSourceGoogleKmsCryptoKeyVersion() *schema.Resource {
 			},
 			"public_key": {
 				Type:     schema.TypeList,
-				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5552
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5219

`google_kms_crypto_key_version`: `public_key` was not set to computed, so terraform did not wait for the datasource to resolve before complaining that the list was empty. The [original documentation](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/third_party/terraform/website/docs/d/google_kms_crypto_key_version.html.markdown#L47) implies that this field was meant to be implemented as computed.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
kms: Fixed issue where `google_kms_crypto_key_version` datasource would throw an Invalid Index error on plan
```
