### PR TITLE
Refactor error predicates

### DIFF
--- a/third_party/terraform/utils/metadata.go
+++ b/third_party/terraform/utils/metadata.go
@@ -3,6 +3,7 @@ package google
 import (
 	"errors"
 	"fmt"
+	"log"
 
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
@@ -21,14 +22,14 @@ func MetadataRetryWrapper(update func() error) error {
 			return nil
 		}
 
-		if !isFingerprintError(err) {
+		if ok, _ := isFingerprintError(err); !ok {
 			// Something else went wrong, don't retry
 			return err
 		}
 
+		log.Printf("[DEBUG] Dismissed an error as retryable as a fingerprint mismatch: %s", err)
 		attempt++
 	}
-
 	return fmt.Errorf("Failed to update metadata after %d retries", attempt)
 }
 

--- a/third_party/terraform/utils/retry_utils.go
+++ b/third_party/terraform/utils/retry_utils.go
@@ -3,7 +3,6 @@ package google
 import (
 	"log"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/errwrap"
@@ -19,16 +18,14 @@ func retryTime(retryFunc func() error, minutes int) error {
 	return retryTimeDuration(retryFunc, time.Duration(minutes)*time.Minute)
 }
 
-func retryTimeDuration(retryFunc func() error, duration time.Duration, errorRetryPredicates ...func(e error) (bool, string)) error {
+func retryTimeDuration(retryFunc func() error, duration time.Duration, errorRetryPredicates ...RetryErrorPredicateFunc) error {
 	return resource.Retry(duration, func() *resource.RetryError {
 		err := retryFunc()
 		if err == nil {
 			return nil
 		}
-		for _, e := range getAllTypes(err, &googleapi.Error{}, &url.Error{}) {
-			if isRetryableError(e, errorRetryPredicates) {
-				return resource.RetryableError(e)
-			}
+		if isRetryableError(err, errorRetryPredicates...) {
+			return resource.RetryableError(err)
 		}
 		return resource.NonRetryableError(err)
 	})
@@ -45,41 +42,17 @@ func getAllTypes(err error, args ...interface{}) []error {
 	return result
 }
 
-func isRetryableError(err error, retryPredicates []func(e error) (bool, string)) bool {
-	// These operations are always hitting googleapis.com - they should rarely
-	// time out, and if they do, that timeout is retryable.
-	if urlerr, ok := err.(*url.Error); ok && urlerr.Timeout() {
-		log.Printf("[DEBUG] Dismissed an error as retryable based on googleapis.com target: %s", err)
-		return true
-	}
+func isRetryableError(topErr error, customPredicates ...RetryErrorPredicateFunc) bool {
+	retryPredicates := append(defaultErrorRetryPredicates, customPredicates...)
 
-	if gerr, ok := err.(*googleapi.Error); ok {
-		if gerr.Code == 429 || gerr.Code == 500 || gerr.Code == 502 || gerr.Code == 503 {
-			log.Printf("[DEBUG] Dismissed an error as retryable based on error code: %s", err)
-			return true
-		}
-
-		if gerr.Code == 409 && strings.Contains(gerr.Body, "operationInProgress") {
-			// 409's are retried because cloud sql throws a 409 when concurrent calls are made.
-			// The only way right now to determine it is a SQL 409 due to concurrent calls is to
-			// look at the contents of the error message.
-			// See https://github.com/terraform-providers/terraform-provider-google/issues/3279
-			log.Printf("[DEBUG] Dismissed an error as retryable based on error code 409 and error reason 'operationInProgress': %s", err)
-			return true
-		}
-
-		if gerr.Code == 412 && isFingerprintError(err) {
-			log.Printf("[DEBUG] Dismissed an error as retryable as a fingerprint mismatch: %s", err)
-			return true
-		}
-
-	}
-	for _, pred := range retryPredicates {
-		if retry, reason := (pred(err)); retry {
-			log.Printf("[DEBUG] Dismissed an error as retryable. %s - %s", reason, err)
-			return true
+	// Check all wrapped errors for a retryable error status.
+	for _, err := range getAllTypes(topErr, &googleapi.Error{}, &url.Error{}) {
+		for _, pred := range retryPredicates {
+			if retry, reason := pred(err); retry {
+				log.Printf("[DEBUG] Dismissed an error as retryable. %s - %s", reason, err)
+				return true
+			}
 		}
 	}
-
 	return false
 }

--- a/third_party/terraform/utils/retry_utils.go
+++ b/third_party/terraform/utils/retry_utils.go
@@ -43,7 +43,10 @@ func getAllTypes(err error, args ...interface{}) []error {
 }
 
 func isRetryableError(topErr error, customPredicates ...RetryErrorPredicateFunc) bool {
-	retryPredicates := append(defaultErrorRetryPredicates, customPredicates...)
+	retryPredicates := append(
+		// Global error retry predicates are registered in this default list.
+		defaultErrorRetryPredicates,
+		customPredicates...)
 
 	// Check all wrapped errors for a retryable error status.
 	for _, err := range getAllTypes(topErr, &googleapi.Error{}, &url.Error{}) {

--- a/third_party/terraform/utils/transport.go
+++ b/third_party/terraform/utils/transport.go
@@ -35,11 +35,11 @@ func isEmptyValue(v reflect.Value) bool {
 	return false
 }
 
-func sendRequest(config *Config, method, project, rawurl string, body map[string]interface{}, errorRetryPredicates ...func(e error) (bool, string)) (map[string]interface{}, error) {
+func sendRequest(config *Config, method, project, rawurl string, body map[string]interface{}, errorRetryPredicates ...RetryErrorPredicateFunc) (map[string]interface{}, error) {
 	return sendRequestWithTimeout(config, method, project, rawurl, body, DefaultRequestTimeout, errorRetryPredicates...)
 }
 
-func sendRequestWithTimeout(config *Config, method, project, rawurl string, body map[string]interface{}, timeout time.Duration, errorRetryPredicates ...func(e error) (bool, string)) (map[string]interface{}, error) {
+func sendRequestWithTimeout(config *Config, method, project, rawurl string, body map[string]interface{}, timeout time.Duration, errorRetryPredicates ...RetryErrorPredicateFunc) (map[string]interface{}, error) {
 	reqHeaders := make(http.Header)
 	reqHeaders.Set("User-Agent", config.userAgent)
 	reqHeaders.Set("Content-Type", "application/json")


### PR DESCRIPTION
- Refactored default error predicates into their own functions so now custom error preds are appended to these defaults when testing retryability
- (**LOGIC CHANGE**) Reuse isFingerprintError as a error pred, now it checks for error code inside of the actual function
- Created custom function type for error predicates so we dont have to keep writing this function signature (I can be swayed to not have this)

```release-note:none

```
