### PR TITLE
Set database and collection during import of firestore index.

### DIFF
--- a/templates/terraform/custom_import/index_self_link_as_name_set_project.go.erb
+++ b/templates/terraform/custom_import/index_self_link_as_name_set_project.go.erb
@@ -16,4 +16,6 @@
 	}
 
 	d.Set("project", stringParts[1])
+	d.Set("database", stringParts[3])
+	d.Set("collection", stringParts[5])
 	return []*schema.ResourceData{d}, nil


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
firestore: fixed import of `google_firestore_index` when database or collection were non-default.
```

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5588.