### PR TITLE
Documentation change to reflect the fact that beta provider blocks are optional.

### DIFF
--- a/third_party/terraform/website/docs/guides/provider_versions.html.markdown
+++ b/third_party/terraform/website/docs/guides/provider_versions.html.markdown
@@ -43,20 +43,24 @@ their GA launch.
 
 ## Using the `google-beta` provider
 
-To use the `google-beta` provider, explicitly define a `google-beta` provider
-block, and state on the resource which provider you wish to use.
+To use the `google-beta` provider, simply set the `provider` field on each
+resource where you want to use `google-beta`.
+
+```hcl
+resource "google_compute_instance" "beta-instance" {
+  provider = google-beta
+  # ...
+}
+```
+
+To customize the behavior of the beta provider, you can define a `google-beta`
+provider block, which accepts the same arguments as the `google` provider block.
 
 ```hcl
 provider "google-beta" {
   credentials = "${file("account.json")}"
   project     = "my-project-id"
   region      = "us-central1"
-}
-
-resource "google_compute_instance" "beta-instance" {
-  provider = "google-beta"
-
-  # ...
 }
 ```
 
@@ -65,7 +69,27 @@ resource "google_compute_instance" "beta-instance" {
 
 ## Using both provider versions together
 
-To have resources at different API versions, set up provider blocks for each version:
+It is safe to use both provider versions in the same configuration.
+
+In each resource, state which provider that resource should be used with.
+We recommend that you set `provider = google` even though it is the default,
+for clarity.
+
+```hcl
+resource "google_compute_instance" "ga-instance" {
+  provider = google
+
+  # ...
+}
+
+resource "google_compute_instance" "beta-instance" {
+  provider = google-beta
+
+  # ...
+}
+```
+
+You can define parallel provider blocks - they will not interfere with each other.
 
 ```hcl
 provider "google" {
@@ -78,22 +102,6 @@ provider "google-beta" {
   credentials = "${file("account.json")}"
   project     = "my-project-id"
   region      = "us-central1"
-}
-```
-
-In each resource, state which provider that resource should be used with:
-
-```hcl
-resource "google_compute_instance" "ga-instance" {
-  provider = "google"
-
-  # ...
-}
-
-resource "google_compute_instance" "beta-instance" {
-  provider = "google-beta"
-
-  # ...
 }
 ```
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5519.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```