### PR TITLE
Bigtable Instance changes

### DIFF
--- a/third_party/terraform/tests/resource_bigtable_instance_test.go
+++ b/third_party/terraform/tests/resource_bigtable_instance_test.go
@@ -29,17 +29,19 @@ func TestAccBigtableInstance_basic(t *testing.T) {
 				Config: testAccBigtableInstance(instanceName, 3),
 			},
 			{
-				ResourceName:      "google_bigtable_instance.instance",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigtable_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"instance_type"}, // we don't read instance type back
 			},
 			{
 				Config: testAccBigtableInstance(instanceName, 4),
 			},
 			{
-				ResourceName:      "google_bigtable_instance.instance",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigtable_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"instance_type"}, // we don't read instance type back
 			},
 		},
 	})
@@ -63,33 +65,37 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 				Config: testAccBigtableInstance_cluster(instanceName, 3),
 			},
 			{
-				ResourceName:      "google_bigtable_instance.instance",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigtable_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"instance_type"}, // we don't read instance type back
 			},
 			{
 				Config: testAccBigtableInstance_clusterReordered(instanceName, 5),
 			},
 			{
-				ResourceName:      "google_bigtable_instance.instance",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigtable_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"instance_type"}, // we don't read instance type back
 			},
 			{
 				Config: testAccBigtableInstance_clusterModified(instanceName, 5),
 			},
 			{
-				ResourceName:      "google_bigtable_instance.instance",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigtable_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"instance_type"}, // we don't read instance type back
 			},
 			{
 				Config: testAccBigtableInstance_clusterReordered(instanceName, 5),
 			},
 			{
-				ResourceName:      "google_bigtable_instance.instance",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigtable_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"instance_type"}, // we don't read instance type back
 			},
 		},
 	})
@@ -106,20 +112,13 @@ func TestAccBigtableInstance_development(t *testing.T) {
 		CheckDestroy: testAccCheckBigtableInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccBigtableInstance_development_invalid_no_cluster(instanceName),
-				ExpectError: regexp.MustCompile("config is invalid: instance with instance_type=\"DEVELOPMENT\" should have exactly one \"cluster\" block"),
-			},
-			{
-				Config:      testAccBigtableInstance_development_invalid_num_nodes(instanceName),
-				ExpectError: regexp.MustCompile("config is invalid: num_nodes cannot be set for instance_type=\"DEVELOPMENT\""),
-			},
-			{
 				Config: testAccBigtableInstance_development(instanceName),
 			},
 			{
-				ResourceName:      "google_bigtable_instance.instance",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigtable_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"instance_type"}, // we don't read instance type back
 			},
 		},
 	})
@@ -310,27 +309,4 @@ resource "google_bigtable_instance" "instance" {
   instance_type = "DEVELOPMENT"
 }
 `, instanceName, instanceName)
-}
-
-func testAccBigtableInstance_development_invalid_num_nodes(instanceName string) string {
-	return fmt.Sprintf(`
-resource "google_bigtable_instance" "instance" {
-  name = "%s"
-  cluster {
-    cluster_id = "%s"
-    zone       = "us-central1-b"
-    num_nodes  = 3
-  }
-  instance_type = "DEVELOPMENT"
-}
-`, instanceName, instanceName)
-}
-
-func testAccBigtableInstance_development_invalid_no_cluster(instanceName string) string {
-	return fmt.Sprintf(`
-resource "google_bigtable_instance" "instance" {
-  name          = "%s"
-  instance_type = "DEVELOPMENT"
-}
-`, instanceName)
 }


### PR DESCRIPTION
* instance_type and display_name are now updatable
* don't detect drift on instance_type to prepare for API changes
* get rid of customdiff for development instances because they sort of compare against config but sort of compare against state and I just think we're going to see more problems with it down the line especially if there are upcoming API changes
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
* bigtable: added update support for `display_name` and `instance_type`
```
