### PR TITLE
Remove `ExactlyOneOf` restriction for `auto_provisioning_defaults`

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -335,19 +335,11 @@ func resourceContainerCluster() *schema.Resource {
 										Computed: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
 										DiffSuppressFunc: containerClusterAddedScopesSuppress,
-										ExactlyOneOf: []string{
-											"cluster_autoscaling.0.auto_provisioning_defaults.0.oauth_scopes",
-											"cluster_autoscaling.0.auto_provisioning_defaults.0.service_account",
-										},
 									},
 									"service_account": {
 										Type:     schema.TypeString,
 										Optional: true,
 										Default:  "default",
-										ExactlyOneOf: []string{
-											"cluster_autoscaling.0.auto_provisioning_defaults.0.oauth_scopes",
-											"cluster_autoscaling.0.auto_provisioning_defaults.0.service_account",
-										},
 									},
 								},
 							},

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -378,12 +378,10 @@ for a list of types.
 The `auto_provisioning_defaults` block supports:
 
 * `oauth_scopes` - (Optional) Scopes that are used by NAP when creating node pools.
-If `oauth_scopes` are specified, `service_account` must be empty.
 
 -> `monitoring.write` is always enabled regardless of user input.  `monitoring` and `logging.write` may also be enabled depending on the values for `monitoring_service` and `logging_service`.
 
 * `service_account` - (Optional) The Google Cloud Platform Service Account to be used by the node VMs.
-If `service_account` is specified, `oauth_scopes` must be empty.
 
 The `authenticator_groups_config` block supports:
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5545
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: Removed restriction on `auto_provisioning_defaults` to allow both `oauth_scopes` and `service_account` to be set
```
