### PR TITLE
Fix the SQL API URL in MM

### DIFF
--- a/products/sql/api.yaml
+++ b/products/sql/api.yaml
@@ -17,7 +17,7 @@ display_name: Cloud SQL
 versions:
   - !ruby/object:Api::Product::Version
     name: ga
-    base_url: https://sqladmin.googleapis.com/v1beta4/
+    base_url: https://sqladmin.googleapis.com/sql/v1beta4/
 scopes:
   - https://www.googleapis.com/auth/sqlservice.admin
 apis_required:

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -314,7 +314,7 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 	c.clientStorage.UserAgent = userAgent
 	c.clientStorage.BasePath = storageClientBasePath
 
-	sqlClientBasePath := removeBasePathVersion(c.SQLBasePath)
+	sqlClientBasePath := removeBasePathVersion(removeBasePathVersion(c.SQLBasePath))
 	log.Printf("[INFO] Instantiating Google SqlAdmin client for path %s", sqlClientBasePath)
 	c.clientSqlAdmin, err = sqladmin.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {


### PR DESCRIPTION
Fix-forward for https://github.com/GoogleCloudPlatform/magic-modules/pull/3099

Confusingly, the SQL API has kept `sql/` in the path. It's got a unique URL pattern now, a combination of old `https://www.googleapis.com/compute/v1/` and new `https://container.googleapis.com/v1/`. The client library variable looks like the new form, but appends the `sql/` part at call time.

A test using both handwritten + generated resources succeeded, I'll run the full gauntlet post-merge to make sure it's working as expected.

/cc @slevenick @rambleraptor this should fix 404s in InSpec/Ansible, sorry about the disruption!

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
