### PR TITLE
Rename inst-test networks to tf-test for sweeper

### DIFF
--- a/third_party/terraform/tests/resource_compute_instance_template_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_template_test.go
@@ -1760,7 +1760,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_secondaryAliasIpRange(i string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "inst-test-network" {
-  name = "inst-test-network-%s"
+  name = "tf-test-network-%s"
 }
 
 resource "google_compute_subnetwork" "inst-test-subnetwork" {

--- a/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_test.go
@@ -3046,7 +3046,7 @@ data "google_compute_image" "my_image" {
 }
 
 resource "google_compute_network" "inst-test-network" {
-  name = "inst-test-network-%s"
+  name = "tf-test-network-%s"
 
   auto_create_subnetworks = true
 }
@@ -3079,7 +3079,7 @@ data "google_compute_image" "my_image" {
 }
 
 resource "google_compute_network" "inst-test-network" {
-  name = "inst-test-network-%s"
+  name = "tf-test-network-%s"
 
   auto_create_subnetworks = false
 }
@@ -3152,7 +3152,7 @@ resource "google_compute_shared_vpc_service_project" "service_project" {
 }
 
 resource "google_compute_network" "inst-test-network" {
-  name    = "inst-test-network-%s"
+  name    = "tf-test-network-%s"
   project = google_compute_shared_vpc_host_project.host_project.project
 
   auto_create_subnetworks = false
@@ -3196,7 +3196,7 @@ data "google_compute_image" "my_image" {
 }
 
 resource "google_compute_network" "inst-test-network" {
-  name = "inst-test-network-%s"
+  name = "tf-test-network-%s"
 }
 
 resource "google_compute_subnetwork" "inst-test-subnetwork" {
@@ -3234,7 +3234,7 @@ data "google_compute_image" "my_image" {
 }
 
 resource "google_compute_network" "inst-test-network" {
-  name = "inst-test-network-%s"
+  name = "tf-test-network-%s"
 }
 
 resource "google_compute_subnetwork" "inst-test-subnetwork" {


### PR DESCRIPTION
We had a bunch of leftover networks last night using up routes quota. This will help them get cleaned up. Also filed https://github.com/terraform-providers/terraform-provider-google/issues/5651 since a few had single instances in them.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
