### PR TITLE
Add state waiting to google_container_node_pool

### DIFF
--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -302,7 +302,20 @@ func resourceContainerNodePoolCreate(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[INFO] GKE NodePool %s has been created", nodePool.Name)
 
-	return resourceContainerNodePoolRead(d, meta)
+	if err = resourceContainerNodePoolRead(d, meta); err != nil {
+		return err
+	}
+
+	state, err := containerNodePoolAwaitRestingState(config, d.Id(), d.Timeout(schema.TimeoutCreate))
+	if err != nil {
+		return err
+	}
+
+	if containerNodePoolRestingStates[state] == ErrorState {
+		return fmt.Errorf("NodePool %s was created in the error state %q", nodePool.Name, state)
+	}
+
+	return nil
 }
 
 func resourceContainerNodePoolRead(d *schema.ResourceData, meta interface{}) error {
@@ -357,11 +370,21 @@ func resourceContainerNodePoolUpdate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
+	_, err = containerNodePoolAwaitRestingState(config, d.Id(), d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return err
+	}
+
 	d.Partial(true)
 	if err := nodePoolUpdate(d, meta, nodePoolInfo, "", timeoutInMinutes); err != nil {
 		return err
 	}
 	d.Partial(false)
+
+	_, err = containerNodePoolAwaitRestingState(config, d.Id(), d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return err
+	}
 
 	return resourceContainerNodePoolRead(d, meta)
 }
@@ -375,6 +398,11 @@ func resourceContainerNodePoolDelete(d *schema.ResourceData, meta interface{}) e
 	}
 
 	name := getNodePoolName(d.Id())
+
+	_, err = containerNodePoolAwaitRestingState(config, d.Id(), d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return err
+	}
 
 	timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
 
@@ -444,9 +472,14 @@ func resourceContainerNodePoolStateImporter(d *schema.ResourceData, meta interfa
 
 	id, err := replaceVars(d, config, "projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/nodePools/{{name}}")
 	if err != nil {
-	return nil, err
+		return nil, err
   }
+
 	d.SetId(id)
+
+	if _, err := containerNodePoolAwaitRestingState(config, d.Id(), d.Timeout(schema.TimeoutCreate)); err != nil {
+		return nil, err
+	}
 
 	return []*schema.ResourceData{d}, nil
 }
@@ -868,4 +901,35 @@ func getNodePoolName(id string) string {
 	// name can be specified with name, name_prefix, or neither, so read it from the id.
 	splits := strings.Split(id, "/")
 	return splits[len(splits)-1]
+}
+
+var containerNodePoolRestingStates = RestingStates{
+	"RUNNING":            ReadyState,
+	"RUNNING_WITH_ERROR": ErrorState,
+	"ERROR":              ErrorState,
+}
+
+// takes in a config object, full node pool name, and the current CRUD action timeout
+// returns a state with no error if the state is a resting state, and the last state with an error otherwise
+func containerNodePoolAwaitRestingState(config *Config, name string, timeout time.Duration) (state string, err error) {
+	err = resource.Retry(timeout, func() *resource.RetryError {
+		nodePool, gErr := config.clientContainerBeta.Projects.Locations.Clusters.NodePools.Get(name).Do()
+		if gErr != nil {
+			return resource.NonRetryableError(gErr)
+		}
+
+		state = nodePool.Status
+		switch stateType := containerNodePoolRestingStates[state]; stateType {
+		case ReadyState:
+			log.Printf("[DEBUG] NodePool %q has status %q with message %q.", name, state, nodePool.StatusMessage)
+			return nil
+		case ErrorState:
+			log.Printf("[DEBUG] NodePool %q has error state %q with message %q.", name, state, nodePool.StatusMessage)
+			return nil
+		default:
+			return resource.RetryableError(fmt.Errorf("NodePool %q has state %q with message %q", name, state, nodePool.StatusMessage))
+		}
+	})
+
+	return state, err
 }


### PR DESCRIPTION
Same as https://github.com/GoogleCloudPlatform/magic-modules/pull/3077, but for node pool.

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/3304

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: `google_container_node_pool` will allow importing / updating / deleting node pools in error states and will wait for a stable state after any changes.
```

```release-note:enhancement
container: `google_container_node_pool` resources created in an error state will be marked as tainted on creation.
```
