### PR TITLE
Add more generic error predicates

### DIFF
--- a/third_party/terraform/utils/error_retry_predicates.go
+++ b/third_party/terraform/utils/error_retry_predicates.go
@@ -11,37 +11,45 @@ import (
 	"google.golang.org/api/googleapi"
 )
 
-const connectionResetByPeerErr = "connection reset by peer"
-
 type RetryErrorPredicateFunc func(error) (bool, string)
 
 /** ADD GLOBAL ERROR RETRY PREDICATES HERE **/
 // Retry predicates that shoud apply to all requests should be added here.
 var defaultErrorRetryPredicates = []RetryErrorPredicateFunc{
-	isTemporaryError,
-	isUrlTimeoutError,
+	// Common network errors (usually wrapped by URL error)
+	isNetworkTemporaryError,
+	isNetworkTimeoutError,
 	isIoEOFError,
+	isConnectionResetNetworkError,
 	isTemporaryNetOpError,
+
+	// Common GCP error codes
 	isCommonRetryableErrorCode,
 
 	//While this might apply only to Cloud SQL, historically,
-	// we had this in our global default error retries, so it is a default
-	// for now.
+	// we had this in our global default error retries.
+	// Keeping it as a default for now.
 	is409OperationInProgressError,
 }
 
 /** END GLOBAL ERROR RETRY PREDICATES HERE **/
 
-func isTemporaryError(err error) (bool, string) {
-	if tempErr, ok := err.(interface{ Temporary() bool }); ok && tempErr.Temporary() {
-		return true, fmt.Sprintf("Got temporary error %v", err)
+func isNetworkTemporaryError(err error) (bool, string) {
+	if netErr, ok := err.(*net.OpError); ok && netErr.Temporary() {
+		return true, "marked as timeout"
+	}
+	if urlerr, ok := err.(*url.Error); ok && urlerr.Temporary() {
+		return true, "marked as timeout"
 	}
 	return false, ""
 }
 
-func isUrlTimeoutError(err error) (bool, string) {
+func isNetworkTimeoutError(err error) (bool, string) {
+	if netErr, ok := err.(*net.OpError); ok && netErr.Timeout() {
+		return true, "marked as timeout"
+	}
 	if urlerr, ok := err.(*url.Error); ok && urlerr.Timeout() {
-		return true, "Got URL timeout error"
+		return true, "marked as timeout"
 	}
 	return false, ""
 }
@@ -51,7 +59,7 @@ func isIoEOFError(err error) (bool, string) {
 		return true, "Got unexpected EOF"
 	}
 
-	if urlerr, ok := err.(*url.Error); ok {
+	if urlerr, urlok := err.(*url.Error); urlok {
 		wrappedErr := urlerr.Unwrap()
 		if wrappedErr == io.ErrUnexpectedEOF {
 			return true, "Got unexpected EOF"
@@ -60,17 +68,18 @@ func isIoEOFError(err error) (bool, string) {
 	return false, ""
 }
 
-func isTemporaryNetOpError(err error) (bool, string) {
+const connectionResetByPeerErr = "connection reset by peer"
+
+func isConnectionResetNetworkError(err error) (bool, string) {
 	neterr, ok := err.(*net.OpError)
 	if !ok {
-		if urlerr, ok := err.(*url.Error); ok {
+		if urlerr, urlok := err.(*url.Error); urlok {
 			wrappedErr := urlerr.Unwrap()
 			neterr, ok = wrappedErr.(*net.OpError)
 		}
 	}
-
 	if ok && neterr.Err.Error() == connectionResetByPeerErr {
-		return true, fmt.Sprintf("Connection reset by peer: %v", neterr.Err.Error())
+		return true, fmt.Sprintf("Connection reset by peer")
 	}
 	return false, ""
 }

--- a/third_party/terraform/utils/error_retry_predicates.go
+++ b/third_party/terraform/utils/error_retry_predicates.go
@@ -21,7 +21,6 @@ var defaultErrorRetryPredicates = []RetryErrorPredicateFunc{
 	isNetworkTimeoutError,
 	isIoEOFError,
 	isConnectionResetNetworkError,
-	isTemporaryNetOpError,
 
 	// Common GCP error codes
 	isCommonRetryableErrorCode,

--- a/third_party/terraform/utils/error_retry_predicates.go
+++ b/third_party/terraform/utils/error_retry_predicates.go
@@ -30,8 +30,12 @@ var defaultErrorRetryPredicates = []RetryErrorPredicateFunc{
 
 /** END GLOBAL ERROR RETRY PREDICATES HERE **/
 
+type temporary interface {
+	Temporary() bool
+}
+
 func isTemporaryError(err error) (bool, string) {
-	if _, ok := err.(interface{ Temporary() bool }); ok {
+	if _, ok := err.(temporary); ok {
 		return true, "Got temporary error %v"
 	}
 	return false, ""


### PR DESCRIPTION
- Added check for Temporary() error
- Added check for connection reset by peer error

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/3957
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Added retries for common network errors we've encountered.
```
