### PR TITLE
add 'PARQUET' to documentation

### DIFF
--- a/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -160,7 +160,7 @@ The `external_data_configuration` block supports:
     BigQuery can ignore when reading data.
 
 * `source_format` (Required) - The data format. Supported values are:
-    "CSV", "GOOGLE_SHEETS", "NEWLINE_DELIMITED_JSON", "AVRO",
+    "CSV", "GOOGLE_SHEETS", "NEWLINE_DELIMITED_JSON", "AVRO", "PARQUET",
     and "DATSTORE_BACKUP". To use "GOOGLE_SHEETS"
     the `scopes` must include
     "https://www.googleapis.com/auth/drive.readonly".


### PR DESCRIPTION
add 'PARQUET' to documentation for `google_bigquery_table.external_data_configuration.source_format`

```release-note:none

```

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5658
