### PR TITLE
We need to flatten spanner names - previously it hadn't mattered whether we do it or not, but now since we get the name from the operation, it starts to matter.

### DIFF
--- a/products/spanner/terraform.yaml
+++ b/products/spanner/terraform.yaml
@@ -32,6 +32,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           regex: '^[a-z][a-z0-9_\-]*[a-z0-9]$'
+        custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
       extraStatements: !ruby/object:Overrides::Terraform::PropertyOverride
         name: ddl
         ignore_read: true
@@ -66,6 +67,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         # system, which is done in the encoder.  Consequently we have
         # to interpret "not set" as "use the name in state".
         default_from_api: true
+        custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
       nodeCount: !ruby/object:Overrides::Terraform::PropertyOverride
         name: num_nodes
       config: !ruby/object:Overrides::Terraform::PropertyOverride


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```

(let me know if an empty release note is right - this fixes an unreleased bug.)