### PR TITLE
add metadata to storage_bucket_object

### DIFF
--- a/third_party/terraform/resources/resource_storage_bucket_object.go
+++ b/third_party/terraform/resources/resource_storage_bucket_object.go
@@ -139,6 +139,13 @@ func resourceStorageBucketObject() *schema.Resource {
 				Computed: true,
 			},
 
+			"metadata": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
 			"self_link": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
@@ -37,6 +37,8 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the object. If you're interpolating the name of this object, see `output_name` instead.
 
+* `metadata` - (Optional) User-provided metadata, in key/value pairs.
+
 One of the following is required:
 
 * `content` - (Optional, Sensitive) Data as `string` to be uploaded. Must be defined if `source` is not. **Note**: The `content` field is marked as sensitive. To view the raw contents of the object, please define an [output](/docs/configuration/outputs.html).


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5464

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
storage: added `metadata` to `google_storage_bucket_object`.
```
