### PR TITLE
Add tests for healthcare store pubsub topic removal

### DIFF
--- a/third_party/terraform/tests/resource_healthcare_dicom_store_test.go.erb
+++ b/third_party/terraform/tests/resource_healthcare_dicom_store_test.go.erb
@@ -3,12 +3,13 @@ package google
 <% unless version == 'ga' -%>
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"path"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccHealthcareDicomStoreIdParsing(t *testing.T) {
@@ -103,6 +104,18 @@ func TestAccHealthcareDicomStore_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			// TODO(b/148536607): Uncomment once b/148536607 is fixed.
+			// {
+			// 	Config: testGoogleHealthcareDicomStore_basic(dicomStoreName, datasetName),
+			// 	Check: resource.ComposeTestCheckFunc(
+			// 		testAccCheckGoogleHealthcareDicomStoreRemoveTopic(),
+			// 	),
+			// },
+			// {
+			// 	ResourceName:      resourceName,
+			// 	ImportState:       true,
+			// 	ImportStateVerify: true,
+			// },
 		},
 	})
 }
@@ -209,6 +222,41 @@ func testAccCheckGoogleHealthcareDicomStoreUpdate(pubsubTopic string) resource.T
 		return nil
 	}
 }
+
+// TODO(b/148536607): Uncomment once b/148536607 is fixed.
+// func testAccCheckGoogleHealthcareDicomStoreRemoveTopic() resource.TestCheckFunc {
+// 	return func(s *terraform.State) error {
+// 		var foundResource = false
+// 		for _, rs := range s.RootModule().Resources {
+// 			if rs.Type != "google_healthcare_dicom_store" {
+// 				continue
+// 			}
+// 			foundResource = true
+
+// 			config := testAccProvider.Meta().(*Config)
+
+// 			gcpResourceUri, err := replaceVarsForTest(config, rs, "{{dataset}}/dicomStores/{{name}}")
+// 			if err != nil {
+// 				return err
+// 			}
+
+// 			response, err := config.clientHealthcare.Projects.Locations.Datasets.DicomStores.Get(gcpResourceUri).Do()
+// 			if err != nil {
+// 				return fmt.Errorf("Unexpected failure while verifying 'updated' dataset: %s", err)
+// 			}
+
+// 			notificationConfig := response.NotificationConfig
+// 			if notificationConfig != nil {
+// 				return fmt.Errorf("dicomStore 'NotificationConfig' not removed (%v): %s", notificationConfig, gcpResourceUri)
+// 			}
+// 		}
+
+// 		if !foundResource {
+// 			return fmt.Errorf("google_healthcare_dicom_store resource was missing")
+// 		}
+// 		return nil
+// 	}
+// }
 <% else %>
 // Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
 <% end -%>

--- a/third_party/terraform/tests/resource_healthcare_dicom_store_test.go.erb
+++ b/third_party/terraform/tests/resource_healthcare_dicom_store_test.go.erb
@@ -107,9 +107,6 @@ func TestAccHealthcareDicomStore_basic(t *testing.T) {
 			// TODO(b/148536607): Uncomment once b/148536607 is fixed.
 			// {
 			// 	Config: testGoogleHealthcareDicomStore_basic(dicomStoreName, datasetName),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		testAccCheckGoogleHealthcareDicomStoreRemoveTopic(),
-			// 	),
 			// },
 			// {
 			// 	ResourceName:      resourceName,
@@ -222,41 +219,6 @@ func testAccCheckGoogleHealthcareDicomStoreUpdate(pubsubTopic string) resource.T
 		return nil
 	}
 }
-
-// TODO(b/148536607): Uncomment once b/148536607 is fixed.
-// func testAccCheckGoogleHealthcareDicomStoreRemoveTopic() resource.TestCheckFunc {
-// 	return func(s *terraform.State) error {
-// 		var foundResource = false
-// 		for _, rs := range s.RootModule().Resources {
-// 			if rs.Type != "google_healthcare_dicom_store" {
-// 				continue
-// 			}
-// 			foundResource = true
-
-// 			config := testAccProvider.Meta().(*Config)
-
-// 			gcpResourceUri, err := replaceVarsForTest(config, rs, "{{dataset}}/dicomStores/{{name}}")
-// 			if err != nil {
-// 				return err
-// 			}
-
-// 			response, err := config.clientHealthcare.Projects.Locations.Datasets.DicomStores.Get(gcpResourceUri).Do()
-// 			if err != nil {
-// 				return fmt.Errorf("Unexpected failure while verifying 'updated' dataset: %s", err)
-// 			}
-
-// 			notificationConfig := response.NotificationConfig
-// 			if notificationConfig != nil {
-// 				return fmt.Errorf("dicomStore 'NotificationConfig' not removed (%v): %s", notificationConfig, gcpResourceUri)
-// 			}
-// 		}
-
-// 		if !foundResource {
-// 			return fmt.Errorf("google_healthcare_dicom_store resource was missing")
-// 		}
-// 		return nil
-// 	}
-// }
 <% else %>
 // Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
 <% end -%>

--- a/third_party/terraform/tests/resource_healthcare_fhir_store_test.go.erb
+++ b/third_party/terraform/tests/resource_healthcare_fhir_store_test.go.erb
@@ -106,9 +106,6 @@ func TestAccHealthcareFhirStore_basic(t *testing.T) {
 			},
 			{
 				Config: testGoogleHealthcareFhirStore_basic(fhirStoreName, datasetName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleHealthcareFhirStoreRemoveTopic(),
-				),
 			},
 			{
 				ResourceName:      resourceName,
@@ -230,40 +227,6 @@ func testAccCheckGoogleHealthcareFhirStoreUpdate(pubsubTopic string) resource.Te
 			topicName := path.Base(response.NotificationConfig.PubsubTopic)
 			if topicName != pubsubTopic {
 				return fmt.Errorf("fhirStore 'NotificationConfig' not updated ('%s' != '%s'): %s", topicName, pubsubTopic, gcpResourceUri)
-			}
-		}
-
-		if !foundResource {
-			return fmt.Errorf("google_healthcare_fhir_store resource was missing")
-		}
-		return nil
-	}
-}
-
-func testAccCheckGoogleHealthcareFhirStoreRemoveTopic() resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		var foundResource = false
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "google_healthcare_fhir_store" {
-				continue
-			}
-			foundResource = true
-
-			config := testAccProvider.Meta().(*Config)
-
-			gcpResourceUri, err := replaceVarsForTest(config, rs, "{{dataset}}/fhirStores/{{name}}")
-			if err != nil {
-				return err
-			}
-
-			response, err := config.clientHealthcare.Projects.Locations.Datasets.FhirStores.Get(gcpResourceUri).Do()
-			if err != nil {
-				return fmt.Errorf("Unexpected failure while verifying 'updated' dataset: %s", err)
-			}
-
-			notificationConfig := response.NotificationConfig
-			if notificationConfig != nil {
-				return fmt.Errorf("fhirStore 'NotificationConfig' not removed (%v): %s", notificationConfig, gcpResourceUri)
 			}
 		}
 

--- a/third_party/terraform/tests/resource_healthcare_fhir_store_test.go.erb
+++ b/third_party/terraform/tests/resource_healthcare_fhir_store_test.go.erb
@@ -104,6 +104,17 @@ func TestAccHealthcareFhirStore_basic(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testGoogleHealthcareFhirStore_basic(fhirStoreName, datasetName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleHealthcareFhirStoreRemoveTopic(),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -219,6 +230,40 @@ func testAccCheckGoogleHealthcareFhirStoreUpdate(pubsubTopic string) resource.Te
 			topicName := path.Base(response.NotificationConfig.PubsubTopic)
 			if topicName != pubsubTopic {
 				return fmt.Errorf("fhirStore 'NotificationConfig' not updated ('%s' != '%s'): %s", topicName, pubsubTopic, gcpResourceUri)
+			}
+		}
+
+		if !foundResource {
+			return fmt.Errorf("google_healthcare_fhir_store resource was missing")
+		}
+		return nil
+	}
+}
+
+func testAccCheckGoogleHealthcareFhirStoreRemoveTopic() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		var foundResource = false
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "google_healthcare_fhir_store" {
+				continue
+			}
+			foundResource = true
+
+			config := testAccProvider.Meta().(*Config)
+
+			gcpResourceUri, err := replaceVarsForTest(config, rs, "{{dataset}}/fhirStores/{{name}}")
+			if err != nil {
+				return err
+			}
+
+			response, err := config.clientHealthcare.Projects.Locations.Datasets.FhirStores.Get(gcpResourceUri).Do()
+			if err != nil {
+				return fmt.Errorf("Unexpected failure while verifying 'updated' dataset: %s", err)
+			}
+
+			notificationConfig := response.NotificationConfig
+			if notificationConfig != nil {
+				return fmt.Errorf("fhirStore 'NotificationConfig' not removed (%v): %s", notificationConfig, gcpResourceUri)
 			}
 		}
 

--- a/third_party/terraform/tests/resource_healthcare_hl7_v2_store_test.go.erb
+++ b/third_party/terraform/tests/resource_healthcare_hl7_v2_store_test.go.erb
@@ -3,12 +3,13 @@ package google
 <% unless version == 'ga' -%>
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"path"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
 func TestAccHealthcareHl7V2StoreIdParsing(t *testing.T) {
@@ -96,6 +97,17 @@ func TestAccHealthcareHl7V2Store_basic(t *testing.T) {
 				Config: testGoogleHealthcareHl7V2Store_update(hl7_v2StoreName, datasetName, pubsubTopic),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleHealthcareHl7V2StoreUpdate(pubsubTopic),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testGoogleHealthcareHl7V2Store_basic(hl7_v2StoreName, datasetName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleHealthcareHl7V2StoreRemoveTopic(),
 				),
 			},
 			{
@@ -217,6 +229,40 @@ func testAccCheckGoogleHealthcareHl7V2StoreUpdate(pubsubTopic string) resource.T
 			topicName := path.Base(response.NotificationConfig.PubsubTopic)
 			if topicName != pubsubTopic {
 				return fmt.Errorf("hl7_v2_store 'NotificationConfig' not updated ('%s' != '%s'): %s", topicName, pubsubTopic, gcpResourceUri)
+			}
+		}
+
+		if !foundResource {
+			return fmt.Errorf("google_healthcare_hl7_v2_store resource was missing")
+		}
+		return nil
+	}
+}
+
+func testAccCheckGoogleHealthcareHl7V2StoreRemoveTopic() resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		var foundResource = false
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "google_healthcare_hl7_v2_store" {
+				continue
+			}
+			foundResource = true
+
+			config := testAccProvider.Meta().(*Config)
+
+			gcpResourceUri, err := replaceVarsForTest(config, rs, "{{dataset}}/hl7V2Stores/{{name}}")
+			if err != nil {
+				return err
+			}
+
+			response, err := config.clientHealthcare.Projects.Locations.Datasets.Hl7V2Stores.Get(gcpResourceUri).Do()
+			if err != nil {
+				return fmt.Errorf("Unexpected failure while verifying 'updated' dataset: %s", err)
+			}
+
+			notificationConfig := response.NotificationConfig
+			if notificationConfig != nil {
+				return fmt.Errorf("hl7_v2_store 'NotificationConfig' not removed (%v): %s", notificationConfig, gcpResourceUri)
 			}
 		}
 

--- a/third_party/terraform/tests/resource_healthcare_hl7_v2_store_test.go.erb
+++ b/third_party/terraform/tests/resource_healthcare_hl7_v2_store_test.go.erb
@@ -106,9 +106,6 @@ func TestAccHealthcareHl7V2Store_basic(t *testing.T) {
 			},
 			{
 				Config: testGoogleHealthcareHl7V2Store_basic(hl7_v2StoreName, datasetName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleHealthcareHl7V2StoreRemoveTopic(),
-				),
 			},
 			{
 				ResourceName:      resourceName,
@@ -229,40 +226,6 @@ func testAccCheckGoogleHealthcareHl7V2StoreUpdate(pubsubTopic string) resource.T
 			topicName := path.Base(response.NotificationConfig.PubsubTopic)
 			if topicName != pubsubTopic {
 				return fmt.Errorf("hl7_v2_store 'NotificationConfig' not updated ('%s' != '%s'): %s", topicName, pubsubTopic, gcpResourceUri)
-			}
-		}
-
-		if !foundResource {
-			return fmt.Errorf("google_healthcare_hl7_v2_store resource was missing")
-		}
-		return nil
-	}
-}
-
-func testAccCheckGoogleHealthcareHl7V2StoreRemoveTopic() resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		var foundResource = false
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "google_healthcare_hl7_v2_store" {
-				continue
-			}
-			foundResource = true
-
-			config := testAccProvider.Meta().(*Config)
-
-			gcpResourceUri, err := replaceVarsForTest(config, rs, "{{dataset}}/hl7V2Stores/{{name}}")
-			if err != nil {
-				return err
-			}
-
-			response, err := config.clientHealthcare.Projects.Locations.Datasets.Hl7V2Stores.Get(gcpResourceUri).Do()
-			if err != nil {
-				return fmt.Errorf("Unexpected failure while verifying 'updated' dataset: %s", err)
-			}
-
-			notificationConfig := response.NotificationConfig
-			if notificationConfig != nil {
-				return fmt.Errorf("hl7_v2_store 'NotificationConfig' not removed (%v): %s", notificationConfig, gcpResourceUri)
 			}
 		}
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
healthcare: added tests for pubsub topic removal in `google_healthcare_dicom_store`, `google_healthcare_fhir_store` and `google_healthcare_hl7_v2_store`
```
