### PR TITLE
Fully remove `use_ip_aliases` and `create_subnetwork`

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -736,21 +736,6 @@ func resourceContainerCluster() *schema.Resource {
 							ConflictsWith: ipAllocationCidrBlockFields,
 						},
 
-						"use_ip_aliases": {
-							Type:     schema.TypeBool,
-							Removed:  "This field is removed as of 3.0.0. If previously set to true, remove it from your config. If false, remove it.",
-							Computed: true,
-							Optional: true,
-						},
-
-						// GKE creates subnetwork automatically
-						"create_subnetwork": {
-							Type:     schema.TypeBool,
-							Removed:  "This field is removed as of 3.0.0. Define an explicit google_compute_subnetwork and use subnetwork instead.",
-							Computed: true,
-							Optional: true,
-						},
-
 						"subnetwork_name": {
 							Type:     schema.TypeString,
 							Removed:  "This field is removed as of 3.0.0. Define an explicit google_compute_subnetwork and use subnetwork instead.",


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5586

These two fields were previously set to `Removed` and [scheduled for full removal](https://www.terraform.io/docs/extend/best-practices/deprecations.html#provider-attribute-removal) from the schema during the next major release. However, due to their existence within the schema, the fields still show in state with default values which is misleading for users. The fact that these `Removed` fields still show in state is a [bug](https://github.com/hashicorp/terraform-plugin-sdk/issues/320). 

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
container:Fully removed `use_ip_aliases` and `create_subnetwork` fields
```
