### PR TITLE
clarify virtual fields vs url_param_only

### DIFF
--- a/api/type.rb
+++ b/api/type.rb
@@ -36,7 +36,7 @@ module Api
 
       # url_param_only will not send the field in the resource body and will
       # not attempt to read the field from the API response.
-      # NOTE - this doesn't work for nested Terraform fields
+      # NOTE - this doesn't work for nested fields
       attr_reader :url_param_only
       attr_reader :required
 

--- a/api/type.rb
+++ b/api/type.rb
@@ -33,7 +33,11 @@ module Api
 
       attr_reader :output # If set value will not be sent to server on sync
       attr_reader :input # If set to true value is used only on creation
-      attr_reader :url_param_only # If, true will not be send in request body
+
+      # url_param_only will not send the field in the resource body and will
+      # not attempt to read the field from the API response.
+      # NOTE - this doesn't work for nested Terraform fields
+      attr_reader :url_param_only
       attr_reader :required
 
       attr_reader :update_verb

--- a/overrides/terraform/resource_override.rb
+++ b/overrides/terraform/resource_override.rb
@@ -45,7 +45,8 @@ module Overrides
           # corresponding OiCS walkthroughs.
           :examples,
 
-          # Virtual fields on the Terraform resource.
+          # Virtual fields on the Terraform resource. Usage and differences from url_param_only
+          # are documented in provider/terraform/virtual_fields.rb
           :virtual_fields,
 
           # TODO(alexstephen): Deprecate once all resources using autogen async.

--- a/provider/terraform/virtual_fields.rb
+++ b/provider/terraform/virtual_fields.rb
@@ -23,6 +23,16 @@ module Provider
     # behaviour. They often don't map to underlying API fields (although they
     # may map to parameters), and will require custom code to be added to
     # control them.
+    #
+    # Virtual fields only support top level, boolean Terraform fields
+    #
+    # Virtual fields are similar to url_param_only fields in that they create
+    # a schema entry which is not read from or submitted to the API. However
+    # virtual fields are boolean only whereas url_param_only fields do not have
+    # type restrictions. Functionally virtual fields are largely behavioral
+    # flags for determining resource behavior, such as
+    # `delete_contents_on_destroy` whereas url_param_only fields _should_ be
+    # for constructing url strings
     class VirtualFields < Api::Object
       include Compile::Core
       include Google::GolangUtils

--- a/provider/terraform/virtual_fields.rb
+++ b/provider/terraform/virtual_fields.rb
@@ -24,15 +24,15 @@ module Provider
     # may map to parameters), and will require custom code to be added to
     # control them.
     #
-    # Virtual fields only support top level, boolean Terraform fields
-    #
     # Virtual fields are similar to url_param_only fields in that they create
     # a schema entry which is not read from or submitted to the API. However
-    # virtual fields are boolean only whereas url_param_only fields do not have
-    # type restrictions. Functionally virtual fields are largely behavioral
-    # flags for determining resource behavior, such as
-    # `delete_contents_on_destroy` whereas url_param_only fields _should_ be
-    # for constructing url strings
+    # virtual fields are meant to provider toggles for resource behavior
+    # (eg: delete_contents_on_destroy) whereas url_param_only fields _should_
+    # be used for url construction.
+    #
+    # Both are resource level fields and do not make sense, and are also not
+    # supported, for nested fields. Nested fields that shouldn't be included
+    # in API payloads are better handled with custom expand/encoder logic.
     class VirtualFields < Api::Object
       include Compile::Core
       include Google::GolangUtils

--- a/provider/terraform/virtual_fields.rb
+++ b/provider/terraform/virtual_fields.rb
@@ -20,13 +20,13 @@ require 'provider/abstract_core'
 module Provider
   class Terraform < Provider::AbstractCore
     # Virtual fields are Terraform-only fields that control Terraform's
-    # behaviour. They often don't map to underlying API fields (although they
+    # behaviour. They don't map to underlying API fields (although they
     # may map to parameters), and will require custom code to be added to
     # control them.
     #
     # Virtual fields are similar to url_param_only fields in that they create
     # a schema entry which is not read from or submitted to the API. However
-    # virtual fields are meant to provider toggles for resource behavior
+    # virtual fields are meant to provide toggles for Terraform-specific behavior in a resource
     # (eg: delete_contents_on_destroy) whereas url_param_only fields _should_
     # be used for url construction.
     #


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
@c2thorn reviewer as a user of the two fields to ensure that the distinction is clear
@rileykarson reviewer as the author of virtual field to ensure the intent is correct