### PR TITLE
[Terraform] Add support for dns_cache_config to resource_container_cluster

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -56,6 +56,7 @@ var (
 	<% unless version == 'ga' -%>
 		"addons_config.0.istio_config",
 		"addons_config.0.cloudrun_config",
+		"addons_config.0.dns_cache_config",
 	<% end -%>
 	}
 )
@@ -278,6 +279,22 @@ func resourceContainerCluster() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"disabled": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+								},
+							},
+						},
+						"dns_cache_config": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: addonsConfigKeys,
+							ForceNew:     true,
+							MaxItems:     1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
 										Type:     schema.TypeBool,
 										Required: true,
 									},
@@ -2207,6 +2224,14 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 			ForceSendFields: []string{"Disabled"},
 		}
 	}
+
+	if v, ok := config["dns_cache_config"]; ok && len(v.([]interface{})) > 0 {
+		addon := v.([]interface{})[0].(map[string]interface{})
+		ac.DnsCacheConfig = &containerBeta.DnsCacheConfig{
+			Enabled:        addon["enabled"].(bool),
+			ForceSendFields: []string{"Enabled"},
+		}
+	}
 <% end -%>
 
 	return ac
@@ -2617,6 +2642,14 @@ func flattenClusterAddonsConfig(c *containerBeta.AddonsConfig) []map[string]inte
 			},
 		}
 	}
+
+	if c.DnsCacheConfig != nil {
+  		result["dns_cache_config"] = []map[string]interface{}{
+  			{
+  				"enabled": c.DnsCacheConfig.Enabled,
+  			},
+  		}
+  	}
 <% end -%>
 	return []map[string]interface{}{result}
 }

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -146,6 +146,7 @@ func TestAccContainerCluster_withAddons(t *testing.T) {
 				ResourceName:		 "google_container_cluster.primary",
 				ImportState:		 true,
 				ImportStateVerify:	 true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
 			},
 			{
 				Config: testAccContainerCluster_updateAddons(clusterName),
@@ -154,6 +155,7 @@ func TestAccContainerCluster_withAddons(t *testing.T) {
 				ResourceName:		 "google_container_cluster.primary",
 				ImportState:		 true,
 				ImportStateVerify:	 true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
 			},
 		},
 	})
@@ -1957,6 +1959,8 @@ resource "google_container_cluster" "primary" {
   location           = "us-central1-a"
   initial_node_count = 1
 
+  min_master_version = "latest"
+
   addons_config {
     http_load_balancing {
       disabled = true
@@ -1990,6 +1994,8 @@ resource "google_container_cluster" "primary" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1
+
+  min_master_version = "latest"
 
   addons_config {
     http_load_balancing {

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1975,6 +1975,9 @@ resource "google_container_cluster" "primary" {
     cloudrun_config {
       disabled = true
     }
+    dns_cache_config {
+      enabled = false
+    }
 <% end -%>
   }
 }
@@ -2005,6 +2008,9 @@ resource "google_container_cluster" "primary" {
     }
     cloudrun_config {
       disabled = false
+    }
+    dns_cache_config {
+      enabled = true
     }
 <% end -%>
   }

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -324,6 +324,13 @@ The `addons_config` block supports:
 * `cloudrun_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)).
     The status of the CloudRun addon. It requires `istio_config` enabled. It is disabled by default.
     Set `disabled = false` to enable. This addon can only be enabled at cluster creation time.
+    
+* `dns_cache_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)).
+    The status of the NodeLocal DNSCache addon. It is disabled by default.
+    Set `enabled = true` to enable. 
+    
+    **Enabling/Disabling NodeLocal DNSCache in an existing cluster is a disruptive operation.
+    All cluster nodes running GKE 1.15 and higher are recreated.**
 
 This example `addons_config` disables two addons:
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5150

Adds support for NodeLocal DNSCache addon to terraform.

```release-note:enhancement
container: added `dns_cache_config` field to `google_container_cluster` resource
```