### PR TITLE
upstream terraform-providers/terraform-provider-google/pull/5647

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -806,6 +806,11 @@ func resourceContainerCluster() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
+			"label_fingerprint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"default_max_pods_per_node": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -1360,6 +1365,7 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 <% end -%>
 
 	d.Set("resource_labels", cluster.ResourceLabels)
+	d.Set("label_fingerprint", cluster.LabelFingerprint)
 
 	<% unless version == 'ga' -%>
 	if err := d.Set("resource_usage_export_config", flattenResourceUsageExportConfig(cluster.ResourceUsageExportConfig)); err != nil {
@@ -1934,8 +1940,10 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 	if d.HasChange("resource_labels") {
 		resourceLabels := d.Get("resource_labels").(map[string]interface{})
+		labelFingerprint := d.Get("label_fingerprint").(string)
 		req := &containerBeta.SetLabelsRequest{
 			ResourceLabels: convertStringMap(resourceLabels),
+			LabelFingerprint: labelFingerprint,
 		}
 		updateF := func() error {
 			name := containerClusterFullName(project, location, clusterName)

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -712,6 +712,8 @@ exported:
 * `instance_group_urls` - List of instance group URLs which have been assigned
     to the cluster.
 
+* `label_fingerprint` - The fingerprint of the set of labels for this cluster.
+
 * `maintenance_policy.0.daily_maintenance_window.0.duration` - Duration of the time window, automatically chosen to be
     smallest possible in the given scenario.
     Duration will be in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) format "PTnHnMnS".


### PR DESCRIPTION
Upstream of:
https://github.com/terraform-providers/terraform-provider-google/pull/5647
https://github.com/terraform-providers/terraform-provider-google-beta/pull/1750
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
