### PR TITLE
add version field to fhir store

### DIFF
--- a/products/healthcare/api.yaml
+++ b/products/healthcare/api.yaml
@@ -184,6 +184,16 @@ objects:
           ** Changing this property may recreate the FHIR store (removing all data) **
         required: true
         input: true
+      - !ruby/object:Api::Type::Enum
+          name: version
+          description: |
+            The FHIR specification version.
+          required: false # TODO: Make this field required in GA.
+          default_value: :STU3
+          values:
+            - :DSTU2
+            - :STU3
+            - :R4
       - !ruby/object:Api::Type::Boolean
         name: 'enableUpdateCreate'
         description: |

--- a/products/healthcare/api.yaml
+++ b/products/healthcare/api.yaml
@@ -187,8 +187,9 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: version
         description: |
-          The FHIR specification version.
+          The FHIR specification version. Supported values include DSTU2, STU3 and R4. Defaults to STU3.
         required: false # TODO: Make this field required in GA.
+        input: true
         default_value: :STU3
         values:
           - :DSTU2

--- a/products/healthcare/api.yaml
+++ b/products/healthcare/api.yaml
@@ -185,15 +185,15 @@ objects:
         required: true
         input: true
       - !ruby/object:Api::Type::Enum
-          name: version
-          description: |
-            The FHIR specification version.
-          required: false # TODO: Make this field required in GA.
-          default_value: :STU3
-          values:
-            - :DSTU2
-            - :STU3
-            - :R4
+        name: version
+        description: |
+          The FHIR specification version.
+        required: false # TODO: Make this field required in GA.
+        default_value: :STU3
+        values:
+          - :DSTU2
+          - :STU3
+          - :R4
       - !ruby/object:Api::Type::Boolean
         name: 'enableUpdateCreate'
         description: |

--- a/templates/terraform/examples/healthcare_fhir_store_basic.tf.erb
+++ b/templates/terraform/examples/healthcare_fhir_store_basic.tf.erb
@@ -1,6 +1,7 @@
 resource "google_healthcare_fhir_store" "default" {
   name    = "<%= ctx[:vars]['fhir_store_name'] %>"
   dataset = google_healthcare_dataset.dataset.id
+  version = "R4"
 
   enable_update_create          = false
   disable_referential_integrity = false


### PR DESCRIPTION
https://cloud.google.com/healthcare/docs/reference/rest/v1beta1/projects.locations.datasets.fhirStores#FhirStore

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
healthcare: added `version` field to `google_healthcare_fhir_store`
```
