### PR TITLE
clarify specification of audit log types

### DIFF
--- a/third_party/terraform/website/docs/r/google_project_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_iam.html.markdown
@@ -139,6 +139,9 @@ resource "google_project_iam_audit_config" "project" {
   project = "your-project-id"
   service = "allServices"
   audit_log_config {
+    log_type = "ADMIN_READ"
+  }
+  audit_log_config {
     log_type = "DATA_READ"
     exempted_members = [
       "user:joebloggs@hashicorp.com",


### PR DESCRIPTION
This change is intended to avoid the confusion outlined in
https://github.com/terraform-providers/terraform-provider-google/issues/5446,
which I also ran into. Having multiple audit logs in the example should
make it readily apparent how the resource is intended to be used.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
Improve documentation for multiple log_type values in google_project_iam_audit_config resource
```
