### PR TITLE
Add type field to google_dataflow_job.

### DIFF
--- a/third_party/terraform/resources/resource_dataflow_job.go
+++ b/third_party/terraform/resources/resource_dataflow_job.go
@@ -114,7 +114,10 @@ func resourceDataflowJob() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-
+			"type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"service_account_email": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -228,6 +231,7 @@ func resourceDataflowJobRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("job_id", job.Id)
 	d.Set("state", job.CurrentState)
 	d.Set("name", job.Name)
+	d.Set("type", job.Type)
 	d.Set("project", project)
 	d.Set("labels", job.Labels)
 

--- a/third_party/terraform/website/docs/r/dataflow_job.html.markdown
+++ b/third_party/terraform/website/docs/r/dataflow_job.html.markdown
@@ -63,4 +63,5 @@ The following arguments are supported:
 ## Attributes Reference
 
 * `job_id` - The unique ID of this job.
+* `type` - The type of this job, selected from the [JobType enum](https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.jobs#Job.JobType)
 * `state` - The current state of the resource, selected from the [JobState enum](https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.jobs#Job.JobState)


### PR DESCRIPTION
Upstreams https://github.com/terraform-providers/terraform-provider-google/pull/5684

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dataflow: added computed `type` field to `google_dataflow_job`.
```