### PR TITLE
Update go .ci containers to go 1.13

### DIFF
--- a/.ci/containers/go-ruby-python/Dockerfile
+++ b/.ci/containers/go-ruby-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/magic-modules/go-ruby:1.11.5-2.6.0-v6
+FROM gcr.io/magic-modules/go-ruby:1.3-2.6.0
 
 # Install python & python libraries.
 RUN apt-get update

--- a/.ci/containers/go-ruby-python/Dockerfile
+++ b/.ci/containers/go-ruby-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/magic-modules/go-ruby:1.3-2.6.0
+FROM gcr.io/magic-modules/go-ruby:1.13.8-2.6.0
 
 # Install python & python libraries.
 RUN apt-get update

--- a/.ci/containers/go-ruby/Dockerfile
+++ b/.ci/containers/go-ruby/Dockerfile
@@ -1,4 +1,4 @@
-from golang:1.11-stretch as resource
+from golang:1.13-stretch as resource
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
Update these as we need go 1.13 due to recent updates

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
