### PR TITLE
Update to https scheme in idp saml config tests

### DIFF
--- a/templates/terraform/examples/identity_platform_inbound_saml_config_basic.tf.erb
+++ b/templates/terraform/examples/identity_platform_inbound_saml_config_basic.tf.erb
@@ -4,7 +4,7 @@ resource "google_identity_platform_inbound_saml_config" "<%= ctx[:primary_resour
   idp_config {
     idp_entity_id = "<%= ctx[:vars]["idp_entity_id"] %>"
     sign_request  = true
-    sso_url       = "example.com"
+    sso_url       = "https://example.com"
     idp_certificates {
       x509_certificate = file("test-fixtures/rsa_cert.pem")
     }

--- a/templates/terraform/examples/identity_platform_tenant_inbound_saml_config_basic.tf.erb
+++ b/templates/terraform/examples/identity_platform_tenant_inbound_saml_config_basic.tf.erb
@@ -9,7 +9,7 @@ resource "google_identity_platform_tenant_inbound_saml_config" "<%= ctx[:primary
   idp_config {
     idp_entity_id = "<%= ctx[:vars]["idp_entity_id"] %>"
     sign_request  = true
-    sso_url       = "example.com"
+    sso_url       = "https://example.com"
     idp_certificates {
       x509_certificate = file("test-fixtures/rsa_cert.pem")
     }

--- a/third_party/terraform/tests/resource_identity_platform_inbound_saml_config_test.go
+++ b/third_party/terraform/tests/resource_identity_platform_inbound_saml_config_test.go
@@ -46,7 +46,7 @@ resource "google_identity_platform_inbound_saml_config" "saml_config" {
   display_name = "Display Name"
   idp_config {
     idp_entity_id = "tf-idp%{random_suffix}"
-    sso_url = "example.com"
+    sso_url = "https://example.com"
     idp_certificates {
       x509_certificate = file("test-fixtures/rsa_cert.pem")
     }
@@ -67,7 +67,7 @@ resource "google_identity_platform_inbound_saml_config" "saml_config" {
   display_name = "Display Name2"
   idp_config {
     idp_entity_id = "tf-idp%{random_suffix}"
-    sso_url = "example123.com"
+    sso_url = "https://example123.com"
     sign_request = true
     idp_certificates {
       x509_certificate = file("test-fixtures/rsa_cert.pem")

--- a/third_party/terraform/tests/resource_identity_platform_tenant_indound_saml_config_test.go
+++ b/third_party/terraform/tests/resource_identity_platform_tenant_indound_saml_config_test.go
@@ -54,7 +54,7 @@ resource "google_identity_platform_tenant_inbound_saml_config" "tenant_saml_conf
   idp_config {
     idp_entity_id = "tf-idp%{random_suffix}"
     sign_request  = true
-    sso_url       = "example.com"
+    sso_url       = "https://example.com"
     idp_certificates {
       x509_certificate = file("test-fixtures/rsa_cert.pem")
     }
@@ -81,7 +81,7 @@ resource "google_identity_platform_tenant_inbound_saml_config" "tenant_saml_conf
   idp_config {
     idp_entity_id = "tf-idp%{random_suffix}"
     sign_request  = false
-    sso_url       = "example123.com"
+    sso_url       = "https://example123.com"
     idp_certificates {
       x509_certificate = file("test-fixtures/rsa_cert.pem")
     }


### PR DESCRIPTION
Fix IDP tests. The API now enforces that sso_url has the https scheme

Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/5705

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
