### PR TITLE
Ansible needs elements listed in docs

### DIFF
--- a/provider/ansible/documentation.rb
+++ b/provider/ansible/documentation.rb
@@ -37,6 +37,8 @@ module Provider
               (choices_description(prop) \
                if prop.is_a?(Api::Type::Enum) && prop.contain_extra_docs)
             ].flatten.compact,
+            'elements' => (python_type(prop.item_type) \
+              if prop.is_a?(Api::Type::Array) && python_type(prop.item_type)),
             'required' => required,
             'default' => (
               if prop.default_value&.is_a?(::Hash)


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->
Ansible has changed the specs for documentation. For all arrays, the docs now need to list what type should be contained inside the list.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
