### PR TITLE
Make connection reset error pred more generic, debug logs

### DIFF
--- a/third_party/terraform/utils/error_retry_predicates.go
+++ b/third_party/terraform/utils/error_retry_predicates.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 
+	"golang.org/x/oauth2"
 	"google.golang.org/api/googleapi"
 )
 

--- a/third_party/terraform/utils/error_retry_predicates.go
+++ b/third_party/terraform/utils/error_retry_predicates.go
@@ -67,18 +67,24 @@ func isIoEOFError(err error) (bool, string) {
 	return false, ""
 }
 
-const connectionResetByPeerErr = "connection reset by peer"
-
+const connectionResetByPeerErr = ": connection reset by peer"
 func isConnectionResetNetworkError(err error) (bool, string) {
-	neterr, ok := err.(*net.OpError)
-	if !ok {
-		if urlerr, urlok := err.(*url.Error); urlok {
-			wrappedErr := urlerr.Unwrap()
-			neterr, ok = wrappedErr.(*net.OpError)
+	if strings.HasSuffix(err.Error(), connectionResetByPeerErr) {
+		//TODO(emilymye, TPG#3957): Remove these debug logs
+		log.Printf("[DEBUG] Found connection reset by peer error of type %T", err)
+		switch err.(type) {
+		case *url.Error:
+		case *net.OpError:
+			log.Printf("[DEBUG] Connection reset error returned from net/url")
+		case *googleapi.Error:
+			log.Printf("[DEBUG] Connection reset error wrapped by googleapi.Error")
+		case *oauth2.RetrieveError:
+			log.Printf("[DEBUG] Connection reset error wrapped by oauth2")
+		default:
+			log.Printf("[DEBUG] Connection reset error wrapped by %T", err)
 		}
-	}
-	if ok && neterr.Err.Error() == connectionResetByPeerErr {
-		return true, fmt.Sprintf("Connection reset by peer")
+
+		return true, fmt.Sprintf("reset connection")
 	}
 	return false, ""
 }

--- a/third_party/terraform/utils/error_retry_predicates.go
+++ b/third_party/terraform/utils/error_retry_predicates.go
@@ -68,6 +68,7 @@ func isIoEOFError(err error) (bool, string) {
 }
 
 const connectionResetByPeerErr = ": connection reset by peer"
+
 func isConnectionResetNetworkError(err error) (bool, string) {
 	if strings.HasSuffix(err.Error(), connectionResetByPeerErr) {
 		//TODO(emilymye, TPG#3957): Remove these debug logs


### PR DESCRIPTION
```release-note:enhancement
Make check for retrying "connection reset by peer" errors more generic
```

Continues https://github.com/terraform-providers/terraform-provider-google/issues/3957 