### PR TITLE
Add check for google_compute_router bgp.advertise_mode.

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1484,6 +1484,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           router_name: "my-router"
           network_name: "my-network"
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      constants: templates/terraform/constants/router.go.erb
+      resource_definition: templates/terraform/resource_definition/router.go.erb
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true

--- a/templates/terraform/constants/router.go.erb
+++ b/templates/terraform/constants/router.go.erb
@@ -1,5 +1,5 @@
 <%- # the license inside this block applies to this file
-	# Copyright 2019 Google Inc.
+	# Copyright 2020 Google Inc.
 	# Licensed under the Apache License, Version 2.0 (the "License");
 	# you may not use this file except in compliance with the License.
 	# You may obtain a copy of the License at

--- a/templates/terraform/constants/router.go.erb
+++ b/templates/terraform/constants/router.go.erb
@@ -1,0 +1,31 @@
+<%- # the license inside this block applies to this file
+	# Copyright 2019 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+// customizeDiff func for additional checks on google_compute_router properties:
+func resourceComputeRouterCustomDiff(diff *schema.ResourceDiff, meta interface{}) error {
+
+	block := diff.Get("bgp.0").(map[string]interface{})
+	advertiseMode := block["advertise_mode"]
+	advertisedGroups := block["advertised_groups"].([]interface{})
+	advertisedIPRanges := block["advertised_ip_ranges"].([]interface{})
+
+	if advertiseMode == "DEFAULT" && len(advertisedGroups) != 0 {
+		return fmt.Errorf("Error in bgp: advertised_groups cannot be specified when using advertise_mode DEFAULT")
+	}
+	if advertiseMode == "DEFAULT" && len(advertisedIPRanges) != 0 {
+		return fmt.Errorf("Error in bgp: advertised_ip_ranges cannot be specified when using advertise_mode DEFAULT")
+	}
+
+	return nil
+}

--- a/templates/terraform/resource_definition/router.go.erb
+++ b/templates/terraform/resource_definition/router.go.erb
@@ -1,0 +1,15 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+CustomizeDiff: resourceComputeRouterCustomDiff,


### PR DESCRIPTION
Fixes terraform-providers/terraform-provider-google#5382

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added check on `google_compute_router` for non-empty advertised_groups or advertised_ip_ranges values when advertise_mode is DEFAULT in the bgp block.
```
