### PR TITLE
Google project precheck

### DIFF
--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -191,7 +191,7 @@ func resourceGoogleProjectCheckPreRequisites(config *Config, d *schema.ResourceD
 	if err != nil {
 		return fmt.Errorf("failed to check permissions on billing account %q: %v", ba, err)
 	}
-	if has := sliceContains(perm, resp.Permissions); !has {
+	if !stringInSlice(resp.Permissions); !has {
 		return fmt.Errorf("missing permissions on %q: %v", ba, perm)
 	}
 	return nil

--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -191,7 +191,7 @@ func resourceGoogleProjectCheckPreRequisites(config *Config, d *schema.ResourceD
 		return fmt.Errorf("failed to check permissions on billing account %q: %v", ba, err)
 	}
 	if diff := diffStringSlices(resp.Permissions, req.Permissions); len(diff) > 0 {
-		return fmt.Errorf("missing permissions on org %q: %v", ba, diff)
+		return fmt.Errorf("missing permissions on billing account %q: %v", ba, diff)
 	}
 	return nil
 }

--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -191,19 +191,10 @@ func resourceGoogleProjectCheckPreRequisites(config *Config, d *schema.ResourceD
 	if err != nil {
 		return fmt.Errorf("failed to check permissions on billing account %q: %v", ba, err)
 	}
-	if !stringInSlice(resp.Permissions); !has {
-		return fmt.Errorf("missing permissions on %q: %v", ba, perm)
+	if !stringInSlice(resp.Permissions, perm) {
+		return fmt.Errorf("missing permission on %q: %v", ba, perm)
 	}
 	return nil
-}
-
-func sliceContains(want string, ss []string) bool {
-	for _, s := range ss {
-		if s == want {
-			return true
-		}
-	}
-	return false
 }
 
 func resourceGoogleProjectRead(d *schema.ResourceData, meta interface{}) error {

--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -191,7 +191,7 @@ func resourceGoogleProjectCheckPreRequisites(config *Config, d *schema.ResourceD
 		return fmt.Errorf("failed to check permissions on billing account %q: %v", ba, err)
 	}
 	if diff := diffStringSlices(resp.Permissions, req.Permissions); len(diff) > 0 {
-		return fmt.Errorf("missing permissions on billing account %q: %v", ba, diff)
+		return fmt.Errorf("missing permissions on %q: %v", ba, diff)
 	}
 	return nil
 }

--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -179,18 +179,19 @@ func resourceGoogleProjectCreate(d *schema.ResourceData, meta interface{}) error
 
 func resourceGoogleProjectCheckPreRequisites(config *Config, d *schema.ResourceData) error {
 	ib, ok := d.GetOk("billing_account")
-	if ok {
-		ba := "billingAccounts/" + ib.(string)
-		req := &cloudbilling.TestIamPermissionsRequest{
-			Permissions: []string{"billing.resourceAssociations.create"},
-		}
-		resp, err := config.clientBilling.BillingAccounts.TestIamPermissions(ba, req).Do()
-		if err != nil {
-			return fmt.Errorf("failed to check permissions on billing account %q: %v", ba, err)
-		}
-		if diff := diffStringSlices(resp.Permissions, req.Permissions); len(diff) > 0 {
-			return fmt.Errorf("missing permissions on org %q: %v", ba, diff)
-		}
+	if !ok {
+		return nil
+	}
+	ba := "billingAccounts/" + ib.(string)
+	req := &cloudbilling.TestIamPermissionsRequest{
+		Permissions: []string{"billing.resourceAssociations.create"},
+	}
+	resp, err := config.clientBilling.BillingAccounts.TestIamPermissions(ba, req).Do()
+	if err != nil {
+		return fmt.Errorf("failed to check permissions on billing account %q: %v", ba, err)
+	}
+	if diff := diffStringSlices(resp.Permissions, req.Permissions); len(diff) > 0 {
+		return fmt.Errorf("missing permissions on org %q: %v", ba, diff)
 	}
 	return nil
 }


### PR DESCRIPTION
closes https://github.com/terraform-providers/terraform-provider-google/pull/5671 as it's the upstream pr.
fixes https://github.com/terraform-providers/terraform-provider-google/issues/5222
references terraform-google-modules/terraform-google-project-factory#373
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: Updated `google_project` to check for valid permissions on the parent billing account before creating and tainting the resource.
```
