### PR TITLE
Add decoder after OperationWaitTimeWithResponse

### DIFF
--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -234,26 +234,46 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     }
 <%    end -%>
 <%    if object.async.is_a? Api::OpAsync -%>
-    <% if object.async.result.resource_inside_response and not object.identity.empty? -%>
-    var response map[string]interface{}
+<%      if object.async.result.resource_inside_response and not object.identity.empty? -%>
+    // Use the resource in the operation response to populate
+    // identity fields and d.Id() before read
+    var opRes map[string]interface{}
     err = <%= client_name_camel -%>OperationWaitTimeWithResponse(
-    config, res, &response, <% if has_project -%> project, <% end -%> "Creating <%= object.name -%>",
+    config, res, &opRes, <% if has_project -%> project, <% end -%> "Creating <%= object.name -%>",
         int(d.Timeout(schema.TimeoutCreate).Minutes()))
-
     if err != nil {
-<%      if object.custom_code.post_create_failure -%>
+<%        if object.custom_code.post_create_failure -%>
         resource<%= resource_name -%>PostCreateFailure(d, meta)
-<%      end -%>
+<%        end -%>
         // The resource didn't actually create
         d.SetId("")
         return fmt.Errorf("Error waiting to create <%= object.name -%>: %s", err)
     }
+
+<%      if object.nested_query -%>
+    opRes, err = flattenNested<%= resource_name -%>(d, meta, opRes)
+    if err != nil {
+        return fmt.Errorf("Error getting nested object from operation response: %s", err)
+    }
+    if opRes == nil {
+        // Object isn't there any more - remove it from the state.
+        return fmt.Errorf("Error decoding response from operation, could not find nested object")
+    }
+<%      end -%>
+<%      if object.custom_code.decoder -%>
+    opRes, err = resource<%= resource_name -%>Decoder(d, meta, opRes)
+    if err != nil {
+        return fmt.Errorf("Error decoding response from operation: %s", err)
+    }
+    if opRes == nil {
+        return fmt.Errorf("Error decoding response from operation, could not find object")
+    }
+<%      end -%>
     <% object.gettable_properties.each do |prop| -%>
     <% if object.identity.include?(prop) -%>
-    if err := d.Set("<%= prop.name.underscore -%>", flatten<%= resource_name -%><%= titlelize_property(prop) -%>(response["<%= prop.api_name -%>"], d, config)); err != nil {
+    if err := d.Set("<%= prop.name.underscore -%>", flatten<%= resource_name -%><%= titlelize_property(prop) -%>(opRes["<%= prop.api_name -%>"], d, config)); err != nil {
         return err
     }
-
     <% end -%>
     <% end -%>
 
@@ -327,15 +347,7 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
         d.SetId("")
         return nil
     }
-<%  end -%>
 
-<%- unless object.virtual_fields.empty? -%>
-  // Explicitly set virtual fields to default values if unset
-<%-   object.virtual_fields.each do |field| -%>
-    if _, ok := d.GetOk("<%= field.name -%>"); !ok {
-      d.Set("<%= field.name -%>", false)
-    }
-<%    end -%>
 <%  end -%>
 
 <%  if object.custom_code.decoder -%>
@@ -350,8 +362,16 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
         d.SetId("")
         return nil
     }
-<%  end -%>
 
+<%  end -%>
+<%- unless object.virtual_fields.empty? -%>
+  // Explicitly set virtual fields to default values if unset
+<%-   object.virtual_fields.each do |field| -%>
+    if _, ok := d.GetOk("<%= field.name -%>"); !ok {
+      d.Set("<%= field.name -%>", false)
+    }
+<%    end -%>
+<%  end -%>
 <%  if has_project -%>
     if err := d.Set("project", project); err != nil {
         return fmt.Errorf("Error reading <%= object.name -%>: %s", err)
@@ -776,3 +796,4 @@ func resource<%= resource_name -%>PostCreateFailure(d *schema.ResourceData, meta
 <% if object.schema_version -%>
 <%= lines(compile("templates/terraform/state_migrations/#{product_ns.underscore}_#{object.name.underscore}.go.erb")) -%>
 <%  end -%>
+


### PR DESCRIPTION
Since #3085 hasn't been added to a release yet, I'm going to exclude the release note, but this should fix an issue with post-create read of AccessContextManager service perimeter resource

(fixes https://github.com/terraform-providers/terraform-provider-google/issues/5704)


<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
