### PR TITLE
Allow `projects/` prefix for the project field in project IAM resources

### DIFF
--- a/third_party/terraform/utils/iam_project.go
+++ b/third_party/terraform/utils/iam_project.go
@@ -10,10 +10,11 @@ import (
 
 var IamProjectSchema = map[string]*schema.Schema{
 	"project": {
-		Type:     schema.TypeString,
-		Optional: true,
-		Computed: true,
-		ForceNew: true,
+		Type:             schema.TypeString,
+		Optional:         true,
+		Computed:         true,
+		ForceNew:         true,
+		DiffSuppressFunc: compareProjectName,
 	},
 }
 
@@ -42,7 +43,8 @@ func ProjectIdParseFunc(d *schema.ResourceData, _ *Config) error {
 }
 
 func (u *ProjectIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Policy, error) {
-	p, err := u.Config.clientResourceManager.Projects.GetIamPolicy(u.resourceId,
+	projectId := GetResourceNameFromSelfLink(u.resourceId)
+	p, err := u.Config.clientResourceManager.Projects.GetIamPolicy(projectId,
 		&cloudresourcemanager.GetIamPolicyRequest{
 			Options: &cloudresourcemanager.GetPolicyOptions{
 				RequestedPolicyVersion: iamPolicyVersion,
@@ -57,10 +59,12 @@ func (u *ProjectIamUpdater) GetResourceIamPolicy() (*cloudresourcemanager.Policy
 }
 
 func (u *ProjectIamUpdater) SetResourceIamPolicy(policy *cloudresourcemanager.Policy) error {
-	_, err := u.Config.clientResourceManager.Projects.SetIamPolicy(u.resourceId, &cloudresourcemanager.SetIamPolicyRequest{
-		Policy:     policy,
-		UpdateMask: "bindings,etag,auditConfigs",
-	}).Do()
+	projectId := GetResourceNameFromSelfLink(u.resourceId)
+	_, err := u.Config.clientResourceManager.Projects.SetIamPolicy(projectId,
+		&cloudresourcemanager.SetIamPolicyRequest{
+			Policy:     policy,
+			UpdateMask: "bindings,etag,auditConfigs",
+		}).Do()
 
 	if err != nil {
 		return errwrap.Wrapf(fmt.Sprintf("Error setting IAM policy for %s: {{err}}", u.DescribeResource()), err)

--- a/third_party/terraform/utils/iam_project.go
+++ b/third_party/terraform/utils/iam_project.go
@@ -1,4 +1,3 @@
-<% autogen_exception -%>
 package google
 
 import (


### PR DESCRIPTION
Upstreams https://github.com/terraform-providers/terraform-provider-google/pull/5722

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
iam: `google_project_iam_member` and `google_project_iam_binding`'s `project` field can be specified with an optional `projects/` prefix
```
