### PR TITLE
added website, cors and lifecycle examples to storage_bucket resource

### DIFF
--- a/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -39,6 +39,43 @@ resource "google_storage_bucket" "image-store" {
 }
 ```
 
+```hcl
+resource "google_storage_bucket" "image-store" {
+  name     = "image-store.com"
+  location = "US"
+  force_destroy = true
+
+  bucket_policy_only = true
+
+  website {
+    main_page_suffix = "index.html"
+    not_found_page   = "404.html"
+  }
+  cors {
+    origin = ["http://image-store.com"]
+    method = ["GET", "HEAD", "PUT", "POST", "DELETE"]
+    response_header = ["*"]
+    max_age_seconds = 3600
+  }
+ }
+```
+
+```hcl
+resource "google_storage_bucket" "image-store" {
+  name     = "image-store-bucket"
+  location = "US"
+  force_destroy = true
+
+  lifecycle_rule {
+    condition {
+     age = "3"
+    }
+    action {
+       type = "Delete"
+    }
+  }
+}
+```
 ## Argument Reference
 
 The following arguments are supported:

--- a/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -27,8 +27,8 @@ determined which will require enabling the compute api.
 
 ```hcl
 resource "google_storage_bucket" "static-site" {
-  name     = "image-store.com"
-  location = "EU"
+  name          = "image-store.com"
+  location      = "EU"
   force_destroy = true
 
   bucket_policy_only = true
@@ -38,25 +38,25 @@ resource "google_storage_bucket" "static-site" {
     not_found_page   = "404.html"
   }
   cors {
-    origin = ["http://image-store.com"]
-    method = ["GET", "HEAD", "PUT", "POST", "DELETE"]
+    origin          = ["http://image-store.com"]
+    method          = ["GET", "HEAD", "PUT", "POST", "DELETE"]
     response_header = ["*"]
     max_age_seconds = 3600
   }
- }
+}
 ```
 
 ## Example Usage - Life cycle settings for storage bucket objects
 
 ```hcl
 resource "google_storage_bucket" "auto-expire" {
-  name     = "auto-expiring-bucket"
-  location = "US"
+  name          = "auto-expiring-bucket"
+  location      = "US"
   force_destroy = true
 
   lifecycle_rule {
     condition {
-    age = "3"
+      age = "3"
     }
     action {
       type = "Delete"

--- a/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -23,26 +23,12 @@ and
 determined which will require enabling the compute api.
 
 
-## Example Usage
-
-Example creating a private bucket in standard storage, in the EU region.
+## Example Usage - creating a private bucket in standard storage, in the EU region. Bucket configured as static website and CORS configurations
 
 ```hcl
-resource "google_storage_bucket" "image-store" {
-  name     = "image-store-bucket"
-  location = "EU"
-
-  website {
-    main_page_suffix = "index.html"
-    not_found_page   = "404.html"
-  }
-}
-```
-
-```hcl
-resource "google_storage_bucket" "image-store" {
+resource "google_storage_bucket" "static-site" {
   name     = "image-store.com"
-  location = "US"
+  location = "EU"
   force_destroy = true
 
   bucket_policy_only = true
@@ -60,18 +46,20 @@ resource "google_storage_bucket" "image-store" {
  }
 ```
 
+## Example Usage - Life cycle settings for storage bucket objects
+
 ```hcl
-resource "google_storage_bucket" "image-store" {
-  name     = "image-store-bucket"
+resource "google_storage_bucket" "auto-expire" {
+  name     = "auto-expiring-bucket"
   location = "US"
   force_destroy = true
 
   lifecycle_rule {
     condition {
-     age = "3"
+    age = "3"
     }
     action {
-       type = "Delete"
+      type = "Delete"
     }
   }
 }


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/2810