### PR TITLE
Add 404-retries for pubsub and poll async utils

### DIFF
--- a/api/async.rb
+++ b/api/async.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc.
+# Copyright 2020 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/products/cloudrun/api.yaml
+++ b/products/cloudrun/api.yaml
@@ -33,12 +33,6 @@ objects:
       api: 'https://cloud.google.com/run/docs/reference/rest/v1alpha1/projects.locations.domainmappings'
   description: |-
     Resource to hold the state and status of a user's domain mapping.
-  async: !ruby/object:Api::PollAsync
-    actions: ['create', 'update']
-    operation: !ruby/object:Api::PollAsync::Operation
-      timeouts: !ruby/object:Api::Timeouts
-          insert_minutes: 6
-          update_minutes: 6
   input: true
   parameters:
   - !ruby/object:Api::Type::String
@@ -225,13 +219,6 @@ objects:
   name: Service
   kind: Service
   base_url: apis/serving.knative.dev/v1/namespaces/{{project}}/services
-  async: !ruby/object:Api::PollAsync
-    actions: ['create', 'update']
-    operation: !ruby/object:Api::PollAsync::Operation
-      timeouts: !ruby/object:Api::Timeouts
-          insert_minutes: 6
-          update_minutes: 6
-          delete_minutes: 4
   references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Official Documentation':

--- a/products/cloudrun/terraform.yaml
+++ b/products/cloudrun/terraform.yaml
@@ -16,6 +16,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   DomainMapping: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: "locations/{{location}}/namespaces/{{project}}/domainmappings/{{name}}"
     import_format: ["locations/{{location}}/namespaces/{{project}}/domainmappings/{{name}}"]
+    async: !ruby/object:Provider::Terraform::PollAsync
+      check_response_func: PollCheckKnativeStatus
+      actions: ['create', 'update']
+      operation: !ruby/object:Api::Async::Operation
+        timeouts: !ruby/object:Api::Timeouts
+          insert_minutes: 6
+          update_minutes: 6
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "cloud_run_domain_mapping_basic"
@@ -50,6 +57,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   Service: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: "locations/{{location}}/namespaces/{{project}}/services/{{name}}"
     import_format: ["locations/{{location}}/namespaces/{{project}}/services/{{name}}"]
+    async: !ruby/object:Provider::Terraform::PollAsync
+      check_response_func: PollCheckKnativeStatus
+      actions: ['create', 'update']
+      operation: !ruby/object:Api::Async::Operation
+        timeouts: !ruby/object:Api::Timeouts
+          insert_minutes: 6
+          update_minutes: 6
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "cloud_run_service_basic"

--- a/products/pubsub/api.yaml
+++ b/products/pubsub/api.yaml
@@ -27,10 +27,18 @@ apis_required:
 objects:
   - !ruby/object:Api::Resource
     name: 'Topic'
-    base_url: projects/{{project}}/topics
-    create_verb: :PUT
     description: |
       A named resource to which messages are sent by publishers.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Managing Topics':
+          'https://cloud.google.com/pubsub/docs/admin#managing_topics'
+      api: 'https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics'
+    base_url: projects/{{project}}/topics
+    create_verb: :PUT
+    update_verb: :PATCH
+    update_mask: true
+    update_url: projects/{{project}}/topics/{{name}}
     iam_policy: !ruby/object:Api::Resource::IamPolicy
       exclude: false
       method_name_separator: ':'
@@ -48,7 +56,6 @@ objects:
           to messages published on this topic. Your project's PubSub service account
           (`service-{{PROJECT_NUMBER}}@gcp-sa-pubsub.iam.gserviceaccount.com`) must have
           `roles/cloudkms.cryptoKeyEncrypterDecrypter` to use this feature.
-          
           The expected format is `projects/*/locations/*/keyRings/*/cryptoKeys/*`
         input: true
       - !ruby/object:Api::Type::KeyValuePairs
@@ -73,29 +80,21 @@ objects:
               and is not a valid configuration.
             item_type: Api::Type::String
             required: true
-    update_verb: :PATCH
-    update_mask: true
-    update_url: projects/{{project}}/topics/{{name}}
-    references: !ruby/object:Api::Resource::ReferenceLinks
-      guides:
-        'Managing Topics':
-          'https://cloud.google.com/pubsub/docs/admin#managing_topics'
-      api: 'https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics'
   - !ruby/object:Api::Resource
     name: 'Subscription'
-    base_url: projects/{{project}}/subscriptions
-    create_verb: :PUT
     description: |
       A named resource representing the stream of messages from a single,
       specific topic, to be delivered to the subscribing application.
-    update_verb: :PATCH
-    update_mask: true
-    update_url: projects/{{project}}/subscriptions/{{name}}
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Managing Subscriptions':
           'https://cloud.google.com/pubsub/docs/admin#managing_subscriptions'
       api: 'https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions'
+    base_url: projects/{{project}}/subscriptions
+    create_verb: :PUT
+    update_verb: :PATCH
+    update_mask: true
+    update_url: projects/{{project}}/subscriptions/{{name}}
     iam_policy: !ruby/object:Api::Resource::IamPolicy
       exclude: true
       method_name_separator: ':'

--- a/products/pubsub/terraform.yaml
+++ b/products/pubsub/terraform.yaml
@@ -14,6 +14,21 @@
 --- !ruby/object:Provider::Terraform::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
   Topic: !ruby/object:Overrides::Terraform::ResourceOverride
+    # PubSub resources don't have operations but are negatively cached
+    # and eventually consistent.
+    # Because some users check whether the PubSub resource exists prior
+    # to applying a new resource, we need to add this PollAsync to GET the
+    # resource until it exists and the negative cached result goes away.
+    # Context: terraform-providers/terraform-provider-google#4993
+    async: !ruby/object:Provider::Terraform::PollAsync
+      check_response_func: PollCheckForExistence
+      actions: ['create']
+      operation: !ruby/object:Api::Async::Operation
+        timeouts: !ruby/object:Api::Timeouts
+          insert_minutes: 6
+          update_minutes: 6
+          delete_minutes: 4
+      suppress_error: true
     error_retry_predicates: ["pubsubTopicProjectNotReady"]
     iam_policy: !ruby/object:Api::Resource::IamPolicy
       parent_resource_attribute: 'topic'
@@ -49,6 +64,21 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       encoder: templates/terraform/encoders/no_send_name.go.erb
       update_encoder: templates/terraform/update_encoder/pubsub_topic.erb
   Subscription: !ruby/object:Overrides::Terraform::ResourceOverride
+    # PubSub resources don't have operations but are negatively cached
+    # and eventually consistent.
+    # Because some users check whether the PubSub resource exists prior
+    # to applying a new resource, we need to add this PollAsync to GET the
+    # resource until it exists and the negative cached result goes away.
+    # Context: terraform-providers/terraform-provider-google#4993
+    async: !ruby/object:Provider::Terraform::PollAsync
+      check_response_func: PollCheckForExistence
+      actions: ['create']
+      operation: !ruby/object:Api::Async::Operation
+        timeouts: !ruby/object:Api::Timeouts
+          insert_minutes: 6
+          update_minutes: 6
+          delete_minutes: 4
+      suppress_error: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "pubsub_subscription_push"

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -12,6 +12,7 @@
 # limitations under the License.
 
 require 'provider/abstract_core'
+require 'provider/terraform/async'
 require 'provider/terraform/config'
 require 'provider/terraform/import'
 require 'provider/terraform/custom_code'

--- a/provider/terraform/async.rb
+++ b/provider/terraform/async.rb
@@ -1,0 +1,43 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'api/async'
+require 'provider/abstract_core'
+
+module Provider
+  class Terraform < Provider::AbstractCore
+    # Async implementation for polling in Terraform
+    class PollAsync < Api::Async
+      # Details how to poll for an eventually-consistent resource state.
+
+      # Function to call for checking the Poll response
+      attr_reader :check_response_func
+
+      # Custom code to get a poll response, if needed.
+      # Will default to same logic as Read() to get current resource
+      attr_reader :custom_poll_read
+
+      # If true, will suppress errors from polling and default to the
+      # result of the final Read()
+      attr_reader :suppress_error
+
+      def validate
+        super
+
+        check :check_response_func, type: String, required: true
+        check :custom_poll_read, type: String
+        check :suppress_error, type: :boolean, default: false
+      end
+    end
+  end
+end

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -576,7 +576,6 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
             return fmt.Errorf("Error updating <%= object.name -%> %q: %s", d.Id(), err)
         }
 
-
 <%      if object.async&.allow?('update') -%>
 <%          if object.async.is_a? Api::OpAsync-%>
         err = <%= client_name_camel -%>OperationWaitTime(
@@ -664,26 +663,17 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
         project = parts[1]
     }
 <%  end -%>
-<%  if object.async&.allow?('update') && object.async.operation&.result&.resource_inside_response -%>
-    res, err = sendRequestWithTimeout(config, "<%= object.update_verb -%>", <% if has_project || object.supports_indirect_user_project_override %>project<% else %>""<% end %>, url, obj, d.Timeout(schema.TimeoutUpdate)<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
+<%  if object.async.is_a? Api::OpAsync-%>
+    res, err := sendRequestWithTimeout(config, "<%= object.update_verb -%>", <% if has_project || object.supports_indirect_user_project_override %>project<% else %>""<% end %>, url, obj, d.Timeout(schema.TimeoutUpdate)<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
 <%  else -%>
     _, err = sendRequestWithTimeout(config, "<%= object.update_verb -%>", <% if has_project || object.supports_indirect_user_project_override %>project<% else %>""<% end %>, url, obj, d.Timeout(schema.TimeoutUpdate)<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
-<% end -%>
+<%  end -%>
+
     if err != nil {
         return fmt.Errorf("Error updating <%= object.name -%> %q: %s", d.Id(), err)
     }
 
 <%  if object.async&.allow?('update') -%>
-<%    if object.async.is_a? Provider::Terraform::PollAsync -%>
-    err = PollingWaitTime(resource<%= resource_name -%>PollRead(d, meta), <%= object.async.check_response_func -%>, "Updating <%= object.name -%>", d.Timeout(schema.TimeoutUpdate))
-    if err != nil {
-<%      if object.async.suppress_error-%>
-        log.Printf("[ERROR] Unable to confirm eventually consistent <%= object.name -%> %q finished updating: %q", d.Id(), err)
-<%      else -%>
-        return err
-<%      end -%>
-    }
-<%    end -%>
 <%    if object.async.is_a? Api::OpAsync -%>
     err = <%= client_name_camel -%>OperationWaitTime(
         config, res, <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
@@ -691,6 +681,15 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
 
     if err != nil {
         return err
+    }
+<%    elsif object.async.is_a? Provider::Terraform::PollAsync -%>
+    err = PollingWaitTime(resource<%= resource_name -%>PollRead(d, meta), <%= object.async.check_response_func -%>, "Updating <%= object.name -%>", d.Timeout(schema.TimeoutUpdate))
+    if err != nil {
+<%      if object.async.suppress_error-%>
+        log.Printf("[ERROR] Unable to confirm eventually consistent <%= object.name -%> %q finished updating: %q", d.Id(), err)
+<%      else -%>
+        return err
+<%      end -%>
     }
 <%    end -%>
 <%  end -%>

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -215,23 +215,20 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     }
     d.SetId(id)
 
-<%  if !object.async.nil? && object.async.allow?('create') -%>
-<%    if object.async.is_a? Api::PollAsync -%>
-    waitURL, err := replaceVars(d, config, "<%= "{{#{object.__product.name}BasePath}}#{object.self_link_uri}" -%>")
+<%  if object.async&.allow?('create') -%>
+<%    if object.async.is_a? Provider::Terraform::PollAsync -%>
+    err = PollingWaitTime(resource<%= resource_name -%>PollRead(d, meta), <%= object.async.check_response_func -%>, "Creating <%= object.name -%>", d.Timeout(schema.TimeoutCreate))
     if err != nil {
-        return err
-    }
-
-    err = <%= client_name_camel -%>PollingWaitTime(
-    config, res,<% if has_project -%> project, <% end -%> waitURL, "Creating <%= object.name -%>",
-        int(d.Timeout(schema.TimeoutCreate).Minutes()))
-
-    if err != nil {
-<%      if object.custom_code.post_create_failure -%>
+<%      if object.async.suppress_error -%>
+        log.Printf("[ERROR] Unable to confirm eventually consistent <%= object.name -%> %q finished updating: %q", d.Id(), err)
+<%      else -%>
+<%        if object.custom_code.post_create_failure -%>
         resource<%= resource_name -%>PostCreateFailure(d, meta)
-<%      end -%>
+<%        end -%>
         return fmt.Errorf("Error waiting to create <%= object.name -%>: %s", err)
+<%        end -%>
     }
+
 <%    end -%>
 <%    if object.async.is_a? Api::OpAsync -%>
 <%      if object.async.result.resource_inside_response and not object.identity.empty? -%>
@@ -309,6 +306,70 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     return resource<%= resource_name -%>Read(d, meta)
 <%  end # if custom_create  -%>
 }
+
+<%  if object.async&.is_a? Provider::Terraform::PollAsync -%>
+func resource<%= resource_name -%>PollRead(d *schema.ResourceData, meta interface{}) PollReadFunc {
+    return func() (map[string]interface{}, error) {
+<%    if object.async.custom_poll_read -%>
+<%= lines(compile(object.async.custom_poll_read)) -%>
+<%    else -%>
+        config := meta.(*Config)
+
+        url, err := replaceVars(d, config, "<%= "{{#{object.__product.name}BasePath}}#{object.self_link_uri}" -%>")
+        if err != nil {
+            return nil, err
+        }
+
+    <%  if has_project -%>
+        project, err := getProject(d, config)
+        if err != nil {
+            return nil, err
+        }
+    <%  end -%>
+    <%  if object.supports_indirect_user_project_override -%>
+        var project string
+        if parts := regexp.MustCompile(`projects\/([^\/]+)\/`).FindStringSubmatch(url); parts != nil {
+            project = parts[1]
+        }
+    <%  end -%>
+        res, err := sendRequest(config, "<%= object.read_verb.to_s.upcase -%>", <% if has_project || object.supports_indirect_user_project_override %>project<% else %>""<% end %>, url, nil<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
+        if err != nil {
+            return res, err
+        }
+    <%  if object.nested_query -%>
+        res, err = flattenNested<%= resource_name -%>(d, meta, res)
+        if err != nil {
+            return nil, err
+        }
+
+        if res == nil {
+            // Nested object not found, spoof a 404 error for poll
+            return nil, &googleapi.Error{
+                Code: 404,
+                Message: "nested object <%= resource_name%> not found",
+            }
+        }
+
+    <%  end -%>
+    <%  if object.custom_code.decoder -%>
+        res, err = resource<%= resource_name -%>Decoder(d, meta, res)
+        if err != nil {
+            return nil, err
+        }
+        if res == nil {
+            // Decoded object not found, spoof a 404 error for poll
+            return nil, &googleapi.Error{
+                Code: 404,
+                Message: "could not find object <%= resource_name%>",
+            }
+        }
+
+    <%  end -%>
+        return res, nil
+<%    end # ifelse object.async.custom_poll_read -%>
+    }
+}
+<%  end -%>
 
 func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{}) error {
     config := meta.(*Config)
@@ -506,37 +567,34 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
             project = parts[1]
         }
 <%      end -%>
-<%      if object.async.nil? -%>
-        _, err = sendRequestWithTimeout(config, "<%= key[:update_verb] -%>", <% if has_project || object.supports_indirect_user_project_override %>project<% else %>""<% end %>, url, obj, d.Timeout(schema.TimeoutUpdate)<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
-<%      else -%>
+<%      if object.async.is_a? Api::OpAsync-%>
         res, err := sendRequestWithTimeout(config, "<%= key[:update_verb] -%>", <% if has_project || object.supports_indirect_user_project_override %>project<% else %>""<% end %>, url, obj, d.Timeout(schema.TimeoutUpdate)<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
+<%      else -%>
+        _, err = sendRequestWithTimeout(config, "<%= key[:update_verb] -%>", <% if has_project || object.supports_indirect_user_project_override %>project<% else %>""<% end %>, url, obj, d.Timeout(schema.TimeoutUpdate)<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
 <%      end -%>
         if err != nil {
             return fmt.Errorf("Error updating <%= object.name -%> %q: %s", d.Id(), err)
         }
 
-<%      if !object.async.nil? && object.async.allow?('update') -%>
-<%        if object.async.is_a? Api::PollAsync -%>
-        waitURL, err := replaceVars(d, config, "<%= "{{#{object.__product.name}BasePath}}#{object.self_link_uri}" -%>")
-        if err != nil {
-            return err
-        }
 
-        err = <%= client_name_camel -%>PollingWaitTime(
-            config, res, <% if has_project -%> project, <% end -%> waitURL, "Updating <%= object.name -%>",
-            int(d.Timeout(schema.TimeoutUpdate).Minutes()))
-        if err != nil {
-            return err
-        }
-<%        end -%>
-<%        if object.async.is_a? Api::OpAsync -%>
+<%      if object.async&.allow?('update') -%>
+<%          if object.async.is_a? Api::OpAsync-%>
         err = <%= client_name_camel -%>OperationWaitTime(
             config, res, <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
             int(d.Timeout(schema.TimeoutUpdate).Minutes()))
         if err != nil {
             return err
         }
-<%        end -%>
+<%          elsif object.async.is_a? Provider::Terraform::PollAsync -%>
+        err = PollingWaitTime(resource<%= resource_name -%>PollRead(d, meta), <%= object.async.check_response_func -%>, "Updating <%= object.name -%>", d.Timeout(schema.TimeoutUpdate))
+        if err != nil {
+<%              if object.async.suppress_error-%>
+        log.Printf("[ERROR] Unable to confirm eventually consistent <%= object.name -%> %q finished updating: %q", d.Id(), err)
+<%              else -%>
+        return err
+<%              end -%>
+        }
+<%          end -%>
 <%      end -%>
 
 <%      props.each do |prop|    -%>
@@ -606,29 +664,24 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
         project = parts[1]
     }
 <%  end -%>
-<%  if object.async.nil? -%>
-    _, err = sendRequestWithTimeout(config, "<%= object.update_verb -%>", <% if has_project || object.supports_indirect_user_project_override %>project<% else %>""<% end %>, url, obj, d.Timeout(schema.TimeoutUpdate)<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
+<%  if object.async&.allow?('update') && object.async.operation&.result&.resource_inside_response -%>
+    res, err = sendRequestWithTimeout(config, "<%= object.update_verb -%>", <% if has_project || object.supports_indirect_user_project_override %>project<% else %>""<% end %>, url, obj, d.Timeout(schema.TimeoutUpdate)<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
 <%  else -%>
-    res, err := sendRequestWithTimeout(config, "<%= object.update_verb -%>", <% if has_project || object.supports_indirect_user_project_override %>project<% else %>""<% end %>, url, obj, d.Timeout(schema.TimeoutUpdate)<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
+    _, err = sendRequestWithTimeout(config, "<%= object.update_verb -%>", <% if has_project || object.supports_indirect_user_project_override %>project<% else %>""<% end %>, url, obj, d.Timeout(schema.TimeoutUpdate)<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
 <% end -%>
-
     if err != nil {
-    return fmt.Errorf("Error updating <%= object.name -%> %q: %s", d.Id(), err)
+        return fmt.Errorf("Error updating <%= object.name -%> %q: %s", d.Id(), err)
     }
 
-<%  if !object.async.nil? && object.async.allow?('update') -%>
-<%    if object.async.is_a? Api::PollAsync -%>
-    waitURL, err := replaceVars(d, config, "<%= "{{#{object.__product.name}BasePath}}#{object.self_link_uri}" -%>")
+<%  if object.async&.allow?('update') -%>
+<%    if object.async.is_a? Provider::Terraform::PollAsync -%>
+    err = PollingWaitTime(resource<%= resource_name -%>PollRead(d, meta), <%= object.async.check_response_func -%>, "Updating <%= object.name -%>", d.Timeout(schema.TimeoutUpdate))
     if err != nil {
+<%      if object.async.suppress_error-%>
+        log.Printf("[ERROR] Unable to confirm eventually consistent <%= object.name -%> %q finished updating: %q", d.Id(), err)
+<%      else -%>
         return err
-    }
-
-    err = <%= client_name_camel -%>PollingWaitTime(
-        config, res, <% if has_project -%> project, <% end -%> waitURL, "Updating <%= object.name -%>",
-        int(d.Timeout(schema.TimeoutUpdate).Minutes()))
-
-    if err != nil {
-        return err
+<%      end -%>
     }
 <%    end -%>
 <%    if object.async.is_a? Api::OpAsync -%>
@@ -704,7 +757,7 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
         return handleNotFoundError(err, d, "<%= object.name -%>")
     }
 
-<%  if !object.async.nil? && object.async.allow?('delete') -%>
+<%  if object.async&.allow?('delete') -%>
     err = <%= client_name_camel -%>OperationWaitTime(
         config, res, <% if has_project -%> project, <% end -%> "Deleting <%= object.name -%>",
         int(d.Timeout(schema.TimeoutDelete).Minutes()))

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -226,7 +226,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
         resource<%= resource_name -%>PostCreateFailure(d, meta)
 <%        end -%>
         return fmt.Errorf("Error waiting to create <%= object.name -%>: %s", err)
-<%        end -%>
+<%      end -%>
     }
 
 <%    end -%>

--- a/third_party/terraform/utils/common_polling.go
+++ b/third_party/terraform/utils/common_polling.go
@@ -1,0 +1,55 @@
+package google
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+type (
+	// Function handling for polling for a resource
+	PollReadFunc func() (resp map[string]interface{}, respErr error)
+
+	// Function to check the response from polling once
+	PollCheckResponseFunc func(resp map[string]interface{}, respErr error) PollResult
+
+	PollResult *resource.RetryError
+)
+
+// Helper functions to construct result of single pollRead as return result for a PollCheckResponseFunc
+func ErrorPollResult(err error) PollResult {
+	return resource.NonRetryableError(err)
+}
+
+func PendingStatusPollResult(status string) PollResult {
+	return resource.RetryableError(fmt.Errorf("got pending status %q", status))
+}
+
+func SuccessPollResult() PollResult {
+	return nil
+}
+
+func PollingWaitTime(pollF PollReadFunc, checkResponse PollCheckResponseFunc, activity string, timeout time.Duration) error {
+	log.Printf("[DEBUG] %s: Polling until expected state is read", activity)
+	return resource.Retry(timeout, func() *resource.RetryError {
+		readResp, readErr := pollF()
+		return checkResponse(readResp, readErr)
+	})
+}
+
+/**
+ * Common PollCheckResponseFunc implementations
+ */
+
+// PollCheckForExistence waits for a successful response, continues polling on 404, and returns any other error.
+func PollCheckForExistence(_ map[string]interface{}, respErr error) PollResult {
+	if respErr != nil {
+		if isGoogleApiErrorWithCode(respErr, 404) {
+			return PendingStatusPollResult("not found")
+		}
+		return ErrorPollResult(respErr)
+	}
+	return SuccessPollResult()
+}


### PR DESCRIPTION
- Add PollWaitTime util for generic polling
- Add PollWaiter interface and changed Cloud Run polling to match
- Added two generic PollWaiters, one for 404-checking and one for matching state
- Added PollAsync to pubsub

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
pubsub: Add polling to ensure correct resource state for negative-cached PubSub resources 
```

Fixes https://github.com/GoogleCloudPlatform/magic-modules/pull/3155
