### PR TITLE
Add packet mirroring to beta.

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -7593,9 +7593,9 @@ objects:
         description: |
             A means of specifying which resources to mirror.
         at_least_one_of:
-            - subnetworks
-            - instances
-            - tags
+            - mirrored_resources.0.subnetworks
+            - mirrored_resources.0.instances
+            - mirrored_resources.0.tags
         properties:
           - !ruby/object:Api::Type::Array
             name: subnetworks

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -7592,13 +7592,13 @@ objects:
         required: true
         description: |
             A means of specifying which resources to mirror.
-        at_least_one_of:
-            - mirrored_resources.0.subnetworks
-            - mirrored_resources.0.instances
-            - mirrored_resources.0.tags
         properties:
           - !ruby/object:Api::Type::Array
             name: subnetworks
+            at_least_one_of:
+                - mirrored_resources.0.subnetworks
+                - mirrored_resources.0.instances
+                - mirrored_resources.0.tags
             description: |
                 All instances in one of these subnetworks will be mirrored.
             item_type: !ruby/object:Api::Type::NestedObject
@@ -7613,6 +7613,10 @@ objects:
             name: instances
             description: |
                 All the listed instances will be mirrored.  Specify at most 50.
+            at_least_one_of:
+                - mirrored_resources.0.subnetworks
+                - mirrored_resources.0.instances
+                - mirrored_resources.0.tags
             item_type: !ruby/object:Api::Type::NestedObject
               name: instances
               description: The instances that should be mirrored.
@@ -7623,6 +7627,10 @@ objects:
                   required: true
           - !ruby/object:Api::Type::Array
             name: tags
+            at_least_one_of:
+                - mirrored_resources.0.subnetworks
+                - mirrored_resources.0.instances
+                - mirrored_resources.0.tags
             description: |
                 All instances with these tags will be mirrored.
             item_type: Api::Type::String

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -3164,6 +3164,16 @@ objects:
         name: 'creationTimestamp'
         description: 'Creation timestamp in RFC3339 text format.'
         output: true
+      - !ruby/object:Api::Type::Boolean
+        name: 'isMirroringCollector'
+        description: |
+            Indicates whether or not this load balancer can be used
+            as a collector for packet mirroring. To prevent mirroring loops,
+            instances behind this load balancer will not have their traffic
+            mirrored even if a PacketMirroring rule applies to them. This
+            can only be set to true for load balancers that have their
+            loadBalancingScheme set to INTERNAL.
+        min_version: beta
       - !ruby/object:Api::Type::String
         name: 'description'
         description: |
@@ -7476,6 +7486,147 @@ objects:
             values:
               - :RESTART_NODE_ON_ANY_SERVER
               - :RESTART_NODE_ON_MINIMAL_SERVERS
+  - !ruby/object:Api::Resource
+    name: 'PacketMirroring'
+    min_version: beta
+    base_url: projects/{{project}}/regions/{{region}}/packetMirrorings
+    update_verb: :PATCH
+    self_link: projects/{{project}}/regions/{{region}}/packetMirrorings/{{name}}
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Using Packet Mirroring': 'https://cloud.google.com/vpc/docs/using-packet-mirroring#creating'
+      api: 'https://cloud.google.com/compute/docs/reference/rest/v1/packetMirroring'
+    description: |
+      Packet Mirroring mirrors traffic to and from particular VM instances.
+      You can use the collected traffic to help you detect security threats
+      and monitor application performance.
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+        kind: 'compute#operation'
+        path: 'name'
+        base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
+        wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+        path: 'targetLink'
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'status'
+        complete: 'DONE'
+        allowed:
+          - 'PENDING'
+          - 'RUNNING'
+          - 'DONE'
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error/errors'
+        message: 'message'
+
+    properties:
+      - !ruby/object:Api::Type::String
+        name: name
+        description: The name of the packet mirroring rule
+        required: true
+      - !ruby/object:Api::Type::String
+        name: description 
+        description: A human-readable description of the rule.
+        input: true
+      - !ruby/object:Api::Type::String
+        name: region
+        description: The region where this rule is active.
+        required: true
+      - !ruby/object:Api::Type::NestedObject
+        name: network
+        description: |
+            Specifies the mirrored VPC network. Only packets in this network
+            will be mirrored. All mirrored VMs should have a NIC in the given
+            network. All mirrored subnetworks should belong to the given network.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: url
+            description: The full self_link URL of the network where this rule is active.
+            required: true
+        required: true
+      - !ruby/object:Api::Type::Integer
+        name: priority
+        description: |
+            Since only one rule can be active at a time, priority is
+            used to break ties in the case of two rules that apply to
+            the same instances.
+        required: true
+      - !ruby/object:Api::Type::NestedObject
+        name: collectorIlb
+        description: |
+            The Forwarding Rule resource (of type loadBalancingScheme=INTERNAL)
+            that will be used as collector for mirrored traffic. The
+            specified forwarding rule must have isMirroringCollector
+            set to true.
+        required: true
+        properties:
+          - !ruby/object:Api::Type::String
+            name: url
+            required: true
+            description: The URL of the forwarding rule.
+      - !ruby/object:Api::Type::NestedObject
+        name: filter 
+        description: |
+            A filter for mirrored traffic.  If unset, all traffic is mirrored.
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: ipProtocols
+            api_name: 'IPProtocols'
+            description: |
+                Protocols that apply as a filter on mirrored traffic.
+            item_type: !ruby/object:Api::Type::Enum
+              name: ipProtocols
+              description: Possible IP protocols to filter on.
+              values:
+                - tcp
+                - udp
+                - icmp
+          - !ruby/object:Api::Type::Array
+            name: cidrRanges
+            description: |
+                IP CIDR ranges that apply as a filter on the source (ingress) or
+                destination (egress) IP in the IP header. Only IPv4 is supported.
+            item_type: Api::Type::String
+      - !ruby/object:Api::Type::NestedObject
+        name: mirroredResources
+        required: true
+        description: |
+            A means of specifying which resources to mirror.
+        at_least_one_of:
+            - subnetworks
+            - instances
+            - tags
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: subnetworks
+            description: |
+                All instances in one of these subnetworks will be mirrored.
+            item_type: !ruby/object:Api::Type::NestedObject
+              name: subnetworks
+              description: The subnetworks that should be mirrored.  Specify at most 5.
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: url
+                  description: The URL of the subnetwork where this rule should be active.
+                  required: true
+          - !ruby/object:Api::Type::Array
+            name: instances
+            description: |
+                All the listed instances will be mirrored.  Specify at most 50.
+            item_type: !ruby/object:Api::Type::NestedObject
+              name: instances
+              description: The instances that should be mirrored.
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: url
+                  description: The URL of the instances where this rule should be active.
+                  required: true
+          - !ruby/object:Api::Type::Array
+            name: tags
+            description: |
+                All instances with these tags will be mirrored.
+            item_type: Api::Type::String
+ 
   - !ruby/object:Api::Resource
     name: 'ProjectInfo'
     base_url: projects

--- a/products/compute/inspec.yaml
+++ b/products/compute/inspec.yaml
@@ -104,6 +104,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     exclude: true
   NetworkPeeringRoutesConfig: !ruby/object:Overrides::Inspec::ResourceOverride
     exclude: true
+  PacketMirroring:  !ruby/object:Overrides::Inspec::ResourceOverride
+    exclude: true
   ProjectInfo:  !ruby/object:Overrides::Inspec::ResourceOverride
     singular_only: true
     singular_extra_examples: third_party/inspec/documentation/google_compute_project_info.md

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1130,6 +1130,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "compute_packet_mirroring_full"
         primary_resource_id: "foobar"
+        min_version: 'beta'
         vars:
           instance_name: "my-instance"
           subnetwork_name: "my-subnetwork"

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1125,6 +1125,40 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           If it is not provided, the provider region is used.
       serverBinding: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+  PacketMirroring: !ruby/object:Overrides::Terraform::ResourceOverride
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "compute_packet_mirroring_full"
+        primary_resource_id: "foobar"
+        vars:
+          instance_name: "my-instance"
+          subnetwork_name: "my-subnetwork"
+          service_name: "my-service"
+          hc_name: "my-healthcheck"
+          mirroring_name: "my-mirroring"
+          network_name: "my-network"
+
+    properties:
+      name: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validateGCPName'
+      priority: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: false
+        default_from_api: true
+      collectorIlb: !ruby/object:Overrides::Terraform::PropertyOverride
+        description: |
+            The Forwarding Rule resource (of type load_balancing_scheme=INTERNAL)
+            that will be used as collector for mirrored traffic. The
+            specified forwarding rule must have is_mirroring_collector
+            set to true.
+      region: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: false
+        default_from_api: true
+        custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
+        description: |
+          The Region in which the created address should reside.
+          If it is not provided, the provider region is used.
+
   ProjectInfo: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true
   Region: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/templates/terraform/examples/compute_packet_mirroring_full.tf.erb
+++ b/templates/terraform/examples/compute_packet_mirroring_full.tf.erb
@@ -1,5 +1,6 @@
 resource "google_compute_instance" "mirror" {
   name = "<%= ctx[:vars]['instance_name'] %>"
+  provider = google-beta
   machine_type = "n1-standard-1"
 
   boot_disk {
@@ -18,6 +19,7 @@ resource "google_compute_instance" "mirror" {
 
 resource "google_compute_packet_mirroring" "<%= ctx[:primary_resource_id] %>" {
   name = "<%= ctx[:vars]['mirroring_name'] %>"
+  provider = google-beta
   description = "bar"
   network {
     url = google_compute_network.default.self_link
@@ -38,10 +40,12 @@ resource "google_compute_packet_mirroring" "<%= ctx[:primary_resource_id] %>" {
 }
 resource "google_compute_network" "default" {
   name = "<%= ctx[:vars]['network_name'] %>"
+  provider = google-beta
 }
 
 resource "google_compute_subnetwork" "default" {
   name = "<%= ctx[:vars]['subnetwork_name'] %>"
+  provider = google-beta
   network       = google_compute_network.default.self_link
   ip_cidr_range = "10.2.0.0/16"
 
@@ -49,12 +53,14 @@ resource "google_compute_subnetwork" "default" {
 
 resource "google_compute_region_backend_service" "default" {
   name = "<%= ctx[:vars]['service_name'] %>"
+  provider = google-beta
   region        = "us-east1"
   health_checks = ["${google_compute_health_check.default.self_link}"]
 }
 
 resource "google_compute_health_check" "default" {
   name = "<%= ctx[:vars]['hc_name'] %>"
+  provider = google-beta
   check_interval_sec = 1
   timeout_sec        = 1
   tcp_health_check {
@@ -64,6 +70,7 @@ resource "google_compute_health_check" "default" {
 
 resource "google_compute_forwarding_rule" "default" {
   depends_on = [google_compute_subnetwork.default]
+  provider = google-beta
   name       = "<%= ctx[:vars]['ilb_rule_name'] %>"
 
   is_mirroring_collector = true

--- a/templates/terraform/examples/compute_packet_mirroring_full.tf.erb
+++ b/templates/terraform/examples/compute_packet_mirroring_full.tf.erb
@@ -1,0 +1,77 @@
+resource "google_compute_instance" "mirror" {
+  name = "<%= ctx[:vars]['instance_name'] %>"
+  machine_type = "n1-standard-1"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+  zone = "us-east1-b"
+
+  network_interface {
+    network = google_compute_network.default.self_link
+    access_config {
+    }
+  }
+}
+
+resource "google_compute_packet_mirroring" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['mirroring_name'] %>"
+  description = "bar"
+  network {
+    url = google_compute_network.default.self_link
+  }
+  collector_ilb {
+    url = google_compute_forwarding_rule.default.self_link
+  }
+  mirrored_resources {
+    tags = ["foo"]
+    instances {
+      url = google_compute_instance.mirror.self_link
+    }
+  }
+  filter {
+    ip_protocols = ["tcp"]
+    cidr_ranges = ["0.0.0.0/0"]
+  }
+}
+resource "google_compute_network" "default" {
+  name = "<%= ctx[:vars]['network_name'] %>"
+}
+
+resource "google_compute_subnetwork" "default" {
+  name = "<%= ctx[:vars]['subnetwork_name'] %>"
+  network       = google_compute_network.default.self_link
+  ip_cidr_range = "10.2.0.0/16"
+
+}
+
+resource "google_compute_region_backend_service" "default" {
+  name = "<%= ctx[:vars]['service_name'] %>"
+  region        = "us-east1"
+  health_checks = ["${google_compute_health_check.default.self_link}"]
+}
+
+resource "google_compute_health_check" "default" {
+  name = "<%= ctx[:vars]['hc_name'] %>"
+  check_interval_sec = 1
+  timeout_sec        = 1
+  tcp_health_check {
+    port = "80"
+  }
+}
+
+resource "google_compute_forwarding_rule" "default" {
+  depends_on = [google_compute_subnetwork.default]
+  name       = "<%= ctx[:vars]['ilb_rule_name'] %>"
+
+  is_mirroring_collector = true
+  ip_protocol            = "TCP"
+  load_balancing_scheme  = "INTERNAL"
+  backend_service        = google_compute_region_backend_service.default.self_link
+  all_ports              = true
+  network                = google_compute_network.default.self_link
+  subnetwork             = google_compute_subnetwork.default.self_link
+  network_tier           = "PREMIUM"
+}

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -692,6 +692,10 @@
       <a href="/docs/providers/google/r/compute_node_template.html">google_compute_node_template</a>
       </li>
 
+      <li<%%= sidebar_current("docs-google-compute-packet-mirroring") %>>
+      <a href="/docs/providers/google/r/compute_packet_mirroring.html">google_compute_packet_mirroring</a>
+      </li>
+
       <li<%%= sidebar_current("docs-google-compute-project-default-network-tier") %>>
       <a href="/docs/providers/google/r/compute_project_default_network_tier.html">google_compute_project_default_network_tier</a>
       </li>


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_compute_packet_mirroring`
```