### PR TITLE
Vcr provider test

### DIFF
--- a/third_party/terraform/tests/resource_pubsub_topic_test.go
+++ b/third_party/terraform/tests/resource_pubsub_topic_test.go
@@ -16,7 +16,7 @@ func TestAccPubsubTopic_update(t *testing.T) {
 
 	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(10))
 	providers := getTestAccProviders(t.Name())
-	defer closeRecorder(t.Name())
+	defer closeRecorder(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/third_party/terraform/tests/resource_pubsub_topic_test.go
+++ b/third_party/terraform/tests/resource_pubsub_topic_test.go
@@ -12,10 +12,12 @@ func TestAccPubsubTopic_update(t *testing.T) {
 	t.Parallel()
 
 	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(10))
+	providers := getTestAccProviders(t.Name())
+	defer closeRecorder(t.Name())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		Providers:    providers,
 		CheckDestroy: testAccCheckPubsubTopicDestroy,
 		Steps: []resource.TestStep{
 			{

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -4,9 +4,11 @@ package google
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"math/rand"
 	"net/http"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
@@ -74,7 +76,10 @@ var billingAccountEnvVars = []string{
 	"GOOGLE_BILLING_ACCOUNT",
 }
 
+var configs map[string]interface{}
+
 func init() {
+	configs = make(map[string]interface{})
 	testAccProvider = Provider().(*schema.Provider)
 	testAccRandomProvider = random.Provider().(*schema.Provider)
 	<% if version == 'ga' -%>
@@ -88,19 +93,32 @@ func init() {
 		"random": testAccRandomProvider,
 	}
 
+	// The OiCS provider map is used to ensure that OiCS examples use `google-beta`
+	// if the example is versioned as beta; normal beta tests should continue to
+	// use the standard provider map.
+	testAccProvidersOiCS = map[string]terraform.ResourceProvider{
+<%# Add a google-#{version} provider for each version that is supported by this version. This allows us to run google-beta tests within a google-alpha provider.  -%>
+<% Api::Product::Version::ORDER[1..Api::Product::Version::ORDER.index(version)].each do |aliased_version| -%>
+		"google-<%= aliased_version -%>": testAccProvider,
+<% end -%>
+		"random": testAccRandomProvider,
+	}
+	<% end -%>
+}
+
 var lock = &sync.Mutex{}
 
-func get(d *schema.ResourceData, old func(d *schema.ResourceData) (interface{}, error), testName string) (interface{}, error) {
+// Returns a cached config if VCR testing is enabled. This enables us to use a single HTTP transport
+// for a given test, allowing for recording of HTTP interactions.
+func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.ResourceData) (interface{}, error), testName string) (interface{}, error) {
 	lock.Lock()
 	defer lock.Unlock()
-	if _, ok := singles[testName]; !ok {
-		// No existing client found, create one.
-		single, err := old(d)
+	if _, ok := configs[testName]; !ok {
+		c, err := configureFunc(d)
 		if err != nil {
 			return nil, err
 		}
-		config := single.(*Config)
-		path := fmt.Sprintf("/Users/slevenick/go-workspace/src/github.com/terraform-providers/terraform-provider-google-beta/fixtures/%s", testName)
+		config := c.(*Config)
 		vcrMode := recorder.ModeDisabled
 		switch vcrEnv := os.Getenv("VCR_MODE"); vcrEnv {
 		case "RECORDING":
@@ -108,8 +126,16 @@ func get(d *schema.ResourceData, old func(d *schema.ResourceData) (interface{}, 
 		case "REPLAYING":
 			vcrMode = recorder.ModeReplaying
 		default:
-			return single, nil
+			log.Printf("[DEBUG] No valid environment var set for VCR_MODE, skipping VCR. VCR_MODE: %s", vcrEnv)
+			return c, nil
 		}
+
+		envPath := os.Getenv("VCR_PATH")
+		if envPath == "" {
+			log.Printf("[DEBUG] No environment var set for VCR_PATH, skipping VCR for test: %s", testName)
+			return c, nil
+		}
+		path := filepath.Join(envPath, testName)
 
 		rec, err := recorder.NewAsMode(path, vcrMode, config.client.Transport)
 		if err != nil {
@@ -127,32 +153,39 @@ func get(d *schema.ResourceData, old func(d *schema.ResourceData) (interface{}, 
 			return cassette.DefaultMatcher(r, i) && (b.String() == "" || b.String() == i.Body)
 		})
 		config.client.Transport = rec
-		singles[testName] = single
-		return single, err
+		configs[testName] = c
+		return c, err
 	}
-	return singles[testName], nil
+	return configs[testName], nil
 }
 
 // We need to explicitly close the VCR recorder to save the cassette
 func closeRecorder(testName string) {
-	if config, ok := singles[testName]; ok {
+	if config, ok := configs[testName]; ok {
+		// We did not cache the config if it does not use VCR
 		config.(*Config).client.Transport.(*recorder.Recorder).Stop()
-		// Clean up test provider
-		delete(singles, testName)
+		// Clean up test config
+		delete(configs, testName)
 	}
 }
 
-	// The OiCS provider map is used to ensure that OiCS examples use `google-beta`
-	// if the example is versioned as beta; normal beta tests should continue to
-	// use the standard provider map.
-	testAccProvidersOiCS = map[string]terraform.ResourceProvider{
-<%# Add a google-#{version} provider for each version that is supported by this version. This allows us to run google-beta tests within a google-alpha provider.  -%>
-<% Api::Product::Version::ORDER[1..Api::Product::Version::ORDER.index(version)].each do |aliased_version| -%>
-		"google-<%= aliased_version -%>": testAccProvider,
-<% end -%>
-		"random": testAccRandomProvider,
+func getTestAccProviders(testName string) map[string]terraform.ResourceProvider {
+	prov := Provider().(*schema.Provider)
+	provRand := random.Provider().(*schema.Provider)
+	if v := os.Getenv("VCR_ENABLED"); v != "" {
+		old := prov.ConfigureFunc
+		ap.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {
+			r, err := getCachedConfig(d, old, testName)
+			return r, err
+		}
+	} else {
+		log.Print("[DEBUG] No environment var set for VCR_ENABLED, skipping VCR")
 	}
-	<% end -%>
+	// TODO(slevenick): Add OICS provider
+	return map[string]terraform.ResourceProvider{
+		"google": prov,
+		"random": provRand,
+	}
 }
 
 func TestProvider(t *testing.T) {

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -76,10 +76,10 @@ var billingAccountEnvVars = []string{
 	"GOOGLE_BILLING_ACCOUNT",
 }
 
-var configs map[string]interface{}
+var configs map[string]*Config
 
 func init() {
-	configs = make(map[string]interface{})
+	configs = make(map[string]*Config)
 	testAccProvider = Provider().(*schema.Provider)
 	testAccRandomProvider = random.Provider().(*schema.Provider)
 	<% if version == 'ga' -%>
@@ -110,60 +110,64 @@ var lock = &sync.Mutex{}
 
 // Returns a cached config if VCR testing is enabled. This enables us to use a single HTTP transport
 // for a given test, allowing for recording of HTTP interactions.
-func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.ResourceData) (interface{}, error), testName string) (interface{}, error) {
+func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.ResourceData) (interface{}, error), testName string) (*Config, error) {
 	lock.Lock()
 	defer lock.Unlock()
-	if _, ok := configs[testName]; !ok {
-		c, err := configureFunc(d)
-		if err != nil {
-			return nil, err
-		}
-		config := c.(*Config)
-		vcrMode := recorder.ModeDisabled
-		switch vcrEnv := os.Getenv("VCR_MODE"); vcrEnv {
-		case "RECORDING":
-			vcrMode = recorder.ModeRecording
-		case "REPLAYING":
-			vcrMode = recorder.ModeReplaying
-		default:
-			log.Printf("[DEBUG] No valid environment var set for VCR_MODE, skipping VCR. VCR_MODE: %s", vcrEnv)
-			return c, nil
-		}
-
-		envPath := os.Getenv("VCR_PATH")
-		if envPath == "" {
-			log.Print("[DEBUG] No environment var set for VCR_PATH, skipping VCR")
-			return c, nil
-		}
-		path := filepath.Join(envPath, testName)
-
-		rec, err := recorder.NewAsMode(path, vcrMode, config.client.Transport)
-		if err != nil {
-			return nil, err
-		}
-		rec.SetMatcher(func(r *http.Request, i cassette.Request) bool {
-			if r.Body == nil {
-				return cassette.DefaultMatcher(r, i)
-			}
-			var b bytes.Buffer
-			if _, err := b.ReadFrom(r.Body); err != nil {
-				return false
-			}
-			r.Body = ioutil.NopCloser(&b)
-			return cassette.DefaultMatcher(r, i) && (b.String() == "" || b.String() == i.Body)
-		})
-		config.client.Transport = rec
-		configs[testName] = c
-		return c, err
+	if v, ok := configs[testName]; ok {
+		return v, nil
 	}
-	return configs[testName], nil
+	c, err := configureFunc(d)
+	if err != nil {
+		return nil, err
+	}
+	config := c.(*Config)
+	vcrMode := recorder.ModeDisabled
+	switch vcrEnv := os.Getenv("VCR_MODE"); vcrEnv {
+	case "RECORDING":
+		vcrMode = recorder.ModeRecording
+	case "REPLAYING":
+		vcrMode = recorder.ModeReplaying
+	default:
+		log.Printf("[DEBUG] No valid environment var set for VCR_MODE, expected RECORDING or REPLAYING, skipping VCR. VCR_MODE: %s", vcrEnv)
+		return config, nil
+	}
+
+	envPath := os.Getenv("VCR_PATH")
+	if envPath == "" {
+		log.Print("[DEBUG] No environment var set for VCR_PATH, skipping VCR")
+		return config, nil
+	}
+	path := filepath.Join(envPath, testName)
+
+	rec, err := recorder.NewAsMode(path, vcrMode, config.client.Transport)
+	if err != nil {
+		return nil, err
+	}
+	// Defines how VCR will match requests to responses.
+	rec.SetMatcher(func(r *http.Request, i cassette.Request) bool {
+		// Default matcher compares method and URL only
+		defaultMatch := cassette.DefaultMatcher(r, i)
+		if r.Body == nil {
+			return defaultMatch
+		}
+		var b bytes.Buffer
+		if _, err := b.ReadFrom(r.Body); err != nil {
+			return false
+		}
+		r.Body = ioutil.NopCloser(&b)
+		// body must match recorded body if it exists
+		return defaultMatch && ((b.String() == "" && i.Body == "") || b.String() == i.Body)
+	})
+	config.client.Transport = rec
+	configs[testName] = config
+	return config, err
 }
 
 // We need to explicitly close the VCR recorder to save the cassette
 func closeRecorder(testName string) {
 	if config, ok := configs[testName]; ok {
 		// We did not cache the config if it does not use VCR
-		config.(*Config).client.Transport.(*recorder.Recorder).Stop()
+		config.client.Transport.(*recorder.Recorder).Stop()
 		// Clean up test config
 		delete(configs, testName)
 	}
@@ -172,14 +176,15 @@ func closeRecorder(testName string) {
 func getTestAccProviders(testName string) map[string]terraform.ResourceProvider {
 	prov := Provider().(*schema.Provider)
 	provRand := random.Provider().(*schema.Provider)
-	if v := os.Getenv("VCR_ENABLED"); v != "" {
+	envPath := os.Getenv("VCR_PATH")
+	recordingMode := os.Getenv("VCR_MODE")
+	if envPath != "" && recordingMode != "" {
 		old := prov.ConfigureFunc
 		prov.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {
-			r, err := getCachedConfig(d, old, testName)
-			return r, err
+			return getCachedConfig(d, old, testName)
 		}
 	} else {
-		log.Print("[DEBUG] No environment var set for VCR_ENABLED, skipping VCR")
+		log.Print("[DEBUG] VCR_PATH or VCR_MODE not set, skipping VCR")
 	}
 	// TODO(slevenick): Add OICS provider
 	return map[string]terraform.ResourceProvider{

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -132,7 +132,7 @@ func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.Resour
 
 		envPath := os.Getenv("VCR_PATH")
 		if envPath == "" {
-			log.Printf("[DEBUG] No environment var set for VCR_PATH, skipping VCR for test: %s", testName)
+			log.Print("[DEBUG] No environment var set for VCR_PATH, skipping VCR")
 			return c, nil
 		}
 		path := filepath.Join(envPath, testName)

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -120,7 +120,7 @@ func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.Resour
 		return nil, err
 	}
 	config := c.(*Config)
-	vcrMode := recorder.ModeDisabled
+	var vcrMode recorder.Mode
 	switch vcrEnv := os.Getenv("VCR_MODE"); vcrEnv {
 	case "RECORDING":
 		vcrMode = recorder.ModeRecording
@@ -164,12 +164,15 @@ func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.Resour
 }
 
 // We need to explicitly close the VCR recorder to save the cassette
-func closeRecorder(testName string) {
-	if config, ok := configs[testName]; ok {
+func closeRecorder(t *testing.T) {
+	if config, ok := configs[t.Name()]; ok {
 		// We did not cache the config if it does not use VCR
-		config.client.Transport.(*recorder.Recorder).Stop()
+		err := config.client.Transport.(*recorder.Recorder).Stop()
+		if err != nil {
+			t.Error(err)
+		}
 		// Clean up test config
-		delete(configs, testName)
+		delete(configs, t.Name())
 	}
 }
 

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -106,13 +105,13 @@ func init() {
 	<% end -%>
 }
 
-var lock = &sync.Mutex{}
-
 // Returns a cached config if VCR testing is enabled. This enables us to use a single HTTP transport
 // for a given test, allowing for recording of HTTP interactions.
+// Why this exists: schema.Provider.ConfigureFunc is called multiple times for a given test
+// ConfigureFunc on our provider creates a new HTTP client and sets base paths (config.go LoadAndValidate)
+// VCR requires a single HTTP client to handle all interactions so it can record and replay responses so
+// this caches HTTP clients per test by replacing ConfigureFunc
 func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.ResourceData) (interface{}, error), testName string) (*Config, error) {
-	lock.Lock()
-	defer lock.Unlock()
 	if v, ok := configs[testName]; ok {
 		return v, nil
 	}
@@ -152,11 +151,12 @@ func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.Resour
 		}
 		var b bytes.Buffer
 		if _, err := b.ReadFrom(r.Body); err != nil {
+			log.Printf("[DEBUG] Failed to read request body from cassette: %v", err)
 			return false
 		}
 		r.Body = ioutil.NopCloser(&b)
-		// body must match recorded body if it exists
-		return defaultMatch && ((b.String() == "" && i.Body == "") || b.String() == i.Body)
+		// body must match recorded body
+		return defaultMatch && b.String() == i.Body
 	})
 	config.client.Transport = rec
 	configs[testName] = config

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -174,7 +174,7 @@ func getTestAccProviders(testName string) map[string]terraform.ResourceProvider 
 	provRand := random.Provider().(*schema.Provider)
 	if v := os.Getenv("VCR_ENABLED"); v != "" {
 		old := prov.ConfigureFunc
-		ap.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {
+		prov.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {
 			r, err := getCachedConfig(d, old, testName)
 			return r, err
 		}

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -4,12 +4,17 @@ package google
 import (
 	"fmt"
 	"io/ioutil"
+	"math/rand"
+	"net/http"
 	"os"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/dnaeon/go-vcr/cassette"
+	"github.com/dnaeon/go-vcr/recorder"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -82,6 +87,60 @@ func init() {
 		"google": testAccProvider,
 		"random": testAccRandomProvider,
 	}
+
+var lock = &sync.Mutex{}
+
+func get(d *schema.ResourceData, old func(d *schema.ResourceData) (interface{}, error), testName string) (interface{}, error) {
+	lock.Lock()
+	defer lock.Unlock()
+	if _, ok := singles[testName]; !ok {
+		// No existing client found, create one.
+		single, err := old(d)
+		if err != nil {
+			return nil, err
+		}
+		config := single.(*Config)
+		path := fmt.Sprintf("/Users/slevenick/go-workspace/src/github.com/terraform-providers/terraform-provider-google-beta/fixtures/%s", testName)
+		vcrMode := recorder.ModeDisabled
+		switch vcrEnv := os.Getenv("VCR_MODE"); vcrEnv {
+		case "RECORDING":
+			vcrMode = recorder.ModeRecording
+		case "REPLAYING":
+			vcrMode = recorder.ModeReplaying
+		default:
+			return single, nil
+		}
+
+		rec, err := recorder.NewAsMode(path, vcrMode, config.client.Transport)
+		if err != nil {
+			return nil, err
+		}
+		rec.SetMatcher(func(r *http.Request, i cassette.Request) bool {
+			if r.Body == nil {
+				return cassette.DefaultMatcher(r, i)
+			}
+			var b bytes.Buffer
+			if _, err := b.ReadFrom(r.Body); err != nil {
+				return false
+			}
+			r.Body = ioutil.NopCloser(&b)
+			return cassette.DefaultMatcher(r, i) && (b.String() == "" || b.String() == i.Body)
+		})
+		config.client.Transport = rec
+		singles[testName] = single
+		return single, err
+	}
+	return singles[testName], nil
+}
+
+// We need to explicitly close the VCR recorder to save the cassette
+func closeRecorder(testName string) {
+	if config, ok := singles[testName]; ok {
+		config.(*Config).client.Transport.(*recorder.Recorder).Stop()
+		// Clean up test provider
+		delete(singles, testName)
+	}
+}
 
 	// The OiCS provider map is used to ensure that OiCS examples use `google-beta`
 	// if the example is versioned as beta; normal beta tests should continue to


### PR DESCRIPTION
No user facing changes.

Adds support for VCR testing in provider_test.go, and an example of an implementation for `TestAccPubsubTopic_update`

Randomness needs to be modified for this to work, or else randomly generated suffixes will change between runs making VCR useless

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
