### PR TITLE
Adding support for google game services

### DIFF
--- a/products/gameservices/api.yaml
+++ b/products/gameservices/api.yaml
@@ -1,0 +1,489 @@
+# Copyright 2019 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: GameServices
+display_name: Google Game Services
+scopes:
+- https://www.googleapis.com/auth/compute
+versions:
+- !ruby/object:Api::Product::Version
+  name: beta
+  base_url: https://gameservices.googleapis.com/v1beta/
+
+objects:
+### Realm ###
+- !ruby/object:Api::Resource
+  name: Realm
+  references: !ruby/object:Api::Resource::ReferenceLinks
+    guides:
+      'Official Documentation': 'https://cloud.google.com/game-servers/docs'
+    api: 'https://cloud.google.com/game-servers/docs/reference/rest/v1beta/projects.locations.realms'
+  create_url: projects/{{project}}/locations/{{location}}/realms?realmId={{realm_id}}
+  base_url: projects/{{project}}/locations/{{location}}/realms/
+  self_link: projects/{{project}}/locations/{{location}}/realms/{{realm_id}}
+  update_verb: :PATCH
+  update_mask: true
+  description: A Realm resource.
+  async: !ruby/object:Api::OpAsync
+    operation: !ruby/object:Api::OpAsync::Operation
+      path: 'name'
+      base_url: '{{op_id}}'
+      wait_ms: 1000
+    result: !ruby/object:Api::OpAsync::Result
+      path: 'response'
+      resource_inside_response: true
+    status: !ruby/object:Api::OpAsync::Status
+      path: 'done'
+      complete: true
+      allowed:
+        - true
+        - false
+    error: !ruby/object:Api::OpAsync::Error
+      path: 'error/errors'
+      message: 'message'
+  parameters:
+  - !ruby/object:Api::Type::String
+    name: location
+    url_param_only: true
+    default_value: global
+    description: Location of the Realm.
+  - !ruby/object:Api::Type::String
+    name: realmId
+    input: true
+    url_param_only: true
+    required: true
+    description: GCP region of the Realm.
+  properties:
+  - !ruby/object:Api::Type::String
+    name: name
+    output: true
+    description: |-
+      The resource id of the realm, of the form:
+      `projects/{project_id}/locations/{location}/realms/{realm_id}`. For
+      example, `projects/my-project/locations/{location}/realms/my-realm`.
+  - !ruby/object:Api::Type::KeyValuePairs
+    name: labels
+    description: The labels associated with this realm. Each label is a key-value
+      pair.
+  - !ruby/object:Api::Type::String
+    name: timeZone
+    required: true
+    description: |-
+      Required. Time zone where all realm-specific policies are evaluated. The value of
+      this field must be from the IANA time zone database:
+      https://www.iana.org/time-zones.
+  - !ruby/object:Api::Type::String
+    name: etag
+    output: true
+    description: ETag of the resource.
+  - !ruby/object:Api::Type::String
+    name: description
+    description: Human readable description of the realm.
+
+### GameServerCluster ###
+- !ruby/object:Api::Resource
+  name: GameServerCluster
+  references: !ruby/object:Api::Resource::ReferenceLinks
+    guides:
+      'Official Documentation': 'https://cloud.google.com/game-servers/docs'
+    api: 'https://cloud.google.com/game-servers/docs/reference/rest/v1beta/projects.locations.realms.gameServerClusters'
+  update_verb: :PATCH
+  update_mask: true
+  base_url: projects/{{project}}/locations/{{location}}/realms/{{realm_id}}/gameServerClusters
+  create_url: projects/{{project}}/locations/{{location}}/realms/{{realm_id}}/gameServerClusters?gameServerClusterId={{cluster_id}}
+  self_link: projects/{{project}}/locations/{{location}}/realms/{{realm_id}}/gameServerClusters/{{cluster_id}}
+  description: A game server cluster resource.
+  async: !ruby/object:Api::OpAsync
+    operation: !ruby/object:Api::OpAsync::Operation
+      path: 'name'
+      base_url: '{{op_id}}'
+      wait_ms: 1000
+    result: !ruby/object:Api::OpAsync::Result
+      path: 'response'
+      resource_inside_response: true
+    status: !ruby/object:Api::OpAsync::Status
+      path: 'done'
+      complete: true
+      allowed:
+        - true
+        - false
+    error: !ruby/object:Api::OpAsync::Error
+      path: 'error/errors'
+      message: 'message'
+  properties:
+  - !ruby/object:Api::Type::String
+    input: true
+    name: clusterId
+    required: true
+    url_param_only: true
+    description: |-
+      Required. The resource name of the game server cluster
+  - !ruby/object:Api::Type::String
+    name: name
+    output: true
+    description: |-
+      The resource id of the game server cluster, eg:
+
+      `projects/{project_id}/locations/{location}/realms/{realm_id}/gameServerClusters/{cluster_id}`.
+      For example,
+
+      `projects/my-project/locations/{location}/realms/zanzibar/gameServerClusters/my-onprem-cluster`.
+  - !ruby/object:Api::Type::ResourceRef
+    name: realmId
+    url_param_only: true
+    resource: Realm
+    imports: name
+    required: true
+    description: |-
+      The realm id of the game server realm.
+  - !ruby/object:Api::Type::String
+    name: location
+    url_param_only: true
+    default_value: global
+    description: Location of the Cluster.
+  - !ruby/object:Api::Type::KeyValuePairs
+    name: labels
+    description: |-
+      The labels associated with this game server cluster. Each label is a
+      key-value pair.
+  - !ruby/object:Api::Type::NestedObject
+    name: connectionInfo
+    required: true
+    input: true
+    description: |-
+      Game server cluster connection information. This information is used to
+      manage game server clusters.
+    properties:
+    - !ruby/object:Api::Type::NestedObject
+      name: gkeClusterReference
+      required: true
+      input: true
+      description: Reference of the GKE cluster where the game servers are installed.
+      properties:
+      - !ruby/object:Api::Type::String
+        name: cluster
+        required: true
+        input: true
+        description: |-
+          The full or partial name of a GKE cluster, using one of the following
+          forms:
+
+          * `projects/{project_id}/locations/{location}/clusters/{cluster_id}`
+          * `locations/{location}/clusters/{cluster_id}`
+          * `{cluster_id}`
+
+          If project and location are not specified, the project and location of the
+          GameServerCluster resource are used to generate the full name of the
+          GKE cluster.
+    - !ruby/object:Api::Type::String
+      name: namespace
+      required: true
+      description: |-
+        Namespace designated on the game server cluster where the game server
+        instances will be created. The namespace existence will be validated
+        during creation.
+  - !ruby/object:Api::Type::String
+    name: description
+    description: Human readable description of the cluster.
+
+### GameServerDeployment ###
+- !ruby/object:Api::Resource
+  name: GameServerDeployment
+  references: !ruby/object:Api::Resource::ReferenceLinks
+    guides:
+      'Official Documentation': 'https://cloud.google.com/game-servers/docs'
+    api: 'https://cloud.google.com/game-servers/docs/reference/rest/v1beta/projects.locations.gameServerDeployments'
+  base_url: projects/{{project}}/locations/{{location}}/gameServerDeployments
+  create_url: projects/{{project}}/locations/{{location}}/gameServerDeployments?deploymentId={{deployment_id}}
+  self_link: projects/{{project}}/locations/{{location}}/gameServerDeployments/{{deployment_id}}
+  update_mask: true
+  update_verb: :PATCH
+  description: A game server deployment resource.
+  async: !ruby/object:Api::OpAsync
+    operation: !ruby/object:Api::OpAsync::Operation
+      path: 'name'
+      base_url: '{{op_id}}'
+      wait_ms: 1000
+    result: !ruby/object:Api::OpAsync::Result
+      path: 'response'
+      resource_inside_response: true
+    status: !ruby/object:Api::OpAsync::Status
+      path: 'done'
+      complete: true
+      allowed:
+        - true
+        - false
+    error: !ruby/object:Api::OpAsync::Error
+      path: 'error/errors'
+      message: 'message'
+  properties:
+  - !ruby/object:Api::Type::String
+    name: name
+    output: true
+    description: |-
+      The resource id of the game server deployment, eg:
+
+      `projects/{project_id}/locations/{location}/gameServerDeployments/{deployment_id}`.
+      For example,
+
+      `projects/my-project/locations/{location}/gameServerDeployments/my-deployment`.
+  - !ruby/object:Api::Type::String
+    name: description
+    description: Human readable description of the game server deployment.
+  - !ruby/object:Api::Type::String
+    name: deploymentId
+    input: true
+    required: true
+    url_param_only: true
+    description: |
+      A unique id for the deployment.
+  - !ruby/object:Api::Type::String
+    name: location
+    # The only acceptable location currently is 'global'
+    # TODO - either hard code or set as computed
+    url_param_only: true
+    default_value: global
+    description: Location of the Deployment.
+  - !ruby/object:Api::Type::KeyValuePairs
+    name: labels
+    description: |-
+      The labels associated with this game server deployment. Each label is a
+      key-value pair.
+
+### GameServerConfig  ###
+- !ruby/object:Api::Resource
+  name: GameServerConfig
+  references: !ruby/object:Api::Resource::ReferenceLinks
+    guides:
+      'Official Documentation': 'https://cloud.google.com/game-servers/docs'
+    api: 'https://cloud.google.com/game-servers/docs/reference/rest/v1beta/projects.locations.gameServerDeployments.configs'
+  create_url: projects/{{project}}/locations/{{location}}/gameServerDeployments/{{deployment_id}}/configs?configId={{config_id}}
+  base_url: projects/{{project}}/locations/{{location}}/gameServerDeployments/{{deployment_id}}/configs
+  self_link: projects/{{project}}/locations/{{location}}/gameServerDeployments/{{deployment_id}}/configs/{{config_id}}
+  input: true
+  async: !ruby/object:Api::OpAsync
+    operation: !ruby/object:Api::OpAsync::Operation
+      path: 'name'
+      base_url: '{{op_id}}'
+      wait_ms: 1000
+    result: !ruby/object:Api::OpAsync::Result
+      path: 'response'
+      resource_inside_response: true
+    status: !ruby/object:Api::OpAsync::Status
+      path: 'done'
+      complete: true
+      allowed:
+        - true
+        - false
+    error: !ruby/object:Api::OpAsync::Error
+      path: 'error/errors'
+      message: 'message'
+  description: A game server config resource. Configs are global and immutable.
+  properties:
+  - !ruby/object:Api::Type::String
+    name: name
+    output: true
+    description: |-
+      The resource name of the game server config, in the form:
+
+      `projects/{project_id}/locations/{location}/gameServerDeployments/{deployment_id}/configs/{config_id}`.
+  - !ruby/object:Api::Type::String
+    name: configId
+    input: true
+    required: true
+    url_param_only: true
+    description: |
+      A unique id for the deployment config.
+  - !ruby/object:Api::Type::String
+    name: location
+    # The only acceptable location currently is 'global'
+    # TODO - either hard code or set as computed
+    url_param_only: true
+    default_value: global
+    description: Location of the Deployment.
+  - !ruby/object:Api::Type::ResourceRef
+    name: deploymentId
+    resource: 'GameServerDeployment'
+    imports: 'deploymentId'
+    input: true
+    required: true
+    url_param_only: true
+    description: |
+      A unique id for the deployment.
+  - !ruby/object:Api::Type::String
+    name: description
+    description: The description of the game server config.
+  - !ruby/object:Api::Type::KeyValuePairs
+    name: labels
+    description: |-
+      The labels associated with this game server config. Each label is a
+      key-value pair.
+  - !ruby/object:Api::Type::Array
+    name: fleetConfigs
+    required: true
+    description: |-
+      The fleet config contains list of fleet specs. In the Single Cloud, there
+      will be only one.
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+      - !ruby/object:Api::Type::String
+        required: true
+        name: fleetSpec
+        description: |-
+          The fleet spec, which is sent to Agones to configure fleet. This must be a valid json payload.
+
+          The format of the spec can be found :
+          `https://agones.dev/site/docs/reference/fleet/`.
+      - !ruby/object:Api::Type::String
+        name: name
+        required: true
+        description: The name of the FleetConfig.
+  - !ruby/object:Api::Type::Array
+    name: scalingConfigs
+    description: Optional. This contains the autoscaling settings.
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+      - !ruby/object:Api::Type::String
+        name: name
+        required: true
+        description: The name of the ScalingConfig
+      - !ruby/object:Api::Type::String
+        required: true
+        name: fleetAutoscalerSpec
+        description: |-
+          Fleet autoscaler spec, which is sent to Agones.
+          Example spec can be found :
+          https://agones.dev/site/docs/reference/fleetautoscaler/
+      - !ruby/object:Api::Type::Array
+        name: selectors
+        description: |-
+          Labels used to identify the clusters to which this scaling config
+          applies. A cluster is subject to this scaling config if its labels match
+          any of the selector entries.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+          - !ruby/object:Api::Type::KeyValuePairs
+            name: labels
+            description: Set of labels to group by.
+      - !ruby/object:Api::Type::Array
+        name: schedules
+        description: The schedules to which this scaling config applies.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+          - !ruby/object:Api::Type::String
+            name: startTime
+            description: |-
+              The start time of the event.
+
+              A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: "2014-10-02T15:01:23.045123456Z".
+          - !ruby/object:Api::Type::String
+            name: endTime
+            description: |-
+              The end time of the event.
+
+              A timestamp in RFC3339 UTC "Zulu" format, accurate to nanoseconds. Example: "2014-10-02T15:01:23.045123456Z".
+          - !ruby/object:Api::Type::String
+            name: cronJobDuration
+            description: |-
+              The duration for the cron job event. The duration of the event is effective
+              after the cron job's start time.
+
+              A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s".
+          - !ruby/object:Api::Type::String
+            name: cronSpec
+            description: |-
+              The cron definition of the scheduled event. See
+              https://en.wikipedia.org/wiki/Cron. Cron spec specifies the local time as
+              defined by the realm.
+
+### GameServerDeploymentRollout ###
+- !ruby/object:Api::Resource
+  name: GameServerDeploymentRollout
+  references: !ruby/object:Api::Resource::ReferenceLinks
+    guides:
+      'Official Documentation': 'https://cloud.google.com/game-servers/docs'
+    api: 'https://cloud.google.com/game-servers/docs/reference/rest/v1beta/GameServerDeploymentRollout'
+  create_url: projects/{{project}}/locations/global/gameServerDeployments/{{deployment_id}}/rollout
+  base_url: projects/{{project}}/locations/global/gameServerDeployments/{{deployment_id}}/rollout
+  update_url: projects/{{project}}/locations/global/gameServerDeployments/{{deployment_id}}/rollout
+  # Deleting a rollout is synonymous with removing the default game server config
+  delete_url: projects/{{project}}/locations/global/gameServerDeployments/{{deployment_id}}/rollout?updateMask=defaultGameServerConfig
+  update_verb: :PATCH
+  delete_verb: :PATCH
+  update_mask: true
+  self_link: projects/{{project}}/locations/global/gameServerDeployments/{{deployment_id}}/rollout
+  async: !ruby/object:Api::OpAsync
+    operation: !ruby/object:Api::OpAsync::Operation
+      path: 'name'
+      base_url: '{{op_id}}'
+      wait_ms: 1000
+    result: !ruby/object:Api::OpAsync::Result
+      path: 'response'
+      resource_inside_response: true
+    status: !ruby/object:Api::OpAsync::Status
+      path: 'done'
+      complete: true
+      allowed:
+        - true
+        - false
+    error: !ruby/object:Api::OpAsync::Error
+      path: 'error/errors'
+      message: 'message'
+  description: |-
+    This represents the rollout state. This is part of the game server
+    deployment.
+  properties:
+  - !ruby/object:Api::Type::String
+    name: name
+    output: true
+    description: |-
+      The resource id of the game server deployment
+
+      eg: `projects/my-project/locations/global/gameServerDeployments/my-deployment/rollout`.
+  - !ruby/object:Api::Type::ResourceRef
+    name: deploymentId
+    resource: GameServerDeployment
+    url_param_only: true
+    required: true
+    imports: name
+    description: |
+      The deployment to rollout the new config to. Only 1 rollout must be associated with each deployment.
+  - !ruby/object:Api::Type::String
+    name: defaultGameServerConfig
+    required: true
+    description: |-
+      This field points to the game server config that is
+      applied by default to all realms and clusters. For example,
+
+      `projects/my-project/locations/global/gameServerDeployments/my-game/configs/my-config`.
+  - !ruby/object:Api::Type::Array
+    name: gameServerConfigOverrides
+    description: |-
+      The game_server_config_overrides contains the per game server config
+      overrides. The overrides are processed in the order they are listed. As
+      soon as a match is found for a cluster, the rest of the list is not
+      processed.
+    item_type: !ruby/object:Api::Type::NestedObject
+      properties:
+      - !ruby/object:Api::Type::NestedObject
+        name: realmsSelector
+        description: Selection by realms.
+        properties:
+        - !ruby/object:Api::Type::Array
+          name: realms
+          description: List of realms to match against.
+          item_type: Api::Type::String
+      - !ruby/object:Api::Type::String
+        name: configVersion
+        description: Version of the configuration.

--- a/products/gameservices/terraform.yaml
+++ b/products/gameservices/terraform.yaml
@@ -1,0 +1,79 @@
+# Copyright 2019 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Terraform::Config
+overrides: !ruby/object:Overrides::ResourceOverrides
+  Realm: !ruby/object:Overrides::Terraform::ResourceOverride
+    autogen_async: true
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        min_version: beta
+        name: "game_service_realm_basic"
+        primary_resource_id: "default"
+        vars:
+          realm_id: "tf-test-realm"
+    properties:
+  GameServerCluster: !ruby/object:Overrides::Terraform::ResourceOverride
+    properties:
+      # clusters can be specified as {name}, locations/{location}/cluster/{name} or as the full
+      # /projects/... style link. So using a substring check instead of normal self link functions
+      connectionInfo.gkeClusterReference.cluster: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: suppressSuffixDiff
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      constants: "templates/terraform/constants/gameserver_cluster_custom_diff.go"
+  GameServerDeployment: !ruby/object:Overrides::Terraform::ResourceOverride
+    autogen_async: true
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        min_version: beta
+        name: "game_service_deployment_basic"
+        primary_resource_id: "default"
+        vars:
+          deployment_id: "tf-test-deployment"
+    properties:
+  GameServerConfig: !ruby/object:Overrides::Terraform::ResourceOverride
+    autogen_async: true
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        min_version: beta
+        name: "game_service_config_basic"
+        primary_resource_id: "default"
+        vars:
+          deployment_id: "tf-test-deployment"
+          config_id: "tf-test-config"
+    properties:
+      fleetConfigs.name: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      fleetConfigs.fleetSpec: !ruby/object:Overrides::Terraform::PropertyOverride
+        description: |
+          The fleet spec, which is sent to Agones to configure fleet.
+          The spec can be passed as inline json but it is recommended to use a file reference
+          instead. File references can contain the json or yaml format of the fleet spec. Eg:
+
+          * fleet_spec = jsonencode(yamldecode(file("fleet_configs.yaml")))
+          * fleet_spec = file("fleet_configs.json")
+
+          The format of the spec can be found :
+          `https://agones.dev/site/docs/reference/fleet/`.
+  GameServerDeploymentRollout: !ruby/object:Overrides::Terraform::ResourceOverride
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        min_version: beta
+        name: "game_service_deployment_rollout_basic"
+        primary_resource_id: "default"
+        vars:
+          deployment_id: "tf-test-deployment"
+          config_id: "tf-test-config"
+    properties:
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      custom_create: 'templates/terraform/custom_create/gameservice_rollout_create.go'

--- a/templates/terraform/constants/gameserver_cluster_custom_diff.go
+++ b/templates/terraform/constants/gameserver_cluster_custom_diff.go
@@ -1,0 +1,8 @@
+func suppressSuffixDiff(_, old, new string, _ *schema.ResourceData) bool {
+	if strings.HasSuffix(old, new) {
+		log.Printf("[INFO] suppressing diff as %s is the same as the full path of %s", new, old)
+		return true
+	}
+
+	return false
+}

--- a/templates/terraform/custom_create/gameservice_rollout_create.go
+++ b/templates/terraform/custom_create/gameservice_rollout_create.go
@@ -1,0 +1,18 @@
+config := meta.(*Config)
+
+// Store the ID now
+id, err := replaceVars(d, config, "projects/{{project}}/locations/global/gameServerDeployments/{{deployment_id}}/rollout")
+if err != nil {
+	return fmt.Errorf("Error constructing id: %s", err)
+}
+d.SetId(id)
+
+log.Printf("[DEBUG] Creating GameServerDeploymentRollout %q: ", d.Id())
+
+err = resourceGameServicesGameServerDeploymentRolloutUpdate(d, meta)
+if err != nil {
+	d.SetId("")
+	return fmt.Errorf("Error trying to create GameServerDeploymentRollout: %s", err)
+}
+
+return nil

--- a/templates/terraform/examples/game_service_config_basic.tf.erb
+++ b/templates/terraform/examples/game_service_config_basic.tf.erb
@@ -1,0 +1,34 @@
+resource "google_game_services_game_server_deployment" "default" {
+  provider = google-private
+
+  deployment_id  = "<%= ctx[:vars]["deployment_id"] %>"
+  description = "a deployment description"
+}
+
+resource "google_game_services_game_server_config" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-private
+
+  config_id     = "<%= ctx[:vars]["config_id"] %>"
+  deployment_id = google_game_services_game_server_deployment.default.deployment_id
+  description   = "a config description"
+
+  fleet_configs {
+    name       = "something-unique"
+    fleet_spec = jsonencode({ "replicas" : 1, "scheduling" : "Packed", "template" : { "metadata" : { "name" : "tf-test-game-server-template" }, "spec" : { "template" : { "spec" : { "containers" : [{ "name" : "simple-udp-server", "image" : "gcr.io/agones-images/udp-server:0.14" }] } } } } })
+  }
+
+  scaling_configs {
+    name = "scaling-config-name"
+    fleet_autoscaler_spec = jsonencode({"spec":{"fleetName":"simple-udp","policy":{"type":"Webhook","webhook":{"service":{"name":"autoscaler-webhook-service","namespace":"default","path":"scale"}}}}})
+    selectors {
+      labels = {
+        "one" : "two"
+      }
+    }
+
+    schedules {
+      cron_job_duration = "3.500s"
+      cron_spec         = "0 0 * * 0"
+    }
+  }
+}

--- a/templates/terraform/examples/game_service_deployment_basic.tf.erb
+++ b/templates/terraform/examples/game_service_deployment_basic.tf.erb
@@ -1,0 +1,7 @@
+resource "google_game_services_game_server_deployment" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-private
+
+  deployment_id  = "<%= ctx[:vars]["deployment_id"] %>"
+  description = "a deployment description"
+}
+

--- a/templates/terraform/examples/game_service_deployment_rollout_basic.tf.erb
+++ b/templates/terraform/examples/game_service_deployment_rollout_basic.tf.erb
@@ -1,0 +1,29 @@
+resource "google_game_services_game_server_deployment" "default" {
+  provider = google-private
+
+  deployment_id  = "<%= ctx[:vars]["deployment_id"] %>"
+  description = "a deployment description"
+}
+
+resource "google_game_services_game_server_config" "default" {
+  provider = google-private
+
+  config_id     = "<%= ctx[:vars]["config_id"] %>"
+  deployment_id = google_game_services_game_server_deployment.default.deployment_id
+  description   = "a config description"
+
+  fleet_configs {
+    name       = "some-non-guid"
+    fleet_spec = jsonencode({ "replicas" : 1, "scheduling" : "Packed", "template" : { "metadata" : { "name" : "tf-test-game-server-template" }, "spec" : { "template" : { "spec" : { "containers" : [{ "name" : "simple-udp-server", "image" : "gcr.io/agones-images/udp-server:0.14" }] } } } } })
+
+    // Alternate usage:
+    // fleet_spec = file(fleet_configs.json)
+  }
+}
+
+resource "google_game_services_game_server_deployment_rollout" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-private
+
+  deployment_id              = google_game_services_game_server_deployment.default.deployment_id
+  default_game_server_config = google_game_services_game_server_config.default.name
+}

--- a/templates/terraform/examples/game_service_realm_basic.tf.erb
+++ b/templates/terraform/examples/game_service_realm_basic.tf.erb
@@ -1,0 +1,10 @@
+resource "google_game_services_realm" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-private
+
+  realm_id  = "<%= ctx[:vars]["realm_id"] %>"
+  time_zone = "EST"
+  location  = "global"
+
+  description = "one of the nine"
+}
+


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**


```release-note:new-resource
gameservices: Added new resource `google_game_services_realm`
```

```release-note:new-resource
gameservices: Added new resource `google_game_services_game_server_cluster`
```

```release-note:new-resource
gameservices: Added new resource `google_game_services_game_server_config`
```

```release-note:new-resource
gameservices: Added new resource `google_game_services_game_server_deployment`
```

```release-note:new-resource
gameservices: Added new resource `google_game_services_game_server_deployment_rollout`
```