### PR TITLE
Change storage name in resource policy doc

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -10350,7 +10350,8 @@ objects:
                   - snapshot_schedule_policy.0.snapshot_properties.0.guest_flush
                 max_size: 1
                 description: |
-                  GCS bucket location in which to store the snapshot (regional or multi-regional).
+                  Cloud Storage bucket location to store the auto snapshot
+                  (regional or multi-regional)
                 item_type: Api::Type::String
               - !ruby/object:Api::Type::Boolean
                 name: 'guestFlush'


### PR DESCRIPTION
Fixes  https://github.com/terraform-providers/terraform-provider-google/issues/5737 

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
