### PR TITLE
Remove iap base path as tunnel is generated

### DIFF
--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -45,9 +45,6 @@ import (
 <% end -%>
 	"google.golang.org/api/iam/v1"
 	iamcredentials "google.golang.org/api/iamcredentials/v1"
-<% unless version == 'ga' -%>
-	iap "google.golang.org/api/iap/v1beta1"
-<% end -%>
 	cloudlogging "google.golang.org/api/logging/v2"
 	"google.golang.org/api/pubsub/v1"
 	"google.golang.org/api/runtimeconfig/v1beta1"

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -145,9 +145,6 @@ type Config struct {
 	<% unless version == 'ga' -%>
 
 	clientHealthcare   *healthcare.Service
-
-	IAPBasePath string
-	clientIAP   *iap.Service
 	<% end -%>
 
 	clientServiceMan          *servicemanagement.APIService
@@ -381,18 +378,6 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 	}
 	c.clientIamCredentials.UserAgent = userAgent
 	c.clientIamCredentials.BasePath = iamCredentialsClientBasePath
-
-
-	<% unless version == 'ga' -%>
-	iapClientBasePath := removeBasePathVersion(c.IAPBasePath)
-	log.Printf("[INFO] Instantiating IAP client for path %s", iapClientBasePath)
-	c.clientIAP, err = iap.NewService(ctx, option.WithHTTPClient(client))
-	if err != nil {
-		return err
-	}
-	c.clientIAP.UserAgent = userAgent
-	c.clientIAP.BasePath = iapClientBasePath
-	<% end -%>
 
 	serviceManagementClientBasePath := removeBasePathVersion(c.ServiceManagementBasePath)
 	log.Printf("[INFO] Instantiating Google Cloud Service Management client for path %s", serviceManagementClientBasePath)
@@ -661,11 +646,6 @@ func ConfigureBasePaths(c *Config) {
 	<% end -%>
 
 	// Handwritten Products / Versioned / Atypical Entries
-	<% unless version == 'ga' -%>
-	// start beta-only products
-	c.IAPBasePath = IAPDefaultBasePath
-	// end beta-only products
-	<% end -%>
 	c.CloudBillingBasePath = CloudBillingDefaultBasePath
 	c.ComposerBasePath = ComposerDefaultBasePath
 	c.ComputeBetaBasePath = ComputeBetaDefaultBasePath

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -446,9 +446,6 @@ func providerConfigure(d *schema.ResourceData, p *schema.Provider, terraformVers
 	<% end -%>
 
 	// Handwritten Products / Versioned / Atypical Entries
-	<% unless version == 'ga' -%>
-	config.IAPBasePath = d.Get(IAPCustomEndpointEntryKey).(string)
-	<% end -%>
 
 	config.CloudBillingBasePath = d.Get(CloudBillingCustomEndpointEntryKey).(string)
 	config.ComposerBasePath = d.Get(ComposerCustomEndpointEntryKey).(string)


### PR DESCRIPTION
Should not cause downstream issues. This is causing problems for https://github.com/GoogleCloudPlatform/magic-modules/pull/3135 in the beta provider

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
