### PR TITLE
 5750 - fixing a typo in google_access_context_manager_service_perimeter_resource

### DIFF
--- a/templates/terraform/examples/access_context_manager_service_perimeter_resource_basic.tf.erb
+++ b/templates/terraform/examples/access_context_manager_service_perimeter_resource_basic.tf.erb
@@ -1,5 +1,5 @@
 resource "google_access_context_manager_service_perimeter_resource" "<%= ctx[:primary_resource_id] %>" {
-  perimiter_name = google_access_context_manager_service_perimeter.<%= ctx[:primary_resource_id] %>.name
+  perimeter_name = google_access_context_manager_service_perimeter.<%= ctx[:primary_resource_id] %>.name
   resource = "projects/987654321"
 }
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

fixes https://github.com/terraform-providers/terraform-provider-google/issues/5750

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
