### PR TITLE
Fix Data Fusion network config to mention self link

### DIFF
--- a/products/datafusion/api.yaml
+++ b/products/datafusion/api.yaml
@@ -178,8 +178,6 @@ objects:
           - !ruby/object:Api::Type::String
             name: 'network'
             description: |
-              Name of the network in the project with which the tenant project
-              will be peered for executing pipelines. In case of shared VPC where the network resides in another host
-              project the network should specified in the form of projects/{host-project-id}/global/networks/{network}
+              Self link of the network. The tenant project will be peered into this network for executing pipelines. 
             required: true
             input: true


### PR DESCRIPTION
While the data fusion instance API accepts both self link and name of the network in the POST call, it always seems to return the self link in the GET call. This can cause a recreation of the instance. Clarify that this should be the self link for simplicity.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
