### PR TITLE
Generate correct stats for oics

### DIFF
--- a/.ci/containers/github-differ/generate_comment.sh
+++ b/.ci/containers/github-differ/generate_comment.sh
@@ -86,7 +86,7 @@ OICSDIFFS=$(bash -e <<TRY
     pushd $TFOICS_LOCAL_PATH > /dev/null
     git fetch origin $OLD_BRANCH
     if ! git diff --exit-code --quiet origin/$OLD_BRANCH origin/$NEW_BRANCH; then
-        SUMMARY=`git diff origin/$OLD_BRANCH origin/$NEW_BRANCH --shortstat`
+        SUMMARY="$(git diff origin/$OLD_BRANCH origin/$NEW_BRANCH --shortstat)"
         echo "TF OiCS: [Diff](https://github.com/modular-magician/docs-examples/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY)"
     fi
     popd > /dev/null

--- a/.ci/containers/github-differ/generate_comment.sh
+++ b/.ci/containers/github-differ/generate_comment.sh
@@ -74,30 +74,16 @@ if ! git diff --exit-code origin/$OLD_BRANCH origin/$NEW_BRANCH; then
 fi
 popd
 
-# Temporary guards for OiCS since this container image will be newer than YAML
-# for existing PRs. We need to be backwards-compatible with old GCB runs that
-# don't generate OiCS. This should be safe to remove after Feb 18th or so.
-set +e
-# Use a subshell to run commands serially and fail when one fails
-OICSDIFFS=$(bash -e <<TRY
-    # TF OICS
-    mkdir -p $TFOICS_LOCAL_PATH
-    git clone -b $NEW_BRANCH $TFOICS_SCRATCH_PATH $TFOICS_LOCAL_PATH
-    pushd $TFOICS_LOCAL_PATH > /dev/null
-    git fetch origin $OLD_BRANCH
-    if ! git diff --exit-code --quiet origin/$OLD_BRANCH origin/$NEW_BRANCH; then
-        SUMMARY="$(git diff origin/$OLD_BRANCH origin/$NEW_BRANCH --shortstat)"
-        echo "TF OiCS: [Diff](https://github.com/modular-magician/docs-examples/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY)"
-    fi
-    popd > /dev/null
-TRY
-)
-if [ $? -ne 0 ]; then
-  echo failed to generate OiCS
-else
-  DIFFS="${DIFFS}${NEWLINE}${OICSDIFFS}"
+# TF OICS
+mkdir -p $TFOICS_LOCAL_PATH
+git clone -b $NEW_BRANCH $TFOICS_SCRATCH_PATH $TFOICS_LOCAL_PATH
+pushd $TFOICS_LOCAL_PATH
+git fetch origin $OLD_BRANCH
+if ! git diff --exit-code --quiet origin/$OLD_BRANCH origin/$NEW_BRANCH; then
+    SUMMARY="$(git diff origin/$OLD_BRANCH origin/$NEW_BRANCH --shortstat)"
+    DIFFS="${DIFFS}${NEWLINE}TF OiCS: [Diff](https://github.com/modular-magician/docs-examples/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY)"
 fi
-set -e
+popd
 
 # Inspec
 mkdir -p $INSPEC_LOCAL_PATH


### PR DESCRIPTION
You're gonna hate this one - backticks are evaluated before the subshell spawns, so this is producing the git stats for the previous directory (whatever it may be) instead of OiCS.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
