### PR TITLE
Remove beta-only tags, beta provider from cf vpc connector test

### DIFF
--- a/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
+++ b/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
@@ -319,7 +319,6 @@ func TestAccCloudFunctionsFunction_serviceAccountEmail(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccCloudFunctionsFunction_vpcConnector(t *testing.T) {
 	t.Parallel()
 
@@ -333,7 +332,7 @@ func TestAccCloudFunctionsFunction_vpcConnector(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProvidersOiCS,
+		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFunctionsFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
@@ -342,7 +341,6 @@ func TestAccCloudFunctionsFunction_vpcConnector(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func testAccCheckCloudFunctionsFunctionDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
@@ -760,19 +758,15 @@ resource "google_cloudfunctions_function" "function" {
 `, bucketName, zipFilePath, functionName)
 }
 
-<% unless version == 'ga' -%>
 func testAccCloudFunctionsFunction_vpcConnector(projectNumber, networkName, functionName, bucketName, zipFilePath, vpcConnectorName string) string {
 	return fmt.Sprintf(`
-provider "google-beta" { }
 
 resource "google_project_iam_member" "gcfadmin" {
-  provider = "google-beta"
   role     = "roles/editor"
   member   = "serviceAccount:service-%s@gcf-admin-robot.iam.gserviceaccount.com"
 }
 
 resource "google_compute_network" "vpc" {
-	provider = "google-beta"
 	name = "%s"
 	auto_create_subnetworks = false
 }
@@ -785,12 +779,10 @@ resource "google_vpc_access_connector" "connector" {
 }
 
 resource "google_storage_bucket" "bucket" {
-  provider = "google-beta"
   name     = "%s"
 }
 
 resource "google_storage_bucket_object" "archive" {
-  provider = "google-beta"
   name     = "index.zip"
   bucket   = google_storage_bucket.bucket.name
   source   = "%s"
@@ -799,7 +791,6 @@ resource "google_storage_bucket_object" "archive" {
 resource "google_cloudfunctions_function" "function" {
   name     = "%s"
   runtime  = "nodejs8"
-  provider = "google-beta"
 
   description           = "test function"
   available_memory_mb   = 128
@@ -821,4 +812,3 @@ resource "google_cloudfunctions_function" "function" {
 }
 `, projectNumber, networkName, vpcConnectorName, bucketName, zipFilePath, functionName)
 }
-<% end -%>


### PR DESCRIPTION
Some leftover from the beta-->ga

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
