### PR TITLE
Bump up default create timeout for datastore index

### DIFF
--- a/products/datastore/terraform.yaml
+++ b/products/datastore/terraform.yaml
@@ -23,7 +23,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     # identity.
     skip_sweeper: true
     timeouts: !ruby/object:Api::Timeouts
-      insert_minutes: 10
+      insert_minutes: 20
       delete_minutes: 10
     examples:
       - !ruby/object:Provider::Terraform::Examples


### PR DESCRIPTION
Fixes flaky test failure from timeout
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
