### PR TITLE
Allow id for bigtable appprofile instance

### DIFF
--- a/products/bigtable/terraform.yaml
+++ b/products/bigtable/terraform.yaml
@@ -39,9 +39,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read_extra:
           - "ignore_warnings"
     properties:
+      instance: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: compareResourceNames
       multiClusterRoutingUseAny: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/bigtable_app_profile_routing.erb'
         custom_flatten: 'templates/terraform/custom_flatten/bigtable_app_profile_routing.erb'
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      encoder: templates/terraform/encoders/bigtable_app_profile.go.erb
+
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/templates/terraform/encoders/bigtable_app_profile.go.erb
+++ b/templates/terraform/encoders/bigtable_app_profile.go.erb
@@ -1,0 +1,20 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+<%# Because instance is a URL param only, it does not get expanded and
+  # the URL is constructed from ResourceData. Set it in
+  # state and use a encoder instead of a field expander -%>
+// Instance is a URL parameter only, so replace self-link/path with resource name only.
+d.Set("instance", GetResourceNameFromSelfLink(d.Get("instance").(string)))
+return obj, nil

--- a/third_party/terraform/tests/resource_bigtable_app_profile_test.go
+++ b/third_party/terraform/tests/resource_bigtable_app_profile_test.go
@@ -53,7 +53,7 @@ resource "google_bigtable_instance" "instance" {
 }
 
 resource "google_bigtable_app_profile" "ap" {
-  instance       = google_bigtable_instance.instance.name
+  instance       = google_bigtable_instance.instance.id
   app_profile_id = "test"
 
   multi_cluster_routing_use_any = true
@@ -75,7 +75,7 @@ resource "google_bigtable_instance" "instance" {
 }
 
 resource "google_bigtable_app_profile" "ap" {
-  instance       = google_bigtable_instance.instance.name
+  instance       = google_bigtable_instance.instance.id
   app_profile_id = "test"
   description    = "add a description"
 

--- a/third_party/terraform/utils/self_link_helpers.go
+++ b/third_party/terraform/utils/self_link_helpers.go
@@ -11,6 +11,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
+// Compare only the resource name of two self links/paths.
+func compareResourceNames(_, old, new string, _ *schema.ResourceData) bool {
+	return GetResourceNameFromSelfLink(old) == GetResourceNameFromSelfLink(new)
+}
+
 // Compare only the relative path of two self links.
 func compareSelfLinkRelativePaths(_, old, new string, _ *schema.ResourceData) bool {
 	oldStripped, err := getRelativePath(old)


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5751

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigtable: Added support for full-name/id `instance` value in `google_bigtable_app_profile`
```
