### PR TITLE
Upstream terraform-provider-google-beta#1766

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -2790,9 +2790,12 @@ func flattenMasterAuth(ma *containerBeta.MasterAuth) []map[string]interface{} {
 
 func flattenClusterAutoscaling(a *containerBeta.ClusterAutoscaling) []map[string]interface{} {
 	r := make(map[string]interface{})
-	if a == nil || !a.EnableNodeAutoprovisioning {
+	if a == nil {
 		r["enabled"] = false
-	} else {
+		return []map[string]interface{}{r}
+	}
+
+	if a.EnableNodeAutoprovisioning {
 		resourceLimits := make([]interface{}, 0, len(a.ResourceLimits))
 		for _, rl := range a.ResourceLimits {
 			resourceLimits = append(resourceLimits, map[string]interface{}{
@@ -2804,6 +2807,8 @@ func flattenClusterAutoscaling(a *containerBeta.ClusterAutoscaling) []map[string
 		r["resource_limits"] = resourceLimits
 		r["enabled"] = true
 		r["auto_provisioning_defaults"] = flattenAutoProvisioningDefaults(a.AutoprovisioningNodePoolDefaults)
+	} else {
+		r["enabled"] = false
 	}
 	<% unless version == 'ga' -%>
 	r["autoscaling_profile"] = a.AutoscalingProfile


### PR DESCRIPTION
Upstream https://github.com/terraform-providers/terraform-provider-google-beta/pull/1766/files

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5768

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: Fixed panic when upgrading `google_container_cluster` with autoscaling block 
```
