### PR TITLE
Add mutexes to storage ACLs

### DIFF
--- a/products/storage/terraform.yaml
+++ b/products/storage/terraform.yaml
@@ -50,6 +50,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         bucket_name: "static-content-bucket"
     id_format: "{{bucket}}/{{entity}}"
     import_format: ["{{bucket}}/{{entity}}"]
+    mutex: "storage/buckets/{{bucket}}"
     # This resource is a child resource
     skip_sweeper: true
     properties:
@@ -72,6 +73,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         object_name: "public-object"
     id_format: "{{bucket}}/{{object}}/{{entity}}"
     import_format: ["{{bucket}}/{{object}}/{{entity}}"]
+    mutex: "storage/buckets/{{bucket}}/objects/{{object}}"
     # This resource is a child resource
     skip_sweeper: true
     properties:
@@ -91,6 +93,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         bucket_name: "static-content-bucket"
     id_format: "{{bucket}}/{{entity}}"
     import_format: ["{{bucket}}/{{entity}}"]
+    mutex: "storage/buckets/{{bucket}}"
     # This resource is a child resource
     skip_sweeper: true
     properties:

--- a/third_party/terraform/resources/resource_storage_bucket_acl.go
+++ b/third_party/terraform/resources/resource_storage_bucket_acl.go
@@ -120,6 +120,13 @@ func resourceStorageBucketAclCreate(d *schema.ResourceData, meta interface{}) er
 		default_acl = v.(string)
 	}
 
+	lockName, err := replaceVars(d, config, "storage/buckets/{{bucket}}")
+	if err != nil {
+		return err
+	}
+	mutexKV.Lock(lockName)
+	defer mutexKV.Unlock(lockName)
+
 	if len(predefined_acl) > 0 {
 		res, err := config.clientStorage.Buckets.Get(bucket).Do()
 
@@ -198,6 +205,13 @@ func resourceStorageBucketAclRead(d *schema.ResourceData, meta interface{}) erro
 
 	bucket := d.Get("bucket").(string)
 
+	lockName, err := replaceVars(d, config, "storage/buckets/{{bucket}}")
+	if err != nil {
+		return err
+	}
+	mutexKV.Lock(lockName)
+	defer mutexKV.Unlock(lockName)
+
 	// The API offers no way to retrieve predefined ACLs,
 	// and we can't tell which access controls were created
 	// by the predefined roles, so...
@@ -232,6 +246,13 @@ func resourceStorageBucketAclUpdate(d *schema.ResourceData, meta interface{}) er
 	config := meta.(*Config)
 
 	bucket := d.Get("bucket").(string)
+
+	lockName, err := replaceVars(d, config, "storage/buckets/{{bucket}}")
+	if err != nil {
+		return err
+	}
+	mutexKV.Lock(lockName)
+	defer mutexKV.Unlock(lockName)
 
 	if d.HasChange("role_entity") {
 		bkt, err := config.clientStorage.Buckets.Get(bucket).Do()
@@ -319,6 +340,13 @@ func resourceStorageBucketAclDelete(d *schema.ResourceData, meta interface{}) er
 	config := meta.(*Config)
 
 	bucket := d.Get("bucket").(string)
+
+	lockName, err := replaceVars(d, config, "storage/buckets/{{bucket}}")
+	if err != nil {
+		return err
+	}
+	mutexKV.Lock(lockName)
+	defer mutexKV.Unlock(lockName)
 
 	bkt, err := config.clientStorage.Buckets.Get(bucket).Do()
 	if err != nil {

--- a/third_party/terraform/resources/resource_storage_default_object_acl.go
+++ b/third_party/terraform/resources/resource_storage_default_object_acl.go
@@ -46,6 +46,13 @@ func resourceStorageDefaultObjectAclCreateUpdate(d *schema.ResourceData, meta in
 		})
 	}
 
+	lockName, err := replaceVars(d, config, "storage/buckets/{{bucket}}")
+	if err != nil {
+		return err
+	}
+	mutexKV.Lock(lockName)
+	defer mutexKV.Unlock(lockName)
+
 	res, err := config.clientStorage.Buckets.Get(bucket).Do()
 	if err != nil {
 		return fmt.Errorf("Error reading bucket %s: %v", bucket, err)
@@ -71,6 +78,13 @@ func resourceStorageDefaultObjectAclCreateUpdate(d *schema.ResourceData, meta in
 func resourceStorageDefaultObjectAclRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
+	lockName, err := replaceVars(d, config, "storage/buckets/{{bucket}}")
+	if err != nil {
+		return err
+	}
+	mutexKV.Lock(lockName)
+	defer mutexKV.Unlock(lockName)
+
 	bucket := d.Get("bucket").(string)
 	res, err := config.clientStorage.Buckets.Get(bucket).Projection("full").Do()
 	if err != nil {
@@ -95,6 +109,13 @@ func resourceStorageDefaultObjectAclRead(d *schema.ResourceData, meta interface{
 
 func resourceStorageDefaultObjectAclDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
+
+	lockName, err := replaceVars(d, config, "storage/buckets/{{bucket}}")
+	if err != nil {
+		return err
+	}
+	mutexKV.Lock(lockName)
+	defer mutexKV.Unlock(lockName)
 
 	bucket := d.Get("bucket").(string)
 	res, err := config.clientStorage.Buckets.Get(bucket).Do()

--- a/third_party/terraform/resources/resource_storage_object_acl.go
+++ b/third_party/terraform/resources/resource_storage_object_acl.go
@@ -114,6 +114,13 @@ func resourceStorageObjectAclCreate(d *schema.ResourceData, meta interface{}) er
 	bucket := d.Get("bucket").(string)
 	object := d.Get("object").(string)
 
+	lockName, err := replaceVars(d, config, "storage/buckets/{{bucket}}/objects/{{object}}")
+	if err != nil {
+		return err
+	}
+	mutexKV.Lock(lockName)
+	defer mutexKV.Unlock(lockName)
+
 	// If we're using a predefined acl we just use the canned api.
 	if predefinedAcl, ok := d.GetOk("predefined_acl"); ok {
 		res, err := config.clientStorage.Objects.Get(bucket, object).Do()
@@ -161,6 +168,13 @@ func resourceStorageObjectAclRead(d *schema.ResourceData, meta interface{}) erro
 	bucket := d.Get("bucket").(string)
 	object := d.Get("object").(string)
 
+	lockName, err := replaceVars(d, config, "storage/buckets/{{bucket}}/objects/{{object}}")
+	if err != nil {
+		return err
+	}
+	mutexKV.Lock(lockName)
+	defer mutexKV.Unlock(lockName)
+
 	roleEntities, err := getRoleEntitiesAsStringsFromApi(config, bucket, object)
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("Storage Object ACL for Bucket %q", d.Get("bucket").(string)))
@@ -180,6 +194,13 @@ func resourceStorageObjectAclUpdate(d *schema.ResourceData, meta interface{}) er
 
 	bucket := d.Get("bucket").(string)
 	object := d.Get("object").(string)
+
+	lockName, err := replaceVars(d, config, "storage/buckets/{{bucket}}/objects/{{object}}")
+	if err != nil {
+		return err
+	}
+	mutexKV.Lock(lockName)
+	defer mutexKV.Unlock(lockName)
 
 	if _, ok := d.GetOk("predefined_acl"); d.HasChange("predefined_acl") && ok {
 		res, err := config.clientStorage.Objects.Get(bucket, object).Do()
@@ -224,6 +245,13 @@ func resourceStorageObjectAclDelete(d *schema.ResourceData, meta interface{}) er
 
 	bucket := d.Get("bucket").(string)
 	object := d.Get("object").(string)
+
+	lockName, err := replaceVars(d, config, "storage/buckets/{{bucket}}/objects/{{object}}")
+	if err != nil {
+		return err
+	}
+	mutexKV.Lock(lockName)
+	defer mutexKV.Unlock(lockName)
 
 	res, err := config.clientStorage.Objects.Get(bucket, object).Do()
 	if err != nil {


### PR DESCRIPTION
should fix https://github.com/terraform-providers/terraform-provider-google/issues/5781
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
storage: Added locking for operations involving `google_storage_*_access_control` resources to prevent errors from ACLs being added at the same time.
```
