### PR TITLE
`project_service` update to read/acquire a service on create

### DIFF
--- a/third_party/terraform/website/docs/r/google_project_service.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_service.html.markdown
@@ -46,4 +46,4 @@ Project services can be imported using the `project_id` and `service`, e.g.
 $ terraform import google_project_service.my_project your-project-id/iam.googleapis.com
 ```
 
-Note that unlike other resources that fail if they already exist, `terraform apply` can be successfully used to re-enable already enabled services. This means that when importing existing resources into Terraform, you can either import the `google_project_service` resources or treat them as new infrastructure and run `terraform apply` to re-enable them and add them to state.
+Note that unlike other resources that fail if they already exist, `terraform apply` can be successfully used to verify already enabled services. This means that when importing existing resources into Terraform, you can either import the `google_project_service` resources or treat them as new infrastructure and run `terraform apply` to add them to state.


### PR DESCRIPTION
Instead of trying to enable the API every time on Create, I added a read to check if the API was already enabled first.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
`google_project_service` will no longer attempt to enable a service that is already enabled.
```
