### PR TITLE
Fix terraform-google-conversion google.golang.org/api v0.16.0 compatibility issue.

### DIFF
--- a/third_party/validator/sql_database_instance.go
+++ b/third_party/validator/sql_database_instance.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 
-	"google.golang.org/api/googleapi"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 

--- a/third_party/validator/sql_database_instance.go
+++ b/third_party/validator/sql_database_instance.go
@@ -111,7 +111,7 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, secondGen bool)
 	// 1st Generation instances don't support the disk_autoresize parameter
 	// and it defaults to true - so we shouldn't set it if this is first gen
 	if secondGen {
-		settings.StorageAutoResize = *googleapi.Bool(_settings["disk_autoresize"].(bool))
+		settings.StorageAutoResize = _settings["disk_autoresize"].(bool)
 	}
 
 	return settings

--- a/third_party/validator/sql_database_instance.go
+++ b/third_party/validator/sql_database_instance.go
@@ -111,7 +111,7 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, secondGen bool)
 	// 1st Generation instances don't support the disk_autoresize parameter
 	// and it defaults to true - so we shouldn't set it if this is first gen
 	if secondGen {
-		settings.StorageAutoResize = googleapi.Bool(_settings["disk_autoresize"].(bool))
+		settings.StorageAutoResize = *googleapi.Bool(_settings["disk_autoresize"].(bool))
 	}
 
 	return settings


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Fix terraform-google-conversion google.golang.org/api v0.16.0 compatibility issue.
```
