### PR TITLE
Add custom code constants to terraform conversion

### DIFF
--- a/templates/terraform/objectlib/base.go.erb
+++ b/templates/terraform/objectlib/base.go.erb
@@ -10,6 +10,8 @@ package google
     asset_name_template = '//' + product_ns.downcase + '.googleapis.com/' + (!object.self_link.nil? && !object.self_link.empty? ? object.self_link : object.base_url + '/{{name}}')
 %>
 
+<%= lines(compile(object.custom_code.constants)) if object.custom_code.constants -%>
+
 func Get<%= resource_name -%>CaiObject(d TerraformResourceData, config *Config) (Asset, error) {
     name, err := assetName(d, config, "<%= asset_name_template -%>")
     if err != nil {


### PR DESCRIPTION
Many terraform resources use constants for actual constants or for helper
methods used on validation, diff supress or other custom logic. This will add
dead code for many resources but should avoid breaking the coversion lib's
build when an expander or encoder relies on a constant.

An example of a PR that would have introduced broken code: https://github.com/GoogleCloudPlatform/magic-modules/pull/3177

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
