### PR TITLE
add sql_source_representation_instance

### DIFF
--- a/products/sql/ansible.yaml
+++ b/products/sql/ansible.yaml
@@ -64,6 +64,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     exclude: true
   Flag: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
+  SourceRepresentationInstance: !ruby/object:Overrides::Ansible::ResourceOverride
+    exclude: true
 files: !ruby/object:Provider::Config::Files
   resource:
 <%= lines(indent(compile('provider/ansible/resource~compile.yaml'), 4)) -%>

--- a/products/sql/api.yaml
+++ b/products/sql/api.yaml
@@ -655,6 +655,7 @@ objects:
         name: 'databaseVersion'
         description: |
           The MySQL version running on your source database server: MYSQL_5_6 or MYSQL_5_7.
+        required: true
         values:
           - :MYSQL_5_6
           - :MYSQL_5_7
@@ -662,15 +663,19 @@ objects:
         name: 'onPremisesConfiguration'
         description: |
           Configuration specific to on-premises instances.
+        required: true
         properties:
           - !ruby/object:Api::Type::String
             name: 'host'
             description: |
               The externally accessible IPv4 address for the source database server.
+            required: true
           - !ruby/object:Api::Type::Integer
             name: 'port'
+            default_value: 3306
             description: |
               The externally accessible port for the source database server.
+              Defaults to 3306.
 
   # 'Operation' is not idempotent and will not be covered.
   # (it is used internally to assert the state of operations being performed)

--- a/products/sql/api.yaml
+++ b/products/sql/api.yaml
@@ -629,6 +629,49 @@ objects:
         item_type: Api::Type::String
         description: 'The applicable regions for this tier.'
         output: true
+  - !ruby/object:Api::Resource
+    name: 'SourceRepresentationInstance'
+    kind: 'sql#instance'
+    description: |
+      A source representation instance is a Cloud SQL instance that represents
+      the source database server to the Cloud SQL replica. It is visible in the
+      Cloud Console and appears the same as a regular Cloud SQL instance, but it
+      contains no data, requires no configuration or maintenance, and does not
+      affect billing. You cannot update the source representation instance.
+    base_url: projects/{{project}}/instances
+    input: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+            The name of the source representation instance. Use any valid Cloud SQL instance name.
+        required: true
+      - !ruby/object:Api::Type::String
+        name: 'region'
+        description: |
+          The region where you want your Cloud SQL replicas to reside.
+        required: true
+      - !ruby/object:Api::Type::Enum
+        name: 'databaseVersion'
+        description: |
+          The MySQL version running on your source database server: MYSQL_5_6 or MYSQL_5_7.
+        values:
+          - :MYSQL_5_6
+          - :MYSQL_5_7
+      - !ruby/object:Api::Type::NestedObject
+        name: 'onPremisesConfiguration'
+        description: |
+          Configuration specific to on-premises instances.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'host'
+            description: |
+              The externally accessible IPv4 address for the source database server.
+          - !ruby/object:Api::Type::Integer
+            name: 'port'
+            description: |
+              The externally accessible port for the source database server.
+
   # 'Operation' is not idempotent and will not be covered.
   # (it is used internally to assert the state of operations being performed)
   # | - !ruby/object:Api::Resource

--- a/products/sql/inspec.yaml
+++ b/products/sql/inspec.yaml
@@ -52,3 +52,5 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     exclude: true
   Tier: !ruby/object:Overrides::Inspec::ResourceOverride
     exclude: true
+  SourceRepresentationInstance: !ruby/object:Overrides::Inspec::ResourceOverride
+    exclude: true

--- a/products/sql/terraform.yaml
+++ b/products/sql/terraform.yaml
@@ -39,6 +39,28 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       charset: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+  SourceRepresentationInstance: !ruby/object:Overrides::Terraform::ResourceOverride
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "sql_source_representation_instance_basic"
+        primary_resource_id: "instance"
+        vars:
+          name: "my-instance"
+    properties:
+      onPremisesConfiguration: !ruby/object:Overrides::Terraform::PropertyOverride
+        flatten_object: true
+      onPremisesConfiguration.host: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validateIpAddress'
+      region: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: false
+        default_from_api: true
+        description: |
+          The Region in which the created address should reside.
+          If it is not provided, the provider region is used.
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      encoder: 'templates/terraform/encoders/sql_source_representation_instance.go.erb'
+      decoder: 'templates/terraform/decoders/sql_source_representation_instance.go.erb'
   Flag: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true
   Instance: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/products/sql/terraform.yaml
+++ b/products/sql/terraform.yaml
@@ -52,6 +52,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       onPremisesConfiguration.host: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateIpAddress'
+      onPremisesConfiguration.port: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.IntBetween(0, 65535)'
       region: !ruby/object:Overrides::Terraform::PropertyOverride
         required: false
         default_from_api: true

--- a/products/sql/terraform.yaml
+++ b/products/sql/terraform.yaml
@@ -59,7 +59,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         required: false
         default_from_api: true
         description: |
-          The Region in which the created address should reside.
+          The Region in which the created instance should reside.
           If it is not provided, the provider region is used.
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       encoder: 'templates/terraform/encoders/sql_source_representation_instance.go.erb'

--- a/templates/terraform/decoders/sql_source_representation_instance.go.erb
+++ b/templates/terraform/decoders/sql_source_representation_instance.go.erb
@@ -1,0 +1,30 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+if v, ok := res["onPremisesConfiguration"]; ok {
+	opc := v.(map[string]interface{})
+	hostPort := opc["hostPort"]
+	spl := strings.Split(hostPort.(string), ":")
+	if len(spl) != 2 {
+		return nil, fmt.Errorf("unexpected value for hostPort, expected [host]:[port], got %q", hostPort)
+	}
+	opc["host"] = spl[0]
+	p, err := strconv.Atoi(spl[1])
+	if err != nil {
+		return nil, fmt.Errorf("error converting port %q to int: %v", spl[1], err)
+	}
+	opc["port"] = p
+	delete(opc, "hostPort")
+}
+return res, nil

--- a/templates/terraform/encoders/sql_source_representation_instance.go.erb
+++ b/templates/terraform/encoders/sql_source_representation_instance.go.erb
@@ -1,0 +1,19 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+opc := obj["onPremisesConfiguration"].(map[string]interface{})
+opc["hostPort"] = fmt.Sprintf("%v:%v", opc["host"], opc["port"])
+delete(opc, "host")
+delete(opc, "port")
+return obj, nil

--- a/templates/terraform/examples/sql_source_representation_instance_basic.tf.erb
+++ b/templates/terraform/examples/sql_source_representation_instance_basic.tf.erb
@@ -1,0 +1,7 @@
+resource "google_sql_source_representation_instance" "<%= ctx[:primary_resource_id] %>" {
+  name             = "<%= ctx[:vars]['name'] %>"
+  region           = "us-central1"
+  database_version = "MYSQL_5_7"
+  host             = "10.20.30.40"
+  port             = 3306
+}

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -1405,6 +1405,10 @@
       <a href="/docs/providers/google/r/sql_database_instance.html">google_sql_database_instance</a>
       </li>
 
+      <li<%%= sidebar_current("docs-google-sql-source-representation-instance") %>>
+      <a href="/docs/providers/google/r/sql_source_representation_instance.html">google_sql_source_representation_instance</a>
+      </li>
+
       <li<%%= sidebar_current("docs-google-sql-ssl-cert") %>>
       <a href="/docs/providers/google/r/sql_ssl_cert.html">google_sql_ssl_cert</a>
       </li>


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/3704
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_sql_source_representation_instance`
```
