### PR TITLE
Exclude validator from copying interconnect constants

### DIFF
--- a/templates/terraform/constants/interconnect_attachment.go.erb
+++ b/templates/terraform/constants/interconnect_attachment.go.erb
@@ -1,3 +1,4 @@
+<% unless compiler == "terraformobjectlibrary-codegen" -%>
 // waitForAttachmentToBeProvisioned waits for an attachment to leave the
 // "UNPROVISIONED" state, to indicate that it's either ready or awaiting partner
 // activity.
@@ -16,3 +17,4 @@ func waitForAttachmentToBeProvisioned(d *schema.ResourceData, config *Config, ti
 		return nil
 	})
 }
+<% end -%>


### PR DESCRIPTION
Looks like there was one constant that referenced generated code which the conversion library doesn't generate.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
