### PR TITLE
Update appengine split traffic example to fix test

### DIFF
--- a/products/appengine/terraform.yaml
+++ b/products/appengine/terraform.yaml
@@ -124,7 +124,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "app_engine_service_split_traffic"
-        primary_resource_id: 'myapp'
+        primary_resource_id: 'liveapp'
         vars:
           service_id: "default"
           split.allocations.v1: "1"

--- a/templates/terraform/examples/app_engine_service_split_traffic.tf.erb
+++ b/templates/terraform/examples/app_engine_service_split_traffic.tf.erb
@@ -4,68 +4,57 @@ resource "google_storage_bucket" "bucket" {
 
 resource "google_storage_bucket_object" "object" {
 	name   = "hello-world.zip"
-	bucket = "${google_storage_bucket.bucket.name}"
+	bucket = google_storage_bucket.bucket.name
 	source = "./test-fixtures/appengine/hello-world.zip"
 }
 
-resource "google_app_engine_standard_app_version" "myapp_v1" {
+resource "google_app_engine_standard_app_version" "liveapp_v1" {
   version_id = "v1"
-  service = "myapp"
+  service = "liveapp"
+  delete_service_on_destroy = true
+
   runtime = "nodejs10"
-  noop_on_destroy = true
   entrypoint {
     shell = "node ./app.js"
   }
   deployment {
     zip {
-      source_url = "https://storage.googleapis.com/${google_storage_bucket.bucket.name}/hello-world.zip"
+      source_url = "https://storage.googleapis.com/${google_storage_bucket.bucket.name}/${google_storage_bucket_object.object.name}"
     }  
   }
   env_variables = {
     port = "8080"
-  } 
-  depends_on = ["google_storage_bucket_object.object"]
-
+  }
 }
-resource "google_app_engine_standard_app_version" "myapp_v2" {
+
+resource "google_app_engine_standard_app_version" "liveapp_v2" {
   version_id = "v2"
-  service = "myapp"
+  service = "liveapp"
+  noop_on_destroy = true
+
   runtime = "nodejs10"
   entrypoint {
     shell = "node ./app.js"
   }
   deployment {
     zip {
-      source_url = "https://storage.googleapis.com/${google_storage_bucket.bucket.name}/hello-world.zip"
+      source_url = "https://storage.googleapis.com/${google_storage_bucket.bucket.name}/${google_storage_bucket_object.object.name}"
     }  
   }
   env_variables = {
     port = "8080"
-  } 
-  depends_on = ["google_app_engine_standard_app_version.myapp_v1"]
+  }
 }
 
-resource "google_app_engine_service_split_traffic" "myapp" {
-  service = "${google_app_engine_standard_app_version.myapp_v2.service}"
+resource "google_app_engine_service_split_traffic" "<%= ctx[:primary_resource_id] %>" {
+  service = google_app_engine_standard_app_version.liveapp_v2.service
+
   migrate_traffic = false
   split {
     shard_by = "IP"
     allocations = {
-      v1 = 0.75
-      v2 = 0.25
+      (google_app_engine_standard_app_version.liveapp_v1.version_id) = 0.75
+      (google_app_engine_standard_app_version.liveapp_v2.version_id) = 0.25
     }
   }
-  depends_on = ["google_app_engine_standard_app_version.myapp_v2"]
-}
-
-
-resource "google_app_engine_service_split_traffic" "myapp2" {
-  service = "${google_app_engine_standard_app_version.myapp_v2.service}"
-  migrate_traffic = false
-  split {
-    allocations = {
-      v1 = 1
-    }
-  }
-  depends_on = ["google_app_engine_service_split_traffic.myapp"]
 }


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5743

Mutexes are only in-process, and we had two services with the same name. Also clean up the Terraform DAG a little, most of the dependencies can be added implicitly.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
