### PR TITLE
Replace user agent string in terraform object library

### DIFF
--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -293,5 +293,9 @@ module Provider
     def id_format(object)
       object.id_format || object.self_link_uri
     end
+
+    def conversion?
+      false
+    end
   end
 end

--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -138,5 +138,9 @@ module Provider
     def generate_iam_policy(data) end
 
     def generate_resource_sweepers(data) end
+
+    def conversion?
+      true
+    end
   end
 end

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -210,7 +210,9 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 	client.Timeout = c.synchronousTimeout()
 
 	tfUserAgent := httpclient.TerraformUserAgent(c.terraformVersion)
-	<% if version.nil? || version == 'ga' -%>
+	<% if conversion? -%>
+	providerVersion := "terraform-google-conversion"
+	<% elsif version.nil? || version == 'ga' -%>
 	providerVersion := fmt.Sprintf("terraform-provider-google/%s", version.ProviderVersion)
 	<% else -%>
 	providerVersion := fmt.Sprintf("terraform-provider-google-<%= version -%>/%s", version.ProviderVersion)


### PR DESCRIPTION
Should remove dependency on TPG within the conversion library as well as correctly identifying the user agent

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
