### PR TITLE
Vcr wrapper

### DIFF
--- a/templates/terraform/operation.go.erb
+++ b/templates/terraform/operation.go.erb
@@ -55,7 +55,7 @@ func <%= product_name.camelize(:lower) -%>OperationWaitTimeWithResponse(config *
       // If w is nil, the op was synchronous.
       return err
   }
-  if err := OperationWait(w, activity, timeoutMinutes); err != nil {
+  if err := OperationWait(w, activity, timeoutMinutes, config.PollInterval); err != nil {
       return err
   }
   return json.Unmarshal([]byte(w.CommonOperationWaiter.Op.Response), response)
@@ -68,5 +68,5 @@ func <%= product_name.camelize(:lower) -%>OperationWaitTime(config *Config, op m
       // If w is nil, the op was synchronous.
       return err
   }
-  return OperationWait(w, activity, timeoutMinutes)
+  return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
 }

--- a/third_party/terraform/resources/common_operation_test.go
+++ b/third_party/terraform/resources/common_operation_test.go
@@ -3,6 +3,7 @@ package google
 import (
 	"net/url"
 	"testing"
+	"time"
 )
 
 type TestWaiter struct {
@@ -54,7 +55,7 @@ func TestOperationWait_TimeoutsShouldRetry(t *testing.T) {
 	testWaiter := TestWaiter{
 		runCount: 0,
 	}
-	err := OperationWait(&testWaiter, "my-activity", 1)
+	err := OperationWait(&testWaiter, "my-activity", 1, 0*time.Second)
 	if err != nil {
 		t.Fatalf("unexpected error waiting for operation: got '%v', want 'nil'", err)
 	}

--- a/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -356,7 +356,7 @@ func resourceCloudFunctionsCreate(d *schema.ResourceData, meta interface{}) erro
 	// Name of function should be unique
 	d.SetId(cloudFuncId.cloudFunctionId())
 
-	err = cloudFunctionsOperationWait(config.clientCloudFunctions, op, "Creating CloudFunctions Function",
+	err = cloudFunctionsOperationWait(config, op, "Creating CloudFunctions Function",
 		int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if err != nil {
 		return err
@@ -504,7 +504,7 @@ func resourceCloudFunctionsUpdate(d *schema.ResourceData, meta interface{}) erro
 			return fmt.Errorf("Error while updating cloudfunction configuration: %s", err)
 		}
 
-		err = cloudFunctionsOperationWait(config.clientCloudFunctions, op, "Updating CloudFunctions Function",
+		err = cloudFunctionsOperationWait(config, op, "Updating CloudFunctions Function",
 			int(d.Timeout(schema.TimeoutUpdate).Minutes()))
 		if err != nil {
 			return err
@@ -527,7 +527,7 @@ func resourceCloudFunctionsDestroy(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
-	err = cloudFunctionsOperationWait(config.clientCloudFunctions, op, "Deleting CloudFunctions Function",
+	err = cloudFunctionsOperationWait(config, op, "Deleting CloudFunctions Function",
 		int(d.Timeout(schema.TimeoutDelete).Minutes()))
 	if err != nil {
 		return err

--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -355,7 +355,7 @@ func resourceComposerEnvironmentCreate(d *schema.ResourceData, meta interface{})
 	d.SetId(id)
 
 	waitErr := composerOperationWaitTime(
-		config.clientComposer, op, envName.Project, "Creating Environment",
+		config, op, envName.Project, "Creating Environment",
 		int(d.Timeout(schema.TimeoutCreate).Minutes()))
 
 	if waitErr != nil {
@@ -566,7 +566,7 @@ func resourceComposerEnvironmentPatchField(updateMask string, env *composer.Envi
 	}
 
 	waitErr := composerOperationWaitTime(
-		config.clientComposer, op, envName.Project, "Updating newly created Environment",
+		config, op, envName.Project, "Updating newly created Environment",
 		int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if waitErr != nil {
 		// The resource didn't actually update.
@@ -592,7 +592,7 @@ func resourceComposerEnvironmentDelete(d *schema.ResourceData, meta interface{})
 	}
 
 	err = composerOperationWaitTime(
-		config.clientComposer, op, envName.Project, "Deleting Environment",
+		config, op, envName.Project, "Deleting Environment",
 		int(d.Timeout(schema.TimeoutDelete).Minutes()))
 	if err != nil {
 		return err
@@ -1049,7 +1049,7 @@ func handleComposerEnvironmentCreationOpFailure(id string, envName *composerEnvi
 	}
 
 	waitErr := composerOperationWaitTime(
-		config.clientComposer, op, envName.Project,
+		config, op, envName.Project,
 		fmt.Sprintf("Deleting invalid created Environment with state %q", env.State),
 		int(d.Timeout(schema.TimeoutCreate).Minutes()))
 	if waitErr != nil {

--- a/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -609,7 +609,7 @@ func testSweepComposerEnvironments(config *Config) error {
 				allErrors = multierror.Append(allErrors, fmt.Errorf("Unable to delete environment %q: %s", e.Name, deleteErr))
 				continue
 			}
-			waitErr := composerOperationWaitTime(config.clientComposer, op, config.Project, "Sweeping old test environments", 10)
+			waitErr := composerOperationWaitTime(config, op, config.Project, "Sweeping old test environments", 10)
 			if waitErr != nil {
 				allErrors = multierror.Append(allErrors, fmt.Errorf("Unable to delete environment %q: %s", e.Name, waitErr))
 			}

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -162,9 +162,9 @@ func TestAccContainerCluster_withAddons(t *testing.T) {
 func TestAccContainerCluster_withMasterAuthConfig(t *testing.T) {
 	t.Parallel()
 
-	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(10))
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:	  func() { testAccPreCheck(t) },
 		Providers:	  testAccProviders,
 		CheckDestroy: testAccCheckContainerClusterDestroy,
@@ -214,7 +214,7 @@ func TestAccContainerCluster_withMasterAuthConfig(t *testing.T) {
 				ImportStateVerify:	 true,
 			},
 		},
-	})
+	}, testAccCheckContainerClusterDestroyProducer)
 }
 
 func TestAccContainerCluster_withMasterAuthConfig_NoCert(t *testing.T) {
@@ -1776,6 +1776,27 @@ func testAccCheckContainerClusterDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccCheckContainerClusterDestroyProducer(provider *schema.Provider) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		config := provider.Meta().(*Config)
+
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "google_container_cluster" {
+				continue
+			}
+
+			attributes := rs.Primary.Attributes
+			_, err := config.clientContainer.Projects.Zones.Clusters.Get(
+				config.Project, attributes["location"], attributes["name"]).Do()
+			if err == nil {
+				return fmt.Errorf("Cluster still exists")
+			}
+		}
+
+		return nil
+	}
 }
 
 func getResourceAttributes(n string, s *terraform.State) (map[string]string, error) {

--- a/third_party/terraform/tests/resource_pubsub_topic_test.go
+++ b/third_party/terraform/tests/resource_pubsub_topic_test.go
@@ -18,7 +18,7 @@ func TestAccPubsubTopic_update(t *testing.T) {
 	providers := getTestAccProviders(t.Name())
 	defer closeRecorder(t)
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    providers,
 		CheckDestroy: testAccCheckPubsubTopicDestroyProducer(providers["google"].(*schema.Provider)),

--- a/third_party/terraform/tests/resource_pubsub_topic_test.go
+++ b/third_party/terraform/tests/resource_pubsub_topic_test.go
@@ -21,7 +21,7 @@ func TestAccPubsubTopic_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    providers,
-		CheckDestroy: testAccCheckPubsubTopicDestroy,
+		CheckDestroy: testAccCheckPubsubTopicDestroyProducer(providers["google"].(*schema.Provider)),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPubsubTopic_update(topic, "foo", "bar"),

--- a/third_party/terraform/tests/resource_pubsub_topic_test.go
+++ b/third_party/terraform/tests/resource_pubsub_topic_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccPubsubTopic_update(t *testing.T) {
 	t.Parallel()
 
-	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(10))
+	topic := fmt.Sprintf("tf-test-topic-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/third_party/terraform/tests/resource_pubsub_topic_test.go
+++ b/third_party/terraform/tests/resource_pubsub_topic_test.go
@@ -21,7 +21,7 @@ func TestAccPubsubTopic_update(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    providers,
-		CheckDestroy: testAccCheckPubsubTopicDestroyProducer(providers["google"].(*schema.Provider)),
+		CheckDestroy: testAccCheckPubsubTopicDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPubsubTopic_update(topic, "foo", "bar"),

--- a/third_party/terraform/tests/resource_pubsub_topic_test.go
+++ b/third_party/terraform/tests/resource_pubsub_topic_test.go
@@ -15,13 +15,11 @@ func TestAccPubsubTopic_update(t *testing.T) {
 	t.Parallel()
 
 	topic := fmt.Sprintf("tf-test-topic-%s", acctest.RandString(10))
-	providers := getTestAccProviders(t.Name())
-	defer closeRecorder(t)
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    providers,
-		CheckDestroy: testAccCheckPubsubTopicDestroyProducer(providers["google"].(*schema.Provider)),
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPubsubTopicDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPubsubTopic_update(topic, "foo", "bar"),
@@ -42,7 +40,7 @@ func TestAccPubsubTopic_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 		},
-	})
+	}, testAccCheckPubsubTopicDestroyProducer)
 }
 
 func TestAccPubsubTopic_cmek(t *testing.T) {
@@ -53,8 +51,9 @@ func TestAccPubsubTopic_cmek(t *testing.T) {
 	topicName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPubsubTopicDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccPubsubTopic_cmek(pid, topicName, kms.CryptoKey.Name),

--- a/third_party/terraform/utils/appengine_operation.go
+++ b/third_party/terraform/utils/appengine_operation.go
@@ -70,5 +70,5 @@ func appEngineOperationWaitTime(config *Config, res interface{}, appId, activity
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	return OperationWait(w, activity, timeoutMinutes, 0*time.Second)
+	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
 }

--- a/third_party/terraform/utils/appengine_operation.go
+++ b/third_party/terraform/utils/appengine_operation.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"time"
 
 	"google.golang.org/api/appengine/v1"
 )

--- a/third_party/terraform/utils/appengine_operation.go
+++ b/third_party/terraform/utils/appengine_operation.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"time"
 
 	"google.golang.org/api/appengine/v1"
 )
@@ -48,7 +49,7 @@ func appEngineOperationWaitTimeWithResponse(config *Config, res interface{}, res
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	if err := OperationWait(w, activity, timeoutMinutes); err != nil {
+	if err := OperationWait(w, activity, timeoutMinutes, config.PollInterval); err != nil {
 		return err
 	}
 	return json.Unmarshal([]byte(w.CommonOperationWaiter.Op.Response), response)
@@ -69,5 +70,5 @@ func appEngineOperationWaitTime(config *Config, res interface{}, appId, activity
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	return OperationWait(w, activity, timeoutMinutes)
+	return OperationWait(w, activity, timeoutMinutes, 0*time.Second)
 }

--- a/third_party/terraform/utils/cloudfunctions_operation.go
+++ b/third_party/terraform/utils/cloudfunctions_operation.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"time"
 
 	"google.golang.org/api/cloudfunctions/v1"
 )
@@ -25,5 +26,5 @@ func cloudFunctionsOperationWait(service *cloudfunctions.Service, op *cloudfunct
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	return OperationWait(w, activity, timeoutMin)
+	return OperationWait(w, activity, timeoutMin, 0*time.Second)
 }

--- a/third_party/terraform/utils/cloudfunctions_operation.go
+++ b/third_party/terraform/utils/cloudfunctions_operation.go
@@ -2,7 +2,6 @@ package google
 
 import (
 	"fmt"
-	"time"
 
 	"google.golang.org/api/cloudfunctions/v1"
 )

--- a/third_party/terraform/utils/cloudfunctions_operation.go
+++ b/third_party/terraform/utils/cloudfunctions_operation.go
@@ -19,12 +19,12 @@ func (w *CloudFunctionsOperationWaiter) QueryOp() (interface{}, error) {
 	return w.Service.Operations.Get(w.Op.Name).Do()
 }
 
-func cloudFunctionsOperationWait(service *cloudfunctions.Service, op *cloudfunctions.Operation, activity string, timeoutMin int) error {
+func cloudFunctionsOperationWait(config *Config, op *cloudfunctions.Operation, activity string, timeoutMin int) error {
 	w := &CloudFunctionsOperationWaiter{
-		Service: service,
+		Service: config.clientCloudFunctions,
 	}
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	return OperationWait(w, activity, timeoutMin, 0*time.Second)
+	return OperationWait(w, activity, timeoutMin, config.PollInterval)
 }

--- a/third_party/terraform/utils/common_operation.go
+++ b/third_party/terraform/utils/common_operation.go
@@ -126,7 +126,7 @@ func CommonRefreshFunc(w Waiter) resource.StateRefreshFunc {
 	}
 }
 
-func OperationWait(w Waiter, activity string, timeoutMinutes int, pollingInterval time.Duration) error {
+func OperationWait(w Waiter, activity string, timeoutMinutes int, pollInterval time.Duration) error {
 	if OperationDone(w) {
 		if w.Error() != nil {
 			return w.Error()
@@ -140,7 +140,7 @@ func OperationWait(w Waiter, activity string, timeoutMinutes int, pollingInterva
 		Refresh:      CommonRefreshFunc(w),
 		Timeout:      time.Duration(timeoutMinutes) * time.Minute,
 		MinTimeout:   2 * time.Second,
-		PollInterval: pollingInterval,
+		PollInterval: pollInterval,
 	}
 	opRaw, err := c.WaitForState()
 	if err != nil {

--- a/third_party/terraform/utils/common_operation.go
+++ b/third_party/terraform/utils/common_operation.go
@@ -126,7 +126,7 @@ func CommonRefreshFunc(w Waiter) resource.StateRefreshFunc {
 	}
 }
 
-func OperationWait(w Waiter, activity string, timeoutMinutes int) error {
+func OperationWait(w Waiter, activity string, timeoutMinutes int, pollingInterval time.Duration) error {
 	if OperationDone(w) {
 		if w.Error() != nil {
 			return w.Error()
@@ -135,11 +135,12 @@ func OperationWait(w Waiter, activity string, timeoutMinutes int) error {
 	}
 
 	c := &resource.StateChangeConf{
-		Pending:    w.PendingStates(),
-		Target:     w.TargetStates(),
-		Refresh:    CommonRefreshFunc(w),
-		Timeout:    time.Duration(timeoutMinutes) * time.Minute,
-		MinTimeout: 2 * time.Second,
+		Pending:      w.PendingStates(),
+		Target:       w.TargetStates(),
+		Refresh:      CommonRefreshFunc(w),
+		Timeout:      time.Duration(timeoutMinutes) * time.Minute,
+		MinTimeout:   2 * time.Second,
+		PollInterval: pollingInterval,
 	}
 	opRaw, err := c.WaitForState()
 	if err != nil {

--- a/third_party/terraform/utils/composer_operation.go
+++ b/third_party/terraform/utils/composer_operation.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"time"
 
 	composer "google.golang.org/api/composer/v1beta1"
 )
@@ -25,5 +26,6 @@ func composerOperationWaitTime(service *composer.Service, op *composer.Operation
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	return OperationWait(w, activity, timeoutMinutes)
+	// TODO(slevenick): fix
+	return OperationWait(w, activity, timeoutMinutes, 0*time.Second)
 }

--- a/third_party/terraform/utils/composer_operation.go
+++ b/third_party/terraform/utils/composer_operation.go
@@ -19,13 +19,12 @@ func (w *ComposerOperationWaiter) QueryOp() (interface{}, error) {
 	return w.Service.Operations.Get(w.Op.Name).Do()
 }
 
-func composerOperationWaitTime(service *composer.Service, op *composer.Operation, project, activity string, timeoutMinutes int) error {
+func composerOperationWaitTime(config *Config, op *composer.Operation, project, activity string, timeoutMinutes int) error {
 	w := &ComposerOperationWaiter{
-		Service: service.Projects.Locations,
+		Service: config.clientComposer.Projects.Locations,
 	}
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	// TODO(slevenick): fix
-	return OperationWait(w, activity, timeoutMinutes, 0*time.Second)
+	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
 }

--- a/third_party/terraform/utils/composer_operation.go
+++ b/third_party/terraform/utils/composer_operation.go
@@ -2,7 +2,6 @@ package google
 
 import (
 	"fmt"
-	"time"
 
 	composer "google.golang.org/api/composer/v1beta1"
 )

--- a/third_party/terraform/utils/compute_operation.go
+++ b/third_party/terraform/utils/compute_operation.go
@@ -98,7 +98,7 @@ func computeOperationWaitTime(config *Config, res interface{}, project, activity
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	return OperationWait(w, activity, timeoutMinutes)
+	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
 }
 
 // ComputeOperationError wraps compute.OperationError and implements the

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -70,6 +70,7 @@ type Config struct {
 	BatchingConfig		*batchingConfig
 	UserProjectOverride bool
 	RequestTimeout  time.Duration
+	// This is only set during VCR tests. Otherwise use the default value
 	PollInterval time.Duration
 
 	client           *http.Client

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -70,6 +70,7 @@ type Config struct {
 	BatchingConfig		*batchingConfig
 	UserProjectOverride bool
 	RequestTimeout  time.Duration
+	PollInterval time.Duration
 
 	client           *http.Client
 	context          context.Context

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -70,7 +70,8 @@ type Config struct {
 	BatchingConfig		*batchingConfig
 	UserProjectOverride bool
 	RequestTimeout  time.Duration
-	// This is only set during VCR tests. Otherwise use the default value
+	// PollInterval is passed to resource.StateChangeConf in common_operation.go
+	// It controls the interval at which we poll for successful operations
 	PollInterval time.Duration
 
 	client           *http.Client
@@ -557,6 +558,8 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 
 	c.requestBatcherServiceUsage = NewRequestBatcher("Service Usage", ctx, c.BatchingConfig)
 	c.requestBatcherIam = NewRequestBatcher("IAM", ctx, c.BatchingConfig)
+
+	c.PollInterval = 10 * time.Second
 
 	return nil
 }

--- a/third_party/terraform/utils/container_operation.go
+++ b/third_party/terraform/utils/container_operation.go
@@ -109,5 +109,5 @@ func containerOperationWait(config *Config, op *container.Operation, project, lo
 		return err
 	}
 
-	return OperationWait(w, activity, timeoutMinutes)
+	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
 }

--- a/third_party/terraform/utils/dataproc_cluster_operation.go
+++ b/third_party/terraform/utils/dataproc_cluster_operation.go
@@ -25,5 +25,5 @@ func dataprocClusterOperationWait(config *Config, op *dataproc.Operation, activi
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	return OperationWait(w, activity, timeoutMinutes)
+	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
 }

--- a/third_party/terraform/utils/dataproc_job_operation.go
+++ b/third_party/terraform/utils/dataproc_job_operation.go
@@ -72,7 +72,7 @@ func dataprocJobOperationWait(config *Config, region, projectId, jobId string, a
 		ProjectId: projectId,
 		JobId:     jobId,
 	}
-	return OperationWait(w, activity, timeoutMinutes)
+	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
 }
 
 type DataprocDeleteJobOperationWaiter struct {
@@ -112,5 +112,5 @@ func dataprocDeleteOperationWait(config *Config, region, projectId, jobId string
 			JobId:     jobId,
 		},
 	}
-	return OperationWait(w, activity, timeoutMinutes)
+	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
 }

--- a/third_party/terraform/utils/deployment_manager_operation.go
+++ b/third_party/terraform/utils/deployment_manager_operation.go
@@ -50,7 +50,7 @@ func deploymentManagerOperationWaitTime(config *Config, resp interface{}, projec
 		return err
 	}
 
-	return OperationWait(w, activity, timeoutMinutes)
+	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
 }
 
 func (w *DeploymentManagerOperationWaiter) Error() error {

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -229,6 +229,9 @@ func vcrSource(t *testing.T, path, mode string) (rand.Source, error) {
 		}
 		defer f.Close()
 		_, err = f.WriteString(strconv.FormatInt(seed, 10))
+		if err != nil {
+			return nil, err
+		}
 		sources[t.Name()] = s
 		return s, nil
 	case "REPLAYING":

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -23,14 +23,6 @@ import (
 	"github.com/terraform-providers/terraform-provider-random/random"
 )
 
-func vcrTest(t *testing.T, c resource.TestCase, destroyFuncProducer func(provider *schema.Provider) (func(s *terraform.State) error)) {
-	providers := getTestAccProviders(t.Name())
-	c.Providers = providers
-	defer closeRecorder(t.Name())
-	c.CheckDestroy = destroyFuncProducer(providers["google"].(*schema.Provider))
-	resource.Test(t, c)
-}
-
 var testAccProviders map[string]terraform.ResourceProvider
 <% unless version == 'ga' -%>
 var testAccProvidersOiCS map[string]terraform.ResourceProvider
@@ -84,9 +76,11 @@ var billingAccountEnvVars = []string{
 }
 
 var configs map[string]*Config
+var sources map[string]rand.Source
 
 func init() {
 	configs = make(map[string]*Config)
+	sources = make(map[string]rand.Source)
 	testAccProvider = Provider().(*schema.Provider)
 	testAccRandomProvider = random.Provider().(*schema.Provider)
 	<% if version == 'ga' -%>
@@ -111,96 +105,6 @@ func init() {
 		"random": testAccRandomProvider,
 	}
 	<% end -%>
-}
-
-// Returns a cached config if VCR testing is enabled. This enables us to use a single HTTP transport
-// for a given test, allowing for recording of HTTP interactions.
-// Why this exists: schema.Provider.ConfigureFunc is called multiple times for a given test
-// ConfigureFunc on our provider creates a new HTTP client and sets base paths (config.go LoadAndValidate)
-// VCR requires a single HTTP client to handle all interactions so it can record and replay responses so
-// this caches HTTP clients per test by replacing ConfigureFunc
-func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.ResourceData) (interface{}, error), testName string) (*Config, error) {
-	if v, ok := configs[testName]; ok {
-		return v, nil
-	}
-	c, err := configureFunc(d)
-	if err != nil {
-		return nil, err
-	}
-	config := c.(*Config)
-	vcrMode := recorder.ModeDisabled
-	realTransport := config.client.Transport
-	switch vcrEnv := os.Getenv("VCR_MODE"); vcrEnv {
-	case "RECORDING":
-		vcrMode = recorder.ModeRecording
-	case "REPLAYING":
-		vcrMode = recorder.ModeReplaying
-		realTransport = nil
-	default:
-		log.Printf("[DEBUG] No valid environment var set for VCR_MODE, expected RECORDING or REPLAYING, skipping VCR. VCR_MODE: %s", vcrEnv)
-		return config, nil
-	}
-
-	envPath := os.Getenv("VCR_PATH")
-	if envPath == "" {
-		log.Print("[DEBUG] No environment var set for VCR_PATH, skipping VCR")
-		return config, nil
-	}
-	path := filepath.Join(envPath, testName)
-
-	rec, err := recorder.NewAsMode(path, vcrMode, realTransport)
-	if err != nil {
-		return nil, err
-	}
-	// Defines how VCR will match requests to responses.
-	rec.SetMatcher(func(r *http.Request, i cassette.Request) bool {
-		// Default matcher compares method and URL only
-		defaultMatch := cassette.DefaultMatcher(r, i)
-		if r.Body == nil {
-			return defaultMatch
-		}
-		var b bytes.Buffer
-		if _, err := b.ReadFrom(r.Body); err != nil {
-			log.Printf("[DEBUG] Failed to read request body from cassette: %v", err)
-			return false
-		}
-		r.Body = ioutil.NopCloser(&b)
-		// body must match recorded body
-		return defaultMatch && b.String() == i.Body
-	})
-	config.client.Transport = rec
-	configs[testName] = config
-	return config, err
-}
-
-// We need to explicitly close the VCR recorder to save the cassette
-func closeRecorder(testName string) {
-	if config, ok := configs[testName]; ok {
-		// We did not cache the config if it does not use VCR
-		config.client.Transport.(*recorder.Recorder).Stop()
-		// Clean up test config
-		delete(configs, testName)
-	}
-}
-
-func getTestAccProviders(testName string) map[string]terraform.ResourceProvider {
-	prov := Provider().(*schema.Provider)
-	provRand := random.Provider().(*schema.Provider)
-	envPath := os.Getenv("VCR_PATH")
-	recordingMode := os.Getenv("VCR_MODE")
-	if envPath != "" && recordingMode != "" {
-		old := prov.ConfigureFunc
-		prov.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {
-			return getCachedConfig(d, old, testName)
-		}
-	} else {
-		log.Print("[DEBUG] VCR_PATH or VCR_MODE not set, skipping VCR")
-	}
-	// TODO(slevenick): Add OICS provider
-	return map[string]terraform.ResourceProvider{
-		"google": prov,
-		"random": provRand,
-	}
 }
 
 // Returns a cached config if VCR testing is enabled. This enables us to use a single HTTP transport
@@ -292,6 +196,81 @@ func getTestAccProviders(testName string) map[string]terraform.ResourceProvider 
 		"google": prov,
 		"random": provRand,
 	}
+}
+
+// Wrapper for resource.Test to swap out providers for VCR providers and handle VCR specific things
+// Can be called when VCR is not enabled, and it will behave as normal
+func vcrTest(t *testing.T, c resource.TestCase, destroyFuncProducer func(provider *schema.Provider) func(s *terraform.State) error) {
+	providers := getTestAccProviders(t.Name())
+	c.Providers = providers
+	defer closeRecorder(t)
+	c.CheckDestroy = destroyFuncProducer(providers["google"].(*schema.Provider))
+	resource.Test(t, c)
+}
+
+// Produces a rand.Source for VCR testing based on the given mode.
+// In RECORDING mode, generates a new seed and saves it to a file, using the seed for the source
+// In REPLAYING mode, reads a seed from a file and creates a source from it
+func vcrSource(t *testing.T, path, mode string) (rand.Source, error) {
+	if s, ok := sources[t.Name()]; ok {
+		return s, nil
+	}
+	fileName := filepath.Join(path, fmt.Sprintf("%s.seed", t.Name()))
+	switch mode {
+	case "RECORDING":
+		seed := rand.Int63()
+		s := rand.NewSource(seed)
+		f, err := os.Create(fileName)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		_, err = f.WriteString(strconv.FormatInt(seed, 10))
+		sources[t.Name()] = s
+		return s, nil
+	case "REPLAYING":
+		data := make([]byte, 19)
+		f, err := os.Open(fileName)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		_, err = f.Read(data)
+		if err != nil {
+			return nil, err
+		}
+		seed := string(data)
+		seedInt, err := strconv.ParseInt(seed, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		s := rand.NewSource(seedInt)
+		sources[t.Name()] = s
+		return s, nil
+	default:
+		log.Printf("[DEBUG] No valid environment var set for VCR_MODE, expected RECORDING or REPLAYING, skipping VCR. VCR_MODE: %s", mode)
+		return nil, errors.New("No valid VCR_MODE set")
+	}
+}
+
+func randString(t *testing.T, length int) string {
+	envPath := os.Getenv("VCR_PATH")
+	vcrMode := os.Getenv("VCR_MODE")
+	if envPath == "" || vcrMode == "" {
+		return acctest.RandString(10)
+	}
+	s, err := vcrSource(t, envPath, vcrMode)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := rand.New(s)
+	result := make([]byte, length)
+	set := "abcdefghijklmnopqrstuvwxyz012346789"
+	for i := 0; i < length; i++ {
+		result[i] = set[r.Intn(len(set))]
+	}
+	return string(result)
 }
 
 func TestProvider(t *testing.T) {

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -128,6 +128,8 @@ func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.Resour
 		vcrMode = recorder.ModeRecording
 	case "REPLAYING":
 		vcrMode = recorder.ModeReplaying
+		// When replaying, set the poll interval low to speed up tests
+		config.PollInterval = 10 * time.Millisecond
 	default:
 		log.Printf("[DEBUG] No valid environment var set for VCR_MODE, expected RECORDING or REPLAYING, skipping VCR. VCR_MODE: %s", vcrEnv)
 		return config, nil

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -93,19 +93,32 @@ func init() {
 		"random": testAccRandomProvider,
 	}
 
+	// The OiCS provider map is used to ensure that OiCS examples use `google-beta`
+	// if the example is versioned as beta; normal beta tests should continue to
+	// use the standard provider map.
+	testAccProvidersOiCS = map[string]terraform.ResourceProvider{
+<%# Add a google-#{version} provider for each version that is supported by this version. This allows us to run google-beta tests within a google-alpha provider.  -%>
+<% Api::Product::Version::ORDER[1..Api::Product::Version::ORDER.index(version)].each do |aliased_version| -%>
+		"google-<%= aliased_version -%>": testAccProvider,
+<% end -%>
+		"random": testAccRandomProvider,
+	}
+	<% end -%>
+}
+
 var lock = &sync.Mutex{}
 
-func get(d *schema.ResourceData, old func(d *schema.ResourceData) (interface{}, error), testName string) (interface{}, error) {
+// Returns a cached config if VCR testing is enabled. This enables us to use a single HTTP transport
+// for a given test, allowing for recording of HTTP interactions.
+func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.ResourceData) (interface{}, error), testName string) (interface{}, error) {
 	lock.Lock()
 	defer lock.Unlock()
-	if _, ok := singles[testName]; !ok {
-		// No existing client found, create one.
-		single, err := old(d)
+	if _, ok := configs[testName]; !ok {
+		c, err := configureFunc(d)
 		if err != nil {
 			return nil, err
 		}
-		config := single.(*Config)
-		path := fmt.Sprintf("/Users/slevenick/go-workspace/src/github.com/terraform-providers/terraform-provider-google-beta/fixtures/%s", testName)
+		config := c.(*Config)
 		vcrMode := recorder.ModeDisabled
 		switch vcrEnv := os.Getenv("VCR_MODE"); vcrEnv {
 		case "RECORDING":
@@ -113,8 +126,16 @@ func get(d *schema.ResourceData, old func(d *schema.ResourceData) (interface{}, 
 		case "REPLAYING":
 			vcrMode = recorder.ModeReplaying
 		default:
-			return single, nil
+			log.Printf("[DEBUG] No valid environment var set for VCR_MODE, skipping VCR. VCR_MODE: %s", vcrEnv)
+			return c, nil
 		}
+
+		envPath := os.Getenv("VCR_PATH")
+		if envPath == "" {
+			log.Printf("[DEBUG] No environment var set for VCR_PATH, skipping VCR for test: %s", testName)
+			return c, nil
+		}
+		path := filepath.Join(envPath, testName)
 
 		rec, err := recorder.NewAsMode(path, vcrMode, config.client.Transport)
 		if err != nil {
@@ -132,32 +153,39 @@ func get(d *schema.ResourceData, old func(d *schema.ResourceData) (interface{}, 
 			return cassette.DefaultMatcher(r, i) && (b.String() == "" || b.String() == i.Body)
 		})
 		config.client.Transport = rec
-		singles[testName] = single
-		return single, err
+		configs[testName] = c
+		return c, err
 	}
-	return singles[testName], nil
+	return configs[testName], nil
 }
 
 // We need to explicitly close the VCR recorder to save the cassette
 func closeRecorder(testName string) {
-	if config, ok := singles[testName]; ok {
+	if config, ok := configs[testName]; ok {
+		// We did not cache the config if it does not use VCR
 		config.(*Config).client.Transport.(*recorder.Recorder).Stop()
-		// Clean up test provider
-		delete(singles, testName)
+		// Clean up test config
+		delete(configs, testName)
 	}
 }
 
-	// The OiCS provider map is used to ensure that OiCS examples use `google-beta`
-	// if the example is versioned as beta; normal beta tests should continue to
-	// use the standard provider map.
-	testAccProvidersOiCS = map[string]terraform.ResourceProvider{
-<%# Add a google-#{version} provider for each version that is supported by this version. This allows us to run google-beta tests within a google-alpha provider.  -%>
-<% Api::Product::Version::ORDER[1..Api::Product::Version::ORDER.index(version)].each do |aliased_version| -%>
-		"google-<%= aliased_version -%>": testAccProvider,
-<% end -%>
-		"random": testAccRandomProvider,
+func getTestAccProviders(testName string) map[string]terraform.ResourceProvider {
+	prov := Provider().(*schema.Provider)
+	provRand := random.Provider().(*schema.Provider)
+	if v := os.Getenv("VCR_ENABLED"); v != "" {
+		old := prov.ConfigureFunc
+		ap.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {
+			r, err := getCachedConfig(d, old, testName)
+			return r, err
+		}
+	} else {
+		log.Print("[DEBUG] No environment var set for VCR_ENABLED, skipping VCR")
 	}
-	<% end -%>
+	// TODO(slevenick): Add OICS provider
+	return map[string]terraform.ResourceProvider{
+		"google": prov,
+		"random": provRand,
+	}
 }
 
 // Returns a cached config if VCR testing is enabled. This enables us to use a single HTTP transport

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -110,60 +110,64 @@ var lock = &sync.Mutex{}
 
 // Returns a cached config if VCR testing is enabled. This enables us to use a single HTTP transport
 // for a given test, allowing for recording of HTTP interactions.
-func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.ResourceData) (interface{}, error), testName string) (interface{}, error) {
+func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.ResourceData) (interface{}, error), testName string) (*Config, error) {
 	lock.Lock()
 	defer lock.Unlock()
-	if _, ok := configs[testName]; !ok {
-		c, err := configureFunc(d)
-		if err != nil {
-			return nil, err
-		}
-		config := c.(*Config)
-		vcrMode := recorder.ModeDisabled
-		switch vcrEnv := os.Getenv("VCR_MODE"); vcrEnv {
-		case "RECORDING":
-			vcrMode = recorder.ModeRecording
-		case "REPLAYING":
-			vcrMode = recorder.ModeReplaying
-		default:
-			log.Printf("[DEBUG] No valid environment var set for VCR_MODE, skipping VCR. VCR_MODE: %s", vcrEnv)
-			return c, nil
-		}
-
-		envPath := os.Getenv("VCR_PATH")
-		if envPath == "" {
-			log.Print("[DEBUG] No environment var set for VCR_PATH, skipping VCR")
-			return c, nil
-		}
-		path := filepath.Join(envPath, testName)
-
-		rec, err := recorder.NewAsMode(path, vcrMode, config.client.Transport)
-		if err != nil {
-			return nil, err
-		}
-		rec.SetMatcher(func(r *http.Request, i cassette.Request) bool {
-			if r.Body == nil {
-				return cassette.DefaultMatcher(r, i)
-			}
-			var b bytes.Buffer
-			if _, err := b.ReadFrom(r.Body); err != nil {
-				return false
-			}
-			r.Body = ioutil.NopCloser(&b)
-			return cassette.DefaultMatcher(r, i) && (b.String() == "" || b.String() == i.Body)
-		})
-		config.client.Transport = rec
-		configs[testName] = c
-		return c, err
+	if v, ok := configs[testName]; ok {
+		return v, nil
 	}
-	return configs[testName], nil
+	c, err := configureFunc(d)
+	if err != nil {
+		return nil, err
+	}
+	config := c.(*Config)
+	vcrMode := recorder.ModeDisabled
+	switch vcrEnv := os.Getenv("VCR_MODE"); vcrEnv {
+	case "RECORDING":
+		vcrMode = recorder.ModeRecording
+	case "REPLAYING":
+		vcrMode = recorder.ModeReplaying
+	default:
+		log.Printf("[DEBUG] No valid environment var set for VCR_MODE, expected RECORDING or REPLAYING, skipping VCR. VCR_MODE: %s", vcrEnv)
+		return config, nil
+	}
+
+	envPath := os.Getenv("VCR_PATH")
+	if envPath == "" {
+		log.Print("[DEBUG] No environment var set for VCR_PATH, skipping VCR")
+		return config, nil
+	}
+	path := filepath.Join(envPath, testName)
+
+	rec, err := recorder.NewAsMode(path, vcrMode, config.client.Transport)
+	if err != nil {
+		return nil, err
+	}
+	// Defines how VCR will match requests to responses.
+	rec.SetMatcher(func(r *http.Request, i cassette.Request) bool {
+		// Default matcher compares method and URL only
+		defaultMatch := cassette.DefaultMatcher(r, i)
+		if r.Body == nil {
+			return defaultMatch
+		}
+		var b bytes.Buffer
+		if _, err := b.ReadFrom(r.Body); err != nil {
+			return false
+		}
+		r.Body = ioutil.NopCloser(&b)
+		// body must match recorded body if it exists
+		return defaultMatch && ((b.String() == "" && i.Body == "") || b.String() == i.Body)
+	})
+	config.client.Transport = rec
+	configs[testName] = config
+	return config, err
 }
 
 // We need to explicitly close the VCR recorder to save the cassette
 func closeRecorder(testName string) {
 	if config, ok := configs[testName]; ok {
 		// We did not cache the config if it does not use VCR
-		config.(*Config).client.Transport.(*recorder.Recorder).Stop()
+		config.client.Transport.(*recorder.Recorder).Stop()
 		// Clean up test config
 		delete(configs, testName)
 	}
@@ -172,14 +176,15 @@ func closeRecorder(testName string) {
 func getTestAccProviders(testName string) map[string]terraform.ResourceProvider {
 	prov := Provider().(*schema.Provider)
 	provRand := random.Provider().(*schema.Provider)
-	if v := os.Getenv("VCR_ENABLED"); v != "" {
+	envPath := os.Getenv("VCR_PATH")
+	recordingMode := os.Getenv("VCR_MODE")
+	if envPath != "" && recordingMode != "" {
 		old := prov.ConfigureFunc
 		prov.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {
-			r, err := getCachedConfig(d, old, testName)
-			return r, err
+			return getCachedConfig(d, old, testName)
 		}
 	} else {
-		log.Print("[DEBUG] No environment var set for VCR_ENABLED, skipping VCR")
+		log.Print("[DEBUG] VCR_PATH or VCR_MODE not set, skipping VCR")
 	}
 	// TODO(slevenick): Add OICS provider
 	return map[string]terraform.ResourceProvider{

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -132,7 +132,7 @@ func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.Resour
 
 		envPath := os.Getenv("VCR_PATH")
 		if envPath == "" {
-			log.Printf("[DEBUG] No environment var set for VCR_PATH, skipping VCR for test: %s", testName)
+			log.Print("[DEBUG] No environment var set for VCR_PATH, skipping VCR")
 			return c, nil
 		}
 		path := filepath.Join(envPath, testName)

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -175,6 +175,7 @@ func closeRecorder(t *testing.T) {
 		}
 		// Clean up test config
 		delete(configs, t.Name())
+		delete(sources, t.Name())
 	}
 }
 
@@ -229,6 +230,7 @@ func vcrSource(t *testing.T, path, mode string) (rand.Source, error) {
 		sources[t.Name()] = s
 		return s, nil
 	case "REPLAYING":
+		// Max number of digits for int64 is 19
 		data := make([]byte, 19)
 		f, err := os.Open(fileName)
 		if err != nil {
@@ -261,6 +263,7 @@ func randString(t *testing.T, length int) string {
 	}
 	s, err := vcrSource(t, envPath, vcrMode)
 	if err != nil {
+		// At this point we haven't created any resources, so fail fast
 		t.Fatal(err)
 	}
 

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -106,13 +105,13 @@ func init() {
 	<% end -%>
 }
 
-var lock = &sync.Mutex{}
-
 // Returns a cached config if VCR testing is enabled. This enables us to use a single HTTP transport
 // for a given test, allowing for recording of HTTP interactions.
+// Why this exists: schema.Provider.ConfigureFunc is called multiple times for a given test
+// ConfigureFunc on our provider creates a new HTTP client and sets base paths (config.go LoadAndValidate)
+// VCR requires a single HTTP client to handle all interactions so it can record and replay responses so
+// this caches HTTP clients per test by replacing ConfigureFunc
 func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.ResourceData) (interface{}, error), testName string) (*Config, error) {
-	lock.Lock()
-	defer lock.Unlock()
 	if v, ok := configs[testName]; ok {
 		return v, nil
 	}
@@ -152,11 +151,12 @@ func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.Resour
 		}
 		var b bytes.Buffer
 		if _, err := b.ReadFrom(r.Body); err != nil {
+			log.Printf("[DEBUG] Failed to read request body from cassette: %v", err)
 			return false
 		}
 		r.Body = ioutil.NopCloser(&b)
-		// body must match recorded body if it exists
-		return defaultMatch && ((b.String() == "" && i.Body == "") || b.String() == i.Body)
+		// body must match recorded body
+		return defaultMatch && b.String() == i.Body
 	})
 	config.client.Transport = rec
 	configs[testName] = config

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -174,7 +174,7 @@ func getTestAccProviders(testName string) map[string]terraform.ResourceProvider 
 	provRand := random.Provider().(*schema.Provider)
 	if v := os.Getenv("VCR_ENABLED"); v != "" {
 		old := prov.ConfigureFunc
-		ap.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {
+		prov.ConfigureFunc = func(d *schema.ResourceData) (interface{}, error) {
 			r, err := getCachedConfig(d, old, testName)
 			return r, err
 		}

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -91,6 +92,60 @@ func init() {
 		"google": testAccProvider,
 		"random": testAccRandomProvider,
 	}
+
+var lock = &sync.Mutex{}
+
+func get(d *schema.ResourceData, old func(d *schema.ResourceData) (interface{}, error), testName string) (interface{}, error) {
+	lock.Lock()
+	defer lock.Unlock()
+	if _, ok := singles[testName]; !ok {
+		// No existing client found, create one.
+		single, err := old(d)
+		if err != nil {
+			return nil, err
+		}
+		config := single.(*Config)
+		path := fmt.Sprintf("/Users/slevenick/go-workspace/src/github.com/terraform-providers/terraform-provider-google-beta/fixtures/%s", testName)
+		vcrMode := recorder.ModeDisabled
+		switch vcrEnv := os.Getenv("VCR_MODE"); vcrEnv {
+		case "RECORDING":
+			vcrMode = recorder.ModeRecording
+		case "REPLAYING":
+			vcrMode = recorder.ModeReplaying
+		default:
+			return single, nil
+		}
+
+		rec, err := recorder.NewAsMode(path, vcrMode, config.client.Transport)
+		if err != nil {
+			return nil, err
+		}
+		rec.SetMatcher(func(r *http.Request, i cassette.Request) bool {
+			if r.Body == nil {
+				return cassette.DefaultMatcher(r, i)
+			}
+			var b bytes.Buffer
+			if _, err := b.ReadFrom(r.Body); err != nil {
+				return false
+			}
+			r.Body = ioutil.NopCloser(&b)
+			return cassette.DefaultMatcher(r, i) && (b.String() == "" || b.String() == i.Body)
+		})
+		config.client.Transport = rec
+		singles[testName] = single
+		return single, err
+	}
+	return singles[testName], nil
+}
+
+// We need to explicitly close the VCR recorder to save the cassette
+func closeRecorder(testName string) {
+	if config, ok := singles[testName]; ok {
+		config.(*Config).client.Transport.(*recorder.Recorder).Stop()
+		// Clean up test provider
+		delete(singles, testName)
+	}
+}
 
 	// The OiCS provider map is used to ensure that OiCS examples use `google-beta`
 	// if the example is versioned as beta; normal beta tests should continue to

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -223,41 +223,53 @@ func vcrSource(t *testing.T, path, mode string) (rand.Source, error) {
 	case "RECORDING":
 		seed := rand.Int63()
 		s := rand.NewSource(seed)
-		f, err := os.Create(fileName)
-		if err != nil {
-			return nil, err
-		}
-		defer f.Close()
-		_, err = f.WriteString(strconv.FormatInt(seed, 10))
+		err := writeSeedToFile(seed, fileName)
 		if err != nil {
 			return nil, err
 		}
 		sources[t.Name()] = s
 		return s, nil
 	case "REPLAYING":
-		// Max number of digits for int64 is 19
-		data := make([]byte, 19)
-		f, err := os.Open(fileName)
+		seed, err := readSeedFromFile(fileName)
 		if err != nil {
 			return nil, err
 		}
-		defer f.Close()
-		_, err = f.Read(data)
-		if err != nil {
-			return nil, err
-		}
-		seed := string(data)
-		seedInt, err := strconv.ParseInt(seed, 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		s := rand.NewSource(seedInt)
+		s := rand.NewSource(seed)
 		sources[t.Name()] = s
 		return s, nil
 	default:
 		log.Printf("[DEBUG] No valid environment var set for VCR_MODE, expected RECORDING or REPLAYING, skipping VCR. VCR_MODE: %s", mode)
 		return nil, errors.New("No valid VCR_MODE set")
 	}
+}
+
+func readSeedFromFile(fileName string) (int64, error) {
+	// Max number of digits for int64 is 19
+	data := make([]byte, 19)
+	f, err := os.Open(fileName)
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	_, err = f.Read(data)
+	if err != nil {
+		return 0, err
+	}
+	seed := string(data)
+	return strconv.ParseInt(seed, 10, 64)
+}
+
+func writeSeedToFile(seed int64, fileName string) error {
+	f, err := os.Create(fileName)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(strconv.FormatInt(seed, 10))
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func randString(t *testing.T, length int) string {

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -23,6 +23,13 @@ import (
 	"github.com/terraform-providers/terraform-provider-random/random"
 )
 
+func vcrTest(t *testing.T, c resource.TestCase) {
+	providers := getTestAccProviders(t.Name())
+	defer closeRecorder(t.Name())
+	c.Providers = providers
+	resource.Test(t, c)
+}
+
 var testAccProviders map[string]terraform.ResourceProvider
 <% unless version == 'ga' -%>
 var testAccProvidersOiCS map[string]terraform.ResourceProvider
@@ -121,11 +128,13 @@ func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.Resour
 	}
 	config := c.(*Config)
 	vcrMode := recorder.ModeDisabled
+	realTransport := config.client.Transport
 	switch vcrEnv := os.Getenv("VCR_MODE"); vcrEnv {
 	case "RECORDING":
 		vcrMode = recorder.ModeRecording
 	case "REPLAYING":
 		vcrMode = recorder.ModeReplaying
+		realTransport = nil
 	default:
 		log.Printf("[DEBUG] No valid environment var set for VCR_MODE, expected RECORDING or REPLAYING, skipping VCR. VCR_MODE: %s", vcrEnv)
 		return config, nil
@@ -138,7 +147,7 @@ func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.Resour
 	}
 	path := filepath.Join(envPath, testName)
 
-	rec, err := recorder.NewAsMode(path, vcrMode, config.client.Transport)
+	rec, err := recorder.NewAsMode(path, vcrMode, realTransport)
 	if err != nil {
 		return nil, err
 	}

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -23,10 +23,11 @@ import (
 	"github.com/terraform-providers/terraform-provider-random/random"
 )
 
-func vcrTest(t *testing.T, c resource.TestCase) {
+func vcrTest(t *testing.T, c resource.TestCase, destroyFuncProducer func(provider *schema.Provider) (func(s *terraform.State) error)) {
 	providers := getTestAccProviders(t.Name())
-	defer closeRecorder(t.Name())
 	c.Providers = providers
+	defer closeRecorder(t.Name())
+	c.CheckDestroy = destroyFuncProducer(providers["google"].(*schema.Provider))
 	resource.Test(t, c)
 }
 

--- a/third_party/terraform/utils/service_networking_operation.go
+++ b/third_party/terraform/utils/service_networking_operation.go
@@ -25,5 +25,5 @@ func serviceNetworkingOperationWaitTime(config *Config, op *servicenetworking.Op
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	return OperationWait(w, activity, timeoutMinutes)
+	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
 }

--- a/third_party/terraform/utils/serviceman_operation.go
+++ b/third_party/terraform/utils/serviceman_operation.go
@@ -32,7 +32,7 @@ func serviceManagementOperationWaitTime(config *Config, op *servicemanagement.Op
 		return nil, err
 	}
 
-	if err := OperationWait(w, activity, timeoutMinutes); err != nil {
+	if err := OperationWait(w, activity, timeoutMinutes, config.PollInterval); err != nil {
 		return nil, err
 	}
 	return w.Op.Response, nil

--- a/third_party/terraform/utils/serviceusage_operation.go
+++ b/third_party/terraform/utils/serviceusage_operation.go
@@ -36,7 +36,7 @@ func serviceUsageOperationWaitTime(config *Config, op *serviceusage.Operation, a
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	return OperationWait(w, activity, timeoutMinutes)
+	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
 }
 
 func handleServiceUsageRetryableError(err error) error {

--- a/third_party/terraform/utils/sqladmin_operation.go
+++ b/third_party/terraform/utils/sqladmin_operation.go
@@ -118,7 +118,7 @@ func sqlAdminOperationWaitTime(config *Config, res interface{}, project, activit
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	return OperationWait(w, activity, timeoutMinutes)
+	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
 }
 
 // SqlAdminOperationError wraps sqladmin.OperationError and implements the


### PR DESCRIPTION
Add more support for VCR testing.

Adds a wrapper around `resource.Test` that does VCR-based config setup.

Adds support for seeding random variables used in tests from a known value that is stored in a file alongside the cassette to ensure the same values at replay time.

Adds support for setting a poll interval on the StateChangeConf that we can override during VCR replay mode to speed up tests that poll during the actual run (looking at you GKE)

Using `0*time.Second` gives us a zero value for the `PollInterval` which is ignored by terraform and the default is used.

Should be no user facing changes

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
