### PR TITLE
Fix `google_compute_instance_template` crash

### DIFF
--- a/third_party/terraform/resources/resource_compute_instance_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_template.go
@@ -134,6 +134,7 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
+							ForceNew: true,
 						},
 
 						"interface": {
@@ -504,11 +505,6 @@ func resourceComputeInstanceTemplateSourceImageCustomizeDiff(diff *schema.Resour
 			var err error
 			old, new := diff.GetChange(key)
 			if old == "" || new == "" {
-				// no sense in resolving empty strings
-				err = diff.ForceNew(key)
-				if err != nil {
-					return err
-				}
 				continue
 			}
 			// project must be retrieved once we know there is a diff to resolve, otherwise it will
@@ -535,10 +531,6 @@ func resourceComputeInstanceTemplateSourceImageCustomizeDiff(diff *schema.Resour
 				return err
 			}
 			if oldResolved != newResolved {
-				err = diff.ForceNew(key)
-				if err != nil {
-					return err
-				}
 				continue
 			}
 			err = diff.Clear(key)


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5018

ForceNew logic for `source_image` was handled with in a custom diff. When `source_image` was a self_link to another resource, the custom diff would ForceNew the field before the dependent resource was resolved. This would lead to the SDK trying to sort out a change to a nil value.

To fix this, I took the forcenew logic out of the custom diff, and just set the field to ForceNew in the schema. This way, Terraform will resolve the ForceNew normally. The remaining custom diff acts as a more complicated diffSuppress. I'm not sure if it can be rewritten as an actual diffSuppress, since it takes in the `meta` object, where diffSuppress does not.

Also added a test that tests this specific scenario since it wasn't covered in the current set of tests.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Fixed a scenario where `google_compute_instance_template` would cause a crash.
```
