### PR TITLE
Initial retry transport

### DIFF
--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -128,6 +128,8 @@ module Provider
                         'third_party/terraform/utils/batcher.go'],
                        ['google/retry_utils.go',
                         'third_party/terraform/utils/retry_utils.go'],
+                       ['google/retry_transport.go',
+                        'third_party/terraform/utils/retry_transport.go'],
                        ['google/error_retry_predicates.go',
                         'third_party/terraform/utils/error_retry_predicates.go']
                      ])

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/terraform-providers/terraform-provider-google-beta/version"
 	"google.golang.org/api/option"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -9,6 +9,9 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/terraform-providers/terraform-provider-google-beta/version"
+	"google.golang.org/api/option"
+	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/logging"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/pathorcontents"
 	"github.com/hashicorp/terraform-plugin-sdk/httpclient"
@@ -204,8 +207,23 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 	}
 	c.tokenSource = tokenSource
 
-	client := oauth2.NewClient(context.Background(), tokenSource)
-	client.Transport = logging.NewTransport("Google", client.Transport)
+	cleanCtx := context.WithValue(ctx, oauth2.HTTPClient, cleanhttp.DefaultClient())
+
+	// 1. OAUTH2 TRANSPORT/CLIENT - sets up proper auth headers
+	client := oauth2.NewClient(cleanCtx, tokenSource)
+
+	// 2. Logging Transport - ensure we log HTTP requests to GCP APIs.
+	loggingTransport := logging.NewTransport("Google", client.Transport)
+
+	// 3. Retry Transport - retries common temporary errors
+	// Keep order for wrapping logging so we log each retried request as well.
+	// This value should be used if needed to create shallow copies with additional retry predicates.
+	// See ClientWithAdditionalRetries
+	retryTransport := NewTransportWithDefaultRetries(loggingTransport)
+
+	// Set final transport value.
+	client.Transport = retryTransport
+
 	// This timeout is a timeout per HTTP request, not per logical operation.
 	client.Timeout = c.synchronousTimeout()
 
@@ -318,7 +336,8 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 
 	pubsubClientBasePath := removeBasePathVersion(c.PubsubBasePath)
 	log.Printf("[INFO] Instantiating Google Pubsub client for path %s", pubsubClientBasePath)
-	c.clientPubsub, err = pubsub.NewService(ctx, option.WithHTTPClient(client))
+	wrappedPubsubClient := ClientWithAdditionalRetries(client, retryTransport, pubsubTopicProjectNotReady)
+	c.clientPubsub, err = pubsub.NewService(ctx, option.WithHTTPClient(wrappedPubsubClient))
 	if err != nil {
 		return err
 	}
@@ -417,7 +436,8 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 
 	bigQueryClientBasePath := c.BigQueryBasePath
 	log.Printf("[INFO] Instantiating Google Cloud BigQuery client for path %s", bigQueryClientBasePath)
-	c.clientBigQuery, err = bigquery.NewService(ctx, option.WithHTTPClient(client))
+	wrappedBigQueryClient := ClientWithAdditionalRetries(client, retryTransport, iamMemberMissing)
+	c.clientBigQuery, err = bigquery.NewService(ctx, option.WithHTTPClient(wrappedBigQueryClient))
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/utils/error_retry_predicates.go
+++ b/third_party/terraform/utils/error_retry_predicates.go
@@ -71,7 +71,7 @@ const connectionResetByPeerErr = ": connection reset by peer"
 
 func isConnectionResetNetworkError(err error) (bool, string) {
 	if strings.HasSuffix(err.Error(), connectionResetByPeerErr) {
-		return true, fmt.Sprintf("reset connection")
+		return true, fmt.Sprintf("reset connection error: %v", err)
 	}
 	return false, ""
 }

--- a/third_party/terraform/utils/error_retry_predicates.go
+++ b/third_party/terraform/utils/error_retry_predicates.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 	"strings"
 
-	"golang.org/x/oauth2"
 	"google.golang.org/api/googleapi"
 )
 
@@ -72,20 +71,6 @@ const connectionResetByPeerErr = ": connection reset by peer"
 
 func isConnectionResetNetworkError(err error) (bool, string) {
 	if strings.HasSuffix(err.Error(), connectionResetByPeerErr) {
-		//TODO(emilymye, TPG#3957): Remove these debug logs
-		log.Printf("[DEBUG] Found connection reset by peer error of type %T", err)
-		switch err.(type) {
-		case *url.Error:
-		case *net.OpError:
-			log.Printf("[DEBUG] Connection reset error returned from net/url")
-		case *googleapi.Error:
-			log.Printf("[DEBUG] Connection reset error wrapped by googleapi.Error")
-		case *oauth2.RetrieveError:
-			log.Printf("[DEBUG] Connection reset error wrapped by oauth2")
-		default:
-			log.Printf("[DEBUG] Connection reset error wrapped by %T", err)
-		}
-
 		return true, fmt.Sprintf("reset connection")
 	}
 	return false, ""

--- a/third_party/terraform/utils/retry_transport.go
+++ b/third_party/terraform/utils/retry_transport.go
@@ -87,7 +87,7 @@ func (t *retryTransport) RoundTrip(req *http.Request) (resp *http.Response, resp
 	var ccancel context.CancelFunc
 	if _, ok := ctx.Deadline(); !ok {
 		ctx, ccancel = context.WithTimeout(ctx, defaultRetryTransportTimeoutSec*time.Second)
-		defer func(){
+		defer func() {
 			if ctx.Err() == nil {
 				// Cleanup child context created for retry loop if ctx not done.
 				ccancel()
@@ -153,7 +153,7 @@ func copyHttpRequest(req *http.Request) (*http.Request, error) {
 	newRequest := *req
 
 	if req.Body == nil || req.Body == http.NoBody {
-		return newRequest, nil
+		return &newRequest, nil
 	}
 
 	// Helpers like http.NewRequest add a GetBody for copying.

--- a/third_party/terraform/utils/retry_transport.go
+++ b/third_party/terraform/utils/retry_transport.go
@@ -1,0 +1,181 @@
+// A http.RoundTripper that retries common errors, with convenience constructors.
+//
+// NOTE: This meant for TEMPORARY, TRANSIENT ERRORS.
+// Do not use for waiting on operations or polling of resource state,
+// especially if the expected state (operation done, resource ready, etc)
+// takes longer to reach than the default client Timeout.
+// In those cases, retryTimeDuration(...)/resource.Retry with appropriate timeout
+// and error predicates/handling should be used as a wrapper around the request
+// instead.
+//
+// Example Usage:
+
+// For handwritten/Go clients, the retry transport should be provided via
+// the main client or a shallow copy of the HTTP resources, depending on the
+// API-specific retry predicates.
+// Example Usage in Terraform Config:
+//      client := oauth2.NewClient(ctx, tokenSource)
+//     // Create with default retry predicates
+//     client.Transport := NewTransportWithDefaultRetries(client.Transport, defaultTimeout)
+//
+//      // If API uses just default retry predicates:
+//		c.clientCompute, err = compute.NewService(ctx, option.WithHTTPClient(client))
+//		...
+//		// If API needs custom additional retry predicates:
+//      sqlAdminHttpClient := ClientWithAdditionalRetries(client, retryTransport,
+//     		isTemporarySqlError1,
+//    		isTemporarySqlError2)
+//		c.clientSqlAdmin, err = compute.NewService(ctx, option.WithHTTPClient(sqlAdminHttpClient))
+//		...
+
+package google
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"google.golang.org/api/googleapi"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"time"
+)
+
+const defaultRetryTransportTimeoutSec = 30
+
+// NewTransportWithDefaultRetries constructs a default retryTransport that will retry common temporary errors
+func NewTransportWithDefaultRetries(t http.RoundTripper) *retryTransport {
+	return &retryTransport{
+		retryPredicates: defaultErrorRetryPredicates,
+		internal:        t,
+	}
+}
+
+// Helper method to create a shallow copy of an HTTP client with a shallow-copied retryTransport
+// s.t. the base HTTP transport is the same (i.e. client connection pools are shared, retryPredicates are different)
+func ClientWithAdditionalRetries(baseClient *http.Client, baseRetryTransport *retryTransport, predicates ...RetryErrorPredicateFunc) *http.Client {
+	copied := *baseClient
+	if baseRetryTransport == nil {
+		baseRetryTransport = NewTransportWithDefaultRetries(baseClient.Transport)
+	}
+	copied.Transport = baseRetryTransport.WithAddedPredicates(predicates...)
+	return &copied
+}
+
+// Returns a shallow copy of the retry transport with additional retry predicates but same internal transport
+// (http.RoundTripper)
+func (t *retryTransport) WithAddedPredicates(predicates ...RetryErrorPredicateFunc) *retryTransport {
+	copyT := *t
+	copyT.retryPredicates = append(t.retryPredicates, predicates...)
+	return &copyT
+}
+
+type retryTransport struct {
+	retryPredicates []RetryErrorPredicateFunc
+	internal        http.RoundTripper
+}
+
+//
+func (t *retryTransport) RoundTrip(req *http.Request) (resp *http.Response, respErr error) {
+	// Set timeout to default value.
+	ctx := req.Context()
+	var ccancel context.CancelFunc
+	if _, ok := ctx.Deadline(); !ok {
+		ctx, ccancel = context.WithTimeout(ctx, defaultRetryTransportTimeoutSec*time.Second)
+	}
+
+	attempts := 0
+	backoff := time.Millisecond * 500
+
+	log.Printf("[DEBUG] Retry Transport: starting RoundTrip retry loop")
+Retry:
+	for {
+		log.Printf("[DEBUG] Retry Transport: request attempt %d", attempts)
+		newRequest, copyErr := t.copyRequest(req)
+		if copyErr != nil {
+			respErr = errwrap.Wrapf("unable to copy invalid http.Request for retry: {{err}}", copyErr)
+			break Retry
+		}
+
+		resp, respErr = t.internal.RoundTrip(newRequest)
+		attempts++
+
+		retryErr := t.checkForRetryableError(resp, respErr)
+		if retryErr == nil {
+			log.Printf("[WARN] Retry Transport: Stopping retries, last request was successful")
+			break Retry
+		}
+		if !retryErr.Retryable {
+			log.Printf("[WARN] Retry Transport: Stopping retries, last request failed with non-retryable error: %s", retryErr.Err)
+			break Retry
+		}
+
+		log.Printf("[DEBUG] Retry Transport: Continue retry after waiting for  %s", backoff)
+		select {
+		case <-ctx.Done():
+			log.Printf("[DEBUG] Retry Transport: Stopping retries, context done: %v", ctx.Err())
+			if attempts == 0 {
+				respErr = ctx.Err()
+			}
+			break Retry
+		case <-time.After(backoff):
+			log.Printf("[DEBUG] Retry Transport: Finished waiting")
+			backoff *= 2
+			continue
+		}
+	}
+	// Cancel context if needed
+	if ctx.Err() == nil && ccancel != nil {
+		ccancel()
+	}
+
+	log.Printf("[DEBUG] Retry Transport: Returning after %d attempts", attempts)
+	return resp, respErr
+}
+
+func (t *retryTransport) copyRequest(req *http.Request) (*http.Request, error) {
+	if req.Body == nil || req.Body == http.NoBody {
+		return req, nil
+	}
+
+	if req.GetBody == nil {
+		return nil, errors.New("invalid HTTP request for transport, expected request.GetBody for non-empty Body")
+	}
+
+	bd, err := req.GetBody()
+	if err != nil {
+		return nil, err
+	}
+
+	newRequest := *req
+	newRequest.Body = bd
+	return &newRequest, nil
+}
+
+func (t *retryTransport) checkForRetryableError(resp *http.Response, respErr error) *resource.RetryError {
+	var errToCheck error
+
+	if respErr != nil {
+		errToCheck = respErr
+	} else {
+		respToCheck := *resp
+		if resp.Body != nil && resp.Body != http.NoBody {
+			dumpBytes, err := httputil.DumpResponse(resp, true)
+			if err != nil {
+				return resource.NonRetryableError(fmt.Errorf("unable to check response for error: %v", err))
+			}
+			respToCheck = *resp
+			respToCheck.Body = ioutil.NopCloser(bytes.NewReader(dumpBytes))
+		}
+		errToCheck = googleapi.CheckResponse(&respToCheck)
+	}
+
+	if isRetryableError(errToCheck, t.retryPredicates...) {
+		return resource.RetryableError(errToCheck)
+	}
+	return resource.NonRetryableError(errToCheck)
+}

--- a/third_party/terraform/utils/retry_transport_test.go
+++ b/third_party/terraform/utils/retry_transport_test.go
@@ -1,0 +1,273 @@
+package google
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"google.golang.org/api/googleapi"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const testRetryTransportErrorMessageRetry = "retry error"
+const testRetryTransportErrorMessageSuccess = "success"
+const testRetryTransportErrorMessageFailure = "fail the request"
+
+// Check for no errors if the request succeeds the first time
+func TestRetryTransport_SingleRequestSuccess(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+			if _, err := w.Write([]byte(testRetryTransportErrorMessageSuccess)); err != nil {
+				t.Errorf("unable to write to response writer: %s", err)
+			}
+		}))
+	defer ts.Close()
+
+	client := ts.Client()
+	client.Transport = &retryTransport{
+		internal:        http.DefaultTransport,
+		retryPredicates: []RetryErrorPredicateFunc{testRetryTransportRetryPredicate},
+	}
+
+	resp, err := client.Get(ts.URL)
+	testRetryTransportCheckResponseForSuccess(t, resp, err)
+}
+
+// Check for error if the request fails the first time
+func TestRetryTransport_SingleRequestError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(400)
+			w.Write([]byte(testRetryTransportErrorMessageFailure))
+		}))
+	defer ts.Close()
+
+	client := ts.Client()
+	client.Transport = &retryTransport{
+		internal:        http.DefaultTransport,
+		retryPredicates: []RetryErrorPredicateFunc{testRetryTransportRetryPredicate},
+	}
+
+	resp, err := client.Get(ts.URL)
+	testRetryTransportCheckResponseForFailure(t, resp, err, 400, testRetryTransportErrorMessageFailure)
+}
+
+// Check for no errors if the request succeeds after a certain amount of time
+func TestRetryTransport_SuccessAfterRetries(t *testing.T) {
+	ts := httptest.NewServer(testRetryTransportSucceedAfterHandler(t, time.Second*1))
+	defer ts.Close()
+
+	client := ts.Client()
+	client.Transport = &retryTransport{
+		internal:        http.DefaultTransport,
+		retryPredicates: []RetryErrorPredicateFunc{testRetryTransportRetryPredicate},
+	}
+
+	ctx, cc := context.WithTimeout(context.Background(), time.Second*2)
+	defer cc()
+	req, err := http.NewRequestWithContext(ctx, "GET", ts.URL, nil)
+	if err != nil {
+		t.Fatalf("unable to construct err: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	testRetryTransportCheckResponseForSuccess(t, resp, err)
+}
+
+func TestRetryTransport_FailAfterRetries(t *testing.T) {
+	ts := httptest.NewServer(testRetryTransportFailAfterHandler(t, time.Second*1))
+	defer ts.Close()
+
+	client := ts.Client()
+	client.Transport = &retryTransport{
+		internal:        http.DefaultTransport,
+		retryPredicates: []RetryErrorPredicateFunc{testRetryTransportRetryPredicate},
+	}
+
+	ctx, cc := context.WithTimeout(context.Background(), time.Second*2)
+	defer cc()
+	req, err := http.NewRequestWithContext(ctx, "GET", ts.URL, nil)
+	if err != nil {
+		t.Fatalf("unable to construct err: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	testRetryTransportCheckResponseForFailure(t, resp, err, 400, testRetryTransportErrorMessageFailure)
+}
+
+func TestRetryTransport_ContextTimeout(t *testing.T) {
+	ts := httptest.NewServer(testRetryTransportSucceedAfterHandler(t, time.Second*4))
+	defer ts.Close()
+
+	client := ts.Client()
+	client.Transport = &retryTransport{
+		internal:        http.DefaultTransport,
+		retryPredicates: []RetryErrorPredicateFunc{testRetryTransportRetryPredicate},
+	}
+
+	ctx, cc := context.WithTimeout(context.Background(), time.Second*2)
+	defer cc()
+	req, err := http.NewRequestWithContext(ctx, "GET", ts.URL, nil)
+	if err != nil {
+		t.Fatalf("unable to construct err: %v", err)
+	}
+	resp, err := client.Do(req)
+	// Last failure should have been a retryable error since we timed out
+	testRetryTransportCheckResponseForFailure(t, resp, err, 500, testRetryTransportErrorMessageRetry)
+}
+
+// Check for no errors if the request succeeds after a certain amount of time
+func TestRetryTransport_SuccessAfterRetriesWithBody(t *testing.T) {
+	ts := httptest.NewServer(testRetryTransportSuccessCheckBodyHandler(t, time.Second*1))
+	defer ts.Close()
+
+	client := ts.Client()
+	client.Transport = &retryTransport{
+		internal:        http.DefaultTransport,
+		retryPredicates: []RetryErrorPredicateFunc{testRetryTransportRetryPredicate},
+	}
+
+	msg := "body for successful request"
+	ctx, cc := context.WithTimeout(context.Background(), time.Second*2)
+	defer cc()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", ts.URL, bytes.NewReader([]byte(msg)))
+	if err != nil {
+		t.Fatalf("unable to construct err: %v", err)
+	}
+
+	resp, err := client.Do(req)
+	testRetryTransportCheckResponseForSuccess(t, resp, err)
+}
+
+// SUCCESS handlers and check
+func testRetryTransportSucceedAfterHandler(t *testing.T, successInterval time.Duration) http.Handler {
+	var firstReqTime time.Time
+	var testOnce sync.Once
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testOnce.Do(func() {
+			firstReqTime = time.Now()
+		})
+		if time.Since(firstReqTime) >= successInterval {
+			w.WriteHeader(200)
+			if _, err := w.Write([]byte(testRetryTransportErrorMessageSuccess)); err != nil {
+				t.Errorf("[ERROR] unable to write to response writer: %v", err)
+			}
+		} else {
+			w.WriteHeader(500)
+			if _, err := w.Write([]byte(testRetryTransportErrorMessageRetry)); err != nil {
+				t.Errorf("[ERROR] unable to write to response writer: %v", err)
+			}
+		}
+	})
+}
+
+func testRetryTransportSuccessCheckBodyHandler(t *testing.T, successInterval time.Duration) http.Handler {
+	var firstReqTime time.Time
+	var testOnce sync.Once
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testOnce.Do(func() {
+			firstReqTime = time.Now()
+		})
+
+		slurp, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(400)
+			if _, err := w.Write([]byte(fmt.Sprintf("unable to read request body: %v", err))); err != nil {
+				t.Errorf("[ERROR] unable to write to response writer: %v", err)
+			}
+			return
+		}
+
+		if time.Since(firstReqTime) >= successInterval {
+			w.WriteHeader(200)
+			resp := fmt.Sprintf("%s\nRequest Body: %s", testRetryTransportErrorMessageSuccess, string(slurp))
+			if _, err := w.Write([]byte(resp)); err != nil {
+				t.Errorf("[ERROR] unable to write to response writer: %v", err)
+			}
+		} else {
+			w.WriteHeader(500)
+			resp := fmt.Sprintf("%s\nRequest Body: %s", testRetryTransportErrorMessageRetry, string(slurp))
+			if _, err := w.Write([]byte(resp)); err != nil {
+				t.Errorf("[ERROR] unable to write to response writer: %v", err)
+			}
+		}
+	})
+}
+
+func testRetryTransportCheckResponseForSuccess(t *testing.T, resp *http.Response, respErr error) {
+	if respErr != nil {
+		t.Fatalf("expected no error, got: %v", respErr)
+	}
+
+	err := googleapi.CheckResponse(resp)
+	if err != nil {
+		t.Fatalf("expected no error, got response error: %v", err)
+	}
+}
+
+// FAILURE handler and check
+func testRetryTransportFailAfterHandler(t *testing.T, successInterval time.Duration) http.Handler {
+	var firstReqTime time.Time
+	var testOnce sync.Once
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		testOnce.Do(func() {
+			firstReqTime = time.Now()
+		})
+		if time.Since(firstReqTime) >= successInterval {
+			w.WriteHeader(400)
+			if _, err := w.Write([]byte(testRetryTransportErrorMessageFailure)); err != nil {
+				t.Errorf("[ERROR] unable to write to response writer: %v", err)
+			}
+		} else {
+			w.WriteHeader(500)
+			if _, err := w.Write([]byte(testRetryTransportErrorMessageRetry)); err != nil {
+				t.Errorf("[ERROR] unable to write to response writer: %v", err)
+			}
+		}
+	})
+}
+
+func testRetryTransportCheckResponseForFailure(t *testing.T, resp *http.Response, respErr error, expectedCode int, expectedMsg string) {
+	if respErr != nil {
+		t.Fatalf("expected response error, got actual error for doing request: %v", respErr)
+	}
+
+	err := googleapi.CheckResponse(resp)
+	if err == nil {
+		t.Fatalf("expected googleapi error, got no error")
+	}
+
+	gerr, ok := err.(*googleapi.Error)
+	if !ok {
+		t.Fatalf("expected error to be googleapi error: %v", err)
+	}
+
+	if gerr.Code != expectedCode {
+		t.Errorf("expected error code 400, got error: %v", err)
+	}
+
+	if !strings.Contains(gerr.Body, expectedMsg) {
+		t.Errorf("expected error %q in %v", testRetryTransportErrorMessageFailure, err)
+	}
+}
+
+// ERROR RETRY PREDICATE
+// Retries 500.
+func testRetryTransportRetryPredicate(err error) (bool, string) {
+	if gerr, ok := err.(*googleapi.Error); ok {
+		if gerr.Code == 500 && gerr.Message == "retry error" {
+			return true, "retry error"
+		}
+	}
+	return false, ""
+}

--- a/third_party/terraform/utils/retry_transport_test.go
+++ b/third_party/terraform/utils/retry_transport_test.go
@@ -44,7 +44,9 @@ func TestRetryTransport_SingleRequestError(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(400)
-			w.Write([]byte(testRetryTransportErrorMessageFailure))
+			if _, err := w.Write([]byte(testRetryTransportErrorMessageFailure)); err != nil {
+				t.Errorf("unable to write to response writer: %s", err)
+			}
 		}))
 	defer ts.Close()
 


### PR DESCRIPTION
At this stage, this only adds a retry transport but doesn't change the retry loops outside of the transport (i.e. those wrapping httpClient.Do(req) in `sendRequest()` or golangClient.Request().Do()). 

I think removal of retry-loop work needs to be done more carefully, in case we end up changing the behavior, but we should hopefully move to having sendRequest/resource.Retry only send API/resource specific errorRetryPredicates. 


<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
provider: Added provider-wide request retries for common temporary GCP error codes and network errors
```
