### PR TITLE
Add missing fields to instance template's network_interfaces schema

### DIFF
--- a/third_party/terraform/resources/resource_compute_instance.go
+++ b/third_party/terraform/resources/resource_compute_instance.go
@@ -230,15 +230,15 @@ func resourceComputeInstance() *schema.Resource {
 							ForceNew: true,
 						},
 
-						"name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
-
 						"network_ip": {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
+							Computed: true,
+						},
+
+						"name": {
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 

--- a/third_party/terraform/resources/resource_compute_instance_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_template.go
@@ -246,12 +246,6 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 							DiffSuppressFunc: compareSelfLinkOrResourceName,
 						},
 
-						"network_ip": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-						},
-
 						"subnetwork": {
 							Type:             schema.TypeString,
 							Optional:         true,
@@ -264,6 +258,17 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
+							Computed: true,
+						},
+
+						"network_ip": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"name": {
+							Type:     schema.TypeString,
 							Computed: true,
 						},
 
@@ -284,6 +289,11 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 										Optional:     true,
 										Computed:     true,
 										ValidateFunc: validation.StringInSlice([]string{"PREMIUM", "STANDARD"}, false),
+									},
+									// Possibly configurable- this was added so we don't break if it's inadvertently set
+									"public_ptr_domain_name": {
+										Type:     schema.TypeString,
+										Computed: true,
 									},
 								},
 							},


### PR DESCRIPTION
Fix for b/150632967

The `name` field getting returned hasn't happened in prod, but this should make us more resilient when it happens. Also reorder the schemas to have the same ordering.

I tried to test this, but it didn't appear in beta staging. I'm confident that adding new fields to the schema is safe to do.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
