### PR TITLE
add customize diff to prevent two rules with the same priority

### DIFF
--- a/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -22,6 +22,7 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: resourceSecurityPolicyStateImporter,
 		},
+		CustomizeDiff: rulesCustomizeDiff,
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(4 * time.Minute),
@@ -149,6 +150,22 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 			},
 		},
 	}
+}
+
+func rulesCustomizeDiff(diff *schema.ResourceDiff, _ interface{}) error {
+	_, n := diff.GetChange("rule")
+	nSet := n.(*schema.Set)
+
+	nPriorities := map[int64]bool{}
+	for _, rule := range nSet.List() {
+		priority := int64(rule.(map[string]interface{})["priority"].(int))
+		if nPriorities[priority] {
+			return fmt.Errorf("Two rules have the same priority, please update one of the priorities to be different.")
+		}
+		nPriorities[priority] = true
+	}
+
+	return nil
 }
 
 func resourceComputeSecurityPolicyCreate(d *schema.ResourceData, meta interface{}) error {

--- a/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -98,6 +98,11 @@ func TestAccComputeSecurityPolicy_update(t *testing.T) {
 			},
 
 			{
+				Config: testAccComputeSecurityPolicy_updateSamePriority(spName),
+				ExpectError: regexp.MustCompile("Two rules have the same priority, please update one of the priorities to be different."),
+			},
+
+			{
 				Config: testAccComputeSecurityPolicy_update(spName),
 			},
 			{
@@ -161,6 +166,52 @@ resource "google_compute_security_policy" "policy" {
       }
     }
     description = "default rule"
+  }
+
+  rule {
+    action   = "allow"
+    priority = "2000"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["10.0.0.0/24"]
+      }
+    }
+    preview = true
+  }
+}
+`, spName)
+}
+
+func testAccComputeSecurityPolicy_updateSamePriority(spName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_security_policy" "policy" {
+  name        = "%s"
+  description = "updated description"
+
+  // keep this
+  rule {
+    action   = "allow"
+    priority = "2147483647"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["*"]
+      }
+    }
+    description = "default rule"
+  }
+
+  // add this
+  rule {
+    action   = "deny(403)"
+    priority = "2000"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["10.0.1.0/24"]
+      }
+    }
   }
 
   rule {


### PR DESCRIPTION
Added CustomizeDiff to prevent users from adding/updating the security policy with two rules of the same priority.

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5804

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed `google_compute_security_policy` from allowing two rules with the same priority.
```
