### PR TITLE
Add id field to resources bigtable and bigquery

### DIFF
--- a/templates/terraform/examples/bigquery_dataset_cmek.tf.erb
+++ b/templates/terraform/examples/bigquery_dataset_cmek.tf.erb
@@ -6,13 +6,13 @@ resource "google_bigquery_dataset" "<%= ctx[:primary_resource_id] %>" {
   default_table_expiration_ms = 3600000
 
   default_encryption_configuration {
-    kms_key_name = google_kms_crypto_key.crypto_key.self_link
+    kms_key_name = google_kms_crypto_key.crypto_key.id
   }
 }
 
 resource "google_kms_crypto_key" "crypto_key" {
   name     = "<%= ctx[:vars]['key_name'] %>"
-  key_ring = google_kms_key_ring.key_ring.self_link
+  key_ring = google_kms_key_ring.key_ring.id
 }
 
 resource "google_kms_key_ring" "key_ring" {

--- a/templates/terraform/examples/bigtable_app_profile_multicluster.tf.erb
+++ b/templates/terraform/examples/bigtable_app_profile_multicluster.tf.erb
@@ -9,7 +9,7 @@ resource "google_bigtable_instance" "instance" {
 }
 
 resource "google_bigtable_app_profile" "ap" {
-  instance       = google_bigtable_instance.instance.name
+  instance       = google_bigtable_instance.instance.id
   app_profile_id = "<%= ctx[:vars]['app_profile_name'] %>"
 
   multi_cluster_routing_use_any = true

--- a/templates/terraform/examples/bigtable_app_profile_singlecluster.tf.erb
+++ b/templates/terraform/examples/bigtable_app_profile_singlecluster.tf.erb
@@ -9,7 +9,7 @@ resource "google_bigtable_instance" "instance" {
 }
 
 resource "google_bigtable_app_profile" "ap" {
-  instance       = google_bigtable_instance.instance.name
+  instance       = google_bigtable_instance.instance.id
   app_profile_id = "<%= ctx[:vars]['app_profile_name'] %>"
 
   single_cluster_routing {

--- a/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
@@ -29,7 +29,7 @@ resource "google_bigtable_instance" "instance" {
 
 resource "google_bigtable_table" "table" {
   name          = "tf-table"
-  instance_name = google_bigtable_instance.instance.name
+  instance_name = google_bigtable_instance.instance.id
 
   column_family {
     family = "name"
@@ -37,8 +37,8 @@ resource "google_bigtable_table" "table" {
 }
 
 resource "google_bigtable_gc_policy" "policy" {
-  instance_name = google_bigtable_instance.instance.name
-  table         = google_bigtable_table.table.name
+  instance_name = google_bigtable_instance.instance.id
+  table         = google_bigtable_table.table.id
   column_family = "name"
 
   max_age {
@@ -51,8 +51,8 @@ Multiple conditions is also supported. `UNION` when any of its sub-policies appl
 
 ```hcl
 resource "google_bigtable_gc_policy" "policy" {
-  instance_name = google_bigtable_instance.instance.name
-  table         = google_bigtable_table.table.name
+  instance_name = google_bigtable_instance.instance.id
+  table         = google_bigtable_table.table.id
   column_family = "name"
 
   mode = "UNION"

--- a/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -88,8 +88,6 @@ for a `DEVELOPMENT` instance.
 
 * id - an identifier for the resource with format projects/{{project}}/instances/{{name}}
 
-* name - The unique name of the requested big table instance. Values are of the form projects/<project>/instances/<instanceId>.
-
 ## Import
 
 Bigtable Instances can be imported using any of these accepted formats:

--- a/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -86,7 +86,9 @@ for a `DEVELOPMENT` instance.
 
 ## Attributes Reference
 
-Only the arguments listed above are exposed as attributes.
+* id - an identifier for the resource with format projects/{{project}}/instances/{{name}}
+
+* name - The unique name of the requested big table instance. Values are of the form projects/<project>/instances/<instanceId>.
 
 ## Import
 

--- a/third_party/terraform/website/docs/r/bigtable_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_table.html.markdown
@@ -60,8 +60,6 @@ The following arguments are supported:
 
 * id - an identifier for the resource with format projects/{{project}}/instances/{{instance}}/tables/{{name}}
 
-* name - an identifier for the resource with format projects/{{project}}/instances/{{instance}}/tables/{{tableId}}
-
 Only the arguments listed above are exposed as attributes.
 
 ## Import

--- a/third_party/terraform/website/docs/r/bigtable_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_table.html.markdown
@@ -30,7 +30,7 @@ resource "google_bigtable_instance" "instance" {
 
 resource "google_bigtable_table" "table" {
   name          = "tf-table"
-  instance_name = google_bigtable_instance.instance.name
+  instance_name = google_bigtable_instance.instance.id
   split_keys    = ["a", "b", "c"]
 }
 ```
@@ -57,6 +57,10 @@ The following arguments are supported:
 * `family` - (Optional) The name of the column family.
 
 ## Attributes Reference
+
+* id - an identifier for the resource with format projects/{{project}}/instances/{{instance}}/tables/{{name}}
+
+* name - an identifier for the resource with format projects/{{project}}/instances/{{instance}}/tables/{{tableId}}
 
 Only the arguments listed above are exposed as attributes.
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

Modified examples and doc to reference id attribute 

- google_big_query_dataset
- google_bigtable_app_profile
- google_bigtable_gc_policy
- google_bigtable_instance
- google_bigtable_table


NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
