### PR TITLE
Much longer docs about metadata attributes, including links to non-linux load-bearing attributes.

### DIFF
--- a/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -133,9 +133,9 @@ The following arguments are supported:
     startup-script metadata key on the created instance and thus the two
     mechanisms are not allowed to be used simultaneously.  Users are free to use
     either mechanism - the only distinction is that this separate attribute
-    willl cause a recreate on modification.  On import, `metadata.startup-script`
-    will be set, but `metadata_startup_script` will not - if you choose to use this
-    mechanism, you will see a diff immediately after import, which will cause a
+    willl cause a recreate on modification.  On import, `metadata_startup_script`
+    will be set, but `metadata.startup-script` will not - if you choose to use the
+    other mechanism, you will see a diff immediately after import, which will cause a
     destroy/recreate operation.  You may want to modify your state file manually
     using `terraform state` commands, depending on your use case.
 

--- a/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -116,15 +116,28 @@ The following arguments are supported:
     within the instance. Ssh keys attached in the Cloud Console will be removed.
     Add them to your config in order to keep them attached to your instance.
 
--> On import, `metadata_startup_script` will be set while 
-`metadata.startup-script` will not be. You'll need to match 
-`metadata_startup_script` to your `startup-script` value.
+-> Depending on the OS you choose for your instance, some metadata keys have
+   special functionality.  Most linux-based images will run the content of
+   `metadata.startup-script` in a shell on every boot.  At a minimum,
+   Debian, CentOS, RHEL, SLES, Container-Optimized OS, and Ubuntu images
+   support this key.  Windows instances require other keys depending on the format
+   of the script and the time you would like it to run - see [this table](https://cloud.google.com/compute/docs/startupscript#providing_a_startup_script_for_windows_instances).
+   For Container-Optimized OS, `metadata.user-data` accepts an Ignition Config,
+   see [this page](https://coreos.com/os/docs/latest/booting-on-google-compute-engine.html)
+   for more information.  For the convenience of the users of `metadata.startup-script`,
+   we provide a special attribute, `metadata_startup_script`, which is documented below.
 
 * `metadata_startup_script` - (Optional) An alternative to using the
     startup-script metadata key, except this one forces the instance to be
     recreated (thus re-running the script) if it is changed. This replaces the
     startup-script metadata key on the created instance and thus the two
-    mechanisms are not allowed to be used simultaneously.
+    mechanisms are not allowed to be used simultaneously.  Users are free to use
+    either mechanism - the only distinction is that this separate attribute
+    willl cause a recreate on modification.  On import, `metadata.startup-script`
+    will be set, but `metadata_startup_script` will not - if you choose to use this
+    mechanism, you will see a diff immediately after import, which will cause a
+    destroy/recreate operation.  You may want to modify your state file manually
+    using `terraform state` commands, depending on your use case.
 
 * `min_cpu_platform` - (Optional) Specifies a minimum CPU platform for the VM instance. Applicable values are the friendly names of CPU platforms, such as
 `Intel Haswell` or `Intel Skylake`. See the complete list [here](https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform).


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/2896 by explaining how to use metadata for that particular use case.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```