### PR TITLE
Move drain_nat_ips to GA from beta.

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -10950,7 +10950,6 @@ objects:
           A list of URLs of the IP resources to be drained. These IPs must be
           valid static external IPs that have been assigned to the NAT.
         send_empty_value: true
-        min_version: beta
         item_type: !ruby/object:Api::Type::ResourceRef
           name: 'address'
           resource: 'Address'


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5566.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: moved `google_compute_router_nat`'s `drain_nat_ips` from beta to ga.
```