### PR TITLE
add vpc_connector to update

### DIFF
--- a/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -484,6 +484,11 @@ func resourceCloudFunctionsUpdate(d *schema.ResourceData, meta interface{}) erro
 		updateMaskArr = append(updateMaskArr, "environmentVariables")
 	}
 
+	if d.HasChange("vpc_connector") {
+		function.VpcConnector = d.Get("vpc_connector").(string)
+		updateMaskArr = append(updateMaskArr, "vpcConnector")
+	}
+
 	if d.HasChange("event_trigger") {
 		function.EventTrigger = expandEventTrigger(d.Get("event_trigger").([]interface{}), project)
 		updateMaskArr = append(updateMaskArr, "eventTrigger", "eventTrigger.failurePolicy.retry")

--- a/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
+++ b/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
@@ -322,10 +322,11 @@ func TestAccCloudFunctionsFunction_serviceAccountEmail(t *testing.T) {
 func TestAccCloudFunctionsFunction_vpcConnector(t *testing.T) {
 	t.Parallel()
 
+	funcResourceName := "google_cloudfunctions_function.function"
 	functionName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	bucketName := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
 	networkName := fmt.Sprintf("tf-test-net-%d", acctest.RandInt())
-	vpcConnectorName := fmt.Sprintf("tf-test-connector-%s",  acctest.RandString(5))
+	vpcConnectorName := fmt.Sprintf("tf-test-conn-%s",  acctest.RandString(5))
 	zipFilePath := createZIPArchiveForCloudFunctionSource(t, testHTTPTriggerPath)
 	projectNumber := os.Getenv("GOOGLE_PROJECT_NUMBER")
 	defer os.Remove(zipFilePath) // clean up
@@ -336,7 +337,20 @@ func TestAccCloudFunctionsFunction_vpcConnector(t *testing.T) {
 		CheckDestroy: testAccCheckCloudFunctionsFunctionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudFunctionsFunction_vpcConnector(projectNumber, networkName, functionName, bucketName, zipFilePath, vpcConnectorName),
+				Config: testAccCloudFunctionsFunction_vpcConnector(projectNumber, networkName, functionName, bucketName, zipFilePath, "10.10.0.0/28", vpcConnectorName),
+			},
+			{
+				ResourceName:      funcResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCloudFunctionsFunction_vpcConnector(projectNumber, networkName, functionName, bucketName, zipFilePath, "10.20.0.0/28", vpcConnectorName+"-update"),
+			},
+			{
+				ResourceName:      funcResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -758,7 +772,7 @@ resource "google_cloudfunctions_function" "function" {
 `, bucketName, zipFilePath, functionName)
 }
 
-func testAccCloudFunctionsFunction_vpcConnector(projectNumber, networkName, functionName, bucketName, zipFilePath, vpcConnectorName string) string {
+func testAccCloudFunctionsFunction_vpcConnector(projectNumber, networkName, functionName, bucketName, zipFilePath, vpcIp, vpcConnectorName string) string {
 	return fmt.Sprintf(`
 
 resource "google_project_iam_member" "gcfadmin" {
@@ -771,10 +785,10 @@ resource "google_compute_network" "vpc" {
 	auto_create_subnetworks = false
 }
 
-resource "google_vpc_access_connector" "connector" {
+resource "google_vpc_access_connector" "%s" {
   name          = "%s"
   region        = "us-central1"
-  ip_cidr_range = "10.10.0.0/28"
+  ip_cidr_range = "%s"
   network       = google_compute_network.vpc.name
 }
 
@@ -806,9 +820,9 @@ resource "google_cloudfunctions_function" "function" {
 	TEST_ENV_VARIABLE = "test-env-variable-value"
   }
   max_instances = 10
-  vpc_connector = google_vpc_access_connector.connector.self_link
+  vpc_connector = google_vpc_access_connector.%s.self_link
 
   depends_on = [google_project_iam_member.gcfadmin]
 }
-`, projectNumber, networkName, vpcConnectorName, bucketName, zipFilePath, functionName)
+`, projectNumber, networkName, vpcConnectorName, vpcConnectorName, vpcIp, bucketName, zipFilePath, functionName, vpcConnectorName)
 }


### PR DESCRIPTION
Added `vpc_connector` to update function.

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5811

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudfunctions: fixed `vpc_connector` to be updated properly in `google_cloudfunctions_function`
```
