### PR TITLE
Ensure that code that doesn't compile returns useful errors.

### DIFF
--- a/.ci/containers/terraform-tester/test_terraform.sh
+++ b/.ci/containers/terraform-tester/test_terraform.sh
@@ -20,6 +20,7 @@ mkdir -p "$(dirname $LOCAL_PATH)"
 git clone $SCRATCH_PATH $LOCAL_PATH --single-branch --branch "auto-pr-$REFERENCE" --depth 1
 pushd $LOCAL_PATH
 
+make # The errors are unintuitive if you call 'make lint' on code that doesn't compile.
 make tools
 make docscheck
 make lint


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
