### PR TITLE
Bigquery reservation

### DIFF
--- a/products/bigqueryreservation/api.yaml
+++ b/products/bigqueryreservation/api.yaml
@@ -1,0 +1,68 @@
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: BigqueryReservation
+display_name: BigQueryReservation
+versions:
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://bigqueryreservation.googleapis.com/v1beta1/
+scopes:
+  - https://www.googleapis.com/auth/bigquery
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: BigQueryDataTransfer API
+    url: https://console.cloud.google.com/apis/api/bigquerydatatransfer.googleapis.com/
+objects:
+  - !ruby/object:Api::Resource
+    name: 'Reservation'
+    base_url: projects/{{project}}/locations/{{location}}/reservations
+    self_link: projects/{{project}}/locations/{{location}}/reservations/{{name}}
+    create_url: projects/{{project}}/locations/{{location}}/reservations?reservationId={{name}}
+    update_verb: :PATCH
+    update_mask: true
+    description: |
+      A reservation is a mechanism used to guarantee BigQuery slots to users.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        "Introduction to Reservations": "https://cloud.google.com/bigquery/docs/reservations-intro"
+      api: "https://cloud.google.com/bigquery/docs/reference/reservations/rest/v1beta1/projects.locations.reservations/create"
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: 'location'
+        url_param_only: true
+        input: true
+        default_value: US
+        description: |
+          The geographic location where the transfer config should reside.
+          Examples: US, EU, asia-northeast1. The default value is US.
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        url_param_only: true
+        input: true
+        description: |
+          The name of the reservation. This field must only contain alphanumeric characters or dash.
+    properties:
+      - !ruby/object:Api::Type::Integer
+        name: 'slotCapacity'
+        required: true
+        description: |
+          The user specified display name for the transfer config.
+      - !ruby/object:Api::Type::Boolean
+        name: 'ignoreIdleSlots'
+        send_empty_value: true
+        description: |
+          If false, any query using this reservation will use idle slots from other reservations within
+          the same admin project. If true, a query using this reservation will execute with the slot
+          capacity specified above at most.

--- a/products/bigqueryreservation/api.yaml
+++ b/products/bigqueryreservation/api.yaml
@@ -22,8 +22,8 @@ scopes:
   - https://www.googleapis.com/auth/bigquery
 apis_required:
   - !ruby/object:Api::Product::ApiReference
-    name: BigQueryDataTransfer API
-    url: https://console.cloud.google.com/apis/api/bigquerydatatransfer.googleapis.com/
+    name: BigQueryReservation API
+    url: https://console.cloud.google.com/apis/api/bigqueryreservation.googleapis.com/
 objects:
   - !ruby/object:Api::Resource
     name: 'Reservation'

--- a/products/bigqueryreservation/api.yaml
+++ b/products/bigqueryreservation/api.yaml
@@ -62,6 +62,7 @@ objects:
           unit of parallelism. Queries using this reservation might use more slots during runtime if ignoreIdleSlots is set to false.
       - !ruby/object:Api::Type::Boolean
         name: 'ignoreIdleSlots'
+        default_value: false
         description: |
           If false, any query using this reservation will use idle slots from other reservations within
           the same admin project. If true, a query using this reservation will execute with the slot

--- a/products/bigqueryreservation/api.yaml
+++ b/products/bigqueryreservation/api.yaml
@@ -51,6 +51,7 @@ objects:
         name: 'name'
         url_param_only: true
         input: true
+        required: true
         description: |
           The name of the reservation. This field must only contain alphanumeric characters or dash.
     properties:
@@ -61,7 +62,6 @@ objects:
           The user specified display name for the transfer config.
       - !ruby/object:Api::Type::Boolean
         name: 'ignoreIdleSlots'
-        send_empty_value: true
         description: |
           If false, any query using this reservation will use idle slots from other reservations within
           the same admin project. If true, a query using this reservation will execute with the slot

--- a/products/bigqueryreservation/api.yaml
+++ b/products/bigqueryreservation/api.yaml
@@ -28,7 +28,6 @@ objects:
   - !ruby/object:Api::Resource
     name: 'Reservation'
     base_url: projects/{{project}}/locations/{{location}}/reservations
-    self_link: projects/{{project}}/locations/{{location}}/reservations/{{name}}
     create_url: projects/{{project}}/locations/{{location}}/reservations?reservationId={{name}}
     update_verb: :PATCH
     update_mask: true

--- a/products/bigqueryreservation/api.yaml
+++ b/products/bigqueryreservation/api.yaml
@@ -58,7 +58,8 @@ objects:
         name: 'slotCapacity'
         required: true
         description: |
-          The user specified display name for the transfer config.
+          Minimum slots available to this reservation. A slot is a unit of computational power in BigQuery, and serves as the
+          unit of parallelism. Queries using this reservation might use more slots during runtime if ignoreIdleSlots is set to false.
       - !ruby/object:Api::Type::Boolean
         name: 'ignoreIdleSlots'
         description: |

--- a/products/bigqueryreservation/terraform.yaml
+++ b/products/bigqueryreservation/terraform.yaml
@@ -1,0 +1,30 @@
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Terraform::Config
+legacy_name: bigquery
+overrides: !ruby/object:Overrides::ResourceOverrides
+  Reservation: !ruby/object:Overrides::Terraform::ResourceOverride
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        min_version: beta
+        name: "bigquery_reservation_basic"
+        primary_resource_id: "reservation"
+        vars:
+          name: 'reservation'
+# This is for copying files over
+files: !ruby/object:Provider::Config::Files
+  # These files have templating (ERB) code that will be run.
+  # This is usually to add licensing info, autogeneration notices, etc.
+  compile:
+<%= lines(indent(compile('provider/terraform/product~compile.yaml'), 4)) -%>

--- a/templates/terraform/examples/bigquery_reservation_basic.tf.erb
+++ b/templates/terraform/examples/bigquery_reservation_basic.tf.erb
@@ -1,0 +1,9 @@
+resource "google_bigquery_reservation" "<%= ctx[:primary_resource_id] %>" {
+	provider       = "google-beta"
+	name           = "<%= ctx[:vars]['name'] %>"
+	location       = "asia-northeast1"
+	// Set to 0 for testing purposes
+	// In reality this would be larger than zero
+	slot_capacity  = 0
+	ignore_idle_slots = true
+}

--- a/templates/terraform/examples/bigquery_reservation_basic.tf.erb
+++ b/templates/terraform/examples/bigquery_reservation_basic.tf.erb
@@ -1,5 +1,5 @@
 resource "google_bigquery_reservation" "<%= ctx[:primary_resource_id] %>" {
-	provider       = "google-beta"
+	provider       = google-beta
 	name           = "<%= ctx[:vars]['name'] %>"
 	location       = "asia-northeast1"
 	// Set to 0 for testing purposes

--- a/third_party/terraform/tests/resource_bigquery_reservation_test.go.erb
+++ b/third_party/terraform/tests/resource_bigquery_reservation_test.go.erb
@@ -1,0 +1,76 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccBigqueryReservationReservation_bigqueryReservationUpdate(t *testing.T) {
+	t.Parallel()
+
+	location := "asia-northeast1"
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(10),
+		"location":      location,
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBigqueryReservationReservationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigqueryReservationReservation_bigqueryReservationBasic(context),
+			},
+			{
+				ResourceName:      "google_bigquery_reservation.reservation",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBigqueryReservationReservation_bigqueryReservationUpdate(context),
+			},
+			{
+				ResourceName:      "google_bigquery_reservation.reservation",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccBigqueryReservationReservation_bigqueryReservationBasic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_bigquery_reservation" "reservation" {
+	name           = "reservation%{random_suffix}"
+	location       = "%{location}"
+	// Set to 0 for testing purposes
+	// In reality this would be larger than zero
+	slot_capacity  = 0
+	ignore_idle_slots = true
+}
+`, context)
+}
+
+func testAccBigqueryReservationReservation_bigqueryReservationUpdate(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_bigquery_reservation" "reservation" {
+	name           = "reservation%{random_suffix}"
+	location       = "%{location}"
+	// Set to 0 for testing purposes
+	// In reality this would be larger than zero
+	slot_capacity  = 0
+	ignore_idle_slots = false
+}
+`, context)
+}
+<% else %>
+// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
+<% end -%>

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -282,6 +282,14 @@
     </ul>
     </li>
 
+    <li<%%= sidebar_current("docs-google-bigquery-data-transfer") %>>
+    <a href="#">Google BigQuery Reservation Resources</a>
+    <ul class="nav nav-visible">
+      <li<%%= sidebar_current("docs-google-bigquery-reservation") %>>
+      <a href="/docs/providers/google/r/bigquery_reservation.html">google_bigquery_reservation</a>
+    </ul>
+    </li>
+
     <li<%%= sidebar_current("docs-google-bigtable") %>>
     <a href="#">Google Bigtable Resources</a>
     <ul class="nav nav-visible">


### PR DESCRIPTION
Add support for bigquery reservation resource.

Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/5125

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
google_bigquery_reservation
```
