### PR TITLE
Fix batcher error messages after single request split-out

### DIFF
--- a/third_party/terraform/utils/batcher.go
+++ b/third_party/terraform/utils/batcher.go
@@ -176,11 +176,9 @@ func (b *RequestBatcher) SendRequestWithTimeout(batchKey string, request *BatchR
 	select {
 	case resp := <-respCh:
 		if resp.err != nil {
-			// use wrapf so we can potentially extract the original error type
-			errMsg := fmt.Sprintf(
-				"Batch %q for request %q returned error: {{err}}. To debug individual requests, try disabling batching: https://www.terraform.io/docs/providers/google/guides/provider_reference.html#enable_batching",
-				batchKey, request.DebugId)
-			return nil, errwrap.Wrapf(errMsg, resp.err)
+			return nil, errwrap.Wrapf(
+				fmt.Sprintf("Request %q returned error: {{err}}", request.DebugId),
+				resp.err)
 		}
 		return resp.body, nil
 	case <-ctx.Done():
@@ -256,7 +254,7 @@ func (b *RequestBatcher) sendBatchWithSingleRetry(batchKey string, batch *starte
 
 			if singleResp.IsError() {
 				singleResp.err = errwrap.Wrapf(
-					"batch request and retry as single request failed - final error: {{err}}",
+					fmt.Sprintf("Batch request and retried single request %q both failed. Final error: {{err}}", sub.singleRequest.DebugId),
 					singleResp.err)
 			}
 			sub.respCh <- singleResp

--- a/third_party/terraform/utils/batcher_test.go
+++ b/third_party/terraform/utils/batcher_test.go
@@ -184,10 +184,6 @@ func TestRequestBatcher_errInSend(t *testing.T) {
 					t.Errorf("expected error for request %d, got none", idx)
 				}
 				// Check error message
-				expectedErrPrefix := "batch request and retry as single request failed - final error: "
-				if !strings.Contains(err.Error(), expectedErrPrefix) {
-					t.Errorf("expected error %q to contain %q", err, expectedErrPrefix)
-				}
 				if !strings.Contains(err.Error(), expectedErrMsg) {
 					t.Errorf("expected error %q to contain %q", err, expectedErrMsg)
 				}


### PR DESCRIPTION
Noticed from some of our tests - we should just remove batch request message in the error, since we split them out and retry as single requests afterwards now 

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
