### PR TITLE
fix race condition with modification of global state across processes.

### DIFF
--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -65,8 +65,8 @@ pushd ../mm-$REPO-$VERSION-$COMMAND
 
 clone_repo
 
-git config --global user.name "Modular Magician"
-git config --global user.email "magic-modules@google.com"
+git config --local user.name "Modular Magician"
+git config --local user.email "magic-modules@google.com"
 
 if [ "$COMMAND" == "head" ]; then
     BRANCH=auto-pr-$REFERENCE
@@ -100,6 +100,8 @@ else
 fi
 
 pushd $LOCAL_PATH
+git config --local user.name "Modular Magician"
+git config --local user.email "magic-modules@google.com"
 git add .
 git checkout -b $BRANCH
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```

Fixes issues like https://console.cloud.google.com/cloud-build/builds/9bd6a2b7-b518-4506-98fb-91502f18b096;step=10?project=graphite-docker-images