### PR TITLE
bigtable_table and bigtable_gc_policy support long form ids

### DIFF
--- a/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -24,9 +24,10 @@ func resourceBigtableGCPolicy() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"instance_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: compareResourceNames,
 			},
 
 			"table": {
@@ -95,11 +96,12 @@ func resourceBigtableGCPolicyCreate(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	instanceName := d.Get("instance_name").(string)
+	instanceName := GetResourceNameFromSelfLink(d.Get("instance_name").(string))
 	c, err := config.bigtableClientFactory.NewAdminClient(project, instanceName)
 	if err != nil {
 		return fmt.Errorf("Error starting admin client. %s", err)
 	}
+	d.Set("instance_name", instanceName)
 
 	defer c.Close()
 
@@ -138,7 +140,7 @@ func resourceBigtableGCPolicyRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	instanceName := d.Get("instance_name").(string)
+	instanceName := GetResourceNameFromSelfLink(d.Get("instance_name").(string))
 	c, err := config.bigtableClientFactory.NewAdminClient(project, instanceName)
 	if err != nil {
 		return fmt.Errorf("Error starting admin client. %s", err)
@@ -175,7 +177,7 @@ func resourceBigtableGCPolicyDestroy(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	instanceName := d.Get("instance_name").(string)
+	instanceName := GetResourceNameFromSelfLink(d.Get("instance_name").(string))
 	c, err := config.bigtableClientFactory.NewAdminClient(project, instanceName)
 	if err != nil {
 		return fmt.Errorf("Error starting admin client. %s", err)

--- a/third_party/terraform/resources/resource_bigtable_table.go
+++ b/third_party/terraform/resources/resource_bigtable_table.go
@@ -40,9 +40,10 @@ func resourceBigtableTable() *schema.Resource {
 			},
 
 			"instance_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: compareResourceNames,
 			},
 
 			"split_keys": {
@@ -71,11 +72,12 @@ func resourceBigtableTableCreate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	instanceName := d.Get("instance_name").(string)
+	instanceName := GetResourceNameFromSelfLink(d.Get("instance_name").(string))
 	c, err := config.bigtableClientFactory.NewAdminClient(project, instanceName)
 	if err != nil {
 		return fmt.Errorf("Error starting admin client. %s", err)
 	}
+	d.Set("instance_name", instanceName)
 
 	defer c.Close()
 
@@ -129,7 +131,7 @@ func resourceBigtableTableRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	instanceName := d.Get("instance_name").(string)
+	instanceName := GetResourceNameFromSelfLink(d.Get("instance_name").(string))
 	c, err := config.bigtableClientFactory.NewAdminClient(project, instanceName)
 	if err != nil {
 		return fmt.Errorf("Error starting admin client. %s", err)
@@ -160,7 +162,7 @@ func resourceBigtableTableDestroy(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	instanceName := d.Get("instance_name").(string)
+	instanceName := GetResourceNameFromSelfLink(d.Get("instance_name").(string))
 	c, err := config.bigtableClientFactory.NewAdminClient(project, instanceName)
 	if err != nil {
 		return fmt.Errorf("Error starting admin client. %s", err)

--- a/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -139,7 +139,7 @@ resource "google_bigtable_instance" "instance" {
 
 resource "google_bigtable_table" "table" {
   name          = "%s"
-  instance_name = google_bigtable_instance.instance.name
+  instance_name = google_bigtable_instance.instance.id
 
   column_family {
     family = "%s"
@@ -147,7 +147,7 @@ resource "google_bigtable_table" "table" {
 }
 
 resource "google_bigtable_gc_policy" "policy" {
-  instance_name = google_bigtable_instance.instance.name
+  instance_name = google_bigtable_instance.instance.id
   table         = google_bigtable_table.table.name
   column_family = "%s"
 

--- a/third_party/terraform/tests/resource_bigtable_table_test.go
+++ b/third_party/terraform/tests/resource_bigtable_table_test.go
@@ -143,7 +143,7 @@ resource "google_bigtable_instance" "instance" {
 
 resource "google_bigtable_table" "table" {
   name          = "%s"
-  instance_name = google_bigtable_instance.instance.name
+  instance_name = google_bigtable_instance.instance.id
 }
 `, instanceName, instanceName, tableName)
 }
@@ -161,7 +161,7 @@ resource "google_bigtable_instance" "instance" {
 
 resource "google_bigtable_table" "table" {
   name          = "%s"
-  instance_name = google_bigtable_instance.instance.name
+  instance_name = google_bigtable_instance.instance.id
   split_keys    = ["a", "b", "c"]
 }
 `, instanceName, instanceName, tableName)


### PR DESCRIPTION
Added support for full-name/id `instance_name` value in `google_bigtable_table` and `google_bigtable_gc_policy`

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5820

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigtable: Added support for full-name/id `instance_name` value in `google_bigtable_table` and `google_bigtable_gc_policy`
```
