### PR TITLE
network endpoint support long form ids for network endpoint groups

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1028,6 +1028,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_expand: "templates/terraform/custom_expand/resource_from_self_link.go.erb"
       networkEndpointGroup: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
+        diff_suppress_func: compareResourceNames
       port: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/float64_to_int.go.erb
       zone: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/templates/terraform/encoders/compute_network_endpoint.go.erb
+++ b/templates/terraform/encoders/compute_network_endpoint.go.erb
@@ -12,6 +12,9 @@
   # See the License for the specific language governing permissions and
   # limitations under the License.
 -%>
+// Network Endpoint Group is a URL parameter only, so replace self-link/path with resource name only.
+d.Set("network_endpoint_group", GetResourceNameFromSelfLink(d.Get("network_endpoint_group").(string)))
+
 wrappedReq := map[string]interface{}{
 	"networkEndpoints": []interface{}{obj},
 }

--- a/third_party/terraform/tests/resource_compute_network_endpoint_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_network_endpoint_test.go.erb
@@ -81,7 +81,7 @@ func testAccComputeNetworkEndpoint_networkEndpointsBasic(context map[string]inte
 	return Nprintf(`
 resource "google_compute_network_endpoint" "default" {
   zone                   = "us-central1-a"
-  network_endpoint_group = google_compute_network_endpoint_group.neg.name
+  network_endpoint_group = google_compute_network_endpoint_group.neg.id
 
   instance   = google_compute_instance.default.name
   ip_address = google_compute_instance.default.network_interface[0].network_ip
@@ -107,7 +107,7 @@ func testAccComputeNetworkEndpoint_networkEndpointsAdditional(context map[string
 	return Nprintf(`
 resource "google_compute_network_endpoint" "default" {
   zone                   = "us-central1-a"
-  network_endpoint_group = google_compute_network_endpoint_group.neg.name
+  network_endpoint_group = google_compute_network_endpoint_group.neg.id
 
   instance   = google_compute_instance.default.name
   ip_address = google_compute_instance.default.network_interface[0].network_ip
@@ -116,7 +116,7 @@ resource "google_compute_network_endpoint" "default" {
 
 resource "google_compute_network_endpoint" "add1" {
   zone                   = "us-central1-a"
-  network_endpoint_group = google_compute_network_endpoint_group.neg.name
+  network_endpoint_group = google_compute_network_endpoint_group.neg.id
 
   instance   = google_compute_instance.default.name
   ip_address = google_compute_instance.default.network_interface[0].network_ip


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5822

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added support for full-name/id `network_endpoint_group` value in `google_network_endpoint`
```
