### PR TITLE
change NOT to NOT_IN for node_affinities operator

### DIFF
--- a/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_test.go
@@ -4241,6 +4241,12 @@ resource "google_compute_instance" "foobar" {
     }
 
     node_affinities {
+      key      = "tfacc"
+      operator = "NOT_IN"
+      values   = ["not_here"]
+    }
+
+    node_affinities {
       key      = "compute.googleapis.com/node-group-name"
       operator = "IN"
       values   = [google_compute_node_group.nodes.name]
@@ -4300,6 +4306,12 @@ resource "google_compute_instance" "foobar" {
       key      = "tfacc"
       operator = "IN"
       values   = ["test", "updatedlabel"]
+    }
+
+    node_affinities {
+      key      = "tfacc"
+      operator = "NOT_IN"
+      values   = ["not_here"]
     }
 
     node_affinities {

--- a/third_party/terraform/utils/compute_instance_helpers.go
+++ b/third_party/terraform/utils/compute_instance_helpers.go
@@ -22,7 +22,7 @@ func instanceSchedulingNodeAffinitiesElemSchema() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"IN", "NOT"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"IN", "NOT_IN"}, false),
 			},
 			"values": {
 				Type:     schema.TypeSet,

--- a/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -333,7 +333,7 @@ The `node_affinities` block supports:
 * `key` (Required) - The key for the node affinity label.
 
 * `operator` (Required) - The operator. Can be `IN` for node-affinities
-    or `NOT` for anti-affinities.
+    or `NOT_IN` for anti-affinities.
 
 * `value` (Required) - The values for the node affinity label.
 

--- a/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -394,7 +394,7 @@ The `node_affinities` block supports:
 * `key` (Required) - The key for the node affinity label.
 
 * `operator` (Required) - The operator. Can be `IN` for node-affinities
-    or `NOT` for anti-affinities.
+    or `NOT_IN` for anti-affinities.
 
 * `value` (Required) - The values for the node affinity label.
 


### PR DESCRIPTION
Fix `NOT` to `NOT_IN` for  `google_compute_instance.scheduling.node_affinities.operator`

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed bug where `google_compute_instance.scheduling.node_affinities.operator` will accept the correct `NOT_IN` rather than `NOT`.
```
