### PR TITLE
Add node group autoscaling policy

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -7358,6 +7358,38 @@ objects:
           The total number of nodes in the node group.
         required: true
         send_empty_value: true
+      - !ruby/object:Api::Type::NestedObject
+        name: 'autoscalingPolicy'
+        min_version: beta
+        description: |
+          If you use sole-tenant nodes for your workloads, you can use the node
+          group autoscaler to automatically manage the sizes of your node groups.
+        properties:
+          - !ruby/object:Api::Type::Enum
+            name: 'mode'
+            required: true
+            description: |
+              The autoscaling mode. Set to one of the following:
+                - OFF: Disables the autoscaler.
+                - ON: Enables scaling in and scaling out.
+                - ONLY_SCALE_OUT: Enables only scaling out. 
+                You must use this mode if your node groups are configured to 
+                restart their hosted VMs on minimal servers.
+            values:
+              - :OFF
+              - :ON
+              - :ONLY_SCALE_OUT
+          - !ruby/object:Api::Type::Integer
+            name: 'minNodes'
+            description: |
+              Minimum size of the node group, and must be an integer value less 
+              than or equal to max-nodes. The default value is 0.
+          - !ruby/object:Api::Type::Integer
+            name: 'maxNodes'
+            description: |
+              Maximum size of the node group. Set to a value less than or equal
+              to 100 and greater than or equal to min-nodes.
+            required: true
   - !ruby/object:Api::Resource
     name: 'NetworkPeeringRoutesConfig'
     base_url:  'projects/{{project}}/global/networks/{{network}}'

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -7382,7 +7382,7 @@ objects:
           - !ruby/object:Api::Type::Integer
             name: 'minNodes'
             description: |
-              Minimum size of the node group, and must be an integer value less 
+              Minimum size of the node group. Must be less 
               than or equal to max-nodes. The default value is 0.
           - !ruby/object:Api::Type::Integer
             name: 'maxNodes'

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1119,11 +1119,20 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           group_name: "soletenant-group"
           template_name: "soletenant-tmpl"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "node_group_autoscaling_policy"
+        min_version: beta
+        primary_resource_id: "nodes"
+        vars:
+          group_name: "soletenant-group"
+          template_name: "soletenant-tmpl"
     properties:
       zone: !ruby/object:Overrides::Terraform::PropertyOverride
         required: false
         default_from_api: true
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
+      autoscalingPolicy.minNodes: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
   NodeTemplate: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1131,7 +1131,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         required: false
         default_from_api: true
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
+      autoscalingPolicy: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      autoscalingPolicy.mode: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       autoscalingPolicy.minNodes: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      autoscalingPolicy.maxNodes: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
   NodeTemplate: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:

--- a/templates/terraform/examples/node_group_autoscaling_policy.tf.erb
+++ b/templates/terraform/examples/node_group_autoscaling_policy.tf.erb
@@ -20,6 +20,7 @@ resource "google_compute_node_group" "<%= ctx[:primary_resource_id] %>" {
   node_template = google_compute_node_template.soletenant-tmpl.self_link
   autoscaling_policy {
     mode = "ON"
+    min_nodes = 1
     max_nodes = 10
   }
 }

--- a/templates/terraform/examples/node_group_autoscaling_policy.tf.erb
+++ b/templates/terraform/examples/node_group_autoscaling_policy.tf.erb
@@ -1,0 +1,25 @@
+data "google_compute_node_types" "central1a" {
+  provider = google-beta
+  zone = "us-central1-a"
+}
+
+resource "google_compute_node_template" "soletenant-tmpl" {
+  provider = google-beta
+  name      = "<%= ctx[:vars]['template_name'] %>"
+  region    = "us-central1"
+  node_type = data.google_compute_node_types.central1a.names[0]
+}
+
+resource "google_compute_node_group" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+  name        = "<%= ctx[:vars]['group_name'] %>"
+  zone        = "us-central1-a"
+  description = "example google_compute_node_group for Terraform Google Provider"
+
+  size          = 1
+  node_template = google_compute_node_template.soletenant-tmpl.self_link
+  autoscaling_policy {
+    mode = "ON"
+    max_nodes = 10
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5628
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added `autoscaling_policy` to `google_compute_node_group`
```
