### PR TITLE
update link name for app engine service split traffic

### DIFF
--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -258,7 +258,7 @@
       <li<%%= sidebar_current("docs-google-app-engine-application-url-dispatch-rules") %>>
       <a href="/docs/providers/google/r/app_engine_application_url_dispatch_rules.html">google_app_engine_application_url_dispatch_rules</a>
       <li<%%= sidebar_current("docs-google-app-engine-service-split-traffic") %>>
-      <a href="/docs/providers/google/r/app_engine_service_split_traffic.html">google_app_engine_standard_app_version</a>
+      <a href="/docs/providers/google/r/app_engine_service_split_traffic.html">google_app_engine_service_split_traffic</a>
       </li>
     </ul>
     </li>


### PR DESCRIPTION
Update website link name to be service split traffic instead of standard app version

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
