### PR TITLE
bump container rake dependency

### DIFF
--- a/.ci/containers/go-ruby/Gemfile.lock
+++ b/.ci/containers/go-ruby/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
       ast (~> 2.4.0)
     public_suffix (3.0.3)
     rainbow (3.0.0)
-    rake (12.3.1)
+    rake (12.3.3)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)


### PR DESCRIPTION
Catching build containers up with https://github.com/GoogleCloudPlatform/magic-modules/pull/3204
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
