### PR TITLE
Add a resource for fine-grained management of named ports 

### DIFF
--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -303,6 +303,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     exclude: true
   DiskType: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
+  InstanceGroupNamedPort: !ruby/object:Overrides::Ansible::ResourceOverride
+    exclude: true
   License: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
   MachineType: !ruby/object:Overrides::Ansible::ResourceOverride

--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -27,6 +27,8 @@ datasources: !ruby/object:Overrides::ResourceOverrides
   # Readonly resources.
   DiskType: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
+  InstanceGroupNamedPort: !ruby/object:Overrides::Ansible::ResourceOverride
+    exclude: true
   License: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
   MachineType: !ruby/object:Overrides::Ansible::ResourceOverride

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -6484,8 +6484,7 @@ objects:
       Mange the named ports setting for a managed instance group without
       managing the group as whole. This resource is primarily intended for use
       with GKE-generated groups that shouldn't otherwise be managed by other
-      tools. Deleting this resource is a no-op and the group will not be
-      modified.
+      tools.
     create_verb: :POST
     create_url: 'projects/{{project}}/zones/{{zone}}/instanceGroups/{{group}}/setNamedPorts'
     delete_verb: :POST
@@ -6543,11 +6542,13 @@ objects:
     properties:
       - !ruby/object:Api::Type::String
         name: 'name'
+        required: true
         description: |
           The name for this named port. The name must be 1-63 characters
           long, and comply with RFC1035.
       - !ruby/object:Api::Type::Integer
         name: 'port'
+        required: true
         description:
           The port number, which can be a value between 1 and 65535.
   - !ruby/object:Api::Resource

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -6479,6 +6479,7 @@ objects:
     name: 'InstanceGroupNamedPort'
     base_url:  'projects/{{project}}/zones/{{zone}}/instanceGroups/{{group}}'
     self_link: 'projects/{{project}}/zones/{{zone}}/instanceGroups/{{group}}'
+    input: true
     description: |
       Mange the named ports setting for a managed instance group without
       managing the group as whole. This resource is primarily intended for use
@@ -6487,8 +6488,8 @@ objects:
       modified.
     create_verb: :POST
     create_url: 'projects/{{project}}/zones/{{zone}}/instanceGroups/{{group}}/setNamedPorts'
-    update_verb: :POST
-    update_url: 'projects/{{project}}/zones/{{zone}}/instanceGroups/{{group}}/setNamedPorts'
+    delete_verb: :POST
+    delete_url: 'projects/{{project}}/zones/{{zone}}/instanceGroups/{{group}}/setNamedPorts'
     identity:
       - port
       - name

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -6476,6 +6476,80 @@ objects:
           group. Deleting or abandoning instances reduces this number. Resizing
           the group changes this number.
   - !ruby/object:Api::Resource
+    name: 'InstanceGroupNamedPort'
+    base_url:  'projects/{{project}}/zones/{{zone}}/instanceGroups/{{group}}'
+    self_link: 'projects/{{project}}/zones/{{zone}}/instanceGroups/{{group}}'
+    description: |
+      Mange the named ports setting for a managed instance group without
+      managing the group as whole. This resource is primarily intended for use
+      with GKE-generated groups that shouldn't otherwise be managed by other
+      tools. Deleting this resource is a no-op and the group will not be
+      modified.
+    create_verb: :POST
+    create_url: 'projects/{{project}}/zones/{{zone}}/instanceGroups/{{group}}/setNamedPorts'
+    update_verb: :POST
+    update_url: 'projects/{{project}}/zones/{{zone}}/instanceGroups/{{group}}/setNamedPorts'
+    identity:
+      - port
+      - name
+    nested_query: !ruby/object:Api::Resource::NestedQuery
+      modify_by_patch: true
+      keys:
+        - namedPorts
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation': 'https://cloud.google.com/compute/docs/instance-groups/'
+      api: 'https://cloud.google.com/compute/docs/reference/rest/v1/instanceGroup'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+        kind: 'compute#operation'
+        path: 'name'
+        base_url: 'projects/{{project}}/zones/{{zone}}/operations/{{op_id}}'
+        wait_ms: 1000
+        timeouts: !ruby/object:Api::Timeouts
+          insert_minutes: 6
+          update_minutes: 6
+          delete_minutes: 6
+      result: !ruby/object:Api::OpAsync::Result
+        path: 'targetLink'
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'status'
+        complete: 'DONE'
+        allowed:
+          - 'PENDING'
+          - 'RUNNING'
+          - 'DONE'
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error/errors'
+        message: 'message'
+    parameters:
+      - !ruby/object:Api::Type::ResourceRef
+        name: 'group'
+        resource: 'InstanceGroup'
+        imports: 'name'
+        required: true
+        url_param_only: true
+        description: |
+          The name of the instance group.
+      - !ruby/object:Api::Type::ResourceRef
+        name: 'zone'
+        resource: 'Zone'
+        imports: 'name'
+        required: true
+        url_param_only: true
+        description: |
+          The zone of the instance group.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          The name for this named port. The name must be 1-63 characters
+          long, and comply with RFC1035.
+      - !ruby/object:Api::Type::Integer
+        name: 'port'
+        description:
+          The port number, which can be a value between 1 and 65535.
+  - !ruby/object:Api::Resource
     name: 'RegionInstanceGroupManager'
     kind: 'compute#instanceGroupManager'
     base_url: projects/{{project}}/regions/{{region}}/instanceGroupManagers

--- a/products/compute/inspec.yaml
+++ b/products/compute/inspec.yaml
@@ -85,6 +85,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         override_name: "instance_group_id"
       name: !ruby/object:Overrides::Inspec::PropertyOverride
         override_name: "instance_group_name"
+  InstanceGroupNamedPort: !ruby/object:Overrides::Inspec::ResourceOverride
+    exclude: true
   InterconnectAttachment: !ruby/object:Overrides::Inspec::ResourceOverride
     exclude: true
   License: !ruby/object:Overrides::Inspec::ResourceOverride

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -942,6 +942,27 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     exclude: true
   InstanceGroupManager: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true
+  InstanceGroupNamedPort: !ruby/object:Overrides::Terraform::ResourceOverride
+    id_format: 'projects/{{project}}/zones/{{zone}}/instanceGroups/{{group}}/{{port}}/{{name}}'
+    import_format: ['projects/{{project}}/zones/{{zone}}/instanceGroups/{{group}}/{{port}}/{{name}}']
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "instance_group_named_port_gke"
+        primary_resource_id: "my_port"
+        vars:
+          network_name: "container-network"
+          subnetwork_name: "container-subnetwork"
+          gke_cluster_name: "my-cluster"
+    properties:
+      group: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: 'compareResourceNames'
+      zone: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: false
+        default_from_api: true
+        ignore_read: true
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      encoder: 'templates/terraform/encoders/normalize_group.go.erb'
+      custom_delete: 'templates/terraform/custom_delete/skip_delete.go.erb'
   InstanceTemplate: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true
   InterconnectAttachment: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -962,7 +962,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       encoder: 'templates/terraform/encoders/normalize_group.go.erb'
-      custom_delete: 'templates/terraform/custom_delete/skip_delete.go.erb'
   InstanceTemplate: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true
   InterconnectAttachment: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -945,6 +945,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   InstanceGroupNamedPort: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: 'projects/{{project}}/zones/{{zone}}/instanceGroups/{{group}}/{{port}}/{{name}}'
     import_format: ['projects/{{project}}/zones/{{zone}}/instanceGroups/{{group}}/{{port}}/{{name}}']
+    mutex: 'projects/{{project}}/zones/{{zone}}/instanceGroups/{{group}}'
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "instance_group_named_port_gke"

--- a/templates/terraform/encoders/normalize_group.go.erb
+++ b/templates/terraform/encoders/normalize_group.go.erb
@@ -1,2 +1,11 @@
-d.Set("group", GetResourceNameFromSelfLink(d.Get("group").(string)))
+config := meta.(*Config)
+ig, err := ParseInstanceGroupFieldValue(d.Get("group").(string), d, config)
+if err != nil {
+  return nil, err
+}
+
+d.Set("group", ig.Name)
+d.Set("zone", ig.Zone)
+d.Set("project", ig.Project)
+
 return obj, nil

--- a/templates/terraform/encoders/normalize_group.go.erb
+++ b/templates/terraform/encoders/normalize_group.go.erb
@@ -1,0 +1,2 @@
+d.Set("group", GetResourceNameFromSelfLink(d.Get("group").(string)))
+return obj, nil

--- a/templates/terraform/examples/instance_group_named_port_gke.tf.erb
+++ b/templates/terraform/examples/instance_group_named_port_gke.tf.erb
@@ -1,0 +1,33 @@
+resource "google_compute_instance_group_named_port" "<%= ctx[:primary_resource_id] %>" {
+  group = google_container_cluster.my_cluster.instance_group_urls[0]
+  zone = "us-central1-a"
+
+  name = "http"
+  port = 8080
+}
+
+resource "google_compute_network" "container_network" {
+  name                    = "<%= ctx[:vars]['network_name'] %>"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "container_subnetwork" {
+  name                     = "<%= ctx[:vars]['subnetwork_name'] %>"
+  region                   = "us-central1"
+  network                  = google_compute_network.container_network.name
+  ip_cidr_range            = "10.0.36.0/24"
+}
+
+resource "google_container_cluster" "my_cluster" {
+  name               = "<%= ctx[:vars]['gke_cluster_name'] %>"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  network    = google_compute_network.container_network.name
+  subnetwork = google_compute_subnetwork.container_subnetwork.name
+
+  ip_allocation_policy {
+    cluster_ipv4_cidr_block  = "/19"
+    services_ipv4_cidr_block = "/22"
+  }
+}

--- a/templates/terraform/examples/instance_group_named_port_gke.tf.erb
+++ b/templates/terraform/examples/instance_group_named_port_gke.tf.erb
@@ -6,6 +6,14 @@ resource "google_compute_instance_group_named_port" "<%= ctx[:primary_resource_i
   port = 8080
 }
 
+resource "google_compute_instance_group_named_port" "<%= ctx[:primary_resource_id] %>s" {
+  group = google_container_cluster.my_cluster.instance_group_urls[0]
+  zone = "us-central1-a"
+
+  name = "https"
+  port = 4443
+}
+
 resource "google_compute_network" "container_network" {
   name                    = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks = false

--- a/templates/terraform/flatten_property_method.erb
+++ b/templates/terraform/flatten_property_method.erb
@@ -96,9 +96,16 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
 	if strVal, ok := v.(string); ok {
 		if intVal, err := strconv.ParseInt(strVal, 10, 64); err == nil {
 			return intVal
-		} // let terraform core handle it if we can't convert the string to an int.
+		}
 	}
-	return v
+
+	// number values are represented as float64
+	if floatVal, ok := v.(float64); ok {
+		intVal := int(floatVal)
+		return intVal
+	}
+
+	return v // let terraform core handle it otherwise
 <% elsif property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::ResourceRef) -%>
   if v == nil {
     return v

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -672,6 +672,10 @@
       <a href="/docs/providers/google/r/compute_instance_group_manager.html">google_compute_instance_group_manager</a>
       </li>
 
+      <li<%%= sidebar_current("docs-google-compute-instance-group-named-port") %>>
+      <a href="/docs/providers/google/r/compute_instance_group_named_port.html">google_compute_instance_group_named_port</a>
+      </li>
+
       <li<%%= sidebar_current("docs-google-compute-instance-template") %>>
       <a href="/docs/providers/google/r/compute_instance_template.html">google_compute_instance_template</a>
       </li>


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/1480

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_compute_instance_group_named_port`
```
