### PR TITLE
Make instance into a resourceref, so that you can use full self_link.

### DIFF
--- a/products/bigtable/api.yaml
+++ b/products/bigtable/api.yaml
@@ -43,8 +43,10 @@ objects:
         required: true
         input: true
         url_param_only: true
-      - !ruby/object:Api::Type::String
+      - !ruby/object:Api::Type::ResourceRef
         name: 'instance'
+        resource: 'Instance'
+        imports: 'name'
         description: 'The name of the instance to create the app profile within.'
         input: true
         url_param_only: true

--- a/products/bigtable/terraform.yaml
+++ b/products/bigtable/terraform.yaml
@@ -41,6 +41,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       instance: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: compareResourceNames
+        custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
       multiClusterRoutingUseAny: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/bigtable_app_profile_routing.erb'
         custom_flatten: 'templates/terraform/custom_flatten/bigtable_app_profile_routing.erb'


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigtable: `google_bigtable_app_profile`'s `instance` field can accept full instance URLs.
```

This will solve https://github.com/terraform-providers/terraform-provider-google/issues/5377.