### PR TITLE
add extra host_rule to example

### DIFF
--- a/templates/terraform/examples/url_map_basic.tf.erb
+++ b/templates/terraform/examples/url_map_basic.tf.erb
@@ -6,11 +6,16 @@ resource "google_compute_url_map" "<%= ctx[:primary_resource_id] %>" {
 
   host_rule {
     hosts        = ["mysite.com"]
-    path_matcher = "allpaths"
+    path_matcher = "mysite"
+  }
+
+  host_rule {
+    hosts        = ["myothersite.com"]
+    path_matcher = "otherpaths"
   }
 
   path_matcher {
-    name            = "allpaths"
+    name            = "mysite"
     default_service = google_compute_backend_service.home.self_link
 
     path_rule {
@@ -27,6 +32,11 @@ resource "google_compute_url_map" "<%= ctx[:primary_resource_id] %>" {
       paths   = ["/static"]
       service = google_compute_backend_bucket.static.self_link
     }
+  }
+
+  path_matcher {
+    name            = "otherpaths"
+    default_service = google_compute_backend_service.home.self_link
   }
 
   test {


### PR DESCRIPTION
Add extra `host_rule` to example to show multiple.
Addresses issue: https://github.com/terraform-providers/terraform-provider-google/issues/5844

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
