### PR TITLE
Ensure that no matter what the ID is, we can still wait for state.

### DIFF
--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -369,8 +369,9 @@ func resourceContainerNodePoolUpdate(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
+	name := getNodePoolName(d.Id())
 
-	_, err = containerNodePoolAwaitRestingState(config, d.Id(), d.Timeout(schema.TimeoutUpdate))
+	_, err = containerNodePoolAwaitRestingState(config, nodePoolInfo.fullyQualifiedName(name), d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
 		return err
 	}
@@ -381,7 +382,7 @@ func resourceContainerNodePoolUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 	d.Partial(false)
 
-	_, err = containerNodePoolAwaitRestingState(config, d.Id(), d.Timeout(schema.TimeoutUpdate))
+	_, err = containerNodePoolAwaitRestingState(config, nodePoolInfo.fullyQualifiedName(name), d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
 		return err
 	}
@@ -399,7 +400,7 @@ func resourceContainerNodePoolDelete(d *schema.ResourceData, meta interface{}) e
 
 	name := getNodePoolName(d.Id())
 
-	_, err = containerNodePoolAwaitRestingState(config, d.Id(), d.Timeout(schema.TimeoutDelete))
+	_, err = containerNodePoolAwaitRestingState(config, nodePoolInfo.fullyQualifiedName(name), d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return err
 	}
@@ -473,7 +474,7 @@ func resourceContainerNodePoolStateImporter(d *schema.ResourceData, meta interfa
 	id, err := replaceVars(d, config, "projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/nodePools/{{name}}")
 	if err != nil {
 		return nil, err
-  }
+}
 
 	d.SetId(id)
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5767.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: `google_container_node_pool` resources created in the 2.X series were failing to update after 3.11.
```
