### PR TITLE
Remove the last iap base path leftovers from handwritten tunnel

### DIFF
--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -121,11 +121,6 @@ func Provider() terraform.ResourceProvider {
 			<% end -%>
 
 			// Handwritten Products / Versioned / Atypical Entries
-			<% unless version == 'ga' -%>
-			// start beta-only products
-			IAPCustomEndpointEntryKey: IAPCustomEndpointEntry,
-			// end beta-only products
-			<% end -%>
 			CloudBillingCustomEndpointEntryKey:           CloudBillingCustomEndpointEntry,
 			ComposerCustomEndpointEntryKey:               ComposerCustomEndpointEntry,
 			ComputeBetaCustomEndpointEntryKey:            ComputeBetaCustomEndpointEntry,

--- a/third_party/terraform/utils/provider_handwritten_endpoint.go.erb
+++ b/third_party/terraform/utils/provider_handwritten_endpoint.go.erb
@@ -139,19 +139,6 @@ var IamCredentialsCustomEndpointEntry = &schema.Schema{
 	}, IamCredentialsDefaultBasePath),
 }
 
-<% unless version == 'ga' -%>
-var IAPDefaultBasePath = "https://iap.googleapis.com/v1beta1/"
-var IAPCustomEndpointEntryKey = "iap_custom_endpoint"
-var IAPCustomEndpointEntry = &schema.Schema{
-	Type:         schema.TypeString,
-	Optional:     true,
-	ValidateFunc: validateCustomEndpoint,
-	DefaultFunc: schema.MultiEnvDefaultFunc([]string{
-		"GOOGLE_IAP_CUSTOM_ENDPOINT",
-	}, IAPDefaultBasePath),
-}
-
-<% end -%>
 var ResourceManagerV2Beta1DefaultBasePath = "https://cloudresourcemanager.googleapis.com/v2beta1/"
 var ResourceManagerV2Beta1CustomEndpointEntryKey = "resource_manager_v2beta1_custom_endpoint"
 var ResourceManagerV2Beta1CustomEndpointEntry = &schema.Schema{


### PR DESCRIPTION
Continuation of https://github.com/GoogleCloudPlatform/magic-modules/pull/3162 that I missed

Allows https://github.com/GoogleCloudPlatform/magic-modules/pull/3135 to work in beta.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
