### PR TITLE
Ignore empty vs null list in data source tests

### DIFF
--- a/third_party/terraform/utils/test_utils.go
+++ b/third_party/terraform/utils/test_utils.go
@@ -112,6 +112,10 @@ func checkDataSourceStateMatchesResourceStateWithIgnores(dataSourceName, resourc
 				continue
 			}
 			if dsAttr[k] != rsAttr[k] {
+				// ignore data sources where an empty list is being compared against a null list.
+				if k[len(k)-1:] == "#" && (dsAttr[k] == "" || dsAttr[k] == "0") && (rsAttr[k] == "" || rsAttr[k] == "0") {
+					continue
+				}
 				errMsg += fmt.Sprintf("%s is %s; want %s\n", k, dsAttr[k], rsAttr[k])
 			}
 		}


### PR DESCRIPTION
Since null and empty lists are equivalent when translated through the sdk it
doesn't make sense to fail on this.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
test fix
```
