### PR TITLE
Memorystore Redis connectMode support

### DIFF
--- a/products/redis/api.yaml
+++ b/products/redis/api.yaml
@@ -79,6 +79,13 @@ objects:
           will be used.
         input: true
       - !ruby/object:Api::Type::Time
+        name: connectMode
+        description: |
+          The connection mode of the Redis instance. Can be either
+          `DIRECT_PEERING` or `PRIVATE_SERVICE_ACCESS`. The default
+          connect mode if not provided is `DIRECT_PEERING`.
+        input: true
+      - !ruby/object:Api::Type::Time
         name: createTime
         description: |
           The time the instance was created in RFC3339 UTC "Zulu" format,

--- a/products/redis/api.yaml
+++ b/products/redis/api.yaml
@@ -78,13 +78,17 @@ objects:
           instance is connected. If left unspecified, the default network
           will be used.
         input: true
-      - !ruby/object:Api::Type::Time
+      - !ruby/object:Api::Type::Enum
         name: connectMode
         description: |
           The connection mode of the Redis instance. Can be either
           `DIRECT_PEERING` or `PRIVATE_SERVICE_ACCESS`. The default
           connect mode if not provided is `DIRECT_PEERING`.
         input: true
+        values:
+          - :DIRECT_PEERING
+          - :PRIVATE_SERVICE_ACCESS
+        default_value: :DIRECT_PEERING
       - !ruby/object:Api::Type::Time
         name: createTime
         description: |

--- a/products/redis/terraform.yaml
+++ b/products/redis/terraform.yaml
@@ -35,6 +35,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           network_name: "redis-test-network"
         test_vars_overrides:
           network_name: 'BootstrapSharedTestNetwork(t, "redis-full")'
+      - !ruby/object:Provider::Terraform::Examples
+        name: "redis_instance_private_service"
+        primary_resource_id: "cache"
     properties:
       alternativeLocationId: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
@@ -42,6 +45,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
         custom_expand: 'templates/terraform/custom_expand/redis_instance_authorized_network.erb'
         diff_suppress_func: 'compareSelfLinkOrResourceName'
+      connectMode: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       locationId: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       name: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/products/redis/terraform.yaml
+++ b/products/redis/terraform.yaml
@@ -45,8 +45,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
         custom_expand: 'templates/terraform/custom_expand/redis_instance_authorized_network.erb'
         diff_suppress_func: 'compareSelfLinkOrResourceName'
-      connectMode: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
       locationId: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       name: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/templates/terraform/examples/redis_instance_private_service.tf.erb
+++ b/templates/terraform/examples/redis_instance_private_service.tf.erb
@@ -1,0 +1,35 @@
+resource "google_compute_network" "network" {
+  name = "tf-test%{random_suffix}"
+}
+
+resource "google_compute_global_address" "service_range" {
+  name          = "tf-test%{random_suffix}"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.network.self_link
+}
+
+resource "google_service_networking_connection" "private_service_connection" {
+  network                 = google_compute_network.network.self_link
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.service_range.name]
+}
+
+resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
+  name           = "tf-test%{random_suffix}"
+  tier           = "STANDARD_HA"
+  memory_size_gb = 1
+
+  location_id             = "us-central1-a"
+  alternative_location_id = "us-central1-f"
+
+  authorized_network = google_compute_network.network.self_link
+  connect_mode       = "PRIVATE_SERVICE_ACCESS"
+
+  redis_version     = "REDIS_3_2"
+  display_name      = "Terraform Test Instance"
+
+  depends_on = [ google_service_networking_connection.private_service_connection ]
+
+}


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->
Fixes terraform-providers/terraform-provider-google#5792

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
redis: added `connect_mode` field to `google_redis_instance` resource
```
