### PR TITLE
remove ForceNew from metadata_startup_script

### DIFF
--- a/third_party/terraform/resources/resource_compute_instance.go
+++ b/third_party/terraform/resources/resource_compute_instance.go
@@ -401,7 +401,6 @@ func resourceComputeInstance() *schema.Resource {
 			"metadata_startup_script": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"min_cpu_platform": {
@@ -1044,7 +1043,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	// Enable partial mode for the resource since it is possible
 	d.Partial(true)
 
-	if d.HasChange("metadata") {
+	if d.HasChange("metadata") || d.HasChange("metadata_startup_script") {
 		metadata, err := resourceInstanceMetadata(d)
 		if err != nil {
 			return fmt.Errorf("Error parsing metadata: %s", err)
@@ -1085,7 +1084,13 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return err
 		}
 
-		d.SetPartial("metadata")
+		if d.HasChange("metadata") {
+			d.SetPartial("metadata")
+		}
+
+		if d.HasChange("metadata_startup_script") {
+			d.SetPartial("metadata_startup_script")
+		}
 	}
 
 	if d.HasChange("tags") {


### PR DESCRIPTION
This addresses a bug where a user changed the `metadata_startup_script` and the instance was destroyed and recreated.  However, if the instance is destroyed, the `network_endpoint` is also destroyed, but because all the output values of `compute_instance` were staying the same, Terraform didn't see there would be a change, and thus the `network_endpoint` didn't show in the plan and was not recreated in the same apply.
After changing the startup script in the console, I realized the instance didn't need to be destroyed and recreated.

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5798

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: added ability to update `metadata_startup_script` on `google_compute_instance` without re-creating the entire instance.
```
