### PR TITLE
upgrade_settings is now ga, and O+C

### DIFF
--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -110,10 +110,12 @@ var schemaNodePool = map[string]*schema.Schema{
 		Computed: true,
 		Elem:     &schema.Schema{Type: schema.TypeString},
 	},
+<% end -%>
 
 	"upgrade_settings": {
 		Type:     schema.TypeList,
 		Optional: true,
+		Computed: true,
 		MaxItems: 1,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
@@ -131,7 +133,6 @@ var schemaNodePool = map[string]*schema.Schema{
 			},
 		},
 	},
-<% end -%>
 
 	"initial_node_count": &schema.Schema{
 		Type:     schema.TypeInt,
@@ -556,7 +557,6 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*containerBeta.NodeP
 		}
 	}
 
-<% unless version == 'ga' -%>
 	if v, ok := d.GetOk(prefix + "upgrade_settings"); ok {
 		upgradeSettingsConfig := v.([]interface{})[0].(map[string]interface{})
 		np.UpgradeSettings = &containerBeta.UpgradeSettings{}
@@ -569,7 +569,6 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*containerBeta.NodeP
 			np.UpgradeSettings.MaxUnavailable = int64(v.(int))
 		}
 	}
-<% end -%>
 
 	return np, nil
 }
@@ -628,7 +627,6 @@ func flattenNodePool(d *schema.ResourceData, config *Config, np *containerBeta.N
 		},
 	}
 
-<% unless version == 'ga' -%>
 	if np.UpgradeSettings != nil {
 		nodePool["upgrade_settings"] = []map[string]interface{}{
 			{
@@ -639,7 +637,6 @@ func flattenNodePool(d *schema.ResourceData, config *Config, np *containerBeta.N
 	} else {
 		delete(nodePool, "upgrade_settings")
 	}
-<% end -%>
 
 	return nodePool, nil
 }
@@ -860,6 +857,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 			d.SetPartial("node_locations")
 		}
 	}
+<% end -%>
 
 	if d.HasChange(prefix + "upgrade_settings") {
 		upgradeSettings := &containerBeta.UpgradeSettings{}
@@ -893,7 +891,6 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 			d.SetPartial("upgrade_settings")
 		}
 	}
-<% end -%>
 
 	return nil
 }

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -275,6 +275,7 @@ func TestAccContainerNodePool_withBootDiskKmsKey(t *testing.T) {
 		},
 	})
 }
+<% end -%>
 
 func TestAccContainerNodePool_withUpgradeSettings(t *testing.T) {
 	t.Parallel()
@@ -325,7 +326,6 @@ func TestAccContainerNodePool_withInvalidUpgradeSettings(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccContainerNodePool_withGPU(t *testing.T) {
 	t.Parallel()
@@ -1328,6 +1328,7 @@ resource "google_container_node_pool" "with_boot_disk_kms_key" {
 }
 `, project, cluster, cluster, cluster, np)
 }
+<% end -%>
 
 func testAccContainerNodePool_withUpgradeSettings(clusterName string, nodePoolName string, maxSurge int, maxUnavailable int) string {
 	return fmt.Sprintf(`
@@ -1354,7 +1355,6 @@ resource "google_container_node_pool" "with_upgrade_settings" {
 }
 `, clusterName, nodePoolName, maxSurge, maxUnavailable)
 }
-<% end -%>
 
 func testAccContainerNodePool_withGPU(cluster, np string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5845

```release-note:enhancement
container: added `node_pool.upgrade_settings` (TPG only)
```

```release-note:enhancement
container: updated `node_pool.upgrade_settings` to read defaults from API (TPGB only)
```
