### PR TITLE
GA ILB global access

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -3403,7 +3403,6 @@ objects:
           'projects/{{project}}/regions/{{region}}/forwardingRules/{{name}}/setTarget'
       - !ruby/object:Api::Type::Boolean
         name: 'allowGlobalAccess'
-        min_version: beta
         description: |
           If true, clients can access ILB from all regions.
           Otherwise only allows from the local region the ILB is located at.

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -566,7 +566,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "forwarding_rule_global_internallb"
-        min_version: beta
         primary_resource_id: "default"
         vars:
           forwarding_rule_name: "website-forwarding-rule"

--- a/templates/terraform/examples/forwarding_rule_global_internallb.tf.erb
+++ b/templates/terraform/examples/forwarding_rule_global_internallb.tf.erb
@@ -1,6 +1,5 @@
 // Forwarding rule for Internal Load Balancing
 resource "google_compute_forwarding_rule" "<%= ctx[:primary_resource_id] %>" {
-  provider = "google-beta"
   name                  = "<%= ctx[:vars]['forwarding_rule_name'] %>"
   region                = "us-central1"
   load_balancing_scheme = "INTERNAL"
@@ -11,13 +10,11 @@ resource "google_compute_forwarding_rule" "<%= ctx[:primary_resource_id] %>" {
   subnetwork            = "${google_compute_subnetwork.default.name}"
 }
 resource "google_compute_region_backend_service" "backend" {
-  provider = "google-beta"
   name                  = "<%= ctx[:vars]['backend_name'] %>"
   region                = "us-central1"
   health_checks         = ["${google_compute_health_check.hc.self_link}"]
 }
 resource "google_compute_health_check" "hc" {
-  provider = "google-beta"
   name               = "check-<%= ctx[:vars]['backend_name'] %>"
   check_interval_sec = 1
   timeout_sec        = 1
@@ -26,12 +23,10 @@ resource "google_compute_health_check" "hc" {
   }
 }
 resource "google_compute_network" "default" {
-  provider = "google-beta"
   name = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks = false
 }
 resource "google_compute_subnetwork" "default" {
-  provider = "google-beta"
   name          = "<%= ctx[:vars]['network_name'] %>"
   ip_cidr_range = "10.0.0.0/16"
   region        = "us-central1"


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/5724

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added `allow_global_access` for to `google_compute_forwarding_rule` resource.
```
