### PR TITLE
Add podSecurityPolicyConfig to gke cluster

### DIFF
--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -673,6 +673,14 @@ objects:
             - !ruby/object:Api::Type::String
               name: 'name'
               description: Name of the node pool
+      - !ruby/object:Api::Type::NestedObject
+        name: 'podSecurityPolicyConfig'
+        description: Configuration for the PodSecurityPolicy feature.
+        min_version: beta
+        properties:
+          - !ruby/object:Api::Type::Boolean
+            name: 'enabled'
+            description: If enabled, pods must be valid under a PodSecurityPolicy to be created.
   - !ruby/object:Api::Resource
     name: 'NodePool'
     base_url: projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/nodePools

--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -681,6 +681,13 @@ objects:
           - !ruby/object:Api::Type::Boolean
             name: 'enabled'
             description: If enabled, pods must be valid under a PodSecurityPolicy to be created.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'binaryAuthorization'
+        description: Configuration for the BinaryAuthorization feature.
+        properties:
+          - !ruby/object:Api::Type::Boolean
+            name: 'enabled'
+            description: If enabled, all container images will be validated by Binary Authorization.
   - !ruby/object:Api::Resource
     name: 'NodePool'
     base_url: projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/nodePools


### PR DESCRIPTION
For InSpec. This object is beta, so this will fix https://github.com/inspec/inspec-gcp/issues/174

Also add BinaryAuthorization object

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
