### PR TITLE
Add retry for `google_kms_crypto_key_version`

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_kms_crypto_key_version.go
+++ b/third_party/terraform/data_sources/data_source_google_kms_crypto_key_version.go
@@ -106,10 +106,7 @@ func dataSourceGoogleKmsCryptoKeyVersionRead(d *schema.ResourceData, meta interf
 		}
 		log.Printf("[DEBUG] Getting public key of CryptoKeyVersion: %#v", url)
 
-		err = retryTimeDuration(func() error {
-			res, err = sendRequest(config, "GET", cryptoKeyId.KeyRingId.Project, url, nil)
-			return err
-		}, d.Timeout(schema.TimeoutRead), isCryptoKeyVersionsPendingGeneration)
+		res, err = sendRequestWithTimeout(config, "GET", cryptoKeyId.KeyRingId.Project, url, nil, d.Timeout(schema.TimeoutRead), isCryptoKeyVersionsPendingGeneration)
 
 		if err != nil {
 			log.Printf("Error generating public key: %s", err)

--- a/third_party/terraform/utils/error_retry_predicates.go
+++ b/third_party/terraform/utils/error_retry_predicates.go
@@ -195,6 +195,16 @@ func isAppEngineRetryableError(err error) (bool, string) {
 	return false, ""
 }
 
+// Retry if KMS CryptoKeyVersions returns a 400 for PENDING_GENERATION
+func isCryptoKeyVersionsPendingGeneration(err error) (bool, string) {
+	if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 400 {
+		if strings.Contains(gerr.Body, "PENDING_GENERATION") {
+			return true, "Waiting for pending key generation"
+		}
+	}
+	return false, ""
+}
+
 // Retry if getting a resource/operation returns a 404 for specific operations.
 // opType should describe the operation for which 404 can be retryable.
 func isNotFoundRetryableError(opType string) RetryErrorPredicateFunc {


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5895
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
kms: Fixed an issue in `google_kms_crypto_key_version` where `public_key` would return empty after apply
```
