### PR TITLE
Placement policy support for Compute Instance

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -10743,7 +10743,7 @@ objects:
               - group_placement_policy.0.vm_count
               - group_placement_policy.0.availability_domain_count
             description: |
-              Number of vms in this placement group
+              Number of vms in this placement group.
           - !ruby/object:Api::Type::Integer
             name: 'availabilityDomainCount'
             at_least_one_of:
@@ -10756,7 +10756,9 @@ objects:
             name: 'collocation'
             description: |
               Collocation specifies whether to place VMs inside the same availability domain on the same low-latency network.
-              Specify `COLLOCATED` to enable collocation. Can only be specified with `vm_count`.
+              Specify `COLLOCATED` to enable collocation. Can only be specified with `vm_count`. If compute instances are created
+              with a COLLOCATED policy, then exactly `vm_count` instances must be created at the same time with the resource policy
+              attached.
             values:
               - :COLLOCATED
   - !ruby/object:Api::Resource

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -10587,6 +10587,8 @@ objects:
           which cannot be a dash.
       - !ruby/object:Api::Type::NestedObject
         name: 'snapshotSchedulePolicy'
+        conflicts:
+          - 'groupPlacementPolicy'
         description: |
           Policy for creating snapshots of persistent disks.
         properties:
@@ -10728,6 +10730,35 @@ objects:
                   - snapshot_schedule_policy.0.snapshot_properties.0.guest_flush
                 description: |
                   Whether to perform a 'guest aware' snapshot.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'groupPlacementPolicy'
+        conflicts:
+          - 'snapshotSchedulePolicy'
+        description: |
+          Policy for creating snapshots of persistent disks.
+        properties:
+          - !ruby/object:Api::Type::Integer
+            name: 'vmCount'
+            at_least_one_of:
+              - group_placement_policy.0.vm_count
+              - group_placement_policy.0.availability_domain_count
+            description: |
+              Number of vms in this placement group
+          - !ruby/object:Api::Type::Integer
+            name: 'availabilityDomainCount'
+            at_least_one_of:
+              - group_placement_policy.0.vm_count
+              - group_placement_policy.0.availability_domain_count
+            description: |
+              The number of availability domains instances will be spread across. If two instances are in different
+              availability domain, they will not be put in the same low latency network
+          - !ruby/object:Api::Type::Enum
+            name: 'collocation'
+            description: |
+              Collocation specifies whether to place VMs inside the same availability domain on the same low-latency network.
+              Specify `COLLOCATED` to enable collocation. Can only be specified with `vm_count`.
+            values:
+              - :COLLOCATED
   - !ruby/object:Api::Resource
     name: 'Route'
     kind: 'compute#route'

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1487,6 +1487,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "bar"
         vars:
           name: "policy"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "resource_policy_placement_policy"
+        primary_resource_id: "baz"
+        vars:
+          name: "policy"
     properties:
       region: !ruby/object:Overrides::Terraform::PropertyOverride
         required: false

--- a/templates/terraform/examples/resource_policy_placement_policy.tf.erb
+++ b/templates/terraform/examples/resource_policy_placement_policy.tf.erb
@@ -1,0 +1,8 @@
+resource "google_compute_resource_policy" "baz" {
+  name   = "<%= ctx[:vars]['name'] %>"
+  region = "us-central1"
+  group_placement_policy {
+    vm_count = 2
+    collocation = "COLLOCATED"
+  }
+}

--- a/third_party/terraform/resources/resource_compute_instance.go
+++ b/third_party/terraform/resources/resource_compute_instance.go
@@ -596,6 +596,15 @@ func resourceComputeInstance() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+
+			"resource_policies": {
+				Type:             schema.TypeList,
+				Elem:             &schema.Schema{Type: schema.TypeString},
+				DiffSuppressFunc: compareSelfLinkRelativePaths,
+				Optional:         true,
+				ForceNew:         true,
+				MaxItems:         1,
+			},
 		},
 		CustomizeDiff: customdiff.All(
 			customdiff.If(
@@ -723,6 +732,7 @@ func expandComputeInstance(project string, d *schema.ResourceData, config *Confi
 		ForceSendFields:    []string{"CanIpForward", "DeletionProtection"},
 		ShieldedVmConfig:   expandShieldedVmConfigs(d),
 		DisplayDevice:      expandDisplayDevice(d),
+		ResourcePolicies:   convertStringArr(d.Get("resource_policies").([]interface{})),
 	}, nil
 }
 
@@ -986,6 +996,9 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 			}
 		}
 	}
+
+	d.Set("resource_policies", instance.ResourcePolicies)
+
 	// Remove nils from map in case there were disks in the config that were not present on read;
 	// i.e. a disk was detached out of band
 	ads := []map[string]interface{}{}

--- a/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_test.go
@@ -4547,7 +4547,7 @@ data "google_compute_image" "my_image" {
 resource "google_compute_instance" "foobar" {
   name           = "%s"
   machine_type   = "c2-standard-4"
-  zone           = "us-central1-f"
+  zone           = "us-central1-a"
   can_ip_forward = false
   tags           = ["foo", "bar"]
 
@@ -4566,6 +4566,7 @@ resource "google_compute_instance" "foobar" {
   scheduling {
     # Instances with resource policies do not support live migration.
     on_host_maintenance = "TERMINATE"
+    automatic_restart = false
   }
 
   resource_policies = [google_compute_resource_policy.foo.self_link]

--- a/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_test.go
@@ -1784,6 +1784,24 @@ func TestAccComputeInstance_updateTerminated_desiredStatusRunning_notAllowStoppi
 	})
 }
 
+func TestAccComputeInstance_resourcePolicyCollocate(t *testing.T) {
+	t.Parallel()
+
+	instanceName := fmt.Sprintf("terraform-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_resourcePolicyCollocate(instanceName),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{"allow_stopping_for_update"}),
+		},
+	})
+}
+
 func testAccCheckComputeInstanceUpdateMachineType(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -4517,4 +4535,50 @@ resource "google_compute_instance" "foobar" {
 	}
 }
 `, instance)
+}
+
+func testAccComputeInstance_resourcePolicyCollocate(instance string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name           = "%s"
+  machine_type   = "c2-standard-4"
+  zone           = "us-central1-f"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  //deletion_protection = false is implicit in this config due to default value
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  scheduling {
+    # Instances with resource policies do not support live migration.
+    on_host_maintenance = "TERMINATE"
+  }
+
+  resource_policies = [google_compute_resource_policy.foo.self_link]
+}
+
+resource "google_compute_resource_policy" "foo" {
+  name   = "tf-test-policy-%s"
+  region = "us-central1"
+  group_placement_policy {
+    vm_count = 2
+    collocation = "COLLOCATED"
+  }
+}
+
+`, instance, acctest.RandString(10))
 }

--- a/third_party/terraform/tests/resource_compute_resource_policy_test.go
+++ b/third_party/terraform/tests/resource_compute_resource_policy_test.go
@@ -1,0 +1,80 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccComputeResourcePolicy_attached(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeResourcePolicyDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeResourcePolicy_attached(),
+			},
+			{
+				ResourceName:      "google_compute_resource_policy.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccComputeResourcePolicy_attached() string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name           = "tf-test-%s"
+  machine_type   = "n1-standard-1"
+  zone           = "us-central1-a"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  //deletion_protection = false is implicit in this config due to default value
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  metadata = {
+    foo            = "bar"
+    baz            = "qux"
+    startup-script = "echo Hello"
+  }
+
+  labels = {
+    my_key       = "my_value"
+    my_other_key = "my_other_value"
+  }
+
+  resource_policies = [google_compute_resource_policy.foo.self_link]
+}
+
+resource "google_compute_resource_policy" "foo" {
+  name   = "tf-test-policy-%s"
+  region = "us-central1"
+  group_placement_policy {
+    availability_domain_count = 2
+  }
+}
+
+`, acctest.RandString(10), acctest.RandString(10))
+}

--- a/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -164,6 +164,8 @@ The following arguments are supported:
 * `enable_display` - (Optional) Enable [Virtual Displays](https://cloud.google.com/compute/docs/instances/enable-instance-virtual-display#verify_display_driver) on this instance.
 **Note**: [`allow_stopping_for_update`](#allow_stopping_for_update) must be set to true or your instance must have a `desired_status` of `TERMINATED` in order to update this field.
 
+* `resource_policies` (Optional) -- A list of short names or self_links of resource policies to attach to the instance. Modifying this list will cause the instance to recreate. Currently a max of 1 resource policy is supported.
+
 
 ---
 


### PR DESCRIPTION
Revert my last commit that reverted the placement policy for compute instance addition. Thanks Git!

This reverts commit 18d6446fcf9284ac5562d1693877df1c75cc28a2.

See https://github.com/GoogleCloudPlatform/magic-modules/pull/3217 for previous PR that was reverted due to quota issues in CI testing

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added support for `google_compute_resource_policy` group placement policies
```

```release-note:enhancement
compute: Added support for `google_compute_instance` `resource_policies` field
```

