### PR TITLE
RouterBgpPeer BFD support

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -13540,7 +13540,6 @@ objects:
         name: bfd
         description: |
           BFD configuration for the BGP peering.
-        min_version: beta
         properties:
           - !ruby/object:Api::Type::Enum
             name: sessionInitializationMode

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -13536,14 +13536,58 @@ objects:
           PARTNER InterconnectAttachment is created, updated,
           or deleted.
         output: true
+      - !ruby/object:Api::Type::NestedObject
+        name: bfd
+        description: |
+          BFD configuration for the BGP peering.
+        min_version: beta
+        properties:
+          - !ruby/object:Api::Type::Enum
+            name: sessionInitializationMode
+            description: |
+              The BFD session initialization mode for this BGP peer.
+              If set to `ACTIVE`, the Cloud Router will initiate the BFD session
+              for this BGP peer. If set to `PASSIVE`, the Cloud Router will wait
+              for the peer router to initiate the BFD session for this BGP peer.
+              If set to `DISABLED`, BFD is disabled for this BGP peer.
+            values:
+              - :ACTIVE
+              - :DISABLED
+              - :PASSIVE
+            required: true
+          - !ruby/object:Api::Type::Integer
+            name: minTransmitInterval
+            description: |
+              The minimum interval, in milliseconds, between BFD control packets
+              transmitted to the peer router. The actual value is negotiated
+              between the two routers and is equal to the greater of this value
+              and the corresponding receive interval of the other router. If set,
+              this value must be between 1000 and 30000.
+            default_value: 1000
+          - !ruby/object:Api::Type::Integer
+            name: minReceiveInterval
+            description: |
+              The minimum interval, in milliseconds, between BFD control packets
+              received from the peer router. The actual value is negotiated
+              between the two routers and is equal to the greater of this value
+              and the transmit interval of the other router. If set, this value
+              must be between 1000 and 30000.
+            default_value: 1000
+          - !ruby/object:Api::Type::Integer
+            name: multiplier
+            description: |
+              The number of consecutive BFD packets that must be missed before
+              BFD declares that a peer is unavailable. If set, the value must
+              be a value between 5 and 16.
+            default_value: 5
       - !ruby/object:Api::Type::Boolean
-         name: 'enable'
-         description: |
-           The status of the BGP peer connection. If set to false, any active session
-           with the peer is terminated and all associated routing information is removed.
-           If set to true, the peer connection can be established with routing information.
-           The default is true.
-         default_value: true
+        name: 'enable'
+        description: |
+          The status of the BGP peer connection. If set to false, any active session
+          with the peer is terminated and all associated routing information is removed.
+          If set to true, the peer connection can be established with routing information.
+          The default is true.
+        default_value: true
   - !ruby/object:Api::Resource
     name: 'SecurityPolicy'
     kind: 'compute#securityPolicy'

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2398,6 +2398,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           router_name: "my-router"
           peer_name: "my-router-peer"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "router_peer_bfd"
+        primary_resource_id: "peer"
+        skip_test: true
+        vars:
+          router_name: "my-router"
+          peer_name: "my-router-peer"
     properties:
       advertiseMode: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
@@ -2413,6 +2420,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         description: |
           {{description}}
           If it is not provided, the provider region is used.
+      bfd: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       enable: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/bool_to_upper_string.erb'
         custom_flatten: 'templates/terraform/custom_flatten/string_to_bool_default_true.erb'

--- a/mmv1/templates/terraform/examples/router_peer_bfd.tf.erb
+++ b/mmv1/templates/terraform/examples/router_peer_bfd.tf.erb
@@ -6,5 +6,11 @@ resource "google_compute_router_peer" "<%= ctx[:primary_resource_id] %>" {
   peer_asn                  = 65513
   advertised_route_priority = 100
   interface                 = "interface-1"
-  enable                    = false
+
+  bfd {
+    min_receive_interval        = 1000
+    min_transmit_interval       = 1000
+    multiplier                  = 5
+    session_initialization_mode = "ACTIVE"
+  }
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_router_bgp_peer_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_router_bgp_peer_test.go
@@ -112,6 +112,49 @@ func TestAccComputeRouterPeer_enable(t *testing.T) {
 	})
 }
 
+func TestAccComputeRouterPeer_bfd(t *testing.T) {
+	t.Parallel()
+
+	routerName := fmt.Sprintf("tf-test-router-%s", randString(t, 10))
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeRouterPeerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRouterPeerBasic(routerName),
+				Check: testAccCheckComputeRouterPeerExists(
+					t, "google_compute_router_peer.foobar"),
+			},
+			{
+				ResourceName:      "google_compute_router_peer.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterPeerBfd(routerName, "DISABLED"),
+				Check: testAccCheckComputeRouterPeerExists(
+					t, "google_compute_router_peer.foobar"),
+			},
+			{
+				ResourceName:      "google_compute_router_peer.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeRouterPeerBasic(routerName),
+				Check: testAccCheckComputeRouterPeerExists(
+					t, "google_compute_router_peer.foobar"),
+			},
+			{
+				ResourceName:      "google_compute_router_peer.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckComputeRouterPeerDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
@@ -674,4 +717,101 @@ resource "google_compute_router_peer" "foobar" {
   enable                    = %v
 }
 `, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, enable)
+}
+
+func testAccComputeRouterPeerBfd(routerName, bfdMode string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "foobar" {
+  name = "%s-net"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "foobar" {
+  name          = "%s-subnet"
+  network       = google_compute_network.foobar.self_link
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+}
+
+resource "google_compute_address" "foobar" {
+  name   = "%s"
+  region = google_compute_subnetwork.foobar.region
+}
+
+resource "google_compute_vpn_gateway" "foobar" {
+  name    = "%s-gateway"
+  network = google_compute_network.foobar.self_link
+  region  = google_compute_subnetwork.foobar.region
+}
+
+resource "google_compute_forwarding_rule" "foobar_esp" {
+  name        = "%s-frfr1"
+  region      = google_compute_vpn_gateway.foobar.region
+  ip_protocol = "ESP"
+  ip_address  = google_compute_address.foobar.address
+  target      = google_compute_vpn_gateway.foobar.self_link
+}
+
+resource "google_compute_forwarding_rule" "foobar_udp500" {
+  name        = "%s-fr2"
+  region      = google_compute_forwarding_rule.foobar_esp.region
+  ip_protocol = "UDP"
+  port_range  = "500-500"
+  ip_address  = google_compute_address.foobar.address
+  target      = google_compute_vpn_gateway.foobar.self_link
+}
+
+resource "google_compute_forwarding_rule" "foobar_udp4500" {
+  name        = "%s-fr3"
+  region      = google_compute_forwarding_rule.foobar_udp500.region
+  ip_protocol = "UDP"
+  port_range  = "4500-4500"
+  ip_address  = google_compute_address.foobar.address
+  target      = google_compute_vpn_gateway.foobar.self_link
+}
+
+resource "google_compute_router" "foobar" {
+  name    = "%s"
+  region  = google_compute_forwarding_rule.foobar_udp500.region
+  network = google_compute_network.foobar.self_link
+  bgp {
+    asn = 64514
+  }
+}
+
+resource "google_compute_vpn_tunnel" "foobar" {
+  name               = "%s"
+  region             = google_compute_forwarding_rule.foobar_udp4500.region
+  target_vpn_gateway = google_compute_vpn_gateway.foobar.self_link
+  shared_secret      = "unguessable"
+  peer_ip            = "8.8.8.8"
+  router             = google_compute_router.foobar.name
+}
+
+resource "google_compute_router_interface" "foobar" {
+  name       = "%s"
+  router     = google_compute_router.foobar.name
+  region     = google_compute_router.foobar.region
+  ip_range   = "169.254.3.1/30"
+  vpn_tunnel = google_compute_vpn_tunnel.foobar.name
+}
+
+resource "google_compute_router_peer" "foobar" {
+  name                      = "%s"
+  router                    = google_compute_router.foobar.name
+  region                    = google_compute_router.foobar.region
+  ip_address                = "169.254.3.1"
+  peer_ip_address           = "169.254.3.2"
+  peer_asn                  = 65515
+  advertised_route_priority = 100
+  interface                 = google_compute_router_interface.foobar.name
+
+  bfd {
+    min_receive_interval        = 2000
+    min_transmit_interval       = 2000
+    multiplier                  = 6
+    session_initialization_mode = "%s"
+  }
+}
+`, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, routerName, bfdMode)
 }


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added `bfd` to `google_compute_router_peer`
```
