### PR TITLE
Remove expression to avoid the interpolation-only expressions warning

### DIFF
--- a/third_party/terraform/website/docs/guides/getting_started.html.markdown
+++ b/third_party/terraform/website/docs/guides/getting_started.html.markdown
@@ -134,7 +134,7 @@ with a subnetwork in each region. Next, change the network of the
 network_interface {
 -  # A default network is created for all GCP projects
 -  network = "default"
-+  network = "${google_compute_network.vpc_network.self_link}"
++  network = google_compute_network.vpc_network.self_link
   access_config {
 ```
 
@@ -189,7 +189,7 @@ resource "google_compute_instance" "vm_instance" {
 
   network_interface {
     # A default network is created for all GCP projects
-    network       = "${google_compute_network.vpc_network.self_link}"
+    network       = google_compute_network.vpc_network.self_link
     access_config {
     }
   }


### PR DESCRIPTION
Upstreams https://github.com/terraform-providers/terraform-provider-google/pull/5908

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
