### PR TITLE
Add region_backend_service portName

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2230,8 +2230,9 @@ objects:
           communication to the backend VMs in that group. Required when the
           loadBalancingScheme is EXTERNAL, INTERNAL_MANAGED, or INTERNAL_SELF_MANAGED
           and the backends are instance groups. The named port must be defined on each
-          backend instance group. This parameter has no meaning if the backends are NEGs.
-          Must be omitted when the loadBalancingScheme is INTERNAL (Internal TCP/UDP Load Blaancing).
+          backend instance group. This parameter has no meaning if the backends are NEGs. API sets a
+          default of "http" if not given.
+          Must be omitted when the loadBalancingScheme is INTERNAL (Internal TCP/UDP Load Balancing).
       - !ruby/object:Api::Type::Enum
         name: 'protocol'
         description: |

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2223,6 +2223,15 @@ objects:
               success rate: mean - (stdev * success_rate_stdev_factor). This factor is divided
               by a thousand to get a double. That is, if the desired factor is 1.9, the
               runtime value should be 1900. Defaults to 1900.
+      - !ruby/object:Api::Type::String
+        name: 'portName'
+        description: |
+          A named port on a backend instance group representing the port for
+          communication to the backend VMs in that group. Required when the
+          loadBalancingScheme is EXTERNAL, INTERNAL_MANAGED, or INTERNAL_SELF_MANAGED
+          and the backends are instance groups. The named port must be defined on each
+          backend instance group. This parameter has no meaning if the backends are NEGs.
+          Must be omitted when the loadBalancingScheme is INTERNAL (Internal TCP/UDP Load Blaancing).
       - !ruby/object:Api::Type::Enum
         name: 'protocol'
         description: |

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -311,6 +311,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         exclude: true
       protocol: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      portName: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       sessionAffinity: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       timeoutSec: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
@@ -244,6 +244,7 @@ func testAccComputeRegionBackendService_ilbBasic(serviceName, checkName string) 
 resource "google_compute_region_backend_service" "foobar" {
   name                  = "%s"
   health_checks         = [google_compute_health_check.health_check.self_link]
+  port_name             = "http"
   protocol              = "HTTP"
   load_balancing_scheme = "INTERNAL_MANAGED"
   locality_lb_policy    = "RING_HASH"
@@ -278,6 +279,7 @@ func testAccComputeRegionBackendService_ilbUpdateBasic(serviceName, checkName st
 resource "google_compute_region_backend_service" "foobar" {
   name                  = "%s"
   health_checks         = [google_compute_health_check.health_check.self_link]
+  port_name             = "http"
   protocol              = "HTTP"
   load_balancing_scheme = "INTERNAL_MANAGED"
   locality_lb_policy    = "RANDOM"
@@ -304,6 +306,7 @@ func testAccComputeRegionBackendService_ilbFull(serviceName, checkName string) s
 resource "google_compute_region_backend_service" "foobar" {
   name                  = "%s"
   health_checks         = [google_compute_health_check.health_check.self_link]
+  port_name             = "http"
   protocol              = "HTTP"
   load_balancing_scheme = "INTERNAL_MANAGED"
   locality_lb_policy    = "MAGLEV"
@@ -340,6 +343,7 @@ func testAccComputeRegionBackendService_ilbUpdateFull(serviceName, igName, insta
 resource "google_compute_region_backend_service" "foobar" {
   name                  = "%s"
   health_checks         = [google_compute_health_check.health_check.self_link]
+  port_name             = "http"
   protocol              = "HTTP"
   load_balancing_scheme = "INTERNAL_MANAGED"
   locality_lb_policy    = "MAGLEV"
@@ -437,6 +441,7 @@ resource "google_compute_region_backend_service" "foobar" {
   name          = "%s"
   health_checks = [google_compute_health_check.zero.self_link]
   region        = "us-central1"
+  port_name     = "http"
 }
 
 resource "google_compute_health_check" "zero" {
@@ -457,6 +462,7 @@ resource "google_compute_region_backend_service" "foobar" {
   name          = "%s"
   health_checks = [google_compute_health_check.one.self_link]
   region        = "us-central1"
+  port_name     = "http"
 }
 
 resource "google_compute_health_check" "zero" {
@@ -492,6 +498,7 @@ data "google_compute_image" "my_image" {
 resource "google_compute_region_backend_service" "lipsum" {
   name        = "%s"
   description = "Hello World 1234"
+  port_name   = "http"
   protocol    = "TCP"
   region      = "us-central1"
   timeout_sec = %v
@@ -561,6 +568,7 @@ data "google_compute_image" "my_image" {
 resource "google_compute_region_backend_service" "lipsum" {
   name        = "%s"
   description = "Hello World 1234"
+  port_name   = "http"
   protocol    = "TCP"
   region      = "us-central1"
   timeout_sec = %v
@@ -662,6 +670,7 @@ data "google_compute_image" "my_image" {
 resource "google_compute_region_backend_service" "lipsum" {
   name        = "%s"
   description = "Hello World 1234"
+  port_name   = "http"
   protocol    = "TCP"
   region      = "us-central1"
 
@@ -724,6 +733,7 @@ resource "google_compute_region_backend_service" "default" {
   }
 
   region      = "us-central1"
+  port_name   = "http"
   protocol    = "HTTP"
   timeout_sec = 10
 
@@ -791,6 +801,7 @@ resource "google_compute_region_backend_service" "default" {
   }
 
   region      = "us-central1"
+  port_name   = "http"
   protocol    = "HTTP"
   timeout_sec = 10
 
@@ -868,6 +879,7 @@ resource "google_compute_region_backend_service" "default" {
   }
 
   region      = "us-central1"
+  port_name   = "http"
   protocol    = "HTTP"
   timeout_sec = 10
 

--- a/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
@@ -279,7 +279,7 @@ func testAccComputeRegionBackendService_ilbUpdateBasic(serviceName, checkName st
 resource "google_compute_region_backend_service" "foobar" {
   name                  = "%s"
   health_checks         = [google_compute_health_check.health_check.self_link]
-  port_name             = "http"
+  port_name             = "https"
   protocol              = "HTTP"
   load_balancing_scheme = "INTERNAL_MANAGED"
   locality_lb_policy    = "RANDOM"
@@ -343,7 +343,7 @@ func testAccComputeRegionBackendService_ilbUpdateFull(serviceName, igName, insta
 resource "google_compute_region_backend_service" "foobar" {
   name                  = "%s"
   health_checks         = [google_compute_health_check.health_check.self_link]
-  port_name             = "http"
+  port_name             = "https"
   protocol              = "HTTP"
   load_balancing_scheme = "INTERNAL_MANAGED"
   locality_lb_policy    = "MAGLEV"
@@ -403,6 +403,16 @@ resource "google_compute_region_backend_service" "foobar" {
 resource "google_compute_instance_group" "group" {
   name      = "%s"
   instances = [google_compute_instance.ig_instance.self_link]
+
+  named_port {
+    name = "http"
+    port = "8080"
+  }
+
+  named_port {
+    name = "https"
+    port = "8443"
+  }
 }
 
 data "google_compute_image" "my_image" {


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5551
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Add region_backend_service portName parameter
```
