### PR TITLE
Add google_compute_instance current_status to data source

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_compute_instance.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_instance.go
@@ -153,6 +153,7 @@ func dataSourceGoogleComputeInstanceRead(d *schema.ResourceData, meta interface{
 	d.Set("instance_id", fmt.Sprintf("%d", instance.Id))
 	d.Set("project", project)
 	d.Set("zone", GetResourceNameFromSelfLink(instance.Zone))
+	d.Set("current_status", instance.Status)
 	d.Set("name", instance.Name)
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, instance.Zone, instance.Name))
 	return nil

--- a/third_party/terraform/resources/resource_compute_instance.go
+++ b/third_party/terraform/resources/resource_compute_instance.go
@@ -543,10 +543,6 @@ func resourceComputeInstance() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"RUNNING", "TERMINATED"}, false),
 			},
-			"current_status": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"tags": {
 				Type:     schema.TypeSet,
 				Optional: true,

--- a/third_party/terraform/resources/resource_compute_instance.go
+++ b/third_party/terraform/resources/resource_compute_instance.go
@@ -543,7 +543,10 @@ func resourceComputeInstance() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"RUNNING", "TERMINATED"}, false),
 			},
-
+			"current_status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"tags": {
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -1011,6 +1014,7 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("name", instance.Name)
 	d.Set("description", instance.Description)
 	d.Set("hostname", instance.Hostname)
+	d.Set("current_status", instance.Status)
 
 	if d.Get("desired_status") != "" {
 		d.Set("desired_status", instance.Status)

--- a/third_party/terraform/resources/resource_compute_instance.go
+++ b/third_party/terraform/resources/resource_compute_instance.go
@@ -1010,7 +1010,6 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("name", instance.Name)
 	d.Set("description", instance.Description)
 	d.Set("hostname", instance.Hostname)
-	d.Set("current_status", instance.Status)
 
 	if d.Get("desired_status") != "" {
 		d.Set("desired_status", instance.Status)

--- a/third_party/terraform/resources/resource_compute_instance.go
+++ b/third_party/terraform/resources/resource_compute_instance.go
@@ -543,6 +543,7 @@ func resourceComputeInstance() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice([]string{"RUNNING", "TERMINATED"}, false),
 			},
+
 			"tags": {
 				Type:     schema.TypeSet,
 				Optional: true,

--- a/third_party/terraform/tests/data_source_google_compute_instance_test.go
+++ b/third_party/terraform/tests/data_source_google_compute_instance_test.go
@@ -53,6 +53,7 @@ func testAccDataSourceComputeInstanceCheck(datasourceName string, resourceName s
 		instanceAttrsToTest := []string{
 			"name",
 			"machine_type",
+			"current_status",
 			"can_ip_forward",
 			"description",
 			"deletion_protection",


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added `current_status` field to `data.google_compute_instance`
```
