### PR TITLE
Allow import of logging_metric in a non-default project.

### DIFF
--- a/products/logging/terraform.yaml
+++ b/products/logging/terraform.yaml
@@ -14,7 +14,7 @@
 overrides: !ruby/object:Overrides::ResourceOverrides
   Metric: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: "{{name}}"
-    import_format: ["{{name}}"]
+    import_format: ["{{name}}", "{{project}} {{name}}"]
     mutex: customMetric/{{project}}
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/templates/terraform/custom_import/self_link_as_name.erb
+++ b/templates/terraform/custom_import/self_link_as_name.erb
@@ -2,7 +2,7 @@
 	config := meta.(*Config)
 	
 	// current import_formats can't import fields with forward slashes in their value
-        if err := parseImportId([]string{"(?P<project>[^ ]+) (?P<name>[^ ]+)", "(?P<name>[^ ]+)"}, d, config); err != nil {
+	if err := parseImportId([]string{"(?P<project>[^ ]+) (?P<name>[^ ]+)", "(?P<name>[^ ]+)"}, d, config); err != nil {
 		return nil, err
 	}
 

--- a/templates/terraform/custom_import/self_link_as_name.erb
+++ b/templates/terraform/custom_import/self_link_as_name.erb
@@ -2,7 +2,7 @@
 	config := meta.(*Config)
 	
 	// current import_formats can't import fields with forward slashes in their value
-	if err := parseImportId([]string{"(?P<name>.+)"}, d, config); err != nil {
+        if err := parseImportId([]string{"(?P<project>[^ ]+) (?P<name>[^ ]+)", "(?P<name>[^ ]+)"}, d, config); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
logging: Fixed import issue with `google_logging_metric` in a non-default project.
```
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5867.