### PR TITLE
Additional Authenticated Data AAD for Cloud KMS secrets

### DIFF
--- a/products/kms/api.yaml
+++ b/products/kms/api.yaml
@@ -169,6 +169,10 @@ objects:
           The plaintext to be encrypted.
         required: true
       - !ruby/object:Api::Type::String
+        name: 'additionalAuthenticatedData'
+        description: |
+          The additional authenticated data used for integrity checks during encryption and decryption.
+      - !ruby/object:Api::Type::String
         name: 'ciphertext'
         description: |
           Contains the result of encrypting the provided plaintext, encoded in base64.

--- a/products/kms/terraform.yaml
+++ b/products/kms/terraform.yaml
@@ -130,6 +130,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read: true
         sensitive: true
         custom_expand: templates/terraform/custom_expand/base64.go.erb
+      additionalAuthenticatedData: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
+        sensitive: true
+        custom_expand: templates/terraform/custom_expand/base64.go.erb
       ciphertext: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode

--- a/third_party/terraform/data_sources/data_source_google_kms_secret.go
+++ b/third_party/terraform/data_sources/data_source_google_kms_secret.go
@@ -27,6 +27,10 @@ func dataSourceGoogleKmsSecret() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
+			"additionalAuthenticatedData": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -44,6 +48,10 @@ func dataSourceGoogleKmsSecretRead(d *schema.ResourceData, meta interface{}) err
 
 	kmsDecryptRequest := &cloudkms.DecryptRequest{
 		Ciphertext: ciphertext,
+	}
+
+	if aad, ok := d.GetOk("additionalAuthenticatedData"); ok {
+		kmsDecryptRequest.AdditionalAuthenticatedData = aad.(string)
 	}
 
 	decryptResponse, err := config.clientKms.Projects.Locations.KeyRings.CryptoKeys.Decrypt(cryptoKeyId.cryptoKeyId(), kmsDecryptRequest).Do()

--- a/third_party/terraform/data_sources/data_source_google_kms_secret.go
+++ b/third_party/terraform/data_sources/data_source_google_kms_secret.go
@@ -27,7 +27,7 @@ func dataSourceGoogleKmsSecret() *schema.Resource {
 				Computed:  true,
 				Sensitive: true,
 			},
-			"additionalAuthenticatedData": {
+			"additional_authenticated_data": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
@@ -50,7 +50,7 @@ func dataSourceGoogleKmsSecretRead(d *schema.ResourceData, meta interface{}) err
 		Ciphertext: ciphertext,
 	}
 
-	if aad, ok := d.GetOk("additionalAuthenticatedData"); ok {
+	if aad, ok := d.GetOk("additional_authenticated_data"); ok {
 		kmsDecryptRequest.AdditionalAuthenticatedData = aad.(string)
 	}
 

--- a/third_party/terraform/tests/data_source_google_kms_secret_ciphertext_test.go
+++ b/third_party/terraform/tests/data_source_google_kms_secret_ciphertext_test.go
@@ -23,7 +23,7 @@ func TestAccDataKmsSecretCiphertext_basic(t *testing.T) {
 			{
 				Config: testGoogleKmsSecretCiphertext_datasource(kms.CryptoKey.Name, plaintext),
 				Check: func(s *terraform.State) error {
-					plaintext, err := testAccDecryptSecretDataWithCryptoKey(s, kms.CryptoKey.Name, "data.google_kms_secret_ciphertext.acceptance")
+					plaintext, err := testAccDecryptSecretDataWithCryptoKey(s, kms.CryptoKey.Name, "data.google_kms_secret_ciphertext.acceptance", "")
 
 					if err != nil {
 						return err

--- a/third_party/terraform/tests/data_source_google_kms_secret_test.go
+++ b/third_party/terraform/tests/data_source_google_kms_secret_test.go
@@ -23,6 +23,7 @@ func TestAccKmsSecret_basic(t *testing.T) {
 	cryptoKeyName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 
 	plaintext := fmt.Sprintf("secret-%s", acctest.RandString(10))
+	aad := "plainaad"
 
 	// The first test creates resources needed to encrypt plaintext and produce ciphertext
 	resource.Test(t, resource.TestCase{
@@ -57,7 +58,7 @@ func TestAccKmsSecret_basic(t *testing.T) {
 			{
 				Config: testGoogleKmsCryptoKey_basic(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
 				Check: func(s *terraform.State) error {
-					ciphertext, cryptoKeyId, err := testAccEncryptSecretDataWithCryptoKey(s, "google_kms_crypto_key.crypto_key", plaintext, "plainaad")
+					ciphertext, cryptoKeyId, err := testAccEncryptSecretDataWithCryptoKey(s, "google_kms_crypto_key.crypto_key", plaintext, aad)
 
 					if err != nil {
 						return err
@@ -69,7 +70,7 @@ func TestAccKmsSecret_basic(t *testing.T) {
 						Providers: testAccProviders,
 						Steps: []resource.TestStep{
 							{
-								Config: testGoogleKmsSecret_aadDatasource(cryptoKeyId.terraformId(), ciphertext, base64.StdEncoding.EncodeToString([]byte("plainaad"))),
+								Config: testGoogleKmsSecret_aadDatasource(cryptoKeyId.terraformId(), ciphertext, base64.StdEncoding.EncodeToString([]byte(aad))),
 								Check:  resource.TestCheckResourceAttr("data.google_kms_secret.acceptance", "plaintext", plaintext),
 							},
 						},

--- a/third_party/terraform/tests/data_source_google_kms_secret_test.go
+++ b/third_party/terraform/tests/data_source_google_kms_secret_test.go
@@ -32,7 +32,7 @@ func TestAccKmsSecret_basic(t *testing.T) {
 			{
 				Config: testGoogleKmsCryptoKey_basic(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
 				Check: func(s *terraform.State) error {
-					ciphertext, cryptoKeyId, err := testAccEncryptSecretDataWithCryptoKey(s, "google_kms_crypto_key.crypto_key", plaintext)
+					ciphertext, cryptoKeyId, err := testAccEncryptSecretDataWithCryptoKey(s, "google_kms_crypto_key.crypto_key", plaintext, "")
 
 					if err != nil {
 						return err
@@ -53,11 +53,36 @@ func TestAccKmsSecret_basic(t *testing.T) {
 					return nil
 				},
 			},
+			// With AAD
+			{
+				Config: testGoogleKmsCryptoKey_basic(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+				Check: func(s *terraform.State) error {
+					ciphertext, cryptoKeyId, err := testAccEncryptSecretDataWithCryptoKey(s, "google_kms_crypto_key.crypto_key", plaintext, "plainaad")
+
+					if err != nil {
+						return err
+					}
+
+					// The second test asserts that the data source has the correct plaintext, given the created ciphertext
+					resource.Test(t, resource.TestCase{
+						PreCheck:  func() { testAccPreCheck(t) },
+						Providers: testAccProviders,
+						Steps: []resource.TestStep{
+							{
+								Config: testGoogleKmsSecret_aadDatasource(cryptoKeyId.terraformId(), ciphertext, base64.StdEncoding.EncodeToString([]byte("plainaad"))),
+								Check:  resource.TestCheckResourceAttr("data.google_kms_secret.acceptance", "plaintext", plaintext),
+							},
+						},
+					})
+
+					return nil
+				},
+			},
 		},
 	})
 }
 
-func testAccEncryptSecretDataWithCryptoKey(s *terraform.State, cryptoKeyResourceName, plaintext string) (string, *kmsCryptoKeyId, error) {
+func testAccEncryptSecretDataWithCryptoKey(s *terraform.State, cryptoKeyResourceName, plaintext, aad string) (string, *kmsCryptoKeyId, error) {
 	config := testAccProvider.Meta().(*Config)
 
 	rs, ok := s.RootModule().Resources[cryptoKeyResourceName]
@@ -73,6 +98,10 @@ func testAccEncryptSecretDataWithCryptoKey(s *terraform.State, cryptoKeyResource
 
 	kmsEncryptRequest := &cloudkms.EncryptRequest{
 		Plaintext: base64.StdEncoding.EncodeToString([]byte(plaintext)),
+	}
+
+	if aad != "" {
+		kmsEncryptRequest.AdditionalAuthenticatedData = base64.StdEncoding.EncodeToString([]byte(aad))
 	}
 
 	encryptResponse, err := config.clientKms.Projects.Locations.KeyRings.CryptoKeys.Encrypt(cryptoKeyId.cryptoKeyId(), kmsEncryptRequest).Do()
@@ -93,4 +122,14 @@ data "google_kms_secret" "acceptance" {
   ciphertext = "%s"
 }
 `, cryptoKeyTerraformId, ciphertext)
+}
+
+func testGoogleKmsSecret_aadDatasource(cryptoKeyTerraformId, ciphertext, aad string) string {
+	return fmt.Sprintf(`
+data "google_kms_secret" "acceptance" {
+  crypto_key                    = "%s"
+  ciphertext                    = "%s"
+  additional_authenticated_data = "%s"
+}
+`, cryptoKeyTerraformId, ciphertext, aad)
 }

--- a/third_party/terraform/website/docs/d/google_kms_secret.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_secret.html.markdown
@@ -90,6 +90,7 @@ The following arguments are supported:
 * `crypto_key` (Required) - The id of the CryptoKey that will be used to
   decrypt the provided ciphertext. This is represented by the format
   `{projectId}/{location}/{keyRingName}/{cryptoKeyName}`.
+* `additional_authenticated_data` (Optional) - The [additional authenticated data](https://cloud.google.com/kms/docs/additional-authenticated-data) used for integrity checks during encryption and decryption.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Allow setting Additional Authenticated Data AAD for Cloud KMS secrets (encryption and decryption)

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/2961

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
kms: Added new field "Additional Authenticated Data" for Cloud KMS data source `google_kms_secret`
```

```release-note:enhancement
kms: Added new field "Additional Authenticated Data" for Cloud KMS resource `google_kms_secret_ciphertext`
```
