### PR TITLE
Revert changes to compute image selflink in examples

### DIFF
--- a/templates/terraform/examples/autoscaler_basic.tf.erb
+++ b/templates/terraform/examples/autoscaler_basic.tf.erb
@@ -22,7 +22,7 @@ resource "google_compute_instance_template" "foobar" {
   tags = ["foo", "bar"]
 
   disk {
-    source_image = data.google_compute_image.debian_9.id
+    source_image = data.google_compute_image.debian_9.self_link
   }
 
   network_interface {

--- a/templates/terraform/examples/autoscaler_single_instance.tf.erb
+++ b/templates/terraform/examples/autoscaler_single_instance.tf.erb
@@ -28,7 +28,7 @@ resource "google_compute_instance_template" "default" {
   tags = ["foo", "bar"]
 
   disk {
-    source_image = data.google_compute_image.debian_9.id
+    source_image = data.google_compute_image.debian_9.self_link
   }
 
   network_interface {

--- a/templates/terraform/examples/instance_with_ip.tf.erb
+++ b/templates/terraform/examples/instance_with_ip.tf.erb
@@ -14,7 +14,7 @@ resource "google_compute_instance" "instance_with_ip" {
 
   boot_disk {
     initialize_params {
-      image = data.google_compute_image.debian_image.id
+      image = data.google_compute_image.debian_image.self_link
     }
   }
 

--- a/templates/terraform/examples/region_autoscaler_basic.tf.erb
+++ b/templates/terraform/examples/region_autoscaler_basic.tf.erb
@@ -22,7 +22,7 @@ resource "google_compute_instance_template" "foobar" {
   tags = ["foo", "bar"]
 
   disk {
-    source_image = data.google_compute_image.debian_9.id
+    source_image = data.google_compute_image.debian_9.self_link
   }
 
   network_interface {


### PR DESCRIPTION
ID is not useful for image right now - will require a followup PR to fix image id

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
