### PR TITLE
Add pollasync to eventually consistent iap brand

### DIFF
--- a/products/iap/api.yaml
+++ b/products/iap/api.yaml
@@ -140,6 +140,8 @@ objects:
     base_url: 'projects/{{project}}/brands'
     self_link: '{{name}}'
     input: true
+    identity:
+      - name
     description: |
       OAuth brand data. Only "Organization Internal" brands can be created
       programatically via API. To convert it into an external brands

--- a/products/iap/terraform.yaml
+++ b/products/iap/terraform.yaml
@@ -151,9 +151,16 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           instance_name: "tunnel-vm"
         primary_resource_name: "fmt.Sprintf(\"tf-test-tunnel-vm%s\", context[\"random_suffix\"])"
   Brand: !ruby/object:Overrides::Terraform::ResourceOverride
+    async: !ruby/object:Provider::Terraform::PollAsync
+      check_response_func: PollCheckForExistence
+      actions: ['create']
+      operation: !ruby/object:Api::Async::Operation
+        timeouts: !ruby/object:Api::Timeouts
+          insert_minutes: 4
+          update_minutes: 4
     description: |
       {{description}}
-    
+
       ~> **Note:** Brands can be created only once for a Google Cloud Platform
       project and cannot be deleted. Destroying a Terraform-managed Brand
       will remove it from state but *will not delete the resource on the server.*

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -207,6 +207,16 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <%  end -%>
         return fmt.Errorf("Error creating <%= object.name -%>: %s", err)
     }
+<% # Don't set resource properties from create API response if it returns the operation -%>
+<%  unless object.async&.is_a? Api::OpAsync -%>
+    <% object.gettable_properties.each do |prop| -%>
+        <% if object.identity.include?(prop) && prop.output -%>
+    if err := d.Set("<%= prop.name.underscore -%>", flatten<%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.api_name -%>"], d, config)); err != nil {
+        return fmt.Errorf(`Error setting identifer field "<%=prop.name.underscore%>": %s`, err)
+    }
+        <% end -%>
+    <% end -%>
+<% end -%>
 
     // Store the ID now
     id, err := replaceVars(d, config, "<%= id_format(object) -%>")

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -207,12 +207,12 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <%  end -%>
         return fmt.Errorf("Error creating <%= object.name -%>: %s", err)
     }
-<% # Don't set resource properties from create API response if it returns the operation -%>
+<% # Set resource properties from create API response (unless it returns an Operation) -%>
 <%  unless object.async&.is_a? Api::OpAsync -%>
     <% object.gettable_properties.each do |prop| -%>
         <% if object.identity.include?(prop) && prop.output -%>
     if err := d.Set("<%= prop.name.underscore -%>", flatten<%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.api_name -%>"], d, config)); err != nil {
-        return fmt.Errorf(`Error setting identifer field "<%=prop.name.underscore%>": %s`, err)
+        return fmt.Errorf(`Error setting computed identity field "<%=prop.name.underscore%>": %s`, err)
     }
         <% end -%>
     <% end -%>


### PR DESCRIPTION
Also fix some issues where the id was set before computed values were set from response. I don't think it is currently causing bugs since autogen Reads don't rely on ID being set. It just makes the debug line `Finished creating ResourceFoo ""` and sets the ID to an incorrect value temporarily. 

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
