### PR TITLE
Consume original request body from retry transport

### DIFF
--- a/third_party/terraform/utils/retry_transport.go
+++ b/third_party/terraform/utils/retry_transport.go
@@ -142,6 +142,12 @@ Retry:
 		}
 	}
 
+	// VCR depends on the original request body being consumed, so consume it here
+	_, err := httputil.DumpRequest(req, true)
+	if err != nil {
+		log.Printf("[DEBUG] Retry Transport: Reading request failed: %v", err)
+	}
+
 	log.Printf("[DEBUG] Retry Transport: Returning after %d attempts", attempts)
 	return resp, respErr
 }

--- a/third_party/terraform/utils/retry_transport.go
+++ b/third_party/terraform/utils/retry_transport.go
@@ -143,7 +143,7 @@ Retry:
 	}
 
 	// VCR depends on the original request body being consumed, so consume it here
-	_, err := httputil.DumpRequest(req, true)
+	_, err := httputil.DumpRequestOut(req, true)
 	if err != nil {
 		log.Printf("[DEBUG] Retry Transport: Reading request failed: %v", err)
 	}


### PR DESCRIPTION
VCR replaces the request body with a TeeReader that writes the body for VCR use when the body is read. The new retry transport copies the request body and never consumes it, so the body is never written via VCR. This consumes the body after the retry transport is finished

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
