### PR TITLE
Removing the license file from third_party file

### DIFF
--- a/spec/copyright_spec.rb
+++ b/spec/copyright_spec.rb
@@ -23,12 +23,11 @@ describe 'ensure files have copyright notice' do
                 .select { |f| File.file?(f) }
                 .select do |f|
                   my_tests = f.start_with?("#{my_path}/data/copyright_")
-                  artifacts = f.start_with?("#{my_root}/build/")
-                  presubmit = f.start_with?("#{my_root}/build/presubmit/")
+                  third_party = f.start_with?("#{my_root}/third_party/")
                   vendor = f.start_with?("#{my_root}/vendor/")
                   version_added = f.include?('ansible_version_added.yaml')
 
-                  !my_tests && !artifacts && !vendor && !presubmit && !version_added
+                  !my_tests && !vendor && !version_added && !third_party
                 end
     checker = Google::CopyrightChecker.new(files)
     missing = checker.check_missing.collect { |f| "  - #{f}" }

--- a/third_party/terraform/utils/test-fixtures/appengine/hello-world-flask/app.yaml
+++ b/third_party/terraform/utils/test-fixtures/appengine/hello-world-flask/app.yaml
@@ -1,15 +1,3 @@
-# Copyright 2020 Google Inc.
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 runtime: python
 env: flex
@@ -18,7 +6,7 @@ entrypoint: gunicorn -b :$PORT main:app
 runtime_config:
   python_version: 3
 
-# This sample incurs costs to run on the App Engine flexible environment. 
+# This sample incurs costs to run on the App Engine flexible environment.
 # The settings below are to reduce costs during testing and are not appropriate
 # for production use. For more information, see:
 # https://cloud.google.com/appengine/docs/flexible/python/configuring-your-app-with-app-yaml


### PR DESCRIPTION
As these files are being treated as part of the terraform codebase and not part
of the magic modules codebase we are keeping them in third_party because the
Terraform provider license is meant to cover them. In this case it would be the
MPL2 instead of apache2.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
