### PR TITLE
Add tfgen to sweepable prefixes

### DIFF
--- a/templates/terraform/sweeper_file.go.erb
+++ b/templates/terraform/sweeper_file.go.erb
@@ -93,7 +93,7 @@ func testSweep<%= sweeper_name -%>(region string) error {
 	<% end -%>
 
 	log.Printf("[INFO][SWEEPER_LOG] Found %d items in %s list response.", len(rl), resourceName)
-	// items who don't match the tf-test prefix
+	// Keep count of items that aren't sweepable for logging.
 	nonPrefixCount := 0
 	for _, ri := range rl {
 		obj := ri.(map[string]interface{})
@@ -103,8 +103,8 @@ func testSweep<%= sweeper_name -%>(region string) error {
 		}
 
 		name := GetResourceNameFromSelfLink(obj["name"].(string))
-		// Only sweep resources with the test prefix
-		if !strings.HasPrefix(name, "tf-test") {
+		// Skip resources that shouldn't be sweeped
+		if !isSweepableTestResource(name) {
 			nonPrefixCount++
 			continue
 		}
@@ -136,7 +136,7 @@ func testSweep<%= sweeper_name -%>(region string) error {
 	}
 
 	if nonPrefixCount > 0 {
-		log.Printf("[INFO][SWEEPER_LOG] %d items without tf_test prefix remain.", nonPrefixCount)
+		log.Printf("[INFO][SWEEPER_LOG] %d items were non-sweepable and skipped.", nonPrefixCount)
 	}
 
 	return nil

--- a/third_party/terraform/tests/resource_app_engine_app_version_sweeper_test.go
+++ b/third_party/terraform/tests/resource_app_engine_app_version_sweeper_test.go
@@ -3,7 +3,6 @@ package google
 import (
 	"context"
 	"log"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )

--- a/third_party/terraform/tests/resource_app_engine_app_version_sweeper_test.go
+++ b/third_party/terraform/tests/resource_app_engine_app_version_sweeper_test.go
@@ -49,7 +49,7 @@ func testSweepAppEngineAppVersion(region string) error {
 	rl := resourceList.([]interface{})
 
 	log.Printf("[INFO][SWEEPER_LOG] Found %d items in %s list response.", len(rl), resourceName)
-	// items who don't match the tf-test prefix
+	// Count items that weren't sweeped.
 	nonPrefixCount := 0
 	for _, ri := range rl {
 		obj := ri.(map[string]interface{})
@@ -59,8 +59,8 @@ func testSweepAppEngineAppVersion(region string) error {
 		}
 
 		id := obj["id"].(string)
-		// Only sweep resources with the test prefix
-		if !strings.HasPrefix(id, "tf-test") {
+		// Increment count and skip if resource is not sweepable.
+		if !isSweepableResource(id) {
 			nonPrefixCount++
 			continue
 		}

--- a/third_party/terraform/tests/resource_app_engine_app_version_sweeper_test.go
+++ b/third_party/terraform/tests/resource_app_engine_app_version_sweeper_test.go
@@ -59,7 +59,7 @@ func testSweepAppEngineAppVersion(region string) error {
 
 		id := obj["id"].(string)
 		// Increment count and skip if resource is not sweepable.
-		if !isSweepableResource(id) {
+		if !isSweepableTestResource(id) {
 			nonPrefixCount++
 			continue
 		}

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -44,7 +44,7 @@ func testSweepContainerClusters(region string) error {
 	}
 
 	for _, cluster := range found.Clusters {
-		if strings.HasPrefix(cluster.Name, "tf-test") {
+		if isSweepableTestResource(cluster.Name) {
 			log.Printf("Sweeping Container Cluster: %s", cluster.Name)
 			clusterURL := fmt.Sprintf("projects/%s/locations/%s/clusters/%s", config.Project, cluster.Location, cluster.Name)
 			_, err := config.clientContainer.Projects.Locations.Clusters.Delete(clusterURL).Do()

--- a/third_party/terraform/tests/resource_monitoring_group_test.go
+++ b/third_party/terraform/tests/resource_monitoring_group_test.go
@@ -10,56 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func init() {
-	resource.AddTestSweepers("gcp_monitoring_group", &resource.Sweeper{
-		Name: "gcp_monitoring_group",
-		F:    testSweepMonitoringGroups,
-	})
-}
-
-func testSweepMonitoringGroups(region string) error {
-	project := getTestProjectFromEnv()
-	config, err := sharedConfigForRegion(region)
-	if err != nil {
-		log.Fatalf("error getting shared config for region: %s", err)
-	}
-
-	err = config.LoadAndValidate(context.Background())
-	if err != nil {
-		log.Fatalf("error loading: %s", err)
-	}
-
-	url := fmt.Sprintf("%sprojects/%s/groups", config.MonitoringBasePath, project)
-	res, err := sendRequest(config, "GET", project, url, nil)
-	if err != nil {
-		log.Fatalf("Unable to list Monitoring Groups: %s", err)
-	}
-
-	groups, ok := res["group"]
-	if !ok {
-		log.Printf("No groups found in Monitoring Groups response")
-		return nil
-	}
-	gs := groups.([]interface{})
-
-	for _, gi := range gs {
-		g := gi.(map[string]interface{})
-
-		// Only sweep monitoring groups with the test prefix
-		if g["name"] != nil && strings.HasPrefix(g["name"].(string), "tf-test") {
-			url := fmt.Sprintf("%s%s", config.MonitoringBasePath, g["name"].(string))
-			log.Printf("Sweeping Monitoring Group: %s", g["name"].(string))
-
-			_, err = sendRequest(config, "DELETE", project, url, nil)
-			if err != nil {
-				log.Printf("Error deleting monitoring group: %s", err)
-			}
-		}
-	}
-
-	return nil
-}
-
 func TestAccMonitoringGroup_update(t *testing.T) {
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_monitoring_group_test.go
+++ b/third_party/terraform/tests/resource_monitoring_group_test.go
@@ -1,10 +1,7 @@
 package google
 
 import (
-	"context"
 	"fmt"
-	"log"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"

--- a/third_party/terraform/utils/gcp_sweeper_test.go
+++ b/third_party/terraform/utils/gcp_sweeper_test.go
@@ -7,6 +7,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
+// List of prefixes used for test resource names
+var testResourcePrefixes = []string{
+	"tf-test",
+	"tfgen",
+}
+
 func TestMain(m *testing.M) {
 	resource.TestMain(m)
 }
@@ -33,4 +39,13 @@ func sharedConfigForRegion(region string) (*Config, error) {
 	ConfigureBasePaths(conf)
 
 	return conf, nil
+}
+
+func isSweepableResource(resourceName string) bool {
+	for _, p := range testResourcePrefixes {
+		if strings.HasPrefix(resourceName, p) {
+			return true
+		}
+	}
+	return false
 }

--- a/third_party/terraform/utils/gcp_sweeper_test.go
+++ b/third_party/terraform/utils/gcp_sweeper_test.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -41,7 +42,7 @@ func sharedConfigForRegion(region string) (*Config, error) {
 	return conf, nil
 }
 
-func isSweepableResource(resourceName string) bool {
+func isSweepableTestResource(resourceName string) bool {
 	for _, p := range testResourcePrefixes {
 		if strings.HasPrefix(resourceName, p) {
 			return true


### PR DESCRIPTION
Also:
- created util for determining if a resource is sweepable
- removed redundant (afaik) handwritten monitoring group sweeper that has an [autogenerated](https://github.com/terraform-providers/terraform-provider-google/blob/master/google/resource_monitoring_group_sweeper_test.go) one


<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
