### PR TITLE
Add resource for enabling firebase

### DIFF
--- a/overrides/terraform/resource_override.rb
+++ b/overrides/terraform/resource_override.rb
@@ -69,6 +69,10 @@ module Overrides
           # If true, skip sweeper generation for this resource
           :skip_sweeper,
 
+          # Set to true for resources that are unable to be deleted, such as KMS keyrings or project
+          # level resources such as firebase project
+          :skip_delete,
+
           # This enables resources that get their project via a reference to a different resource
           # instead of a project field to use User Project Overrides
           :supports_indirect_user_project_override
@@ -102,6 +106,7 @@ module Overrides
         check :error_retry_predicates, type: Array, item_type: String
         check :schema_version, type: Integer
         check :skip_sweeper, type: :boolean, default: false
+        check :skip_delete, type: :boolean, default: false
         check :supports_indirect_user_project_override, type: :boolean, default: false
       end
 

--- a/products/firebase/api.yaml
+++ b/products/firebase/api.yaml
@@ -1,0 +1,69 @@
+# Copyright 2018 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: Firebase
+display_name: Firebase
+versions:
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://firebase.googleapis.com/v1beta1/
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+async: !ruby/object:Api::OpAsync
+  operation: !ruby/object:Api::OpAsync::Operation
+    path: 'name'
+    base_url: '{{op_id}}'
+    wait_ms: 1000
+  result: !ruby/object:Api::OpAsync::Result
+    path: 'response'
+    resource_inside_response: true
+  status: !ruby/object:Api::OpAsync::Status
+    path: 'done'
+    complete: true
+    allowed:
+      - true
+      - false
+  error: !ruby/object:Api::OpAsync::Error
+    path: 'error'
+    message: 'message'
+objects:
+  - !ruby/object:Api::Resource
+    name: 'Project'
+    min_version: beta
+    base_url: projects/{{project}}
+    create_url: projects/{{project}}:addFirebase
+    input: true
+    description: |
+      A Google Cloud Firebase instance. This enables Firebase resources on a given google project.
+      Since a FirebaseProject is actually also a GCP Project, a FirebaseProject uses underlying GCP
+      identifiers (most importantly, the projectId) as its own for easy interop with GCP APIs.
+
+      Once Firebase has been added to a Google Project it cannot be removed.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+          'https://firebase.google.com/'
+      api: 'https://firebase.google.com/docs/projects/api/reference/rest/v1beta1/projects'
+    properties:
+      - !ruby/object:Api::Type::String
+        name: projectNumber
+        output: true
+        description: |
+          The number of the google project that firebase is enabled on.
+      - !ruby/object:Api::Type::String
+        name: displayName
+        output: true
+        description: |
+          The GCP project display name
+

--- a/products/firebase/terraform.yaml
+++ b/products/firebase/terraform.yaml
@@ -20,13 +20,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       update_minutes: 10
       delete_minutes: 10
     autogen_async: true
-    custom_code: !ruby/object:Provider::Terraform::CustomCode
-      custom_delete: templates/terraform/custom_delete/skip_delete.go.erb
+    skip_delete: true
+    skip_sweeper: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "firebase_project_basic"
         min_version: 'beta'
-        skip_delete: true
         primary_resource_id: "basic"
         vars:
           instance_name: "memory-cache"

--- a/products/firebase/terraform.yaml
+++ b/products/firebase/terraform.yaml
@@ -1,0 +1,41 @@
+# Copyright 2017 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Terraform::Config
+overrides: !ruby/object:Overrides::ResourceOverrides
+  Project: !ruby/object:Overrides::Terraform::ResourceOverride
+    import_format: ["projects/{{project}}", "{{project}}"]
+    timeouts: !ruby/object:Api::Timeouts
+      insert_minutes: 10
+      update_minutes: 10
+      delete_minutes: 10
+    autogen_async: true
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      custom_delete: templates/terraform/custom_delete/skip_delete.go.erb
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "firebase_project_basic"
+        min_version: 'beta'
+        skip_delete: true
+        primary_resource_id: "basic"
+        vars:
+          instance_name: "memory-cache"
+        test_env_vars:
+          org_id: :ORG_ID
+
+# This is for copying files over
+files: !ruby/object:Provider::Config::Files
+  # These files have templating (ERB) code that will be run.
+  # This is usually to add licensing info, autogeneration notices, etc.
+  compile:
+<%= lines(indent(compile('provider/terraform/product~compile.yaml'), 4)) -%>

--- a/provider/terraform/examples.rb
+++ b/provider/terraform/examples.rb
@@ -107,8 +107,6 @@ module Provider
       # Whether to skip generating tests for this resource
       attr_reader :skip_test
 
-      attr_reader :skip_delete
-
       # The name of the primary resource for use in IAM tests. IAM tests need
       # a reference to the primary resource to create IAM policies for
       attr_reader :primary_resource_name
@@ -253,7 +251,6 @@ module Provider
         check :ignore_read_extra, type: Array, item_type: String, default: []
         check :primary_resource_name, type: String
         check :skip_test, type: TrueClass
-        check :skip_delete, type: TrueClass
         check :config_path, type: String, default: "templates/terraform/examples/#{name}.tf.erb"
       end
     end

--- a/provider/terraform/examples.rb
+++ b/provider/terraform/examples.rb
@@ -107,6 +107,8 @@ module Provider
       # Whether to skip generating tests for this resource
       attr_reader :skip_test
 
+      attr_reader :skip_delete
+
       # The name of the primary resource for use in IAM tests. IAM tests need
       # a reference to the primary resource to create IAM policies for
       attr_reader :primary_resource_name
@@ -251,6 +253,7 @@ module Provider
         check :ignore_read_extra, type: Array, item_type: String, default: []
         check :primary_resource_name, type: String
         check :skip_test, type: TrueClass
+        check :skip_delete, type: TrueClass
         check :config_path, type: String, default: "templates/terraform/examples/#{name}.tf.erb"
       end
     end

--- a/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/templates/terraform/examples/base_configs/test_file.go.erb
@@ -60,7 +60,9 @@ func TestAcc<%= test_slug -%>(t *testing.T) {
 		<% else -%>
 		Providers:    testAccProvidersOiCS,
 		<% end -%>
+		<% unless example.skip_delete -%>
 		CheckDestroy: testAccCheck<%= "#{resource_name}" -%>Destroy,
+		<% end -%>
 		Steps: []resource.TestStep{
 			{
 				Config: testAcc<%= test_slug -%>(context),

--- a/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/templates/terraform/examples/base_configs/test_file.go.erb
@@ -60,7 +60,7 @@ func TestAcc<%= test_slug -%>(t *testing.T) {
 		<% else -%>
 		Providers:    testAccProvidersOiCS,
 		<% end -%>
-		<% unless example.skip_delete -%>
+		<% unless object.skip_delete -%>
 		CheckDestroy: testAccCheck<%= "#{resource_name}" -%>Destroy,
 		<% end -%>
 		Steps: []resource.TestStep{
@@ -87,6 +87,7 @@ func testAcc<%= test_slug -%>(context map[string]interface{}) string {
 }
 <%- end %>
 
+<% unless object.skip_delete -%>
 func testAccCheck<%= resource_name -%>Destroy(s *terraform.State) error {
 	for name, rs := range s.RootModule().Resources {
 		if rs.Type != "<%= terraform_name -%>" {
@@ -115,3 +116,4 @@ func testAccCheck<%= resource_name -%>Destroy(s *terraform.State) error {
 
 	return nil
 }
+<%- end %>

--- a/templates/terraform/examples/firebase_project_basic.tf.erb
+++ b/templates/terraform/examples/firebase_project_basic.tf.erb
@@ -1,0 +1,12 @@
+resource "google_project" "default" {
+  provider = google-beta
+
+  project_id = "tf-test%{random_suffix}"
+  name       = "tf-test%{random_suffix}"
+  org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
+}
+
+resource "google_firebase_project" "default" {
+  provider = google-beta
+  project  = google_project.default.project_id
+}

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -715,7 +715,14 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
 <% end # if updatable? -%>
 
 func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{}) error {
-<% if object.custom_code.custom_delete -%>
+<% if object.skip_delete -%>
+    log.Printf("[WARNING] <%= object.__product.name + " " + object.name %> resources" +
+    " cannot be deleted from GCP. The resource %s will be removed from Terraform" +
+    " state, but will still be present on the server.", d.Id())
+    d.SetId("")
+
+    return nil
+<% elsif object.custom_code.custom_delete -%>
 <%= lines(compile(object.custom_code.custom_delete)) -%>
 <% else -%>
     config := meta.(*Config)

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -1032,7 +1032,6 @@
       </li>
     </ul>
     </li>
-
 <% unless version == 'ga' %>
     <li<%%= sidebar_current("docs-google-firebase") %>>
     <a href="#">Google Firebase Resources</a>
@@ -1043,7 +1042,6 @@
     </ul>
     </li>
 <% end %>
-
     <li<%%= sidebar_current("docs-google-filestore") %>>
     <a href="#">Google Filestore Resources</a>
     <ul class="nav">

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -1033,6 +1033,17 @@
     </ul>
     </li>
 
+<% unless version == 'ga' %>
+    <li<%%= sidebar_current("docs-google-firebase") %>>
+    <a href="#">Google Firebase Resources</a>
+    <ul class="nav">
+      <li<%%= sidebar_current("docs-google-firebase-index") %>>
+          <a href="/docs/providers/google/r/firebase_project.html">google_firebase_project</a>
+      </li>
+    </ul>
+    </li>
+<% end %>
+
     <li<%%= sidebar_current("docs-google-filestore") %>>
     <a href="#">Google Filestore Resources</a>
     <ul class="nav">


### PR DESCRIPTION
Also adding a new feature to generated tests to not attempt to validate resources with CheckDestroy if they aren't deletable. 

My testing so far as been with service accounts and, unless my environment is leaking personal credentials, the API is tolerating it just fine. Even though the official Firebase documentation contradicts this.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
firebase: Add the `google_firebase_project` resource which will enable Firebase for a referenced Google project.
```

PR for https://github.com/terraform-providers/terraform-provider-google/issues/2973