### PR TITLE
compute: subnet IAM conditions

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1919,6 +1919,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     iam_policy: !ruby/object:Api::Resource::IamPolicy
       allowed_iam_role: 'roles/compute.networkUser'
       parent_resource_attribute: 'subnetwork'
+      iam_conditions_request_type: :QUERY_PARAM
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true

--- a/templates/terraform/resource_iam.html.markdown.erb
+++ b/templates/terraform/resource_iam.html.markdown.erb
@@ -94,7 +94,7 @@ data "google_iam_policy" "admin" {
   }
 }
 
-resource "<%= resource_ns_iam -%>_policy" "editor" {
+resource "<%= resource_ns_iam -%>_policy" "policy" {
 <%= lines(compile(object.iam_policy.example_config_body)) -%>
   policy_data = data.google_iam_policy.admin.policy_data
 }
@@ -119,7 +119,7 @@ data "google_iam_policy" "admin" {
   }
 }
 
-resource "<%= resource_ns_iam -%>_policy" "editor" {
+resource "<%= resource_ns_iam -%>_policy" "policy" {
 <%= lines(compile(object.iam_policy.example_config_body)) -%>
   policy_data = data.google_iam_policy.admin.policy_data
 }
@@ -128,7 +128,7 @@ resource "<%= resource_ns_iam -%>_policy" "editor" {
 ## <%= markdown_escaped_name -%>\_binding
 
 ```hcl
-resource "<%= resource_ns_iam -%>_binding" "editor" {
+resource "<%= resource_ns_iam -%>_binding" "binding" {
 <%= lines(compile(object.iam_policy.example_config_body)) -%>
   role = "<%= object.iam_policy.admin_iam_role || object.iam_policy.allowed_iam_role -%>"
   members = [
@@ -141,7 +141,7 @@ resource "<%= resource_ns_iam -%>_binding" "editor" {
 With IAM Conditions ([beta](https://terraform.io/docs/providers/google/provider_versions.html)):
 
 ```hcl
-resource "<%= resource_ns_iam -%>_binding" "editor" {
+resource "<%= resource_ns_iam -%>_binding" "binding" {
 <%= lines(compile(object.iam_policy.example_config_body)) -%>
   role = "<%= object.iam_policy.admin_iam_role || object.iam_policy.allowed_iam_role -%>"
   members = [
@@ -159,7 +159,7 @@ resource "<%= resource_ns_iam -%>_binding" "editor" {
 ## <%= markdown_escaped_name -%>\_member
 
 ```hcl
-resource "<%= resource_ns_iam -%>_member" "editor" {
+resource "<%= resource_ns_iam -%>_member" "member" {
 <%= lines(compile(object.iam_policy.example_config_body)) -%>
   role = "<%= object.iam_policy.admin_iam_role || object.iam_policy.allowed_iam_role -%>"
   member = "user:jane@example.com"
@@ -170,7 +170,7 @@ resource "<%= resource_ns_iam -%>_member" "editor" {
 With IAM Conditions ([beta](https://terraform.io/docs/providers/google/provider_versions.html)):
 
 ```hcl
-resource "<%= resource_ns_iam -%>_member" "editor" {
+resource "<%= resource_ns_iam -%>_member" "member" {
 <%= lines(compile(object.iam_policy.example_config_body)) -%>
   role = "<%= object.iam_policy.admin_iam_role || object.iam_policy.allowed_iam_role -%>"
   member = "user:jane@example.com"


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added support for IAM conditions in `google_compute_subnet_iam_*` IAM resources
```
