### PR TITLE
removing ansible release pipeline

### DIFF
--- a/.ci/release.yml.tmpl
+++ b/.ci/release.yml.tmpl
@@ -46,17 +46,6 @@ resources:
           uri: git@github.com:terraform-providers/terraform-provider-google.git
           private_key: ((repo-key.private_key))
 jobs:
-    - name: ansible-nightly-release
-      plan:
-          - get: night-trigger
-            trigger: true
-          - get: magic-modules-gcp
-            trigger: false
-          - task: build
-            file: magic-modules-gcp/.ci/magic-modules/release-ansible.yml
-            params:
-                GITHUB_TOKEN: ((github-account.password))
-                CREDS: ((repo-key.private_key))
     - name: coverage-spreadsheet-release
       plan:
           - get: night-trigger


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
