### PR TITLE
GA google_container_cluster maintenance policy recurring window

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -843,6 +843,7 @@ func resourceContainerCluster() *schema.Resource {
 				},
 			},
 
+<% unless version == 'ga' -%>
 			"release_channel": {
 				Type:     schema.TypeList,
 				ForceNew: true,
@@ -862,7 +863,6 @@ func resourceContainerCluster() *schema.Resource {
 				},
 			},
 
-<% unless version == 'ga' -%>
 			"workload_identity_config": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
@@ -1044,12 +1044,12 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			Enabled:         d.Get("enable_binary_authorization").(bool),
 			ForceSendFields: []string{"Enabled"},
 		},
-		ReleaseChannel:          expandReleaseChannel(d.Get("release_channel")),
 <% unless version == 'ga' -%>
 		ShieldedNodes: &containerBeta.ShieldedNodes{
 			Enabled:         d.Get("enable_shielded_nodes").(bool),
 			ForceSendFields: []string{"Enabled"},
 		},
+		ReleaseChannel:          expandReleaseChannel(d.Get("release_channel")),
 		EnableTpu:               d.Get("enable_tpu").(bool),
 		NetworkConfig: &containerBeta.NetworkConfig{
 			EnableIntraNodeVisibility: d.Get("enable_intranode_visibility").(bool),
@@ -1315,11 +1315,11 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("enable_tpu", cluster.EnableTpu)
 	d.Set("tpu_ipv4_cidr_block", cluster.TpuIpv4CidrBlock)
 
-	d.Set("enable_intranode_visibility", cluster.NetworkConfig.EnableIntraNodeVisibility)
-<% end -%>
 	if err := d.Set("release_channel", flattenReleaseChannel(cluster.ReleaseChannel)); err != nil {
 		return err
 	}
+	d.Set("enable_intranode_visibility", cluster.NetworkConfig.EnableIntraNodeVisibility)
+<% end -%>
 	if err := d.Set("authenticator_groups_config", flattenAuthenticatorGroupsConfig(cluster.AuthenticatorGroupsConfig)); err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -465,15 +465,11 @@ func resourceContainerCluster() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"daily_maintenance_window": {
 							Type:     schema.TypeList,
-<% if version == 'ga' -%>
-							Required: true,
-<% else %>
 							Optional:     true,
 							ExactlyOneOf: []string{
 								"maintenance_policy.0.daily_maintenance_window",
 								"maintenance_policy.0.recurring_window",
 							},
-<% end %>
 							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -490,7 +486,6 @@ func resourceContainerCluster() *schema.Resource {
 								},
 							},
 						},
-<% unless version == 'ga' -%>
 						"recurring_window": {
 							Type:         schema.TypeList,
 							Optional:     true,
@@ -519,7 +514,6 @@ func resourceContainerCluster() *schema.Resource {
 								},
 							},
 						},
-<% end %>
 					},
 				},
 			},
@@ -849,7 +843,6 @@ func resourceContainerCluster() *schema.Resource {
 				},
 			},
 
-<% unless version == 'ga' -%>
 			"release_channel": {
 				Type:     schema.TypeList,
 				ForceNew: true,
@@ -869,6 +862,7 @@ func resourceContainerCluster() *schema.Resource {
 				},
 			},
 
+<% unless version == 'ga' -%>
 			"workload_identity_config": {
 				Type:     schema.TypeList,
 				MaxItems: 1,
@@ -1050,12 +1044,12 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			Enabled:         d.Get("enable_binary_authorization").(bool),
 			ForceSendFields: []string{"Enabled"},
 		},
+		ReleaseChannel:          expandReleaseChannel(d.Get("release_channel")),
 <% unless version == 'ga' -%>
 		ShieldedNodes: &containerBeta.ShieldedNodes{
 			Enabled:         d.Get("enable_shielded_nodes").(bool),
 			ForceSendFields: []string{"Enabled"},
 		},
-		ReleaseChannel:          expandReleaseChannel(d.Get("release_channel")),
 		EnableTpu:               d.Get("enable_tpu").(bool),
 		NetworkConfig: &containerBeta.NetworkConfig{
 			EnableIntraNodeVisibility: d.Get("enable_intranode_visibility").(bool),
@@ -1321,11 +1315,11 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("enable_tpu", cluster.EnableTpu)
 	d.Set("tpu_ipv4_cidr_block", cluster.TpuIpv4CidrBlock)
 
+	d.Set("enable_intranode_visibility", cluster.NetworkConfig.EnableIntraNodeVisibility)
+<% end -%>
 	if err := d.Set("release_channel", flattenReleaseChannel(cluster.ReleaseChannel)); err != nil {
 		return err
 	}
-	d.Set("enable_intranode_visibility", cluster.NetworkConfig.EnableIntraNodeVisibility)
-<% end -%>
 	if err := d.Set("authenticator_groups_config", flattenAuthenticatorGroupsConfig(cluster.AuthenticatorGroupsConfig)); err != nil {
 		return err
 	}
@@ -2314,7 +2308,6 @@ func expandMaintenancePolicy(d *schema.ResourceData, meta interface{}) *containe
 			ResourceVersion: resourceVersion,
 		}
 	}
-<% unless version == 'ga' -%>
 	if recurringWindow, ok := maintenancePolicy["recurring_window"]; ok && len(recurringWindow.([]interface{})) > 0 {
 		rw := recurringWindow.([]interface{})[0].(map[string]interface{})
 		return &containerBeta.MaintenancePolicy{
@@ -2331,7 +2324,6 @@ func expandMaintenancePolicy(d *schema.ResourceData, meta interface{}) *containe
 			ResourceVersion: resourceVersion,
 		}
 	}
-<% end %>
 	return nil
 }
 
@@ -2775,7 +2767,6 @@ func flattenMaintenancePolicy(mp *containerBeta.MaintenancePolicy) []map[string]
 			},
 		}
 	}
-<% unless version == 'ga' -%>
 	if mp.Window.RecurringWindow != nil {
 		return []map[string]interface{}{
 			{
@@ -2789,7 +2780,6 @@ func flattenMaintenancePolicy(mp *containerBeta.MaintenancePolicy) []map[string]
 			},
 		}
 	}
-<% end %>
 	return nil
 }
 

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -61,16 +61,6 @@ var (
 	}
 )
 
-<% unless version == 'ga' -%>
-<%# This is here because it is unused in ga, which trips up linters - when it starts being used, move it to validation.go. %>
-func validateRFC3339Date(v interface{}, k string) (warnings []string, errors []error) {
-	_, err := time.Parse(time.RFC3339, v.(string))
-	if err != nil {
-		errors = append(errors, err)
-	}
-	return
-}
-
 func rfc5545RecurrenceDiffSuppress(k, o, n string, d *schema.ResourceData) bool {
 	// This diff gets applied in the cloud console if you specify
 	// "FREQ=DAILY" in your config and add a maintenance exclusion.
@@ -83,7 +73,6 @@ func rfc5545RecurrenceDiffSuppress(k, o, n string, d *schema.ResourceData) bool 
 	// identical.
 	return false
 }
-<% end %>
 
 func resourceContainerCluster() *schema.Resource {
 	return &schema.Resource{

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -336,7 +336,6 @@ func TestAccContainerCluster_withNetworkPolicyEnabled(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccContainerCluster_withReleaseChannelEnabled(t *testing.T) {
 	t.Parallel()
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(10))
@@ -400,7 +399,6 @@ func TestAccContainerCluster_withInvalidReleaseChannel(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccContainerCluster_withMasterAuthorizedNetworksConfig(t *testing.T) {
 	t.Parallel()
@@ -1178,8 +1176,6 @@ func TestAccContainerCluster_withMaintenanceWindow(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
-
 func TestAccContainerCluster_withRecurringMaintenanceWindow(t *testing.T) {
 	t.Parallel()
 	cluster := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(10))
@@ -1224,8 +1220,6 @@ func TestAccContainerCluster_withRecurringMaintenanceWindow(t *testing.T) {
 		},
 	})
 }
-
-<% end %>
 
 func TestAccContainerCluster_withIPAllocationPolicy_existingSecondaryRanges(t *testing.T) {
 	t.Parallel()
@@ -2130,7 +2124,6 @@ resource "google_container_cluster" "with_network_policy_enabled" {
 `, clusterName)
 }
 
-<% unless version == 'ga' -%>
 func testAccContainerCluster_withReleaseChannelEnabled(clusterName string, channel string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_release_channel" {
@@ -2144,7 +2137,6 @@ resource "google_container_cluster" "with_release_channel" {
 }
 `, clusterName, channel)
 }
-<% end -%>
 
 func testAccContainerCluster_removeNetworkPolicy(clusterName string) string {
 	return fmt.Sprintf(`

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -3133,8 +3133,6 @@ resource "google_container_cluster" "with_maintenance_window" {
 `, clusterName, maintenancePolicy)
 }
 
-
-<% unless version == 'ga' -%>
 func testAccContainerCluster_withRecurringMaintenanceWindow(clusterName string, startTime, endTime string) string {
 	maintenancePolicy := ""
 	if len(startTime) > 0 {
@@ -3158,7 +3156,6 @@ resource "google_container_cluster" "with_recurring_maintenance_window" {
 `, clusterName, maintenancePolicy)
 
 }
-<% end %>
 
 func testAccContainerCluster_withIPAllocationPolicy_existingSecondaryRanges(containerNetName string, clusterName string) string {
 	return fmt.Sprintf(`

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -336,6 +336,7 @@ func TestAccContainerCluster_withNetworkPolicyEnabled(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
 func TestAccContainerCluster_withReleaseChannelEnabled(t *testing.T) {
 	t.Parallel()
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", acctest.RandString(10))
@@ -399,6 +400,7 @@ func TestAccContainerCluster_withInvalidReleaseChannel(t *testing.T) {
 		},
 	})
 }
+<% end -%>
 
 func TestAccContainerCluster_withMasterAuthorizedNetworksConfig(t *testing.T) {
 	t.Parallel()
@@ -2124,6 +2126,7 @@ resource "google_container_cluster" "with_network_policy_enabled" {
 `, clusterName)
 }
 
+<% unless version == 'ga' -%>
 func testAccContainerCluster_withReleaseChannelEnabled(clusterName string, channel string) string {
 	return fmt.Sprintf(`
 resource "google_container_cluster" "with_release_channel" {
@@ -2137,6 +2140,7 @@ resource "google_container_cluster" "with_release_channel" {
 }
 `, clusterName, channel)
 }
+<% end -%>
 
 func testAccContainerCluster_removeNetworkPolicy(clusterName string) string {
 	return fmt.Sprintf(`

--- a/third_party/terraform/utils/validation.go
+++ b/third_party/terraform/utils/validation.go
@@ -303,3 +303,11 @@ func validateHourlyOnly(val interface{}, key string) (warns []string, errs []err
 	}
 	return
 }
+
+func validateRFC3339Date(v interface{}, k string) (warnings []string, errors []error) {
+	_, err := time.Parse(time.RFC3339, v.(string))
+	if err != nil {
+		errors = append(errors, err)
+	}
+	return
+}

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -268,7 +268,7 @@ clusters with private nodes. Structure is documented below.
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
 
-* `release_channel` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Configuration options for the
+* `release_channel` - (Optional) Configuration options for the
     [Release channel](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels)
     feature, which provide more control over automatic upgrades of your GKE clusters. Structure is documented below.
 
@@ -413,7 +413,7 @@ maintenance_policy {
 }
 ```
 
-* `recurring_window` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Time window for
+* `recurring_window` - (Optional) Time window for
 recurring maintenance operations.
 
 Specify `start_time` and `end_time` in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) date format.  The start time's date is

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -268,7 +268,7 @@ clusters with private nodes. Structure is documented below.
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
 
-* `release_channel` - (Optional) Configuration options for the
+* `release_channel` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Configuration options for the
     [Release channel](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels)
     feature, which provide more control over automatic upgrades of your GKE clusters. Structure is documented below.
 


### PR DESCRIPTION
Requested in https://github.com/terraform-providers/terraform-provider-google/issues/5391

release_channel is not yet GA, so this only fixes half of that request

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: Added field `maintenance_policy.recurring_window` to  `google_container_cluster` (GA only)
```
