### PR TITLE
Catch googleapi errors from flattenprop

### DIFF
--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -464,6 +464,9 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
 // Terraform must set the top level schema field, but since this object contains collapsed properties
 // it's difficult to know what the top level should be. Instead we just loop over the map returned from flatten.
     if flattenedProp := flatten<%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.api_name -%>"], d, config); flattenedProp != nil {
+        if gerr, ok := flattenedProp.(*googleapi.Error); ok {
+			return fmt.Errorf("Error reading <%= object.name -%>: %s", gerr)
+		}
         casted := flattenedProp.([]interface{})[0]
         if casted != nil {
             for k, v := range casted.(map[string]interface{}) {


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5890

The custom flatten function at https://github.com/GoogleCloudPlatform/magic-modules/blob/master/templates/terraform/custom_flatten/secret_version_access.go.erb#L32 returns `googleapi.Error` when the template is expecting `[]interface {}`, causing a crash.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Fixed an issue where `google_secret_manager_secret_version` would crash due to insufficient permissions
```
