### PR TITLE
Add docs on dataproc cluster optional_components

### DIFF
--- a/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -431,15 +431,16 @@ cluster_config {
    a cluster. For a list of valid properties please see
   [Cluster properties](https://cloud.google.com/dataproc/docs/concepts/cluster-properties)
 
-* `optional_components` - (Optional) The set of optional components to activate on the cluster. Possible values include:
-    "ANACONDA"
-    "DRUID"
-    "HIVE_WEBHCAT"
-    "JUPYTER"
-    "KERBEROS"
-    "PRESTO"
-    "ZEPPELIN"
-    "ZOOKEEPER"
+* `optional_components` - (Optional) The set of optional components to activate on the cluster. 
+    Accepted values are:
+    * ANACONDA
+    * DRUID
+    * HIVE_WEBHCAT
+    * JUPYTER
+    * KERBEROS
+    * PRESTO
+    * ZEPPELIN
+    * ZOOKEEPER
 
 - - -
 

--- a/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -431,6 +431,14 @@ cluster_config {
    a cluster. For a list of valid properties please see
   [Cluster properties](https://cloud.google.com/dataproc/docs/concepts/cluster-properties)
 
+* `optional_components` - (Optional) The set of optional components to activate on the cluster. Possible values include:
+    "ANACONDA"
+    "HIVE_WEBHCAT"
+    "JUPYTER"
+    "PRESTO"
+    "ZEPPELIN"
+    "ZOOKEEPER"
+
 - - -
 
 The `cluster_config.security_config` block supports:

--- a/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -433,8 +433,10 @@ cluster_config {
 
 * `optional_components` - (Optional) The set of optional components to activate on the cluster. Possible values include:
     "ANACONDA"
+    "DRUID"
     "HIVE_WEBHCAT"
     "JUPYTER"
+    "KERBEROS"
     "PRESTO"
     "ZEPPELIN"
     "ZOOKEEPER"


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/5904

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
