### PR TITLE
ACM: service perimeter's restricted_services as set

### DIFF
--- a/products/accesscontextmanager/terraform.yaml
+++ b/products/accesscontextmanager/terraform.yaml
@@ -85,6 +85,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       perimeterType: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/default_if_empty.erb
         input: true
+      status.restrictedServices: !ruby/object:Overrides::Terraform::PropertyOverride
+        is_set: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       encoder: templates/terraform/encoders/access_level_never_send_parent.go.erb
       custom_import: templates/terraform/custom_import/set_access_policy_parent_from_self_link.go.erb

--- a/third_party/terraform/utils/bootstrap_utils_test.go
+++ b/third_party/terraform/utils/bootstrap_utils_test.go
@@ -324,7 +324,7 @@ func BootstrapServicePerimeterProjects(t *testing.T, desiredProjects int) []*clo
 	prefixFilter := fmt.Sprintf("id:%s* parent.id:%s", SharedServicePerimeterProjectPrefix, org)
 	res, err := config.clientResourceManager.Projects.List().Filter(prefixFilter).Do()
 	if err != nil {
-		t.Errorf("Error getting shared test projects: %s", err)
+		t.Fatalf("Error getting shared test projects: %s", err)
 	}
 
 	projects := res.Projects


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
accesscontextmanager: `status.restricted_services` in `google_access_context_manager_service_perimeter` interpolation order may have changed
```

```release-note:enhancement
accesscontextmanager: `status.restricted_services` of `google_access_context_manager_service_perimeter` does not cause a noop update if just the order of services changes.
```
