### PR TITLE
Remove null characters from seed when reading

### DIFF
--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -259,6 +259,8 @@ func readSeedFromFile(fileName string) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
+	// Remove NULL characters from seed
+	data = bytes.Trim(data, "\x00")
 	seed := string(data)
 	return strconv.ParseInt(seed, 10, 64)
 }


### PR DESCRIPTION
Occasionally we would get null characters in the seed file, causing VCR to crash when it tried to read them in. This should fix that

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
