### PR TITLE
Add GKE Resource Consumption Metering, promote resource export to GA

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -893,6 +893,7 @@ func resourceContainerCluster() *schema.Resource {
 					},
 				},
 			},
+<% end -%>
 
 			"resource_usage_export_config": {
 					Type:       schema.TypeList,
@@ -904,6 +905,11 @@ func resourceContainerCluster() *schema.Resource {
 											Type:     schema.TypeBool,
 											Optional: true,
 											Default:  false,
+									},
+									"enable_resource_consumption_metering": {
+											Type:     schema.TypeBool,
+											Optional: true,
+											Default:  true,
 									},
 									"bigquery_destination": {
 											Type:       schema.TypeList,
@@ -921,7 +927,6 @@ func resourceContainerCluster() *schema.Resource {
 							},
 					},
 			},
-<% end -%>
 
 			"enable_intranode_visibility": {
 				Type:     schema.TypeBool,
@@ -1136,10 +1141,11 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	if v, ok := d.GetOk("workload_identity_config"); ok {
 		cluster.WorkloadIdentityConfig = expandWorkloadIdentityConfig(v)
 	}
+<% end -%>
+
 	if v, ok := d.GetOk("resource_usage_export_config"); ok {
 		cluster.ResourceUsageExportConfig = expandResourceUsageExportConfig(v)
 	}
-<% end -%>
 
 	req := &containerBeta.CreateClusterRequest{
 		Cluster: cluster,
@@ -1367,11 +1373,10 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("resource_labels", cluster.ResourceLabels)
 	d.Set("label_fingerprint", cluster.LabelFingerprint)
 
-	<% unless version == 'ga' -%>
 	if err := d.Set("resource_usage_export_config", flattenResourceUsageExportConfig(cluster.ResourceUsageExportConfig)); err != nil {
 			return err
 	}
-	<% end -%>
+
 	return nil
 }
 
@@ -1980,7 +1985,6 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
-<% unless version == 'ga' -%>
 	if d.HasChange("resource_usage_export_config") {
 			c := d.Get("resource_usage_export_config")
 			req := &containerBeta.UpdateClusterRequest{
@@ -2005,7 +2009,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 			d.SetPartial("resource_usage_export_config")
 	}
-<% end -%>
+
 	d.Partial(false)
 
 	if _, err := containerClusterAwaitRestingState(config, project, location, clusterName, d.Timeout(schema.TimeoutUpdate)); err != nil {
@@ -2542,8 +2546,6 @@ func expandDefaultMaxPodsConstraint(v interface{}) *containerBeta.MaxPodsConstra
 		MaxPodsPerNode: int64(v.(int)),
 	}
 }
-
-<% unless version == 'ga' -%>
 func expandResourceUsageExportConfig(configured interface{}) *containerBeta.ResourceUsageExportConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
@@ -2554,6 +2556,10 @@ func expandResourceUsageExportConfig(configured interface{}) *containerBeta.Reso
 
 	result := &containerBeta.ResourceUsageExportConfig{
 			EnableNetworkEgressMetering: resourceUsageConfig["enable_network_egress_metering"].(bool),
+			ConsumptionMeteringConfig: &containerBeta.ConsumptionMeteringConfig{
+				Enabled: resourceUsageConfig["enable_resource_consumption_metering"].(bool),
+				ForceSendFields: []string{"Enabled"},
+			},
 			ForceSendFields: []string{"EnableNetworkEgressMetering"},
 	}
 	if _, ok := resourceUsageConfig["bigquery_destination"]; ok {
@@ -2568,7 +2574,6 @@ func expandResourceUsageExportConfig(configured interface{}) *containerBeta.Reso
 	}
 	return result
 }
-<% end -%>
 
 func flattenNetworkPolicy(c *containerBeta.NetworkPolicy) []map[string]interface{} {
 	result := []map[string]interface{}{}
@@ -2866,21 +2871,28 @@ func flattenPodSecurityPolicyConfig(c *containerBeta.PodSecurityPolicyConfig) []
 		},
 	}
 }
+<% end -%>
 
 func flattenResourceUsageExportConfig(c *containerBeta.ResourceUsageExportConfig) []map[string]interface{} {
 		if c == nil {
 				return nil
 		}
+
+		enableResourceConsumptionMetering := false
+		if c.ConsumptionMeteringConfig != nil && c.ConsumptionMeteringConfig.Enabled == true {
+			enableResourceConsumptionMetering = true
+		}
+
 		return []map[string]interface{}{
 				{
 						"enable_network_egress_metering": c.EnableNetworkEgressMetering,
+						"enable_resource_consumption_metering": enableResourceConsumptionMetering,
 						"bigquery_destination": []map[string]interface{}{
 								{"dataset_id": c.BigqueryDestination.DatasetId},
 						},
 				},
 		}
 }
-<% end -%>
 
 <% unless version == 'ga' -%>
 func flattenDatabaseEncryption(c *containerBeta.DatabaseEncryption) []map[string]interface{} {

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -3278,7 +3278,7 @@ resource "google_container_cluster" "with_resource_usage_export_config" {
   initial_node_count = 1
   resource_usage_export_config {
     enable_network_egress_metering = true
-		enable_resource_consumption_metering = %s
+    enable_resource_consumption_metering = %s
     bigquery_destination {
       dataset_id = google_bigquery_dataset.default.dataset_id
     }

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1649,6 +1649,7 @@ func TestAccContainerCluster_withDatabaseEncryption(t *testing.T) {
 		},
 	})
 }
+<% end -%>
 
 func TestAccContainerCluster_withResourceUsageExportConfig(t *testing.T) {
 	t.Parallel()
@@ -1663,7 +1664,7 @@ func TestAccContainerCluster_withResourceUsageExportConfig(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withResourceUsageExportConfig(clusterName, datesetId, true),
+				Config: testAccContainerCluster_withResourceUsageExportConfig(clusterName, datesetId, "true"),
 			},
 			{
 				ResourceName:        "google_container_cluster.with_resource_usage_export_config",
@@ -1671,7 +1672,15 @@ func TestAccContainerCluster_withResourceUsageExportConfig(t *testing.T) {
 				ImportStateVerify:   true,
 			},
 			{
-				Config: testAccContainerCluster_withResourceUsageExportConfig(clusterName, datesetId, false),
+				Config: testAccContainerCluster_withResourceUsageExportConfig(clusterName, datesetId, "false"),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_resource_usage_export_config",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+			{
+				Config: testAccContainerCluster_withResourceUsageExportConfigNoConfig(clusterName, datesetId),
 			},
 			{
 				ResourceName:        "google_container_cluster.with_resource_usage_export_config",
@@ -1681,8 +1690,6 @@ func TestAccContainerCluster_withResourceUsageExportConfig(t *testing.T) {
 		},
 	})
 }
-<% end -%>
-
 
 func TestAccContainerCluster_withMasterAuthorizedNetworksDisabled(t *testing.T) {
 	t.Parallel()
@@ -3257,21 +3264,8 @@ resource "google_container_cluster" "with_ip_allocation_policy" {
 `, containerNetName, clusterName)
 }
 
-<% unless version == 'ga' -%>
-func testAccContainerCluster_withResourceUsageExportConfig(clusterName, datasetId string, resourceUsage bool) string {
-	resourceUsageConfig := ""
-	if resourceUsage {
-		resourceUsageConfig = `
-  resource_usage_export_config {
-    enable_network_egress_metering = true
-
-    bigquery_destination {
-      dataset_id = google_bigquery_dataset.default.dataset_id
-    }
-  }`
-	}
-
-	config := fmt.Sprintf(`
+func testAccContainerCluster_withResourceUsageExportConfig(clusterName, datasetId, enableMetering string) string {
+	return fmt.Sprintf(`
 resource "google_bigquery_dataset" "default" {
   dataset_id                 = "%s"
   description                = "gke resource usage dataset tests"
@@ -3282,12 +3276,32 @@ resource "google_container_cluster" "with_resource_usage_export_config" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1
-  %s
+  resource_usage_export_config {
+    enable_network_egress_metering = true
+		enable_resource_consumption_metering = %s
+    bigquery_destination {
+      dataset_id = google_bigquery_dataset.default.dataset_id
+    }
+  }
 }
-`, datasetId, clusterName, resourceUsageConfig)
-	return config
+`, datasetId, clusterName, enableMetering)
 }
-<% end -%>
+
+func testAccContainerCluster_withResourceUsageExportConfigNoConfig(clusterName, datasetId string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset" "default" {
+  dataset_id                 = "%s"
+  description                = "gke resource usage dataset tests"
+  delete_contents_on_destroy = true
+}
+
+resource "google_container_cluster" "with_resource_usage_export_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+}
+`, datasetId, clusterName)
+}
 
 func testAccContainerCluster_withPrivateClusterConfigMissingCidrBlock(containerNetName string, clusterName string) string {
 	return fmt.Sprintf(`

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -664,6 +664,12 @@ The `resource_usage_export_config` block supports:
 * `enable_network_egress_metering` (Optional) - Whether to enable network egress metering for this cluster. If enabled, a daemonset will be created
     in the cluster to meter network egress traffic.
 
+* `enable_resource_consumption_metering` (Optional) - Whether to enable resource
+consumption metering on this cluster. When enabled, a table will be created in
+the resource export BigQuery dataset to store resource consumption data. The
+resulting table can be joined with the resource usage table or with BigQuery
+billing export. Defaults to `true`.
+
 * `bigquery_destination` (Required) - Parameters for using BigQuery as the destination of resource usage export.
 
 * `bigquery_destination.dataset_id` (Required) - The ID of a BigQuery Dataset. For Example:
@@ -671,6 +677,7 @@ The `resource_usage_export_config` block supports:
 ```hcl
 resource_usage_export_config {
   enable_network_egress_metering = false
+  enable_resource_consumption_metering = true
 
   bigquery_destination {
     dataset_id = "cluster_resource_usage"


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4634, supersedes https://github.com/GoogleCloudPlatform/magic-modules/pull/2705

Test changes are a little messy, I got rid of a conditional block and made it two cases instead.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `resource_usage_export_config` to `google_container_cluster`, previously only available in `google-beta` (ga only)
```

```release-note:enhancement
container: added `enable_resource_consumption_metering` to `resource_usage_export_config` in `google_container_cluster` (beta only)
```
