### PR TITLE
Add deadLetterPolicy to Pub/Sub Subscription resource

### DIFF
--- a/products/pubsub/api.yaml
+++ b/products/pubsub/api.yaml
@@ -246,7 +246,6 @@ objects:
               Example - "3.5s".
       - !ruby/object:Api::Type::NestedObject
         name: 'deadLetterPolicy'
-        allow_empty_object: true
         send_empty_value: true
         description: |
           A policy that specifies the conditions for dead lettering messages in
@@ -254,7 +253,8 @@ objects:
           is disabled.
           
           The Cloud Pub/Sub service account associated with this subscriptions's
-          parent project (i.e.,\nservice-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com) must have
+          parent project (i.e.,
+          service-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com) must have
           permission to Acknowledge() messages on this subscription.
         properties:
           - !ruby/object:Api::Type::String
@@ -263,7 +263,8 @@ objects:
               The name of the topic to which dead letter messages should be published.
               Format is `projects/{project}/topics/{topic}`.
 
-              The Cloud Pub/Sub service\naccount associated with the enclosing subscription's parent project (i.e., 
+              The Cloud Pub/Sub service\naccount associated with the enclosing subscription's
+              parent project (i.e., 
               service-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com) must have
               permission to Publish() to this topic.
               

--- a/products/pubsub/api.yaml
+++ b/products/pubsub/api.yaml
@@ -244,3 +244,44 @@ objects:
               If ttl is not set, the associated resource never expires.
               A duration in seconds with up to nine fractional digits, terminated by 's'.
               Example - "3.5s".
+      - !ruby/object:Api::Type::NestedObject
+        name: 'deadLetterPolicy'
+        allow_empty_object: true
+        send_empty_value: true
+        description: |
+          A policy that specifies the conditions for dead lettering messages in
+          this subscription. If dead_letter_policy is not set, dead lettering
+          is disabled.
+          
+          The Cloud Pub/Sub service account associated with this subscriptions's
+          parent project (i.e.,\nservice-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com) must have
+          permission to Acknowledge() messages on this subscription.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'deadLetterTopic'
+            description: |
+              The name of the topic to which dead letter messages should be published.
+              Format is `projects/{project}/topics/{topic}`.
+
+              The Cloud Pub/Sub service\naccount associated with the enclosing subscription's parent project (i.e., 
+              service-{project_number}@gcp-sa-pubsub.iam.gserviceaccount.com) must have
+              permission to Publish() to this topic.
+              
+              The operation will fail if the topic does not exist.
+              Users should ensure that there is a subscription attached to this topic
+              since messages published to a topic with no subscriptions are lost.
+          - !ruby/object:Api::Type::Integer
+            name: 'maxDeliveryAttempts'
+            description: |
+              The maximum number of delivery attempts for any message. The value must be
+              between 5 and 100.
+              
+              The number of delivery attempts is defined as 1 + (the sum of number of 
+              NACKs and number of times the acknowledgement deadline has been exceeded for the message).
+              
+              A NACK is any call to ModifyAckDeadline with a 0 deadline. Note that
+              client libraries may automatically extend ack_deadlines.
+              
+              This field will be honored on a best effort basis.
+            
+              If this parameter is 0, a default value of 5 is used.

--- a/products/pubsub/terraform.yaml
+++ b/products/pubsub/terraform.yaml
@@ -102,6 +102,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           topic_project: "topic-project"
           subscription_name: "example-subscription"
           subscription_project: "subscription-project"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "pubsub_subscription_dead_letter"
+        primary_resource_id: "example"
+        vars:
+          topic_name: "example-topic"
+          subscription_name: "example-subscription"
+          max_delivery_attempts: "10"
     docs: !ruby/object:Provider::Terraform::Docs
       attributes: |
         * `path`: Path of the subscription in the format `projects/{project}/subscriptions/{name}`

--- a/products/pubsub/terraform.yaml
+++ b/products/pubsub/terraform.yaml
@@ -108,7 +108,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           topic_name: "example-topic"
           subscription_name: "example-subscription"
-          max_delivery_attempts: "10"
     docs: !ruby/object:Provider::Terraform::Docs
       attributes: |
         * `path`: Path of the subscription in the format `projects/{project}/subscriptions/{name}`

--- a/templates/terraform/examples/pubsub_subscription_dead_letter.tf.erb
+++ b/templates/terraform/examples/pubsub_subscription_dead_letter.tf.erb
@@ -1,0 +1,17 @@
+resource "google_pubsub_topic" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['topic_name'] %>"
+}
+
+resource "google_pubsub_topic" "<%= ctx[:primary_resource_id] %>_dead_letter" {
+  name = "<%= ctx[:vars]['topic_name'] %>"
+}
+
+resource "google_pubsub_subscription" "<%= ctx[:primary_resource_id] %>" {
+  name  = "<%= ctx[:vars]['subscription_name'] %>"
+  topic = google_pubsub_topic.<%= ctx[:primary_resource_id] %>.name
+
+  expiration_policy {
+    dead_letter_topic = google_pubsub_topic.<%= ctx[:primary_resource_id] %>_dead_letter.id
+    max_delivery_attempts = <%= ctx[:vars]['max_delivery_attempts'] %>
+  }
+}

--- a/templates/terraform/examples/pubsub_subscription_dead_letter.tf.erb
+++ b/templates/terraform/examples/pubsub_subscription_dead_letter.tf.erb
@@ -12,6 +12,6 @@ resource "google_pubsub_subscription" "<%= ctx[:primary_resource_id] %>" {
 
   expiration_policy {
     dead_letter_topic = google_pubsub_topic.<%= ctx[:primary_resource_id] %>_dead_letter.id
-    max_delivery_attempts = <%= ctx[:vars]['max_delivery_attempts'] %>
+    max_delivery_attempts = 10
   }
 }

--- a/templates/terraform/examples/pubsub_subscription_dead_letter.tf.erb
+++ b/templates/terraform/examples/pubsub_subscription_dead_letter.tf.erb
@@ -3,14 +3,14 @@ resource "google_pubsub_topic" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_pubsub_topic" "<%= ctx[:primary_resource_id] %>_dead_letter" {
-  name = "<%= ctx[:vars]['topic_name'] %>"
+  name = "<%= ctx[:vars]['topic_name'] %>-dead-letter"
 }
 
 resource "google_pubsub_subscription" "<%= ctx[:primary_resource_id] %>" {
   name  = "<%= ctx[:vars]['subscription_name'] %>"
   topic = google_pubsub_topic.<%= ctx[:primary_resource_id] %>.name
 
-  expiration_policy {
+  dead_letter_policy {
     dead_letter_topic = google_pubsub_topic.<%= ctx[:primary_resource_id] %>_dead_letter.id
     max_delivery_attempts = 10
   }


### PR DESCRIPTION
Support dead_letter_policy as specified in https://pubsub.googleapis.com/$discovery/rest?version=v1

I've tested changes by applying dead_letter_policy with locally build terraform provider following instructions in README.

**Release Note Template for Downstream PRs (will be copied)**
```release-note:enhancement
pubsub: Added `dead_letter_policy` support to `google_pubsub_subscription`
```

Fixes terraform-providers/terraform-provider-google#5522