### PR TITLE
Support compute reservation resize

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -11906,6 +11906,8 @@ objects:
         required: true
         description: |
           Reservation for instances with specific machine shapes.
+        update_verb: :POST
+        update_url: 'projects/{{project}}/zones/{{zone}}/reservations/{{name}}/resize'
         properties:
           - !ruby/object:Api::Type::Integer
             name: 'count'
@@ -11920,6 +11922,7 @@ objects:
           - !ruby/object:Api::Type::NestedObject
             name: 'instanceProperties'
             required: true
+            input: true
             description: |
               The instance properties for the reservation.
             properties:

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1501,6 +1501,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         exclude: true
       specificReservation.instanceProperties.minCpuPlatform: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      specificReservation.count: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.IntAtLeast(1)'
   Route: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1494,6 +1494,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "gce_reservation"
         vars:
           reservation_name: "gce-reservation"
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      update_encoder: templates/terraform/update_encoder/reservation.go.erb
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -563,6 +563,19 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
         }
 <%    end # props.each -%>
 
+<%# We need to decide what encoder to use here - if there's an update encoder, use that! -%>
+<%  if object.custom_code.update_encoder -%>
+    obj, err = resource<%= resource_name -%>UpdateEncoder(d, meta, obj)
+    if err != nil {
+        return err
+    }
+<%  elsif object.custom_code.encoder -%>
+    obj, err = resource<%= resource_name -%>Encoder(d, meta, obj)
+    if err != nil {
+        return err
+    }
+<%  end -%>
+
 <%      if object.mutex -%>
         lockName, err := replaceVars(d, config, "<%= object.mutex -%>")
         if err != nil {

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -569,11 +569,6 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
     if err != nil {
         return err
     }
-<%  elsif object.custom_code.encoder -%>
-    obj, err = resource<%= resource_name -%>Encoder(d, meta, obj)
-    if err != nil {
-        return err
-    }
 <%  end -%>
 
 <%      if object.mutex -%>

--- a/templates/terraform/update_encoder/reservation.go.erb
+++ b/templates/terraform/update_encoder/reservation.go.erb
@@ -1,0 +1,18 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+obj["specificSkuCount"] = obj["specificReservation"].(map[string]interface{})["count"]
+delete(obj, "specificReservation")
+
+return obj, nil

--- a/templates/terraform/update_encoder/reservation.go.erb
+++ b/templates/terraform/update_encoder/reservation.go.erb
@@ -12,7 +12,7 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-obj["specificSkuCount"] = obj["specificReservation"].(map[string]interface{})["count"]
-delete(obj, "specificReservation")
+newObj := make(map[string]interface{})
+newObj["specificSkuCount"] = obj["specificReservation"].(map[string]interface{})["count"]
 
-return obj, nil
+return newObj, nil

--- a/third_party/terraform/tests/resource_compute_reservation_test.go
+++ b/third_party/terraform/tests/resource_compute_reservation_test.go
@@ -1,0 +1,56 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccComputeReservation_update(t *testing.T) {
+	t.Parallel()
+
+	reservationName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeReservationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeReservation_basic(reservationName, "2"),
+			},
+			{
+				ResourceName:      "google_compute_reservation.reservation",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeReservation_basic(reservationName, "1"),
+			},
+			{
+				ResourceName:      "google_compute_reservation.reservation",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccComputeReservation_basic(reservationName, count string) string {
+	return fmt.Sprintf(`
+resource "google_compute_reservation" "reservation" {
+  name = "%s"
+  zone = "us-central1-a"
+
+  specific_reservation {
+    count = %s
+    instance_properties {
+      min_cpu_platform = "Intel Cascade Lake"
+      machine_type     = "n2-standard-2"
+    }
+  }
+}
+`, reservationName, count)
+}


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4937

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added ability to resize `google_compute_reservation`
```
