### PR TITLE
Add missing quotes to example for saving GCP SA key as k8s secret

### DIFF
--- a/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
+++ b/third_party/terraform/website/docs/r/google_service_account_key.html.markdown
@@ -43,7 +43,7 @@ resource "kubernetes_secret" "google-application-credentials" {
     name = "google-application-credentials"
   }
   data = {
-    credentials.json = base64decode(google_service_account_key.mykey.private_key)
+    "credentials.json" = base64decode(google_service_account_key.mykey.private_key)
   }
 }
 ```


### PR DESCRIPTION
Upstreams https://github.com/terraform-providers/terraform-provider-google/pull/5983
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
