### PR TITLE
Add support for VpcConnectorEgressSettings field to cloudfunctions

### DIFF
--- a/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
+++ b/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
@@ -827,6 +827,7 @@ resource "google_cloudfunctions_function" "function" {
   }
   max_instances = 10
   vpc_connector = google_vpc_access_connector.%s.self_link
+  vpc_connector_egress_settings = "PRIVATE_RANGES_ONLY"
 
   depends_on = [google_project_iam_member.gcfadmin]
 }

--- a/third_party/terraform/website/docs/d/datasource_cloudfunctions_function.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_cloudfunctions_function.html.markdown
@@ -54,6 +54,8 @@ exported:
 * `ingress_settings` - Controls what traffic can reach the function.
 * `labels` - A map of labels applied to this function.
 * `service_account_email` - The service account email to be assumed by the cloud function.
+* `vpc_connector` - The VPC Network Connector that this cloud function can connect to. 
+* `vpc_connector_egress_settings` - The egress settings for the connector, controlling what traffic is diverted through it.
 
 The `event_trigger` block contains:
 

--- a/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
+++ b/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
@@ -133,6 +133,8 @@ Eg. `"nodejs8"`, `"nodejs10"`, `"python37"`, `"go111"`.
 
 * `vpc_connector` - (Optional) The VPC Network Connector that this cloud function can connect to. It can be either the fully-qualified URI, or the short name of the network connector resource. The format of this field is `projects/*/locations/*/connectors/*`.
 
+* `vpc_connector_egress_settings` - (Optional) The egress settings for the connector, controlling what traffic is diverted through it. Allowed values are `ALL_TRAFFIC` and `PRIVATE_RANGES_ONLY`. Defaults to `PRIVATE_RANGES_ONLY`. If unset, this field preserves the previously set value.
+
 * `source_archive_bucket` - (Optional) The GCS bucket containing the zip archive which contains the function.
 
 * `source_archive_object` - (Optional) The source archive object (file) in archive bucket.


### PR DESCRIPTION
Upstreams https://github.com/terraform-providers/terraform-provider-google/pull/5984

This is a manual upstream (the cloud functions test file is compiled, so the script didnt work). I added an entry to the datasource docs that I noticed was missing.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
`cloudfunctions`: added support for `vpc_connector_egress_settings` to `google_cloudfunctions_function`
```
