### PR TITLE
add bigquery_dataset_access fine-grained resource

### DIFF
--- a/products/bigquery/ansible.yaml
+++ b/products/bigquery/ansible.yaml
@@ -49,6 +49,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           A unique ID for this dataset, without the project name. The ID
           must contain only letters (a-z, A-Z), numbers (0-9), or
           underscores. The maximum length is 1,024 characters.
+  DatasetAccess: !ruby/object:Overrides::Ansible::ResourceOverride
+    exclude: true
 files: !ruby/object:Provider::Config::Files
   resource:
 <%= lines(indent(compile('provider/ansible/resource~compile.yaml'), 4)) -%>

--- a/products/bigquery/api.yaml
+++ b/products/bigquery/api.yaml
@@ -33,6 +33,10 @@ objects:
     has_self_link: true
     description: |
       Datasets allow you to organize and control access to your tables.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Datasets Intro': 'https://cloud.google.com/bigquery/docs/datasets-intro'
+      api: 'https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets'
     properties:
       - !ruby/object:Api::Type::String
         name: 'name'
@@ -231,6 +235,154 @@ objects:
               Describes the Cloud KMS encryption key that will be used to protect destination
               BigQuery table. The BigQuery Service Account associated with your project requires
               access to this encryption key.
+  - !ruby/object:Api::Resource
+    name: 'DatasetAccess'
+    input: true
+    base_url: projects/{{project}}/datasets/{{dataset_id}}
+    self_link: projects/{{project}}/datasets/{{dataset_id}}
+    create_verb: :PATCH
+    delete_verb: :PATCH
+    nested_query: !ruby/object:Api::Resource::NestedQuery
+      keys:
+        - access
+      modify_by_patch: true
+    identity:
+      - role
+      - userByEmail
+      - groupByEmail
+      - domain
+      - specialGroup
+      - iamMember
+      - view
+    description: |
+      Gives dataset access for a single entity. This resource is intended to be used in cases where
+      it is not possible to compile a full list of access blocks to include in a
+      `google_bigquery_dataset` resource, to enable them to be added separately.
+
+      ~> **Note:** If this resource is used alongside a `google_bigquery_dataset` resource, the
+      dataset resource must either have no defined `access` blocks or a `lifecycle` block with
+      `ignore_changes = [access]` so they don't fight over which accesses should be on the dataset.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Controlling access to datasets': 'https://cloud.google.com/bigquery/docs/dataset-access-controls'
+      api: 'https://cloud.google.com/bigquery/docs/reference/rest/v2/datasets'
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'datasetId'
+        description: |
+          A unique ID for this dataset, without the project name. The ID
+          must contain only letters (a-z, A-Z), numbers (0-9), or
+          underscores (_). The maximum length is 1,024 characters.
+        required: true
+      - !ruby/object:Api::Type::String
+        name: 'role'
+        description: |
+          Describes the rights granted to the user specified by the other
+          member of the access object. Primitive, Predefined and custom
+          roles are supported. Predefined roles that have equivalent
+          primitive roles are swapped by the API to their Primitive
+          counterparts, and will show a diff post-create. See
+          [official docs](https://cloud.google.com/bigquery/docs/access-control).
+      - !ruby/object:Api::Type::String
+        name: 'userByEmail'
+        description: |
+          An email address of a user to grant access to. For example:
+          fred@example.com
+        exactly_one_of:
+          - user_by_email
+          - group_by_email
+          - domain
+          - special_group
+          - iam_member
+          - view
+      - !ruby/object:Api::Type::String
+        name: 'groupByEmail'
+        description: An email address of a Google Group to grant access to.
+        exactly_one_of:
+          - user_by_email
+          - group_by_email
+          - domain
+          - special_group
+          - iam_member
+          - view
+      - !ruby/object:Api::Type::String
+        name: 'domain'
+        description: |
+          A domain to grant access to. Any users signed in with the
+          domain specified will be granted the specified access
+        exactly_one_of:
+          - user_by_email
+          - group_by_email
+          - domain
+          - special_group
+          - iam_member
+          - view
+      - !ruby/object:Api::Type::String
+        name: 'specialGroup'
+        description: |
+          A special group to grant access to. Possible values include:
+          
+          
+          * `projectOwners`: Owners of the enclosing project.
+          
+          
+          * `projectReaders`: Readers of the enclosing project.
+          
+          
+          * `projectWriters`: Writers of the enclosing project.
+          
+          
+          * `allAuthenticatedUsers`: All authenticated BigQuery users.
+        exactly_one_of:
+          - user_by_email
+          - group_by_email
+          - domain
+          - special_group
+          - iam_member
+          - view
+      - !ruby/object:Api::Type::String
+        name: 'iamMember'
+        description: |
+          Some other type of member that appears in the IAM Policy but isn't a user,
+          group, domain, or special group. For example: `allUsers`
+        exactly_one_of:
+          - user_by_email
+          - group_by_email
+          - domain
+          - special_group
+          - iam_member
+          - view
+      - !ruby/object:Api::Type::NestedObject
+        name: 'view'
+        description: |
+          A view from a different dataset to grant access to. Queries
+          executed against that view will have read access to tables in
+          this dataset. The role field is not required when this field is
+          set. If that view is updated by any user, access to the view
+          needs to be granted again via an update operation.
+        exactly_one_of:
+          - user_by_email
+          - group_by_email
+          - domain
+          - special_group
+          - iam_member
+          - view
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'datasetId'
+            description: The ID of the dataset containing this table.
+            required: true
+          - !ruby/object:Api::Type::String
+            name: 'projectId'
+            description: The ID of the project containing this table.
+            required: true
+          - !ruby/object:Api::Type::String
+            name: 'tableId'
+            description: |
+              The ID of the table. The ID must contain only letters (a-z,
+              A-Z), numbers (0-9), or underscores (_). The maximum length
+              is 1,024 characters.
+            required: true
   - !ruby/object:Api::Resource
     name: 'Table'
     kind: 'bigquery#table'

--- a/products/bigquery/inspec.yaml
+++ b/products/bigquery/inspec.yaml
@@ -32,6 +32,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         exclude_plural: true
     additional_functions: 'third_party/inspec/custom_functions/bigquery_dataset_name.erb'
 
+  DatasetAccess: !ruby/object:Overrides::Inspec::ResourceOverride
+    exclude: true
+
   Table: !ruby/object:Overrides::Inspec::ResourceOverride
     properties:
       description: !ruby/object:Overrides::Inspec::PropertyOverride

--- a/products/bigquery/terraform.yaml
+++ b/products/bigquery/terraform.yaml
@@ -64,6 +64,28 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         exclude: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/bigquery_dataset.go.erb
+  DatasetAccess: !ruby/object:Overrides::Terraform::ResourceOverride
+    exclude_import: true
+    skip_sweeper: true  # covered by Dataset sweeper
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "bigquery_dataset_access_basic_user"
+        skip_test: true  # not importable
+        primary_resource_id: "access"
+        vars:
+          dataset_id: "example_dataset"
+          account_name: "bqowner"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "bigquery_dataset_access_view"
+        skip_test: true  # not importable
+        primary_resource_id: "access"
+        vars:
+          dataset_id: "example_dataset"
+          dataset_id2: "example_dataset2"
+          table_id: "example_table"
+    properties:
+      datasetId: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
   Table: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true
 

--- a/products/bigquery/terraform.yaml
+++ b/products/bigquery/terraform.yaml
@@ -68,6 +68,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     exclude_import: true # no unique way to specify
     skip_sweeper: true  # covered by Dataset sweeper
     exclude_validator: true
+    mutex: "{{dataset_id}}"
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_dataset_access_basic_user"

--- a/products/bigquery/terraform.yaml
+++ b/products/bigquery/terraform.yaml
@@ -65,8 +65,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/bigquery_dataset.go.erb
   DatasetAccess: !ruby/object:Overrides::Terraform::ResourceOverride
-    exclude_import: true
+    exclude_import: true # no unique way to specify
     skip_sweeper: true  # covered by Dataset sweeper
+    exclude_validator: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_dataset_access_basic_user"

--- a/templates/terraform/custom_expand/resource_from_self_link.go.erb
+++ b/templates/terraform/custom_expand/resource_from_self_link.go.erb
@@ -1,3 +1,3 @@
-func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+func expand<%= "Nested" if object.nested_query -%><%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
 	return GetResourceNameFromSelfLink(v.(string)), nil
 }

--- a/templates/terraform/custom_expand/resource_from_self_link.go.erb
+++ b/templates/terraform/custom_expand/resource_from_self_link.go.erb
@@ -1,3 +1,3 @@
-func expand<%= "Nested" if object.nested_query -%><%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
 	return GetResourceNameFromSelfLink(v.(string)), nil
 }

--- a/templates/terraform/examples/bigquery_dataset_access_basic_user.tf.erb
+++ b/templates/terraform/examples/bigquery_dataset_access_basic_user.tf.erb
@@ -1,0 +1,13 @@
+resource "google_bigquery_dataset_access" "<%= ctx[:primary_resource_id] %>" {
+  dataset_id    = google_bigquery_dataset.dataset.dataset_id
+  role          = "OWNER"
+  user_by_email = google_service_account.bqowner.email
+}
+
+resource "google_bigquery_dataset" "dataset" {
+  dataset_id = "<%= ctx[:vars]['dataset_id'] %>"
+}
+
+resource "google_service_account" "bqowner" {
+  account_id = "<%= ctx[:vars]['account_name'] %>"
+}

--- a/templates/terraform/examples/bigquery_dataset_access_view.tf.erb
+++ b/templates/terraform/examples/bigquery_dataset_access_view.tf.erb
@@ -1,0 +1,26 @@
+resource "google_bigquery_dataset_access" "<%= ctx[:primary_resource_id] %>" {
+  dataset_id    = google_bigquery_dataset.private.dataset_id
+  view {
+    project_id = google_bigquery_table.public.project
+    dataset_id = google_bigquery_dataset.public.dataset_id
+    table_id   = google_bigquery_table.public.table_id
+  }
+}
+
+resource "google_bigquery_dataset" "private" {
+  dataset_id = "<%= ctx[:vars]['dataset_id'] %>"
+}
+
+resource "google_bigquery_dataset" "public" {
+  dataset_id = "<%= ctx[:vars]['dataset_id2'] %>"
+}
+
+resource "google_bigquery_table" "public" {
+  dataset_id = google_bigquery_dataset.public.dataset_id
+  table_id   = "<%= ctx[:vars]['table_id'] %>"
+
+  view {
+    query          = "SELECT state FROM [lookerdata:cdc.project_tycho_reports]"
+    use_legacy_sql = false
+  }
+}

--- a/templates/terraform/nested_query.go.erb
+++ b/templates/terraform/nested_query.go.erb
@@ -45,6 +45,7 @@ func resource<%=resource_name%>FindNestedObjectInList(d *schema.ResourceData, me
   <%   else -%>
   expected<%= titlelize_property(id_prop) -%> := d.Get("<%= id_prop.name.underscore -%>")
   <%   end # settable_properties.include?(id_prop)-%>
+  expectedFlattened<%= titlelize_property(id_prop) -%> := flattenNested<%= resource_name -%><%= titlelize_property(id_prop) -%>(expected<%= titlelize_property(id_prop) -%>, d, meta.(*Config))
   <% end # object.identity.each -%>
 
   // Search list for this resource.
@@ -70,11 +71,10 @@ func resource<%=resource_name%>FindNestedObjectInList(d *schema.ResourceData, me
     <% end -%>
 
     <% object.identity.each do |prop| -%>
-    // since the 'expected' values are the API representation, compare against the API representation (do not flatten)
-    item<%= titlelize_property(prop) -%> := item["<%= prop.api_name %>"]
+    item<%= titlelize_property(prop) -%> := flattenNested<%= resource_name -%><%= titlelize_property(prop) -%>(item["<%= prop.api_name %>"], d, meta.(*Config))
     // isEmptyValue check so that if one is nil and the other is "", that's considered a match
-    if !(isEmptyValue(reflect.ValueOf(item<%= titlelize_property(prop) -%>)) && isEmptyValue(reflect.ValueOf(expected<%= titlelize_property(prop) -%>))) && !reflect.DeepEqual(item<%= titlelize_property(prop) -%>, expected<%= titlelize_property(prop) -%>) {
-      log.Printf("[DEBUG] Skipping item with <%= prop.api_name %>= %#v, looking for %#v)", item<%= titlelize_property(prop) -%>, expected<%= titlelize_property(prop) -%>)
+    if !(isEmptyValue(reflect.ValueOf(item<%= titlelize_property(prop) -%>)) && isEmptyValue(reflect.ValueOf(expectedFlattened<%= titlelize_property(prop) -%>))) && !reflect.DeepEqual(item<%= titlelize_property(prop) -%>, expectedFlattened<%= titlelize_property(prop) -%>) {
+      log.Printf("[DEBUG] Skipping item with <%= prop.api_name %>= %#v, looking for %#v)", item<%= titlelize_property(prop) -%>, expectedFlattened<%= titlelize_property(prop) -%>)
       continue
     }
     <% end -%>

--- a/templates/terraform/nested_query.go.erb
+++ b/templates/terraform/nested_query.go.erb
@@ -38,7 +38,7 @@ func flattenNested<%= resource_name -%>(d *schema.ResourceData, meta interface{}
 func resource<%=resource_name%>FindNestedObjectInList(d *schema.ResourceData, meta interface{}, items []interface{}) (index int, item map[string]interface{}, err error) {
   <% object.identity.each do |id_prop| -%>
   <%   if settable_properties.include?(id_prop) -%>
-  expected<%= titlelize_property(id_prop) -%>, err := expand<%= resource_name -%><%= titlelize_property(id_prop) -%>(d.Get("<%= id_prop.name.underscore -%>"), d, meta.(*Config))
+  expected<%= titlelize_property(id_prop) -%>, err := expandNested<%= resource_name -%><%= titlelize_property(id_prop) -%>(d.Get("<%= id_prop.name.underscore -%>"), d, meta.(*Config))
   if err != nil {
     return -1, nil, err
   }
@@ -70,8 +70,10 @@ func resource<%=resource_name%>FindNestedObjectInList(d *schema.ResourceData, me
     <% end -%>
 
     <% object.identity.each do |prop| -%>
-    item<%= titlelize_property(prop) -%> := flatten<%= resource_name -%><%= titlelize_property(prop) -%>(item["<%= prop.api_name %>"], d, meta.(*Config))
-    if !reflect.DeepEqual(item<%= titlelize_property(prop) -%>, expected<%= titlelize_property(prop) -%>) {
+    // since the 'expected' values are the API representation, compare against the API representation (do not flatten)
+    item<%= titlelize_property(prop) -%> := item["<%= prop.api_name %>"]
+    // isEmptyValue check so that if one is nil and the other is "", that's considered a match
+    if !(isEmptyValue(reflect.ValueOf(item<%= titlelize_property(prop) -%>)) && isEmptyValue(reflect.ValueOf(expected<%= titlelize_property(prop) -%>))) && !reflect.DeepEqual(item<%= titlelize_property(prop) -%>, expected<%= titlelize_property(prop) -%>) {
       log.Printf("[DEBUG] Skipping item with <%= prop.api_name %>= %#v, looking for %#v)", item<%= titlelize_property(prop) -%>, expected<%= titlelize_property(prop) -%>)
       continue
     }

--- a/templates/terraform/post_create/lien.erb
+++ b/templates/terraform/post_create/lien.erb
@@ -5,5 +5,5 @@
 // us to know the server-side generated name of the object we're
 // trying to fetch, and the only way to know that is to capture
 // it here.  The following two lines do that.
-d.SetId(flattenResourceManagerLienName(res["name"], d, config).(string))
-d.Set("name", flattenResourceManagerLienName(res["name"], d, config))
+d.SetId(flattenNestedResourceManagerLienName(res["name"], d, config).(string))
+d.Set("name", flattenNestedResourceManagerLienName(res["name"], d, config))

--- a/templates/terraform/pre_delete/compute_disk_resource_policies_attachment.go.erb
+++ b/templates/terraform/pre_delete/compute_disk_resource_policies_attachment.go.erb
@@ -16,7 +16,7 @@ if region == "" {
 	return fmt.Errorf("invalid zone %q, unable to infer region from zone", zone)
 }
 
-name, err := expandComputeDiskResourcePolicyAttachmentName(d.Get("name"), d, config)
+name, err := expandNestedComputeDiskResourcePolicyAttachmentName(d.Get("name"), d, config)
 if err != nil {
   return err
 } else if v, ok := d.GetOkExists("name"); !isEmptyValue(reflect.ValueOf(name)) && (ok || !reflect.DeepEqual(v, name)) {

--- a/templates/terraform/pre_delete/compute_network_endpoint.go.erb
+++ b/templates/terraform/pre_delete/compute_network_endpoint.go.erb
@@ -1,22 +1,22 @@
 toDelete := make(map[string]interface{})
-instanceProp, err := expandComputeNetworkEndpointInstance(d.Get("instance"), d, config)
+instanceProp, err := expandNestedComputeNetworkEndpointInstance(d.Get("instance"), d, config)
 if err != nil {
-  return err
+	return err
 }
 toDelete["instance"] = instanceProp
 
-portProp, err := expandComputeNetworkEndpointPort(d.Get("port"), d, config)
+portProp, err := expandNestedComputeNetworkEndpointPort(d.Get("port"), d, config)
 if err != nil {
-  return err
+	return err
 }
 toDelete["port"] = portProp
 
-ipAddressProp, err := expandComputeNetworkEndpointIpAddress(d.Get("ip_address"), d, config)
+ipAddressProp, err := expandNestedComputeNetworkEndpointIpAddress(d.Get("ip_address"), d, config)
 if err != nil {
-  return err
+	return err
 }
 toDelete["ipAddress"] = ipAddressProp
 
 obj = map[string]interface{}{
-  "networkEndpoints": []map[string]interface{}{toDelete},
+	"networkEndpoints": []map[string]interface{}{toDelete},
 } 

--- a/templates/terraform/pre_delete/compute_region_disk_resource_policies_attachment.go.erb
+++ b/templates/terraform/pre_delete/compute_region_disk_resource_policies_attachment.go.erb
@@ -8,7 +8,7 @@ if region == "" {
 	return fmt.Errorf("region must be non-empty - set in resource or at provider-level")
 }
 
-name, err := expandComputeDiskResourcePolicyAttachmentName(d.Get("name"), d, config)
+name, err := expandNestedComputeDiskResourcePolicyAttachmentName(d.Get("name"), d, config)
 if err != nil {
   return err
 } else if v, ok := d.GetOkExists("name"); !isEmptyValue(reflect.ValueOf(name)) && (ok || !reflect.DeepEqual(v, name)) {

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -139,7 +139,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     obj := make(map[string]interface{})
 <%  object.settable_properties.each do |prop| -%>
     <% schemaPrefix = prop.flatten_object ? "nil" : "d.Get( \"#{prop.name.underscore}\" )" -%>
-    <%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(<%= schemaPrefix -%>, d, config)
+    <%= prop.api_name -%>Prop, err := expand<%= "Nested" if object.nested_query -%><%= resource_name -%><%= titlelize_property(prop) -%>(<%= schemaPrefix -%>, d, config)
     if err != nil {
         return err
 <%    if prop.send_empty_value -%>
@@ -281,7 +281,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <%      end -%>
     <% object.gettable_properties.each do |prop| -%>
     <% if object.identity.include?(prop) -%>
-    if err := d.Set("<%= prop.name.underscore -%>", flatten<%= resource_name -%><%= titlelize_property(prop) -%>(opRes["<%= prop.api_name -%>"], d, config)); err != nil {
+    if err := d.Set("<%= prop.name.underscore -%>", flatten<%= "Nested" if object.nested_query -%><%= resource_name -%><%= titlelize_property(prop) -%>(opRes["<%= prop.api_name -%>"], d, config)); err != nil {
         return err
     }
     <% end -%>
@@ -466,7 +466,7 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
 <%    if prop.flatten_object -%>
 // Terraform must set the top level schema field, but since this object contains collapsed properties
 // it's difficult to know what the top level should be. Instead we just loop over the map returned from flatten.
-    if flattenedProp := flatten<%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.api_name -%>"], d, config); flattenedProp != nil {
+    if flattenedProp := flatten<%= "Nested" if object.nested_query -%><%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.api_name -%>"], d, config); flattenedProp != nil {
         if gerr, ok := flattenedProp.(*googleapi.Error); ok {
 			return fmt.Errorf("Error reading <%= object.name -%>: %s", gerr)
 		}
@@ -478,7 +478,7 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
         }
     }
 <%    else -%>
-    if err := d.Set("<%= prop.name.underscore -%>", flatten<%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.api_name -%>"], d, config)); err != nil {
+    if err := d.Set("<%= prop.name.underscore -%>", flatten<%= "Nested" if object.nested_query -%><%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.api_name -%>"], d, config)); err != nil {
         return fmt.Errorf("Error reading <%= object.name -%>: %s", err)
     }
 <%    end -%>
@@ -535,7 +535,7 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
           .reject(&:url_param_only)
           .each do |prop| -%>
         <% schemaPrefix = prop.flatten_object ? "nil" : "d.Get( \"#{prop.name.underscore}\" )" -%>
-        <%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(<%= schemaPrefix -%>, d, config)
+        <%= prop.api_name -%>Prop, err := expand<%= "Nested" if object.nested_query -%><%= resource_name -%><%= titlelize_property(prop) -%>(<%= schemaPrefix -%>, d, config)
         if err != nil {
             return err
 <%#         There is some nuance in when we choose to send a value to an update function.
@@ -626,7 +626,7 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
 <%  update_body_properties.each do |prop| -%>
     <%# flattened objects won't have something stored in state so instead nil is passed to the next expander. -%>
     <% schemaPrefix = prop.flatten_object ? "nil" : "d.Get( \"#{prop.name.underscore}\" )" -%>
-    <%= prop.api_name -%>Prop, err := expand<%= resource_name -%><%= titlelize_property(prop) -%>(<%= schemaPrefix -%>, d, config)
+    <%= prop.api_name -%>Prop, err := expand<%= "Nested" if object.nested_query -%><%= resource_name -%><%= titlelize_property(prop) -%>(<%= schemaPrefix -%>, d, config)
     if err != nil {
         return err
 <%      if prop.send_empty_value -%>
@@ -833,12 +833,13 @@ func resource<%= resource_name -%>Import(d *schema.ResourceData, meta interface{
 }
 <% end -%>
 
+<%- nested_prefix = object.nested_query ? "Nested" : "" -%>
 <% object.gettable_properties.reject(&:ignore_read).each do |prop| -%>
-<%= lines(build_flatten_method(resource_name, prop, object), 1) -%>
+<%= lines(build_flatten_method(nested_prefix+resource_name, prop, object), 1) -%>
 <% end -%>
 
 <% object.settable_properties.each do |prop| -%>
-<%= lines(build_expand_method(resource_name, prop, object), 1) -%>
+<%= lines(build_expand_method(nested_prefix+resource_name, prop, object), 1) -%>
 <% end -%>
 
 <% if object.custom_code.encoder -%>

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -211,7 +211,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <%  unless object.async&.is_a? Api::OpAsync -%>
     <% object.gettable_properties.each do |prop| -%>
         <% if object.identity.include?(prop) && prop.output -%>
-    if err := d.Set("<%= prop.name.underscore -%>", flatten<%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.api_name -%>"], d, config)); err != nil {
+    if err := d.Set("<%= prop.name.underscore -%>", flatten<%= "Nested" if object.nested_query -%><%= resource_name -%><%= titlelize_property(prop) -%>(res["<%= prop.api_name -%>"], d, config)); err != nil {
         return fmt.Errorf(`Error setting computed identity field "<%=prop.name.underscore%>": %s`, err)
     }
         <% end -%>

--- a/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
+++ b/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
@@ -1,0 +1,169 @@
+package google
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccBigQueryDatasetAccess_basic(t *testing.T) {
+	t.Parallel()
+
+	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
+	saID := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+
+	expected := map[string]interface{}{
+		"role":        "OWNER",
+		"userByEmail": fmt.Sprintf("%s@%s.iam.gserviceaccount.com", saID, getTestProjectFromEnv()),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryDatasetAccess_basic(datasetID, saID),
+				Check:  testAccCheckBigQueryDatasetAccessPresent("google_bigquery_dataset.dataset", expected),
+			},
+			{
+				// Destroy step instead of CheckDestroy so we can check the access is removed without deleting the dataset
+				Config: testAccBigQueryDatasetAccess_destroy(datasetID, "dataset"),
+				Check:  testAccCheckBigQueryDatasetAccessAbsent("google_bigquery_dataset.dataset", expected),
+			},
+		},
+	})
+}
+
+func TestAccBigQueryDatasetAccess_view(t *testing.T) {
+	t.Parallel()
+
+	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
+	datasetID2 := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
+	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
+
+	expected := map[string]interface{}{
+		"view": map[string]interface{}{
+			"projectId": getTestProjectFromEnv(),
+			"datasetId": datasetID2,
+			"tableId":   tableID,
+		},
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryDatasetAccess_view(datasetID, datasetID2, tableID),
+				Check:  testAccCheckBigQueryDatasetAccessPresent("google_bigquery_dataset.private", expected),
+			},
+			{
+				Config: testAccBigQueryDatasetAccess_destroy(datasetID, "private"),
+				Check:  testAccCheckBigQueryDatasetAccessAbsent("google_bigquery_dataset.private", expected),
+			},
+		},
+	})
+}
+
+func testAccCheckBigQueryDatasetAccessPresent(n string, expected map[string]interface{}) resource.TestCheckFunc {
+	return testAccCheckBigQueryDatasetAccess(n, expected, true)
+}
+
+func testAccCheckBigQueryDatasetAccessAbsent(n string, expected map[string]interface{}) resource.TestCheckFunc {
+	return testAccCheckBigQueryDatasetAccess(n, expected, false)
+}
+
+func testAccCheckBigQueryDatasetAccess(n string, expected map[string]interface{}, expectPresent bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		url, err := replaceVarsForTest(config, rs, "{{BigQueryBasePath}}projects/{{project}}/datasets/{{dataset_id}}")
+		if err != nil {
+			return err
+		}
+
+		ds, err := sendRequest(config, "GET", "", url, nil)
+		if err != nil {
+			return err
+		}
+		access := ds["access"].([]interface{})
+		for _, a := range access {
+			if reflect.DeepEqual(a, expected) {
+				if !expectPresent {
+					return fmt.Errorf("Found access %+v, expected not present", expected)
+				}
+				return nil
+			}
+		}
+		if expectPresent {
+			return fmt.Errorf("Did not find access %+v, expected present", expected)
+		}
+		return nil
+	}
+}
+
+func testAccBigQueryDatasetAccess_destroy(datasetID, rs string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset" "%s" {
+  dataset_id = "%s"
+}
+`, rs, datasetID)
+}
+
+func testAccBigQueryDatasetAccess_basic(datasetID, saID string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset_access" "access" {
+  dataset_id    = google_bigquery_dataset.dataset.dataset_id
+  role          = "OWNER"
+  user_by_email = google_service_account.bqowner.email
+}
+
+resource "google_bigquery_dataset" "dataset" {
+  dataset_id = "%s"
+}
+
+resource "google_service_account" "bqowner" {
+  account_id = "%s"
+}
+`, datasetID, saID)
+}
+
+func testAccBigQueryDatasetAccess_view(datasetID, datasetID2, tableID string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset_access" "access" {
+  dataset_id    = google_bigquery_dataset.private.dataset_id
+  view {
+    project_id = google_bigquery_table.public.project
+    dataset_id = google_bigquery_dataset.public.dataset_id
+    table_id   = google_bigquery_table.public.table_id
+  }
+}
+
+resource "google_bigquery_dataset" "private" {
+  dataset_id = "%s"
+}
+
+resource "google_bigquery_dataset" "public" {
+  dataset_id = "%s"
+}
+
+resource "google_bigquery_table" "public" {
+  dataset_id = google_bigquery_dataset.public.dataset_id
+  table_id   = "%s"
+
+  view {
+    query          = "%s"
+    use_legacy_sql = false
+  }
+}
+
+`, datasetID, datasetID2, tableID, "SELECT state FROM `lookerdata.cdc.project_tycho_reports`")
+}


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/2686

Includes some changes to nested query func names so they don't conflict with the ones from the parent resource.

Also includes changes to the function that finds matches in nested query: now, instead of comparing the expanded form from the config to the flattened form from the API, it compares the expanded-and-then-flattened form from the config to the flattened form from the API. Without this, we end up comparing a config format (e.g. `user_by_email`) to the API format (e.g. `userByEmail`)
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_bigquery_dataset_access`
```
