### PR TITLE
allow google_dns_managed_zone.dnssec_config to be updated

### DIFF
--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -49,6 +49,7 @@ objects:
         name: 'dnsName'
         description: |
           The DNS name of this managed zone, for instance "example.com.".
+        input: true
         required: true
       - !ruby/object:Api::Type::NestedObject
         name: 'dnssecConfig'
@@ -140,6 +141,7 @@ objects:
         description: |
           User assigned name for this resource.
           Must be unique within the project.
+        input: true
         required: true
       - !ruby/object:Api::Type::Array
         name: 'nameServers'
@@ -150,6 +152,7 @@ objects:
         output: true
       - !ruby/object:Api::Type::String
         name: 'nameServerSet'
+        input: true
         description: |
           Optionally specifies the NameServerSet for this ManagedZone. A
           NameServerSet is a set of DNS name servers that all host the same
@@ -166,6 +169,7 @@ objects:
           A set of key/value label pairs to assign to this ManagedZone.
       - !ruby/object:Api::Type::Enum
         name: 'visibility'
+        input: true
         description: |
           The zone's visibility: public zones are exposed to the Internet,
           while private zones are visible only to Virtual Private Cloud resources.

--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -32,7 +32,7 @@ objects:
     name: 'ManagedZone'
     kind: 'dns#managedZone'
     base_url: 'projects/{{project}}/managedZones'
-    input: true
+    update_verb: :PATCH
     description: |
       A zone is a subtree of the DNS namespace under one administrative
       responsibility. A ManagedZone is a resource that represents a DNS zone
@@ -44,17 +44,12 @@ objects:
           A mutable string of at most 1024 characters associated with this
           resource for the user's convenience. Has no effect on the managed
           zone's function.
-        update_verb: :PATCH
-        update_url: 'projects/{{project}}/managedZones/{{name}}'
         required: true
       - !ruby/object:Api::Type::String
         name: 'dnsName'
         description: |
           The DNS name of this managed zone, for instance "example.com.".
         required: true
-      # TODO: Update support for dnssecConfig. Once this is added, property descriptions should be
-      # modified to state that properties (nonExistence, defaultKeySpecs) can only be updated while
-      # the state is "off".
       - !ruby/object:Api::Type::NestedObject
         name: 'dnssecConfig'
         description: DNSSEC configuration
@@ -77,6 +72,7 @@ objects:
               - dnssec_config.0.default_key_specs
             description: |
               Specifies the mechanism used to provide authenticated denial-of-existence responses.
+              non_existence can only be updated when the state is `off`.
             values:
               - "nsec"
               - "nsec3"
@@ -103,6 +99,7 @@ objects:
               Specifies parameters that will be used for generating initial DnsKeys
               for this ManagedZone. If you provide a spec for keySigning or zoneSigning,
               you must also provide one for the other.
+              default_key_specs can only be updated when the state is `off`.
             item_type: !ruby/object:Api::Type::NestedObject
               properties:
                 - !ruby/object:Api::Type::Enum
@@ -167,8 +164,6 @@ objects:
         name: 'labels'
         description: |
           A set of key/value label pairs to assign to this ManagedZone.
-        update_verb: :PATCH
-        update_url: 'projects/{{project}}/managedZones/{{name}}'
       - !ruby/object:Api::Type::Enum
         name: 'visibility'
         description: |
@@ -184,8 +179,6 @@ objects:
         description: |
           For privately visible zones, the set of Virtual Private Cloud
           resources that the zone is visible from.
-        update_verb: :PATCH
-        update_url: 'projects/{{project}}/managedZones/{{name}}'
         properties:
           - !ruby/object:Api::Type::Array
             name: 'networks'
@@ -208,8 +201,6 @@ objects:
           The presence for this field indicates that outbound forwarding is enabled
           for this zone. The value of this field contains the set of destinations
           to forward to.
-        update_verb: :PATCH
-        update_url: 'projects/{{project}}/managedZones/{{name}}'
         properties:
           - !ruby/object:Api::Type::Array
             name: 'targetNameServers'
@@ -240,8 +231,6 @@ objects:
         description: |
           The presence of this field indicates that DNS Peering is enabled for this
           zone. The value of this field contains the network to peer with.
-        update_verb: :PATCH
-        update_url: 'projects/{{project}}/managedZones/{{name}}'
         properties:
           - !ruby/object:Api::Type::NestedObject
             name: 'targetNetwork'

--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -152,11 +152,11 @@ objects:
         output: true
       - !ruby/object:Api::Type::String
         name: 'nameServerSet'
-        input: true
         description: |
           Optionally specifies the NameServerSet for this ManagedZone. A
           NameServerSet is a set of DNS name servers that all host the same
           ManagedZones. Most users will leave this field unset.
+        input: true
       - !ruby/object:Api::Type::Time
         name: 'creationTime'
         description: |
@@ -254,6 +254,7 @@ objects:
         name: 'reverseLookup'
         api_name: reverseLookupConfig
         min_version: beta
+        input: true
         description: |
           Specifies if this is a managed reverse lookup zone. If true, Cloud DNS will resolve reverse
           lookup queries using automatically configured records for VPC resources. This only applies

--- a/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
+++ b/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
@@ -69,7 +69,7 @@ func TestAccDNSManagedZone_privateUpdate(t *testing.T) {
 	})
 }
 
-func TestAccDNSManagedZone_dnssec_on(t *testing.T) {
+func TestAccDNSManagedZone_dnssec(t *testing.T) {
 	t.Parallel()
 
 	zoneSuffix := acctest.RandString(10)
@@ -87,11 +87,19 @@ func TestAccDNSManagedZone_dnssec_on(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			resource.TestStep{
+				Config: testAccDnsManagedZone_dnssec_off(zoneSuffix),
+			},
+			resource.TestStep{
+				ResourceName:      "google_dns_managed_zone.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
 
-func TestAccDNSManagedZone_dnssec_off(t *testing.T) {
+func TestAccDNSManagedZone_dnssec_empty(t *testing.T) {
 	t.Parallel()
 
 	zoneSuffix := acctest.RandString(10)
@@ -102,7 +110,7 @@ func TestAccDNSManagedZone_dnssec_off(t *testing.T) {
 		CheckDestroy: testAccCheckDNSManagedZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDnsManagedZone_dnssec_off(zoneSuffix),
+				Config: testAccDnsManagedZone_dnssec_empty(zoneSuffix),
 			},
 			resource.TestStep{
 				ResourceName:      "google_dns_managed_zone.foobar",
@@ -202,12 +210,39 @@ resource "google_dns_managed_zone" "foobar" {
       key_length = "2048"
       key_type   = "keySigning"
     }
+
+    non_existence = "nsec"
   }
 }
 `, suffix, suffix)
 }
 
 func testAccDnsManagedZone_dnssec_off(suffix string) string {
+	return fmt.Sprintf(`
+resource "google_dns_managed_zone" "foobar" {
+  name     = "mzone-test-%s"
+  dns_name = "tf-acctest-%s.hashicorptest.com."
+
+  dnssec_config {
+    state = "off"
+    default_key_specs {
+      algorithm  = "rsasha256"
+      key_length = "2048"
+      key_type   = "zoneSigning"
+    }
+    default_key_specs {
+      algorithm  = "rsasha256"
+      key_length = "2048"
+      key_type   = "keySigning"
+    }
+
+    non_existence = "nsec3"
+  }
+}
+`, suffix, suffix)
+}
+
+func testAccDnsManagedZone_dnssec_empty(suffix string) string {
 	return fmt.Sprintf(`
 resource "google_dns_managed_zone" "foobar" {
   name     = "mzone-test-%s"

--- a/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
+++ b/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
@@ -69,7 +69,7 @@ func TestAccDNSManagedZone_privateUpdate(t *testing.T) {
 	})
 }
 
-func TestAccDNSManagedZone_dnssec(t *testing.T) {
+func TestAccDNSManagedZone_dnssec_update(t *testing.T) {
 	t.Parallel()
 
 	zoneSuffix := acctest.RandString(10)


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5440

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dns: added ability to update `google_dns_managed_zone.dnssec_config`
```
