### PR TITLE
Do not return container cluster sweeper errors

### DIFF
--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -34,7 +34,8 @@ func testSweepContainerClusters(region string) error {
 	// List clusters for all zones by using "-" as the zone name
 	found, err := config.clientContainer.Projects.Zones.Clusters.List(config.Project, "-").Do()
 	if err != nil {
-		log.Fatalf("error listing container clusters: %s", err)
+		log.Printf("error listing container clusters: %s", err)
+		return nil
 	}
 
 	if len(found.Clusters) == 0 {
@@ -49,7 +50,8 @@ func testSweepContainerClusters(region string) error {
 			_, err := config.clientContainer.Projects.Locations.Clusters.Delete(clusterURL).Do()
 
 			if err != nil {
-				return fmt.Errorf("Error, failed to delete cluster %s: %s", cluster.Name, err)
+				log.Printf("Error, failed to delete cluster %s: %s", cluster.Name, err)
+				return nil
 			}
 		}
 	}


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
Part of https://github.com/terraform-providers/terraform-provider-google/issues/5994