### PR TITLE
Do not return most sweeper errors

### DIFF
--- a/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
@@ -43,7 +43,8 @@ func testSweepAccessContextManagerPolicies(region string) error {
 
 	resp, err := sendRequest(config, "GET", "", listUrl, nil)
 	if err != nil && !isGoogleApiErrorWithCode(err, 404) {
-		return fmt.Errorf("unable to list AccessPolicies for organization %q: %v", testOrg, err)
+		log.Printf(("unable to list AccessPolicies for organization %q: %v", testOrg, err)
+		return nil
 	}
 	var policies []interface{}
 	if resp != nil {
@@ -57,7 +58,8 @@ func testSweepAccessContextManagerPolicies(region string) error {
 		return nil
 	}
 	if len(policies) > 1 {
-		return fmt.Errorf("unexpected - more than one access policies found, change the tests")
+		log.Printf("unexpected - more than one access policies found, change the tests")
+		return nil
 	}
 
 	policy := policies[0].(map[string]interface{})
@@ -65,7 +67,8 @@ func testSweepAccessContextManagerPolicies(region string) error {
 
 	policyUrl := config.AccessContextManagerBasePath + policy["name"].(string)
 	if _, err := sendRequest(config, "DELETE", "", policyUrl, nil); err != nil && !isGoogleApiErrorWithCode(err, 404) {
-		return fmt.Errorf("unable to delete access policy %q", policy["name"].(string))
+		log.Printf("unable to delete access policy %q", policy["name"].(string))
+		return nil
 	}
 
 	return nil

--- a/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
@@ -43,7 +43,7 @@ func testSweepAccessContextManagerPolicies(region string) error {
 
 	resp, err := sendRequest(config, "GET", "", listUrl, nil)
 	if err != nil && !isGoogleApiErrorWithCode(err, 404) {
-		log.Printf(("unable to list AccessPolicies for organization %q: %v", testOrg, err)
+		log.Printf("unable to list AccessPolicies for organization %q: %v", testOrg, err)
 		return nil
 	}
 	var policies []interface{}

--- a/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
+++ b/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
@@ -512,7 +512,8 @@ func createZIPArchiveForCloudFunctionSource(t *testing.T, sourcePath string) str
 func sweepCloudFunctionSourceZipArchives(_ string) error {
 	files, err := ioutil.ReadDir(os.TempDir())
 	if err != nil {
-		return err
+		log.Printf("Error reading files: %s",err)
+		return nil
 	}
 	for _, f := range files {
 		if f.IsDir() {
@@ -521,7 +522,8 @@ func sweepCloudFunctionSourceZipArchives(_ string) error {
 		if strings.HasPrefix(f.Name(), testFunctionsSourceArchivePrefix) {
 			filepath := fmt.Sprintf("%s/%s", os.TempDir(), f.Name())
 			if err := os.Remove(filepath); err != nil {
-				return err
+				log.Printf("Error removing files: %s",err)
+				return nil
 			}
 			log.Printf("[INFO] cloud functions sweeper removed old file %s", filepath)
 		}

--- a/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -49,7 +49,8 @@ func testSweepDatabases(region string) error {
 
 	found, err := config.clientSqlAdmin.Instances.List(config.Project).Do()
 	if err != nil {
-		log.Fatalf("error listing databases: %s", err)
+		log.Printf("error listing databases: %s", err)
+		return nil
 	}
 
 	if len(found.Items) == 0 {
@@ -100,7 +101,8 @@ func testSweepDatabases(region string) error {
 			op, err := config.clientSqlAdmin.Instances.StopReplica(config.Project, replicaName).Do()
 
 			if err != nil {
-				return fmt.Errorf("error, failed to stop replica instance (%s) for instance (%s): %s", replicaName, d.Name, err)
+				log.Printf("error, failed to stop replica instance (%s) for instance (%s): %s", replicaName, d.Name, err)
+				return nil
 			}
 
 			err = sqlAdminOperationWait(config, op, config.Project, "Stop Replica")
@@ -108,7 +110,8 @@ func testSweepDatabases(region string) error {
 				if strings.Contains(err.Error(), "does not exist") {
 					log.Printf("Replication operation not found")
 				} else {
-					return err
+					log.Printf("Error waiting for sqlAdmin operation: %s", err)
+					return nil
 				}
 			}
 
@@ -130,7 +133,8 @@ func testSweepDatabases(region string) error {
 					continue
 				}
 
-				return fmt.Errorf("Error, failed to delete instance %s: %s", db, err)
+				log.Printf("Error, failed to delete instance %s: %s", db, err)
+				return nil
 			}
 
 			err = sqlAdminOperationWait(config, op, config.Project, "Delete Instance")
@@ -139,7 +143,8 @@ func testSweepDatabases(region string) error {
 					log.Printf("SQL instance not found")
 					continue
 				}
-				return err
+				log.Printf("Error, failed to delete instance %s: %s", db, err)
+				return nil
 			}
 		}
 	}


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5994