### PR TITLE
Do not diffSuppress `port` when `port_specification` is not "USED_FIXED_PORT"

### DIFF
--- a/templates/terraform/constants/health_check.erb
+++ b/templates/terraform/constants/health_check.erb
@@ -72,7 +72,7 @@ func portDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
             newPort, _ := strconv.Atoi(new)
 
             portSpec := d.Get(b[0] + ".0.port_specification")
-            if int64(oldPort) == defaultPort && newPort == 0 && portSpec != "USE_NAMED_PORT" {
+            if int64(oldPort) == defaultPort && newPort == 0 && portSpec == "USE_FIXED_PORT" {
                 return true
             }
         }

--- a/templates/terraform/constants/health_check.erb
+++ b/templates/terraform/constants/health_check.erb
@@ -45,7 +45,7 @@ func healthCheckCustomizeDiff(diff *schema.ResourceDiff, v interface{}) error {
     return nil
 }
 
-func portDiffSuppress(k, old, new string, _ *schema.ResourceData) bool {
+func portDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
     b := strings.Split(k, ".")
     if len(b) > 2 {
         attr := b[2]
@@ -71,7 +71,8 @@ func portDiffSuppress(k, old, new string, _ *schema.ResourceData) bool {
             oldPort, _ := strconv.Atoi(old)
             newPort, _ := strconv.Atoi(new)
 
-            if int64(oldPort) == defaultPort && newPort == 0 {
+			portSpec := d.Get(b[0] + ".0.port_specification")
+			if int64(oldPort) == defaultPort && newPort == 0 && portSpec != "USE_NAMED_PORT" {
                 return true
             }
         }

--- a/templates/terraform/constants/health_check.erb
+++ b/templates/terraform/constants/health_check.erb
@@ -71,8 +71,8 @@ func portDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
             oldPort, _ := strconv.Atoi(old)
             newPort, _ := strconv.Atoi(new)
 
-			portSpec := d.Get(b[0] + ".0.port_specification")
-			if int64(oldPort) == defaultPort && newPort == 0 && portSpec != "USE_NAMED_PORT" {
+            portSpec := d.Get(b[0] + ".0.port_specification")
+            if int64(oldPort) == defaultPort && newPort == 0 && portSpec != "USE_NAMED_PORT" {
                 return true
             }
         }


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5905
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: Fixed an issue where `port` could not be removed from health checks
```
