### PR TITLE
Add BQ SA datasource to the sidebar, plus docs and test.

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_bigquery_default_service_account.go
+++ b/third_party/terraform/data_sources/data_source_google_bigquery_default_service_account.go
@@ -31,7 +31,7 @@ func dataSourceGoogleBigqueryDefaultServiceAccountRead(d *schema.ResourceData, m
 
 	projectResource, err := config.clientBigQuery.Projects.GetServiceAccount(project).Do()
 	if err != nil {
-		return handleNotFoundError(err, d, "GCE service account not found")
+		return handleNotFoundError(err, d, "BigQuery service account not found")
 	}
 
 	d.SetId(projectResource.Email)

--- a/third_party/terraform/tests/data_source_google_bigquery_default_service_account_test.go
+++ b/third_party/terraform/tests/data_source_google_bigquery_default_service_account_test.go
@@ -1,0 +1,31 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceGoogleBigqueryDefaultServiceAccount_basic(t *testing.T) {
+	t.Parallel()
+
+	resourceName := "data.google_bigquery_default_service_account.bq_account"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGoogleBigqueryDefaultServiceAccount_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet(resourceName, "email"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckGoogleBigqueryDefaultServiceAccount_basic = `
+data "google_bigquery_default_service_account" "bq_account" {
+}
+`

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -41,6 +41,9 @@
       <li<%%= sidebar_current("docs-google-datasource-active-folder") %>>
       <a href="/docs/providers/google/d/google_active_folder.html">google_active_folder</a>
       </li>
+      <li<%%= sidebar_current("docs-google-datasource-bigquery-default-service-account") %>>
+        <a href="/docs/providers/google/d/google_bigquery_default_service_account.html">google_bigquery_default_service_account</a>
+      </li>
       <li<%%= sidebar_current("docs-google-datasource-billing-account") %>>
         <a href="/docs/providers/google/d/google_billing_account.html">google_billing_account</a>
       </li>

--- a/third_party/terraform/website/docs/d/google_bigquery_default_service_account.html.markdown
+++ b/third_party/terraform/website/docs/d/google_bigquery_default_service_account.html.markdown
@@ -28,7 +28,7 @@ data "google_bigquery_default_service_account" "bq_sa" {
 resource "google_kms_crypto_key_iam_member" "key_sa_user" {
   crypto_key_id = google_kms_crypto_key.key.id
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:${data.google_bigquery_default_service_account.bq_sa.email_address}"
+  member        = "serviceAccount:${data.google_bigquery_default_service_account.bq_sa.email}"
 }
 ```
 

--- a/third_party/terraform/website/docs/d/google_bigquery_default_service_account.html.markdown
+++ b/third_party/terraform/website/docs/d/google_bigquery_default_service_account.html.markdown
@@ -4,32 +4,43 @@ layout: "google"
 page_title: "Google: google_bigquery_default_service_account"
 sidebar_current: "docs-google-datasource-bigquery-default-service-account"
 description: |-
-  Retrieve default service account used by bigquery encryption in this project
+  Get the email address of the project's BigQuery service account
 ---
 
 # google\_bigquery\_default\_service\_account
 
-Use this data source to retrieve default service account for this project
+Get the email address of a project's unique BigQuery service account.
+
+Each Google Cloud project has a unique service account used by BigQuery. When using
+BigQuery with [customer-managed encryption keys](https://cloud.google.com/bigquery/docs/customer-managed-encryption),
+this account needs to be granted the
+`cloudkms.cryptoKeyEncrypterDecrypter` IAM role on the customer-managed Cloud KMS key used to protect the data.
+
+For more information see
+[the API reference](https://cloud.google.com/bigquery/docs/reference/rest/v2/projects/getServiceAccount).
 
 ## Example Usage
 
 ```hcl
-data "google_bigquery_default_service_account" "default" { }
+data "google_bigquery_default_service_account" "bq_sa" {
+}
 
-output "default_account" {
-  value = "${data.google_bigquery_default_service_account.default.email}"
-} 
+resource "google_kms_crypto_key_iam_member" "key_sa_user" {
+  crypto_key_id = google_kms_crypto_key.key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:${data.google_bigquery_default_service_account.bq_sa.email_address}"
+}
 ```
 
 ## Argument Reference
 
 The following arguments are supported:
 
-* `project` - (Optional) The project ID. If it is not provided, the provider project is used.
-
+* `project` - (Optional) The project the unique service account was created for. If it is not provided, the provider project is used.
 
 ## Attributes Reference
 
 The following attributes are exported:
 
-* `email` - Email address of the default service account used by bigquery encryption in this project
+* `email` - The email address of the service account. This value is often used to refer to the service account
+in order to grant IAM permissions.


### PR DESCRIPTION
Fixes terraform-providers/terraform-provider-google#5996

Turns out @ndmckinley had already fixed this on #2784, so just adding to the sidebar here plus improving the example in the docs.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
