### PR TITLE
ACM: service perimeter's vpc_accessible_services

### DIFF
--- a/products/accesscontextmanager/api.yaml
+++ b/products/accesscontextmanager/api.yaml
@@ -430,6 +430,23 @@ objects:
               - status.0.access_levels
               - status.0.restricted_services
             item_type: Api::Type::String
+          - !ruby/object:Api::Type::NestedObject
+            name: 'vpcAccessibleServices'
+            description: |
+              Specifies how APIs are allowed to communicate within the Service
+              Perimeter.
+            properties:
+            - !ruby/object:Api::Type::Boolean
+              name: 'enableRestriction'
+              description: |
+                Whether to restrict API calls within the Service Perimeter to the
+                list of APIs specified in 'allowedServices'.
+            - !ruby/object:Api::Type::Array
+              name: 'allowedServices'
+              description: |
+                The list of APIs usable within the Service Perimeter.
+                Must be empty unless `enableRestriction` is True.
+              item_type: Api::Type::String
   - !ruby/object:Api::Resource
     name: 'ServicePerimeterResource'
     create_url: "{{perimeter_name}}"

--- a/products/accesscontextmanager/terraform.yaml
+++ b/products/accesscontextmanager/terraform.yaml
@@ -87,6 +87,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         input: true
       status.restrictedServices: !ruby/object:Overrides::Terraform::PropertyOverride
         is_set: true
+      status.vpcAccessibleServices.allowedServices: !ruby/object:Overrides::Terraform::PropertyOverride
+        is_set: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       encoder: templates/terraform/encoders/access_level_never_send_parent.go.erb
       custom_import: templates/terraform/custom_import/set_access_policy_parent_from_self_link.go.erb

--- a/third_party/terraform/tests/resource_access_context_manager_service_perimeter_test.go.erb
+++ b/third_party/terraform/tests/resource_access_context_manager_service_perimeter_test.go.erb
@@ -55,6 +55,14 @@ func testAccAccessContextManagerServicePerimeter_updateTest(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccAccessContextManagerServicePerimeter_updateAllowed(org, "my policy", "level", "perimeter"),
+			},
+			{
+				ResourceName:      "google_access_context_manager_service_perimeter.test-access",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -145,3 +153,42 @@ resource "google_access_context_manager_service_perimeter" "test-access" {
 }
 `, org, policyTitle, levelTitleName, levelTitleName, perimeterTitleName, perimeterTitleName)
 }
+
+func testAccAccessContextManagerServicePerimeter_updateAllowed(org, policyTitle, levelTitleName, perimeterTitleName string) string {
+	return fmt.Sprintf(`
+resource "google_access_context_manager_access_policy" "test-access" {
+  parent = "organizations/%s"
+  title  = "%s"
+}
+
+resource "google_access_context_manager_access_level" "test-access" {
+  parent      = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}"
+  name        = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}/accessLevels/%s"
+  title       = "%s"
+  description = "hello"
+  basic {
+    combining_function = "AND"
+    conditions {
+      ip_subnetworks = ["192.0.4.0/24"]
+    }
+  }
+}
+
+resource "google_access_context_manager_service_perimeter" "test-access" {
+  parent         = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}"
+  name           = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}/servicePerimeters/%s"
+  title          = "%s"
+  perimeter_type = "PERIMETER_TYPE_REGULAR"
+  status {
+    restricted_services = ["bigquery.googleapis.com"]
+	access_levels       = [google_access_context_manager_access_level.test-access.name]
+
+	vpc_accessible_services {
+	  enable_restriction = true
+	  allowed_services   = ["bigquery.googleapis.com"]
+	}
+  }
+}
+`, org, policyTitle, levelTitleName, levelTitleName, perimeterTitleName, perimeterTitleName)
+}
+


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
accesscontextmanager: added `status.vpc_accessible_services` to `google_access_context_manager_service_perimeter` to control which services are available from the perimeter's VPC networks to the restricted Google APIs IP address range.
```
