### PR TITLE
Add game service cluster test

### DIFF
--- a/products/gameservices/terraform.yaml
+++ b/products/gameservices/terraform.yaml
@@ -24,6 +24,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           realm_id: "tf-test-realm"
     properties:
   GameServerCluster: !ruby/object:Overrides::Terraform::ResourceOverride
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        min_version: beta
+        name: "game_service_cluster_basic"
+        primary_resource_id: "default"
+        vars:
+          realm_id: "realm"
+        test_vars_overrides:
+          agones_cluster: "\"bootstrapped-agones-cluster\""
     properties:
       # clusters can be specified as {name}, locations/{location}/cluster/{name} or as the full
       # /projects/... style link. So using a substring check instead of normal self link functions

--- a/templates/terraform/examples/game_service_cluster_basic.tf.erb
+++ b/templates/terraform/examples/game_service_cluster_basic.tf.erb
@@ -1,0 +1,65 @@
+resource "google_game_services_game_server_cluster" "<%= ctx[:primary_resource_id] %>" {
+  provider   = google-beta
+  <%# depends_on = [google_project_iam_member.kubernetes_developer] -%>
+  <%# depends_on = [module.agones_cluster, module.helm_agones] -%>
+
+  cluster_id = "<%= ctx[:vars]['agones_cluster'] %>"
+  realm_id   = google_game_services_realm.default.realm_id
+
+  connection_info {
+    gke_cluster_reference {
+      cluster = "locations/us-west1/clusters/%{agones_cluster}"
+    }
+    namespace = "default"
+  }
+}
+
+resource "google_game_services_realm" "default" {
+  provider = google-beta
+
+  realm_id   = "<%= ctx[:vars]["realm_id"] %>"
+  time_zone  = "PST8PDT"
+
+  description = "Test Game Realm"
+}
+
+
+<%#  -
+This resource requires that a GKE cluster is already created with Agones provisioned
+and configured correctly for this test to succed. Since this set up requires a fair amount
+of bootstrapping that is non-essential to testing that the resource works we've decided to
+set up the cluster in advance and run the tests against it. The following Terraform config
+was used to provision the cluster. Since it is a manual set up this config not garunteed to
+work out of the box.
+
+module "agones_cluster" {
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/gke/?ref=release-1.4.0"
+
+  cluster = {
+    "name"             = var.name
+    "zone"             = "us-west1"
+    "machineType"      = "n1-standard-4"
+    "initialNodeCount" = 1
+    "project"          = "<PROJECT_ID>"
+    "network"          = "default"
+  }
+}
+
+// Install Agones via Helm
+module "helm_agones" {
+  source = "git::https://github.com/googleforgames/agones.git//install/terraform/modules/helm/?ref=release-1.4.0"
+
+  agones_version         = "1.4.0"
+  values_file            = ""
+  chart                  = "agones"
+  host                   = module.agones_cluster.host
+  token                  = module.agones_cluster.token
+  cluster_ca_certificate = module.agones_cluster.cluster_ca_certificate
+}
+
+resource "google_project_iam_member" "agent_create" {
+  project = var.project
+  role    = "roles/container.developer"
+  member  = "serviceAccount:service-<PROJECT_NUMBER>@gcp-sa-gameservices.iam.gserviceaccount.com"
+}
+%>

--- a/templates/terraform/examples/game_service_cluster_basic.tf.erb
+++ b/templates/terraform/examples/game_service_cluster_basic.tf.erb
@@ -26,7 +26,7 @@ resource "google_game_services_realm" "default" {
 
 <%#
 This resource requires that a GKE cluster is already created with Agones provisioned
-and configured correctly for this test to succed. Since this set up requires a fair amount
+and configured correctly for this test to succeed. Since this setup requires a fair amount
 of bootstrapping that is non-essential to testing that the resource works we've decided to
 set up the cluster in advance and run the tests against it. The following Terraform config
 was used to provision the cluster. Since it is a manual set up this config not guaranteed to

--- a/templates/terraform/examples/game_service_cluster_basic.tf.erb
+++ b/templates/terraform/examples/game_service_cluster_basic.tf.erb
@@ -24,12 +24,12 @@ resource "google_game_services_realm" "default" {
 }
 
 
-<%#  -
+<%#
 This resource requires that a GKE cluster is already created with Agones provisioned
 and configured correctly for this test to succed. Since this set up requires a fair amount
 of bootstrapping that is non-essential to testing that the resource works we've decided to
 set up the cluster in advance and run the tests against it. The following Terraform config
-was used to provision the cluster. Since it is a manual set up this config not garunteed to
+was used to provision the cluster. Since it is a manual set up this config not guaranteed to
 work out of the box.
 
 module "agones_cluster" {
@@ -62,4 +62,4 @@ resource "google_project_iam_member" "agent_create" {
   role    = "roles/container.developer"
   member  = "serviceAccount:service-<PROJECT_NUMBER>@gcp-sa-gameservices.iam.gserviceaccount.com"
 }
-%>
+-%>


### PR DESCRIPTION
This test relies on a GKE cluster with agones provisioned to be set up in
advance. Instructions for privisioning this cluster are in the comments of
game_service_cluster_basic.tf.erb

I originally thought we'd have to create a unique namespace for each game server cluster to be able to attach to the running GKE instance, however it appears that multiple game server clusters can exist in the default namespace. 

fixes https://github.com/terraform-providers/terraform-provider-google/issues/5748
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
