### PR TITLE
Define error if there are no settable fields

### DIFF
--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -154,6 +154,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <%  end -%>
 
 <%  if object.custom_code.encoder -%>
+    <%= "var err error"  if object.settable_properties.size == 0 %>
     obj, err = resource<%= resource_name -%>Encoder(d, meta, obj)
     if err != nil {
         return err


### PR DESCRIPTION
When there are no settable properties the err object is never instantiated above
and so the generated code will fail.

This is only an issue for resources that have very small request bodies and the only fields being sent are set outside of expanders, eg: encoders.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
