### PR TITLE
make ipv4_enabled default to true

### DIFF
--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -230,10 +230,9 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 										AtLeastOneOf: ipConfigurationKeys,
 									},
 									"ipv4_enabled": {
-										Type:     schema.TypeBool,
-										Optional: true,
-										// Defaults differ between first and second gen instances
-										Computed:     true,
+										Type:         schema.TypeBool,
+										Optional:     true,
+										Default:      true,
 										AtLeastOneOf: ipConfigurationKeys,
 									},
 									"require_ssl": {

--- a/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -954,7 +954,6 @@ resource "google_sql_database_instance" "instance" {
     tier                   = "db-f1-micro"
 
     ip_configuration {
-      ipv4_enabled = "true"
       authorized_networks {
         value           = "108.12.12.12"
         name            = "misc"


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6012.

Adding a default value will only affect people who had already provisioned instances that did not set a value for that field. If they're a second gen user, the server-side default is true, so their state would already have this value set as true. First gen instances have been decommissioned, so there should be ~0 terraform users using them.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
* sql: fixed error that occurred on `google_sql_database_instance` when `settings.ip_configuration` was set but `ipv4_enabled` was not set to true and `private_network` was not configured, by defaulting `ipv4_enabled` to true.
```
