### PR TITLE
Terraform BigQuery Table Hive partitioning support 

### DIFF
--- a/third_party/terraform/resources/resource_bigquery_table.go
+++ b/third_party/terraform/resources/resource_bigquery_table.go
@@ -162,8 +162,8 @@ func resourceBigQueryTable() *schema.Resource {
 									// Range: [Optional] Range of a sheet to query from. Only used when non-empty.
 									// Typical format: !:
 									"range": {
-										Type:         schema.TypeString,
-										Optional:     true,
+										Type:     schema.TypeString,
+										Optional: true,
 										AtLeastOneOf: []string{
 											"external_data_configuration.0.google_sheets_options.0.skip_leading_rows",
 											"external_data_configuration.0.google_sheets_options.0.range",
@@ -172,8 +172,8 @@ func resourceBigQueryTable() *schema.Resource {
 									// SkipLeadingRows: [Optional] The number of rows at the top
 									// of the sheet that BigQuery will skip when reading the data.
 									"skip_leading_rows": {
-										Type:         schema.TypeInt,
-										Optional:     true,
+										Type:     schema.TypeInt,
+										Optional: true,
 										AtLeastOneOf: []string{
 											"external_data_configuration.0.google_sheets_options.0.skip_leading_rows",
 											"external_data_configuration.0.google_sheets_options.0.range",
@@ -333,7 +333,7 @@ func resourceBigQueryTable() *schema.Resource {
 
 			// RangePartitioning: [Optional] If specified, configures range-based
 			// partitioning for this table.
-			"range_partitioning": &schema.Schema{
+			"range_partitioning": {
 				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
@@ -348,7 +348,7 @@ func resourceBigQueryTable() *schema.Resource {
 						},
 
 						// Range: [Required] Information required to partition based on ranges.
-						"range": &schema.Schema{
+						"range": {
 							Type:     schema.TypeList,
 							Required: true,
 							MaxItems: 1,
@@ -380,7 +380,7 @@ func resourceBigQueryTable() *schema.Resource {
 
 			// Clustering: [Optional] Specifies column names to use for data clustering.  Up to four
 			// top-level columns are allowed, and should be specified in descending priority order.
-			"clustering": &schema.Schema{
+			"clustering": {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,

--- a/third_party/terraform/resources/resource_bigquery_table.go
+++ b/third_party/terraform/resources/resource_bigquery_table.go
@@ -1,5 +1,3 @@
-// <% autogen_exception -%>
-
 package google
 
 import (
@@ -309,11 +307,10 @@ func resourceBigQueryTable() *schema.Resource {
 				},
 			},
 
-			<% unless version == 'ga' -%>
 			// RangePartitioning: [Optional] If specified, configures range-based
 			// partitioning for this table.
 			"range_partitioning": &schema.Schema{
-				Type: schema.TypeList,
+				Type:     schema.TypeList,
 				Optional: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
@@ -328,7 +325,7 @@ func resourceBigQueryTable() *schema.Resource {
 
 						// Range: [Required] Information required to partition based on ranges.
 						"range": &schema.Schema{
-							Type: schema.TypeList,
+							Type:     schema.TypeList,
 							Required: true,
 							MaxItems: 1,
 							Elem: &schema.Resource{
@@ -356,7 +353,6 @@ func resourceBigQueryTable() *schema.Resource {
 					},
 				},
 			},
-			<% end -%>
 
 			// Clustering: [Optional] Specifies column names to use for data clustering.  Up to four
 			// top-level columns are allowed, and should be specified in descending priority order.
@@ -520,7 +516,6 @@ func resourceTable(d *schema.ResourceData, meta interface{}) (*bigquery.Table, e
 		table.TimePartitioning = expandTimePartitioning(v)
 	}
 
-	<% unless version == 'ga' -%>
 	if v, ok := d.GetOk("range_partitioning"); ok {
 		rangePartitioning, err := expandRangePartitioning(v)
 		if err != nil {
@@ -529,7 +524,6 @@ func resourceTable(d *schema.ResourceData, meta interface{}) (*bigquery.Table, e
 
 		table.RangePartitioning = rangePartitioning
 	}
-	<% end -%>
 
 	if v, ok := d.GetOk("clustering"); ok {
 		table.Clustering = &bigquery.Clustering{
@@ -620,13 +614,11 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	<% unless version == 'ga' -%>
 	if res.RangePartitioning != nil {
 		if err := d.Set("range_partitioning", flattenRangePartitioning(res.RangePartitioning)); err != nil {
 			return err
 		}
 	}
-	<% end -%>
 
 	if res.Clustering != nil {
 		d.Set("clustering", res.Clustering.Fields)
@@ -913,7 +905,6 @@ func expandTimePartitioning(configured interface{}) *bigquery.TimePartitioning {
 	return tp
 }
 
-<% unless version == 'ga' -%>
 func expandRangePartitioning(configured interface{}) (*bigquery.RangePartitioning, error) {
 	if configured == nil {
 		return nil, nil
@@ -945,7 +936,6 @@ func expandRangePartitioning(configured interface{}) (*bigquery.RangePartitionin
 
 	return rp, nil
 }
-<% end -%>
 
 func flattenEncryptionConfiguration(ec *bigquery.EncryptionConfiguration) []map[string]interface{} {
 	return []map[string]interface{}{{"kms_key_name": ec.KmsKeyName}}
@@ -969,7 +959,6 @@ func flattenTimePartitioning(tp *bigquery.TimePartitioning) []map[string]interfa
 	return []map[string]interface{}{result}
 }
 
-<% unless version == 'ga' -%>
 func flattenRangePartitioning(rp *bigquery.RangePartitioning) []map[string]interface{} {
 	result := map[string]interface{}{
 		"field": rp.Field,
@@ -984,7 +973,6 @@ func flattenRangePartitioning(rp *bigquery.RangePartitioning) []map[string]inter
 
 	return []map[string]interface{}{result}
 }
-<% end -%>
 
 func expandView(configured interface{}) *bigquery.ViewDefinition {
 	raw := configured.([]interface{})[0].(map[string]interface{})

--- a/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -594,8 +594,6 @@ resource "google_bigquery_table" "test" {
 `, datasetID, bucketName, objectName, content, tableID, format, quoteChar)
 }
 
-
-
 func testAccBigQueryTableFromSheet(context map[string]interface{}) string {
 	return Nprintf(`
 	resource "google_bigquery_table" "table" {

--- a/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -1,4 +1,3 @@
-<% autogen_exception -%>
 package google
 
 import (
@@ -65,7 +64,6 @@ func TestAccBigQueryTable_Kms(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccBigQueryTable_RangePartitioning(t *testing.T) {
 	t.Parallel()
 	resourceName := "google_bigquery_table.test"
@@ -88,7 +86,6 @@ func TestAccBigQueryTable_RangePartitioning(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccBigQueryTable_View(t *testing.T) {
 	t.Parallel()
@@ -357,7 +354,6 @@ EOH
 `, datasetID, cryptoKeyName, tableID)
 }
 
-<% unless version == 'ga' -%>
 func testAccBigQueryTableRangePartitioning(datasetID, tableID string) string {
 	return fmt.Sprintf(`
 	resource "google_bigquery_dataset" "test" {
@@ -392,7 +388,6 @@ EOH
 }
 	`, datasetID, tableID)
 }
-<% end -%>
 
 func testAccBigQueryTableWithView(datasetID, tableID string) string {
 	return fmt.Sprintf(`

--- a/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -66,15 +66,15 @@ func TestAccBigQueryTable_Kms(t *testing.T) {
 
 func TestAccBigQueryTable_HivePartitioning(t *testing.T) {
 	t.Parallel()
-	bucketName := testBucketName()
+	bucketName := testBucketName(t)
 	resourceName := "google_bigquery_table.test"
-	datasetID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
-	tableID := fmt.Sprintf("tf_test_%s", acctest.RandString(10))
+	datasetID := fmt.Sprintf("tf_test_%s", randString(t, 10))
+	tableID := fmt.Sprintf("tf_test_%s", randString(t, 10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckBigQueryTableDestroy,
+		CheckDestroy: testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBigQueryTableHivePartitioning(bucketName, datasetID, tableID),

--- a/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -392,25 +392,25 @@ resource "google_storage_bucket_object" "test" {
 }
 
 resource "google_bigquery_dataset" "test" {
-		dataset_id = "%s"
-	}
+        dataset_id = "%s"
+}
 
-	resource "google_bigquery_table" "test" {
-		table_id   = "%s"
-		dataset_id = google_bigquery_dataset.test.dataset_id
+resource "google_bigquery_table" "test" {
+	table_id   = "%s"
+	dataset_id = google_bigquery_dataset.test.dataset_id
 
-		external_data_configuration {
-		        source_format = "CSV"
-			autodetect = true
-			source_uris= ["gs://${google_storage_bucket.test.name}/*"]
+	external_data_configuration {
+            source_format = "CSV"
+            autodetect = true
+            source_uris= ["gs://${google_storage_bucket.test.name}/*"]
 
-			hive_partitioning_options {
-			    mode = "AUTO"
-			    source_uri_prefix = "gs://${google_storage_bucket.test.name}/"
-			}
+            hive_partitioning_options {
+                mode = "AUTO"
+                source_uri_prefix = "gs://${google_storage_bucket.test.name}/"
+	    }
 
-		}
-		depends_on = ["google_storage_bucket_object.test"]
+        }
+	depends_on = ["google_storage_bucket_object.test"]
 }
 `, bucketName, datasetID, tableID)
 }

--- a/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -215,7 +215,7 @@ The `google_sheets_options` block supports:
 The `hive_partitioning_options` block supports:
 
 * `mode` (Optional) - When set, what mode of hive partitioning to use when
-    reading data. Two modes are supported.
+    reading data. The following modes are supported.
     * AUTO: automatically infer partition key name(s) and type(s).
     * STRINGS: automatically infer partition key name(s). All types are
       Not all storage formats support hive partitioning. Requesting hive

--- a/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -215,19 +215,22 @@ The `google_sheets_options` block supports:
 The `hive_partitioning_options` block supports:
 
 * `mode` (Optional) - When set, what mode of hive partitioning to use when
-    reading data. Two modes are supported. * AUTO: automatically infer
-    partition key name(s) and type(s). * STRINGS: automatically infer
-    partition key name(s). All types are Not all storage formats support hive
-    partitioning. Requesting hive partitioning on an unsupported format will
-    lead to an error. Currently supported formats are: JSON, CSV, ORC, Avro and Parquet.
+    reading data. Two modes are supported.
+    * AUTO: automatically infer partition key name(s) and type(s).
+    * STRINGS: automatically infer partition key name(s). All types are
+      Not all storage formats support hive partitioning. Requesting hive
+      partitioning on an unsupported format will lead to an error.
+      Currently supported formats are: JSON, CSV, ORC, Avro and Parquet.
+    * CUSTOM: when set to `CUSTOM`, you must encode the partition key schema within the `source_uri_prefix` by setting `source_uri_prefix` to `gs://bucket/path_to_table/{key1:TYPE1}/{key2:TYPE2}/{key3:TYPE3}`.
 
 * `source_uri_prefix` (Optional) - When hive partition detection is requested,
     a common for all source uris must be required. The prefix must end immediately
     before the partition key encoding begins. For example, consider files following
-    this data layout. gs://bucket/path_to_table/dt=2019-06-01/country=USA/id=7/file.avro
-    gs://bucket/path_to_table/dt=2019-05-31/country=CA/id=3/file.avro When hive
+    this data layout. `gs://bucket/path_to_table/dt=2019-06-01/country=USA/id=7/file.avro`
+    `gs://bucket/path_to_table/dt=2019-05-31/country=CA/id=3/file.avro` When hive
     partitioning is requested with either AUTO or STRINGS detection, the common prefix
-    can be either of gs://bucket/path_to_table or gs://bucket/path_to_table/.
+    can be either of `gs://bucket/path_to_table` or `gs://bucket/path_to_table/`.
+    Note that when `mode` is set to `CUSTOM`, you must encode the partition key schema within the `source_uri_prefix` by setting `source_uri_prefix` to `gs://bucket/path_to_table/{key1:TYPE1}/{key2:TYPE2}/{key3:TYPE3}`.
 
 The `time_partitioning` block supports:
 

--- a/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -127,7 +127,7 @@ The following arguments are supported:
 * `time_partitioning` - (Optional) If specified, configures time-based
     partitioning for this table. Structure is documented below.
 
-* `range_partitioning` - (Optional, Beta) If specified, configures range-based
+* `range_partitioning` - (Optional) If specified, configures range-based
     partitioning for this table. Structure is documented below.
 
 * `clustering` - (Optional) Specifies column names to use for data clustering.

--- a/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -152,6 +152,11 @@ The `external_data_configuration` block supports:
     `source_format` is set to "GOOGLE_SHEETS". Structure is
     documented below.
 
+* `hive_partitioning_options` (Optional) - When set, configures hive partitioning
+    support. Not all storage formats support hive partitioning -- requesting hive
+    partitioning on an unsupported format will lead to an error, as will providing
+    an invalid specification.
+
 * `ignore_unknown_values` (Optional) - Indicates if BigQuery should
     allow extra values that are not represented in the table schema.
     If true, the extra values are ignored. If false, records with
@@ -206,6 +211,23 @@ The `google_sheets_options` block supports:
 * `skip_leading_rows` (Optional) - The number of rows at the top of the sheet
     that BigQuery will skip when reading the data. At least one of `range` or
     `skip_leading_rows` must be set.
+
+The `hive_partitioning_options` block supports:
+
+* `mode` (Optional) - When set, what mode of hive partitioning to use when
+    reading data. Two modes are supported. * AUTO: automatically infer
+    partition key name(s) and type(s). * STRINGS: automatically infer
+    partition key name(s). All types are Not all storage formats support hive
+    partitioning. Requesting hive partitioning on an unsupported format will
+    lead to an error. Currently supported formats are: JSON, CSV, ORC, Avro and Parquet.
+
+* `source_uri_prefix` (Optional) - When hive partition detection is requested,
+    a common for all source uris must be required. The prefix must end immediately
+    before the partition key encoding begins. For example, consider files following
+    this data layout. gs://bucket/path_to_table/dt=2019-06-01/country=USA/id=7/file.avro
+    gs://bucket/path_to_table/dt=2019-05-31/country=CA/id=3/file.avro When hive
+    partitioning is requested with either AUTO or STRINGS detection, the common prefix
+    can be either of gs://bucket/path_to_table or gs://bucket/path_to_table/.
 
 The `time_partitioning` block supports:
 


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/5664
As of March 2, range partioning / hive partitioning is GA, see https://cloud.google.com/bigquery/docs/release-notes. 
Note: Doesn't support `require_partition_filter` attribute as this isn't available from the used BigQuery SDK.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: Added support for `google_bigquery_table` `hive_partitioning_options`
```

```release-note:enhancement
bigquery: Added `google_bigquery_table` `range_partitioning` to GA
```