### PR TITLE
Add bigquery_dataset_access to sidebar

### DIFF
--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -280,6 +280,8 @@
     <ul class="nav">
       <li<%%= sidebar_current("docs-google-bigquery-dataset") %>>
       <a href="/docs/providers/google/r/bigquery_dataset.html">google_bigquery_dataset</a>
+      <li<%%= sidebar_current("docs-google-bigquery-dataset-access") %>>
+      <a href="/docs/providers/google/r/bigquery_dataset_access.html">google_bigquery_dataset_access</a>
       <li<%%= sidebar_current("docs-google-bigquery-table") %>>
       <a href="/docs/providers/google/r/bigquery_table.html">google_bigquery_table</a>
       </li>


### PR DESCRIPTION
Missing from https://github.com/GoogleCloudPlatform/magic-modules/pull/3312. Caught it before the release, at least 🙃 
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
