### PR TITLE
candidate subnets ignore read, admin enabled computed

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -6761,8 +6761,8 @@ objects:
     kind: 'compute#interconnectAttachment'
     base_url: 'projects/{{project}}/regions/{{region}}/interconnectAttachments'
     collection_url_key: 'items'
+    update_verb: :PATCH
     has_self_link: true
-    input: true
     description: |
       Represents an InterconnectAttachment (VLAN attachment) resource. For more
       information, see Creating VLAN Attachments.
@@ -6798,6 +6798,7 @@ objects:
     properties:
       - !ruby/object:Api::Type::Boolean
         name: 'adminEnabled'
+        send_empty_value: true
         description: |
           Whether the VLAN attachment is enabled or disabled.  When using
           PARTNER type this will Pre-Activate the interconnect attachment
@@ -6815,6 +6816,7 @@ objects:
         output: true
       - !ruby/object:Api::Type::String
         name: 'interconnect'
+        input: true
         description: |
           URL of the underlying Interconnect object that this attachment's
           traffic will traverse through. Required if type is DEDICATED, must not
@@ -6825,6 +6827,7 @@ objects:
           An optional description of this resource.
       - !ruby/object:Api::Type::Enum
         name: 'bandwidth'
+        input: true
         description: |
           Provisioned bandwidth capacity for the interconnect attachment.
           For attachments of type DEDICATED, the user can set the bandwidth.
@@ -6846,6 +6849,7 @@ objects:
           - :BPS_50G
       - !ruby/object:Api::Type::String
         name: 'edgeAvailabilityDomain'
+        input: true
         description: |
           Desired availability domain for the attachment. Only available for type
           PARTNER, at creation time. For improved reliability, customers should
@@ -6882,6 +6886,7 @@ objects:
             output: true
       - !ruby/object:Api::Type::Enum
         name: 'type'
+        input: true
         description: |
           The type of InterconnectAttachment you wish to create. Defaults to
           DEDICATED.
@@ -6924,6 +6929,7 @@ objects:
           automatically connect the Interconnect to the network & region within which the
           Cloud Router is configured.
         required: true
+        input: true
       - !ruby/object:Api::Type::Time
         name: 'creationTimestamp'
         description: |
@@ -6945,8 +6951,10 @@ objects:
           lowercase letter, and all following characters must be a dash, lowercase
           letter, or digit, except the last character, which cannot be a dash.
         required: true
+        input: true
       - !ruby/object:Api::Type::Array
         name: candidateSubnets
+        input: true
         description: |
           Up to 16 candidate prefixes that can be used to restrict the allocation
           of cloudRouterIpAddress and customerRouterIpAddress for this attachment.
@@ -6958,6 +6966,7 @@ objects:
         item_type: Api::Type::String
       - !ruby/object:Api::Type::Integer
         name: vlanTag8021q
+        input: true
         description: |
           The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4094. When
           using PARTNER type this will be managed upstream.

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -6799,6 +6799,7 @@ objects:
       - !ruby/object:Api::Type::Boolean
         name: 'adminEnabled'
         send_empty_value: true
+        default_value: true
         description: |
           Whether the VLAN attachment is enabled or disabled.  When using
           PARTNER type this will Pre-Activate the interconnect attachment

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -993,8 +993,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       vlanTag8021q: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
-      adminEnabled: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
       candidateSubnets: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -993,6 +993,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       vlanTag8021q: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      adminEnabled: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      candidateSubnets: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/interconnect_attachment.go.erb
       post_create: templates/terraform/post_create/interconnect_attachment.go.erb


### PR DESCRIPTION
Candidate subnets does not return from API
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/5982

Admin enabled default to true and send empty value. Enables update for `admin_enabled`
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/5965

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
`compute`: Fixed perma-diff on `google_compute_interconnect_attachment` `candidate_subnets`
```

```release-note:bug
`compute`: Fixed diff on default value for `google_compute_interconnect_attachment` `admin_enabled`
```

```release-note:enhancement
`compute`: Added update support for `google_compute_interconnect_attachment` `admin_enabled`
```
