### PR TITLE
Health Check Logging

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -4759,6 +4759,17 @@ objects:
                 - :USE_FIXED_PORT
                 - :USE_NAMED_PORT
                 - :USE_SERVING_PORT
+      - !ruby/object:Api::Type::NestedObject
+        name: 'logConfig'
+        description: |
+          Configure logging on this health check.
+        min_version: beta
+        properties:
+            - !ruby/object:Api::Type::Boolean
+              name: 'enable'
+              description: |
+                Indicates whether or not to export logs. This is false by default,
+                which means no health check logging will be done.
   - !ruby/object:Api::Resource
     name: 'InstanceTemplate'
     kind: 'compute#instanceTemplate'
@@ -10507,6 +10518,17 @@ objects:
                 - :USE_FIXED_PORT
                 - :USE_NAMED_PORT
                 - :USE_SERVING_PORT
+      - !ruby/object:Api::Type::NestedObject
+        name: 'logConfig'
+        description: |
+          Configure logging on this health check.
+        min_version: beta
+        properties:
+            - !ruby/object:Api::Type::Boolean
+              name: 'enable'
+              description: |
+                Indicates whether or not to export logs. This is false by default,
+                which means no health check logging will be done.
   - !ruby/object:Api::Resource
     name: 'ResourcePolicy'
     kind: 'compute#resourcePolicy'

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -861,6 +861,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "http2-health-check"
         vars:
           health_check_name: "http2-health-check"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "health_check_with_logging"
+        primary_resource_id: "health-check-with-logging"
+        vars:
+          health_check_name: "tcp-health-check"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       encoder: templates/terraform/encoders/health_check_type.erb
       constants: templates/terraform/constants/health_check.erb

--- a/templates/terraform/examples/health_check_with_logging.tf.erb
+++ b/templates/terraform/examples/health_check_with_logging.tf.erb
@@ -1,0 +1,14 @@
+resource "google_compute_health_check" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['health_check_name'] %>"
+
+  timeout_sec        = 1
+  check_interval_sec = 1
+
+  tcp_health_check {
+    port = "22"
+  }
+
+  log_config {
+    enable = true
+  }
+}


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added field `log_config` to `google_compute_health_check` and `google_compute_region_health_check` to enable health check logging.
```
