### PR TITLE
add optional service account for scheduled queries

### DIFF
--- a/products/bigquerydatatransfer/api.yaml
+++ b/products/bigquerydatatransfer/api.yaml
@@ -27,7 +27,7 @@ apis_required:
 objects:
   - !ruby/object:Api::Resource
     name: 'Config'
-    base_url: projects/{{project}}/locations/{{location}}/transferConfigs
+    base_url: projects/{{project}}/locations/{{location}}/transferConfigs?serviceAccountName={{serviceAccountName}}
     self_link: "{{name}}"
     update_verb: :PATCH
     update_mask: true
@@ -47,6 +47,15 @@ objects:
         description: |
           The geographic location where the transfer config should reside.
           Examples: US, EU, asia-northeast1. The default value is US.
+      - !ruby/object:Api::Type::String
+        name: 'serviceAccountName'
+        url_param_only: true
+        input: true
+        default_value: ''
+        description: |
+          Optional service account name. If this field is set, transfer config will
+          be created with this service account credentials. It requires that
+          requesting user calling this API has permissions to act as this service account.
     properties:
       - !ruby/object:Api::Type::String
         name: 'displayName'

--- a/products/bigquerydatatransfer/api.yaml
+++ b/products/bigquerydatatransfer/api.yaml
@@ -28,7 +28,7 @@ objects:
   - !ruby/object:Api::Resource
     name: 'Config'
     base_url: projects/{{project}}/locations/{{location}}/transferConfigs?serviceAccountName={{serviceAccountName}}
-    self_link: "{{name}}"
+    self_link: "{{name}}?serviceAccountName={{serviceAccountName}}"
     update_verb: :PATCH
     update_mask: true
     description: |


### PR DESCRIPTION
- support using service account name when creating scheduled BQ queries
- see [BigQuery Release notes](https://cloud.google.com/bigquery/docs/release-notes#November_21_2019) which
  fixes [Provide ability to schedule BigQuery jobs using a service account [118921817]](https://issuetracker.google.com/issues/118921817)
- see [Discovery ](https://bigquerydatatransfer.googleapis.com/$discovery/rest?version=v1) for parameter documentation
- using '' as default value which matches the bq CLI (`--service_account_name`)

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4449.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->
```release-note:enhancement
bigquery: added `service_account_name` field to `google_bigquery_data_transfer_config` resource
```