### PR TITLE
move deleted project check into project service read

### DIFF
--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -575,7 +575,7 @@ func doEnableServicesRequest(services []string, project string, config *Config, 
 func listCurrentlyEnabledServices(project string, config *Config, timeout time.Duration) (map[string]struct{}, error) {
 	log.Printf("[DEBUG] Listing enabled services for project %s", project)
 	apiServices := make(map[string]struct{})
-	err = retryTimeDuration(func() error {
+	err := retryTimeDuration(func() error {
 		ctx := context.Background()
 		return config.clientServiceUsage.Services.
 			List(fmt.Sprintf("projects/%s", project)).

--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -573,19 +573,6 @@ func doEnableServicesRequest(services []string, project string, config *Config, 
 // forms of the service. LIST responses are expected to return only the old or
 // new form, but we'll always return both.
 func listCurrentlyEnabledServices(project string, config *Config, timeout time.Duration) (map[string]struct{}, error) {
-	// Verify project for services still exists
-	p, err := config.clientResourceManager.Projects.Get(project).Do()
-	if err != nil {
-		return nil, err
-	}
-	if p.LifecycleState == "DELETE_REQUESTED" {
-		// Construct a 404 error for handleNotFoundError
-		return nil, &googleapi.Error{
-			Code:    404,
-			Message: "Project deletion was requested",
-		}
-	}
-
 	log.Printf("[DEBUG] Listing enabled services for project %s", project)
 	apiServices := make(map[string]struct{})
 	err = retryTimeDuration(func() error {

--- a/third_party/terraform/resources/resource_google_project_service.go
+++ b/third_party/terraform/resources/resource_google_project_service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/serviceusage/v1"
 )
 
@@ -154,7 +155,19 @@ func resourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return err
 	}
-	srv := d.Get("service").(string)
+
+	// Verify project for services still exists
+	p, err := config.clientResourceManager.Projects.Get(project).Do()
+	if err != nil {
+		return nil, err
+	}
+	if p.LifecycleState == "DELETE_REQUESTED" {
+		// Construct a 404 error for handleNotFoundError
+		return nil, &googleapi.Error{
+			Code:    404,
+			Message: "Project deletion was requested",
+		}
+	}
 
 	servicesRaw, err := BatchRequestReadServices(project, d, config)
 	if err != nil {
@@ -162,6 +175,7 @@ func resourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}) 
 	}
 	servicesList := servicesRaw.(map[string]struct{})
 
+	srv := d.Get("service").(string)
 	if _, ok := servicesList[srv]; ok {
 		d.Set("project", project)
 		d.Set("service", srv)

--- a/third_party/terraform/resources/resource_google_project_service.go
+++ b/third_party/terraform/resources/resource_google_project_service.go
@@ -159,11 +159,11 @@ func resourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}) 
 	// Verify project for services still exists
 	p, err := config.clientResourceManager.Projects.Get(project).Do()
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if p.LifecycleState == "DELETE_REQUESTED" {
 		// Construct a 404 error for handleNotFoundError
-		return nil, &googleapi.Error{
+		return &googleapi.Error{
 			Code:    404,
 			Message: "Project deletion was requested",
 		}


### PR DESCRIPTION
Previously the check occurred in the list call, which was called in Create and Read. There's no good reason why a user should be trying to set a new service enabled on a deleted project, so I just moved the check to only happen on read.

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6013.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
* serviceusage: fixed issue where `google_project_services` attempted to read a project before enabling the API that allows that read
```
