### PR TITLE
use scheduling from template rather than instance defaults

### DIFF
--- a/third_party/terraform/resources/resource_compute_instance_from_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_from_template.go
@@ -126,6 +126,12 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 		return err
 	}
 
+	// when we make the original call to expandComputeInstance expandScheduling is called, which sets default values.
+	// However, we want the values to be read from the template instead.
+	if _, hasSchedule := d.GetOk("scheduling"); !hasSchedule {
+		instance.Scheduling = it.Properties.Scheduling
+	}
+
 	// Force send all top-level fields that have been set in case they're overridden to zero values.
 	// Initialize ForceSendFields to empty so we don't get things that the instance resource
 	// always force-sends.


### PR DESCRIPTION
Use scheduling from template rather than instance defaults
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6050

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed bug where `google_compute_instance_from_template` instance defaults were overriding `scheduling`
```
