### PR TITLE
VPC SC dry-run mode

### DIFF
--- a/products/accesscontextmanager/api.yaml
+++ b/products/accesscontextmanager/api.yaml
@@ -447,6 +447,85 @@ objects:
                 The list of APIs usable within the Service Perimeter.
                 Must be empty unless `enableRestriction` is True.
               item_type: Api::Type::String
+      - !ruby/object:Api::Type::NestedObject
+        name: 'spec'
+        description: |
+          Proposed (or dry run) ServicePerimeter configuration.
+          This configuration allows to specify and test ServicePerimeter configuration
+          without enforcing actual access restrictions. Only allowed to be set when
+          the `useExplicitDryRunSpec` flag is set.
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: 'resources'
+            description: |
+              A list of GCP resources that are inside of the service perimeter.
+              Currently only projects are allowed.
+              Format: projects/{project_number}
+            at_least_one_of:
+              - status.0.resources
+              - status.0.access_levels
+              - status.0.restricted_services
+            item_type: Api::Type::String
+          - !ruby/object:Api::Type::Array
+            name: 'accessLevels'
+            description: |
+              A list of AccessLevel resource names that allow resources within
+              the ServicePerimeter to be accessed from the internet.
+              AccessLevels listed must be in the same policy as this
+              ServicePerimeter. Referencing a nonexistent AccessLevel is a
+              syntax error. If no AccessLevel names are listed, resources within
+              the perimeter can only be accessed via GCP calls with request
+              origins within the perimeter. For Service Perimeter Bridge, must
+              be empty.
+
+              Format: accessPolicies/{policy_id}/accessLevels/{access_level_name}
+            at_least_one_of:
+              - status.0.resources
+              - status.0.access_levels
+              - status.0.restricted_services
+            item_type: Api::Type::String
+          - !ruby/object:Api::Type::Array
+            name: 'restrictedServices'
+            description: |
+              GCP services that are subject to the Service Perimeter
+              restrictions. Must contain a list of services. For example, if
+              `storage.googleapis.com` is specified, access to the storage
+              buckets inside the perimeter must meet the perimeter's access
+              restrictions.
+            at_least_one_of:
+              - status.0.resources
+              - status.0.access_levels
+              - status.0.restricted_services
+            item_type: Api::Type::String
+          - !ruby/object:Api::Type::NestedObject
+            name: 'vpcAccessibleServices'
+            description: |
+              Specifies how APIs are allowed to communicate within the Service
+              Perimeter.
+            properties:
+            - !ruby/object:Api::Type::Boolean
+              name: 'enableRestriction'
+              description: |
+                Whether to restrict API calls within the Service Perimeter to the
+                list of APIs specified in 'allowedServices'.
+            - !ruby/object:Api::Type::Array
+              name: 'allowedServices'
+              description: |
+                The list of APIs usable within the Service Perimeter.
+                Must be empty unless `enableRestriction` is True.
+              item_type: Api::Type::String
+      - !ruby/object:Api::Type::Boolean
+        name: 'useExplicitDryRunSpec'
+        description: |
+          Use explicit dry run spec flag. Ordinarily, a dry-run spec implicitly exists
+          for all Service Perimeters, and that spec is identical to the status for those
+          Service Perimeters. When this flag is set, it inhibits the generation of the
+          implicit spec, thereby allowing the user to explicitly provide a
+          configuration ("spec") to use in a dry-run version of the Service Perimeter.
+          This allows the user to test changes to the enforced config ("status") without
+          actually enforcing them. This testing is done through analyzing the differences
+          between currently enforced and suggested restrictions. useExplicitDryRunSpec must
+          bet set to True if any of the fields in the spec are set to non-default values.
   - !ruby/object:Api::Resource
     name: 'ServicePerimeterResource'
     create_url: "{{perimeter_name}}"

--- a/products/accesscontextmanager/terraform.yaml
+++ b/products/accesscontextmanager/terraform.yaml
@@ -78,7 +78,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "service-perimeter"
         vars:
           access_level_name: "chromeos_no_lock"
-          service_perimeter_name: "restrict_all"
+          service_perimeter_name: "restrict_storage"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "access_context_manager_service_perimeter_dry-run"
+        skip_test: true
+        primary_resource_id: "service-perimeter"
+        vars:
+          service_perimeter_name: "restrict_bigquery_dryrun_storage"
     properties:
       parent: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true

--- a/templates/terraform/examples/access_context_manager_service_perimeter_basic.tf.erb
+++ b/templates/terraform/examples/access_context_manager_service_perimeter_basic.tf.erb
@@ -20,11 +20,11 @@ resource "google_access_context_manager_access_level" "access-level" {
         }
       }
       regions = [
-	"CH",
-	"IT",
-	"US",
+        "CH",
+        "IT",
+        "US",
       ]
-  }
+    }
   }
 }
 

--- a/templates/terraform/examples/access_context_manager_service_perimeter_dry-run.tf.erb
+++ b/templates/terraform/examples/access_context_manager_service_perimeter_dry-run.tf.erb
@@ -1,0 +1,23 @@
+resource "google_access_context_manager_service_perimeter" "<%= ctx[:primary_resource_id] %>" {
+  parent = "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}"
+  name   = "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}/servicePerimeters/<%= ctx[:vars]['service_perimeter_name'] %>"
+  title  = "<%= ctx[:vars]['service_perimeter_name'] %>"
+
+  # Service 'bigquery.googleapis.com' will be restricted.
+  status {
+    restricted_services = ["bigquery.googleapis.com"]
+  }
+
+  # Service 'storage.googleapis.com' will be in dry-run mode.
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+  }
+
+  use_explicit_dry_run_spec = true
+
+}
+
+resource "google_access_context_manager_access_policy" "access-policy" {
+  parent = "organizations/123456789"
+  title  = "my policy"
+}

--- a/third_party/terraform/tests/resource_access_context_manager_service_perimeter_test.go.erb
+++ b/third_party/terraform/tests/resource_access_context_manager_service_perimeter_test.go.erb
@@ -71,6 +71,14 @@ func testAccAccessContextManagerServicePerimeter_updateTest(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccAccessContextManagerServicePerimeter_updateAllowed(org, "my policy", "level", "perimeter"),
+			},
+			{
+				ResourceName:      "google_access_context_manager_service_perimeter.test-access",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }

--- a/third_party/terraform/tests/resource_access_context_manager_service_perimeter_test.go.erb
+++ b/third_party/terraform/tests/resource_access_context_manager_service_perimeter_test.go.erb
@@ -63,6 +63,14 @@ func testAccAccessContextManagerServicePerimeter_updateTest(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccAccessContextManagerServicePerimeter_updateDryrun(org, "my policy", "level", "perimeter"),
+			},
+			{
+				ResourceName:      "google_access_context_manager_service_perimeter.test-access",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -188,6 +196,45 @@ resource "google_access_context_manager_service_perimeter" "test-access" {
 	  allowed_services   = ["bigquery.googleapis.com"]
 	}
   }
+}
+`, org, policyTitle, levelTitleName, levelTitleName, perimeterTitleName, perimeterTitleName)
+}
+
+func testAccAccessContextManagerServicePerimeter_updateDryrun(org, policyTitle, levelTitleName, perimeterTitleName string) string {
+	return fmt.Sprintf(`
+resource "google_access_context_manager_access_policy" "test-access" {
+  parent = "organizations/%s"
+  title  = "%s"
+}
+
+resource "google_access_context_manager_access_level" "test-access" {
+  parent      = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}"
+  name        = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}/accessLevels/%s"
+  title       = "%s"
+  description = "hello"
+  basic {
+    combining_function = "AND"
+    conditions {
+      ip_subnetworks = ["192.0.4.0/24"]
+    }
+  }
+}
+
+resource "google_access_context_manager_service_perimeter" "test-access" {
+  parent         = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}"
+  name           = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}/servicePerimeters/%s"
+  title          = "%s"
+  perimeter_type = "PERIMETER_TYPE_REGULAR"
+  status {
+    restricted_services = ["bigquery.googleapis.com"]
+  }
+
+  spec {
+    restricted_services = ["storage.googleapis.com"]
+	access_levels       = [google_access_context_manager_access_level.test-access.name]
+  }
+
+  use_explicit_dry_run_spec = true
 }
 `, org, policyTitle, levelTitleName, levelTitleName, perimeterTitleName, perimeterTitleName)
 }


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
accesscontextmanager: added `spec` and `use_explicit_dry_run_spec` to `google_access_context_manager_service_perimeter` to test perimeter configurations in dry-run mode.
```
