### PR TITLE
treat project 404s correctly in project service read

### DIFF
--- a/third_party/terraform/resources/resource_google_project_service.go
+++ b/third_party/terraform/resources/resource_google_project_service.go
@@ -158,15 +158,15 @@ func resourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}) 
 
 	// Verify project for services still exists
 	p, err := config.clientResourceManager.Projects.Get(project).Do()
-	if err != nil {
-		return err
-	}
-	if p.LifecycleState == "DELETE_REQUESTED" {
+	if err == nil && p.LifecycleState == "DELETE_REQUESTED" {
 		// Construct a 404 error for handleNotFoundError
-		return &googleapi.Error{
+		err = &googleapi.Error{
 			Code:    404,
 			Message: "Project deletion was requested",
 		}
+	}
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("Project Service %s", d.Id()))
 	}
 
 	servicesRaw, err := BatchRequestReadServices(project, d, config)


### PR DESCRIPTION
Follow up to https://github.com/GoogleCloudPlatform/magic-modules/pull/3350 to fix failing `TestAccProjectService_handleNotFound` test.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
