### PR TITLE
remove ForceNew for dns_cache_config

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -263,7 +263,6 @@ func resourceContainerCluster() *schema.Resource {
 							Optional:     true,
 							Computed:     true,
 							AtLeastOneOf: addonsConfigKeys,
-							ForceNew:     true,
 							MaxItems:     1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -279,7 +279,6 @@ func resourceContainerCluster() *schema.Resource {
 							Optional:     true,
 							Computed:     true,
 							AtLeastOneOf: addonsConfigKeys,
-							ForceNew:     true,
 							MaxItems:     1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{


### PR DESCRIPTION
Removed `ForceNew` from `dns_cache_config`.
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6031

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: made `addons_config.dns_cache_config` able to be updated without recreating and destroying.
```

```release-note:bug
container: made `addons_config.cloudrun_config` able to be updated without recreating and destroying.
```
