### PR TITLE
Remove references to submodules from OiCS tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ final_api.yaml
 # Ansible PR Script
 tools/ansible-pr/templates/*
 !tools/ansible-pr/templates/.keep
+
+# Used by OiCS tutorial
+build/*

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -84,21 +84,15 @@ Now, let's compile those changes.
 
 Since we're running in Cloud Shell, this command will make sure we connect to GitHub via HTTPS
 instead of SSH. You will probably not have to do this in your typical development environment.
-```bash
-git config --file=.gitmodules submodule.build/ansible.url https://github.com/modular-magician/ansible.git && git submodule sync
-```
 
-## Compiling magic-modules
-
-Now, initialize the submodules in order to get an up-to-date version of each provider.
-Since we only changed the URL for Ansible, we'll only initialize that submodule.
-```bash
-git submodule update --init build/ansible
-```
-
-If you haven't already, run `bundle install` to make sure all ruby dependencies are available:
+First, uun `bundle install` to make sure all ruby dependencies are available:
 ```bash
 bundle install
+```
+
+Then, check out a copy of Ansible's GCP collection to a folder called `build/ansible`.
+```bash
+git clone https://github.com/ansible-collections/ansible_collections_google.git ./build/ansible
 ```
 
 Next, run the compiler:
@@ -107,7 +101,7 @@ bundle exec compiler -p products/pubsub -e ansible -o build/ansible
 ```
 
 This command tells us to run the compiler for the pubsub API, and generate Ansible into the
-`build/ansible` directory (where the submodule is).
+`build/ansible` directory.
 
 Let's see our changes! Navigate to the Ansible submodule and run `git diff` to see what changed:
 ```bash

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -85,7 +85,7 @@ Now, let's compile those changes.
 Since we're running in Cloud Shell, this command will make sure we connect to GitHub via HTTPS
 instead of SSH. You will probably not have to do this in your typical development environment.
 
-First, uun `bundle install` to make sure all ruby dependencies are available:
+First, run `bundle install` to make sure all ruby dependencies are available:
 ```bash
 bundle install
 ```


### PR DESCRIPTION
I gitignored the `build/` directory so that we can stage artifacts there. Git will automatically create the path to clone the repo into based on my testing.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
