### PR TITLE
check resource exists before returning error

### DIFF
--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -360,6 +360,10 @@ func resourceComposerEnvironmentCreate(d *schema.ResourceData, meta interface{})
 
 	if waitErr != nil {
 		err = CheckEnvExistsDespiteError(d, config, err)
+		// TODO (mbang): When warnings are available in the SDK, add a warning here, if possible
+		// This will likely create a permadiff, but that's ok, because what's in state won't match the confi
+		// The user will be able to see the diff, and where the error was and what they maybe need to fix. But this way
+		// The environment will at least be in state that they won't need to manually destroy and re-create.
 		if err != nil {
 			// The resource didn't actually get created, remove from state.
 			d.SetId("")
@@ -544,6 +548,10 @@ func resourceComposerEnvironmentPostCreateUpdate(updateEnv *composer.Environment
 		err := resourceComposerEnvironmentPatchField("config.softwareConfig.pypiPackages", updateEnv, d, cfg)
 		if err != nil {
 			err = CheckEnvExistsDespiteError(d, cfg, err)
+			// TODO (mbang): When warnings are available in the SDK, add a warning here, if possible
+			// This will likely create a permadiff, but that's ok, because what's in state won't match the config
+			// The user will be able to see the diff, and where the error was and what they maybe need to fix. But this way
+			// The environment will at least be in state that they won't need to manually destroy and re-create.
 			if err != nil {
 				return err
 			}

--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -359,24 +359,17 @@ func resourceComposerEnvironmentCreate(d *schema.ResourceData, meta interface{})
 		int(d.Timeout(schema.TimeoutCreate).Minutes()))
 
 	if waitErr != nil {
-		err = CheckEnvExistsDespiteError(d, config, err)
-		// TODO (mbang): When warnings are available in the SDK, add a warning here, if possible
-		// This will likely create a permadiff, but that's ok, because what's in state won't match the confi
-		// The user will be able to see the diff, and where the error was and what they maybe need to fix. But this way
-		// The environment will at least be in state that they won't need to manually destroy and re-create.
-		if err != nil {
-			// The resource didn't actually get created, remove from state.
-			d.SetId("")
+		// The resource didn't actually get created, remove from state.
+		d.SetId("")
 
-			errMsg := fmt.Sprintf("Error waiting to create Environment: %s", waitErr)
-			if err := handleComposerEnvironmentCreationOpFailure(id, envName, d, config); err != nil {
-				return fmt.Errorf("Error waiting to create Environment: %s. An initial "+
-					"environment was or is still being created, and clean up failed with "+
-					"error: %s.", errMsg, err)
-			}
-
-			return fmt.Errorf("Error waiting to create Environment: %s", waitErr)
+		errMsg := fmt.Sprintf("Error waiting to create Environment: %s", waitErr)
+		if err := handleComposerEnvironmentCreationOpFailure(id, envName, d, config); err != nil {
+			return fmt.Errorf("Error waiting to create Environment: %s. An initial "+
+				"environment was or is still being created, and clean up failed with "+
+				"error: %s.", errMsg, err)
 		}
+
+		return fmt.Errorf("Error waiting to create Environment: %s", waitErr)
 	}
 
 	log.Printf("[DEBUG] Finished creating Environment %q: %#v", d.Id(), op)

--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -359,17 +359,20 @@ func resourceComposerEnvironmentCreate(d *schema.ResourceData, meta interface{})
 		int(d.Timeout(schema.TimeoutCreate).Minutes()))
 
 	if waitErr != nil {
-		// The resource didn't actually get created, remove from state.
-		d.SetId("")
+		err = CheckEnvExistsDespiteError(d, config, err)
+		if err != nil {
+			// The resource didn't actually get created, remove from state.
+			d.SetId("")
 
-		errMsg := fmt.Sprintf("Error waiting to create Environment: %s", waitErr)
-		if err := handleComposerEnvironmentCreationOpFailure(id, envName, d, config); err != nil {
-			return fmt.Errorf("Error waiting to create Environment: %s. An initial "+
-				"environment was or is still being created, and clean up failed with "+
-				"error: %s.", errMsg, err)
+			errMsg := fmt.Sprintf("Error waiting to create Environment: %s", waitErr)
+			if err := handleComposerEnvironmentCreationOpFailure(id, envName, d, config); err != nil {
+				return fmt.Errorf("Error waiting to create Environment: %s. An initial "+
+					"environment was or is still being created, and clean up failed with "+
+					"error: %s.", errMsg, err)
+			}
+
+			return fmt.Errorf("Error waiting to create Environment: %s", waitErr)
 		}
-
-		return fmt.Errorf("Error waiting to create Environment: %s", waitErr)
 	}
 
 	log.Printf("[DEBUG] Finished creating Environment %q: %#v", d.Id(), op)
@@ -540,7 +543,10 @@ func resourceComposerEnvironmentPostCreateUpdate(updateEnv *composer.Environment
 		log.Printf("[DEBUG] Running post-create update for Environment %q", d.Id())
 		err := resourceComposerEnvironmentPatchField("config.softwareConfig.pypiPackages", updateEnv, d, cfg)
 		if err != nil {
-			return err
+			err = CheckEnvExistsDespiteError(d, cfg, err)
+			if err != nil {
+				return err
+			}
 		}
 
 		log.Printf("[DEBUG] Finish update to Environment %q post create for update only fields", d.Id())
@@ -616,6 +622,22 @@ func resourceComposerEnvironmentImport(d *schema.ResourceData, meta interface{})
 	d.SetId(id)
 
 	return []*schema.ResourceData{d}, nil
+}
+
+
+// In some cases err will be populated, but really the environment is ok, we'll fetch the environment here
+// check that it exists, and if it's fine, we'll continue, if not, we'll return the original error
+func CheckEnvExistsDespiteError(d *schema.ResourceData, cfg *Config, err error) error {
+	envName, envNameErr := resourceComposerEnvironmentName(d, cfg)
+	if envNameErr != nil {
+		return envNameErr
+	}
+
+	if _, readErr := cfg.clientComposer.Projects.Locations.Environments.Get(envName.resourceName()).Do(); readErr != nil {
+		return err
+	}
+
+	return nil
 }
 
 func flattenComposerEnvironmentConfig(envCfg *composer.EnvironmentConfig) interface{} {

--- a/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -241,6 +241,46 @@ func TestAccComposerEnvironment_withSoftwareConfig(t *testing.T) {
 	})
 }
 
+func TestAccComposerEnvironment_withPyPiAirflow(t *testing.T) {
+	t.Parallel()
+	envName := acctest.RandomWithPrefix(testComposerEnvironmentPrefix)
+	network := acctest.RandomWithPrefix(testComposerNetworkPrefix)
+	subnetwork := network + "-1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccComposerEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComposerEnvironment_airflow(envName, network, subnetwork, "foo"),
+			},
+			{
+				ResourceName:      "google_composer_environment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComposerEnvironment_airflow(envName, network, subnetwork, "bar"),
+			},
+			{
+				ResourceName:      "google_composer_environment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// This is a terrible clean-up step in order to get destroy to succeed,
+			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
+			// TODO(emilyye): Remove this check if firewall rules bug gets fixed by Composer.
+			{
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+				Config:             testAccComposerEnvironment_airflow(envName, network, subnetwork, "bar"),
+				Check:              testAccCheckClearComposerEnvironmentFirewalls(network),
+			},
+		},
+	})
+}
+
 // Checks behavior of config for creation for attributes that must
 // be updated during create.
 func TestAccComposerEnvironment_withUpdateOnCreate(t *testing.T) {
@@ -505,6 +545,58 @@ resource "google_compute_subnetwork" "test" {
   network       = google_compute_network.test.self_link
 }
 `, name, network, subnetwork)
+}
+
+func testAccComposerEnvironment_airflow(name, network, subnetwork, label string) string {
+	return fmt.Sprintf(`
+data "google_composer_image_versions" "all" {
+}
+
+resource "google_composer_environment" "test" {
+  name   = "%s"
+  region = "us-central1"
+  config {
+    node_config {
+      network    = google_compute_network.test.self_link
+      subnetwork = google_compute_subnetwork.test.self_link
+      zone       = "us-central1-a"
+    }
+    software_config {
+      python_version = 3
+      pypi_packages = {
+        pytest = ""
+        google-cloud-bigquery = ""
+        google-cloud-storage = ""
+        apache-airflow = "[gcp_api]"
+        werkzeug = "==0.15.4"
+      }
+
+      env_variables = {
+        project_id = "hc-terraform-testing"
+      }
+      image_version  = data.google_composer_image_versions.all.image_versions[0].image_version_id
+    }
+  }
+
+  labels = {
+    foo = "%s"
+  }
+}
+
+// use a separate network to avoid conflicts with other tests running in parallel
+// that use the default network/subnet
+resource "google_compute_network" "test" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+  name          = "%s"
+  ip_cidr_range = "10.2.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.test.self_link
+}
+`, name, label, network, subnetwork)
 }
 
 func testAccComposerEnvironment_updateOnlyFields(name, network, subnetwork string) string {

--- a/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -241,46 +241,6 @@ func TestAccComposerEnvironment_withSoftwareConfig(t *testing.T) {
 	})
 }
 
-func TestAccComposerEnvironment_withPyPiAirflow(t *testing.T) {
-	t.Parallel()
-	envName := acctest.RandomWithPrefix(testComposerEnvironmentPrefix)
-	network := acctest.RandomWithPrefix(testComposerNetworkPrefix)
-	subnetwork := network + "-1"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccComposerEnvironmentDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComposerEnvironment_airflow(envName, network, subnetwork, "foo"),
-			},
-			{
-				ResourceName:      "google_composer_environment.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			{
-				Config: testAccComposerEnvironment_airflow(envName, network, subnetwork, "bar"),
-			},
-			{
-				ResourceName:      "google_composer_environment.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			// This is a terrible clean-up step in order to get destroy to succeed,
-			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
-			// TODO(emilyye): Remove this check if firewall rules bug gets fixed by Composer.
-			{
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: false,
-				Config:             testAccComposerEnvironment_airflow(envName, network, subnetwork, "bar"),
-				Check:              testAccCheckClearComposerEnvironmentFirewalls(network),
-			},
-		},
-	})
-}
-
 // Checks behavior of config for creation for attributes that must
 // be updated during create.
 func TestAccComposerEnvironment_withUpdateOnCreate(t *testing.T) {
@@ -545,58 +505,6 @@ resource "google_compute_subnetwork" "test" {
   network       = google_compute_network.test.self_link
 }
 `, name, network, subnetwork)
-}
-
-func testAccComposerEnvironment_airflow(name, network, subnetwork, label string) string {
-	return fmt.Sprintf(`
-data "google_composer_image_versions" "all" {
-}
-
-resource "google_composer_environment" "test" {
-  name   = "%s"
-  region = "us-central1"
-  config {
-    node_config {
-      network    = google_compute_network.test.self_link
-      subnetwork = google_compute_subnetwork.test.self_link
-      zone       = "us-central1-a"
-    }
-    software_config {
-      python_version = 3
-      pypi_packages = {
-        pytest = ""
-        google-cloud-bigquery = ""
-        google-cloud-storage = ""
-        apache-airflow = "[gcp_api]"
-        werkzeug = "==0.15.4"
-      }
-
-      env_variables = {
-        project_id = "hc-terraform-testing"
-      }
-      image_version  = data.google_composer_image_versions.all.image_versions[0].image_version_id
-    }
-  }
-
-  labels = {
-    foo = "%s"
-  }
-}
-
-// use a separate network to avoid conflicts with other tests running in parallel
-// that use the default network/subnet
-resource "google_compute_network" "test" {
-  name                    = "%s"
-  auto_create_subnetworks = false
-}
-
-resource "google_compute_subnetwork" "test" {
-  name          = "%s"
-  ip_cidr_range = "10.2.0.0/16"
-  region        = "us-central1"
-  network       = google_compute_network.test.self_link
-}
-`, name, label, network, subnetwork)
 }
 
 func testAccComposerEnvironment_updateOnlyFields(name, network, subnetwork string) string {


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/4146

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
composer: added check if `environment` exists after create, and if it does, it won't return the original error
```
