### PR TITLE
make display name optional on monitoring notification channel

### DIFF
--- a/products/monitoring/api.yaml
+++ b/products/monitoring/api.yaml
@@ -901,7 +901,6 @@ objects:
         the channel. This may not exceed 1024 Unicode characters.
     - !ruby/object:Api::Type::String
       name: displayName
-      required: true
       description: An optional human-readable name for this notification channel. It
         is recommended that you specify a non-empty and unique name in order to make
         it easier to identify the channels in your project, though this is not enforced.


### PR DESCRIPTION
I could go either way on this, but to stay consistent with the API, I made it `Optional`.  If we think it should be `Required` (since that is the recommendation of the API), I'm happy to just make a doc update.

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6084

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
monitoring: made `display_name` optional on `google_monitoring_notification_channel `
```
