### PR TITLE
Added name field to both custom project and org roles

### DIFF
--- a/third_party/terraform/resources/resource_google_organization_iam_custom_role.go
+++ b/third_party/terraform/resources/resource_google_organization_iam_custom_role.go
@@ -55,6 +55,10 @@ func resourceGoogleOrganizationIamCustomRole() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"name": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/third_party/terraform/resources/resource_google_organization_iam_custom_role.go
+++ b/third_party/terraform/resources/resource_google_organization_iam_custom_role.go
@@ -122,6 +122,7 @@ func resourceGoogleOrganizationIamCustomRoleRead(d *schema.ResourceData, meta in
 	d.Set("role_id", parsedRoleName.Name)
 	d.Set("org_id", parsedRoleName.OrgId)
 	d.Set("title", role.Title)
+	d.Set("name", role.Name)
 	d.Set("description", role.Description)
 	d.Set("permissions", role.IncludedPermissions)
 	d.Set("stage", role.Stage)

--- a/third_party/terraform/resources/resource_google_organization_iam_custom_role.go
+++ b/third_party/terraform/resources/resource_google_organization_iam_custom_role.go
@@ -56,7 +56,7 @@ func resourceGoogleOrganizationIamCustomRole() *schema.Resource {
 				Computed: true,
 			},
 			"name": {
-				Type:     schema.TypeBool,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},

--- a/third_party/terraform/resources/resource_google_project_iam_custom_role.go
+++ b/third_party/terraform/resources/resource_google_project_iam_custom_role.go
@@ -126,6 +126,7 @@ func resourceGoogleProjectIamCustomRoleRead(d *schema.ResourceData, meta interfa
 
 	d.Set("role_id", GetResourceNameFromSelfLink(role.Name))
 	d.Set("title", role.Title)
+	d.Set("name", role.Name)
 	d.Set("description", role.Description)
 	d.Set("permissions", role.IncludedPermissions)
 	d.Set("stage", role.Stage)

--- a/third_party/terraform/resources/resource_google_project_iam_custom_role.go
+++ b/third_party/terraform/resources/resource_google_project_iam_custom_role.go
@@ -58,6 +58,10 @@ func resourceGoogleProjectIamCustomRole() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
+			"name": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 		},
 	}
 }

--- a/third_party/terraform/resources/resource_google_project_iam_custom_role.go
+++ b/third_party/terraform/resources/resource_google_project_iam_custom_role.go
@@ -59,7 +59,7 @@ func resourceGoogleProjectIamCustomRole() *schema.Resource {
 				Computed: true,
 			},
 			"name": {
-				Type:     schema.TypeBool,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 		},

--- a/third_party/terraform/website/docs/r/google_organization_iam_custom_role.html.markdown
+++ b/third_party/terraform/website/docs/r/google_organization_iam_custom_role.html.markdown
@@ -60,7 +60,9 @@ exported:
 
 * `deleted` - (Optional) The current deleted state of the role.
 
-* `name` - The name of the role which can be used with iam role bindings in the format `organizations/{{org_id}}/roles/{{role_id}}`
+* `id` - an identifier for the resource with the format `organizations/{{org_id}}/roles/{{role_id}}`
+
+* `name` - The name of the role in the format `organizations/{{org_id}}/roles/{{role_id}}`. Like `id`, this field can be used as a reference in other resources such as IAM role bindings.
 
 ## Import
 

--- a/third_party/terraform/website/docs/r/google_organization_iam_custom_role.html.markdown
+++ b/third_party/terraform/website/docs/r/google_organization_iam_custom_role.html.markdown
@@ -60,6 +60,8 @@ exported:
 
 * `deleted` - (Optional) The current deleted state of the role.
 
+* `name` - The name of the role which can be used with iam role bindings in the format `organizations/{{org_id}}/roles/{{role_id}}`
+
 ## Import
 
 Customized IAM organization role can be imported using their URI, e.g.

--- a/third_party/terraform/website/docs/r/google_project_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_iam.html.markdown
@@ -28,7 +28,7 @@ Four different resources help you manage your IAM policy for a project. Each of 
    from anyone without organization-level access to the project. Proceed with caution.
    It's not recommended to use `google_project_iam_policy` with your provider project
    to avoid locking yourself out, and it should generally only be used with projects
-   fully managed by Terraform. If you do use this resource, **import** the policy before
+   fully managed by Terraform. If you do use this resource, it is recommended to **import** the policy before
    applying the change.
 
 ```hcl

--- a/third_party/terraform/website/docs/r/google_project_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_iam.html.markdown
@@ -28,7 +28,8 @@ Four different resources help you manage your IAM policy for a project. Each of 
    from anyone without organization-level access to the project. Proceed with caution.
    It's not recommended to use `google_project_iam_policy` with your provider project
    to avoid locking yourself out, and it should generally only be used with projects
-   fully managed by Terraform.
+   fully managed by Terraform. If you do use this resource, **import** the policy before
+   applying the change.
 
 ```hcl
 resource "google_project_iam_policy" "project" {

--- a/third_party/terraform/website/docs/r/google_project_iam_custom_role.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_iam_custom_role.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `stage` - (Optional) The current launch stage of the role.
     Defaults to `GA`.
-    List of possible stages is [here](https://cloud.google.com/iam/reference/rest/v1/projects.roles#Role.RoleLaunchStage).
+    List of possible stages is [here](https://cloud.google.com/iam/reference/rest/v1/organizations.roles#Role.RoleLaunchStage).
 
 * `description` - (Optional) A human-readable description for the role.
 
@@ -60,7 +60,9 @@ exported:
 
  * `deleted` - (Optional) The current deleted state of the role.
 
- * `name` - The name of the role which can be used with iam role bindings in the format `projects/{{project}}/roles/{{role_id}}`
+ * `id` - an identifier for the resource with the format `projects/{{project}}/roles/{{role_id}}`
+
+ * `name` - The name of the role in the format `projects/{{project}}/roles/{{role_id}}`. Like `id`, this field can be used as a reference in other resources such as IAM role bindings.
 
 ## Import
 

--- a/third_party/terraform/website/docs/r/google_project_iam_custom_role.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_iam_custom_role.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 
 * `stage` - (Optional) The current launch stage of the role.
     Defaults to `GA`.
-    List of possible stages is [here](https://cloud.google.com/iam/reference/rest/v1/organizations.roles#Role.RoleLaunchStage).
+    List of possible stages is [here](https://cloud.google.com/iam/reference/rest/v1/projects.roles#Role.RoleLaunchStage).
 
 * `description` - (Optional) A human-readable description for the role.
 
@@ -59,6 +59,8 @@ The following arguments are supported:
 exported:
 
  * `deleted` - (Optional) The current deleted state of the role.
+
+ * `name` - The name of the role which can be used with iam role bindings in the format `projects/{{project}}/roles/{{role_id}}`
 
 ## Import
 


### PR DESCRIPTION
I updated the custom roles to export the name attribute so it can be used with iam role bindings.

I also updated the project_iam_policy article to include a note about importing the policy first before applying the change.

Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/6089

https://cloud.google.com/iam/docs/reference/rest/v1/projects.roles#resource:-role

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
iam: Added `name` field to `google_project_iam_custom_role`
iam: Added `name` field to `google_organization_iam_custom_role`
```
