### PR TITLE
Service Directory resources

### DIFF
--- a/products/servicedirectory/api.yaml
+++ b/products/servicedirectory/api.yaml
@@ -164,11 +164,12 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'address'
         description: |
-          An IPv4 or IPv6 address.
+          IPv4 or IPv6 address of the endpoint.
       - !ruby/object:Api::Type::Integer
         name: 'port'
         description: |
-          Service Directory will reject values outside of [0, 65535].
+          Port that the endpoint is running on, must be in the
+          range of [0, 65535]. If unspecified, the default is 0.
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'metadata'
         description: |

--- a/products/servicedirectory/api.yaml
+++ b/products/servicedirectory/api.yaml
@@ -58,7 +58,8 @@ objects:
       - !ruby/object:Api::Type::String
         name: namespaceId
         description: |
-          The Resource ID must be 1-63 characters long, and comply with RFC1035.
+          The Resource ID must be 1-63 characters long, including digits,
+          lowercase letters or the hyphen character.
         required: true
         input: true
         url_param_only: true
@@ -105,7 +106,8 @@ objects:
       - !ruby/object:Api::Type::String
         name: serviceId
         description: |
-          The Resource ID must be 1-63 characters long, and comply with RFC1035.
+          The Resource ID must be 1-63 characters long, including digits,
+          lowercase letters or the hyphen character.
         required: true
         input: true
         url_param_only: true
@@ -147,7 +149,8 @@ objects:
       - !ruby/object:Api::Type::String
         name: endpointId
         description: |
-          The Resource ID must be 1-63 characters long, and comply with RFC1035.
+          The Resource ID must be 1-63 characters long, including digits,
+          lowercase letters or the hyphen character.
         required: true
         input: true
         url_param_only: true

--- a/products/servicedirectory/api.yaml
+++ b/products/servicedirectory/api.yaml
@@ -1,0 +1,176 @@
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: ServiceDirectory
+display_name: ServiceDirectory
+versions:
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://servicedirectory.googleapis.com/v1beta1/
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: Service Directory API
+    url: https://console.cloud.google.com/apis/library/servicedirectory.googleapis.com/
+objects:
+  - !ruby/object:Api::Resource
+    name: 'Namespace'
+    base_url: '{{name}}'
+    create_url: 'projects/{{project}}/locations/{{location}}/namespaces?namespaceId={{namespace_id}}'
+    self_link: '{{name}}'
+    update_verb: :PATCH
+    update_mask: true
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Configuring a namespace': 'https://cloud.google.com/service-directory/docs/configuring-service-directory#configuring_a_namespace'
+      api: 'https://cloud.google.com/service-directory/docs/reference/rest/v1beta1/projects.locations.namespaces'
+    iam_policy: !ruby/object:Api::Resource::IamPolicy
+      exclude: false
+      parent_resource_attribute: 'name'
+      method_name_separator: ':'
+      fetch_iam_policy_verb: :POST
+      set_iam_policy_verb: :POST
+    min_version: beta
+    description: |
+      A container for `services`. Namespaces allow administrators to group services
+      together and define permissions for a collection of services.
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: 'location'
+        description: |
+          The location for the Namespace.
+          A full list of valid locations can be found by running
+          `gcloud beta service-directory locations list`.
+        required: true
+        url_param_only: true
+      - !ruby/object:Api::Type::String
+        name: namespaceId
+        description: |
+          The Resource ID must be 1-63 characters long, and comply with RFC1035.
+        required: true
+        input: true
+        url_param_only: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          The resource name for the namespace
+          in the format `projects/*/locations/*/namespaces/*`.
+        output: true
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'labels'
+        description: |
+          Resource labels associated with this Namespace. No more than 64 user
+          labels can be associated with a given resource. Label keys and values can
+          be no longer than 63 characters.
+  - !ruby/object:Api::Resource
+    name: 'Service'
+    base_url: '{{name}}'
+    create_url: '{{namespace}}/services?serviceId={{service_id}}'
+    self_link: '{{name}}'
+    update_verb: :PATCH
+    update_mask: true
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Configuring a service': 'https://cloud.google.com/service-directory/docs/configuring-service-directory#configuring_a_service'
+      api: 'https://cloud.google.com/service-directory/docs/reference/rest/v1beta1/projects.locations.namespaces.services'
+    iam_policy: !ruby/object:Api::Resource::IamPolicy
+      exclude: false
+      parent_resource_attribute: 'name'
+      method_name_separator: ':'
+      fetch_iam_policy_verb: :POST
+      set_iam_policy_verb: :POST
+    min_version: beta
+    description: |
+      An individual service. A service contains a name and optional metadata.
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: 'namespace'
+        description: |
+          The resource name of the namespace this service will belong to.
+        required: true
+        url_param_only: true
+      - !ruby/object:Api::Type::String
+        name: serviceId
+        description: |
+          The Resource ID must be 1-63 characters long, and comply with RFC1035.
+        required: true
+        input: true
+        url_param_only: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          The resource name for the service in the
+          format `projects/*/locations/*/namespaces/*/services/*`.
+        output: true
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'metadata'
+        description: |
+          Metadata for the service. This data can be consumed
+          by service clients. The entire metadata dictionary may contain
+          up to 2000 characters, spread across all key-value pairs.
+          Metadata that goes beyond any these limits will be rejected.
+  - !ruby/object:Api::Resource
+    name: 'Endpoint'
+    base_url: '{{name}}'
+    create_url: '{{service}}/endpoints?endpointId={{endpoint_id}}'
+    self_link: '{{name}}'
+    update_verb: :PATCH
+    update_mask: true
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Configuring an endpoint': 'https://cloud.google.com/service-directory/docs/configuring-service-directory#configuring_an_endpoint'
+      api: 'https://cloud.google.com/service-directory/docs/reference/rest/v1beta1/projects.locations.namespaces.services.endpoints'
+    min_version: beta
+    description: |
+      An individual endpoint that provides a service.
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: 'service'
+        description: |
+          The resource name of the service that this endpoint provides.
+        required: true
+        url_param_only: true
+      - !ruby/object:Api::Type::String
+        name: endpointId
+        description: |
+          The Resource ID must be 1-63 characters long, and comply with RFC1035.
+        required: true
+        input: true
+        url_param_only: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+          The resource name for the endpoint in the format
+          `projects/*/locations/*/namespaces/*/services/*/endpoints/*`.
+        output: true
+      - !ruby/object:Api::Type::String
+        name: 'address'
+        description: |
+          An IPv4 or IPv6 address.
+      - !ruby/object:Api::Type::Integer
+        name: 'port'
+        description: |
+          Service Directory will reject values outside of [0, 65535].
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'metadata'
+        description: |
+          Metadata for the endpoint. This data can be consumed
+          by service clients. The entire metadata dictionary may contain
+          up to 512 characters, spread across all key-value pairs.
+          Metadata that goes beyond any these limits will be rejected.
+

--- a/products/servicedirectory/terraform.yaml
+++ b/products/servicedirectory/terraform.yaml
@@ -25,6 +25,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       location: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
+      namespaceId: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validateRFC1035Name(2, 63)'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/service_directory_namespace.go.erb
   Service: !ruby/object:Overrides::Terraform::ResourceOverride
@@ -40,6 +43,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       namespace: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
+      serviceId: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validateRFC1035Name(2, 63)'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/service_directory_service.go.erb
   Endpoint: !ruby/object:Overrides::Terraform::ResourceOverride
@@ -56,6 +62,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       service: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
+      endpointId: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validateRFC1035Name(2, 63)'
+      address: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validateIpAddress'
+      port: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.IntBetween(0, 65535)'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/service_directory_endpoint.go.erb
 files: !ruby/object:Provider::Config::Files

--- a/products/servicedirectory/terraform.yaml
+++ b/products/servicedirectory/terraform.yaml
@@ -25,8 +25,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       location: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      custom_import: templates/terraform/custom_import/service_directory_namespace.go.erb
   Service: !ruby/object:Overrides::Terraform::ResourceOverride
-    import_format: ["{{namespace}}/services/{{service_id}}"]
+    import_format: ["projects/{{project}}/locations/{{location}}/namespaces/{{namespace_id}}/services/{{service_id}}"]
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "service_directory_service_basic"
@@ -38,8 +40,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       namespace: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      custom_import: templates/terraform/custom_import/service_directory_service.go.erb
   Endpoint: !ruby/object:Overrides::Terraform::ResourceOverride
-    import_format: ["{{service}}/endpoints/{{name}}"]
+    import_format: ["projects/{{project}}/locations/{{location}}/namespaces/{{namespace_id}}/services/{{service_id}}/endpoints/{{endpoint_id}}"]
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "service_directory_endpoint_basic"
@@ -52,6 +56,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       service: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      custom_import: templates/terraform/custom_import/service_directory_endpoint.go.erb
 files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.
   # This is usually to add licensing info, autogeneration notices, etc.

--- a/products/servicedirectory/terraform.yaml
+++ b/products/servicedirectory/terraform.yaml
@@ -1,0 +1,59 @@
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Terraform::Config
+overrides: !ruby/object:Overrides::ResourceOverrides
+  Namespace: !ruby/object:Overrides::Terraform::ResourceOverride
+    import_format: ["projects/{{project}}/locations/{{location}}/namespaces/{{namespace_id}}"]
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "service_directory_namespace_basic"
+        primary_resource_id: "example"
+        vars:
+          namespace_id: "example-namespace"
+        min_version: beta
+    properties:
+      location: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
+  Service: !ruby/object:Overrides::Terraform::ResourceOverride
+    import_format: ["{{namespace}}/services/{{service_id}}"]
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "service_directory_service_basic"
+        primary_resource_id: "example"
+        vars:
+          service_id: "example-service"
+          namespace_id: "example-namespace"
+        min_version: beta
+    properties:
+      namespace: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
+  Endpoint: !ruby/object:Overrides::Terraform::ResourceOverride
+    import_format: ["{{service}}/endpoints/{{name}}"]
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "service_directory_endpoint_basic"
+        primary_resource_id: "example"
+        vars:
+          service_id: "example-service"
+          namespace_id: "example-namespace"
+          endpoint_id: "example-endpoint"
+        min_version: beta
+    properties:
+      service: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
+files: !ruby/object:Provider::Config::Files
+  # These files have templating (ERB) code that will be run.
+  # This is usually to add licensing info, autogeneration notices, etc.
+  compile:
+<%= lines(indent(compile('provider/terraform/product~compile.yaml'), 4)) -%>

--- a/templates/terraform/custom_import/service_directory_endpoint.go.erb
+++ b/templates/terraform/custom_import/service_directory_endpoint.go.erb
@@ -1,0 +1,19 @@
+config := meta.(*Config)
+
+// current import_formats can't import fields with forward slashes in their value
+if err := parseImportId([]string{"(?P<name>.+)"}, d, config); err != nil {
+	return nil, err
+}
+
+nameParts := strings.Split(d.Get("name").(string), "/")
+if len(nameParts) != 10 {
+	return nil, fmt.Errorf(
+			"Saw %s when the name is expected to have shape %s",
+			d.Get("name"),
+			"projects/{{project}}/locations/{{location}}/namespaces/{{namespace_id}}/services/{{service_id}}/endpoints/{{endpoint_id}}",
+		)
+}
+
+d.Set("service", fmt.Sprintf("projects/%s/locations/%s/namespaces/%s/services/%s", nameParts[1], nameParts[3], nameParts[5], nameParts[7]))
+d.Set("endpoint_id", nameParts[9])
+return []*schema.ResourceData{d}, nil

--- a/templates/terraform/custom_import/service_directory_endpoint.go.erb
+++ b/templates/terraform/custom_import/service_directory_endpoint.go.erb
@@ -1,19 +1,39 @@
 config := meta.(*Config)
 
-// current import_formats can't import fields with forward slashes in their value
+// current import_formats cannot import fields with forward slashes in their value
 if err := parseImportId([]string{"(?P<name>.+)"}, d, config); err != nil {
 	return nil, err
 }
 
 nameParts := strings.Split(d.Get("name").(string), "/")
-if len(nameParts) != 10 {
+if len(nameParts) == 10 {
+	// `projects/{{project}}/locations/{{location}}/namespaces/{{namespace_id}}/services/{{service_id}}/endpoints/{{endpoint_id}}`
+	d.Set("service", fmt.Sprintf("projects/%s/locations/%s/namespaces/%s/services/%s", nameParts[1], nameParts[3], nameParts[5], nameParts[7]))
+	d.Set("endpoint_id", nameParts[9])
+} else if len(nameParts) == 5 {
+	// `{{project}}/{{location}}/{{namespace_id}}/{{service_id}}/{{endpoint_id}}`
+	d.Set("service", fmt.Sprintf("projects/%s/locations/%s/namespaces/%s/services/%s", nameParts[0], nameParts[1], nameParts[2], nameParts[3]))
+	d.Set("endpoint_id", nameParts[4])
+	id := fmt.Sprintf("projects/%s/locations/%s/namespaces/%s/services/%s/endpoints/%s", nameParts[0], nameParts[1], nameParts[2], nameParts[3], nameParts[4])
+	d.Set("name", id)
+	d.SetId(id)
+} else if len(nameParts) == 4 {
+	// `{{location}}/{{namespace_id}}/{{service_id}}/{{endpoint_id}}`
+	project, err := getProject(d, config)
+	if err != nil {
+			return nil, err
+	}
+	d.Set("service", fmt.Sprintf("projects/%s/locations/%s/namespaces/%s/services/%s", project, nameParts[0], nameParts[1], nameParts[2]))
+	d.Set("endpoint_id", nameParts[3])
+	id := fmt.Sprintf("projects/%s/locations/%s/namespaces/%s/services/%s/endpoints/%s", project, nameParts[0], nameParts[1], nameParts[2], nameParts[3])
+	d.Set("name", id)
+	d.SetId(id)
+} else {
 	return nil, fmt.Errorf(
-			"Saw %s when the name is expected to have shape %s",
-			d.Get("name"),
-			"projects/{{project}}/locations/{{location}}/namespaces/{{namespace_id}}/services/{{service_id}}/endpoints/{{endpoint_id}}",
-		)
+		"Saw %s when the name is expected to have shape %s, %s or %s",
+		d.Get("name"),
+		"projects/{{project}}/locations/{{location}}/namespaces/{{namespace_id}}/services/{{service_id}}/endpoints/{{endpoint_id}}",
+		"{{project}}/{{location}}/{{namespace_id}}/{{service_id}}/{{endpoint_id}}",
+		"{{location}}/{{namespace_id}}/{{service_id}}/{{endpoint_id}}")
 }
-
-d.Set("service", fmt.Sprintf("projects/%s/locations/%s/namespaces/%s/services/%s", nameParts[1], nameParts[3], nameParts[5], nameParts[7]))
-d.Set("endpoint_id", nameParts[9])
 return []*schema.ResourceData{d}, nil

--- a/templates/terraform/custom_import/service_directory_namespace.go.erb
+++ b/templates/terraform/custom_import/service_directory_namespace.go.erb
@@ -1,0 +1,20 @@
+config := meta.(*Config)
+
+// current import_formats can't import fields with forward slashes in their value
+if err := parseImportId([]string{"(?P<name>.+)"}, d, config); err != nil {
+	return nil, err
+}
+
+nameParts := strings.Split(d.Get("name").(string), "/")
+if len(nameParts) != 6 {
+	return nil, fmt.Errorf(
+			"Saw %s when the name is expected to have shape %s",
+			d.Get("name"),
+			"projects/{{project}}/locations/{{location}}/namespaces/{{namespace_id}}",
+		)
+}
+
+d.Set("project", nameParts[1])
+d.Set("location", nameParts[3])
+d.Set("namespace_id", nameParts[5])
+return []*schema.ResourceData{d}, nil

--- a/templates/terraform/custom_import/service_directory_namespace.go.erb
+++ b/templates/terraform/custom_import/service_directory_namespace.go.erb
@@ -1,20 +1,42 @@
 config := meta.(*Config)
 
-// current import_formats can't import fields with forward slashes in their value
+// current import_formats cannot import fields with forward slashes in their value
 if err := parseImportId([]string{"(?P<name>.+)"}, d, config); err != nil {
 	return nil, err
 }
 
 nameParts := strings.Split(d.Get("name").(string), "/")
-if len(nameParts) != 6 {
+if len(nameParts) == 6 {
+	// `projects/{{project}}/locations/{{location}}/namespaces/{{namespace_id}}`
+	d.Set("project", nameParts[1])
+	d.Set("location", nameParts[3])
+	d.Set("namespace_id", nameParts[5])
+} else if len(nameParts) == 3 {
+	// `{{project}}/{{location}}/{{namespace_id}}`
+	d.Set("project", nameParts[0])
+	d.Set("location", nameParts[1])
+	d.Set("namespace_id", nameParts[2])
+	id := fmt.Sprintf("projects/%s/locations/%s/namespaces/%s", nameParts[0], nameParts[1], nameParts[2])
+	d.Set("name", id)
+	d.SetId(id)
+} else if len(nameParts) == 2 {
+	// `{{location}}/{{namespace_id}}`
+	project, err := getProject(d, config)
+	if err != nil {
+			return nil, err
+	}
+	d.Set("project", project)
+	d.Set("location", nameParts[0])
+	d.Set("namespace_id", nameParts[1])
+	id := fmt.Sprintf("projects/%s/locations/%s/namespaces/%s", project, nameParts[0], nameParts[1])
+	d.Set("name", id)
+	d.SetId(id)
+} else {
 	return nil, fmt.Errorf(
-			"Saw %s when the name is expected to have shape %s",
-			d.Get("name"),
-			"projects/{{project}}/locations/{{location}}/namespaces/{{namespace_id}}",
-		)
+		"Saw %s when the name is expected to have shape %s, %s or %s",
+		d.Get("name"),
+		"projects/{{project}}/locations/{{location}}/namespaces/{{namespace_id}}",
+		"{{project}}/{{location}}/{{namespace_id}}",
+		"{{location}}/{{namespace_id}}")
 }
-
-d.Set("project", nameParts[1])
-d.Set("location", nameParts[3])
-d.Set("namespace_id", nameParts[5])
 return []*schema.ResourceData{d}, nil

--- a/templates/terraform/custom_import/service_directory_service.go.erb
+++ b/templates/terraform/custom_import/service_directory_service.go.erb
@@ -1,0 +1,19 @@
+config := meta.(*Config)
+
+// current import_formats can't import fields with forward slashes in their value
+if err := parseImportId([]string{"(?P<name>.+)"}, d, config); err != nil {
+	return nil, err
+}
+
+nameParts := strings.Split(d.Get("name").(string), "/")
+if len(nameParts) != 8 {
+	return nil, fmt.Errorf(
+			"Saw %s when the name is expected to have shape %s",
+			d.Get("name"),
+			"projects/{{project}}/locations/{{location}}/namespaces/{{namespace_id}}/services/{{service_id}}",
+		)
+}
+
+d.Set("namespace", fmt.Sprintf("projects/%s/locations/%s/namespaces/%s", nameParts[1], nameParts[3], nameParts[5]))
+d.Set("service_id", nameParts[7])
+return []*schema.ResourceData{d}, nil

--- a/templates/terraform/custom_import/service_directory_service.go.erb
+++ b/templates/terraform/custom_import/service_directory_service.go.erb
@@ -1,19 +1,40 @@
 config := meta.(*Config)
 
-// current import_formats can't import fields with forward slashes in their value
+// current import_formats cannot import fields with forward slashes in their value
 if err := parseImportId([]string{"(?P<name>.+)"}, d, config); err != nil {
 	return nil, err
 }
 
 nameParts := strings.Split(d.Get("name").(string), "/")
-if len(nameParts) != 8 {
+if len(nameParts) == 8 {
+	// `projects/{{project}}/locations/{{location}}/namespaces/{{namespace_id}}/services/{{service_id}}`
+	d.Set("namespace", fmt.Sprintf("projects/%s/locations/%s/namespaces/%s", nameParts[1], nameParts[3], nameParts[5]))
+	d.Set("service_id", nameParts[7])
+} else if len(nameParts) == 4 {
+	// `{{project}}/{{location}}/{{namespace_id}}/{{service_id}}`
+	d.Set("namespace", fmt.Sprintf("projects/%s/locations/%s/namespaces/%s", nameParts[0], nameParts[1], nameParts[2]))
+	d.Set("service_id", nameParts[3])
+	id := fmt.Sprintf("projects/%s/locations/%s/namespaces/%s/services/%s", nameParts[0], nameParts[1], nameParts[2], nameParts[3])
+	d.Set("name", id)
+	d.SetId(id)
+} else if len(nameParts) == 3 {
+	// `{{location}}/{{namespace_id}}/{{service_id}}`
+	project, err := getProject(d, config)
+	if err != nil {
+			return nil, err
+	}
+	d.Set("namespace", fmt.Sprintf("projects/%s/locations/%s/namespaces/%s", project, nameParts[0], nameParts[1]))
+	d.Set("service_id", nameParts[2])
+	id := fmt.Sprintf("projects/%s/locations/%s/namespaces/%s/services/%s", project, nameParts[0], nameParts[1], nameParts[2])
+	d.Set("name", id)
+	d.SetId(id)
+} else {
 	return nil, fmt.Errorf(
-			"Saw %s when the name is expected to have shape %s",
-			d.Get("name"),
-			"projects/{{project}}/locations/{{location}}/namespaces/{{namespace_id}}/services/{{service_id}}",
-		)
+		"Saw %s when the name is expected to have shape %s, %s or %s",
+		d.Get("name"),
+		"projects/{{project}}/locations/{{location}}/namespaces/{{namespace_id}}/services/{{service_id}}",
+		"{{project}}/{{location}}/{{namespace_id}}/{{service_id}}",
+		"{{location}}/{{namespace_id}}/{{service_id}}")
 }
-
-d.Set("namespace", fmt.Sprintf("projects/%s/locations/%s/namespaces/%s", nameParts[1], nameParts[3], nameParts[5]))
-d.Set("service_id", nameParts[7])
 return []*schema.ResourceData{d}, nil
+

--- a/templates/terraform/examples/service_directory_endpoint_basic.tf.erb
+++ b/templates/terraform/examples/service_directory_endpoint_basic.tf.erb
@@ -1,0 +1,25 @@
+resource "google_service_directory_namespace" "<%= ctx[:primary_resource_id] %>" {
+  provider     = google-beta
+  namespace_id = "<%= ctx[:vars]["namespace_id"] %>"
+  location     = "us-central1"
+}
+
+resource "google_service_directory_service" "<%= ctx[:primary_resource_id] %>" {
+  provider   = google-beta
+  service_id = "<%= ctx[:vars]["service_id"] %>"
+  namespace  = google_service_directory_namespace.<%= ctx[:primary_resource_id] %>.name
+}
+
+resource "google_service_directory_endpoint" "<%= ctx[:primary_resource_id] %>" {
+  provider    = google-beta
+  endpoint_id = "<%= ctx[:vars]["endpoint_id"] %>"
+  service     = google_service_directory_service.<%= ctx[:primary_resource_id] %>.name
+
+  metadata = {
+    stage  = "prod"
+    region = "us-central1"
+  }
+
+  address = "1.2.3.4"
+  port    = 5353
+}

--- a/templates/terraform/examples/service_directory_endpoint_basic.tf.erb
+++ b/templates/terraform/examples/service_directory_endpoint_basic.tf.erb
@@ -7,13 +7,13 @@ resource "google_service_directory_namespace" "<%= ctx[:primary_resource_id] %>"
 resource "google_service_directory_service" "<%= ctx[:primary_resource_id] %>" {
   provider   = google-beta
   service_id = "<%= ctx[:vars]["service_id"] %>"
-  namespace  = google_service_directory_namespace.<%= ctx[:primary_resource_id] %>.name
+  namespace  = google_service_directory_namespace.<%= ctx[:primary_resource_id] %>.id
 }
 
 resource "google_service_directory_endpoint" "<%= ctx[:primary_resource_id] %>" {
   provider    = google-beta
   endpoint_id = "<%= ctx[:vars]["endpoint_id"] %>"
-  service     = google_service_directory_service.<%= ctx[:primary_resource_id] %>.name
+  service     = google_service_directory_service.<%= ctx[:primary_resource_id] %>.id
 
   metadata = {
     stage  = "prod"

--- a/templates/terraform/examples/service_directory_namespace_basic.tf.erb
+++ b/templates/terraform/examples/service_directory_namespace_basic.tf.erb
@@ -7,5 +7,4 @@ resource "google_service_directory_namespace" "<%= ctx[:primary_resource_id] %>"
     key = "value"
     foo = "bar"
   }
-
 }

--- a/templates/terraform/examples/service_directory_namespace_basic.tf.erb
+++ b/templates/terraform/examples/service_directory_namespace_basic.tf.erb
@@ -1,0 +1,11 @@
+resource "google_service_directory_namespace" "<%= ctx[:primary_resource_id] %>" {
+  provider     = google-beta
+  namespace_id = "<%= ctx[:vars]["namespace_id"] %>"
+  location     = "us-central1"
+
+  labels = {
+    key = "value"
+    foo = "bar"
+  }
+
+}

--- a/templates/terraform/examples/service_directory_service_basic.tf.erb
+++ b/templates/terraform/examples/service_directory_service_basic.tf.erb
@@ -7,7 +7,7 @@ resource "google_service_directory_namespace" "<%= ctx[:primary_resource_id] %>"
 resource "google_service_directory_service" "<%= ctx[:primary_resource_id] %>" {
   provider   = google-beta
   service_id = "<%= ctx[:vars]["service_id"] %>"
-  namespace  = google_service_directory_namespace.<%= ctx[:primary_resource_id] %>.name
+  namespace  = google_service_directory_namespace.<%= ctx[:primary_resource_id] %>.id
 
   metadata = {
     stage  = "prod"

--- a/templates/terraform/examples/service_directory_service_basic.tf.erb
+++ b/templates/terraform/examples/service_directory_service_basic.tf.erb
@@ -1,0 +1,16 @@
+resource "google_service_directory_namespace" "<%= ctx[:primary_resource_id] %>" {
+  provider     = google-beta
+  namespace_id = "<%= ctx[:vars]["namespace_id"] %>"
+  location     = "us-central1"
+}
+
+resource "google_service_directory_service" "<%= ctx[:primary_resource_id] %>" {
+  provider   = google-beta
+  service_id = "<%= ctx[:vars]["service_id"] %>"
+  namespace  = google_service_directory_namespace.<%= ctx[:primary_resource_id] %>.name
+
+  metadata = {
+    stage  = "prod"
+    region = "us-central1"
+  }
+}

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -28,7 +28,7 @@ package google
     client_name_camel = client_name.camelize(:lower)
     client_name_pascal = client_name.camelize(:upper)
     client_name_lower = client_name.downcase
-    has_project = object.base_url.include?('{{project}}') || object.create_url && object.create_url.include?('{{project}}')
+    has_project = object.base_url.include?('{{project}}') || (object.create_url && object.create_url.include?('{{project}}'))
     has_region = object.base_url.include?('{{region}}') && object.parameters.any?{ |p| p.name == 'region' && p.ignore_read }
     # In order of preference, use TF override,
     # general defined timeouts, or default Timeouts

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -28,7 +28,7 @@ package google
     client_name_camel = client_name.camelize(:lower)
     client_name_pascal = client_name.camelize(:upper)
     client_name_lower = client_name.downcase
-    has_project = object.base_url.include?('{{project}}')
+    has_project = object.base_url.include?('{{project}}') || object.create_url && object.create_url.include?('{{project}}')
     has_region = object.base_url.include?('{{region}}') && object.parameters.any?{ |p| p.name == 'region' && p.ignore_read }
     # In order of preference, use TF override,
     # general defined timeouts, or default Timeouts

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -120,7 +120,7 @@ The following arguments are supported:
 <% object.root_properties.reject(&:required).reject(&:output).each do |prop| -%>
 <%=    lines(build_property_documentation(prop)) -%>
 <% end -%>
-<% if object.base_url.include?("{{project}}")-%>
+<% if object.base_url.include?("{{project}}") || object.create_url && object.create_url.include?('{{project}}')-%>
 <%# The following new line allow for project to be bullet-formatted properly. -%>
 
 * `project` - (Optional) The ID of the project in which the resource belongs.

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -120,7 +120,7 @@ The following arguments are supported:
 <% object.root_properties.reject(&:required).reject(&:output).each do |prop| -%>
 <%=    lines(build_property_documentation(prop)) -%>
 <% end -%>
-<% if object.base_url.include?("{{project}}") || object.create_url && object.create_url.include?('{{project}}')-%>
+<% if object.base_url.include?("{{project}}") || (object.create_url && object.create_url.include?('{{project}}'))-%>
 <%# The following new line allow for project to be bullet-formatted properly. -%>
 
 * `project` - (Optional) The ID of the project in which the resource belongs.

--- a/third_party/terraform/tests/resource_service_directory_endpoint_test.go.erb
+++ b/third_party/terraform/tests/resource_service_directory_endpoint_test.go.erb
@@ -15,9 +15,9 @@ import (
 func TestAccServiceDirectoryEndpoint_serviceDirectoryEndpointUpdateExample(t *testing.T) {
 	t.Parallel()
 
-	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(10),
-	}
+	project := getTestProjectFromEnv()
+	location := "us-central1"
+	testId := fmt.Sprintf("tf-test-example-endpoint%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -25,7 +25,7 @@ func TestAccServiceDirectoryEndpoint_serviceDirectoryEndpointUpdateExample(t *te
 		CheckDestroy: testAccCheckServiceDirectoryEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceDirectoryEndpoint_basic(context),
+				Config: testAccServiceDirectoryEndpoint_basic(location, testId),
 			},
 			{
 				ResourceName:      "google_service_directory_endpoint.example",
@@ -33,7 +33,21 @@ func TestAccServiceDirectoryEndpoint_serviceDirectoryEndpointUpdateExample(t *te
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccServiceDirectoryEndpoint_update(context),
+				ResourceName:      "google_service_directory_endpoint.example",
+				// {{project}}/{{location}}/{{namespace_id}}/{{service_id}}/{{endpoint_id}}
+				ImportStateId:     fmt.Sprintf("%s/%s/%s/%s/%s", project, location, testId, testId, testId),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "google_service_directory_endpoint.example",
+				// {{location}}/{{namespace_id}}/{{service_id}}/{{endpoint_id}}
+				ImportStateId:     fmt.Sprintf("%s/%s/%s/%s", location, testId, testId, testId),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccServiceDirectoryEndpoint_update(location, testId),
 			},
 			{
 				ResourceName:      "google_service_directory_endpoint.example",
@@ -44,20 +58,39 @@ func TestAccServiceDirectoryEndpoint_serviceDirectoryEndpointUpdateExample(t *te
 	})
 }
 
-func testAccServiceDirectoryEndpoint_basic(context map[string]interface{}) string {
-	return Nprintf(`
+func testAccServiceDirectoryEndpoint_basic(location, testId string) string {
+	return fmt.Sprintf(`
 resource "google_service_directory_namespace" "example" {
-  namespace_id = "tf-test-example-namespace%{random_suffix}"
-  location     = "us-central1"
+  namespace_id = "%s"
+  location     = "%s"
 }
 
 resource "google_service_directory_service" "example" {
-  service_id = "tf-test-example-service%{random_suffix}"
+  service_id = "%s"
   namespace  = google_service_directory_namespace.example.id
 }
 
 resource "google_service_directory_endpoint" "example" {
-  endpoint_id = "tf-test-example-endpoint%{random_suffix}"
+  endpoint_id = "%s"
+  service     = google_service_directory_service.example.id
+}
+`, testId, location, testId, testId)
+}
+
+func testAccServiceDirectoryEndpoint_update(location, testId string) string {
+	return fmt.Sprintf(`
+resource "google_service_directory_namespace" "example" {
+  namespace_id = "%s"
+  location     = "%s"
+}
+
+resource "google_service_directory_service" "example" {
+  service_id = "%s"
+  namespace  = google_service_directory_namespace.example.id
+}
+
+resource "google_service_directory_endpoint" "example" {
+  endpoint_id = "%s"
   service     = google_service_directory_service.example.id
 
   metadata = {
@@ -68,33 +101,6 @@ resource "google_service_directory_endpoint" "example" {
   address = "1.2.3.4"
   port    = 5353
 }
-`, context)
-}
-
-func testAccServiceDirectoryEndpoint_update(context map[string]interface{}) string {
-	return Nprintf(`
-resource "google_service_directory_namespace" "example" {
-  namespace_id = "tf-test-example-namespace%{random_suffix}"
-  location     = "us-central1"
-}
-
-resource "google_service_directory_service" "example" {
-  service_id = "tf-test-example-service%{random_suffix}"
-  namespace  = google_service_directory_namespace.example.id
-}
-
-resource "google_service_directory_endpoint" "example" {
-  endpoint_id = "tf-test-example-endpoint%{random_suffix}"
-  service     = google_service_directory_service.example.id
-
-  metadata = {
-    stage  = "dev"
-    region = "us-central1"
-  }
-
-  address = "4.3.2.1"
-  port    = 3535
-}
-`, context)
+`, testId, location, testId, testId)
 }
 <% end -%>

--- a/third_party/terraform/tests/resource_service_directory_endpoint_test.go.erb
+++ b/third_party/terraform/tests/resource_service_directory_endpoint_test.go.erb
@@ -22,7 +22,7 @@ func TestAccServiceDirectoryEndpoint_serviceDirectoryEndpointUpdateExample(t *te
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckServiceDirectoryEndpointDestroy,
+		CheckDestroy: testAccCheckServiceDirectoryEndpointDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceDirectoryEndpoint_basic(location, testId),

--- a/third_party/terraform/tests/resource_service_directory_endpoint_test.go.erb
+++ b/third_party/terraform/tests/resource_service_directory_endpoint_test.go.erb
@@ -1,0 +1,100 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccServiceDirectoryEndpoint_serviceDirectoryEndpointUpdateExample(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(10),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceDirectoryEndpointDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDirectoryEndpoint_basic(context),
+			},
+			{
+				ResourceName:      "google_service_directory_endpoint.example",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccServiceDirectoryEndpoint_update(context),
+			},
+			{
+				ResourceName:      "google_service_directory_endpoint.example",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccServiceDirectoryEndpoint_basic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_service_directory_namespace" "example" {
+  namespace_id = "tf-test-example-namespace%{random_suffix}"
+  location     = "us-central1"
+}
+
+resource "google_service_directory_service" "example" {
+  service_id = "tf-test-example-service%{random_suffix}"
+  namespace  = google_service_directory_namespace.example.id
+}
+
+resource "google_service_directory_endpoint" "example" {
+  endpoint_id = "tf-test-example-endpoint%{random_suffix}"
+  service     = google_service_directory_service.example.id
+
+  metadata = {
+    stage  = "prod"
+    region = "us-central1"
+  }
+
+  address = "1.2.3.4"
+  port    = 5353
+}
+`, context)
+}
+
+func testAccServiceDirectoryEndpoint_update(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_service_directory_namespace" "example" {
+  namespace_id = "tf-test-example-namespace%{random_suffix}"
+  location     = "us-central1"
+}
+
+resource "google_service_directory_service" "example" {
+  service_id = "tf-test-example-service%{random_suffix}"
+  namespace  = google_service_directory_namespace.example.id
+}
+
+resource "google_service_directory_endpoint" "example" {
+  endpoint_id = "tf-test-example-endpoint%{random_suffix}"
+  service     = google_service_directory_service.example.id
+
+  metadata = {
+    stage  = "dev"
+    region = "us-central1"
+  }
+
+  address = "4.3.2.1"
+  port    = 3535
+}
+`, context)
+}
+<% end -%>

--- a/third_party/terraform/tests/resource_service_directory_namespace_test.go.erb
+++ b/third_party/terraform/tests/resource_service_directory_namespace_test.go.erb
@@ -1,0 +1,74 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccServiceDirectoryNamespace_serviceDirectoryNamespaceUpdateExample(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(10),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceDirectoryNamespaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDirectoryNamespace_basic(context),
+			},
+			{
+				ResourceName:      "google_service_directory_namespace.example",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccServiceDirectoryNamespace_update(context),
+			},
+			{
+				ResourceName:      "google_service_directory_namespace.example",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccServiceDirectoryNamespace_basic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_service_directory_namespace" "example" {
+  namespace_id = "tf-test-example-namespace%{random_suffix}"
+  location     = "us-central1"
+
+  labels = {
+    key = "value"
+    foo = "bar"
+  }
+}
+`, context)
+}
+
+func testAccServiceDirectoryNamespace_update(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_service_directory_namespace" "example" {
+  namespace_id = "tf-test-example-namespace%{random_suffix}"
+  location     = "us-central1"
+
+  labels = {
+    key2 = "value2"
+    foo2 = "bar2"
+  }
+}
+`, context)
+}
+<% end -%>

--- a/third_party/terraform/tests/resource_service_directory_namespace_test.go.erb
+++ b/third_party/terraform/tests/resource_service_directory_namespace_test.go.erb
@@ -15,9 +15,9 @@ import (
 func TestAccServiceDirectoryNamespace_serviceDirectoryNamespaceUpdateExample(t *testing.T) {
 	t.Parallel()
 
-	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(10),
-	}
+	project := getTestProjectFromEnv()
+	location := "us-central1"
+	testId := fmt.Sprintf("tf-test-example-namespace%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -25,7 +25,7 @@ func TestAccServiceDirectoryNamespace_serviceDirectoryNamespaceUpdateExample(t *
 		CheckDestroy: testAccCheckServiceDirectoryNamespaceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceDirectoryNamespace_basic(context),
+				Config: testAccServiceDirectoryNamespace_basic(location, testId),
 			},
 			{
 				ResourceName:      "google_service_directory_namespace.example",
@@ -33,7 +33,21 @@ func TestAccServiceDirectoryNamespace_serviceDirectoryNamespaceUpdateExample(t *
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccServiceDirectoryNamespace_update(context),
+				ResourceName:      "google_service_directory_namespace.example",
+				// {{project}}/{{location}}/{{namespace_id}}
+				ImportStateId:     fmt.Sprintf("%s/%s/%s", project, location, testId),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "google_service_directory_namespace.example",
+				// {{location}}/{{namespace_id}}
+				ImportStateId:     fmt.Sprintf("%s/%s", location, testId),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccServiceDirectoryNamespace_update(location, testId),
 			},
 			{
 				ResourceName:      "google_service_directory_namespace.example",
@@ -44,31 +58,26 @@ func TestAccServiceDirectoryNamespace_serviceDirectoryNamespaceUpdateExample(t *
 	})
 }
 
-func testAccServiceDirectoryNamespace_basic(context map[string]interface{}) string {
-	return Nprintf(`
+func testAccServiceDirectoryNamespace_basic(location, testId string) string {
+	return fmt.Sprintf(`
 resource "google_service_directory_namespace" "example" {
-  namespace_id = "tf-test-example-namespace%{random_suffix}"
-  location     = "us-central1"
+  namespace_id = "%s"
+  location     = "%s"
+}
+`, testId, location)
+}
+
+func testAccServiceDirectoryNamespace_update(location, testId string) string {
+	return fmt.Sprintf(`
+resource "google_service_directory_namespace" "example" {
+  namespace_id = "%s"
+  location     = "%s"
 
   labels = {
     key = "value"
     foo = "bar"
   }
 }
-`, context)
-}
-
-func testAccServiceDirectoryNamespace_update(context map[string]interface{}) string {
-	return Nprintf(`
-resource "google_service_directory_namespace" "example" {
-  namespace_id = "tf-test-example-namespace%{random_suffix}"
-  location     = "us-central1"
-
-  labels = {
-    key2 = "value2"
-    foo2 = "bar2"
-  }
-}
-`, context)
+`, testId, location)
 }
 <% end -%>

--- a/third_party/terraform/tests/resource_service_directory_namespace_test.go.erb
+++ b/third_party/terraform/tests/resource_service_directory_namespace_test.go.erb
@@ -22,7 +22,7 @@ func TestAccServiceDirectoryNamespace_serviceDirectoryNamespaceUpdateExample(t *
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckServiceDirectoryNamespaceDestroy,
+		CheckDestroy: testAccCheckServiceDirectoryNamespaceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceDirectoryNamespace_basic(location, testId),

--- a/third_party/terraform/tests/resource_service_directory_service_test.go.erb
+++ b/third_party/terraform/tests/resource_service_directory_service_test.go.erb
@@ -22,7 +22,7 @@ func TestAccServiceDirectoryService_serviceDirectoryServiceUpdateExample(t *test
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckServiceDirectoryServiceDestroy,
+		CheckDestroy: testAccCheckServiceDirectoryServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
 				Config: testAccServiceDirectoryService_basic(location, testId),

--- a/third_party/terraform/tests/resource_service_directory_service_test.go.erb
+++ b/third_party/terraform/tests/resource_service_directory_service_test.go.erb
@@ -1,0 +1,83 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccServiceDirectoryService_serviceDirectoryServiceUpdateExample(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(10),
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceDirectoryServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServiceDirectoryService_basic(context),
+			},
+			{
+				ResourceName:      "google_service_directory_service.example",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccServiceDirectoryService_update(context),
+			},
+			{
+				ResourceName:      "google_service_directory_service.example",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccServiceDirectoryService_basic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_service_directory_namespace" "example" {
+  namespace_id = "tf-test-example-namespace%{random_suffix}"
+  location     = "us-central1"
+}
+
+resource "google_service_directory_service" "example" {
+  service_id = "tf-test-example-service%{random_suffix}"
+  namespace  = google_service_directory_namespace.example.id
+
+  metadata = {
+	stage  = "prod"
+	region = "us-central1"
+  }
+}
+`, context)
+}
+
+func testAccServiceDirectoryService_update(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_service_directory_namespace" "example" {
+  namespace_id = "tf-test-example-namespace%{random_suffix}"
+  location     = "us-central1"
+}
+
+resource "google_service_directory_service" "example" {
+  service_id = "tf-test-example-service%{random_suffix}"
+  namespace  = google_service_directory_namespace.example.id
+
+  metadata = {
+    stage  = "dev"
+  }
+}
+`, context)
+}
+<% end -%>

--- a/third_party/terraform/tests/resource_service_directory_service_test.go.erb
+++ b/third_party/terraform/tests/resource_service_directory_service_test.go.erb
@@ -15,9 +15,9 @@ import (
 func TestAccServiceDirectoryService_serviceDirectoryServiceUpdateExample(t *testing.T) {
 	t.Parallel()
 
-	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(10),
-	}
+	project := getTestProjectFromEnv()
+	location := "us-central1"
+	testId := fmt.Sprintf("tf-test-example-service%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -25,7 +25,7 @@ func TestAccServiceDirectoryService_serviceDirectoryServiceUpdateExample(t *test
 		CheckDestroy: testAccCheckServiceDirectoryServiceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccServiceDirectoryService_basic(context),
+				Config: testAccServiceDirectoryService_basic(location, testId),
 			},
 			{
 				ResourceName:      "google_service_directory_service.example",
@@ -33,7 +33,21 @@ func TestAccServiceDirectoryService_serviceDirectoryServiceUpdateExample(t *test
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccServiceDirectoryService_update(context),
+				ResourceName:      "google_service_directory_service.example",
+				// {{project}}/{{location}}/{{namespace_id}}/{{service_id}}
+				ImportStateId:     fmt.Sprintf("%s/%s/%s/%s", project, location, testId, testId),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "google_service_directory_service.example",
+				// {{location}}/{{namespace_id}}/{{service_id}}
+				ImportStateId:     fmt.Sprintf("%s/%s/%s", location, testId, testId),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccServiceDirectoryService_update(location, testId),
 			},
 			{
 				ResourceName:      "google_service_directory_service.example",
@@ -44,40 +58,36 @@ func TestAccServiceDirectoryService_serviceDirectoryServiceUpdateExample(t *test
 	})
 }
 
-func testAccServiceDirectoryService_basic(context map[string]interface{}) string {
-	return Nprintf(`
+func testAccServiceDirectoryService_basic(location, testId string) string {
+	return fmt.Sprintf(`
 resource "google_service_directory_namespace" "example" {
-  namespace_id = "tf-test-example-namespace%{random_suffix}"
-  location     = "us-central1"
+  namespace_id = "%s"
+  location     = "%s"
 }
 
 resource "google_service_directory_service" "example" {
-  service_id = "tf-test-example-service%{random_suffix}"
+  service_id = "%s"
   namespace  = google_service_directory_namespace.example.id
-
-  metadata = {
-	stage  = "prod"
-	region = "us-central1"
-  }
 }
-`, context)
+`, testId, location, testId)
 }
 
-func testAccServiceDirectoryService_update(context map[string]interface{}) string {
-	return Nprintf(`
+func testAccServiceDirectoryService_update(location, testId string) string {
+	return fmt.Sprintf(`
 resource "google_service_directory_namespace" "example" {
-  namespace_id = "tf-test-example-namespace%{random_suffix}"
-  location     = "us-central1"
+  namespace_id = "%s"
+  location     = "%s"
 }
 
 resource "google_service_directory_service" "example" {
-  service_id = "tf-test-example-service%{random_suffix}"
+  service_id = "%s"
   namespace  = google_service_directory_namespace.example.id
 
   metadata = {
-    stage  = "dev"
+    stage  = "prod"
+    region = "us-central1"
   }
 }
-`, context)
+`, testId, location, testId)
 }
 <% end -%>

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -1447,8 +1447,26 @@
       <li<%%= sidebar_current("docs-google-service-directory-namespace") %>>
       <a href="/docs/providers/google/r/service_directory_namespace.html">google_service_directory_namespace</a>
       </li>
+      <li<%%= sidebar_current("docs-google-service-directory-namespace-iam") %>>
+      <a href="/docs/providers/google/r/service_directory_namespace_iam.html">google_service_directory_namespace_iam_member</a>
+      </li>
+      <li<%%= sidebar_current("docs-google-service-directory-namespace-iam") %>>
+      <a href="/docs/providers/google/r/service_directory_namespace_iam.html">google_service_directory_namespace_iam_binding</a>
+      </li>
+      <li<%%= sidebar_current("docs-google-service-directory-namespace-iam") %>>
+      <a href="/docs/providers/google/r/service_directory_namespace_iam.html">google_service_directory_namespace_iam_policy</a>
+      </li>
       <li<%%= sidebar_current("docs-google-service-directory-service") %>>
       <a href="/docs/providers/google/r/service_directory_service.html">google_service_directory_service</a>
+      </li>
+      <li<%%= sidebar_current("docs-google-service-directory-service-iam") %>>
+      <a href="/docs/providers/google/r/service_directory_service_iam.html">google_service_directory_service_iam_member</a>
+      </li>
+      <li<%%= sidebar_current("docs-google-service-directory-service-iam") %>>
+      <a href="/docs/providers/google/r/service_directory_service_iam.html">google_service_directory_service_iam_binding</a>
+      </li>
+      <li<%%= sidebar_current("docs-google-service-directory-service-iam") %>>
+      <a href="/docs/providers/google/r/service_directory_service_iam.html">google_service_directory_service_iam_policy</a>
       </li>
     </ul>
     </li>

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -1437,6 +1437,23 @@
     </li>
 <% end -%>
 
+<% unless version == 'ga' %>
+    <li<%%= sidebar_current("docs-google-service-directory") %>>
+    <a href="#">Google Service Directory Resources</a>
+    <ul class="nav">
+      <li<%%= sidebar_current("docs-google-service-directory-endpoint") %>>
+      <a href="/docs/providers/google/r/service_directory_endpoint.html">google_service_directory_endpoint</a>
+      </li>
+      <li<%%= sidebar_current("docs-google-service-directory-namespace") %>>
+      <a href="/docs/providers/google/r/service_directory_namespace.html">google_service_directory_namespace</a>
+      </li>
+      <li<%%= sidebar_current("docs-google-service-directory-service") %>>
+      <a href="/docs/providers/google/r/service_directory_service.html">google_service_directory_service</a>
+      </li>
+    </ul>
+    </li>
+<% end -%>
+
     <li<%%= sidebar_current("docs-google-service-networking") %>>
     <a href="#">Google Service Networking Resources</a>
     <ul class="nav">


### PR DESCRIPTION
Fixes terraform-providers/terraform-provider-google#6053
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
google_service_directory_namespace
```
```release-note:new-resource
google_service_directory_service
```
```release-note:new-resource
google_service_directory_endpoint
```

