### PR TITLE
Add compute security policy to inspec

### DIFF
--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -51,6 +51,8 @@ datasources: !ruby/object:Overrides::ResourceOverrides
     exclude: true
   RouterNat: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
+  SecurityPolicy: !ruby/object:Overrides::Ansible::ResourceOverride
+    exclude: true
   Zone: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
 overrides: !ruby/object:Overrides::ResourceOverrides
@@ -328,6 +330,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   RouterBgpPeer: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
   RouterNat: !ruby/object:Overrides::Ansible::ResourceOverride
+    exclude: true
+  SecurityPolicy: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
   Zone: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -11565,6 +11565,106 @@ objects:
           or deleted.
         output: true
   - !ruby/object:Api::Resource
+    name: 'SecurityPolicy'
+    kind: 'compute#securityPolicy'
+    base_url: projects/{{project}}/global/securityPolicies
+    collection_url_key: 'items'
+    has_self_link: true
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation': 'https://cloud.google.com/armor/docs/security-policy-concepts'
+      api: 'https://cloud.google.com/compute/docs/reference/rest/v1/securityPolicies'
+    description: |
+      Represents a Cloud Armor Security Policy resource.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: 'Name of the security policy.'
+        required: true
+      - !ruby/object:Api::Type::Integer
+        name: 'id'
+        description: 'The unique identifier for the resource.'
+        output: true
+      - !ruby/object:Api::Type::Array
+        name: 'rules'
+        description: |
+          A list of rules that belong to this policy.
+          There must always be a default rule (rule with priority 2147483647 and match "*").
+          If no rules are provided when creating a security policy, a default rule with action "allow" will be added.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'description'
+              description: |
+                A description of the rule.
+            - !ruby/object:Api::Type::Integer
+              name: 'priority'
+              description: |
+                An integer indicating the priority of a rule in the list. The priority must be a positive value
+                between 0 and 2147483647. Rules are evaluated from highest to lowest priority where 0 is the
+                highest priority and 2147483647 is the lowest prority.
+            - !ruby/object:Api::Type::String
+              name: 'action'
+              description: |
+                The Action to preform when the client connection triggers the rule. Can currently be either
+                "allow" or "deny()" where valid values for status are 403, 404, and 502.
+            - !ruby/object:Api::Type::Boolean
+              name: 'preview'
+              description: |
+                If set to true, the specified action is not enforced.
+            - !ruby/object:Api::Type::NestedObject
+              name: 'match'
+              description:
+                A match condition that incoming traffic is evaluated against. If it evaluates to true,
+                the corresponding 'action' is enforced.
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'description'
+                  description: |
+                    A description of the rule.
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'expr'
+                  description:
+                    User defined CEVAL expression. A CEVAL expression is used to specify match criteria such as origin.ip,
+                    source.region_code and contents in the request header.
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: 'expression'
+                      description: |
+                        Textual representation of an expression in Common Expression Language syntax.
+                    - !ruby/object:Api::Type::String
+                      name: 'title'
+                      description: |
+                        Optional. Title for the expression, i.e. a short string describing its purpose.
+                        This can be used e.g. in UIs which allow to enter the expression.
+                    - !ruby/object:Api::Type::String
+                      name: 'description'
+                      description: |
+                        Optional. Description of the expression. This is a longer text which describes the expression,
+                        e.g. when hovered over it in a UI.
+                    - !ruby/object:Api::Type::String
+                      name: 'location'
+                      description: |
+                        Optional. String indicating the location of the expression for error reporting,
+                        e.g. a file name and a position in the file.
+                - !ruby/object:Api::Type::String
+                  name: 'versionedExpr'
+                  description: |
+                    Preconfigured versioned expression. If this field is specified, config must also be specified.
+                    Available preconfigured expressions along with their requirements are: `SRC_IPS_V1` - must specify
+                    the corresponding srcIpRange field in config.
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'config'
+                  description:
+                    The configuration options available when specifying versionedExpr. This field must be specified
+                    if versionedExpr is specified and cannot be specified if versionedExpr is not specified.
+                  properties:
+                    - !ruby/object:Api::Type::Array
+                      name: 'srcIpRanges'
+                      description: |
+                        CIDR IP address range.
+                      item_type: Api::Type::String
+  - !ruby/object:Api::Resource
     name: 'Snapshot'
     kind: 'compute#snapshot'
     input: true

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1738,6 +1738,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         description: |
           {{description}}
           If it is not provided, the provider region is used.
+  SecurityPolicy: !ruby/object:Overrides::Terraform::ResourceOverride
+    exclude: true
   Snapshot: !ruby/object:Overrides::Terraform::ResourceOverride
     timeouts: !ruby/object:Api::Timeouts
       insert_minutes: 5

--- a/templates/inspec/examples/google_compute_security_policy/google_compute_security_policies.erb
+++ b/templates/inspec/examples/google_compute_security_policy/google_compute_security_policies.erb
@@ -1,0 +1,6 @@
+<% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
+<% security_policy = grab_attributes['security_policy'] -%>
+describe google_compute_security_policies(project: <%= gcp_project_id -%>) do
+  its('count') { should be >= 1 }
+  its('names') { should include <%= doc_generation ? "'#{security_policy['name']}'" : "security_policy['name']" -%> }
+end

--- a/templates/inspec/examples/google_compute_security_policy/google_compute_security_policy.erb
+++ b/templates/inspec/examples/google_compute_security_policy/google_compute_security_policy.erb
@@ -1,0 +1,12 @@
+<% gcp_project_id = "#{external_attribute('gcp_project_id', doc_generation)}" -%>
+<% security_policy = grab_attributes['security_policy'] -%>
+describe google_compute_security_policy(project: <%= gcp_project_id -%>, name: <%= doc_generation ? "'#{security_policy['name']}'" : "security_policy['name']" -%>) do
+  it { should exist }
+  its('rules.size') { should cmp 2 }
+  its('rules.first.priority') { should cmp <%= doc_generation ? "'#{security_policy['priority']}'" : "security_policy['priority']" -%> }
+  its('rules.first.match.config.src_ip_ranges.first') { should cmp <%= doc_generation ? "'#{security_policy['ip_range']}'" : "security_policy['ip_range']" -%> }
+end
+
+describe google_compute_security_policy(project: <%= gcp_project_id -%>, name: 'nonexistent') do
+  it { should_not exist }
+end

--- a/templates/inspec/examples/google_compute_security_policy/google_compute_security_policy_attributes.erb
+++ b/templates/inspec/examples/google_compute_security_policy/google_compute_security_policy_attributes.erb
@@ -1,0 +1,2 @@
+gcp_project_id = attribute(:gcp_project_id, default: '<%= external_attribute('gcp_project_id') -%>', description: 'The GCP project identifier.')
+security_policy = attribute('security_policy', default: <%= JSON.pretty_generate(grab_attributes['security_policy']) -%>, description: 'Security Policy description')

--- a/templates/inspec/tests/integration/build/gcp-mm.tf
+++ b/templates/inspec/tests/integration/build/gcp-mm.tf
@@ -1215,3 +1215,36 @@ resource "google_organization_iam_custom_role" "generic_org_iam_custom_role" {
   description = "Custom role allowing to list IAM roles only"
   permissions = ["iam.roles.list"]
 }
+
+variable "security_policy" {
+  type = any
+}
+
+resource "google_compute_security_policy" "policy" {
+  project = var.gcp_project_id
+  name = var.security_policy["name"]
+
+  rule {
+    action   = var.security_policy["action"]
+    priority = var.security_policy["priority"]
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = [var.security_policy["ip_range"]]
+      }
+    }
+    description = var.security_policy["description"]
+  }
+
+  rule {
+    action   = "allow"
+    priority = "2147483647"
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["*"]
+      }
+    }
+    description = "default rule"
+  }
+}

--- a/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -438,3 +438,9 @@ compute_image:
   name: inspec-image
   source: https://storage.googleapis.com/bosh-cpi-artifacts/bosh-stemcell-3262.4-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz
  
+security_policy:
+  name: sec-policy
+  action: deny(403)
+  priority: "1000"
+  ip_range: "9.9.9.0/24"
+  description: my description


### PR DESCRIPTION
Add compute security policy to inspec

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
