### PR TITLE
Remove missed status check in nodepool

### DIFF
--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -322,27 +322,13 @@ func resourceContainerNodePoolCreate(d *schema.ResourceData, meta interface{}) e
 func resourceContainerNodePoolRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 	nodePoolInfo, err := extractNodePoolInformation(d, config)
-
-	name := getNodePoolName(d.Id())
-
 	if err != nil {
 		return err
 	}
 
-	var nodePool = &containerBeta.NodePool{}
-	err = resource.Retry(2*time.Minute, func() *resource.RetryError {
-		nodePool, err = config.clientContainerBeta.
-			Projects.Locations.Clusters.NodePools.Get(nodePoolInfo.fullyQualifiedName(name)).Do()
+	name := getNodePoolName(d.Id())
 
-		if err != nil {
-			return resource.NonRetryableError(err)
-		}
-		if nodePool.Status != "RUNNING" {
-			return resource.RetryableError(fmt.Errorf("Nodepool %q has status %q with message %q", d.Get("name"), nodePool.Status, nodePool.StatusMessage))
-		}
-		return nil
-	})
-
+	nodePool, err := config.clientContainerBeta.Projects.Locations.Clusters.NodePools.Get(nodePoolInfo.fullyQualifiedName(name)).Do()
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("NodePool %q from cluster %q", name, nodePoolInfo.cluster))
 	}


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6110

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: fixed importing/reading `google_container_node_pool` resources in non-RUNNING states
```
