### PR TITLE
Dataproc Cluster: Preserve preemptible config fields when preeemptible group removed.

### DIFF
--- a/third_party/terraform/resources/resource_dataproc_cluster.go.erb
+++ b/third_party/terraform/resources/resource_dataproc_cluster.go.erb
@@ -1371,6 +1371,22 @@ func flattenGceClusterConfig(d *schema.ResourceData, gcc *dataproc.GceClusterCon
 }
 
 func flattenPreemptibleInstanceGroupConfig(d *schema.ResourceData, icg *dataproc.InstanceGroupConfig) []map[string]interface{} {
+	// if num_instances is 0, icg will always be returned nil. This means the
+	// server has discarded diskconfig etc. However, the only way to remove the
+	// preemptible group is to set the size to 0, because it's O+C. Many users
+	// won't remove the rest of the config (eg disk config). Therefore, we need to
+	// preserve the other set fields by using the old state to stop users from
+	// getting a diff.
+	if icg == nil {
+		icgSchema := d.Get("cluster_config.0.preemptible_worker_config")
+		log.Printf("[DEBUG] state of preemptible is %#v", icgSchema)
+		if v, ok := icgSchema.([]interface{}); ok && len(v) > 0 {
+			if m, ok := v[0].(map[string]interface{}); ok {
+				return []map[string]interface{}{m}
+			}
+		}
+	}
+
 	disk := map[string]interface{}{}
 	data := map[string]interface{}{}
 

--- a/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -371,6 +371,14 @@ func TestAccDataprocCluster_updatable(t *testing.T) {
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.preemptible_worker_config.0.num_instances", "1")),
 			},
 			{
+				Config: testAccDataprocCluster_updatable(rnd, 2, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataprocClusterExists("google_dataproc_cluster.updatable", &cluster),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.master_config.0.num_instances", "1"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.worker_config.0.num_instances", "2"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.preemptible_worker_config.0.num_instances", "0")),
+			},
+			{
 				Config: testAccDataprocCluster_updatable(rnd, 3, 2),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("google_dataproc_cluster.updatable", "cluster_config.0.master_config.0.num_instances", "1"),


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/2861

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
dataproc: fixed diff when `google_dataproc_cluster` `preemptible_worker_config.0.num_instances` is sized to 0 and other `preemptible_worker_config` subfields are set
```
