### PR TITLE
fix: [Terraform] Store SHA 256 of certificate SSL private keys

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1872,8 +1872,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       privateKey: !ruby/object:Overrides::Terraform::PropertyOverride
         sensitive: true
         ignore_read: true
-        custom_flatten: 'templates/terraform/custom_flatten/sha256.erb'
-        diff_suppress_func: 'sha256DiffSuppress'
+        state_func: 'sha256HashState'
   RegionSslCertificate: !ruby/object:Overrides::Terraform::ResourceOverride
     docs: !ruby/object:Provider::Terraform::Docs
       optional_properties: |
@@ -1925,8 +1924,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       privateKey: !ruby/object:Overrides::Terraform::PropertyOverride
         sensitive: true
         ignore_read: true
-        custom_flatten: 'templates/terraform/custom_flatten/sha256.erb'
-        diff_suppress_func: 'sha256DiffSuppress'
+        state_func: 'sha256HashState'
   SslPolicy: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/templates/terraform/custom_flatten/sha256.erb
+++ b/templates/terraform/custom_flatten/sha256.erb
@@ -1,3 +1,0 @@
-func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) interface{} {
-	return hex.EncodeToString(sha256.New().Sum([]byte(v.(string))))
-}

--- a/third_party/terraform/utils/common_diff_suppress.go.erb
+++ b/third_party/terraform/utils/common_diff_suppress.go.erb
@@ -52,12 +52,6 @@ func ipCidrRangeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	return false
 }
 
-// sha256DiffSuppress
-// if old is the hex-encoded sha256 sum of new, treat them as equal
-func sha256DiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
-	return hex.EncodeToString(sha256.New().Sum([]byte(old))) == new
-}
-
 func caseDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 	return strings.ToUpper(old) == strings.ToUpper(new)
 }

--- a/third_party/terraform/utils/common_state_func.go.erb
+++ b/third_party/terraform/utils/common_state_func.go.erb
@@ -1,0 +1,14 @@
+<% autogen_exception -%>
+// Contains common diff suppress functions.
+
+package google
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+func sha256HashState(val interface{}) string {
+	hash := sha256.Sum256([]byte(val.(string)))
+	return hex.EncodeToString(hash[:])
+}

--- a/third_party/terraform/utils/common_state_func.go.erb
+++ b/third_party/terraform/utils/common_state_func.go.erb
@@ -1,5 +1,6 @@
 <% autogen_exception -%>
-// Contains common diff suppress functions.
+// Contains common state functions.
+// https://www.terraform.io/docs/extend/schemas/schema-behaviors.html#statefunc
 
 package google
 


### PR DESCRIPTION
related issue: 
- https://github.com/terraform-providers/terraform-provider-google/issues/6119
- https://github.com/terraform-providers/terraform-provider-google/issues/927 (old one, closed)

`custom_flatten` introduced in https://github.com/GoogleCloudPlatform/magic-modules/pull/1336 doesn't work for `privateKey` field since it has `ignore_read` set to `true`. Use `state_func` instead.

see also: https://github.com/terraform-providers/terraform-provider-google/pull/2976

both the `custom_flatten` function and `sha256DiffSuppress` were removed because:
- there seems no other usage of those functions
- usage of `Sum` is not correct in those functions

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
