### PR TITLE
Update urlRedirect property of UrlMap and RegionUrlMap

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -9420,35 +9420,45 @@ objects:
                       - !ruby/object:Api::Type::String
                         name: 'hostRedirect'
                         description: |
-                          The host that will be used in the redirect response instead of the one that was
-                          supplied in the request. The value must be between 1 and 255 characters.
+                          The host that will be used in the redirect response instead of the one
+                          that was supplied in the request. The value must be between 1 and 255
+                          characters.
                       - !ruby/object:Api::Type::Boolean
                         name: 'httpsRedirect'
                         default_value: false
                         description: |
-                          If set to true, the URL scheme in the redirected request is set to https. If set
-                          to false, the URL scheme of the redirected request will remain the same as that
-                          of the request. This must only be set for UrlMaps used in TargetHttpProxys.
-                          Setting this true for TargetHttpsProxy is not permitted. Defaults to false.
+                          If set to true, the URL scheme in the redirected request is set to https.
+                          If set to false, the URL scheme of the redirected request will remain the
+                          same as that of the request. This must only be set for UrlMaps used in
+                          TargetHttpProxys. Setting this true for TargetHttpsProxy is not
+                          permitted. The default is set to false.
                       - !ruby/object:Api::Type::String
                         name: 'pathRedirect'
                         description: |
-                          The path that will be used in the redirect response instead of the one that was
-                          supplied in the request. Only one of pathRedirect or prefixRedirect must be
-                          specified. The value must be between 1 and 1024 characters.
+                          The path that will be used in the redirect response instead of the one
+                          that was supplied in the request. pathRedirect cannot be supplied
+                          together with prefixRedirect. Supply one alone or neither. If neither is
+                          supplied, the path of the original request will be used for the redirect.
+                          The value must be between 1 and 1024 characters.
                       - !ruby/object:Api::Type::String
                         name: 'prefixRedirect'
                         description: |
-                          The prefix that replaces the prefixMatch specified in the HttpRouteRuleMatch,
-                          retaining the remaining portion of the URL before redirecting the request.
+                          The prefix that replaces the prefixMatch specified in the
+                          HttpRouteRuleMatch, retaining the remaining portion of the URL before
+                          redirecting the request. prefixRedirect cannot be supplied together with
+                          pathRedirect. Supply one alone or neither. If neither is supplied, the
+                          path of the original request will be used for the redirect. The value
+                          must be between 1 and 1024 characters.
                       - !ruby/object:Api::Type::Enum
                         name: 'redirectResponseCode'
                         description: |
-                          The HTTP Status code to use for this RedirectAction. Supported values are:   -
-                          MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.  -
-                          FOUND, which corresponds to 302.  - SEE_OTHER which corresponds to 303.  -
-                          TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
-                          will be retained.  - PERMANENT_REDIRECT, which corresponds to 308. In this case,
+                          The HTTP Status code to use for this RedirectAction. Supported values are:
+                          - MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+                          - FOUND, which corresponds to 302.
+                          - SEE_OTHER which corresponds to 303.
+                          - TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+                          will be retained.
+                          - PERMANENT_REDIRECT, which corresponds to 308. In this case,
                           the request method will be retained.
                         values:
                           - :FOUND
@@ -9460,9 +9470,9 @@ objects:
                         name: 'stripQuery'
                         default_value: false
                         description: |
-                          If set to true, any accompanying query portion of the original URL is removed
-                          prior to redirecting the request. If set to false, the query portion of the
-                          original URL is retained. Defaults to false.
+                          If set to true, any accompanying query portion of the original URL is
+                          removed prior to redirecting the request. If set to false, the query
+                          portion of the original URL is retained. The default is set to false.
             - !ruby/object:Api::Type::Array
               name: 'pathRules'
               description: |
@@ -9822,34 +9832,42 @@ objects:
                   - !ruby/object:Api::Type::NestedObject
                     name: 'urlRedirect'
                     description: |
-                      When a path pattern is matched, the request is redirected to a URL specified by
-                      urlRedirect. If urlRedirect is specified, service or routeAction must not be
-                      set.
+                      When a path pattern is matched, the request is redirected to a URL specified
+                      by urlRedirect. If urlRedirect is specified, service or routeAction must not
+                      be set.
                     properties:
                       - !ruby/object:Api::Type::String
                         name: 'hostRedirect'
                         description: |
-                          The host that will be used in the redirect response instead of the one that was
-                          supplied in the request. The value must be between 1 and 255 characters.
+                          The host that will be used in the redirect response instead of the one
+                          that was supplied in the request. The value must be between 1 and 255
+                          characters.
                       - !ruby/object:Api::Type::Boolean
                         name: 'httpsRedirect'
                         default_value: false
                         description: |
-                          If set to true, the URL scheme in the redirected request is set to https. If set
-                          to false, the URL scheme of the redirected request will remain the same as that
-                          of the request. This must only be set for UrlMaps used in TargetHttpProxys.
-                          Setting this true for TargetHttpsProxy is not permitted. Defaults to false.
+                          If set to true, the URL scheme in the redirected request is set to https.
+                          If set to false, the URL scheme of the redirected request will remain the
+                          same as that of the request. This must only be set for UrlMaps used in
+                          TargetHttpProxys. Setting this true for TargetHttpsProxy is not
+                          permitted. The default is set to false.
                       - !ruby/object:Api::Type::String
                         name: 'pathRedirect'
                         description: |
-                          The path that will be used in the redirect response instead of the one that was
-                          supplied in the request. Only one of pathRedirect or prefixRedirect must be
-                          specified. The value must be between 1 and 1024 characters.
+                          The path that will be used in the redirect response instead of the one
+                          that was supplied in the request. pathRedirect cannot be supplied
+                          together with prefixRedirect. Supply one alone or neither. If neither is
+                          supplied, the path of the original request will be used for the redirect.
+                          The value must be between 1 and 1024 characters.
                       - !ruby/object:Api::Type::String
                         name: 'prefixRedirect'
                         description: |
-                          The prefix that replaces the prefixMatch specified in the HttpRouteRuleMatch,
-                          retaining the remaining portion of the URL before redirecting the request.
+                          The prefix that replaces the prefixMatch specified in the
+                          HttpRouteRuleMatch, retaining the remaining portion of the URL before
+                          redirecting the request. prefixRedirect cannot be supplied together with
+                          pathRedirect. Supply one alone or neither. If neither is supplied, the
+                          path of the original request will be used for the redirect. The value
+                          must be between 1 and 1024 characters.
                       - !ruby/object:Api::Type::Enum
                         name: 'redirectResponseCode'
                         description: |
@@ -9869,11 +9887,11 @@ objects:
                           - :TEMPORARY_REDIRECT
                       - !ruby/object:Api::Type::Boolean
                         name: 'stripQuery'
-                        required: true
+                        default_value: false
                         description: |
-                          If set to true, any accompanying query portion of the original URL is removed
-                          prior to redirecting the request. If set to false, the query portion of the
-                          original URL is retained.
+                          If set to true, any accompanying query portion of the original URL is
+                          removed prior to redirecting the request. If set to false, the query
+                          portion of the original URL is retained. The default is set to false.
       - !ruby/object:Api::Type::Array
         name: 'tests'
         description: |
@@ -14254,34 +14272,42 @@ objects:
                   - !ruby/object:Api::Type::NestedObject
                     name: 'urlRedirect'
                     description: |
-                      When a path pattern is matched, the request is redirected to a URL specified by
-                      urlRedirect. If urlRedirect is specified, service or routeAction must not be
-                      set.
+                      When a path pattern is matched, the request is redirected to a URL specified
+                      by urlRedirect. If urlRedirect is specified, service or routeAction must not
+                      be set.
                     properties:
                       - !ruby/object:Api::Type::String
                         name: 'hostRedirect'
                         description: |
-                          The host that will be used in the redirect response instead of the one that was
-                          supplied in the request. The value must be between 1 and 255 characters.
+                          The host that will be used in the redirect response instead of the one
+                          that was supplied in the request. The value must be between 1 and 255
+                          characters.
                       - !ruby/object:Api::Type::Boolean
                         name: 'httpsRedirect'
                         default_value: false
                         description: |
-                          If set to true, the URL scheme in the redirected request is set to https. If set
-                          to false, the URL scheme of the redirected request will remain the same as that
-                          of the request. This must only be set for UrlMaps used in TargetHttpProxys.
-                          Setting this true for TargetHttpsProxy is not permitted. Defaults to false.
+                          If set to true, the URL scheme in the redirected request is set to https.
+                          If set to false, the URL scheme of the redirected request will remain the
+                          same as that of the request. This must only be set for UrlMaps used in
+                          TargetHttpProxys. Setting this true for TargetHttpsProxy is not
+                          permitted. The default is set to false.
                       - !ruby/object:Api::Type::String
                         name: 'pathRedirect'
                         description: |
-                          The path that will be used in the redirect response instead of the one that was
-                          supplied in the request. Only one of pathRedirect or prefixRedirect must be
-                          specified. The value must be between 1 and 1024 characters.
+                          The path that will be used in the redirect response instead of the one
+                          that was supplied in the request. pathRedirect cannot be supplied
+                          together with prefixRedirect. Supply one alone or neither. If neither is
+                          supplied, the path of the original request will be used for the redirect.
+                          The value must be between 1 and 1024 characters.
                       - !ruby/object:Api::Type::String
                         name: 'prefixRedirect'
                         description: |
-                          The prefix that replaces the prefixMatch specified in the HttpRouteRuleMatch,
-                          retaining the remaining portion of the URL before redirecting the request.
+                          The prefix that replaces the prefixMatch specified in the
+                          HttpRouteRuleMatch, retaining the remaining portion of the URL before
+                          redirecting the request. prefixRedirect cannot be supplied together with
+                          pathRedirect. Supply one alone or neither. If neither is supplied, the
+                          path of the original request will be used for the redirect. The value
+                          must be between 1 and 1024 characters.
                       - !ruby/object:Api::Type::Enum
                         name: 'redirectResponseCode'
                         description: |
@@ -14301,11 +14327,11 @@ objects:
                           - :TEMPORARY_REDIRECT
                       - !ruby/object:Api::Type::Boolean
                         name: 'stripQuery'
-                        required: true
+                        default_value: false
                         description: |
-                          If set to true, any accompanying query portion of the original URL is removed
-                          prior to redirecting the request. If set to false, the query portion of the
-                          original URL is retained.
+                          If set to true, any accompanying query portion of the original URL is
+                          removed prior to redirecting the request. If set to false, the query
+                          portion of the original URL is retained. The default is set to false.
             - !ruby/object:Api::Type::Array
               name: 'routeRules'
               description: |


### PR DESCRIPTION
* The stripQuery parameter should not be required since it is set to
  false by default.
* Documentation has been synced with:
  https://cloud.google.com/compute/docs/reference/rest/v1/urlMaps

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: `google_compute_region_url_map` mark `strip_query` as optional and default to false
```

```release-note:enhancement
compute: `google_compute_url_map` mark `strip_query` as optional and default to false
```
