### PR TITLE
Promote region* compute services to GA

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -8438,7 +8438,7 @@ objects:
       guides:
         'Adding or Resizing Regional Persistent Disks':
           'https://cloud.google.com/compute/docs/disks/regional-persistent-disk'
-      api: 'https://cloud.google.com/compute/docs/reference/rest/beta/regionDisks'
+      api: 'https://cloud.google.com/compute/docs/reference/rest/v1/regionDisks'
     async: !ruby/object:Api::OpAsync
       operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
@@ -10051,7 +10051,7 @@ objects:
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Official Documentation': 'https://cloud.google.com/load-balancing/docs/health-checks'
-      api: 'https://cloud.google.com/compute/docs/reference/rest/beta/regionHealthChecks'
+      api: 'https://cloud.google.com/compute/docs/reference/rest/v1/regionHealthChecks'
     description: |
       Health Checks determine whether instances are responsive and able to do work.
       They are an important part of a comprehensive load balancing configuration,
@@ -12896,7 +12896,7 @@ objects:
       guides:
         'Official Documentation':
           'https://cloud.google.com/compute/docs/load-balancing/http/target-proxies'
-      api: 'https://cloud.google.com/compute/docs/reference/rest/beta/regionTargetHttpProxies'
+      api: 'https://cloud.google.com/compute/docs/reference/rest/v1/regionTargetHttpProxies'
     async: !ruby/object:Api::OpAsync
       operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
@@ -12970,7 +12970,7 @@ objects:
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Official Documentation': 'https://cloud.google.com/compute/docs/load-balancing/http/target-proxies'
-      api: 'https://cloud.google.com/compute/docs/reference/rest/beta/regionTargetHttpsProxies'
+      api: 'https://cloud.google.com/compute/docs/reference/rest/v1/regionTargetHttpsProxies'
     async: !ruby/object:Api::OpAsync
       operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -738,10 +738,10 @@ objects:
         description: |
           Settings controlling the volume of connections to a backend service. This field
           is applicable only when the load_balancing_scheme is set to INTERNAL_SELF_MANAGED.
-        min_version: beta
         properties:
           - !ruby/object:Api::Type::NestedObject
             name: 'connectTimeout'
+            min_version: beta
             at_least_one_of:
               - circuit_breakers.0.connect_timeout
               - circuit_breakers.0.max_requests_per_connection
@@ -842,7 +842,6 @@ objects:
           hashing. This field only applies if the load_balancing_scheme is set to
           INTERNAL_SELF_MANAGED. This field is only applicable when locality_lb_policy is
           set to MAGLEV or RING_HASH.
-        min_version: beta
         properties:
           - !ruby/object:Api::Type::NestedObject
             name: 'httpCookie'
@@ -1036,7 +1035,6 @@ objects:
         output: true
       - !ruby/object:Api::Type::Array
         name: 'customRequestHeaders'
-        min_version: beta
         item_type: Api::Type::String
         description: |
           Headers that the HTTP/S load balancer should add to proxied
@@ -1109,7 +1107,6 @@ objects:
           - :INTERNAL_SELF_MANAGED
       - !ruby/object:Api::Type::Enum
         name: 'localityLbPolicy'
-        min_version: beta
         values:
           - :ROUND_ROBIN
           - :LEAST_REQUEST
@@ -1161,7 +1158,6 @@ objects:
           character, which cannot be a dash.
       - !ruby/object:Api::Type::NestedObject
         name: 'outlierDetection'
-        min_version: beta
         description: |
           Settings controlling eviction of unhealthy hosts from the load balancing pool.
           This field is applicable only when the load_balancing_scheme is set
@@ -1451,7 +1447,6 @@ objects:
           failed request. Default is 30 seconds. Valid range is [1, 86400].
       - !ruby/object:Api::Type::NestedObject
         name: 'logConfig'
-        min_version: beta
         description: |
           This field denotes the logging options for the load balancer traffic served by this backend service.
           If logging is enabled, logs will be exported to Stackdriver.
@@ -1515,7 +1510,6 @@ objects:
     properties:
       - !ruby/object:Api::Type::Integer
         name: 'affinityCookieTtlSec'
-        min_version: beta
         description: |
           Lifetime of cookies in seconds if session_affinity is
           GENERATED_COOKIE. If set to 0, the cookie is non-persistent and lasts
@@ -1562,7 +1556,6 @@ objects:
               description: |
                 This field designates whether this is a failover backend. More
                 than one failover backend can be configured for a given RegionBackendService.
-              min_version: beta
             - !ruby/object:Api::Type::String
               name: 'group'
               required: true
@@ -1657,10 +1650,10 @@ objects:
           Settings controlling the volume of connections to a backend service. This field
           is applicable only when the `load_balancing_scheme` is set to INTERNAL_MANAGED
           and the `protocol` is set to HTTP, HTTPS, or HTTP2.
-        min_version: beta
         properties:
           - !ruby/object:Api::Type::NestedObject
             name: 'connectTimeout'
+            min_version: beta
             at_least_one_of:
               - circuit_breakers.0.connect_timeout
               - circuit_breakers.0.max_requests_per_connection
@@ -1763,7 +1756,6 @@ objects:
             * `load_balancing_scheme` is set to INTERNAL_MANAGED
             * `protocol` is set to HTTP, HTTPS, or HTTP2
             * `locality_lb_policy` is set to MAGLEV or RING_HASH
-        min_version: beta
         properties:
           - !ruby/object:Api::Type::NestedObject
             name: 'httpCookie'
@@ -1861,7 +1853,6 @@ objects:
           An optional description of this resource.
       - !ruby/object:Api::Type::NestedObject
         name: 'failoverPolicy'
-        min_version: beta
         description: |
           Policy for failovers.
         properties:
@@ -1939,7 +1930,6 @@ objects:
           - :INTERNAL_MANAGED
       - !ruby/object:Api::Type::Enum
         name: 'localityLbPolicy'
-        min_version: beta
         values:
           - :ROUND_ROBIN
           - :LEAST_REQUEST
@@ -1991,7 +1981,6 @@ objects:
           character, which cannot be a dash.
       - !ruby/object:Api::Type::NestedObject
         name: 'outlierDetection'
-        min_version: beta
         description: |
           Settings controlling eviction of unhealthy hosts from the load balancing pool.
           This field is applicable only when the `load_balancing_scheme` is set
@@ -2270,7 +2259,6 @@ objects:
           failed request. Default is 30 seconds. Valid range is [1, 86400].
       - !ruby/object:Api::Type::NestedObject
         name: 'logConfig'
-        min_version: beta
         description: |
           This field denotes the logging options for the load balancer traffic served by this backend service.
           If logging is enabled, logs will be exported to Stackdriver.

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -257,21 +257,18 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           health_check_name: "rbs-health-check"
       - !ruby/object:Provider::Terraform::Examples
         name: "region_backend_service_ilb_round_robin"
-        min_version: beta
         primary_resource_id: "default"
         vars:
           region_backend_service_name: "region-service"
           health_check_name: "rbs-health-check"
       - !ruby/object:Provider::Terraform::Examples
         name: "region_backend_service_ilb_ring_hash"
-        min_version: beta
         primary_resource_id: "default"
         vars:
           region_backend_service_name: "region-service"
           health_check_name: "rbs-health-check"
       - !ruby/object:Provider::Terraform::Examples
         name: "region_backend_service_balancing_mode"
-        min_version: beta
         primary_resource_id: "default"
         vars:
           region_backend_service_name: "region-service"

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1385,7 +1385,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "region_health_check_http_logs"
         primary_resource_id: "http-region-health-check"
-        min_version: beta
         vars:
           health_check_name: "http-region-health-check"
       - !ruby/object:Provider::Terraform::Examples
@@ -1440,7 +1439,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       sslHealthCheck: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'portDiffSuppress'
   RegionUrlMap: !ruby/object:Overrides::Terraform::ResourceOverride
-    min_version: 'beta'
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "region_url_map_basic"
@@ -1881,7 +1879,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "default"
       - !ruby/object:Provider::Terraform::Examples
         name: "region_ssl_certificate_target_https_proxies"
-        min_version: "beta"
         primary_resource_id: "default"
         vars:
           region_target_https_proxy_name: "test-proxy"
@@ -2077,7 +2074,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_value: :NONE
         custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
   RegionTargetHttpProxy: !ruby/object:Overrides::Terraform::ResourceOverride
-    min_version: 'beta'
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "region_target_http_proxy_basic"
@@ -2104,7 +2100,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         name: proxyId
   RegionTargetHttpsProxy: !ruby/object:Overrides::Terraform::ResourceOverride
-    min_version: 'beta'
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "region_target_https_proxy_basic"

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1385,6 +1385,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "region_health_check_http_logs"
         primary_resource_id: "http-region-health-check"
+        min_version: beta
         vars:
           health_check_name: "http-region-health-check"
       - !ruby/object:Provider::Terraform::Examples

--- a/templates/terraform/examples/region_backend_service_balancing_mode.tf.erb
+++ b/templates/terraform/examples/region_backend_service_balancing_mode.tf.erb
@@ -1,6 +1,4 @@
 resource "google_compute_region_backend_service" "default" {
-  provider = google-beta
-
   load_balancing_scheme = "INTERNAL_MANAGED"
 
   backend {
@@ -18,15 +16,11 @@ resource "google_compute_region_backend_service" "default" {
 }
 
 data "google_compute_image" "debian_image" {
-  provider = google-beta
-
   family   = "debian-9"
   project  = "debian-cloud"
 }
 
 resource "google_compute_region_instance_group_manager" "rigm" {
-  provider = google-beta
-
   region   = "us-central1"
   name     = "<%= ctx[:vars]['rigm_name'] %>"
   version {
@@ -38,8 +32,6 @@ resource "google_compute_region_instance_group_manager" "rigm" {
 }
 
 resource "google_compute_instance_template" "instance_template" {
-  provider     = google-beta
-
   name         = "template-<%= ctx[:vars]['region_backend_service_name'] %>"
   machine_type = "n1-standard-1"
 
@@ -58,8 +50,6 @@ resource "google_compute_instance_template" "instance_template" {
 }
 
 resource "google_compute_region_health_check" "default" {
-  provider = google-beta
-
   region = "us-central1"
   name   = "<%= ctx[:vars]['region_health_check_name'] %>"
   http_health_check {
@@ -68,16 +58,12 @@ resource "google_compute_region_health_check" "default" {
 }
 
 resource "google_compute_network" "default" {
-  provider = google-beta
-
   name                    = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks = false
   routing_mode            = "REGIONAL"
 }
 
 resource "google_compute_subnetwork" "default" {
-  provider = google-beta
-
   name          = "<%= ctx[:vars]['network_name'] %>-default"
   ip_cidr_range = "10.1.2.0/24"
   region        = "us-central1"

--- a/templates/terraform/examples/region_backend_service_ilb_ring_hash.tf.erb
+++ b/templates/terraform/examples/region_backend_service_ilb_ring_hash.tf.erb
@@ -1,6 +1,4 @@
 resource "google_compute_region_backend_service" "<%= ctx[:primary_resource_id] %>" {
-  provider = "google-beta"
-
   region = "us-central1"
   name = "<%= ctx[:vars]['region_backend_service_name'] %>"
   health_checks = ["${google_compute_health_check.health_check.self_link}"]
@@ -26,8 +24,6 @@ resource "google_compute_region_backend_service" "<%= ctx[:primary_resource_id] 
 }
 
 resource "google_compute_health_check" "health_check" {
-  provider = "google-beta"
-
   name               = "<%= ctx[:vars]['health_check_name'] %>"
   http_health_check {
     port = 80

--- a/templates/terraform/examples/region_backend_service_ilb_round_robin.tf.erb
+++ b/templates/terraform/examples/region_backend_service_ilb_round_robin.tf.erb
@@ -1,6 +1,4 @@
 resource "google_compute_region_backend_service" "<%= ctx[:primary_resource_id] %>" {
-  provider = "google-beta"
-
   region = "us-central1"
   name = "<%= ctx[:vars]['region_backend_service_name'] %>"
   health_checks = ["${google_compute_health_check.health_check.self_link}"]
@@ -10,8 +8,6 @@ resource "google_compute_region_backend_service" "<%= ctx[:primary_resource_id] 
 }
 
 resource "google_compute_health_check" "health_check" {
-  provider = "google-beta"
-
   name               = "<%= ctx[:vars]['health_check_name'] %>"
   http_health_check {
     port = 80

--- a/templates/terraform/examples/region_health_check_http_logs.tf.erb
+++ b/templates/terraform/examples/region_health_check_http_logs.tf.erb
@@ -1,6 +1,4 @@
 resource "google_compute_region_health_check" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
-
   name = "<%= ctx[:vars]['health_check_name'] %>"
 
   timeout_sec        = 1

--- a/templates/terraform/examples/region_health_check_http_logs.tf.erb
+++ b/templates/terraform/examples/region_health_check_http_logs.tf.erb
@@ -1,4 +1,6 @@
 resource "google_compute_region_health_check" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+
   name = "<%= ctx[:vars]['health_check_name'] %>"
 
   timeout_sec        = 1

--- a/templates/terraform/examples/region_ssl_certificate_target_https_proxies.tf.erb
+++ b/templates/terraform/examples/region_ssl_certificate_target_https_proxies.tf.erb
@@ -9,7 +9,6 @@
 // name with name_prefix, or use random_id resource. Example:
 
 resource "google_compute_region_ssl_certificate" "default" {
-  provider    = google-beta
   region      = "us-central1"
   name_prefix = "my-certificate-"
   private_key = file("path/to/private.key")
@@ -21,7 +20,6 @@ resource "google_compute_region_ssl_certificate" "default" {
 }
 
 resource "google_compute_region_target_https_proxy" "default" {
-  provider         = google-beta
   region           = "us-central1"
   name             = "<%= ctx[:vars]['region_target_https_proxy_name'] %>"
   url_map          = google_compute_region_url_map.default.self_link
@@ -29,7 +27,6 @@ resource "google_compute_region_target_https_proxy" "default" {
 }
 
 resource "google_compute_region_url_map" "default" {
-  provider    = google-beta
   region      = "us-central1"
   name        = "<%= ctx[:vars]['region_url_map_name'] %>"
   description = "a description"
@@ -53,7 +50,6 @@ resource "google_compute_region_url_map" "default" {
 }
 
 resource "google_compute_region_backend_service" "default" {
-  provider    = google-beta
   region      = "us-central1"
   name        = "<%= ctx[:vars]['region_backend_service_name'] %>"
   protocol    = "HTTP"
@@ -63,7 +59,6 @@ resource "google_compute_region_backend_service" "default" {
 }
 
 resource "google_compute_region_health_check" "default" {
-  provider = google-beta
   region   = "us-central1"
   name     = "<%= ctx[:vars]['region_health_check_name'] %>"
   http_health_check {

--- a/templates/terraform/examples/region_target_http_proxy_basic.tf.erb
+++ b/templates/terraform/examples/region_target_http_proxy_basic.tf.erb
@@ -1,14 +1,10 @@
 resource "google_compute_region_target_http_proxy" "default" {
-  provider = google-beta
-
   region  = "us-central1"
   name    = "<%= ctx[:vars]['region_target_http_proxy_name'] %>"
   url_map = google_compute_region_url_map.default.self_link
 }
 
 resource "google_compute_region_url_map" "default" {
-  provider = google-beta
-
   region          = "us-central1"
   name            = "<%= ctx[:vars]['region_url_map_name'] %>"
   default_service = google_compute_region_backend_service.default.self_link
@@ -30,8 +26,6 @@ resource "google_compute_region_url_map" "default" {
 }
 
 resource "google_compute_region_backend_service" "default" {
-  provider = google-beta
-
   region      = "us-central1"
   name        = "<%= ctx[:vars]['region_backend_service_name'] %>"
   protocol    = "HTTP"
@@ -41,8 +35,6 @@ resource "google_compute_region_backend_service" "default" {
 }
 
 resource "google_compute_region_health_check" "default" {
-  provider = google-beta
-
   region = "us-central1"
   name   = "<%= ctx[:vars]['region_health_check_name'] %>"
   http_health_check {

--- a/templates/terraform/examples/region_target_http_proxy_https_redirect.tf.erb
+++ b/templates/terraform/examples/region_target_http_proxy_https_redirect.tf.erb
@@ -1,14 +1,10 @@
 resource "google_compute_region_target_http_proxy" "default" {
-  provider = google-beta
-
   region  = "us-central1"
   name    = "<%= ctx[:vars]['region_target_http_proxy_name'] %>"
   url_map = google_compute_region_url_map.default.self_link
 }
 
 resource "google_compute_region_url_map" "default" {
-  provider = google-beta
-
   region          = "us-central1"
   name            = "<%= ctx[:vars]['region_url_map_name'] %>"
   default_url_redirect {

--- a/templates/terraform/examples/region_target_https_proxy_basic.tf.erb
+++ b/templates/terraform/examples/region_target_https_proxy_basic.tf.erb
@@ -1,6 +1,4 @@
 resource "google_compute_region_target_https_proxy" "default" {
-  provider = google-beta
-
   region           = "us-central1"
   name             = "<%= ctx[:vars]['region_target_https_proxy_name'] %>"
   url_map          = google_compute_region_url_map.default.self_link
@@ -8,8 +6,6 @@ resource "google_compute_region_target_https_proxy" "default" {
 }
 
 resource "google_compute_region_ssl_certificate" "default" {
-  provider = google-beta
-
   region      = "us-central1"
   name        = "<%= ctx[:vars]['region_ssl_certificate_name'] %>"
   private_key = file("path/to/private.key")
@@ -17,8 +13,6 @@ resource "google_compute_region_ssl_certificate" "default" {
 }
 
 resource "google_compute_region_url_map" "default" {
-  provider = google-beta
-
   region      = "us-central1"
   name        = "<%= ctx[:vars]['region_url_map_name'] %>"
   description = "a description"
@@ -42,8 +36,6 @@ resource "google_compute_region_url_map" "default" {
 }
 
 resource "google_compute_region_backend_service" "default" {
-  provider = google-beta
-
   region      = "us-central1"
   name        = "<%= ctx[:vars]['region_backend_service_name'] %>"
   protocol    = "HTTP"
@@ -53,8 +45,6 @@ resource "google_compute_region_backend_service" "default" {
 }
 
 resource "google_compute_region_health_check" "default" {
-  provider = google-beta
-
   region = "us-central1"
   name   = "<%= ctx[:vars]['region_health_check_name'] %>"
   http_health_check {

--- a/templates/terraform/examples/region_url_map_basic.tf.erb
+++ b/templates/terraform/examples/region_url_map_basic.tf.erb
@@ -1,6 +1,4 @@
 resource "google_compute_region_url_map" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
-
   region = "us-central1"
 
   name        = "<%= ctx[:vars]['region_url_map_name'] %>"
@@ -36,8 +34,6 @@ resource "google_compute_region_url_map" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_compute_region_backend_service" "login" {
-  provider = google-beta
-
   region = "us-central1"
 
   name        = "<%= ctx[:vars]['login_region_backend_service_name'] %>"
@@ -48,8 +44,6 @@ resource "google_compute_region_backend_service" "login" {
 }
 
 resource "google_compute_region_backend_service" "home" {
-  provider = google-beta
-
   region = "us-central1"
 
   name        = "<%= ctx[:vars]['home_region_backend_service_name'] %>"
@@ -60,8 +54,6 @@ resource "google_compute_region_backend_service" "home" {
 }
 
 resource "google_compute_region_health_check" "default" {
-  provider = google-beta
-
   region = "us-central1"
 
   name               = "<%= ctx[:vars]['region_health_check_name'] %>"

--- a/templates/terraform/examples/region_url_map_l7_ilb_path.tf.erb
+++ b/templates/terraform/examples/region_url_map_l7_ilb_path.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_region_url_map" "<%= ctx[:primary_resource_id] %>" {
-  provider = "google-beta"
   name        = "<%= ctx[:vars]['region_url_map_name'] %>"
   description = "a description"
   default_service = google_compute_region_backend_service.home.self_link
@@ -86,7 +85,6 @@ resource "google_compute_region_url_map" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_compute_region_backend_service" "home" {
-  provider = "google-beta"
   name        = "<%= ctx[:vars]['home_region_backend_service_name'] %>"
   protocol    = "HTTP"
   timeout_sec = 10
@@ -96,7 +94,6 @@ resource "google_compute_region_backend_service" "home" {
 }
 
 resource "google_compute_region_health_check" "default" {
-  provider = "google-beta"
   name               = "<%= ctx[:vars]['region_health_check_name'] %>"
   http_health_check {
     port = 80

--- a/templates/terraform/examples/region_url_map_l7_ilb_path_partial.tf.erb
+++ b/templates/terraform/examples/region_url_map_l7_ilb_path_partial.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_region_url_map" "<%= ctx[:primary_resource_id] %>" {
-  provider = "google-beta"
   name        = "<%= ctx[:vars]['region_url_map_name'] %>"
   description = "a description"
   default_service = google_compute_region_backend_service.home.self_link
@@ -54,7 +53,6 @@ resource "google_compute_region_url_map" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_compute_region_backend_service" "home" {
-  provider = "google-beta"
   name        = "<%= ctx[:vars]['home_region_backend_service_name'] %>"
   protocol    = "HTTP"
   timeout_sec = 10
@@ -64,7 +62,6 @@ resource "google_compute_region_backend_service" "home" {
 }
 
 resource "google_compute_region_health_check" "default" {
-  provider = "google-beta"
   name               = "<%= ctx[:vars]['region_health_check_name'] %>"
   http_health_check {
     port = 80

--- a/templates/terraform/examples/region_url_map_l7_ilb_route.tf.erb
+++ b/templates/terraform/examples/region_url_map_l7_ilb_route.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_region_url_map" "<%= ctx[:primary_resource_id] %>" {
-  provider        = "google-beta"
   name            = "<%= ctx[:vars]['region_url_map_name'] %>"
   description     = "a description"
   default_service = google_compute_region_backend_service.home.self_link
@@ -67,7 +66,6 @@ resource "google_compute_region_url_map" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_compute_region_backend_service" "home" {
-  provider    = "google-beta"
   name        = "<%= ctx[:vars]['home_region_backend_service_name'] %>"
   protocol    = "HTTP"
   timeout_sec = 10
@@ -77,7 +75,6 @@ resource "google_compute_region_backend_service" "home" {
 }
 
 resource "google_compute_region_health_check" "default" {
-  provider = "google-beta"
   name     = "<%= ctx[:vars]['region_health_check_name'] %>"
   http_health_check {
     port = 80

--- a/templates/terraform/examples/region_url_map_l7_ilb_route_partial.tf.erb
+++ b/templates/terraform/examples/region_url_map_l7_ilb_route_partial.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_region_url_map" "<%= ctx[:primary_resource_id] %>" {
-  provider = "google-beta"
   name        = "<%= ctx[:vars]['region_url_map_name'] %>"
   description = "a description"
   default_service = google_compute_region_backend_service.home.self_link
@@ -42,7 +41,6 @@ resource "google_compute_region_url_map" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_compute_region_backend_service" "home" {
-  provider = "google-beta"
   name        = "<%= ctx[:vars]['home_region_backend_service_name'] %>"
   protocol    = "HTTP"
   timeout_sec = 10
@@ -52,7 +50,6 @@ resource "google_compute_region_backend_service" "home" {
 }
 
 resource "google_compute_region_health_check" "default" {
-  provider = "google-beta"
   name               = "<%= ctx[:vars]['region_health_check_name'] %>"
   http_health_check {
     port = 80

--- a/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
@@ -501,7 +501,6 @@ func TestAccComputeBackendService_withMaxConnectionsPerEndpoint(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccComputeBackendService_withCustomHeaders(t *testing.T) {
 	t.Parallel()
 
@@ -532,9 +531,7 @@ func TestAccComputeBackendService_withCustomHeaders(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
-<% unless version == 'ga' -%>
 func TestAccComputeBackendService_internalLoadBalancing(t *testing.T) {
 	t.Parallel()
 
@@ -560,9 +557,7 @@ func TestAccComputeBackendService_internalLoadBalancing(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
-<% unless version == 'ga' -%>
 func TestAccComputeBackendService_withLogConfig(t *testing.T) {
 	t.Parallel()
 
@@ -593,9 +588,7 @@ func TestAccComputeBackendService_withLogConfig(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
-<% unless version == 'ga' -%>
 func TestAccComputeBackendService_trafficDirectorUpdateBasic(t *testing.T) {
 	t.Parallel()
 
@@ -626,7 +619,6 @@ func TestAccComputeBackendService_trafficDirectorUpdateBasic(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 <% unless version == 'ga' -%>
 func TestAccComputeBackendService_trafficDirectorUpdateFull(t *testing.T) {
@@ -661,7 +653,6 @@ func TestAccComputeBackendService_trafficDirectorUpdateFull(t *testing.T) {
 }
 <% end -%>
 
-<% unless version == 'ga' -%>
 func testAccComputeBackendService_trafficDirectorBasic(serviceName, checkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
@@ -694,9 +685,7 @@ resource "google_compute_health_check" "health_check" {
 }
 `, serviceName, checkName)
 }
-<% end -%>
 
-<% unless version == 'ga' -%>
 func testAccComputeBackendService_trafficDirectorUpdateBasic(serviceName, checkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
@@ -720,7 +709,6 @@ resource "google_compute_health_check" "health_check" {
 }
 `, serviceName, checkName)
 }
-<% end -%>
 
 <% unless version == 'ga' -%>
 func testAccComputeBackendService_trafficDirectorFull(serviceName, checkName string) string {
@@ -1384,7 +1372,6 @@ resource "google_compute_health_check" "default" {
 `, service, maxRate, instance, neg, network, network, check)
 }
 
-<% unless version == 'ga' -%>
 func testAccComputeBackendService_withCustomHeaders(serviceName, checkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
@@ -1402,9 +1389,7 @@ resource "google_compute_http_health_check" "zero" {
 }
 `, serviceName, checkName)
 }
-<% end -%>
 
-<% unless version == 'ga' -%>
 <%# This test is for import functionality. It can be removed and added to examples when this goes GA %>
 func testAccComputeBackendService_internalLoadBalancing(fr, proxy, backend, hc, urlmap string) string {
 	return fmt.Sprintf(`
@@ -1502,9 +1487,7 @@ resource "google_compute_instance_template" "foobar" {
 }
 `, fr, proxy, backend, hc, urlmap)
 }
-<% end -%>
 
-<% unless version == 'ga' -%>
 func testAccComputeBackendService_withLogConfig(serviceName, checkName string, sampleRate float64) string {
 	return fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
@@ -1525,4 +1508,3 @@ resource "google_compute_http_health_check" "zero" {
 }
 `, serviceName, sampleRate, checkName)
 }
-<% end -%>

--- a/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
@@ -202,6 +202,7 @@ func TestAccComputeRegionBackendService_ilbUpdateBasic(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
 func TestAccComputeRegionBackendService_ilbUpdateFull(t *testing.T) {
 	t.Parallel()
 
@@ -236,6 +237,7 @@ func TestAccComputeRegionBackendService_ilbUpdateFull(t *testing.T) {
 		},
 	})
 }
+<% end -%>
 
 func testAccComputeRegionBackendService_ilbBasic(serviceName, checkName string) string {
 	return fmt.Sprintf(`
@@ -296,6 +298,7 @@ resource "google_compute_health_check" "health_check" {
 `, serviceName, checkName)
 }
 
+<% unless version == 'ga' -%>
 func testAccComputeRegionBackendService_ilbFull(serviceName, checkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_backend_service" "foobar" {
@@ -329,7 +332,9 @@ resource "google_compute_health_check" "health_check" {
 }
 `, serviceName, checkName)
 }
+<% end -%>
 
+<% unless version == 'ga' -%>
 func testAccComputeRegionBackendService_ilbUpdateFull(serviceName, igName, instanceName, checkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_backend_service" "foobar" {
@@ -424,6 +429,7 @@ resource "google_compute_health_check" "health_check" {
 }
 `, serviceName, igName, instanceName, checkName)
 }
+<% end -%>
 
 func testAccComputeRegionBackendService_basic(serviceName, checkName string) string {
 	return fmt.Sprintf(`

--- a/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
@@ -171,7 +171,6 @@ func TestAccComputeRegionBackendService_withConnectionDrainingAndUpdate(t *testi
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccComputeRegionBackendService_ilbUpdateBasic(t *testing.T) {
 	t.Parallel()
 
@@ -202,9 +201,7 @@ func TestAccComputeRegionBackendService_ilbUpdateBasic(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
-<% unless version == 'ga' -%>
 func TestAccComputeRegionBackendService_ilbUpdateFull(t *testing.T) {
 	t.Parallel()
 
@@ -239,9 +236,7 @@ func TestAccComputeRegionBackendService_ilbUpdateFull(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
-<% unless version == 'ga' -%>
 func testAccComputeRegionBackendService_ilbBasic(serviceName, checkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_backend_service" "foobar" {
@@ -275,9 +270,7 @@ resource "google_compute_health_check" "health_check" {
 }
 `, serviceName, checkName)
 }
-<% end -%>
 
-<% unless version == 'ga' -%>
 func testAccComputeRegionBackendService_ilbUpdateBasic(serviceName, checkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_backend_service" "foobar" {
@@ -302,9 +295,7 @@ resource "google_compute_health_check" "health_check" {
 }
 `, serviceName, checkName)
 }
-<% end -%>
 
-<% unless version == 'ga' -%>
 func testAccComputeRegionBackendService_ilbFull(serviceName, checkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_backend_service" "foobar" {
@@ -338,9 +329,7 @@ resource "google_compute_health_check" "health_check" {
 }
 `, serviceName, checkName)
 }
-<% end -%>
 
-<% unless version == 'ga' -%>
 func testAccComputeRegionBackendService_ilbUpdateFull(serviceName, igName, instanceName, checkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_backend_service" "foobar" {
@@ -435,7 +424,6 @@ resource "google_compute_health_check" "health_check" {
 }
 `, serviceName, igName, instanceName, checkName)
 }
-<% end -%>
 
 func testAccComputeRegionBackendService_basic(serviceName, checkName string) string {
 	return fmt.Sprintf(`

--- a/third_party/terraform/tests/resource_compute_region_target_http_proxy_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_target_http_proxy_test.go.erb
@@ -1,7 +1,6 @@
 <% autogen_exception -%>
 package google
 
-<% unless version == 'ga' -%>
 import (
 	"fmt"
 	"testing"
@@ -176,4 +175,3 @@ resource "google_compute_region_url_map" "foobar2" {
 }
 `, target, backend, hc, urlmap1, urlmap2)
 }
-<% end -%>

--- a/third_party/terraform/tests/resource_compute_region_target_https_proxy_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_target_https_proxy_test.go.erb
@@ -1,7 +1,6 @@
 <% autogen_exception -%>
 package google
 
-<% unless version == 'ga' -%>
 import (
 	"fmt"
 	"testing"
@@ -231,4 +230,3 @@ resource "google_compute_region_ssl_certificate" "foobar2" {
 }
 `, id, id, id, id, id, id, id, id, id)
 }
-<% end -%>

--- a/third_party/terraform/tests/resource_compute_region_url_map_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_url_map_test.go.erb
@@ -1,7 +1,6 @@
 <% autogen_exception -%>
 package google
 
-<% unless version == 'ga' -%>
 import (
 	"fmt"
 	"testing"
@@ -855,4 +854,3 @@ resource "google_compute_region_url_map" "foobar" {
 }
 `, randomSuffix)
 }
-<% end -%>


### PR DESCRIPTION
Many of the `region*` resources are still marked as beta (at least for terraform). Some beta-restrictions were lifted in the past:

- 1a509e2698d173896c52cefd7bebb6a586e98308 
- 0cb7099ddf8f72e3f9cc683f639d1f9321dc8c02

But others still seem to be missing. Anything holding us back from promoting all the `Region*` resources to GA?

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_compute_region_url_map` is now GA
```
```release-note:new-resource
`google_compute_region_target_http_proxy` is now GA
```
```release-note:new-resource
`google_compute_region_target_https_proxy` is now GA
```
```release-note:enhancement
compute: Promoted the following `google_compute_backend_service` fields to GA: `circuit_breakers`, `consistent_hash`, `custom_request_headers`, `locality_lb_policy`, `outlier_detection`
```
```release-note:enhancement
compute: Promoted the following `google_compute_region_backend_service` fields to GA: `affinity_cookie_ttl_sec`,`circuit_breakers`, `consistent_hash`, `failover_policy`, `locality_lb_policy`, `outlier_detection`, `log_config`, `failover`
```