### PR TITLE
add min_cpu_platform to google_container_cluster.cluster_autoscaling.auto_provisioning_defaults

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -395,6 +395,13 @@ func resourceContainerCluster() *schema.Resource {
 										Optional: true,
 										Default:  "default",
 									},
+									<% unless version == 'ga' -%>
+									"min_cpu_platform": {
+										Type:  schema.TypeString,
+										Optional: true,
+										DiffSuppressFunc: emptyOrDefaultStringSuppress("automatic"),
+									},
+									<% end -%>
 								},
 							},
 						},
@@ -2467,10 +2474,20 @@ func expandAutoProvisioningDefaults(configured interface{}, d *schema.ResourceDa
 	}
 	config := l[0].(map[string]interface{})
 
-	return &containerBeta.AutoprovisioningNodePoolDefaults{
+	npd := &containerBeta.AutoprovisioningNodePoolDefaults{
 		OauthScopes:    convertStringArr(config["oauth_scopes"].([]interface{})),
 		ServiceAccount: config["service_account"].(string),
 	}
+
+	<% unless version == 'ga' -%>
+	cpu := config["min_cpu_platform"].(string)
+	// the only way to unset the field is to pass "automatic" as its value
+	if cpu == "" {
+		cpu = "automatic"
+	}
+	npd.MinCpuPlatform = cpu
+	<% end -%>
+	return npd
 }
 
 func expandAuthenticatorGroupsConfig(configured interface{}) *containerBeta.AuthenticatorGroupsConfig {
@@ -2958,6 +2975,9 @@ func flattenAutoProvisioningDefaults(a *containerBeta.AutoprovisioningNodePoolDe
 	r := make(map[string]interface{})
 	r["oauth_scopes"] = a.OauthScopes
 	r["service_account"] = a.ServiceAccount
+	<% unless version == 'ga' -%>
+	r["min_cpu_platform"] = a.MinCpuPlatform
+	<% end -%>
 
 	return []map[string]interface{}{r}
 }

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1414,6 +1414,41 @@ func TestAccContainerCluster_withShieldedNodes(t *testing.T) {
 }
 
 <% unless version == 'ga' -%>
+// consider merging this test with TestAccContainerCluster_nodeAutoprovisioningDefaults
+// once the feature is GA
+func TestAccContainerCluster_nodeAutoprovisioningDefaultsMinCpuPlatform(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	includeMinCpuPlatform := true
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:	  func() { testAccPreCheck(t) },
+		Providers:	  testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_autoprovisioningDefaultsMinCpuPlatform(clusterName, includeMinCpuPlatform),
+			},
+			{
+				ResourceName:		 "google_container_cluster.with_autoprovisioning",
+				ImportState:		 true,
+				ImportStateVerify:	 true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
+			{
+				Config: testAccContainerCluster_autoprovisioningDefaultsMinCpuPlatform(clusterName, !includeMinCpuPlatform),
+			},
+			{
+				ResourceName:		 "google_container_cluster.with_autoprovisioning",
+				ImportState:		 true,
+				ImportStateVerify:	 true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_withAutoscalingProfile(t *testing.T) {
 	t.Parallel()
 	clusterName := fmt.Sprintf("cluster-test-%s", randString(t, 10))
@@ -3057,6 +3092,45 @@ if monitoringWrite {
 }`
 	return config
 }
+
+<% unless version == 'ga' -%>
+func testAccContainerCluster_autoprovisioningDefaultsMinCpuPlatform(cluster string, includeMinCpuPlatform bool) string {
+	minCpuPlatformCfg := ""
+	if includeMinCpuPlatform {
+		minCpuPlatformCfg = `min_cpu_platform = "Intel Haswell"`
+	}
+
+	return fmt.Sprintf(`
+data "google_container_engine_versions" "central1a" {
+  location = "us-central1-a"
+}
+
+resource "google_container_cluster" "with_autoprovisioning" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+
+  cluster_autoscaling {
+    enabled = true
+
+    resource_limits {
+      resource_type = "cpu"
+      maximum       = 2
+    }
+    resource_limits {
+      resource_type = "memory"
+      maximum       = 2048
+    }
+
+    auto_provisioning_defaults {
+      %s
+    }
+  }
+}`, cluster, minCpuPlatformCfg)
+}
+<% end -%>
 
 func testAccContainerCluster_withNodePoolAutoscaling(cluster, np string) string {
 	return fmt.Sprintf(`

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -140,7 +140,7 @@ in this cluster in CIDR notation (e.g. `10.96.0.0/14`). Leave blank to have one
 automatically chosen or specify a `/14` block in `10.0.0.0/8`. This field will
 only work for routes-based clusters, where `ip_allocation_policy` is not defined.
 
-* `cluster_autoscaling` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+* `cluster_autoscaling` - (Optional)
 Per-cluster configuration of Node Auto-Provisioning with Cluster Autoscaler to
 automatically adjust the size of the cluster and create/delete node pools based
 on the current needs of the cluster's workload. See the
@@ -407,6 +407,11 @@ for a list of types.
 * `maximum` - (Optional) Maximum amount of the resource in the cluster.
 
 The `auto_provisioning_defaults` block supports:
+
+* `min_cpu_platform` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+Minimum CPU platform to be used for NAP created node pools. The instance may be scheduled on the
+specified or newer CPU platform. Applicable values are the friendly names of CPU platforms, such
+as "Intel Haswell" or "Intel Sandy Bridge".
 
 * `oauth_scopes` - (Optional) Scopes that are used by NAP when creating node pools.
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5947

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
* container: added `min_cpu_platform` to google_container_cluster.cluster_autoscaling.auto_provisioning_defaults [beta-only]
```
