### PR TITLE
Add encryption, retention policy to buckets

### DIFF
--- a/products/storage/ansible.yaml
+++ b/products/storage/ansible.yaml
@@ -25,6 +25,12 @@ datasources: !ruby/object:Overrides::ResourceOverrides
   Object: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
 overrides: !ruby/object:Overrides::ResourceOverrides
+  Bucket: !ruby/object:Overrides::Ansible::ResourceOverride
+    properties:
+      retentionPolicy: !ruby/object:Overrides::Ansible::PropertyOverride
+        exclude: true
+      encryption: !ruby/object:Overrides::Ansible::PropertyOverride
+        exclude: true
   ObjectAccessControl: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
   Object: !ruby/object:Overrides::Ansible::ResourceOverride

--- a/products/storage/ansible.yaml
+++ b/products/storage/ansible.yaml
@@ -27,7 +27,7 @@ datasources: !ruby/object:Overrides::ResourceOverrides
 overrides: !ruby/object:Overrides::ResourceOverrides
   Bucket: !ruby/object:Overrides::Ansible::ResourceOverride
     properties:
-      retentionPolicy: !ruby/object:Overrides::Ansible::PropertyOverride
+      retention_policy: !ruby/object:Overrides::Ansible::PropertyOverride
         exclude: true
       encryption: !ruby/object:Overrides::Ansible::PropertyOverride
         exclude: true

--- a/products/storage/ansible.yaml
+++ b/products/storage/ansible.yaml
@@ -27,7 +27,7 @@ datasources: !ruby/object:Overrides::ResourceOverrides
 overrides: !ruby/object:Overrides::ResourceOverrides
   Bucket: !ruby/object:Overrides::Ansible::ResourceOverride
     properties:
-      retention_policy: !ruby/object:Overrides::Ansible::PropertyOverride
+      retentionPolicy: !ruby/object:Overrides::Ansible::PropertyOverride
         exclude: true
       encryption: !ruby/object:Overrides::Ansible::PropertyOverride
         exclude: true

--- a/products/storage/api.yaml
+++ b/products/storage/api.yaml
@@ -407,6 +407,39 @@ objects:
               object is missing, if applicable, the service will return the
               named object from this bucket as the content for a 404 Not Found
               result.
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'labels'
+        description: |
+          Labels applied to this bucket.  A list of key->value pairs.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'encryption'
+        description: |
+          Encryption configuration for the bucket
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'defaultKmsKeyName'
+            description: |
+              A Cloud KMS key that will be used to encrypt objects inserted into this bucket,
+              if no encryption method is specified.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'rententionPolicy'
+        description: |
+          Retention policy for the bucket
+        properties:
+          - !ruby/object:Api::Type::Time
+            name: 'effectiveTime'
+            description: |
+              The time from which the retention policy was effective
+          - !ruby/object:Api::Type::Boolean
+            name: 'isLocked'
+            description: |
+              If the retention policy is locked. If true, the retention policy cannot be removed and the period cannot
+              be reduced.
+          - !ruby/object:Api::Type::Integer
+            name: 'retentionPeriod'
+            description: |
+              The period of time, in seconds, that objects in the bucket must be retained and cannot be deleted,
+              overwritten, or made noncurrent.
     parameters:
       - !ruby/object:Api::Type::String
         name: 'project'
@@ -438,10 +471,6 @@ objects:
           - :projectPrivate
           - :publicRead
         input: true
-      - !ruby/object:Api::Type::KeyValuePairs
-        name: 'labels'
-        description: |
-          Labels applied to this bucket.  A list of key->value pairs.
   - !ruby/object:Api::Resource
     name: 'BucketAccessControl'
     kind: 'storage#bucketAccessControl'

--- a/products/storage/api.yaml
+++ b/products/storage/api.yaml
@@ -422,7 +422,7 @@ objects:
               A Cloud KMS key that will be used to encrypt objects inserted into this bucket,
               if no encryption method is specified.
       - !ruby/object:Api::Type::NestedObject
-        name: 'rententionPolicy'
+        name: 'retentionPolicy'
         description: |
           Retention policy for the bucket
         properties:

--- a/templates/inspec/examples/google_storage_bucket/google_storage_bucket.erb
+++ b/templates/inspec/examples/google_storage_bucket/google_storage_bucket.erb
@@ -7,7 +7,6 @@ describe google_storage_bucket(name: <%= doc_generation ? "bucket-name" : "\"ins
   its('storage_class') { should eq "STANDARD" }
   its('labels') { should include("key" => "value") }
   its('retention_policy.retention_period') { should cmp 1000 }
-  its('retention_policy.is_locked') { should be false }
 end
 
 describe google_storage_bucket(name: "nonexistent") do

--- a/templates/inspec/examples/google_storage_bucket/google_storage_bucket.erb
+++ b/templates/inspec/examples/google_storage_bucket/google_storage_bucket.erb
@@ -6,6 +6,8 @@ describe google_storage_bucket(name: <%= doc_generation ? "bucket-name" : "\"ins
 
   its('storage_class') { should eq "STANDARD" }
   its('labels') { should include("key" => "value") }
+  its('retention_policy.retention_period') { should cmp 1000 }
+  its('retention_policy.is_locked') { should be false }
 end
 
 describe google_storage_bucket(name: "nonexistent") do

--- a/templates/inspec/tests/integration/build/gcp-mm.tf
+++ b/templates/inspec/tests/integration/build/gcp-mm.tf
@@ -656,6 +656,10 @@ resource "google_storage_bucket" "bucket" {
   labels = {
     "key" = "value"
   }
+
+  retention_policy {
+    retention_period = 1000
+  }
 }
 
 resource "google_storage_bucket_object" "object" {

--- a/third_party/inspec/documentation/google_service_account_keys.md
+++ b/third_party/inspec/documentation/google_service_account_keys.md
@@ -1,11 +1,11 @@
 ### Test that there are no more than a specified number of keys for the service account
 
-    describe google_service_account_keys(service_account: 'projects/sample-project/serviceAccounts/sample-account@sample-project.iam.gserviceaccount.com') do
+    describe google_service_account_keys(project: 'sample-project', service_account: 'sample-account@sample-project.iam.gserviceaccount.com') do
       its('count') { should be <= 1000}
     end
     
 ### Test that a service account with expected name is available
 
-    describe google_service_account_keys(service_account: 'projects/sample-project/serviceAccounts/sample-account@sample-project.iam.gserviceaccount.com') do
+    describe google_service_account_keys(project: 'sample-project', service_account: 'sample-account@sample-project.iam.gserviceaccount.com') do
       its('key_names'){ should include "projects/sample-project/serviceAccounts/test-sa@sample-project.iam.gserviceaccount.com/keys/c6bd986da9fac6d71178db41d1741cbe751a5080" }
     end


### PR DESCRIPTION
Support for encryption object and retention policy for storage bucket

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
