### PR TITLE
Changes for upgraded googleapi library

### DIFF
--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -690,7 +690,8 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, secondGen bool)
 	// 1st Generation instances don't support the disk_autoresize parameter
 	// and it defaults to true - so we shouldn't set it if this is first gen
 	if secondGen {
-		settings.StorageAutoResize = _settings["disk_autoresize"].(bool)
+		resize := _settings["disk_autoresize"].(bool)
+		settings.StorageAutoResize = &resize
 	}
 
 	return settings


### PR DESCRIPTION
Changes related to:
https://github.com/terraform-providers/terraform-provider-google/pull/6138
https://github.com/terraform-providers/terraform-provider-google-beta/pull/1960

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
