### PR TITLE
Add sleep so google_project is ready before returning

### DIFF
--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -151,6 +151,10 @@ func resourceGoogleProjectCreate(d *schema.ResourceData, meta interface{}) error
 		}
 	}
 
+	// Sleep for 10s, letting the billing account settle before other resources
+	// try to use this project.
+	time.Sleep(10 * time.Second)
+
 	err = resourceGoogleProjectRead(d, meta)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5649

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
resourcemanager: added a wait to `google_project` so that projects are more likely to be ready before the resource finishes creation
```
