### PR TITLE
skip SecretVersion sweeper

### DIFF
--- a/products/secretmanager/terraform.yaml
+++ b/products/secretmanager/terraform.yaml
@@ -28,6 +28,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_expand: templates/terraform/custom_expand/bool_to_object.go.erb
 
   SecretVersion: !ruby/object:Overrides::Terraform::ResourceOverride
+    # Versions will be sweeped by the Secret sweeper
+    skip_sweeper: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "secret_version_basic"


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5632

skip SecretVersion sweeper since it's a child of Secret and versions will be deleted with the Secret sweeper

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
