### PR TITLE
Restructure google.erb

### DIFF
--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -242,9 +242,108 @@
     </ul>
     </li>
 
+    <li>
+    <a href="#">Google Cloud Platform Resources</a>
+    <ul class="nav">
+      <li>
+        <a href="/docs/providers/google/r/google_billing_account_iam_binding.html">google_billing_account_iam_binding</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_billing_account_iam_member.html">google_billing_account_iam_member</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_billing_account_iam_policy.html">google_billing_account_iam_policy</a>
+      </li>
+<% unless version == 'ga' -%>
+      <li>
+        <a href="/docs/providers/google/r/billing_budget.html">google_billing_budget</a>
+      </li>
+<% end -%>
+      <li>
+        <a href="/docs/providers/google/r/google_folder.html">google_folder</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_folder_iam_binding.html">google_folder_iam_binding</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_folder_iam_member.html">google_folder_iam_member</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_folder_iam_policy.html">google_folder_iam_policy</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_folder_organization_policy.html">google_folder_organization_policy</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_organization_policy.html">google_organization_policy</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_organization_iam_audit_config.html">google_organization_iam_audit_config</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_organization_iam_binding.html">google_organization_iam_binding</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_organization_iam_custom_role.html">google_organization_iam_custom_role</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_organization_iam_member.html">google_organization_iam_member</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_organization_iam_policy.html">google_organization_iam_policy</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_project.html">google_project</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_project_iam.html">google_project_iam_audit_config</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_project_iam.html">google_project_iam_binding</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_project_iam.html">google_project_iam_member</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_project_iam.html">google_project_iam_policy</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_project_iam_custom_role.html">google_project_iam_custom_role</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_project_organization_policy.html">google_project_organization_policy</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_project_service.html">google_project_service</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/usage_export_bucket.html">google_project_usage_export_bucket</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/resource_manager_lien.html">google_resource_manager_lien</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_service_account.html">google_service_account</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_service_account_iam.html">google_service_account_iam_binding</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_service_account_iam.html">google_service_account_iam_member</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_service_account_iam.html">google_service_account_iam_policy</a>
+      </li>
+      <li>
+      <a href="/docs/providers/google/r/google_service_account_key.html">google_service_account_key</a>
+      </li>
+
+    </ul>
+    </li>
+
 <% unless version == 'ga' %>
     <li>
-    <a href="#">Access Context Manager / VPC Service Control Resources</a>
+    <a href="#">Access Context Manager / VPC Service Control</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/access_context_manager_access_level.html">google_access_context_manager_access_level</a>
@@ -261,7 +360,7 @@
 <% end -%>
 
     <li>
-    <a href="#">Google App Engine Resources</a>
+    <a href="#">App Engine</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/app_engine_application.html">google_app_engine_application</a>
@@ -426,99 +525,66 @@
     </li>
 
     <li>
-    <a href="#">Google Cloud Platform Resources</a>
+    <a href="#">Cloud (Stackdriver) Logging</a>
     <ul class="nav">
       <li>
-        <a href="/docs/providers/google/r/google_billing_account_iam_binding.html">google_billing_account_iam_binding</a>
+      <a href="/docs/providers/google/r/logging_billing_account_exclusion.html">google_logging_billing_account_exclusion</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/logging_billing_account_sink.html">google_logging_billing_account_sink</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/logging_folder_exclusion.html">google_logging_folder_exclusion</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/logging_folder_sink.html">google_logging_folder_sink</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/logging_organization_exclusion.html">google_logging_organization_exclusion</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/logging_organization_sink.html">google_logging_organization_sink</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/logging_metric.html">google_logging_metric</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/logging_project_exclusion.html">google_logging_project_exclusion</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/logging_project_sink.html">google_logging_project_sink</a>
+      </li>
+    </ul>
+    </li>
+
+    <li>
+    <a href="#">Cloud (Stackdriver) Monitoring</a>
+    <ul class="nav">
+      <li>
+      <a href="/docs/providers/google/r/monitoring_alert_policy.html">google_monitoring_alert_policy</a>
       </li>
       <li>
-        <a href="/docs/providers/google/r/google_billing_account_iam_member.html">google_billing_account_iam_member</a>
+      <a href="/docs/providers/google/r/monitoring_group.html">google_monitoring_group</a>
       </li>
       <li>
-        <a href="/docs/providers/google/r/google_billing_account_iam_policy.html">google_billing_account_iam_policy</a>
-      </li>
-<% unless version == 'ga' -%>
-      <li>
-        <a href="/docs/providers/google/r/billing_budget.html">google_billing_budget</a>
-      </li>
-<% end -%>
-      <li>
-        <a href="/docs/providers/google/r/google_folder.html">google_folder</a>
+      <a href="/docs/providers/google/r/monitoring_notification_channel.html">google_monitoring_notification_channel</a>
       </li>
       <li>
-        <a href="/docs/providers/google/r/google_folder_iam_binding.html">google_folder_iam_binding</a>
+      <a href="/docs/providers/google/r/monitoring_service.html">google_monitoring_custom_service</a>
       </li>
       <li>
-        <a href="/docs/providers/google/r/google_folder_iam_member.html">google_folder_iam_member</a>
+      <a href="/docs/providers/google/r/monitoring_slo.html">google_monitoring_slo</a>
       </li>
       <li>
-        <a href="/docs/providers/google/r/google_folder_iam_policy.html">google_folder_iam_policy</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_folder_organization_policy.html">google_folder_organization_policy</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_organization_policy.html">google_organization_policy</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_organization_iam_audit_config.html">google_organization_iam_audit_config</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_organization_iam_binding.html">google_organization_iam_binding</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_organization_iam_custom_role.html">google_organization_iam_custom_role</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_organization_iam_member.html">google_organization_iam_member</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_organization_iam_policy.html">google_organization_iam_policy</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_project.html">google_project</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_project_iam.html">google_project_iam_audit_config</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_project_iam.html">google_project_iam_binding</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_project_iam.html">google_project_iam_member</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_project_iam.html">google_project_iam_policy</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_project_iam_custom_role.html">google_project_iam_custom_role</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_project_organization_policy.html">google_project_organization_policy</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_project_service.html">google_project_service</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/usage_export_bucket.html">google_project_usage_export_bucket</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/resource_manager_lien.html">google_resource_manager_lien</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_service_account.html">google_service_account</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_service_account_iam.html">google_service_account_iam_binding</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_service_account_iam.html">google_service_account_iam_member</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_service_account_iam.html">google_service_account_iam_policy</a>
-      </li>
-      <li>
-      <a href="/docs/providers/google/r/google_service_account_key.html">google_service_account_key</a>
+      <a href="/docs/providers/google/r/monitoring_uptime_check_config.html">google_monitoring_uptime_check_config</a>
       </li>
 
     </ul>
@@ -566,6 +632,106 @@
     </ul>
     </li>
 <% end -%>
+
+    <li>
+    <a href="#">Cloud Source Repositories</a>
+    <ul class="nav">
+      <li>
+      <a href="/docs/providers/google/r/sourcerepo_repository.html">google_sourcerepo_repository</a>
+      </li>
+      <li>
+      <a href="/docs/providers/google/r/sourcerepo_repository_iam.html">google_sourcerepo_repository_iam_binding</a>
+      </li>
+      <li>
+      <a href="/docs/providers/google/r/sourcerepo_repository_iam.html">google_sourcerepo_repository_iam_member</a>
+      </li>
+      <li>
+      <a href="/docs/providers/google/r/sourcerepo_repository_iam.html">google_sourcerepo_repository_iam_policy</a>
+      </li>
+    </ul>
+    </li>
+
+    <li>
+    <a href="#">Cloud SQL</a>
+    <ul class="nav">
+      <li>
+      <a href="/docs/providers/google/r/sql_database.html">google_sql_database</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/sql_database_instance.html">google_sql_database_instance</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/sql_source_representation_instance.html">google_sql_source_representation_instance</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/sql_ssl_cert.html">google_sql_ssl_cert</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/sql_user.html">google_sql_user</a>
+      </li>
+    </ul>
+    </li>
+
+    <li>
+    <a href="#">Cloud Storage</a>
+    <ul class="nav">
+      <li>
+      <a href="/docs/providers/google/r/storage_bucket.html">google_storage_bucket</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/storage_bucket_access_control.html">google_storage_bucket_access_control</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/storage_bucket_acl.html">google_storage_bucket_acl</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/storage_bucket_iam.html">google_storage_bucket_iam_binding</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/storage_bucket_iam.html">google_storage_bucket_iam_member</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/storage_bucket_iam.html">google_storage_bucket_iam_policy</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/storage_bucket_object.html">google_storage_bucket_object</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/storage_default_object_access_control.html">google_storage_default_object_access_control</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/storage_default_object_acl.html">google_storage_default_object_acl</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/storage_hmac_key.html">google_storage_hmac_key</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/storage_notification.html">google_storage_notification</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/storage_object_access_control.html">google_storage_object_access_control</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/storage_object_acl.html">google_storage_object_acl</a>
+      </li>
+    </ul>
+    </li>
 
     <li>
       <a href="#">Cloud Tasks</a>
@@ -936,19 +1102,6 @@
     </ul>
     </li>
 
-    <li>
-    <a href="#">Kubernetes (Container) Engine</a>
-    <ul class="nav">
-      <li>
-      <a href="/docs/providers/google/r/container_cluster.html">google_container_cluster</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/container_node_pool.html">google_container_node_pool</a>
-      </li>
-    </ul>
-    </li>
-
 <% unless version == 'ga' %>
     <li>
     <a href="#">Data Fusion</a>
@@ -970,53 +1123,53 @@
     </li>
 
     <li>
+    <a href="#">Dataproc</a>
+    <ul class="nav">
+      <li>
+      <a href="/docs/providers/google/r/dataproc_autoscaling_policy.html">google_dataproc_autoscaling_policy</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/dataproc_cluster.html">google_dataproc_cluster</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/dataproc_cluster_iam.html">google_dataproc_cluster_iam_binding</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/dataproc_cluster_iam.html">google_dataproc_cluster_iam_member</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/dataproc_cluster_iam.html">google_dataproc_cluster_iam_policy</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/dataproc_job.html">google_dataproc_job</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/dataproc_job_iam.html">google_dataproc_job_iam_binding</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/dataproc_job_iam.html">google_dataproc_job_iam_member</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/dataproc_job_iam.html">google_dataproc_job_iam_policy</a>
+      </li>
+    </ul>
+    </li>
+
+    <li>
     <a href="#">Datastore</a>
     <ul class="nav">
       <li>
           <a href="/docs/providers/google/r/datastore_index.html">google_datastore_index</a>
       </li>
     </ul>
-    </li>
-
-    <li>
-        <a href="#">Dataproc</a>
-        <ul class="nav">
-          <li>
-          <a href="/docs/providers/google/r/dataproc_autoscaling_policy.html">google_dataproc_autoscaling_policy</a>
-          </li>
-
-          <li>
-          <a href="/docs/providers/google/r/dataproc_cluster.html">google_dataproc_cluster</a>
-          </li>
-
-          <li>
-          <a href="/docs/providers/google/r/dataproc_cluster_iam.html">google_dataproc_cluster_iam_binding</a>
-          </li>
-
-          <li>
-          <a href="/docs/providers/google/r/dataproc_cluster_iam.html">google_dataproc_cluster_iam_member</a>
-          </li>
-
-          <li>
-          <a href="/docs/providers/google/r/dataproc_cluster_iam.html">google_dataproc_cluster_iam_policy</a>
-          </li>
-
-          <li>
-          <a href="/docs/providers/google/r/dataproc_job.html">google_dataproc_job</a>
-          </li>
-
-          <li>
-          <a href="/docs/providers/google/r/dataproc_job_iam.html">google_dataproc_job_iam_binding</a>
-          </li>
-
-          <li>
-          <a href="/docs/providers/google/r/dataproc_job_iam.html">google_dataproc_job_iam_member</a>
-          </li>
-
-          <li>
-          <a href="/docs/providers/google/r/dataproc_job_iam.html">google_dataproc_job_iam_policy</a>
-          </li>
-        </ul>
     </li>
 
     <li>
@@ -1076,6 +1229,16 @@
       </li>
     </ul>
     </li>
+
+    <li>
+    <a href="#">Filestore</a>
+    <ul class="nav">
+      <li>
+          <a href="/docs/providers/google/r/filestore_instance.html">google_filestore_instance</a>
+      </li>
+    </ul>
+    </li>
+
 <% unless version == 'ga' %>
     <li>
     <a href="#">Firebase</a>
@@ -1096,15 +1259,6 @@
     </ul>
     </li>
 <% end %>
-    <li>
-    <a href="#">Filestore</a>
-    <ul class="nav">
-      <li>
-          <a href="/docs/providers/google/r/filestore_instance.html">google_filestore_instance</a>
-      </li>
-    </ul>
-    </li>
-
     <li>
     <a href="#">Firestore</a>
     <ul class="nav">
@@ -1191,39 +1345,6 @@
       </li>
     </ul>
 <% end -%>
-
-    <li>
-    <a href="#">Key Management Service</a>
-    <ul class="nav">
-      <li>
-        <a href="/docs/providers/google/r/kms_crypto_key.html">google_kms_crypto_key</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_kms_crypto_key_iam.html">google_kms_crypto_key_iam_binding</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_kms_crypto_key_iam.html">google_kms_crypto_key_iam_member</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_kms_crypto_key_iam.html">google_kms_crypto_key_iam_policy</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/kms_key_ring.html">google_kms_key_ring</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_binding</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_member</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_policy</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/kms_secret_ciphertext.html">google_kms_secret_ciphertext</a>
-      </li>
-    </ul>
-    </li>
 
     <li>
     <a href="#">IAP</a>
@@ -1327,6 +1448,52 @@
     </li>
 
     <li>
+    <a href="#">Key Management Service</a>
+    <ul class="nav">
+      <li>
+        <a href="/docs/providers/google/r/kms_crypto_key.html">google_kms_crypto_key</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_kms_crypto_key_iam.html">google_kms_crypto_key_iam_binding</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_kms_crypto_key_iam.html">google_kms_crypto_key_iam_member</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_kms_crypto_key_iam.html">google_kms_crypto_key_iam_policy</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/kms_key_ring.html">google_kms_key_ring</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_binding</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_member</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_policy</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/kms_secret_ciphertext.html">google_kms_secret_ciphertext</a>
+      </li>
+    </ul>
+    </li>
+
+    <li>
+    <a href="#">Kubernetes (Container) Engine</a>
+    <ul class="nav">
+      <li>
+      <a href="/docs/providers/google/r/container_cluster.html">google_container_cluster</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/container_node_pool.html">google_container_node_pool</a>
+      </li>
+    </ul>
+    </li>
+
+    <li>
     <a href="#">ML Engine</a>
     <ul class="nav">
       <li>
@@ -1383,7 +1550,7 @@
     </li>
 
     <li>
-    <a href="#">RuntimeConfig</a>
+    <a href="#">Runtime Configurator</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/runtimeconfig_config.html">google_runtimeconfig_config</a>
@@ -1401,15 +1568,6 @@
 
       <li>
       <a href="/docs/providers/google/r/runtimeconfig_variable.html">google_runtimeconfig_variable</a>
-      </li>
-    </ul>
-    </li>
-
-    <li>
-    <a href="#">Security Command Center (SCC)</a>
-    <ul class="nav">
-      <li>
-          <a href="/docs/providers/google/r/scc_source.html">google_scc_source</a>
       </li>
     </ul>
     </li>
@@ -1436,6 +1594,24 @@
     </ul>
     </li>
 <% end -%>
+
+    <li>
+    <a href="#">Security Command Center (SCC)</a>
+    <ul class="nav">
+      <li>
+          <a href="/docs/providers/google/r/scc_source.html">google_scc_source</a>
+      </li>
+    </ul>
+    </li>
+
+    <li>
+    <a href="#">Serverless VPC Access</a>
+    <ul class="nav">
+      <li>
+      <a href="/docs/providers/google/r/vpc_access_connector.html">google_vpc_access_connector</a>
+      </li>
+    </ul>
+    </li>
 
 <% unless version == 'ga' %>
     <li>
@@ -1493,24 +1669,6 @@
 <% end -%>
 
     <li>
-    <a href="#">Cloud Source Repositories</a>
-    <ul class="nav">
-      <li>
-      <a href="/docs/providers/google/r/sourcerepo_repository.html">google_sourcerepo_repository</a>
-      </li>
-      <li>
-      <a href="/docs/providers/google/r/sourcerepo_repository_iam.html">google_sourcerepo_repository_iam_binding</a>
-      </li>
-      <li>
-      <a href="/docs/providers/google/r/sourcerepo_repository_iam.html">google_sourcerepo_repository_iam_member</a>
-      </li>
-      <li>
-      <a href="/docs/providers/google/r/sourcerepo_repository_iam.html">google_sourcerepo_repository_iam_policy</a>
-      </li>
-    </ul>
-    </li>
-
-    <li>
     <a href="#">Spanner</a>
     <ul class="nav">
       <li>
@@ -1542,167 +1700,10 @@
     </li>
 
     <li>
-    <a href="#">Cloud SQL</a>
-    <ul class="nav">
-      <li>
-      <a href="/docs/providers/google/r/sql_database.html">google_sql_database</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/sql_database_instance.html">google_sql_database_instance</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/sql_source_representation_instance.html">google_sql_source_representation_instance</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/sql_ssl_cert.html">google_sql_ssl_cert</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/sql_user.html">google_sql_user</a>
-      </li>
-    </ul>
-    </li>
-
-    <li>
-    <a href="#">Cloud (Stackdriver) Logging</a>
-    <ul class="nav">
-      <li>
-      <a href="/docs/providers/google/r/logging_billing_account_exclusion.html">google_logging_billing_account_exclusion</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/logging_billing_account_sink.html">google_logging_billing_account_sink</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/logging_folder_exclusion.html">google_logging_folder_exclusion</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/logging_folder_sink.html">google_logging_folder_sink</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/logging_organization_exclusion.html">google_logging_organization_exclusion</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/logging_organization_sink.html">google_logging_organization_sink</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/logging_metric.html">google_logging_metric</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/logging_project_exclusion.html">google_logging_project_exclusion</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/logging_project_sink.html">google_logging_project_sink</a>
-      </li>
-    </ul>
-    </li>
-
-    <li>
-    <a href="#">Cloud (Stackdriver) Monitoring</a>
-    <ul class="nav">
-      <li>
-      <a href="/docs/providers/google/r/monitoring_alert_policy.html">google_monitoring_alert_policy</a>
-      </li>
-      <li>
-      <a href="/docs/providers/google/r/monitoring_group.html">google_monitoring_group</a>
-      </li>
-      <li>
-      <a href="/docs/providers/google/r/monitoring_notification_channel.html">google_monitoring_notification_channel</a>
-      </li>
-      <li>
-      <a href="/docs/providers/google/r/monitoring_service.html">google_monitoring_custom_service</a>
-      </li>
-      <li>
-      <a href="/docs/providers/google/r/monitoring_slo.html">google_monitoring_slo</a>
-      </li>
-      <li>
-      <a href="/docs/providers/google/r/monitoring_uptime_check_config.html">google_monitoring_uptime_check_config</a>
-      </li>
-
-    </ul>
-    </li>
-
-    <li>
-    <a href="#">Cloud Storage</a>
-    <ul class="nav">
-      <li>
-      <a href="/docs/providers/google/r/storage_bucket.html">google_storage_bucket</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/storage_bucket_access_control.html">google_storage_bucket_access_control</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/storage_bucket_acl.html">google_storage_bucket_acl</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/storage_bucket_iam.html">google_storage_bucket_iam_binding</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/storage_bucket_iam.html">google_storage_bucket_iam_member</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/storage_bucket_iam.html">google_storage_bucket_iam_policy</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/storage_bucket_object.html">google_storage_bucket_object</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/storage_default_object_access_control.html">google_storage_default_object_access_control</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/storage_default_object_acl.html">google_storage_default_object_acl</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/storage_hmac_key.html">google_storage_hmac_key</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/storage_notification.html">google_storage_notification</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/storage_object_access_control.html">google_storage_object_access_control</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/storage_object_acl.html">google_storage_object_acl</a>
-      </li>
-    </ul>
-    </li>
-
-    <li>
     <a href="#">Storage Transfer</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/storage_transfer_job.html">google_storage_transfer_job</a>
-      </li>
-    </ul>
-    </li>
-
-    <li>
-    <a href="#">Serverless VPC Access</a>
-    <ul class="nav">
-      <li>
-      <a href="/docs/providers/google/r/vpc_access_connector.html">google_vpc_access_connector</a>
       </li>
     </ul>
     </li>

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -7,549 +7,549 @@
   <%% content_for :sidebar do %>
   <div class="docs-sidebar hidden-print affix-top" role="complementary">
   <ul class="nav docs-sidenav">
-    <li<%%= sidebar_current("docs-home") %>>
+    <li>
     <a class="back" href="/docs/providers/index.html">All Providers</a>
     </li>
 
-    <li<%%= sidebar_current("docs-google-provider") %>>
+    <li>
       <a href="/docs/providers/google/index.html">Google Provider</a>
       <ul class="nav">
-        <li<%%= sidebar_current("docs-google-provider-x") %>>
+        <li>
           <a href="/docs/providers/google/index.html">Provider Info</a>
         </li>
-        <li<%%= sidebar_current("docs-google-provider-reference") %>>
+        <li>
           <a href="/docs/providers/google/guides/provider_reference.html">Provider Configuration Reference</a>
         </li>
-        <li<%%= sidebar_current("docs-google-provider-versions") %>>
+        <li>
           <a href="/docs/providers/google/guides/provider_versions.html">Google Provider Versions</a>
         </li>
-        <li<%%= sidebar_current("docs-google-provider-getting-started") %>>
+        <li>
           <a href="/docs/providers/google/guides/getting_started.html">Getting Started Guide</a>
         </li>
-        <li<%%= sidebar_current("docs-google-provider-version-2-upgrade") %>>
+        <li>
           <a href="/docs/providers/google/guides/version_2_upgrade.html">2.0.0 Upgrade Guide</a>
         </li>
-        <li<%%= sidebar_current("docs-google-provider-version-3-upgrade") %>>
+        <li>
           <a href="/docs/providers/google/guides/version_3_upgrade.html">3.0.0 Upgrade Guide</a>
         </li>
       </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-datasource") %>>
+    <li>
     <a href="#">Google Cloud Platform Data Sources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-datasource-active-folder") %>>
+      <li>
       <a href="/docs/providers/google/d/google_active_folder.html">google_active_folder</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-bigquery-default-service-account") %>>
+      <li>
         <a href="/docs/providers/google/d/google_bigquery_default_service_account.html">google_bigquery_default_service_account</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-billing-account") %>>
+      <li>
         <a href="/docs/providers/google/d/google_billing_account.html">google_billing_account</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-client-config") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_client_config.html">google_client_config</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-google-client-openid-userinfo") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_google_client_openid_userinfo.html">google_client_openid_userinfo</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-cloudfunctions-function") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_cloudfunctions_function.html">google_cloudfunctions_function</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-composer-image-versions") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_google_composer_image_versions.html">google_composer_image_versions</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-address") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_compute_address.html">google_compute_address</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-backend-service") %>>
+      <li>
       <a href="/docs/providers/google/d/datasource_google_compute_backend_service.html">google_compute_backend_service</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-backend-bucket") %>>
+      <li>
       <a href="/docs/providers/google/d/datasource_google_compute_backend_bucket.html">google_compute_backend_bucket</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-default-service-account") %>>
+      <li>
         <a href="/docs/providers/google/d/google_compute_default_service_account.html">google_compute_default_service_account</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-forwarding-rule") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_compute_forwarding_rule.html">google_compute_forwarding_rule</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-global-address") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_compute_global_address.html">google_compute_global_address</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-image") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_compute_image.html">google_compute_image</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-instance-x") %>>
+      <li>
       <a href="/docs/providers/google/d/datasource_compute_instance.html">google_compute_instance</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-instance-group") %>>
+      <li>
       <a href="/docs/providers/google/d/google_compute_instance_group.html">google_compute_instance_group</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-instance-serial-port") %>>
+      <li>
       <a href="/docs/providers/google/d/datasource_compute_instance_serial_port.html">google_compute_instance_serial_port</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-lb-ip-ranges") %>>
+      <li>
       <a href="/docs/providers/google/d/datasource_compute_lb_ip_ranges.html">google_compute_lb_ip_ranges</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-network") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_compute_network.html">google_compute_network</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-network-endpoint-group") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_google_compute_network_endpoint_group.html">google_compute_network_endpoint_group</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-node-types") %>>
+      <li>
       <a href="/docs/providers/google/d/google_compute_node_types.html">google_compute_node_types</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-regions") %>>
+      <li>
       <a href="/docs/providers/google/d/google_compute_regions.html">google_compute_regions</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-region-instance-group") %>>
+      <li>
       <a href="/docs/providers/google/d/datasource_compute_region_instance_group.html">google_compute_region_instance_group</a>
       </li>
 <% unless version == 'ga' -%>
-      <li<%%= sidebar_current("docs-google-datasource-compute-resource-policy") %>>
+      <li>
           <a href="/docs/providers/google/d/google_compute_resource_policy.html">google_compute_resource_policy</a>
       </li>
 <% end  -%>
-      <li<%%= sidebar_current("docs-google-datasource-compute-router") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_compute_router.html">google_compute_router</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-ssl-certificate") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_compute_ssl_certificate.html">google_compute_ssl_certificate</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-ssl-policy") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_compute_ssl_policy.html">google_compute_ssl_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-subnetwork") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_compute_subnetwork.html">google_compute_subnetwork</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-vpn-gateway") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_compute_vpn_gateway.html">google_compute_vpn_gateway</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-compute-zones") %>>
+      <li>
       <a href="/docs/providers/google/d/google_compute_zones.html">google_compute_zones</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-container-cluster") %>>
+      <li>
       <a href="/docs/providers/google/d/google_container_cluster.html">google_container_cluster</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-container-versions") %>>
+      <li>
       <a href="/docs/providers/google/d/google_container_engine_versions.html">google_container_engine_versions</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-container-image") %>>
+      <li>
       <a href="/docs/providers/google/d/google_container_registry_image.html">google_container_registry_image</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-container-repo") %>>
+      <li>
       <a href="/docs/providers/google/d/google_container_registry_repository.html">google_container_registry_repository</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-dns-keys") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_dns_keys.html">google_dns_keys</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-dns-managed-zone") %>>
+      <li>
       <a href="/docs/providers/google/d/dns_managed_zone.html">google_dns_managed_zone</a>
       </li>
 <% unless version == 'ga' -%>
-      <li<%%= sidebar_current("docs-google-datasource-firebase-web-app") %>>
+      <li>
           <a href="/docs/providers/google/d/datasource_firebase_web_app.html">google_firebase_web_app</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-firebase-web-app-config") %>>
+      <li>
           <a href="/docs/providers/google/d/datasource_firebase_web_app_config.html">google_firebase_web_app_config</a>
       </li>
 <% end  -%>
-      <li<%%= sidebar_current("docs-google-datasource-iam-policy") %>>
+      <li>
         <a href="/docs/providers/google/d/google_iam_policy.html">google_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-iam-role") %>>
+      <li>
       <a href="/docs/providers/google/d/datasource_google_iam_role.html">google_iam_role</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-kms-crypto-key") %>>
+      <li>
         <a href="/docs/providers/google/d/google_kms_crypto_key.html">google_kms_crypto_key</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-kms-crypto-key-version") %>>
+      <li>
         <a href="/docs/providers/google/d/google_kms_crypto_key_version.html">google_kms_crypto_key_version</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-kms-key-ring") %>>
+      <li>
         <a href="/docs/providers/google/d/google_kms_key_ring.html">google_kms_key_ring</a>
       </li>
-      <li<%%= sidebar_current("docs-google-kms-secret") %>>
+      <li>
         <a href="/docs/providers/google/d/google_kms_secret.html">google_kms_secret</a>
       </li>
-      <li<%%= sidebar_current("docs-google-kms-secret-ciphertext") %>>
+      <li>
         <a href="/docs/providers/google/d/google_kms_secret_ciphertext.html">google_kms_secret_ciphertext</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-folder") %>>
+      <li>
       <a href="/docs/providers/google/d/google_folder.html">google_folder</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-folder-organization-policy") %>>
+      <li>
       <a href="/docs/providers/google/d/datasource_google_folder_organization_policy.html">google_folder_organization_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-monitoring-notification-channel") %>>
+      <li>
       <a href="/docs/providers/google/d/datasource_monitoring_notification_channel.html">google_monitoring_notification_channel</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-monitoring-app-engine-service") %>>
+      <li>
       <a href="/docs/providers/google/d/datasource_monitoring_app_engine_service.html">google_monitoring_app_engine_service</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-google-monitoring-uptime-check-ips") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_google_monitoring_uptime_check_ips.html">google_monitoring_uptime_check_ips</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-netblock-ip-ranges") %>>
+      <li>
       <a href="/docs/providers/google/d/datasource_google_netblock_ip_ranges.html">google_netblock_ip_ranges</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-organization") %>>
+      <li>
       <a href="/docs/providers/google/d/google_organization.html">google_organization</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-project") %>>
+      <li>
       <a href="/docs/providers/google/d/google_project.html">google_project</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-projects") %>>
+      <li>
       <a href="/docs/providers/google/d/google_projects.html">google_projects</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-project-organization-policy") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_google_project_organization_policy.html">google_project_organization_policy</a>
       </li>
 <% unless version == 'ga' -%>
-      <li<%%= sidebar_current("docs-google-datasource-secret-manager-secret-version") %>>
+      <li>
           <a href="/docs/providers/google/d/datasource_google_secret_manager_secret_version.html">google_secret_manager_secret_version</a>
       </li>
 <% end  -%>
-      <li<%%= sidebar_current("docs-google-datasource-service-account") %>>
+      <li>
       <a href="/docs/providers/google/d/datasource_google_service_account.html">google_service_account</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-service-account-access-token") %>>
+      <li>
       <a href="/docs/providers/google/d/datasource_google_service_account_access_token.html">google_service_account_access_token</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-service-account-key") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_google_service_account_key.html">google_service_account_key</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-sql-ca-certs") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_google_sql_ca_certs.html">google_sql_ca_certs</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-storage-bucket-object") %>>
+      <li>
         <a href="/docs/providers/google/d/storage_bucket_object.html">google_storage_bucket_object</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-signed_url") %>>
+      <li>
         <a href="/docs/providers/google/d/signed_url.html">google_storage_object_signed_url</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-storage-project-service-account") %>>
+      <li>
         <a href="/docs/providers/google/d/google_storage_project_service_account.html">google_storage_project_service_account</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-storage-transfer-project-service-account") %>>
+      <li>
         <a href="/docs/providers/google/d/google_storage_transfer_project_service_account.html">google_storage_transfer_project_service_account</a>
       </li>
-      <li<%%= sidebar_current("docs-google-datasource-tpu-tensorflow-versions") %>>
+      <li>
         <a href="/docs/providers/google/d/datasource_tpu_tensorflow_versions.html">google_tpu_tensorflow_versions</a>
       </li>
     </ul>
     </li>
 
 <% unless version == 'ga' %>
-    <li<%%= sidebar_current("docs-google-access-context-manager") %>>
+    <li>
     <a href="#">Google Access Context Manager / VPC Service Control Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-access-context-manager-access-level") %>>
+      <li>
       <a href="/docs/providers/google/r/access_context_manager_access_level.html">google_access_context_manager_access_level</a>
-      <li<%%= sidebar_current("docs-google-access-context-manager-access-policy") %>>
+      <li>
       <a href="/docs/providers/google/r/access_context_manager_access_policy.html">google_access_context_manager_access_policy</a>
-      <li<%%= sidebar_current("docs-google-access-context-manager-service-perimeter") %>>
+      <li>
       <a href="/docs/providers/google/r/access_context_manager_service_perimeter.html">google_access_context_manager_service_perimeter</a>
       </li>
-      <li<%%= sidebar_current("docs-google-access-context-manager-service-perimeter-resource") %>>
+      <li>
       <a href="/docs/providers/google/r/access_context_manager_service_perimeter_resource.html">google_access_context_manager_service_perimeter_resource</a>
       </li>
     </ul>
     </li>
 <% end -%>
 
-    <li<%%= sidebar_current("docs-google-app-engine") %>>
+    <li>
     <a href="#">Google App Engine Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-app-engine-application") %>>
+      <li>
       <a href="/docs/providers/google/r/app_engine_application.html">google_app_engine_application</a>
       </li>
-      <li<%%= sidebar_current("docs-google-app-engine-domain-mapping") %>>
+      <li>
       <a href="/docs/providers/google/r/app_engine_domain_mapping.html">google_app_engine_domain_mapping</a>
       </li>
-      <li<%%= sidebar_current("docs-google-app-engine-firewall-rule") %>>
+      <li>
       <a href="/docs/providers/google/r/app_engine_firewall_rule.html">google_app_engine_firewall_rule</a>
       </li>
-      <li<%%= sidebar_current("docs-google-app-engine-flexible-app-version") %>>
+      <li>
       <a href="/docs/providers/google/r/app_engine_flexible_app_version.html">google_app_engine_flexible_app_version</a>
       </li>
-      <li<%%= sidebar_current("docs-google-app-engine-standard-app-version") %>>
+      <li>
       <a href="/docs/providers/google/r/app_engine_standard_app_version.html">google_app_engine_standard_app_version</a>
       </li>
-      <li<%%= sidebar_current("docs-google-app-engine-application-url-dispatch-rules") %>>
+      <li>
       <a href="/docs/providers/google/r/app_engine_application_url_dispatch_rules.html">google_app_engine_application_url_dispatch_rules</a>
-      <li<%%= sidebar_current("docs-google-app-engine-service-split-traffic") %>>
+      <li>
       <a href="/docs/providers/google/r/app_engine_service_split_traffic.html">google_app_engine_service_split_traffic</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-bigquery") %>>
+    <li>
     <a href="#">Google BigQuery Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-bigquery-dataset") %>>
+      <li>
       <a href="/docs/providers/google/r/bigquery_dataset.html">google_bigquery_dataset</a>
       </li>
-      <li<%%= sidebar_current("docs-google-bigquery-dataset-access") %>>
+      <li>
       <a href="/docs/providers/google/r/bigquery_dataset_access.html">google_bigquery_dataset_access</a>
       </li>
-      <li<%%= sidebar_current("docs-google-bigquery-job") %>>
+      <li>
       <a href="/docs/providers/google/r/bigquery_job.html">google_bigquery_job</a>
       </li>
-      <li<%%= sidebar_current("docs-google-bigquery-table") %>>
+      <li>
       <a href="/docs/providers/google/r/bigquery_table.html">google_bigquery_table</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-bigquery-data-transfer") %>>
+    <li>
     <a href="#">Google BigQuery Data Transfer Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-bigquery-data-transfer-config") %>>
+      <li>
       <a href="/docs/providers/google/r/bigquery_data_transfer_config.html">google_bigquery_data_transfer_config</a>
     </ul>
     </li>
 
 <% unless version == 'ga' -%>
-    <li<%%= sidebar_current("docs-google-bigquery-data-transfer") %>>
+    <li>
     <a href="#">Google BigQuery Reservation Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-bigquery-reservation") %>>
+      <li>
       <a href="/docs/providers/google/r/bigquery_reservation.html">google_bigquery_reservation</a>
     </ul>
     </li>
 <% end -%>
 
-    <li<%%= sidebar_current("docs-google-bigtable") %>>
+    <li>
     <a href="#">Google Bigtable Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-bigtable-app-profile") %>>
+      <li>
       <a href="/docs/providers/google/r/bigtable_app_profile.html">google_bigtable_app_profile</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-bigtable-gc-policy") %>>
+      <li>
       <a href="/docs/providers/google/r/bigtable_gc_policy.html">google_bigtable_gc_policy</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-bigtable-instance") %>>
+      <li>
       <a href="/docs/providers/google/r/bigtable_instance.html">google_bigtable_instance</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-bigtable-instance-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/bigtable_instance_iam.html">google_bigtable_instance_iam_binding</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-bigtable-instance-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/bigtable_instance_iam.html">google_bigtable_instance_iam_member</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-bigtable-instance-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/bigtable_instance_iam.html">google_bigtable_instance_iam_policy</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-bigtable-table") %>>
+      <li>
       <a href="/docs/providers/google/r/bigtable_table.html">google_bigtable_table</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-binary-authorization") %>>
+    <li>
     <a href="#">Google Binary Authorization Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-binary-authorization-attestor") %>>
+      <li>
         <a href="/docs/providers/google/r/binary_authorization_attestor.html">google_binary_authorization_attestor</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-binary-authorization-attestor-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/binary_authorization_attestor_iam.html">google_binary_authorization_attestor_iam_binding</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-binary-authorization-attestor-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/binary_authorization_attestor_iam.html">google_binary_authorization_attestor_iam_member</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-binary-authorization-attestor-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/binary_authorization_attestor_iam.html">google_binary_authorization_attestor_iam_policy</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-binary-authorization-policy") %>>
+      <li>
       <a href="/docs/providers/google/r/binary_authorization_policy.html">google_binary_authorization_policy</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-cloudbuild") %>>
+    <li>
     <a href="#">Google Cloud Build Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-cloudbuild-trigger") %>>
+      <li>
       <a href="/docs/providers/google/r/cloudbuild_trigger.html">google_cloudbuild_trigger</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-composer") %>>
+    <li>
       <a href="#">Google Cloud Composer Resources</a>
       <ul class="nav">
-        <li<%%= sidebar_current("docs-google-composer-environment") %>>
+        <li>
           <a href="/docs/providers/google/r/composer_environment.html">google_composer_environment</a>
         </li>
       </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-cloudfunctions") %>>
+    <li>
     <a href="#">Google Cloud Functions Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-cloudfunctions-function") %>>
+      <li>
       <a href="/docs/providers/google/r/cloudfunctions_function.html">google_cloudfunctions_function</a>
       </li>
-      <li<%%= sidebar_current("docs-google-cloudfunctions-function-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/cloudfunctions_cloud_function_iam.html">google_cloudfunctions_function_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-cloudfunctions-function-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/cloudfunctions_cloud_function_iam.html">google_cloudfunctions_function_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-cloudfunctions-function-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/cloudfunctions_cloud_function_iam.html">google_cloudfunctions_function_iam_policy</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-cloudiot") %>>
+    <li>
       <a href="#">Google Cloud IoT Core</a>
       <ul class="nav">
-        <li<%%= sidebar_current("docs-google-cloudiot-registry-x") %>>
+        <li>
           <a href="/docs/providers/google/r/cloudiot_registry.html">google_cloudiot_registry</a>
         </li>
       </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-(project|service)") %>>
+    <li>
     <a href="#">Google Cloud Platform Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-billing-account-iam-binding") %>>
+      <li>
         <a href="/docs/providers/google/r/google_billing_account_iam_binding.html">google_billing_account_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-billing-account-iam-member") %>>
+      <li>
         <a href="/docs/providers/google/r/google_billing_account_iam_member.html">google_billing_account_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-billing-account-iam-policy") %>>
+      <li>
         <a href="/docs/providers/google/r/google_billing_account_iam_policy.html">google_billing_account_iam_policy</a>
       </li>
 <% unless version == 'ga' -%>
-      <li<%%= sidebar_current("docs-google-billing-budget") %>>
+      <li>
         <a href="/docs/providers/google/r/billing_budget.html">google_billing_budget</a>
       </li>
 <% end -%>
-      <li<%%= sidebar_current("docs-google-folder-x") %>>
+      <li>
         <a href="/docs/providers/google/r/google_folder.html">google_folder</a>
       </li>
-      <li<%%= sidebar_current("docs-google-folder-iam-binding") %>>
+      <li>
         <a href="/docs/providers/google/r/google_folder_iam_binding.html">google_folder_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-folder-iam-member") %>>
+      <li>
         <a href="/docs/providers/google/r/google_folder_iam_member.html">google_folder_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-folder-iam-policy") %>>
+      <li>
         <a href="/docs/providers/google/r/google_folder_iam_policy.html">google_folder_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-folder-organization-policy") %>>
+      <li>
         <a href="/docs/providers/google/r/google_folder_organization_policy.html">google_folder_organization_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-organization-policy") %>>
+      <li>
         <a href="/docs/providers/google/r/google_organization_policy.html">google_organization_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-organization-iam-audit-config") %>>
+      <li>
         <a href="/docs/providers/google/r/google_organization_iam_audit_config.html">google_organization_iam_audit_config</a>
       </li>
-      <li<%%= sidebar_current("docs-google-organization-iam-binding") %>>
+      <li>
         <a href="/docs/providers/google/r/google_organization_iam_binding.html">google_organization_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-organization-iam-custom-role") %>>
+      <li>
         <a href="/docs/providers/google/r/google_organization_iam_custom_role.html">google_organization_iam_custom_role</a>
       </li>
-      <li<%%= sidebar_current("docs-google-organization-iam-member") %>>
+      <li>
         <a href="/docs/providers/google/r/google_organization_iam_member.html">google_organization_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-organization-iam-policy") %>>
+      <li>
         <a href="/docs/providers/google/r/google_organization_iam_policy.html">google_organization_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-project-x") %>>
+      <li>
         <a href="/docs/providers/google/r/google_project.html">google_project</a>
       </li>
-      <li<%%= sidebar_current("docs-google-project-iam-x") %>>
+      <li>
         <a href="/docs/providers/google/r/google_project_iam.html">google_project_iam_audit_config</a>
       </li>
-      <li<%%= sidebar_current("docs-google-project-iam-x") %>>
+      <li>
         <a href="/docs/providers/google/r/google_project_iam.html">google_project_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-project-iam-x") %>>
+      <li>
         <a href="/docs/providers/google/r/google_project_iam.html">google_project_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-project-iam-x") %>>
+      <li>
         <a href="/docs/providers/google/r/google_project_iam.html">google_project_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-project-iam-custom-role") %>>
+      <li>
         <a href="/docs/providers/google/r/google_project_iam_custom_role.html">google_project_iam_custom_role</a>
       </li>
-      <li<%%= sidebar_current("docs-google-project-organization-policy") %>>
+      <li>
         <a href="/docs/providers/google/r/google_project_organization_policy.html">google_project_organization_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-project-service-x") %>>
+      <li>
         <a href="/docs/providers/google/r/google_project_service.html">google_project_service</a>
       </li>
-      <li<%%= sidebar_current("docs-google-project-usage-export-bucket") %>>
+      <li>
         <a href="/docs/providers/google/r/usage_export_bucket.html">google_project_usage_export_bucket</a>
       </li>
-      <li<%%= sidebar_current("docs-google-resource-manager-lien") %>>
+      <li>
         <a href="/docs/providers/google/r/resource_manager_lien.html">google_resource_manager_lien</a>
       </li>
-      <li<%%= sidebar_current("docs-google-service-account-x") %>>
+      <li>
         <a href="/docs/providers/google/r/google_service_account.html">google_service_account</a>
       </li>
-      <li<%%= sidebar_current("docs-google-service-account-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/google_service_account_iam.html">google_service_account_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-service-account-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/google_service_account_iam.html">google_service_account_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-service-account-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/google_service_account_iam.html">google_service_account_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-service-account-key") %>>
+      <li>
       <a href="/docs/providers/google/r/google_service_account_key.html">google_service_account_key</a>
       </li>
 
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-cloud-run") %>>
+    <li>
     <a href="#">Google Cloud Run Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-cloud-run-domain-mapping") %>>
+      <li>
       <a href="/docs/providers/google/r/cloud_run_domain_mapping.html">google_cloud_run_domain_mapping</a>
       </li>
-      <li<%%= sidebar_current("docs-google-cloud-run-service") %>>
+      <li>
       <a href="/docs/providers/google/r/cloud_run_service.html">google_cloud_run_service</a>
       </li>
-      <li<%%= sidebar_current("docs-google-cloud-run-service-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/cloud_run_service_iam.html">google_cloud_run_service_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-cloud-run-service-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/cloud_run_service_iam.html">google_cloud_run_service_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-cloud-run-service-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/cloud_run_service_iam.html">google_cloud_run_service_iam_policy</a>
       </li>
     </ul>
     </li>
 
 <% unless version == 'ga' %>
-    <li<%%= sidebar_current("docs-google-cloud-scheduler") %>>
+    <li>
     <a href="#">Google Cloud Scheduler Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-cloud-scheduler-job") %>>
+      <li>
       <a href="/docs/providers/google/r/cloud_scheduler_job.html">google_cloud_scheduler_job</a>
       </li>
     </ul>
@@ -557,580 +557,580 @@
 <% end -%>
 
 <% unless version == 'ga' %>
-    <li<%%= sidebar_current("docs-google-security-scanner") %>>
+    <li>
     <a href="#">Google Cloud Security Scanner Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-security-scanner-scan-config") %>>
+      <li>
       <a href="/docs/providers/google/r/security_scanner_scan_config.html">google_security_scanner_scan_config</a>
       </li>
     </ul>
     </li>
 <% end -%>
 
-    <li<%%= sidebar_current("docs-google-cloud-tasks") %>>
+    <li>
       <a href="#">Google Cloud Tasks</a>
       <ul class="nav">
-        <li<%%= sidebar_current("docs-google-cloud-tasks-queue") %>>
+        <li>
           <a href="/docs/providers/google/r/cloud_tasks_queue.html">google_cloud_tasks_queue</a>
         </li>
       </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-tpu") %>>
+    <li>
       <a href="#">Google Cloud TPU</a>
       <ul class="nav">
-        <li<%%= sidebar_current("docs-google-tpu-node") %>>
+        <li>
           <a href="/docs/providers/google/r/tpu_node.html">google_tpu_node</a>
         </li>
       </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-compute") %>>
+    <li>
     <a href="#">Google Compute Engine Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-compute-address") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_address.html">google_compute_address</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-attached-disk") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_attached_disk.html">google_compute_attached_disk</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-autoscaler") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_autoscaler.html">google_compute_autoscaler</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-backend-bucket") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_backend_bucket.html">google_compute_backend_bucket</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-backend-bucket-signed-url-key") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_backend_bucket_signed_url_key.html">google_compute_backend_bucket_signed_url_key</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-backend-service") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_backend_service.html">google_compute_backend_service</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-backend-service-signed-url-key") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_backend_service_signed_url_key.html">google_compute_backend_service_signed_url_key</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-disk") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_disk.html">google_compute_disk</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-disk-resource-policy-attachment") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_disk_resource_policy_attachment.html">google_compute_disk_resource_policy_attachment</a>
       </li>
 
 <% unless version == 'ga' %>
-      <li<%%= sidebar_current("docs-google-compute-external-vpn-gateway") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_external_vpn_gateway.html">google_compute_external_vpn_gateway</a>
       </li>
 
 <% end -%>
-      <li<%%= sidebar_current("docs-google-compute-firewall") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_firewall.html">google_compute_firewall</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-forwarding-rule") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_forwarding_rule.html">google_compute_forwarding_rule</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-global-address") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_global_address.html">google_compute_global_address</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-global-forwarding-rule") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_global_forwarding_rule.html">google_compute_global_forwarding_rule</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-global-network-endpoint") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_global_network_endpoint.html">google_compute_global_network_endpoint</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-global-network-endpoint-group") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_global_network_endpoint_group.html">google_compute_global_network_endpoint_group</a>
       </li>
 
 <% unless version == 'ga' %>
-      <li<%%= sidebar_current("docs-google-compute-ha-vpn-gateway") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_ha_vpn_gateway.html">google_compute_ha_vpn_gateway</a>
       </li>
 
 <% end -%>
-      <li<%%= sidebar_current("docs-google-compute-health-check") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_health_check.html">google_compute_health_check</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-http-health-check") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_http_health_check.html">google_compute_http_health_check</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-https-health-check") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_https_health_check.html">google_compute_https_health_check</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-image") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_image.html">google_compute_image</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-instance-x") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_instance.html">google_compute_instance</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-instance-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_instance_iam.html">google_compute_instance_iam_binding</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-instance-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_instance_iam.html">google_compute_instance_iam_member</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-instance-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_instance_iam.html">google_compute_instance_iam_policy</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-instance-from-template") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_instance_from_template.html">google_compute_instance_from_template</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-instance-group-x") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_instance_group.html">google_compute_instance_group</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-instance-group-manager") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_instance_group_manager.html">google_compute_instance_group_manager</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-instance-group-named-port") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_instance_group_named_port.html">google_compute_instance_group_named_port</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-instance-template") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_instance_template.html">google_compute_instance_template</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-interconnect-attachment") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_interconnect_attachment.html">google_compute_interconnect_attachment</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-network-x") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_network.html">google_compute_network</a>
       </li>
 
 <% unless version == 'ga' %>
-      <li<%%= sidebar_current("docs-google-compute-network-endpoint") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_network_endpoint.html">google_compute_network_endpoint</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-network-endpoint-group") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_network_endpoint_group.html">google_compute_network_endpoint_group</a>
       </li>
 
 <% end -%>
-      <li<%%= sidebar_current("docs-google-compute-network-peering") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_network_peering.html">google_compute_network_peering</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-network-peering-routes-config") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_network_peering_routes_config.html">google_compute_network_peering_routes_config</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-node-group") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_node_group.html">google_compute_node_group</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-node-template") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_node_template.html">google_compute_node_template</a>
       </li>
 
 <% unless version == 'ga' -%>
-      <li<%%= sidebar_current("docs-google-compute-packet-mirroring") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_packet_mirroring.html">google_compute_packet_mirroring</a>
       </li>
 <% end -%>
 
-      <li<%%= sidebar_current("docs-google-compute-project-default-network-tier") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_project_default_network_tier.html">google_compute_project_default_network_tier</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-project-metadata") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_project_metadata.html">google_compute_project_metadata</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-project-metadata-item") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_project_metadata_item.html">google_compute_project_metadata_item</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-region-autoscaler") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_region_autoscaler.html">google_compute_region_autoscaler</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-region-backend-service") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_region_backend_service.html">google_compute_region_backend_service</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-region-disk") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_region_disk.html">google_compute_region_disk</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-region-disk-resource-policy-attachment") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_region_disk_resource_policy_attachment.html">google_compute_region_disk_resource_policy_attachment</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-region-health-check") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_region_health_check.html">google_compute_region_health_check</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-region-instance-group-manager") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_region_instance_group_manager.html">google_compute_region_instance_group_manager</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-region-ssl-certificate") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_region_ssl_certificate.html">google_compute_region_ssl_certificate</a>
       </li>
 
 <% unless version == 'ga' -%>
-      <li<%%= sidebar_current("docs-google-compute-region-target-http-proxy") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_region_target_http_proxy.html">google_compute_region_target_http_proxy</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-region-target-https-proxy") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_region_target_https_proxy.html">google_compute_region_target_https_proxy</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-region-url-map") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_region_url_map.html">google_compute_region_url_map</a>
       </li>
 <% end -%>
 
-      <li<%%= sidebar_current("docs-google-compute-reservation") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_reservation.html">google_compute_reservation</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-resource-policy") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_resource_policy.html">google_compute_resource_policy</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-route-x") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_route.html">google_compute_route</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-router-x") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_router.html">google_compute_router</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-router-interface") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_router_interface.html">google_compute_router_interface</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-router-nat") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_router_nat.html">google_compute_router_nat</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-router-peer") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_router_bgp_peer.html">google_compute_router_peer</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-security-policy") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_security_policy.html">google_compute_security_policy</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-shared-vpc-host-project") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_shared_vpc_host_project.html">google_compute_shared_vpc_host_project</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-shared-vpc-service-project") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_shared_vpc_service_project.html">google_compute_shared_vpc_service_project</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-snapshot") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_snapshot.html">google_compute_snapshot</a>
       </li>
 
 <% unless version == 'ga' %>
-      <li<%%= sidebar_current("docs-google-compute-managed-ssl-certificate") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_managed_ssl_certificate.html">google_compute_managed_ssl_certificate</a>
       </li>
 <% end -%>
 
-      <li<%%= sidebar_current("docs-google-compute-ssl-certificate") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_ssl_certificate.html">google_compute_ssl_certificate</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-ssl-policy") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_ssl_policy.html">google_compute_ssl_policy</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-subnetwork-x") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_subnetwork.html">google_compute_subnetwork</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-subnetwork-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/compute_subnetwork_iam.html">google_compute_subnetwork_iam_binding</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-subnetwork-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/compute_subnetwork_iam.html">google_compute_subnetwork_iam_member</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-subnetwork-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/compute_subnetwork_iam.html">google_compute_subnetwork_iam_policy</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-target-http-proxy") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_target_http_proxy.html">google_compute_target_http_proxy</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-target-https-proxy") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_target_https_proxy.html">google_compute_target_https_proxy</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-target-instance") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_target_instance.html">google_compute_target_instance</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-target-ssl-proxy") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_target_ssl_proxy.html">google_compute_target_ssl_proxy</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-target-tcp-proxy") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_target_tcp_proxy.html">google_compute_target_tcp_proxy</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-target-pool") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_target_pool.html">google_compute_target_pool</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-url-map") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_url_map.html">google_compute_url_map</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-vpn-gateway") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_vpn_gateway.html">google_compute_vpn_gateway</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-compute-vpn-tunnel") %>>
+      <li>
       <a href="/docs/providers/google/r/compute_vpn_tunnel.html">google_compute_vpn_tunnel</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-container-analysis") %>>
+    <li>
     <a href="#">Google Container Analysis Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-container-analysis-note") %>>
+      <li>
       <a href="/docs/providers/google/r/container_analysis_note.html">google_container_analysis_note</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-container-registry") %>>
+    <li>
     <a href="#">Google Container Registry Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-container-registry") %>>
+      <li>
       <a href="/docs/providers/google/r/container_registry.html">google_container_registry</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-container") %>>
+    <li>
     <a href="#">Google Kubernetes (Container) Engine Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-container-cluster") %>>
+      <li>
       <a href="/docs/providers/google/r/container_cluster.html">google_container_cluster</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-container-node-pool") %>>
+      <li>
       <a href="/docs/providers/google/r/container_node_pool.html">google_container_node_pool</a>
       </li>
     </ul>
     </li>
 
 <% unless version == 'ga' %>
-    <li<%%= sidebar_current("docs-google-data-fusion") %>>
+    <li>
     <a href="#">Google Data Fusion Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-data-fusion") %>>
+      <li>
           <a href="/docs/providers/google/r/data_fusion_instance.html">google_data_fusion_instance</a>
       </li>
     </ul>
     </li>
 <% end -%>
 
-    <li<%%= sidebar_current("docs-google-dataflow") %>>
+    <li>
     <a href="#">Google Dataflow Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-dataflow-job") %>>
+      <li>
           <a href="/docs/providers/google/r/dataflow_job.html">google_dataflow_job</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-datastore") %>>
+    <li>
     <a href="#">Google Datastore Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-datastore-index") %>>
+      <li>
           <a href="/docs/providers/google/r/datastore_index.html">google_datastore_index</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-dataproc") %>>
+    <li>
         <a href="#">Google Dataproc Resources</a>
         <ul class="nav">
-          <li<%%= sidebar_current("docs-google-dataproc-autoscaling-policy") %>>
+          <li>
           <a href="/docs/providers/google/r/dataproc_autoscaling_policy.html">google_dataproc_autoscaling_policy</a>
           </li>
 
-          <li<%%= sidebar_current("docs-google-dataproc-cluster") %>>
+          <li>
           <a href="/docs/providers/google/r/dataproc_cluster.html">google_dataproc_cluster</a>
           </li>
 
-          <li<%%= sidebar_current("docs-google-dataproc-cluster-iam") %>>
+          <li>
           <a href="/docs/providers/google/r/dataproc_cluster_iam.html">google_dataproc_cluster_iam_binding</a>
           </li>
 
-          <li<%%= sidebar_current("docs-google-dataproc-cluster-iam") %>>
+          <li>
           <a href="/docs/providers/google/r/dataproc_cluster_iam.html">google_dataproc_cluster_iam_member</a>
           </li>
 
-          <li<%%= sidebar_current("docs-google-dataproc-cluster-iam") %>>
+          <li>
           <a href="/docs/providers/google/r/dataproc_cluster_iam.html">google_dataproc_cluster_iam_policy</a>
           </li>
 
-          <li<%%= sidebar_current("docs-google-dataproc-job") %>>
+          <li>
           <a href="/docs/providers/google/r/dataproc_job.html">google_dataproc_job</a>
           </li>
 
-          <li<%%= sidebar_current("docs-google-dataproc-job-iam") %>>
+          <li>
           <a href="/docs/providers/google/r/dataproc_job_iam.html">google_dataproc_job_iam_binding</a>
           </li>
 
-          <li<%%= sidebar_current("docs-google-dataproc-job-iam") %>>
+          <li>
           <a href="/docs/providers/google/r/dataproc_job_iam.html">google_dataproc_job_iam_member</a>
           </li>
 
-          <li<%%= sidebar_current("docs-google-dataproc-job-iam") %>>
+          <li>
           <a href="/docs/providers/google/r/dataproc_job_iam.html">google_dataproc_job_iam_policy</a>
           </li>
         </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-deployment-manager") %>>
+    <li>
     <a href="#">Google Deployment Manager Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-deployment-manager-deployment") %>>
+      <li>
           <a href="/docs/providers/google/r/deployment_manager_deployment.html">google_deployment_manager_deployment</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-dialogflow") %>>
+    <li>
     <a href="#">Google Dialogflow Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-dialogflow-agent") %>>
+      <li>
           <a href="/docs/providers/google/r/dialogflow_agent.html">google_dialogflow_agent</a>
       </li>
-      <li<%%= sidebar_current("docs-google-dialogflow-intent") %>>
+      <li>
           <a href="/docs/providers/google/r/dialogflow_intent.html">google_dialogflow_intent</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-dns") %>>
+    <li>
     <a href="#">Google DNS Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-dns-managed-zone") %>>
+      <li>
       <a href="/docs/providers/google/r/dns_managed_zone.html">google_dns_managed_zone</a>
       </li>
 
 <% unless version == 'ga' %>
-      <li<%%= sidebar_current("docs-google-dns-policy") %>>
+      <li>
       <a href="/docs/providers/google/r/dns_policy.html">google_dns_policy</a>
       </li>
 
 <% end -%>
-      <li<%%= sidebar_current("docs-google-dns-record-set") %>>
+      <li>
       <a href="/docs/providers/google/r/dns_record_set.html">google_dns_record_set</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-endpoints") %>>
+    <li>
     <a href="#">Google Endpoints Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-endpoints-service") %>>
+      <li>
           <a href="/docs/providers/google/r/endpoints_service.html">google_endpoints_service</a>
       </li>
-      <li<%%= sidebar_current("docs-google-endpoints-service-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/endpoints_service_iam.html">google_endpoints_service_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-endpoints-service-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/endpoints_service_iam.html">google_endpoints_service_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-endpoints-service-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/endpoints_service_iam.html">google_endpoints_service_iam_policy</a>
       </li>
     </ul>
     </li>
 <% unless version == 'ga' %>
-    <li<%%= sidebar_current("docs-google-firebase") %>>
+    <li>
     <a href="#">Google Firebase Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-firebase-project") %>>
+      <li>
           <a href="/docs/providers/google/r/firebase_project.html">google_firebase_project</a>
       </li>
     </ul>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-firebase-project-location") %>>
+      <li>
           <a href="/docs/providers/google/r/firebase_project_location.html">google_firebase_project_location</a>
       </li>
     </ul>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-firebase-web-app") %>>
+      <li>
           <a href="/docs/providers/google/r/firebase_web_app.html">google_firebase_web_app</a>
       </li>
     </ul>
     </li>
 <% end %>
-    <li<%%= sidebar_current("docs-google-filestore") %>>
+    <li>
     <a href="#">Google Filestore Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-filestore-instance") %>>
+      <li>
           <a href="/docs/providers/google/r/filestore_instance.html">google_filestore_instance</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-firestore") %>>
+    <li>
     <a href="#">Google Firestore Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-firestore-index") %>>
+      <li>
           <a href="/docs/providers/google/r/firestore_index.html">google_firestore_index</a>
       </li>
     </ul>
     </li>
 
 <% unless version == 'ga' %>
-    <li<%%= sidebar_current("docs-google-cloud-game-services") %>>
+    <li>
     <a href="#">Google Cloud Game Servers</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-cloud-game-services") %>>
+      <li>
           <a href="/docs/providers/google/r/game_services_realm.html">game_services_realm.html</a>
       </li>
-      <li<%%= sidebar_current("docs-google-cloud-game-services") %>>
+      <li>
           <a href="/docs/providers/google/r/game_services_game_server_cluster.html">game_services_game_server_cluster.html</a>
       </li>
-      <li<%%= sidebar_current("docs-google-cloud-game-services") %>>
+      <li>
           <a href="/docs/providers/google/r/game_services_game_server_config.html">game_services_game_server_config.html</a>
       </li>
-      <li<%%= sidebar_current("docs-google-cloud-game-services") %>>
+      <li>
           <a href="/docs/providers/google/r/game_services_game_server_deployment.html">game_services_game_server_deployment.html</a>
       </li>
-      <li<%%= sidebar_current("docs-google-cloud-game-services") %>>
+      <li>
           <a href="/docs/providers/google/r/game_services_game_server_deployment_rollout.html">game_services_game_server_deployment_rollout.html</a>
       </li>
     </ul>
@@ -1138,299 +1138,299 @@
 <% end %>
 
 <% unless version == 'ga' %>
-    <li<%%= sidebar_current("docs-google-healthcare") %>>
+    <li>
     <a href="#">Google Healthcare Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-healthcare-dataset") %>>
+      <li>
         <a href="/docs/providers/google/r/healthcare_dataset.html">google_healthcare_dataset</a>
       </li>
-      <li<%%= sidebar_current("docs-google-healthcare-dataset-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/healthcare_dataset_iam.html">google_healthcare_dataset_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-healthcare-dataset-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/healthcare_dataset_iam.html">google_healthcare_dataset_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-healthcare-dataset-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/healthcare_dataset_iam.html">google_healthcare_dataset_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-healthcare-fhir-store") %>>
+      <li>
         <a href="/docs/providers/google/r/healthcare_fhir_store.html">google_healthcare_fhir_store</a>
       </li>
-      <li<%%= sidebar_current("docs-google-healthcare-fhir-store-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/healthcare_fhir_store_iam.html">google_healthcare_fhir_store_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-healthcare-fhir-store-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/healthcare_fhir_store_iam.html">google_healthcare_fhir_store_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-healthcare-fhir-store-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/healthcare_fhir_store_iam.html">google_healthcare_fhir_store_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-healthcare-dicom-store") %>>
+      <li>
         <a href="/docs/providers/google/r/healthcare_dicom_store.html">google_healthcare_dicom_store</a>
       </li>
-      <li<%%= sidebar_current("docs-google-healthcare-dicom-store-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/healthcare_dicom_store_iam.html">google_healthcare_dicom_store_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-healthcare-dicom-store-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/healthcare_dicom_store_iam.html">google_healthcare_dicom_store_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-healthcare-dicom-store-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/healthcare_dicom_store_iam.html">google_healthcare_dicom_store_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-healthcare-hl7-v2-store") %>>
+      <li>
         <a href="/docs/providers/google/r/healthcare_hl7_v2_store.html">google_healthcare_hl7_v2_store</a>
       </li>
-      <li<%%= sidebar_current("docs-google-healthcare-hl7-v2-store-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/healthcare_hl7_v2_store_iam.html">google_healthcare_hl7_v2_store_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-healthcare-hl7-v2-store-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/healthcare_hl7_v2_store_iam.html">google_healthcare_hl7_v2_store_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-healthcare-hl7-v2-store-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/healthcare_hl7_v2_store_iam.html">google_healthcare_hl7_v2_store_iam_policy</a>
       </li>
     </ul>
 <% end -%>
 
-    <li<%%= sidebar_current("docs-google-kms") %>>
+    <li>
     <a href="#">Google Key Management Service Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-kms-crypto-key-x") %>>
+      <li>
         <a href="/docs/providers/google/r/kms_crypto_key.html">google_kms_crypto_key</a>
       </li>
-      <li<%%= sidebar_current("docs-google-kms-crypto-key-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/google_kms_crypto_key_iam.html">google_kms_crypto_key_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-kms-crypto-key-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/google_kms_crypto_key_iam.html">google_kms_crypto_key_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-kms-crypto-key-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/google_kms_crypto_key_iam.html">google_kms_crypto_key_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-kms-key-ring-x") %>>
+      <li>
         <a href="/docs/providers/google/r/kms_key_ring.html">google_kms_key_ring</a>
       </li>
-      <li<%%= sidebar_current("docs-google-kms-key-ring-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-kms-key-ring-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-kms-key-ring-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-kms-secret-ciphertext") %>>
+      <li>
         <a href="/docs/providers/google/r/kms_secret_ciphertext.html">google_kms_secret_ciphertext</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-iap") %>>
+    <li>
     <a href="#">Google IAP Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-iap-brand") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_brand.html">google_iap_brand</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-client") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_client.html">google_iap_client</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-tunnel-instance-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_tunnel_instance_iam.html">google_iap_tunnel_instance_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-tunnel-instance-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_tunnel_instance_iam.html">google_iap_tunnel_instance_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-tunnel-instance-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_tunnel_instance_iam.html">google_iap_tunnel_instance_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-app-engine-service-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_app_engine_service_iam.html">google_iap_app_engine_service_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-app-engine-service-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_app_engine_service_iam.html">google_iap_app_engine_service_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-app-engine-service-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_app_engine_service_iam.html">google_iap_app_engine_service_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-app-engine-version-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_app_engine_version_iam.html">google_iap_app_engine_version_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-app-engine-version-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_app_engine_version_iam.html">google_iap_app_engine_version_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-app-engine-version-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_app_engine_version_iam.html">google_iap_app_engine_version_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-web-backend-service-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_web_backend_service_iam.html">google_iap_web_backend_service_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-web-backend-service-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_web_backend_service_iam.html">google_iap_web_backend_service_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-web-backend-service-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_web_backend_service_iam.html">google_iap_web_backend_service_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-web-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_web_iam.html">google_iap_web_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-web-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_web_iam.html">google_iap_web_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-web-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_web_iam.html">google_iap_web_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-web-type-app-engine-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_web_type_app_engine_iam.html">google_iap_web_type_app_engine_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-web-type-app-engine-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_web_type_app_engine_iam.html">google_iap_web_type_app_engine_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-web-type-app-engine-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_web_type_app_engine_iam.html">google_iap_web_type_app_engine_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-web-type-compute-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_web_type_compute_iam.html">google_iap_web_type_compute_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-web-type-compute-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_web_type_compute_iam.html">google_iap_web_type_compute_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-iap-web-type-compute-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/iap_web_type_compute_iam.html">google_iap_web_type_compute_iam_policy</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-identityplatform") %>>
+    <li>
     <a href="#">Google Identity Platform Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-identity-platform-default-supported-idp-config") %>>
+      <li>
       <a href="/docs/providers/google/r/identity_platform_default_supported_idp_config.html">google_identity_platform_default_supported_idp_config</a>
       </li>
-      <li<%%= sidebar_current("docs-google-identity-platform-inbound-saml-config") %>>
+      <li>
       <a href="/docs/providers/google/r/identity_platform_inbound_saml_config.html">google_identity_platform_inbound_saml_config</a>
       </li>
-      <li<%%= sidebar_current("docs-google-identity-platform-oauth-idp-config") %>>
+      <li>
       <a href="/docs/providers/google/r/identity_platform_oauth_idp_config.html">google_identity_platform_oauth_idp_config</a>
       </li>
-      <li<%%= sidebar_current("docs-google-identity-platform-tenant") %>>
+      <li>
       <a href="/docs/providers/google/r/identity_platform_tenant.html">google_identity_platform_tenant</a>
       </li>
-      <li<%%= sidebar_current("docs-google-identity-platform-tenant-default-supported-idp-config") %>>
+      <li>
       <a href="/docs/providers/google/r/identity_platform_tenant_default_supported_idp_config.html">google_identity_platform_tenant_default_supported_idp_config</a>
       </li>
-      <li<%%= sidebar_current("docs-google-identity-platform-tenant-inbound-saml-config") %>>
+      <li>
       <a href="/docs/providers/google/r/identity_platform_tenant_inbound_saml_config.html">google_identity_platform_tenant_inbound_saml_config</a>
       </li>
-      <li<%%= sidebar_current("docs-google-identity-platform-tenant-oauth-idp-config") %>>
+      <li>
       <a href="/docs/providers/google/r/identity_platform_tenant_oauth_idp_config.html">google_identity_platform_tenant_oauth_idp_config</a>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-ml") %>>
+    <li>
     <a href="#">Google ML Engine Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-ml-engine-model") %>>
+      <li>
       <a href="/docs/providers/google/r/ml_engine_model.html">google_ml_engine_model</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-os-login-ssh-public-key") %>>
+    <li>
     <a href="#">Google OS Login</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-os-login-ssh-public-key") %>>
+      <li>
       <a href="/docs/providers/google/r/os_login_ssh_public_key.html">google_os_login_ssh_public_key</a>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-pubsub") %>>
+    <li>
     <a href="#">Google PubSub Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-pubsub-subscription-x") %>>
+      <li>
       <a href="/docs/providers/google/r/pubsub_subscription.html">google_pubsub_subscription</a>
       </li>
-      <li<%%= sidebar_current("docs-google-pubsub-subscription-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/pubsub_subscription_iam.html">google_pubsub_subscription_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-pubsub-subscription-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/pubsub_subscription_iam.html">google_pubsub_subscription_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-pubsub-subscription-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/pubsub_subscription_iam.html">google_pubsub_subscription_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-pubsub-topic-x") %>>
+      <li>
       <a href="/docs/providers/google/r/pubsub_topic.html">google_pubsub_topic</a>
       </li>
-      <li<%%= sidebar_current("docs-google-pubsub-topic-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/pubsub_topic_iam.html">google_pubsub_topic_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-pubsub-topic-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/pubsub_topic_iam.html">google_pubsub_topic_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-pubsub-topic-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/pubsub_topic_iam.html">google_pubsub_topic_iam_policy</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-redis") %>>
+    <li>
     <a href="#">Google Redis (Cloud Memorystore) Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-redis-instance") %>>
+      <li>
       <a href="/docs/providers/google/r/redis_instance.html">google_redis_instance</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-runtimeconfig") %>>
+    <li>
     <a href="#">Google RuntimeConfig Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-runtimeconfig-config") %>>
+      <li>
       <a href="/docs/providers/google/r/runtimeconfig_config.html">google_runtimeconfig_config</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-runtimeconfig-config-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/runtimeconfig_config_iam.html">google_runtimeconfig_config_iam</a>
       </li>
-      <li<%%= sidebar_current("docs-google-runtimeconfig-config-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/runtimeconfig_config_iam.html">google_runtimeconfig_config_iam</a>
       </li>
-      <li<%%= sidebar_current("docs-google-runtimeconfig-config-iam") %>>
+      <li>
         <a href="/docs/providers/google/r/runtimeconfig_config_iam.html">google_runtimeconfig_config_iam</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-runtimeconfig-variable") %>>
+      <li>
       <a href="/docs/providers/google/r/runtimeconfig_variable.html">google_runtimeconfig_variable</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-scc") %>>
+    <li>
     <a href="#">Google Cloud Security Command Center (SCC) Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-scc-source") %>>
+      <li>
           <a href="/docs/providers/google/r/scc_source.html">google_scc_source</a>
       </li>
     </ul>
     </li>
 
 <% unless version == 'ga' %>
-    <li<%%= sidebar_current("docs-google-secret-manager") %>>
+    <li>
     <a href="#">Google Secret Manager Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-secret-manager-secret-x") %>>
+      <li>
       <a href="/docs/providers/google/r/secret_manager_secret.html">google_secret_manager_secret</a>
       </li>
-      <li<%%= sidebar_current("docs-google-secret-manager-secret-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/secret_manager_secret_iam.html">google_secret_manager_secret_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-secret-manager-secret-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/secret_manager_secret_iam.html">google_secret_manager_secret_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-secret-manager-secret-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/secret_manager_secret_iam.html">google_secret_manager_secret_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-secret-manager-secret-version") %>>
+      <li>
       <a href="/docs/providers/google/r/secret_manager_secret_version.html">google_secret_manager_secret_version</a>
       </li>
     </ul>
@@ -1438,270 +1438,270 @@
 <% end -%>
 
 <% unless version == 'ga' %>
-    <li<%%= sidebar_current("docs-google-service-directory") %>>
+    <li>
     <a href="#">Google Service Directory Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-service-directory-endpoint") %>>
+      <li>
       <a href="/docs/providers/google/r/service_directory_endpoint.html">google_service_directory_endpoint</a>
       </li>
-      <li<%%= sidebar_current("docs-google-service-directory-namespace") %>>
+      <li>
       <a href="/docs/providers/google/r/service_directory_namespace.html">google_service_directory_namespace</a>
       </li>
-      <li<%%= sidebar_current("docs-google-service-directory-namespace-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/service_directory_namespace_iam.html">google_service_directory_namespace_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-service-directory-namespace-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/service_directory_namespace_iam.html">google_service_directory_namespace_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-service-directory-namespace-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/service_directory_namespace_iam.html">google_service_directory_namespace_iam_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-service-directory-service") %>>
+      <li>
       <a href="/docs/providers/google/r/service_directory_service.html">google_service_directory_service</a>
       </li>
-      <li<%%= sidebar_current("docs-google-service-directory-service-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/service_directory_service_iam.html">google_service_directory_service_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-service-directory-service-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/service_directory_service_iam.html">google_service_directory_service_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-service-directory-service-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/service_directory_service_iam.html">google_service_directory_service_iam_policy</a>
       </li>
     </ul>
     </li>
 <% end -%>
 
-    <li<%%= sidebar_current("docs-google-service-networking") %>>
+    <li>
     <a href="#">Google Service Networking Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-service-networking-connection") %>>
+      <li>
       <a href="/docs/providers/google/r/service_networking_connection.html">google_service_networking_connection</a>
       </li>
     </ul>
     </li>
 
 <% unless version == 'ga' %>
-    <li<%%= sidebar_current("docs-google-service-usage") %>>
+    <li>
     <a href="#">Google Service Usage Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-service-usage-consumer-quota-override") %>>
+      <li>
       <a href="/docs/providers/google/r/service_usage_consumer_quota_override.html">google_service_usage_consumer_quota_override</a>
       </li>
     </ul>
     </li>
 <% end -%>
 
-    <li<%%= sidebar_current("docs-google-sourcerepo") %>>
+    <li>
     <a href="#">Google Source Repositories Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-sourcerepo-repository") %>>
+      <li>
       <a href="/docs/providers/google/r/sourcerepo_repository.html">google_sourcerepo_repository</a>
       </li>
-      <li<%%= sidebar_current("docs-google-sourcerepo-repository-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/sourcerepo_repository_iam.html">google_sourcerepo_repository_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-sourcerepo-repository-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/sourcerepo_repository_iam.html">google_sourcerepo_repository_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-sourcerepo-repository-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/sourcerepo_repository_iam.html">google_sourcerepo_repository_iam_policy</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-spanner") %>>
+    <li>
     <a href="#">Google Spanner Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-spanner-database") %>>
+      <li>
       <a href="/docs/providers/google/r/spanner_database.html">google_spanner_database</a>
       </li>
-      <li<%%= sidebar_current("docs-google-spanner-database-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/spanner_database_iam.html">google_spanner_database_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-spanner-database-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/spanner_database_iam.html">google_spanner_database_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-spanner-database-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/spanner_database_iam.html">google_spanner_database_iam_policy</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-spanner-instance") %>>
+      <li>
       <a href="/docs/providers/google/r/spanner_instance.html">google_spanner_instance</a>
       </li>
-      <li<%%= sidebar_current("docs-google-spanner-instance-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/spanner_instance_iam.html">google_spanner_instance_iam_binding</a>
       </li>
-      <li<%%= sidebar_current("docs-google-spanner-instance-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/spanner_instance_iam.html">google_spanner_instance_iam_member</a>
       </li>
-      <li<%%= sidebar_current("docs-google-spanner-instance-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/spanner_instance_iam.html">google_spanner_instance_iam_policy</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-sql") %>>
+    <li>
     <a href="#">Google SQL Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-sql-database-x") %>>
+      <li>
       <a href="/docs/providers/google/r/sql_database.html">google_sql_database</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-sql-database-instance") %>>
+      <li>
       <a href="/docs/providers/google/r/sql_database_instance.html">google_sql_database_instance</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-sql-source-representation-instance") %>>
+      <li>
       <a href="/docs/providers/google/r/sql_source_representation_instance.html">google_sql_source_representation_instance</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-sql-ssl-cert") %>>
+      <li>
       <a href="/docs/providers/google/r/sql_ssl_cert.html">google_sql_ssl_cert</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-sql-user") %>>
+      <li>
       <a href="/docs/providers/google/r/sql_user.html">google_sql_user</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-logging") %>>
+    <li>
     <a href="#">Google Stackdriver Logging Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-logging-billing-account-exclusion") %>>
+      <li>
       <a href="/docs/providers/google/r/logging_billing_account_exclusion.html">google_logging_billing_account_exclusion</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-logging-billing-account-sink") %>>
+      <li>
       <a href="/docs/providers/google/r/logging_billing_account_sink.html">google_logging_billing_account_sink</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-logging-folder-exclusion") %>>
+      <li>
       <a href="/docs/providers/google/r/logging_folder_exclusion.html">google_logging_folder_exclusion</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-logging-folder-sink") %>>
+      <li>
       <a href="/docs/providers/google/r/logging_folder_sink.html">google_logging_folder_sink</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-logging-organization-exclusion") %>>
+      <li>
       <a href="/docs/providers/google/r/logging_organization_exclusion.html">google_logging_organization_exclusion</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-logging-organization-sink") %>>
+      <li>
       <a href="/docs/providers/google/r/logging_organization_sink.html">google_logging_organization_sink</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-logging-metric") %>>
+      <li>
       <a href="/docs/providers/google/r/logging_metric.html">google_logging_metric</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-logging-project-exclusion") %>>
+      <li>
       <a href="/docs/providers/google/r/logging_project_exclusion.html">google_logging_project_exclusion</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-logging-project-sink") %>>
+      <li>
       <a href="/docs/providers/google/r/logging_project_sink.html">google_logging_project_sink</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-monitoring") %>>
+    <li>
     <a href="#">Google Stackdriver Monitoring Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-monitoring-alert-policy") %>>
+      <li>
       <a href="/docs/providers/google/r/monitoring_alert_policy.html">google_monitoring_alert_policy</a>
       </li>
-      <li<%%= sidebar_current("docs-google-monitoring-group") %>>
+      <li>
       <a href="/docs/providers/google/r/monitoring_group.html">google_monitoring_group</a>
       </li>
-      <li<%%= sidebar_current("docs-google-monitoring-notification-channel") %>>
+      <li>
       <a href="/docs/providers/google/r/monitoring_notification_channel.html">google_monitoring_notification_channel</a>
       </li>
-      <li<%%= sidebar_current("docs-google-monitoring-custom-service") %>>
+      <li>
       <a href="/docs/providers/google/r/monitoring_service.html">google_monitoring_custom_service</a>
       </li>
-      <li<%%= sidebar_current("docs-google-monitoring-slo") %>>
+      <li>
       <a href="/docs/providers/google/r/monitoring_slo.html">google_monitoring_slo</a>
       </li>
-      <li<%%= sidebar_current("docs-google-monitoring-uptime-check-config") %>>
+      <li>
       <a href="/docs/providers/google/r/monitoring_uptime_check_config.html">google_monitoring_uptime_check_config</a>
       </li>
 
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-storage") %>>
+    <li>
     <a href="#">Google Storage Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-storage-bucket-x") %>>
+      <li>
       <a href="/docs/providers/google/r/storage_bucket.html">google_storage_bucket</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-storage-bucket-access-control") %>>
+      <li>
       <a href="/docs/providers/google/r/storage_bucket_access_control.html">google_storage_bucket_access_control</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-storage-bucket-acl") %>>
+      <li>
       <a href="/docs/providers/google/r/storage_bucket_acl.html">google_storage_bucket_acl</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-storage-bucket-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/storage_bucket_iam.html">google_storage_bucket_iam_binding</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-storage-bucket-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/storage_bucket_iam.html">google_storage_bucket_iam_member</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-storage-bucket-iam") %>>
+      <li>
       <a href="/docs/providers/google/r/storage_bucket_iam.html">google_storage_bucket_iam_policy</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-storage-bucket-object") %>>
+      <li>
       <a href="/docs/providers/google/r/storage_bucket_object.html">google_storage_bucket_object</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-storage-default-object-access-control") %>>
+      <li>
       <a href="/docs/providers/google/r/storage_default_object_access_control.html">google_storage_default_object_access_control</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-storage-default-object-acl") %>>
+      <li>
       <a href="/docs/providers/google/r/storage_default_object_acl.html">google_storage_default_object_acl</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-storage-hmac-key") %>>
+      <li>
       <a href="/docs/providers/google/r/storage_hmac_key.html">google_storage_hmac_key</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-storage-notification") %>>
+      <li>
       <a href="/docs/providers/google/r/storage_notification.html">google_storage_notification</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-storage-object-access-control") %>>
+      <li>
       <a href="/docs/providers/google/r/storage_object_access_control.html">google_storage_object_access_control</a>
       </li>
 
-      <li<%%= sidebar_current("docs-google-storage-object-acl") %>>
+      <li>
       <a href="/docs/providers/google/r/storage_object_acl.html">google_storage_object_acl</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-storage-transfer") %>>
+    <li>
     <a href="#">Google Storage Transfer Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-storage-transfer-job-x") %>>
+      <li>
       <a href="/docs/providers/google/r/storage_transfer_job.html">google_storage_transfer_job</a>
       </li>
     </ul>
     </li>
 
-    <li<%%= sidebar_current("docs-google-vpc") %>>
+    <li>
     <a href="#">Google Serverless VPC Access Resources</a>
     <ul class="nav">
-      <li<%%= sidebar_current("docs-google-vpc-access-connector") %>>
+      <li>
       <a href="/docs/providers/google/r/vpc_access_connector.html">google_vpc_access_connector</a>
       </li>
     </ul>

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -36,7 +36,7 @@
     </li>
 
     <li>
-    <a href="#">Google Cloud Platform Data Sources</a>
+    <a href="#">Provider Data Sources</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/d/google_active_folder.html">google_active_folder</a>
@@ -244,7 +244,7 @@
 
 <% unless version == 'ga' %>
     <li>
-    <a href="#">Google Access Context Manager / VPC Service Control Resources</a>
+    <a href="#">Access Context Manager / VPC Service Control Resources</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/access_context_manager_access_level.html">google_access_context_manager_access_level</a>
@@ -287,7 +287,7 @@
     </li>
 
     <li>
-    <a href="#">Google BigQuery Resources</a>
+    <a href="#">BigQuery</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/bigquery_dataset.html">google_bigquery_dataset</a>
@@ -305,7 +305,7 @@
     </li>
 
     <li>
-    <a href="#">Google BigQuery Data Transfer Resources</a>
+    <a href="#">BigQuery Data Transfer</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/bigquery_data_transfer_config.html">google_bigquery_data_transfer_config</a>
@@ -314,7 +314,7 @@
 
 <% unless version == 'ga' -%>
     <li>
-    <a href="#">Google BigQuery Reservation Resources</a>
+    <a href="#">BigQuery Reservation</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/bigquery_reservation.html">google_bigquery_reservation</a>
@@ -323,7 +323,7 @@
 <% end -%>
 
     <li>
-    <a href="#">Google Bigtable Resources</a>
+    <a href="#">Bigtable</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/bigtable_app_profile.html">google_bigtable_app_profile</a>
@@ -356,7 +356,7 @@
     </li>
 
     <li>
-    <a href="#">Google Binary Authorization Resources</a>
+    <a href="#">Binary Authorization</a>
     <ul class="nav">
       <li>
         <a href="/docs/providers/google/r/binary_authorization_attestor.html">google_binary_authorization_attestor</a>
@@ -381,7 +381,7 @@
     </li>
 
     <li>
-    <a href="#">Google Cloud Build Resources</a>
+    <a href="#">Cloud Build</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/cloudbuild_trigger.html">google_cloudbuild_trigger</a>
@@ -390,7 +390,7 @@
     </li>
 
     <li>
-      <a href="#">Google Cloud Composer Resources</a>
+      <a href="#">Cloud Composer</a>
       <ul class="nav">
         <li>
           <a href="/docs/providers/google/r/composer_environment.html">google_composer_environment</a>
@@ -399,7 +399,7 @@
     </li>
 
     <li>
-    <a href="#">Google Cloud Functions Resources</a>
+    <a href="#">Cloud Functions</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/cloudfunctions_function.html">google_cloudfunctions_function</a>
@@ -417,7 +417,7 @@
     </li>
 
     <li>
-      <a href="#">Google Cloud IoT Core</a>
+      <a href="#">Cloud IoT Core</a>
       <ul class="nav">
         <li>
           <a href="/docs/providers/google/r/cloudiot_registry.html">google_cloudiot_registry</a>
@@ -525,7 +525,7 @@
     </li>
 
     <li>
-    <a href="#">Google Cloud Run Resources</a>
+    <a href="#">Cloud Run</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/cloud_run_domain_mapping.html">google_cloud_run_domain_mapping</a>
@@ -547,7 +547,7 @@
 
 <% unless version == 'ga' %>
     <li>
-    <a href="#">Google Cloud Scheduler Resources</a>
+    <a href="#">Cloud Scheduler</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/cloud_scheduler_job.html">google_cloud_scheduler_job</a>
@@ -558,7 +558,7 @@
 
 <% unless version == 'ga' %>
     <li>
-    <a href="#">Google Cloud Security Scanner Resources</a>
+    <a href="#">Cloud Security Scanner</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/security_scanner_scan_config.html">google_security_scanner_scan_config</a>
@@ -568,7 +568,7 @@
 <% end -%>
 
     <li>
-      <a href="#">Google Cloud Tasks</a>
+      <a href="#">Cloud Tasks</a>
       <ul class="nav">
         <li>
           <a href="/docs/providers/google/r/cloud_tasks_queue.html">google_cloud_tasks_queue</a>
@@ -577,7 +577,7 @@
     </li>
 
     <li>
-      <a href="#">Google Cloud TPU</a>
+      <a href="#">Cloud TPU</a>
       <ul class="nav">
         <li>
           <a href="/docs/providers/google/r/tpu_node.html">google_tpu_node</a>
@@ -586,7 +586,7 @@
     </li>
 
     <li>
-    <a href="#">Google Compute Engine Resources</a>
+    <a href="#">Compute Engine</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/compute_address.html">google_compute_address</a>
@@ -919,7 +919,7 @@
     </li>
 
     <li>
-    <a href="#">Google Container Analysis Resources</a>
+    <a href="#">Container Analysis</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/container_analysis_note.html">google_container_analysis_note</a>
@@ -928,7 +928,7 @@
     </li>
 
     <li>
-    <a href="#">Google Container Registry Resources</a>
+    <a href="#">Container Registry</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/container_registry.html">google_container_registry</a>
@@ -937,7 +937,7 @@
     </li>
 
     <li>
-    <a href="#">Google Kubernetes (Container) Engine Resources</a>
+    <a href="#">Kubernetes (Container) Engine</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/container_cluster.html">google_container_cluster</a>
@@ -951,7 +951,7 @@
 
 <% unless version == 'ga' %>
     <li>
-    <a href="#">Google Data Fusion Resources</a>
+    <a href="#">Data Fusion</a>
     <ul class="nav">
       <li>
           <a href="/docs/providers/google/r/data_fusion_instance.html">google_data_fusion_instance</a>
@@ -961,7 +961,7 @@
 <% end -%>
 
     <li>
-    <a href="#">Google Dataflow Resources</a>
+    <a href="#">Dataflow</a>
     <ul class="nav">
       <li>
           <a href="/docs/providers/google/r/dataflow_job.html">google_dataflow_job</a>
@@ -970,7 +970,7 @@
     </li>
 
     <li>
-    <a href="#">Google Datastore Resources</a>
+    <a href="#">Datastore</a>
     <ul class="nav">
       <li>
           <a href="/docs/providers/google/r/datastore_index.html">google_datastore_index</a>
@@ -979,7 +979,7 @@
     </li>
 
     <li>
-        <a href="#">Google Dataproc Resources</a>
+        <a href="#">Dataproc</a>
         <ul class="nav">
           <li>
           <a href="/docs/providers/google/r/dataproc_autoscaling_policy.html">google_dataproc_autoscaling_policy</a>
@@ -1020,7 +1020,7 @@
     </li>
 
     <li>
-    <a href="#">Google Deployment Manager Resources</a>
+    <a href="#">Deployment Manager</a>
     <ul class="nav">
       <li>
           <a href="/docs/providers/google/r/deployment_manager_deployment.html">google_deployment_manager_deployment</a>
@@ -1029,7 +1029,7 @@
     </li>
 
     <li>
-    <a href="#">Google Dialogflow Resources</a>
+    <a href="#">Dialogflow</a>
     <ul class="nav">
       <li>
           <a href="/docs/providers/google/r/dialogflow_agent.html">google_dialogflow_agent</a>
@@ -1041,7 +1041,7 @@
     </li>
 
     <li>
-    <a href="#">Google DNS Resources</a>
+    <a href="#">DNS</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/dns_managed_zone.html">google_dns_managed_zone</a>
@@ -1060,7 +1060,7 @@
     </li>
 
     <li>
-    <a href="#">Google Endpoints Resources</a>
+    <a href="#">Endpoints</a>
     <ul class="nav">
       <li>
           <a href="/docs/providers/google/r/endpoints_service.html">google_endpoints_service</a>
@@ -1078,7 +1078,7 @@
     </li>
 <% unless version == 'ga' %>
     <li>
-    <a href="#">Google Firebase Resources</a>
+    <a href="#">Firebase</a>
     <ul class="nav">
       <li>
           <a href="/docs/providers/google/r/firebase_project.html">google_firebase_project</a>
@@ -1097,7 +1097,7 @@
     </li>
 <% end %>
     <li>
-    <a href="#">Google Filestore Resources</a>
+    <a href="#">Filestore</a>
     <ul class="nav">
       <li>
           <a href="/docs/providers/google/r/filestore_instance.html">google_filestore_instance</a>
@@ -1106,7 +1106,7 @@
     </li>
 
     <li>
-    <a href="#">Google Firestore Resources</a>
+    <a href="#">Firestore</a>
     <ul class="nav">
       <li>
           <a href="/docs/providers/google/r/firestore_index.html">google_firestore_index</a>
@@ -1116,7 +1116,7 @@
 
 <% unless version == 'ga' %>
     <li>
-    <a href="#">Google Cloud Game Servers</a>
+    <a href="#">Game Servers</a>
     <ul class="nav">
       <li>
           <a href="/docs/providers/google/r/game_services_realm.html">game_services_realm.html</a>
@@ -1139,7 +1139,7 @@
 
 <% unless version == 'ga' %>
     <li>
-    <a href="#">Google Healthcare Resources</a>
+    <a href="#">Healthcare</a>
     <ul class="nav">
       <li>
         <a href="/docs/providers/google/r/healthcare_dataset.html">google_healthcare_dataset</a>
@@ -1193,7 +1193,7 @@
 <% end -%>
 
     <li>
-    <a href="#">Google Key Management Service Resources</a>
+    <a href="#">Key Management Service</a>
     <ul class="nav">
       <li>
         <a href="/docs/providers/google/r/kms_crypto_key.html">google_kms_crypto_key</a>
@@ -1226,7 +1226,7 @@
     </li>
 
     <li>
-    <a href="#">Google IAP Resources</a>
+    <a href="#">IAP</a>
     <ul class="nav">
       <li>
         <a href="/docs/providers/google/r/iap_brand.html">google_iap_brand</a>
@@ -1301,7 +1301,7 @@
     </li>
 
     <li>
-    <a href="#">Google Identity Platform Resources</a>
+    <a href="#">Identity Platform</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/identity_platform_default_supported_idp_config.html">google_identity_platform_default_supported_idp_config</a>
@@ -1327,7 +1327,7 @@
     </li>
 
     <li>
-    <a href="#">Google ML Engine Resources</a>
+    <a href="#">ML Engine</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/ml_engine_model.html">google_ml_engine_model</a>
@@ -1336,7 +1336,7 @@
     </li>
 
     <li>
-    <a href="#">Google OS Login</a>
+    <a href="#">OS Login</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/os_login_ssh_public_key.html">google_os_login_ssh_public_key</a>
@@ -1344,7 +1344,7 @@
     </li>
 
     <li>
-    <a href="#">Google PubSub Resources</a>
+    <a href="#">PubSub</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/pubsub_subscription.html">google_pubsub_subscription</a>
@@ -1374,7 +1374,7 @@
     </li>
 
     <li>
-    <a href="#">Google Redis (Cloud Memorystore) Resources</a>
+    <a href="#">Redis (Cloud Memorystore)</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/redis_instance.html">google_redis_instance</a>
@@ -1383,7 +1383,7 @@
     </li>
 
     <li>
-    <a href="#">Google RuntimeConfig Resources</a>
+    <a href="#">RuntimeConfig</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/runtimeconfig_config.html">google_runtimeconfig_config</a>
@@ -1406,7 +1406,7 @@
     </li>
 
     <li>
-    <a href="#">Google Cloud Security Command Center (SCC) Resources</a>
+    <a href="#">Security Command Center (SCC)</a>
     <ul class="nav">
       <li>
           <a href="/docs/providers/google/r/scc_source.html">google_scc_source</a>
@@ -1416,7 +1416,7 @@
 
 <% unless version == 'ga' %>
     <li>
-    <a href="#">Google Secret Manager Resources</a>
+    <a href="#">Secret Manager</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/secret_manager_secret.html">google_secret_manager_secret</a>
@@ -1439,7 +1439,7 @@
 
 <% unless version == 'ga' %>
     <li>
-    <a href="#">Google Service Directory Resources</a>
+    <a href="#">Service Directory</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/service_directory_endpoint.html">google_service_directory_endpoint</a>
@@ -1473,7 +1473,7 @@
 <% end -%>
 
     <li>
-    <a href="#">Google Service Networking Resources</a>
+    <a href="#">Service Networking</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/service_networking_connection.html">google_service_networking_connection</a>
@@ -1483,7 +1483,7 @@
 
 <% unless version == 'ga' %>
     <li>
-    <a href="#">Google Service Usage Resources</a>
+    <a href="#">Service Usage</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/service_usage_consumer_quota_override.html">google_service_usage_consumer_quota_override</a>
@@ -1493,7 +1493,7 @@
 <% end -%>
 
     <li>
-    <a href="#">Google Source Repositories Resources</a>
+    <a href="#">Cloud Source Repositories</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/sourcerepo_repository.html">google_sourcerepo_repository</a>
@@ -1511,7 +1511,7 @@
     </li>
 
     <li>
-    <a href="#">Google Spanner Resources</a>
+    <a href="#">Spanner</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/spanner_database.html">google_spanner_database</a>
@@ -1542,7 +1542,7 @@
     </li>
 
     <li>
-    <a href="#">Google SQL Resources</a>
+    <a href="#">Cloud SQL</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/sql_database.html">google_sql_database</a>
@@ -1567,7 +1567,7 @@
     </li>
 
     <li>
-    <a href="#">Google Stackdriver Logging Resources</a>
+    <a href="#">Cloud (Stackdriver) Logging</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/logging_billing_account_exclusion.html">google_logging_billing_account_exclusion</a>
@@ -1608,7 +1608,7 @@
     </li>
 
     <li>
-    <a href="#">Google Stackdriver Monitoring Resources</a>
+    <a href="#">Cloud (Stackdriver) Monitoring</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/monitoring_alert_policy.html">google_monitoring_alert_policy</a>
@@ -1633,7 +1633,7 @@
     </li>
 
     <li>
-    <a href="#">Google Storage Resources</a>
+    <a href="#">Cloud Storage</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/storage_bucket.html">google_storage_bucket</a>
@@ -1690,7 +1690,7 @@
     </li>
 
     <li>
-    <a href="#">Google Storage Transfer Resources</a>
+    <a href="#">Storage Transfer</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/storage_transfer_job.html">google_storage_transfer_job</a>
@@ -1699,7 +1699,7 @@
     </li>
 
     <li>
-    <a href="#">Google Serverless VPC Access Resources</a>
+    <a href="#">Serverless VPC Access</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/vpc_access_connector.html">google_vpc_access_connector</a>


### PR DESCRIPTION
In preparation for generating the sidebar (https://github.com/terraform-providers/terraform-provider-google/issues/6001), I made some changes by hand which will hopefully make it easier to verify the diffs that a run of the generator will show us.

Each change is in its own commit for ease of reviewing:
* remove sidebar_current calls (not needed as per https://github.com/terraform-providers/terraform-provider-aws/pull/8224)
* rename products: there's no need to write Google in front of every product, so I took those out. I also removed the word "Resources" from most of the products, because later I want to put data sources underneath the products too (like the aws provider does). I also updated products to their names on the GCP website- basically just calling things "Cloud X" vs "X" when GCP does.
* alphabetize

I left the "Google Cloud Platform Resources" section alone- it probably should be broken up at some point, but I didn't want to confuse people who were used to looking for project-related resources in that section (vs one that said resource manager). Happy to do it here though if you think that's best.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
