### PR TITLE
add note in docs to generated sensitive fields

### DIFF
--- a/api/resource.rb
+++ b/api/resource.rb
@@ -205,6 +205,16 @@ module Api
       all_user_properties.select(&:required)
     end
 
+    def all_nested_properties(parent, props)
+      nested = props
+      props.each do |prop|
+        if !prop.flatten_object && prop.nested_properties?
+          nested = nested + all_nested_properties(prop.name, prop.nested_properties)
+        end
+      end
+      nested
+    end
+
     # Returns all resourcerefs at any depth
     def all_resourcerefs
       resourcerefs_for_properties(all_user_properties, self)

--- a/api/resource.rb
+++ b/api/resource.rb
@@ -205,11 +205,11 @@ module Api
       all_user_properties.select(&:required)
     end
 
-    def all_nested_properties(parent, props)
+    def all_nested_properties(props)
       nested = props
       props.each do |prop|
         if !prop.flatten_object && prop.nested_properties?
-          nested = nested + all_nested_properties(prop.name, prop.nested_properties)
+          nested += all_nested_properties(prop.nested_properties)
         end
       end
       nested

--- a/api/type.rb
+++ b/api/type.rb
@@ -132,9 +132,9 @@ module Api
     # The only intended purpose is to allow better error messages. Some objects
     # and at some points in the build this doesn't output a valid output.
     def lineage
-      return name.underscore if __parent.nil?
+      return name&.underscore if __parent.nil?
 
-      __parent.lineage + '.' + name.underscore
+      __parent.lineage + '.' + name&.underscore
     end
 
     def to_json(opts = nil)

--- a/api/type.rb
+++ b/api/type.rb
@@ -132,9 +132,9 @@ module Api
     # The only intended purpose is to allow better error messages. Some objects
     # and at some points in the build this doesn't output a valid output.
     def lineage
-      return name if __parent.nil?
+      return name.underscore if __parent.nil?
 
-      __parent.lineage + '.' + name
+      __parent.lineage + '.' + name.underscore
     end
 
     def to_json(opts = nil)

--- a/compiler.rb
+++ b/compiler.rb
@@ -24,6 +24,7 @@ Dir.chdir(File.dirname(__FILE__))
 ENV['TZ'] = 'UTC'
 
 require 'active_support/inflector'
+require 'active_support/core_ext/array/conversions'
 require 'api/compiler'
 require 'google/logger'
 require 'optparse'

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -166,12 +166,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       keyValue: !ruby/object:Overrides::Terraform::PropertyOverride
         sensitive: true
         ignore_read: true
-    docs: !ruby/object:Provider::Terraform::Docs
-      warning: |
-        All arguments including the key's value will be stored in the raw
-        state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
-        Because the API does not return the sensitive key value,
-        we cannot confirm or reverse changes to a key outside of Terraform.
   BackendService: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples
@@ -346,12 +340,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       keyValue: !ruby/object:Overrides::Terraform::PropertyOverride
         sensitive: true
         ignore_read: true
-    docs: !ruby/object:Provider::Terraform::Docs
-      warning: |
-        All arguments including the key's value will be stored in the raw
-        state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
-        Because the API does not return the sensitive key value,
-        we cannot confirm or reverse changes to a key outside of Terraform.
   RegionDiskResourcePolicyAttachment: !ruby/object:Overrides::Terraform::ResourceOverride
     description: |
       Adds existing resource policies to a disk. You can only add one policy
@@ -487,11 +475,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       encoder: templates/terraform/encoders/disk.erb
       decoder: templates/terraform/decoders/disk.erb
       resource_definition: templates/terraform/resource_definition/disk.erb
-    docs: !ruby/object:Provider::Terraform::Docs
-      warning: |
-        All arguments including the disk encryption key will be stored in the raw
-        state as plain-text.
-        [Read more about sensitive data in state](/docs/state/sensitive-data.html).
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "disk_basic"
@@ -1355,16 +1338,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
       physicalBlockSizeBytes: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      diskEncryptionKey.rawKey: !ruby/object:Overrides::Terraform::PropertyOverride
+        sensitive: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_delete: templates/terraform/pre_delete/detach_disk.erb
       encoder: templates/terraform/encoders/disk.erb
       decoder: templates/terraform/decoders/disk.erb
       resource_definition: templates/terraform/resource_definition/disk.erb
-    docs: !ruby/object:Provider::Terraform::Docs
-      warning: |
-        All arguments including the disk encryption key will be stored in the raw
-        state as plain-text.
-        [Read more about sensitive data in state](/docs/state/sensitive-data.html).
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "region_disk_basic"
@@ -2373,11 +2353,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           udp500_forwarding_rule_name: "fr-udp500"
           udp4500_forwarding_rule_name: "fr-udp4500"
           route_name: "route1"
-    docs: !ruby/object:Provider::Terraform::Docs
-      warning: |
-        All arguments including the shared secret will be stored in the raw
-        state as plain-text.
-        [Read more about sensitive data in state](/docs/state/sensitive-data.html).
     properties:
       targetVpnGateway: !ruby/object:Overrides::Terraform::PropertyOverride
         resource: 'VpnGateway'

--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -14,8 +14,9 @@
 <%   end -%>
 <% end -%>
 <%= indent(property.description.strip.gsub("\n\n", "\n"), 2) -%>
+<% if property.sensitive -%>
+  **Note:** Sensitive fields will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
+<% end -%>
 <% if property.is_a?(Api::Type::NestedObject) || property.is_a?(Api::Type::Map) || (property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::NestedObject)) -%>
   Structure is documented below.
-<%   elsif property.sensitive -%>
-  **Note:** Sensitive fields will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 <% end -%>

--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -14,6 +14,9 @@
 <%   end -%>
 <% end -%>
 <%= indent(property.description.strip.gsub("\n\n", "\n"), 2) -%>
+<% if property.sensitive -%>
+  **Note**: This property is sensitive and will not be displayed in the plan.
+<% end -%>
 <% if property.is_a?(Api::Type::NestedObject) || property.is_a?(Api::Type::Map) || (property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::NestedObject)) -%>
   Structure is documented below.
 <% end -%>

--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -16,4 +16,6 @@
 <%= indent(property.description.strip.gsub("\n\n", "\n"), 2) -%>
 <% if property.is_a?(Api::Type::NestedObject) || property.is_a?(Api::Type::Map) || (property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::NestedObject)) -%>
   Structure is documented below.
+<%   elsif property.sensitive -%>
+  **Note:** Sensitive fields will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
 <% end -%>

--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -14,9 +14,6 @@
 <%   end -%>
 <% end -%>
 <%= indent(property.description.strip.gsub("\n\n", "\n"), 2) -%>
-<% if property.sensitive -%>
-  **Note:** Sensitive fields will be stored in the raw state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
-<% end -%>
 <% if property.is_a?(Api::Type::NestedObject) || property.is_a?(Api::Type::Map) || (property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::NestedObject)) -%>
   Structure is documented below.
 <% end -%>

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -85,20 +85,11 @@ To get more information about <%= object.name -%>, see:
 <%- end -%>
 <%- if !sensitive_props.empty? -%>
 <%-
-  sense_props = sensitive_props.map! {|prop| "`"+prop.name.underscore+"`"}.uniq
-  if sense_props.length == 1
-    sense_props = sense_props[0]
-  elsif sense_props.length == 2
-    sense_props = sense_props[0]+" and "+sense_props[1]
-  else
-    sense_props = sense_props.slice(0,sense_props.length-1).join(", ") + " and " + sense_props[sense_props.length-1]
-  end
+  sense_props = sensitive_props.map! {|prop| "`"+prop.lineage+"`"}.to_sentence
 -%>
 
 ~> **Warning:** All arguments including <%= sense_props -%> will be stored in the raw
 state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
-Because the API does not return the sensitive key value,
-we cannot confirm or reverse changes to a key outside of Terraform.
 <%- end -%>
 
 <%#- We over-generate examples/oics buttons here; they'll all be _valid_ just not necessarily intended for this provider version.

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -40,7 +40,7 @@
   tf_subcategory = (object.__product.display_name)
   terraform_name = object.legacy_name || "google_#{tf_product}_#{object.name.underscore}"
   properties = object.all_user_properties
-  sensitive_props = object.all_nested_properties(object.name, object.root_properties).select(&:sensitive)
+  sensitive_props = object.all_nested_properties(object.root_properties).select(&:sensitive)
   # In order of preference, use TF override,
   # general defined timeouts, or default Timeouts
   timeouts = object.timeouts
@@ -93,7 +93,6 @@ To get more information about <%= object.name -%>, see:
   else
     sense_props = sense_props.slice(0,sense_props.length-1).join(", ") + " and " + sense_props[sense_props.length-1]
   end
-  p sense_props
 -%>
 
 ~> **Warning:** All arguments including <%= sense_props -%> will be stored in the raw

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -40,6 +40,7 @@
   tf_subcategory = (object.__product.display_name)
   terraform_name = object.legacy_name || "google_#{tf_product}_#{object.name.underscore}"
   properties = object.all_user_properties
+  sensitive_props = object.all_nested_properties(object.name, object.root_properties).select(&:sensitive)
   # In order of preference, use TF override,
   # general defined timeouts, or default Timeouts
   timeouts = object.timeouts
@@ -81,6 +82,24 @@ To get more information about <%= object.name -%>, see:
 <%- unless object.docs.warning.nil? -%>
 
 ~> **Warning:** <%= object.docs.warning -%>
+<%- end -%>
+<%- if !sensitive_props.empty? -%>
+<%-
+  sense_props = sensitive_props.map! {|prop| "`"+prop.name.underscore+"`"}.uniq
+  if sense_props.length == 1
+    sense_props = sense_props[0]
+  elsif sense_props.length == 2
+    sense_props = sense_props[0]+" and "+sense_props[1]
+  else
+    sense_props = sense_props.slice(0,sense_props.length-1).join(", ") + " and " + sense_props[sense_props.length-1]
+  end
+  p sense_props
+-%>
+
+~> **Warning:** All arguments including <%= sense_props -%> will be stored in the raw
+state as plain-text. [Read more about sensitive data in state](/docs/state/sensitive-data.html).
+Because the API does not return the sensitive key value,
+we cannot confirm or reverse changes to a key outside of Terraform.
 <%- end -%>
 
 <%#- We over-generate examples/oics buttons here; they'll all be _valid_ just not necessarily intended for this provider version.


### PR DESCRIPTION
add note to generated sensitive fields that values will be stored as plain-text in state.

fixes https://github.com/terraform-providers/terraform-provider-google/issues/5678

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
