### PR TITLE
Reapply bigtable patch

### DIFF
--- a/third_party/terraform/resources/resource_bigtable_instance.go
+++ b/third_party/terraform/resources/resource_bigtable_instance.go
@@ -54,7 +54,7 @@ func resourceBigtableInstance() *schema.Resource {
 							// DEVELOPMENT instances could get returned with either zero or one node,
 							// so mark as computed.
 							Computed:     true,
-							ValidateFunc: validation.IntAtLeast(3),
+							ValidateFunc: validation.IntAtLeast(1),
 						},
 						"storage_type": {
 							Type:         schema.TypeString,

--- a/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -23,7 +23,7 @@ resource "google_bigtable_instance" "production-instance" {
   cluster {
     cluster_id   = "tf-instance-cluster"
     zone         = "us-central1-b"
-    num_nodes    = 3
+    num_nodes    = 1
     storage_type = "HDD"
   }
 }
@@ -73,7 +73,7 @@ cluster must have a different zone in the same region. Zones that support
 Bigtable instances are noted on the [Cloud Bigtable locations page](https://cloud.google.com/bigtable/docs/locations).
 
 * `num_nodes` - (Optional) The number of nodes in your Cloud Bigtable cluster.
-Required, with a minimum of `3` for a `PRODUCTION` instance. Must be left unset
+Required, with a minimum of `1` for a `PRODUCTION` instance. Must be left unset
 for a `DEVELOPMENT` instance.
 
 * `storage_type` - (Optional) The storage type to use. One of `"SSD"` or


### PR DESCRIPTION
Upstreaming the patch from https://github.com/terraform-providers/terraform-provider-google/pull/6083
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigtable: Reduced the minimum number of nodes for the `bigtable_instace` resource from 3 to 1.
```
