### PR TITLE
Add transformation of SQL DB read error so HandleNotFound works

### DIFF
--- a/overrides/terraform/resource_override.rb
+++ b/overrides/terraform/resource_override.rb
@@ -75,7 +75,12 @@ module Overrides
 
           # This enables resources that get their project via a reference to a different resource
           # instead of a project field to use User Project Overrides
-          :supports_indirect_user_project_override
+          :supports_indirect_user_project_override,
+
+          # Function to transform a read error so that handleNotFound recognises
+          # it as a 404. This should be added as a handwritten fn that takes in
+          # an error and returns one.
+          :read_error_transform
         ]
       end
 
@@ -108,6 +113,7 @@ module Overrides
         check :skip_sweeper, type: :boolean, default: false
         check :skip_delete, type: :boolean, default: false
         check :supports_indirect_user_project_override, type: :boolean, default: false
+        check :read_error_transform, type: String
       end
 
       def apply(resource)

--- a/products/sql/terraform.yaml
+++ b/products/sql/terraform.yaml
@@ -16,6 +16,7 @@ client_name: 'SqlAdmin'
 overrides: !ruby/object:Overrides::ResourceOverrides
   Database: !ruby/object:Overrides::Terraform::ResourceOverride
     mutex: "google-sql-database-instance-{{project}}-{{instance}}"
+    read_error_transform: "transformSQLDatabaseReadError"
     import_format: ["projects/{{project}}/instances/{{instance}}/databases/{{name}}",
                     "{{project}}/{{instance}}/{{name}}",
                     "instances/{{instance}}/databases/{{name}}",

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -407,7 +407,11 @@ func resource<%= resource_name -%>Read(d *schema.ResourceData, meta interface{})
 <%  end -%>
     res, err := sendRequest(config, "<%= object.read_verb.to_s.upcase -%>", <% if has_project || object.supports_indirect_user_project_override %>project<% else %>""<% end %>, url, nil<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
     if err != nil {
+<%  if object.read_error_transform -%>
+        return handleNotFoundError(<%= object.read_error_transform %>(err), d, fmt.Sprintf("<%= resource_name -%> %q", d.Id()))
+<%  else -%>
         return handleNotFoundError(err, d, fmt.Sprintf("<%= resource_name -%> %q", d.Id()))
+<%  end -%>
     }
 
 <%  if object.nested_query -%>

--- a/third_party/terraform/utils/sql_utils.go
+++ b/third_party/terraform/utils/sql_utils.go
@@ -1,0 +1,26 @@
+package google
+
+import (
+	"log"
+	"strings"
+
+	"github.com/hashicorp/errwrap"
+	"google.golang.org/api/googleapi"
+)
+
+func transformSQLDatabaseReadError(err error) error {
+	if gErr, ok := errwrap.GetType(err, &googleapi.Error{}).(*googleapi.Error); ok {
+		if gErr.Code == 400 && strings.Contains(gErr.Message, "Invalid request since instance is not running") {
+			// This error occurs when attempting a GET after deleting the sql database and sql instance. It leads to to
+			// inconsistent behavior as handleNotFoundError(...) expects an error code of 404 when a resource does not
+			// exist. To get the desired behavior from handleNotFoundError, modify the return code to 404 so that
+			// handleNotFoundError(...) will treat this as a NotFound error
+			gErr.Code = 404
+		}
+
+		log.Printf("[DEBUG] Transformed SQLDatabase error")
+		return gErr
+	}
+
+	return err
+}


### PR DESCRIPTION
Cross-upstream of https://github.com/terraform-providers/terraform-provider-google/pull/6154

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
sql: fixed behaviour in `google_sql_database` when the parent instance is deleted, removing it from state
```
