### PR TITLE
more product renames

### DIFF
--- a/api/product.rb
+++ b/api/product.rb
@@ -30,8 +30,8 @@ module Api
     # Example inputs: "Compute", "AccessContextManager"
     # attr_reader :name
 
-    # The full name of the GCP product; eg "Cloud Bigtable"
-    attr_reader :display_name
+    # Display Name: The full name of the GCP product; eg "Cloud Bigtable"
+    # A custom getter is used for :display_name instead of `attr_reader`
 
     attr_reader :objects
 
@@ -76,9 +76,9 @@ module Api
 
     # The product full name is the "display name" in string form intended for
     # users to read in documentation; "Google Compute Engine", "Cloud Bigtable"
-    def product_full_name
-      if !display_name.nil?
-        display_name
+    def display_name
+      if !@display_name.nil?
+        @display_name
       else
         name.underscore.humanize
       end
@@ -92,7 +92,7 @@ module Api
           return product_version if ordered_version_name == product_version.name
         end
       end
-      raise "Unable to find lowest version for product #{product_full_name}"
+      raise "Unable to find lowest version for product #{display_name}"
     end
 
     def version_obj(name)
@@ -116,7 +116,7 @@ module Api
         return version_obj(version) if exists_at_version(version)
       end
 
-      raise "Could not find object for version #{name} and product #{product_full_name}"
+      raise "Could not find object for version #{name} and product #{display_name}"
     end
 
     def exists_at_version_or_lower(name)

--- a/products/accesscontextmanager/api.yaml
+++ b/products/accesscontextmanager/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: AccessContextManager
-display_name: Access Context Manager
+display_name: Access Context Manager (VPC Service Controls)
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/bigquerydatatransfer/api.yaml
+++ b/products/bigquerydatatransfer/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: BigqueryDataTransfer
-display_name: BigQueryDataTransfer
+display_name: BigQuery Data Transfer
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/bigqueryreservation/api.yaml
+++ b/products/bigqueryreservation/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: BigqueryReservation
-display_name: BigQueryReservation
+display_name: BigQuery Reservation
 versions:
   - !ruby/object:Api::Product::Version
     name: beta

--- a/products/bigtable/api.yaml
+++ b/products/bigtable/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: Bigtable
-display_name: Bigtable
+display_name: Cloud Bigtable
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/dataproc/api.yaml
+++ b/products/dataproc/api.yaml
@@ -13,7 +13,6 @@
 
 --- !ruby/object:Api::Product
 name: Dataproc
-display_name: Cloud Dataproc
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/datastore/api.yaml
+++ b/products/datastore/api.yaml
@@ -13,7 +13,6 @@
 
 --- !ruby/object:Api::Product
 name: Datastore
-display_name: Cloud Datastore
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/deploymentmanager/api.yaml
+++ b/products/deploymentmanager/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: DeploymentManager
-display_name: Deployment Manager
+display_name: Cloud Deployment Manager
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/filestore/api.yaml
+++ b/products/filestore/api.yaml
@@ -19,7 +19,6 @@
 # include a small hack to rename the library - see
 # templates/terraform/constants/filestore.erb.
 name: Filestore
-display_name: Cloud Filestore
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/firestore/api.yaml
+++ b/products/firestore/api.yaml
@@ -13,7 +13,6 @@
 
 --- !ruby/object:Api::Product
 name: Firestore
-display_name: Cloud Firestore
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/gameservices/api.yaml
+++ b/products/gameservices/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: GameServices
-display_name: Google Game Services
+display_name: Game Servers
 scopes:
 - https://www.googleapis.com/auth/compute
 versions:

--- a/products/kms/api.yaml
+++ b/products/kms/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: KMS
-display_name: Cloud KMS
+display_name: Cloud Key Management Service
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/logging/api.yaml
+++ b/products/logging/api.yaml
@@ -13,7 +13,7 @@
 ---
 !ruby/object:Api::Product
 name: Logging
-display_name: Stackdriver Logging
+display_name: Cloud (Stackdriver) Logging
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/monitoring/api.yaml
+++ b/products/monitoring/api.yaml
@@ -12,7 +12,7 @@
 # limitations under the License.
 --- !ruby/object:Api::Product
 name: Monitoring
-display_name: Stackdriver Monitoring
+display_name: Cloud (Stackdriver) Monitoring
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/redis/api.yaml
+++ b/products/redis/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: Redis
-display_name: Cloud Memorystore
+display_name: Memorystore (Redis)
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/runtimeconfig/api.yaml
+++ b/products/runtimeconfig/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: RuntimeConfig
-display_name: Cloud Runtime Configuration
+display_name: Runtime Configurator
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/securitycenter/api.yaml
+++ b/products/securitycenter/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: SecurityCenter
-display_name: Cloud Security Command Center
+display_name: Security Command Center (SCC)
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/products/servicedirectory/api.yaml
+++ b/products/servicedirectory/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: ServiceDirectory
-display_name: ServiceDirectory
+display_name: Service Directory
 versions:
   - !ruby/object:Api::Product::Version
     name: beta

--- a/products/servicemanagement/api.yaml
+++ b/products/servicemanagement/api.yaml
@@ -13,7 +13,7 @@
 
 --- !ruby/object:Api::Product
 name: ServiceManagement
-display_name: Service Management
+display_name: Cloud Endpoints
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/templates/inspec/iam_binding/iam_binding.erb
+++ b/templates/inspec/iam_binding/iam_binding.erb
@@ -4,7 +4,7 @@
 require 'gcp_backend'
 require 'google/iam/property/iam_policy_bindings'
 
-# A provider to manage <%= @api.product_full_name -%> IAM Binding resources.
+# A provider to manage <%= @api.display_name -%> IAM Binding resources.
 class <%= object.name -%>IamBinding < GcpResourceBase
   name '<%= resource_name(object, product) -%>_iam_binding'
   desc '<%= object.name -%> Iam Binding'

--- a/templates/inspec/iam_policy/iam_policy.erb
+++ b/templates/inspec/iam_policy/iam_policy.erb
@@ -5,7 +5,7 @@ require 'gcp_backend'
 require 'google/iam/property/iam_policy_audit_configs'
 require 'google/iam/property/iam_policy_bindings'
 
-# A provider to manage <%= @api.product_full_name -%> IAM Policy resources.
+# A provider to manage <%= @api.display_name -%> IAM Policy resources.
 class <%= object.name -%>IamPolicy < GcpResourceBase
   name '<%= resource_name(object, product) -%>_iam_policy'
   desc '<%= object.name -%> Iam Policy'

--- a/templates/inspec/singular_resource.erb
+++ b/templates/inspec/singular_resource.erb
@@ -26,7 +26,7 @@
 -%>
 <%= lines(emit_requires(requires)) -%>
 
-# A provider to manage <%= @api.product_full_name -%> resources.
+# A provider to manage <%= @api.display_name -%> resources.
 class <%= object.__product.name.camelize(:upper) -%><%= object.name -%> < GcpResourceBase
   name '<%= resource_name(object, product) -%>'
   desc '<%= object.name -%>'

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -563,6 +563,61 @@
     </ul>
     </li>
 
+<% unless version == 'ga' %>
+    <li>
+    <a href="#">Cloud Healthcare</a>
+    <ul class="nav">
+      <li>
+        <a href="/docs/providers/google/r/healthcare_dataset.html">google_healthcare_dataset</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/healthcare_dataset_iam.html">google_healthcare_dataset_iam_binding</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/healthcare_dataset_iam.html">google_healthcare_dataset_iam_member</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/healthcare_dataset_iam.html">google_healthcare_dataset_iam_policy</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/healthcare_fhir_store.html">google_healthcare_fhir_store</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/healthcare_fhir_store_iam.html">google_healthcare_fhir_store_iam_binding</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/healthcare_fhir_store_iam.html">google_healthcare_fhir_store_iam_member</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/healthcare_fhir_store_iam.html">google_healthcare_fhir_store_iam_policy</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/healthcare_dicom_store.html">google_healthcare_dicom_store</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/healthcare_dicom_store_iam.html">google_healthcare_dicom_store_iam_binding</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/healthcare_dicom_store_iam.html">google_healthcare_dicom_store_iam_member</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/healthcare_dicom_store_iam.html">google_healthcare_dicom_store_iam_policy</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/healthcare_hl7_v2_store.html">google_healthcare_hl7_v2_store</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/healthcare_hl7_v2_store_iam.html">google_healthcare_hl7_v2_store_iam_binding</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/healthcare_hl7_v2_store_iam.html">google_healthcare_hl7_v2_store_iam_member</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/healthcare_hl7_v2_store_iam.html">google_healthcare_hl7_v2_store_iam_policy</a>
+      </li>
+    </ul>
+<% end -%>
+
     <li>
       <a href="#">Cloud IoT Core</a>
       <ul class="nav">
@@ -728,6 +783,37 @@
       </li>
       <li>
       <a href="/docs/providers/google/r/sourcerepo_repository_iam.html">google_sourcerepo_repository_iam_policy</a>
+      </li>
+    </ul>
+    </li>
+
+    <li>
+    <a href="#">Cloud Spanner</a>
+    <ul class="nav">
+      <li>
+      <a href="/docs/providers/google/r/spanner_database.html">google_spanner_database</a>
+      </li>
+      <li>
+      <a href="/docs/providers/google/r/spanner_database_iam.html">google_spanner_database_iam_binding</a>
+      </li>
+      <li>
+      <a href="/docs/providers/google/r/spanner_database_iam.html">google_spanner_database_iam_member</a>
+      </li>
+      <li>
+      <a href="/docs/providers/google/r/spanner_database_iam.html">google_spanner_database_iam_policy</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/spanner_instance.html">google_spanner_instance</a>
+      </li>
+      <li>
+      <a href="/docs/providers/google/r/spanner_instance_iam.html">google_spanner_instance_iam_binding</a>
+      </li>
+      <li>
+      <a href="/docs/providers/google/r/spanner_instance_iam.html">google_spanner_instance_iam_member</a>
+      </li>
+      <li>
+      <a href="/docs/providers/google/r/spanner_instance_iam.html">google_spanner_instance_iam_policy</a>
       </li>
     </ul>
     </li>
@@ -1314,61 +1400,6 @@
     </li>
 <% end %>
 
-<% unless version == 'ga' %>
-    <li>
-    <a href="#">Cloud Healthcare</a>
-    <ul class="nav">
-      <li>
-        <a href="/docs/providers/google/r/healthcare_dataset.html">google_healthcare_dataset</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/healthcare_dataset_iam.html">google_healthcare_dataset_iam_binding</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/healthcare_dataset_iam.html">google_healthcare_dataset_iam_member</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/healthcare_dataset_iam.html">google_healthcare_dataset_iam_policy</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/healthcare_fhir_store.html">google_healthcare_fhir_store</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/healthcare_fhir_store_iam.html">google_healthcare_fhir_store_iam_binding</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/healthcare_fhir_store_iam.html">google_healthcare_fhir_store_iam_member</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/healthcare_fhir_store_iam.html">google_healthcare_fhir_store_iam_policy</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/healthcare_dicom_store.html">google_healthcare_dicom_store</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/healthcare_dicom_store_iam.html">google_healthcare_dicom_store_iam_binding</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/healthcare_dicom_store_iam.html">google_healthcare_dicom_store_iam_member</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/healthcare_dicom_store_iam.html">google_healthcare_dicom_store_iam_policy</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/healthcare_hl7_v2_store.html">google_healthcare_hl7_v2_store</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/healthcare_hl7_v2_store_iam.html">google_healthcare_hl7_v2_store_iam_binding</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/healthcare_hl7_v2_store_iam.html">google_healthcare_hl7_v2_store_iam_member</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/healthcare_hl7_v2_store_iam.html">google_healthcare_hl7_v2_store_iam_policy</a>
-      </li>
-    </ul>
-<% end -%>
-
     <li>
     <a href="#">IAP</a>
     <ul class="nav">
@@ -1657,37 +1688,6 @@
     </ul>
     </li>
 <% end -%>
-
-    <li>
-    <a href="#">Cloud Spanner</a>
-    <ul class="nav">
-      <li>
-      <a href="/docs/providers/google/r/spanner_database.html">google_spanner_database</a>
-      </li>
-      <li>
-      <a href="/docs/providers/google/r/spanner_database_iam.html">google_spanner_database_iam_binding</a>
-      </li>
-      <li>
-      <a href="/docs/providers/google/r/spanner_database_iam.html">google_spanner_database_iam_member</a>
-      </li>
-      <li>
-      <a href="/docs/providers/google/r/spanner_database_iam.html">google_spanner_database_iam_policy</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/spanner_instance.html">google_spanner_instance</a>
-      </li>
-      <li>
-      <a href="/docs/providers/google/r/spanner_instance_iam.html">google_spanner_instance_iam_binding</a>
-      </li>
-      <li>
-      <a href="/docs/providers/google/r/spanner_instance_iam.html">google_spanner_instance_iam_member</a>
-      </li>
-      <li>
-      <a href="/docs/providers/google/r/spanner_instance_iam.html">google_spanner_instance_iam_policy</a>
-      </li>
-    </ul>
-    </li>
 
     <li>
     <a href="#">Storage Transfer</a>

--- a/third_party/terraform/website-compiled/google.erb
+++ b/third_party/terraform/website-compiled/google.erb
@@ -343,7 +343,7 @@
 
 <% unless version == 'ga' %>
     <li>
-    <a href="#">Access Context Manager / VPC Service Control</a>
+    <a href="#">Access Context Manager / VPC Service Controls</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/access_context_manager_access_level.html">google_access_context_manager_access_level</a>
@@ -422,7 +422,32 @@
 <% end -%>
 
     <li>
-    <a href="#">Bigtable</a>
+    <a href="#">Binary Authorization</a>
+    <ul class="nav">
+      <li>
+        <a href="/docs/providers/google/r/binary_authorization_attestor.html">google_binary_authorization_attestor</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/binary_authorization_attestor_iam.html">google_binary_authorization_attestor_iam_binding</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/binary_authorization_attestor_iam.html">google_binary_authorization_attestor_iam_member</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/binary_authorization_attestor_iam.html">google_binary_authorization_attestor_iam_policy</a>
+      </li>
+
+      <li>
+      <a href="/docs/providers/google/r/binary_authorization_policy.html">google_binary_authorization_policy</a>
+      </li>
+    </ul>
+    </li>
+
+    <li>
+    <a href="#">Cloud Bigtable</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/bigtable_app_profile.html">google_bigtable_app_profile</a>
@@ -455,31 +480,6 @@
     </li>
 
     <li>
-    <a href="#">Binary Authorization</a>
-    <ul class="nav">
-      <li>
-        <a href="/docs/providers/google/r/binary_authorization_attestor.html">google_binary_authorization_attestor</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/binary_authorization_attestor_iam.html">google_binary_authorization_attestor_iam_binding</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/binary_authorization_attestor_iam.html">google_binary_authorization_attestor_iam_member</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/binary_authorization_attestor_iam.html">google_binary_authorization_attestor_iam_policy</a>
-      </li>
-
-      <li>
-      <a href="/docs/providers/google/r/binary_authorization_policy.html">google_binary_authorization_policy</a>
-      </li>
-    </ul>
-    </li>
-
-    <li>
     <a href="#">Cloud Build</a>
     <ul class="nav">
       <li>
@@ -495,6 +495,54 @@
           <a href="/docs/providers/google/r/composer_environment.html">google_composer_environment</a>
         </li>
       </ul>
+    </li>
+
+<% unless version == 'ga' %>
+    <li>
+    <a href="#">Cloud Data Fusion</a>
+    <ul class="nav">
+      <li>
+          <a href="/docs/providers/google/r/data_fusion_instance.html">google_data_fusion_instance</a>
+      </li>
+    </ul>
+    </li>
+<% end -%>
+
+    <li>
+    <a href="#">Cloud DNS</a>
+    <ul class="nav">
+      <li>
+      <a href="/docs/providers/google/r/dns_managed_zone.html">google_dns_managed_zone</a>
+      </li>
+
+<% unless version == 'ga' %>
+      <li>
+      <a href="/docs/providers/google/r/dns_policy.html">google_dns_policy</a>
+      </li>
+
+<% end -%>
+      <li>
+      <a href="/docs/providers/google/r/dns_record_set.html">google_dns_record_set</a>
+      </li>
+    </ul>
+    </li>
+
+    <li>
+    <a href="#">Cloud Endpoints</a>
+    <ul class="nav">
+      <li>
+          <a href="/docs/providers/google/r/endpoints_service.html">google_endpoints_service</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/endpoints_service_iam.html">google_endpoints_service_iam_binding</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/endpoints_service_iam.html">google_endpoints_service_iam_member</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/endpoints_service_iam.html">google_endpoints_service_iam_policy</a>
+      </li>
+    </ul>
     </li>
 
     <li>
@@ -522,6 +570,39 @@
           <a href="/docs/providers/google/r/cloudiot_registry.html">google_cloudiot_registry</a>
         </li>
       </ul>
+    </li>
+
+    <li>
+    <a href="#">Cloud Key Management Service</a>
+    <ul class="nav">
+      <li>
+        <a href="/docs/providers/google/r/kms_crypto_key.html">google_kms_crypto_key</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_kms_crypto_key_iam.html">google_kms_crypto_key_iam_binding</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_kms_crypto_key_iam.html">google_kms_crypto_key_iam_member</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_kms_crypto_key_iam.html">google_kms_crypto_key_iam_policy</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/kms_key_ring.html">google_kms_key_ring</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_binding</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_member</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_policy</a>
+      </li>
+      <li>
+        <a href="/docs/providers/google/r/kms_secret_ciphertext.html">google_kms_secret_ciphertext</a>
+      </li>
+    </ul>
     </li>
 
     <li>
@@ -1085,33 +1166,16 @@
     </li>
 
     <li>
-    <a href="#">Container Analysis</a>
+    <a href="#">Container Registry</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/container_analysis_note.html">google_container_analysis_note</a>
       </li>
-    </ul>
-    </li>
-
-    <li>
-    <a href="#">Container Registry</a>
-    <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/container_registry.html">google_container_registry</a>
       </li>
     </ul>
     </li>
-
-<% unless version == 'ga' %>
-    <li>
-    <a href="#">Data Fusion</a>
-    <ul class="nav">
-      <li>
-          <a href="/docs/providers/google/r/data_fusion_instance.html">google_data_fusion_instance</a>
-      </li>
-    </ul>
-    </li>
-<% end -%>
 
     <li>
     <a href="#">Dataflow</a>
@@ -1173,7 +1237,7 @@
     </li>
 
     <li>
-    <a href="#">Deployment Manager</a>
+    <a href="#">Cloud Deployment Manager</a>
     <ul class="nav">
       <li>
           <a href="/docs/providers/google/r/deployment_manager_deployment.html">google_deployment_manager_deployment</a>
@@ -1189,43 +1253,6 @@
       </li>
       <li>
           <a href="/docs/providers/google/r/dialogflow_intent.html">google_dialogflow_intent</a>
-      </li>
-    </ul>
-    </li>
-
-    <li>
-    <a href="#">DNS</a>
-    <ul class="nav">
-      <li>
-      <a href="/docs/providers/google/r/dns_managed_zone.html">google_dns_managed_zone</a>
-      </li>
-
-<% unless version == 'ga' %>
-      <li>
-      <a href="/docs/providers/google/r/dns_policy.html">google_dns_policy</a>
-      </li>
-
-<% end -%>
-      <li>
-      <a href="/docs/providers/google/r/dns_record_set.html">google_dns_record_set</a>
-      </li>
-    </ul>
-    </li>
-
-    <li>
-    <a href="#">Endpoints</a>
-    <ul class="nav">
-      <li>
-          <a href="/docs/providers/google/r/endpoints_service.html">google_endpoints_service</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/endpoints_service_iam.html">google_endpoints_service_iam_binding</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/endpoints_service_iam.html">google_endpoints_service_iam_member</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/endpoints_service_iam.html">google_endpoints_service_iam_policy</a>
       </li>
     </ul>
     </li>
@@ -1289,7 +1316,7 @@
 
 <% unless version == 'ga' %>
     <li>
-    <a href="#">Healthcare</a>
+    <a href="#">Cloud Healthcare</a>
     <ul class="nav">
       <li>
         <a href="/docs/providers/google/r/healthcare_dataset.html">google_healthcare_dataset</a>
@@ -1440,39 +1467,6 @@
       </li>
       <li>
       <a href="/docs/providers/google/r/identity_platform_tenant_oauth_idp_config.html">google_identity_platform_tenant_oauth_idp_config</a>
-    </ul>
-    </li>
-
-    <li>
-    <a href="#">Key Management Service</a>
-    <ul class="nav">
-      <li>
-        <a href="/docs/providers/google/r/kms_crypto_key.html">google_kms_crypto_key</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_kms_crypto_key_iam.html">google_kms_crypto_key_iam_binding</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_kms_crypto_key_iam.html">google_kms_crypto_key_iam_member</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_kms_crypto_key_iam.html">google_kms_crypto_key_iam_policy</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/kms_key_ring.html">google_kms_key_ring</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_binding</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_member</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/google_kms_key_ring_iam.html">google_kms_key_ring_iam_policy</a>
-      </li>
-      <li>
-        <a href="/docs/providers/google/r/kms_secret_ciphertext.html">google_kms_secret_ciphertext</a>
-      </li>
     </ul>
     </li>
 
@@ -1665,7 +1659,7 @@
 <% end -%>
 
     <li>
-    <a href="#">Spanner</a>
+    <a href="#">Cloud Spanner</a>
     <ul class="nav">
       <li>
       <a href="/docs/providers/google/r/spanner_database.html">google_spanner_database</a>

--- a/third_party/terraform/website/docs/d/datasource_compute_lb_ip_ranges.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_compute_lb_ip_ranges.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Platform"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_lb_ip_ranges"
 sidebar_current: "docs-google-datasource-compute-lb-ip-ranges"

--- a/third_party/terraform/website/docs/d/datasource_google_secret_manager_secret_version.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_secret_manager_secret_version.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Platform"
+subcategory: "Secret Manager"
 layout: "google"
 page_title: "Google: google_secret_manager_secret_version"
 sidebar_current: "docs-google-datasource-secret-manager-secret-version"

--- a/third_party/terraform/website/docs/d/datasource_tpu_tensorflow_versions.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_tpu_tensorflow_versions.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Platform"
+subcategory: "Cloud TPU"
 layout: "google"
 page_title: "Google: google_tpu_tensorflow_versions"
 sidebar_current: "docs-google-datasource-tpu-tensorflow-versions"

--- a/third_party/terraform/website/docs/d/google_compute_default_service_account.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_default_service_account.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Platform"
+subcategory: "Compute Engine"
 layout: "google"
 page_title: "Google: google_compute_default_service_account"
 sidebar_current: "docs-google-datasource-compute-default-service-account"

--- a/third_party/terraform/website/docs/d/google_compute_resource_policy.html.markdown
+++ b/third_party/terraform/website/docs/d/google_compute_resource_policy.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "google"
-subcategory: "Cloud Platform"
+subcategory: "Compute Engine"
 page_title: "Google: google_compute_resource_policy"
 sidebar_current: "docs-google-datasource-compute-resource-policy"
 description: |-

--- a/third_party/terraform/website/docs/d/google_kms_crypto_key.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_crypto_key.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud KMS"
+subcategory: "Cloud Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_crypto_key"
 sidebar_current: "docs-google-datasource-kms-crypto-key"

--- a/third_party/terraform/website/docs/d/google_kms_crypto_key_version.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_crypto_key_version.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud KMS"
+subcategory: "Cloud Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_crypto_key_version"
 sidebar_current: "docs-google-datasource-kms-crypto-key-version"

--- a/third_party/terraform/website/docs/d/google_kms_key_ring.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_key_ring.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud KMS"
+subcategory: "Cloud Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_key_ring"
 sidebar_current: "docs-google-datasource-kms-key-ring"

--- a/third_party/terraform/website/docs/d/google_kms_secret.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_secret.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud KMS"
+subcategory: "Cloud Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_secret"
 sidebar_current: "docs-google-kms-secret"

--- a/third_party/terraform/website/docs/d/google_kms_secret_ciphertext.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_secret_ciphertext.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud KMS"
+subcategory: "Cloud Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_secret_ciphertext"
 sidebar_current: "docs-google-kms-secret-ciphertext"

--- a/third_party/terraform/website/docs/d/google_storage_project_service_account.html.markdown
+++ b/third_party/terraform/website/docs/d/google_storage_project_service_account.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Platform"
+subcategory: "Cloud Storage"
 layout: "google"
 page_title: "Google: google_storage_project_service_account"
 sidebar_current: "docs-google-datasource-storage-project-service-account"

--- a/third_party/terraform/website/docs/d/google_storage_transfer_project_service_account.html.markdown
+++ b/third_party/terraform/website/docs/d/google_storage_transfer_project_service_account.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Platform"
+subcategory: "Storage Transfer Service"
 layout: "google"
 page_title: "Google: google_storage_transfer_project_service_account"
 sidebar_current: "docs-google-datasource-storage-transfer-project-service-account"

--- a/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Bigtable"
+subcategory: "Cloud Bigtable"
 layout: "google"
 page_title: "Google: google_bigtable_gc_policy"
 sidebar_current: "docs-google-bigtable-gc-policy"

--- a/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Bigtable"
+subcategory: "Cloud Bigtable"
 layout: "google"
 page_title: "Google: google_bigtable_instance"
 sidebar_current: "docs-google-bigtable-instance"

--- a/third_party/terraform/website/docs/r/bigtable_instance_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_instance_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Bigtable"
+subcategory: "Cloud Bigtable"
 layout: "google"
 page_title: "Google: google_bigtable_instance_iam"
 sidebar_current: "docs-google-bigtable-instance-iam"

--- a/third_party/terraform/website/docs/r/bigtable_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_table.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Bigtable"
+subcategory: "Cloud Bigtable"
 layout: "google"
 page_title: "Google: google_bigtable_table"
 sidebar_current: "docs-google-bigtable-table"

--- a/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Dataproc"
+subcategory: "Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_cluster"
 sidebar_current: "docs-google-dataproc-cluster"

--- a/third_party/terraform/website/docs/r/dataproc_cluster_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_cluster_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Dataproc"
+subcategory: "Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_cluster_iam"
 sidebar_current: "docs-google-dataproc-cluster-iam"

--- a/third_party/terraform/website/docs/r/dataproc_job.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_job.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Dataproc"
+subcategory: "Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_job"
 sidebar_current: "docs-google-dataproc-job"

--- a/third_party/terraform/website/docs/r/dataproc_job_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_job_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Dataproc"
+subcategory: "Dataproc"
 layout: "google"
 page_title: "Google: google_dataproc_job_iam"
 sidebar_current: "docs-google-dataproc-job-iam"

--- a/third_party/terraform/website/docs/r/google_kms_crypto_key_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/google_kms_crypto_key_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud KMS"
+subcategory: "Cloud Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_crypto_key_iam"
 sidebar_current: "docs-google-kms-crypto-key-iam"

--- a/third_party/terraform/website/docs/r/google_kms_key_ring_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/google_kms_key_ring_iam.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud KMS"
+subcategory: "Cloud Key Management Service"
 layout: "google"
 page_title: "Google: google_kms_key_ring_iam"
 sidebar_current: "docs-google-kms-key-ring-iam"

--- a/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_transfer_job.html.markdown
@@ -1,5 +1,5 @@
 ---
-subcategory: "Cloud Storage"
+subcategory: "Storage Transfer Service"
 layout: "google"
 page_title: "Google: google_storage_transfer_job"
 sidebar_current: "docs-google-storage-transfer-job-x"


### PR DESCRIPTION
Another precursor for https://github.com/terraform-providers/terraform-provider-google/issues/6001.

This makes sure the sidebar product name matches the product name in the markdown files, and adjusts some to match the names at https://cloud.google.com/products (or at least, match it better).

I also took the liberty of updating a few of the data sources that had "Cloud Platform" as their subcategory to putting them with the product they belong in.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
