### PR TITLE
Add enum values generation to documentation

### DIFF
--- a/products/accesscontextmanager/api.yaml
+++ b/products/accesscontextmanager/api.yaml
@@ -156,7 +156,7 @@ objects:
               is granted this AccessLevel. If AND is used, each Condition in
               conditions must be satisfied for the AccessLevel to be applied. If
               OR is used, at least one Condition in conditions must be satisfied
-              for the AccessLevel to be applied. Defaults to AND if unspecified.
+              for the AccessLevel to be applied.
             default_value: :AND
             values:
               - :AND

--- a/products/appengine/api.yaml
+++ b/products/appengine/api.yaml
@@ -735,7 +735,6 @@ objects:
         name: 'servingStatus'
         description: |
           Current serving status of this version. Only the versions with a SERVING status create instances and can be billed.
-          Defaults to SERVING.
         default_value: :SERVING
         values:
           - :SERVING
@@ -757,7 +756,7 @@ objects:
           - !ruby/object:Api::Type::Enum
             name: 'authFailAction'
             description: |
-              Action to take when users access resources that require authentication. Defaults to "AUTH_FAIL_ACTION_REDIRECT".
+              Action to take when users access resources that require authentication.
             default_value: :AUTH_FAIL_ACTION_REDIRECT
             values:
               - :AUTH_FAIL_ACTION_REDIRECT
@@ -765,7 +764,7 @@ objects:
           - !ruby/object:Api::Type::Enum
             name: 'login'
             description: |
-              Level of login required to access this resource. Defaults to "LOGIN_OPTIONAL".
+              Level of login required to access this resource.
             default_value: :LOGIN_OPTIONAL
             values:
               - :LOGIN_OPTIONAL
@@ -986,7 +985,7 @@ objects:
           - !ruby/object:Api::Type::Enum
             name: 'rolloutStrategy'
             description: |
-              Endpoints rollout strategy. If FIXED, configId must be specified. If MANAGED, configId must be omitted. Default is "FIXED".
+              Endpoints rollout strategy. If FIXED, configId must be specified. If MANAGED, configId must be omitted.
             default_value: :FIXED
             values:
               - :FIXED

--- a/products/bigquery/api.yaml
+++ b/products/bigquery/api.yaml
@@ -476,7 +476,7 @@ objects:
                   Specifies whether the job is allowed to create new tables. The following values are supported:
                   CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table.
                   CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result.
-                  The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion
+                  Creation, truncation and append actions occur as one atomic update upon job completion
                 default_value: :CREATE_IF_NEEDED
                 values:
                   - :CREATE_IF_NEEDED
@@ -488,7 +488,7 @@ objects:
                   WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the table data and uses the schema from the query result.
                   WRITE_APPEND: If the table already exists, BigQuery appends the data to the table.
                   WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result.
-                  The default value is WRITE_EMPTY. Each action is atomic and only occurs if BigQuery is able to complete the job successfully.
+                  Each action is atomic and only occurs if BigQuery is able to complete the job successfully.
                   Creation, truncation and append actions occur as one atomic update upon job completion.
                 default_value: :WRITE_EMPTY
                 values:
@@ -510,7 +510,7 @@ objects:
               - !ruby/object:Api::Type::Enum
                 name: 'priority'
                 description: |
-                  Specifies a priority for the query. Possible values include INTERACTIVE and BATCH. The default value is INTERACTIVE.
+                  Specifies a priority for the query.
                 default_value: :INTERACTIVE
                 values:
                   - :INTERACTIVE
@@ -598,7 +598,7 @@ objects:
                     name: 'keyResultStatement'
                     description: |
                       Determines which statement in the script represents the "key result",
-                      used to populate the schema and query results of the script job. Default is LAST.
+                      used to populate the schema and query results of the script job.
                     at_least_one_of:
                       - query.0.scriptOptions.0.statementTimeoutMs
                       - query.0.scriptOptions.0.statementByteBudget
@@ -650,7 +650,7 @@ objects:
                   Specifies whether the job is allowed to create new tables. The following values are supported:
                   CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table.
                   CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result.
-                  The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion
+                  Creation, truncation and append actions occur as one atomic update upon job completion
                 default_value: :CREATE_IF_NEEDED
                 values:
                   - :CREATE_IF_NEEDED
@@ -662,7 +662,7 @@ objects:
                   WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the table data and uses the schema from the query result.
                   WRITE_APPEND: If the table already exists, BigQuery appends the data to the table.
                   WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result.
-                  The default value is WRITE_EMPTY. Each action is atomic and only occurs if BigQuery is able to complete the job successfully.
+                  Each action is atomic and only occurs if BigQuery is able to complete the job successfully.
                   Creation, truncation and append actions occur as one atomic update upon job completion.
                 default_value: :WRITE_EMPTY
                 values:
@@ -850,7 +850,7 @@ objects:
                   Specifies whether the job is allowed to create new tables. The following values are supported:
                   CREATE_IF_NEEDED: If the table does not exist, BigQuery creates the table.
                   CREATE_NEVER: The table must already exist. If it does not, a 'notFound' error is returned in the job result.
-                  The default value is CREATE_IF_NEEDED. Creation, truncation and append actions occur as one atomic update upon job completion
+                  Creation, truncation and append actions occur as one atomic update upon job completion
                 default_value: :CREATE_IF_NEEDED
                 values:
                   - :CREATE_IF_NEEDED
@@ -862,7 +862,7 @@ objects:
                   WRITE_TRUNCATE: If the table already exists, BigQuery overwrites the table data and uses the schema from the query result.
                   WRITE_APPEND: If the table already exists, BigQuery appends the data to the table.
                   WRITE_EMPTY: If the table already exists and contains data, a 'duplicate' error is returned in the job result.
-                  The default value is WRITE_EMPTY. Each action is atomic and only occurs if BigQuery is able to complete the job successfully.
+                  Each action is atomic and only occurs if BigQuery is able to complete the job successfully.
                   Creation, truncation and append actions occur as one atomic update upon job completion.
                 default_value: :WRITE_EMPTY
                 values:

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -94,8 +94,7 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: 'addressType'
         description: |
-          The type of address to reserve, either INTERNAL or EXTERNAL.
-          If unspecified, defaults to EXTERNAL.
+          The type of address to reserve.
         values:
           - :INTERNAL
           - :EXTERNAL
@@ -134,8 +133,7 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: 'networkTier'
         description: |
-          The networking tier used for configuring this address. This field can
-          take the following values: PREMIUM or STANDARD. If this field is not
+          The networking tier used for configuring this address. If this field is not
           specified, it is assumed to be PREMIUM.
         values:
           - :PREMIUM
@@ -364,8 +362,7 @@ objects:
                 name: 'utilizationTargetType'
                 description: |
                   Defines how target utilization value is expressed for a
-                  Stackdriver Monitoring metric. Either GAUGE, DELTA_PER_SECOND,
-                  or DELTA_PER_MINUTE.
+                  Stackdriver Monitoring metric.
                 values:
                   - :GAUGE
                   - :DELTA_PER_SECOND
@@ -1102,8 +1099,7 @@ objects:
         description: |
           Indicates whether the backend service will be used with internal or
           external load balancing. A backend service created for one type of
-          load balancing cannot be used with the other. Must be `EXTERNAL` or
-          `INTERNAL_SELF_MANAGED` for a global backend service. Defaults to `EXTERNAL`.
+          load balancing cannot be used with the other.
         default_value: :EXTERNAL
         # If you're modifying this value, it probably means Global ILB is now
         # an option. If that's the case, all of the documentation is based on
@@ -1420,8 +1416,7 @@ objects:
         name: 'protocol'
         description: |
           The protocol this BackendService uses to communicate with backends.
-          Possible values are HTTP, HTTPS, HTTP2, TCP, and SSL. The default is
-          HTTP. **NOTE**: HTTP2 is only valid for beta HTTP/2 load balancer
+          The default is HTTP. **NOTE**: HTTP2 is only valid for beta HTTP/2 load balancer
           types and may result in errors if used with the GA API.
         values:
           - :HTTP
@@ -1543,7 +1538,7 @@ objects:
                 - :RATE
                 - :CONNECTION
               description: |
-                Specifies the balancing mode for this backend. Defaults to CONNECTION.
+                Specifies the balancing mode for this backend.
             - !ruby/object:Api::Type::Double
               name: 'capacityScaler'
               description: |
@@ -1938,8 +1933,7 @@ objects:
         description: |
           Indicates what kind of load balancing this regional backend service
           will be used for. A backend service created for one type of load
-          balancing cannot be used with the other(s). Must be `INTERNAL` or
-          `INTERNAL_MANAGED`. Defaults to `INTERNAL`.
+          balancing cannot be used with the other(s).
         default_value: :INTERNAL
         values:
           - :INTERNAL
@@ -2246,8 +2240,7 @@ objects:
         name: 'protocol'
         description: |
           The protocol this RegionBackendService uses to communicate with backends.
-          Possible values are HTTP, HTTPS, HTTP2, SSL, TCP, and UDP. The default is
-          HTTP. **NOTE**: HTTP2 is only valid for beta HTTP/2 load balancer
+          The default is HTTP. **NOTE**: HTTP2 is only valid for beta HTTP/2 load balancer
           types and may result in errors if used with the GA API.
         # This is removed to avoid breaking terraform, as default values cannot be
         # unspecified. Providers should include this as needed via overrides
@@ -3273,8 +3266,7 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: 'IPProtocol'
         description: |
-          The IP protocol to which this rule applies. Valid options are TCP,
-          UDP, ESP, AH, SCTP or ICMP.
+          The IP protocol to which this rule applies.
 
           When the load balancing scheme is INTERNAL, only TCP and UDP are
           valid.
@@ -3428,8 +3420,7 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: 'networkTier'
         description: |
-          The networking tier used for configuring this address. This field can
-          take the following values: PREMIUM or STANDARD. If this field is not
+          The networking tier used for configuring this address. If this field is not
           specified, it is assumed to be PREMIUM.
         values:
           - :PREMIUM
@@ -3540,8 +3531,7 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: 'ipVersion'
         description: |
-          The IP Version that will be used by this address. Valid options are
-          `IPV4` or `IPV6`. The default value is `IPV4`.
+          The IP Version that will be used by this address. The default value is `IPV4`.
         values:
           - :IPV4
           - :IPV6
@@ -3562,7 +3552,7 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: 'addressType'
         description: |
-          The type of the address to reserve, default is EXTERNAL.
+          The type of the address to reserve.
 
           * EXTERNAL indicates public/external single IP address.
           * INTERNAL indicates internal IP ranges belonging to some network.
@@ -3671,8 +3661,7 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: 'IPProtocol'
         description: |
-          The IP protocol to which this rule applies. Valid options are TCP,
-          UDP, ESP, AH, SCTP or ICMP. When the load balancing scheme is
+          The IP protocol to which this rule applies. When the load balancing scheme is
           INTERNAL_SELF_MANAGED, only TCP is valid.
         values:
           - :TCP
@@ -3685,7 +3674,6 @@ objects:
         name: 'ipVersion'
         description: |
           The IP Version that will be used by this global forwarding rule.
-          Valid options are IPV4 or IPV6.
         values:
           - :IPV4
           - :IPV6
@@ -4227,7 +4215,7 @@ objects:
                 - http_health_check.0.port_specification
               description: |
                 Specifies the type of proxy header to append before sending data to the
-                backend, either NONE or PROXY_V1. The default is NONE.
+                backend.
               values:
                 - :NONE
                 - :PROXY_V1
@@ -4350,7 +4338,7 @@ objects:
                 - https_health_check.0.port_specification
               description: |
                 Specifies the type of proxy header to append before sending data to the
-                backend, either NONE or PROXY_V1. The default is NONE.
+                backend.
               values:
                 - :NONE
                 - :PROXY_V1
@@ -4455,7 +4443,7 @@ objects:
                 - tcp_health_check.0.port_specification
               description: |
                 Specifies the type of proxy header to append before sending data to the
-                backend, either NONE or PROXY_V1. The default is NONE.
+                backend.
               values:
                 - :NONE
                 - :PROXY_V1
@@ -4559,7 +4547,7 @@ objects:
                 - ssl_health_check.0.port_specification
               description: |
                 Specifies the type of proxy header to append before sending data to the
-                backend, either NONE or PROXY_V1. The default is NONE.
+                backend.
               values:
                 - :NONE
                 - :PROXY_V1
@@ -4681,7 +4669,7 @@ objects:
                 - http2_health_check.0.port_specification
               description: |
                 Specifies the type of proxy header to append before sending data to the
-                backend, either NONE or PROXY_V1. The default is NONE.
+                backend.
               values:
                 - :NONE
                 - :PROXY_V1
@@ -7313,7 +7301,7 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: 'networkEndpointType'
         description: |
-          Type of network endpoints in this network endpoint group. The only supported value is GCE_VM_IP_PORT
+          Type of network endpoints in this network endpoint group.
         values:
           - :GCE_VM_IP_PORT
         default_value: :GCE_VM_IP_PORT
@@ -7472,9 +7460,7 @@ objects:
         name: 'networkEndpointType'
         required: true
         description: |
-          Type of network endpoints in this network endpoint group. Supported values are:
-            * INTERNET_IP_PORT
-            * INTERNET_FQDN_PORT
+          Type of network endpoints in this network endpoint group.
         values:
           - :INTERNET_IP_PORT
           - :INTERNET_FQDN_PORT
@@ -8279,8 +8265,7 @@ objects:
                 name: 'utilizationTargetType'
                 description: |
                   Defines how target utilization value is expressed for a
-                  Stackdriver Monitoring metric. Either GAUGE, DELTA_PER_SECOND,
-                  or DELTA_PER_MINUTE.
+                  Stackdriver Monitoring metric.
                 values:
                   - :GAUGE
                   - :DELTA_PER_SECOND
@@ -10121,7 +10106,7 @@ objects:
                 - http_health_check.0.port_specification
               description: |
                 Specifies the type of proxy header to append before sending data to the
-                backend, either NONE or PROXY_V1. The default is NONE.
+                backend.
               values:
                 - :NONE
                 - :PROXY_V1
@@ -10244,7 +10229,7 @@ objects:
                 - https_health_check.0.port_specification
               description: |
                 Specifies the type of proxy header to append before sending data to the
-                backend, either NONE or PROXY_V1. The default is NONE.
+                backend.
               values:
                 - :NONE
                 - :PROXY_V1
@@ -10349,7 +10334,7 @@ objects:
                 - tcp_health_check.0.port_specification
               description: |
                 Specifies the type of proxy header to append before sending data to the
-                backend, either NONE or PROXY_V1. The default is NONE.
+                backend.
               values:
                 - :NONE
                 - :PROXY_V1
@@ -10453,7 +10438,7 @@ objects:
                 - ssl_health_check.0.port_specification
               description: |
                 Specifies the type of proxy header to append before sending data to the
-                backend, either NONE or PROXY_V1. The default is NONE.
+                backend.
               values:
                 - :NONE
                 - :PROXY_V1
@@ -10575,7 +10560,7 @@ objects:
                 - http2_health_check.0.port_specification
               description: |
                 Specifies the type of proxy header to append before sending data to the
-                backend, either NONE or PROXY_V1. The default is NONE.
+                backend.
               values:
                 - :NONE
                 - :PROXY_V1
@@ -10775,7 +10760,6 @@ objects:
                 description: |
                   Specifies the behavior to apply to scheduled snapshots when
                   the source disk is deleted.
-                  Valid options are KEEP_AUTO_SNAPSHOTS and APPLY_RETENTION_POLICY
                 default_value: :KEEP_AUTO_SNAPSHOTS
                 values:
                   - :KEEP_AUTO_SNAPSHOTS
@@ -11126,8 +11110,6 @@ objects:
             name: advertiseMode
             description: |
               User-specified flag to indicate which mode to use for advertisement.
-
-              Valid values of this enum field are: DEFAULT, CUSTOM
             values:
               - :DEFAULT
               - :CUSTOM
@@ -11360,8 +11342,7 @@ objects:
           - !ruby/object:Api::Type::Enum
             name: 'filter'
             description: |
-              Specifies the desired filtering of logs on this NAT. Valid
-              values are: `"ERRORS_ONLY"`, `"TRANSLATIONS_ONLY"`, `"ALL"`
+              Specifies the desired filtering of logs on this NAT.
             required: true
             values:
               - :ERRORS_ONLY
@@ -12220,8 +12201,7 @@ objects:
                         - :SCSI
                         - :NVME
                       description: |
-                        The disk interface to use for attaching this disk, one
-                        of `SCSI` or `NVME`. The default is `SCSI`.
+                        The disk interface to use for attaching this disk.
                     - !ruby/object:Api::Type::Integer
                       name: 'diskSizeGb'
                       required: true
@@ -12289,8 +12269,7 @@ objects:
         name: 'profile'
         description: |
           Profile specifies the set of SSL features that can be used by the
-          load balancer when negotiating SSL with clients. This can be one of
-          `COMPATIBLE`, `MODERN`, `RESTRICTED`, or `CUSTOM`. If using `CUSTOM`,
+          load balancer when negotiating SSL with clients. If using `CUSTOM`,
           the set of SSL features to enable must be specified in the
           `customFeatures` field.
         values:
@@ -12302,8 +12281,7 @@ objects:
         name: 'minTlsVersion'
         description: |
           The minimum version of SSL protocol that can be used by the clients
-          to establish a connection with the load balancer. This can be one of
-          `TLS_1_0`, `TLS_1_1`, `TLS_1_2`.
+          to establish a connection with the load balancer.
         values:
           - :TLS_1_0
           - :TLS_1_1
@@ -12579,7 +12557,7 @@ objects:
             description: |
               Can only be specified if VPC flow logging for this subnetwork is enabled.
               Configures whether metadata fields should be added to the reported VPC
-              flow logs. Default is `INCLUDE_ALL_METADATA`.
+              flow logs.
             values:
               - :EXCLUDE_ALL_METADATA
               - :INCLUDE_ALL_METADATA
@@ -12721,8 +12699,7 @@ objects:
           whether the load balancer will attempt to negotiate QUIC with clients
           or not. Can specify one of NONE, ENABLE, or DISABLE. If NONE is
           specified, uses the QUIC policy with no user overrides, which is
-          equivalent to DISABLE. Not specifying this field is equivalent to
-          specifying NONE.
+          equivalent to DISABLE.
         values:
           - :NONE
           - :ENABLE
@@ -13248,7 +13225,7 @@ objects:
         name: 'proxyHeader'
         description: |
           Specifies the type of proxy header to append before sending data to
-          the backend, either NONE or PROXY_V1. The default is NONE.
+          the backend.
         values:
           - :NONE
           - :PROXY_V1
@@ -13352,7 +13329,7 @@ objects:
         name: 'proxyHeader'
         description: |
           Specifies the type of proxy header to append before sending data to
-          the backend, either NONE or PROXY_V1. The default is NONE.
+          the backend.
         values:
           - :NONE
           - :PROXY_V1

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1959,10 +1959,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           See the [official documentation](https://cloud.google.com/compute/docs/load-balancing/ssl-policies#profilefeaturesupport)
           for information on what cipher suites each profile provides. If
           `CUSTOM` is used, the `custom_features` attribute **must be set**.
-          Default is `COMPATIBLE`.
       minTlsVersion: !ruby/object:Overrides::Terraform::PropertyOverride
         default_value: :TLS_1_0
-        description : '{{description}} Default is `TLS_1_0`.'
       warnings: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
   Subnetwork: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/products/datastore/api.yaml
+++ b/products/datastore/api.yaml
@@ -73,8 +73,7 @@ objects:
           - :NONE
           - :ALL_ANCESTORS
         description: |
-            Policy for including ancestors in the index.  Either `ALL_ANCESTORS` or `NONE`,
-            the default is `NONE`.
+            Policy for including ancestors in the index.
       - !ruby/object:Api::Type::Array
         name: 'properties'
         description: |
@@ -94,4 +93,4 @@ objects:
                 - :ASCENDING
                 - :DESCENDING
               description: |
-                 The direction the index should optimize for sorting. Possible values are ASCENDING and DESCENDING.
+                 The direction the index should optimize for sorting.

--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -173,7 +173,6 @@ objects:
         description: |
           The zone's visibility: public zones are exposed to the Internet,
           while private zones are visible only to Virtual Private Cloud resources.
-          Must be one of: `public`, `private`.
         values:
         - :private
         - :public

--- a/products/firestore/api.yaml
+++ b/products/firestore/api.yaml
@@ -68,8 +68,7 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: queryScope
         description: |
-          The scope at which a query is run. One of `"COLLECTION"` or
-          `"COLLECTION_GROUP"`. Defaults to `"COLLECTION"`.
+          The scope at which a query is run.
         default_value: :COLLECTION
         values:
           - :COLLECTION

--- a/products/healthcare/api.yaml
+++ b/products/healthcare/api.yaml
@@ -190,7 +190,7 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: version
         description: |
-          The FHIR specification version. Supported values include DSTU2, STU3 and R4. Defaults to STU3.
+          The FHIR specification version.
         required: false # TODO: Make this field required in GA.
         input: true
         default_value: :STU3

--- a/products/redis/api.yaml
+++ b/products/redis/api.yaml
@@ -81,9 +81,7 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: connectMode
         description: |
-          The connection mode of the Redis instance. Can be either
-          `DIRECT_PEERING` or `PRIVATE_SERVICE_ACCESS`. The default
-          connect mode if not provided is `DIRECT_PEERING`.
+          The connection mode of the Redis instance.
         input: true
         values:
           - :DIRECT_PEERING

--- a/products/sql/api.yaml
+++ b/products/sql/api.yaml
@@ -654,7 +654,7 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: 'databaseVersion'
         description: |
-          The MySQL version running on your source database server: MYSQL_5_6 or MYSQL_5_7.
+          The MySQL version running on your source database server.
         required: true
         values:
           - :MYSQL_5_6

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -306,6 +306,10 @@ module Provider
         description_arr += property.item_type.properties.map\
           { |prop| markdown_format(prop, indent + 1) }
         description = description_arr.join("\n\n")
+      elsif property.is_a?(Api::Type::Enum)
+        description_arr = [description, "#{'  ' * indent}Possible values:"]
+        description_arr += property.values.map { |v| "#{'  ' * indent}* #{v}" }
+        description = description_arr.join("\n")
       end
       description
     end

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -308,7 +308,7 @@ module Provider
         description = description_arr.join("\n\n")
       elsif property.is_a?(Api::Type::Enum)
         description_arr = [description, "#{'  ' * indent}Possible values:"]
-        description_arr += property.values.map { |v| "#{'  ' * indent}* #{v}" }
+        description_arr += property.values.map { |v| "#{'  ' * indent + 1}* #{v}" }
         description = description_arr.join("\n")
       end
       description

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -308,7 +308,7 @@ module Provider
         description = description_arr.join("\n\n")
       elsif property.is_a?(Api::Type::Enum)
         description_arr = [description, "#{'  ' * indent}Possible values:"]
-        description_arr += property.values.map { |v| "#{'  ' * indent + 1}* #{v}" }
+        description_arr += property.values.map { |v| "#{'  ' * (indent + 1)}* #{v}" }
         description = description_arr.join("\n")
       end
       description

--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -16,6 +16,7 @@
 <%= indent(property.description.strip.gsub("\n\n", "\n"), 2) -%>
 <% if property.is_a?(Api::Type::Enum) && !property.output -%>
 <% unless property.default_value.nil? || property.default_value == "" -%>
+
   Default value: `<%= property.default_value %>`
 <% end -%>
   Possible values are:

--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -22,6 +22,7 @@
 <% property.values.select { |v| v != "" }.each do |v| -%>
   * `<%= v %>`
 <% end -%>
+<% end -%>
 <% if property.sensitive -%>
   **Note**: This property is sensitive and will not be displayed in the plan.
 <% end -%>

--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -15,8 +15,9 @@
 <% end -%>
 <%= indent(property.description.strip.gsub("\n\n", "\n"), 2) -%>
 <% if property.is_a?(Api::Type::Enum) && !property.output -%>
-<% unless property.default_value.nil? || property.default_value == "" -%>
 
+
+<% unless property.default_value.nil? || property.default_value == "" -%>
   Default value: `<%= property.default_value %>`
 <% end -%>
   Possible values are:

--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -14,6 +14,17 @@
 <%   end -%>
 <% end -%>
 <%= indent(property.description.strip.gsub("\n\n", "\n"), 2) -%>
+<% if property.is_a?(Api::Type::Enum) && property.validation.nil? && !property.output -%>
+<%
+	enum_values = property.values
+%>
+<% unless property.default_value.nil? || property.default_value == "" -%>
+  Default value: `<%= property.default_value %>`
+<% end -%>
+  Possible values are:
+<% enum_values.select { |v| v != "" }.each do |v| -%>
+  * `<%= v %>`
+<% end -%>
 <% if property.sensitive -%>
   **Note**: This property is sensitive and will not be displayed in the plan.
 <% end -%>

--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -14,15 +14,12 @@
 <%   end -%>
 <% end -%>
 <%= indent(property.description.strip.gsub("\n\n", "\n"), 2) -%>
-<% if property.is_a?(Api::Type::Enum) && property.validation.nil? && !property.output -%>
-<%
-	enum_values = property.values
-%>
+<% if property.is_a?(Api::Type::Enum) && !property.output -%>
 <% unless property.default_value.nil? || property.default_value == "" -%>
   Default value: `<%= property.default_value %>`
 <% end -%>
   Possible values are:
-<% enum_values.select { |v| v != "" }.each do |v| -%>
+<% property.values.select { |v| v != "" }.each do |v| -%>
   * `<%= v %>`
 <% end -%>
 <% if property.sensitive -%>

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -67,7 +67,7 @@
 <% enum_values_description = "" -%>
 <% if property.is_a?(Api::Type::Enum) && !property.output -%>
 <% unless property.default_value.nil? || property.default_value == "" -%>
-<% enum_values_description += "\nDefault value: \"#{property.default_value}\"." -%>
+<% enum_values_description += " Default value: \"#{property.default_value}\"" -%>
 <% end -%>
 <% enum_values_description += " Possible values: [" -%>
 <% enum_values_description += property.values.select { |v| v != "" }.map { |v| "\"#{v}\"" }.join(', ') -%>

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -67,7 +67,7 @@
 <% enum_values_description = "" -%>
 <% if property.is_a?(Api::Type::Enum) && !property.output -%>
 <% unless property.default_value.nil? || property.default_value == "" -%>
-<% enum_values_description += " Default value: \"#{property.default_value}\"." -%>
+<% enum_values_description += "\nDefault value: \"#{property.default_value}\"." -%>
 <% end -%>
 <% enum_values_description += " Possible values: [" -%>
 <% enum_values_description += property.values.select { |v| v != "" }.map { |v| "\"#{v}\"" }.join(', ') -%>

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -64,7 +64,16 @@
 <% unless property.state_func.nil? -%>
 	StateFunc: <%= property.state_func %>,
 <% end -%>
-	Description: `<%= property.description.strip.gsub("`", "'") -%>`,
+<% enum_values_description = "" -%>
+<% if property.is_a?(Api::Type::Enum) && !property.output -%>
+<% unless property.default_value.nil? || property.default_value == "" -%>
+<% enum_values_description += " Default value: \"#{property.default_value}\"." -%>
+<% end -%>
+<% enum_values_description += " Possible values: [" -%>
+<% enum_values_description += property.values.select { |v| v != "" }.map { |v| "\"#{v}\"" }.join(', ') -%>
+<% enum_values_description += "]" -%>
+<% end -%>
+	Description: `<%= property.description.strip.gsub("`", "'") + enum_values_description -%>`,
 <% if property.is_a?(Api::Type::NestedObject) -%>
   MaxItems: 1,
   Elem: &schema.Resource{


### PR DESCRIPTION
Generate enum possible values and default in Terraform. Remove old handwritten lists of values unless they add value.

Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/6092

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
