### PR TITLE
add optional service account for scheduled queries

### DIFF
--- a/products/bigquerydatatransfer/api.yaml
+++ b/products/bigquerydatatransfer/api.yaml
@@ -27,8 +27,10 @@ apis_required:
 objects:
   - !ruby/object:Api::Resource
     name: 'Config'
-    base_url: projects/{{project}}/locations/{{location}}/transferConfigs
+    base_url: projects/{{project}}/locations/{{location}}/transferConfigs?serviceAccountName={{service_account_name}}
     self_link: "{{name}}"
+    # see comment at service_account_name, PATCHing service_account_name also required update_mask entry
+    # update_url: "{{name}}?serviceAccountName={{service_account_name}}"
     update_verb: :PATCH
     update_mask: true
     description: |
@@ -47,6 +49,18 @@ objects:
         description: |
           The geographic location where the transfer config should reside.
           Examples: US, EU, asia-northeast1. The default value is US.
+      - !ruby/object:Api::Type::String
+        name: 'serviceAccountName'
+        url_param_only: true
+        # The API would support PATCHing the service account, but setting the
+        # update_mask accordingly for a url_param_only is currently not
+        # supported in magic-modules
+        input: true
+        default_value: ''
+        description: |
+          Optional service account name. If this field is set, transfer config will
+          be created with this service account credentials. It requires that
+          requesting user calling this API has permissions to act as this service account.
     properties:
       - !ruby/object:Api::Type::String
         name: 'displayName'


### PR DESCRIPTION
- https://cloud.google.com/bigquery/docs/release-notes#November_21_2019
- see [Scheduling queries](https://cloud.google.com/bigquery/docs/scheduling-queries#using_a_service_account), parameter documented at [Try API](https://cloud.google.com/bigquery-transfer/docs/reference/datatransfer/rest/v1/projects.locations.transferConfigs/create) or [Discovery ](https://bigquerydatatransfer.googleapis.com/$discovery/rest?version=v1)
- the API does support PATCHing, but magic-modules doesn't really support setting
  the required update_mask for `url_param_only`, hence I marked this parameter as
  input for now (which will replace the resource on update)
- followup to #3347 (sorry for opening a new PR I renamed the branch)
  changes requested by slevenick are addressed and I ran terraform's acceptance test (TestAccBigqueryDataTransferConfig) and tested this manually w/ terraform

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
* bigquery: added `service_account_name` field to `google_bigquery_data_transfer_config` resource
```
