### PR TITLE
don't check the changelog until after tests have run

### DIFF
--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -174,13 +174,8 @@ steps:
       args:
           - $_PR_NUMBER
 
-    - name: 'gcr.io/graphite-docker-images/changelog-checker'
-      secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["diff"]
-      args:
-          - $_PR_NUMBER
-
     - name: 'gcr.io/graphite-docker-images/terraform-tester'
+      id: tpgb-test
       secretEnv: ["GITHUB_TOKEN"]
       waitFor: ["diff"]
       args:
@@ -188,10 +183,17 @@ steps:
           - $_PR_NUMBER
 
     - name: 'gcr.io/graphite-docker-images/terraform-tester'
+      id: tpg-test
       secretEnv: ["GITHUB_TOKEN"]
       waitFor: ["diff"]
       args:
           - 'ga'
+          - $_PR_NUMBER
+
+    - name: 'gcr.io/graphite-docker-images/changelog-checker'
+      secretEnv: ["GITHUB_TOKEN"]
+      waitFor: ["tpg-test", "tpgb-test"]
+      args:
           - $_PR_NUMBER
 
 options:


### PR DESCRIPTION
Since community PRs often don't have changelog entries, that step will commonly fail. Since it runs in parallel with the test steps, that failure fails the whole build, which cancels the in-progress test steps. This will make it easier to see at a glance whether the PR is worth reviewing or whether it needs to be sent back quickly for test/compilation/linter fixes.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
