### PR TITLE
add healthcare iam resources to GA

### DIFF
--- a/third_party/terraform/utils/iam_healthcare_dataset.go
+++ b/third_party/terraform/utils/iam_healthcare_dataset.go
@@ -1,8 +1,8 @@
-<% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
+
 import (
 	"fmt"
+
 	healthcare "google.golang.org/api/healthcare/v1beta1"
 
 	"github.com/hashicorp/errwrap"
@@ -111,6 +111,3 @@ func healthcareToResourceManagerPolicy(p *healthcare.Policy) (*cloudresourcemana
 	}
 	return out, nil
 }
-<% else %>
-// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
-<% end -%>

--- a/third_party/terraform/utils/iam_healthcare_dicom_store.go
+++ b/third_party/terraform/utils/iam_healthcare_dicom_store.go
@@ -1,6 +1,5 @@
-<% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
+
 import (
 	"fmt"
 
@@ -93,6 +92,3 @@ func (u *HealthcareDicomStoreIamUpdater) GetMutexKey() string {
 func (u *HealthcareDicomStoreIamUpdater) DescribeResource() string {
 	return fmt.Sprintf("Healthcare DicomStore %q", u.resourceId)
 }
-<% else %>
-// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
-<% end -%>

--- a/third_party/terraform/utils/iam_healthcare_fhir_store.go
+++ b/third_party/terraform/utils/iam_healthcare_fhir_store.go
@@ -1,8 +1,8 @@
-<% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
+
 import (
 	"fmt"
+
 	healthcare "google.golang.org/api/healthcare/v1beta1"
 
 	"github.com/hashicorp/errwrap"
@@ -92,6 +92,3 @@ func (u *HealthcareFhirStoreIamUpdater) GetMutexKey() string {
 func (u *HealthcareFhirStoreIamUpdater) DescribeResource() string {
 	return fmt.Sprintf("Healthcare FhirStore %q", u.resourceId)
 }
-<% else %>
-// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
-<% end -%>

--- a/third_party/terraform/utils/iam_healthcare_hl7_v2_store.go
+++ b/third_party/terraform/utils/iam_healthcare_hl7_v2_store.go
@@ -1,6 +1,5 @@
-<% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
+
 import (
 	"fmt"
 
@@ -93,6 +92,3 @@ func (u *HealthcareHl7V2StoreIamUpdater) GetMutexKey() string {
 func (u *HealthcareHl7V2StoreIamUpdater) DescribeResource() string {
 	return fmt.Sprintf("Healthcare Hl7V2Store %q", u.resourceId)
 }
-<% else %>
-// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
-<% end -%>

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -331,7 +331,6 @@ end     # products.each do
 				"google_folder_iam_member":                     ResourceIamMember(IamFolderSchema, NewFolderIamUpdater, FolderIdParseFunc),
 				"google_folder_iam_policy":                     ResourceIamPolicy(IamFolderSchema, NewFolderIamUpdater, FolderIdParseFunc),
 				"google_folder_organization_policy":            resourceGoogleFolderOrganizationPolicy(),
-<% unless version == 'ga' -%>
 				"google_healthcare_dataset_iam_binding":        ResourceIamBindingWithBatching(IamHealthcareDatasetSchema, NewHealthcareDatasetIamUpdater, DatasetIdParseFunc, IamBatchingEnabled),
 				"google_healthcare_dataset_iam_member":         ResourceIamMemberWithBatching(IamHealthcareDatasetSchema, NewHealthcareDatasetIamUpdater, DatasetIdParseFunc, IamBatchingEnabled),
 				"google_healthcare_dataset_iam_policy":         ResourceIamPolicy(IamHealthcareDatasetSchema, NewHealthcareDatasetIamUpdater, DatasetIdParseFunc),
@@ -344,7 +343,6 @@ end     # products.each do
 				"google_healthcare_hl7_v2_store_iam_binding":   ResourceIamBindingWithBatching(IamHealthcareHl7V2StoreSchema, NewHealthcareHl7V2StoreIamUpdater, Hl7V2StoreIdParseFunc, IamBatchingEnabled),
 				"google_healthcare_hl7_v2_store_iam_member":    ResourceIamMemberWithBatching(IamHealthcareHl7V2StoreSchema, NewHealthcareHl7V2StoreIamUpdater, Hl7V2StoreIdParseFunc, IamBatchingEnabled),
 				"google_healthcare_hl7_v2_store_iam_policy":    ResourceIamPolicy(IamHealthcareHl7V2StoreSchema, NewHealthcareHl7V2StoreIamUpdater, Hl7V2StoreIdParseFunc),
-<% end -%>
 				"google_logging_billing_account_sink":          resourceLoggingBillingAccountSink(),
 				"google_logging_billing_account_exclusion":     ResourceLoggingExclusion(BillingAccountLoggingExclusionSchema, NewBillingAccountLoggingExclusionUpdater, billingAccountLoggingExclusionIdParseFunc),
 				"google_logging_organization_sink":             resourceLoggingOrganizationSink(),


### PR DESCRIPTION
Missed a version guard for IAM resources from https://github.com/GoogleCloudPlatform/magic-modules/pull/3377
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
release note for the original PR will be udpated.
```
