### PR TITLE
allow updating bigtable table column families

### DIFF
--- a/third_party/terraform/resources/resource_bigtable_instance.go
+++ b/third_party/terraform/resources/resource_bigtable_instance.go
@@ -27,6 +27,10 @@ func resourceBigtableInstance() *schema.Resource {
 			resourceBigtableInstanceClusterReorderTypeList,
 		),
 
+		// ----------------------------------------------------------------------
+		// IMPORTANT: Do not add any additional ForceNew fields to this resource.
+		// Destroying/recreating instances can lead to data loss for users.
+		// ----------------------------------------------------------------------
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,

--- a/third_party/terraform/tests/resource_bigtable_table_test.go
+++ b/third_party/terraform/tests/resource_bigtable_table_test.go
@@ -104,6 +104,38 @@ func TestAccBigtableTable_familyMany(t *testing.T) {
 	})
 }
 
+func TestAccBigtableTable_familyUpdate(t *testing.T) {
+	t.Parallel()
+
+	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	tableName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	family := fmt.Sprintf("tf-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBigtableTableDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigtableTable_familyMany(instanceName, tableName, family),
+			},
+			{
+				ResourceName:      "google_bigtable_table.table",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBigtableTable_familyUpdate(instanceName, tableName, family),
+			},
+			{
+				ResourceName:      "google_bigtable_table.table",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckBigtableTableDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		var ctx = context.Background()
@@ -218,4 +250,36 @@ resource "google_bigtable_table" "table" {
   }
 }
 `, instanceName, instanceName, tableName, family, family)
+}
+
+func testAccBigtableTable_familyUpdate(instanceName, tableName, family string) string {
+	return fmt.Sprintf(`
+resource "google_bigtable_instance" "instance" {
+  name = "%s"
+
+  cluster {
+    cluster_id = "%s"
+    zone       = "us-central1-b"
+  }
+
+  instance_type = "DEVELOPMENT"
+}
+
+resource "google_bigtable_table" "table" {
+  name          = "%s"
+  instance_name = google_bigtable_instance.instance.name
+
+  column_family {
+    family = "%s-third"
+  }
+
+  column_family {
+    family = "%s-fourth"
+  }
+
+  column_family {
+    family = "%s-second"
+  }
+}
+`, instanceName, instanceName, tableName, family, family, family)
 }

--- a/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -13,6 +13,11 @@ Creates a Google Bigtable instance. For more information see
 [the official documentation](https://cloud.google.com/bigtable/) and
 [API](https://cloud.google.com/bigtable/docs/go/reference).
 
+-> **Note**: It is strongly recommended to set `lifecycle { prevent_destroy = true }`
+on instances in order to prevent accidental data loss. See
+[Terraform docs](https://www.terraform.io/docs/configuration/resources.html#prevent_destroy)
+for more information on lifecycle parameters.
+
 
 ## Example Usage - Production Instance
 
@@ -25,6 +30,10 @@ resource "google_bigtable_instance" "production-instance" {
     zone         = "us-central1-b"
     num_nodes    = 1
     storage_type = "HDD"
+  }
+
+  lifecycle {
+    prevent_destroy = true
   }
 }
 ```
@@ -40,6 +49,10 @@ resource "google_bigtable_instance" "development-instance" {
     cluster_id   = "tf-instance-cluster"
     zone         = "us-central1-b"
     storage_type = "HDD"
+  }
+
+  lifecycle {
+    prevent_destroy = true
   }
 }
 ```

--- a/third_party/terraform/website/docs/r/bigtable_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_table.html.markdown
@@ -13,6 +13,11 @@ Creates a Google Cloud Bigtable table inside an instance. For more information s
 [the official documentation](https://cloud.google.com/bigtable/) and
 [API](https://cloud.google.com/bigtable/docs/go/reference).
 
+-> **Note**: It is strongly recommended to set `lifecycle { prevent_destroy = true }`
+on tables in order to prevent accidental data loss. See
+[Terraform docs](https://www.terraform.io/docs/configuration/resources.html#prevent_destroy)
+for more information on lifecycle parameters.
+
 
 ## Example Usage
 
@@ -26,12 +31,20 @@ resource "google_bigtable_instance" "instance" {
     num_nodes    = 3
     storage_type = "HDD"
   }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "google_bigtable_table" "table" {
   name          = "tf-table"
   instance_name = google_bigtable_instance.instance.name
   split_keys    = ["a", "b", "c"]
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 ```
 
@@ -44,6 +57,8 @@ The following arguments are supported:
 * `instance_name` - (Required) The name of the Bigtable instance.
 
 * `split_keys` - (Optional) A list of predefined keys to split the table on.
+!> **Warning:** Modifying the `split_keys` of an existing table will cause Terraform
+to delete/recreate the entire `google_bigtable_table` resource.
 
 * `column_family` - (Optional) A group of columns within a table which share a common configuration. This can be specified multiple times. Structure is documented below.
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5759. Also added a bunch of warnings around ForceNew to our resource code and warnings around lifecycle.prevent_destroy to the docs.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
* bigtable: added ability to add/remove column families in `google_bigtable_table`
```
