### PR TITLE
useless change to generate sidebar

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -11,8 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(nelsonjr): Make all Zone and Region resource ref
-
 --- !ruby/object:Api::Product
 name: Compute
 display_name: Compute Engine


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

Since https://github.com/GoogleCloudPlatform/magic-modules/pull/3414 is in, this should generate the new sidebar.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
* This release includes website changes to put data sources and resources in submenus in t he products they're part of.
```
