### PR TITLE
Allow fields to be removed at a specific version

### DIFF
--- a/api/type.rb
+++ b/api/type.rb
@@ -31,6 +31,11 @@ module Api
       # string, as providers expect a single-line one w/o a newline.
       attr_reader :deprecation_message
 
+      # Add a removed message for fields no longer supported in the API. This should
+      # be used for fields supported in one version but have been removed from
+      # a different version.
+      attr_reader :removed_message
+
       attr_reader :output # If set value will not be sent to server on sync
       attr_reader :input # If set to true value is used only on creation
 
@@ -70,6 +75,7 @@ module Api
       attr_reader :allow_empty_object
 
       attr_reader :min_version
+      attr_reader :exact_version
 
       # A list of properties that conflict with this property.
       attr_reader :conflicts
@@ -99,7 +105,9 @@ module Api
       check :description, type: ::String, required: true
       check :exclude, type: :boolean, default: false, required: true
       check :deprecation_message, type: ::String
+      check :removed_message, type: ::String
       check :min_version, type: ::String
+      check :exact_version, type: ::String
       check :output, type: :boolean
       check :required, type: :boolean
       check :send_empty_value, type: :boolean
@@ -258,7 +266,14 @@ module Api
       end
     end
 
+    def exact_version
+      return nil if @exact_version.nil? || @exact_version.blank?
+
+      @__resource.__product.version_obj(@exact_version)
+    end
+
     def exclude_if_not_in_version!(version)
+      @exclude ||= exact_version != version unless exact_version.nil?
       @exclude ||= version < min_version
     end
 
@@ -287,6 +302,10 @@ module Api
 
     def nested_properties?
       !nested_properties.empty?
+    end
+
+    def removed?
+      !(@removed_message.nil? || @removed_message == '')
     end
 
     def deprecated?

--- a/products/healthcare/api.yaml
+++ b/products/healthcare/api.yaml
@@ -375,9 +375,44 @@ objects:
 
           An object containing a list of "key": value pairs.
           Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+      - !ruby/object:Api::Type::Array
+        name: notificationConfigs
+        description: |-
+          A list of notification configs. Each configuration uses a filter to determine whether to publish a
+          message (both Ingest & Create) on the corresponding notification destination. Only the message name
+          is sent as part of the notification. Supplied by the client.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: pubsubTopic
+              description: |
+                The Cloud Pub/Sub topic that notifications of changes are published on. Supplied by the client.
+                PubsubMessage.Data will contain the resource name. PubsubMessage.MessageId is the ID of this message.
+                It is guaranteed to be unique within the topic. PubsubMessage.PublishTime is the time at which the message
+                was published. Notifications are only sent if the topic is non-empty. Topic names must be scoped to a
+                project. cloud-healthcare@system.gserviceaccount.com must have publisher permissions on the given
+                Cloud Pub/Sub topic. Not having adequate permissions will cause the calls that send notifications to fail.
 
+                If a notification cannot be published to Cloud Pub/Sub, errors will be logged to Stackdriver
+              required: true
+            - !ruby/object:Api::Type::String
+              name: filter
+              description: |
+                Restricts notifications sent for messages matching a filter. If this is empty, all messages
+                are matched. Syntax: https://cloud.google.com/appengine/docs/standard/python/search/query_strings
+
+                Fields/functions available for filtering are:
+
+                * messageType, from the MSH-9.1 field. For example, NOT messageType = "ADT".
+                * send_date or sendDate, the YYYY-MM-DD date the message was sent in the dataset's timeZone, from the MSH-7 segment. For example, send_date < "2017-01-02".
+                * sendTime, the timestamp when the message was sent, using the RFC3339 time format for comparisons, from the MSH-7 segment. For example, sendTime < "2017-01-02T00:00:00-05:00".
+                * sendFacility, the care center that the message came from, from the MSH-4 segment. For example, sendFacility = "ABC".
+                * PatientId(value, type), which matches if the message lists a patient having an ID of the given value and type in the PID-2, PID-3, or PID-4 segments. For example, PatientId("123456", "MRN").
+                * labels.x, a string value of the label with key x as set using the Message.labels map. For example, labels."priority"="high". The operator :* can be used to assert the existence of a label. For example, labels."priority":*.
       - !ruby/object:Api::Type::NestedObject
         name: notificationConfig
+        removed_message: This field has been replaced by notificationConfigs
+        exact_version: ga
         required: false
         update_url: '{{dataset}}/hl7V2Stores/{{name}}'
         properties:
@@ -391,7 +426,24 @@ objects:
               project. cloud-healthcare@system.gserviceaccount.com must have publisher permissions on the given
               Cloud Pub/Sub topic. Not having adequate permissions will cause the calls that send notifications to fail.
             required: true
-
+      - !ruby/object:Api::Type::NestedObject
+        name: notificationConfig
+        # This field is duplicated because beta and ga have different behaviors.
+        deprecation_message: This field has been replaced by notificationConfigs
+        exact_version: beta
+        required: false
+        update_url: '{{dataset}}/hl7V2Stores/{{name}}'
+        properties:
+          - !ruby/object:Api::Type::String
+            name: pubsubTopic
+            description: |
+              The Cloud Pub/Sub topic that notifications of changes are published on. Supplied by the client.
+              PubsubMessage.Data will contain the resource name. PubsubMessage.MessageId is the ID of this message.
+              It is guaranteed to be unique within the topic. PubsubMessage.PublishTime is the time at which the message
+              was published. Notifications are only sent if the topic is non-empty. Topic names must be scoped to a
+              project. cloud-healthcare@system.gserviceaccount.com must have publisher permissions on the given
+              Cloud Pub/Sub topic. Not having adequate permissions will cause the calls that send notifications to fail.
+            required: true
       - !ruby/object:Api::Type::Time
         name: 'creationTime'
         description: |

--- a/provider/terraform/sub_template.rb
+++ b/provider/terraform/sub_template.rb
@@ -54,11 +54,15 @@ module Provider
       end
 
       def build_property_documentation(property)
+        return if property.removed?
+
         compile_template 'templates/terraform/property_documentation.erb',
                          property: property
       end
 
       def build_nested_property_documentation(property)
+        return if property.removed?
+
         compile_template(
           'templates/terraform/nested_property_documentation.erb',
           property: property

--- a/templates/terraform/examples/healthcare_hl7_v2_store_basic.tf.erb
+++ b/templates/terraform/examples/healthcare_hl7_v2_store_basic.tf.erb
@@ -2,7 +2,7 @@ resource "google_healthcare_hl7_v2_store" "default" {
   name    = "<%= ctx[:vars]['hl7_v2_store_name'] %>"
   dataset = google_healthcare_dataset.dataset.id
 
-  notification_config {
+  notification_configs {
     pubsub_topic = google_pubsub_topic.topic.id
   }
 

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -36,7 +36,9 @@
 <% else -%>
   Optional: true,
 <% end -%>
-<% if property.deprecated? -%>
+<% if property.removed? -%>
+  Removed: "<%= property.removed_message %>",
+<% elsif property.deprecated? -%>
   Deprecated: "<%= property.deprecation_message %>",
 <% end -%>
 <% if force_new?(property, object) -%>

--- a/third_party/terraform/tests/resource_healthcare_hl7_v2_store_test.go
+++ b/third_party/terraform/tests/resource_healthcare_hl7_v2_store_test.go
@@ -138,7 +138,7 @@ resource "google_healthcare_hl7_v2_store" "default" {
     segment_terminator = "Jw=="
   }
 
-  notification_config {
+  notification_configs {
     pubsub_topic = google_pubsub_topic.topic.id
   }
 
@@ -195,9 +195,12 @@ func testAccCheckGoogleHealthcareHl7V2StoreUpdate(t *testing.T, pubsubTopic stri
 				return fmt.Errorf("hl7_v2_store labels not updated: %s", gcpResourceUri)
 			}
 
-			topicName := path.Base(response.NotificationConfig.PubsubTopic)
-			if topicName != pubsubTopic {
-				return fmt.Errorf("hl7_v2_store 'NotificationConfig' not updated ('%s' != '%s'): %s", topicName, pubsubTopic, gcpResourceUri)
+			notifications := response.NotificationConfigs
+			if len(notifications) > 0 {
+				topicName := path.Base(notifications[0].PubsubTopic)
+				if topicName != pubsubTopic {
+					return fmt.Errorf("hl7_v2_store 'NotificationConfig' not updated ('%s' != '%s'): %s", topicName, pubsubTopic, gcpResourceUri)
+				}
 			}
 		}
 

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -42,7 +42,7 @@ import (
 	"google.golang.org/api/dns/v1"
 	dnsBeta "google.golang.org/api/dns/v1beta2"
 	file "google.golang.org/api/file/v1beta1"
-	healthcare "google.golang.org/api/healthcare/v1beta1"
+	healthcare "google.golang.org/api/healthcare/v1"
 	"google.golang.org/api/iam/v1"
 	iamcredentials "google.golang.org/api/iamcredentials/v1"
 	cloudlogging "google.golang.org/api/logging/v2"

--- a/third_party/terraform/utils/iam_healthcare_dataset.go
+++ b/third_party/terraform/utils/iam_healthcare_dataset.go
@@ -3,7 +3,7 @@ package google
 import (
 	"fmt"
 
-	healthcare "google.golang.org/api/healthcare/v1beta1"
+	healthcare "google.golang.org/api/healthcare/v1"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/third_party/terraform/utils/iam_healthcare_dicom_store.go
+++ b/third_party/terraform/utils/iam_healthcare_dicom_store.go
@@ -3,7 +3,7 @@ package google
 import (
 	"fmt"
 
-	healthcare "google.golang.org/api/healthcare/v1beta1"
+	healthcare "google.golang.org/api/healthcare/v1"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/third_party/terraform/utils/iam_healthcare_fhir_store.go
+++ b/third_party/terraform/utils/iam_healthcare_fhir_store.go
@@ -3,7 +3,7 @@ package google
 import (
 	"fmt"
 
-	healthcare "google.golang.org/api/healthcare/v1beta1"
+	healthcare "google.golang.org/api/healthcare/v1"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"

--- a/third_party/terraform/utils/iam_healthcare_hl7_v2_store.go
+++ b/third_party/terraform/utils/iam_healthcare_hl7_v2_store.go
@@ -3,7 +3,7 @@ package google
 import (
 	"fmt"
 
-	healthcare "google.golang.org/api/healthcare/v1beta1"
+	healthcare "google.golang.org/api/healthcare/v1"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"


### PR DESCRIPTION
The healthcare API has deprecated a field at beta and removed it from the GA
launch of the api. In order to support this without having to duplicate the
entire resource this change supports defining a single field multiple times
with a different configruation for each version. Specifically it allows a field
to exist as deprecated at one version but not at another.
This also introduces the removed_message field.

This is another follow on to https://github.com/GoogleCloudPlatform/magic-modules/pull/3377 which GA'ed this resource without addressing the removed fields.

TODO - this change requires vendoring changes in both downstream repos.
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_healthcare_dataset` is now GA
```
```release-note:new-resource
`google_healthcare_dicom_store` is now GA
```
```release-note:new-resource
`google_healthcare_fhir_store` is now GA
```
```release-note:new-resource
`google_healthcare_hl7_v2_store` is now GA
```
```release-note:new-resource
`google_healthcare_dataset_iam_binding` is now GA
```
```release-note:new-resource
`google_healthcare_dataset_iam_member` is now GA
```
```release-note:new-resource
`google_healthcare_dataset_iam_policy` is now GA
```
```release-note:new-resource
`google_healthcare_dicom_store_iam_binding` is now GA
```
```release-note:new-resource
`google_healthcare_dicom_store_iam_member` is now GA
```
```release-note:new-resource
`google_healthcare_dicom_store_iam_policy` is now GA
```
```release-note:new-resource
`google_healthcare_fhir_store_iam_binding` is now GA
```
```release-note:new-resource
`google_healthcare_fhir_store_iam_member` is now GA
```
```release-note:new-resource
`google_healthcare_fhir_store_iam_policy` is now GA
```
```release-note:new-resource
`google_healthcare_hl7_v2_store_iam_binding` is now GA
```
```release-note:new-resource
`google_healthcare_hl7_v2_store_iam_member` is now GA
```
```release-note:new-resource
`google_healthcare_hl7_v2_store_iam_policy` is now GA
```

