### PR TITLE
add id's to sweeper templates

### DIFF
--- a/products/bigquery/terraform.yaml
+++ b/products/bigquery/terraform.yaml
@@ -17,6 +17,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   Dataset: !ruby/object:Overrides::Terraform::ResourceOverride
     import_format: ["projects/{{project}}/datasets/{{dataset_id}}"]
     delete_url: projects/{{project}}/datasets/{{dataset_id}}?deleteContents={{delete_contents_on_destroy}}
+    # Skipping sweeper due to the abnormal delete_url
+    skip_sweeper: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_dataset_basic"

--- a/products/dataproc/api.yaml
+++ b/products/dataproc/api.yaml
@@ -31,6 +31,7 @@ objects:
     name: 'AutoscalingPolicy'
     base_url: "projects/{{project}}/locations/{{location}}/autoscalingPolicies"
     self_link: "projects/{{project}}/locations/{{location}}/autoscalingPolicies/{{id}}"
+    collection_url_key: 'policies'
     description: |
       Describes an autoscaling policy for Dataproc cluster autoscaler.
     parameters:

--- a/products/iap/terraform.yaml
+++ b/products/iap/terraform.yaml
@@ -184,6 +184,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     id_format: '{{brand}}/identityAwareProxyClients/{{client_id}}'
     self_link: '{{brand}}/identityAwareProxyClients/{{client_id}}'
     import_format: ['{{brand}}/identityAwareProxyClients/{{client_id}}']
+    # Child of iap brand resource
+    skip_sweeper: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "iap_client"

--- a/products/identityplatform/terraform.yaml
+++ b/products/identityplatform/terraform.yaml
@@ -24,6 +24,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         skip_test: true
   TenantDefaultSupportedIdpConfig: !ruby/object:Overrides::Terraform::ResourceOverride
     import_format: ["projects/{{project}}/tenants/{{tenant}}/defaultSupportedIdpConfigs/{{idp_id}}"]
+    # Child of idp Tenant resource
+    skip_sweeper: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "identity_platform_tenant_default_supported_idp_config_basic"

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -204,7 +204,8 @@ module Provider
     def generate_resource_sweepers(data)
       return if data.object.skip_sweeper ||
                 data.object.custom_code.custom_delete ||
-                data.object.custom_code.pre_delete
+                data.object.custom_code.pre_delete ||
+                data.object.skip_delete
 
       target_folder = File.join(data.output_folder, folder_name(data.version))
 

--- a/templates/terraform/sweeper_file.go.erb
+++ b/templates/terraform/sweeper_file.go.erb
@@ -19,6 +19,7 @@ listUrlTemplate.sub! "zones/{{zone}}", "aggregated"
 aggregatedList = listUrlTemplate.include? "/aggregated/"
 
 deleteUrlTemplate = object.__product.base_url + object.delete_uri
+delete_id = deleteUrlTemplate.include? "_id"
 -%>
 
 func init() {
@@ -97,12 +98,25 @@ func testSweep<%= sweeper_name -%>(region string) error {
 	nonPrefixCount := 0
 	for _, ri := range rl {
 		obj := ri.(map[string]interface{})
+		<% if delete_id -%>
+		var name string
+		// Id detected in the delete URL, attempt to use id.
+		if obj["id"] != nil {
+			name = GetResourceNameFromSelfLink(obj["id"].(string))
+		} else if obj["name"] != nil {
+			name = GetResourceNameFromSelfLink(obj["name"].(string))
+		} else {
+			log.Printf("[INFO][SWEEPER_LOG] %s resource name and id were nil", resourceName)
+			return nil
+		}
+		<% else -%>
 		if obj["name"] == nil {
 			log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
 			return nil
 		}
 
 		name := GetResourceNameFromSelfLink(obj["name"].(string))
+		<% end -%>
 		// Skip resources that shouldn't be sweeped
 		if !isSweepableTestResource(name) {
 			nonPrefixCount++


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5629

After hunting down all of the generated sweepers that used some form of id in the `delete_url` instead of `name`, many of them had reasons to not be generated. So the only a handful of sweepers actually need to be modified.
```release-note:none

```