### PR TITLE
stop converting timeouts to/from minutes

### DIFF
--- a/templates/terraform/custom_delete/appversion_delete.go.erb
+++ b/templates/terraform/custom_delete/appversion_delete.go.erb
@@ -30,7 +30,7 @@ if d.Get("delete_service_on_destroy") == true {
 	}
 	err = appEngineOperationWaitTime(
 		config, res, project, "Deleting Service",
-		int(d.Timeout(schema.TimeoutDelete).Minutes()))
+		d.Timeout(schema.TimeoutDelete))
 
 	if err != nil {
 		return err
@@ -50,7 +50,7 @@ if d.Get("delete_service_on_destroy") == true {
 	}
 	err = appEngineOperationWaitTime(
 		config, res, project, "Deleting AppVersion",
-		int(d.Timeout(schema.TimeoutDelete).Minutes()))
+		d.Timeout(schema.TimeoutDelete))
 
 	if err != nil {
 		return err

--- a/templates/terraform/operation.go.erb
+++ b/templates/terraform/operation.go.erb
@@ -49,24 +49,24 @@ func create<%= product_name %>Waiter(config *Config, op map[string]interface{}, 
     Might as well just nolint it so we can pass the linter checks.
 -%>
 // nolint: deadcode,unused
-func <%= product_name.camelize(:lower) -%>OperationWaitTimeWithResponse(config *Config, op map[string]interface{}, response *map[string]interface{},<% if has_project -%> project,<% end -%> activity string, timeoutMinutes int) error {
+func <%= product_name.camelize(:lower) -%>OperationWaitTimeWithResponse(config *Config, op map[string]interface{}, response *map[string]interface{},<% if has_project -%> project,<% end -%> activity string, timeout time.Duration) error {
   w, err := create<%= product_name %>Waiter(config, op, <% if has_project -%> project, <%end-%> activity)
   if err != nil || w == nil {
       // If w is nil, the op was synchronous.
       return err
   }
-  if err := OperationWait(w, activity, timeoutMinutes, config.PollInterval); err != nil {
+  if err := OperationWait(w, activity, timeout, config.PollInterval); err != nil {
       return err
   }
   return json.Unmarshal([]byte(w.CommonOperationWaiter.Op.Response), response)
 }
 <% end -%>
 
-func <%= product_name.camelize(:lower) -%>OperationWaitTime(config *Config, op map[string]interface{}, <% if has_project -%> project,<% end -%> activity string, timeoutMinutes int) error {
+func <%= product_name.camelize(:lower) -%>OperationWaitTime(config *Config, op map[string]interface{}, <% if has_project -%> project,<% end -%> activity string, timeout time.Duration) error {
   w, err := create<%= product_name %>Waiter(config, op, <% if has_project -%> project, <%end-%> activity)
   if err != nil || w == nil {
       // If w is nil, the op was synchronous.
       return err
   }
-  return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
+  return OperationWait(w, activity, timeout, config.PollInterval)
 }

--- a/templates/terraform/post_create/labels.erb
+++ b/templates/terraform/post_create/labels.erb
@@ -27,7 +27,7 @@ if v, ok := d.GetOkExists("labels"); !isEmptyValue(reflect.ValueOf(v)) && (ok ||
 
     err = computeOperationWaitTime(
         config, res, project, "Updating <%= resource_name -%> Labels",
-        int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+        d.Timeout(schema.TimeoutUpdate))
 
     if err != nil {
         return err

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -248,7 +248,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     var opRes map[string]interface{}
     err = <%= client_name_camel -%>OperationWaitTimeWithResponse(
     config, res, &opRes, <% if has_project -%> project, <% end -%> "Creating <%= object.name -%>",
-        int(d.Timeout(schema.TimeoutCreate).Minutes()))
+        d.Timeout(schema.TimeoutCreate))
     if err != nil {
 <%        if object.custom_code.post_create_failure -%>
         resource<%= resource_name -%>PostCreateFailure(d, meta)
@@ -298,7 +298,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     <% else -%>
     err = <%= client_name_camel -%>OperationWaitTime(
     config, res, <% if has_project -%> project, <% end -%> "Creating <%= object.name -%>",
-        int(d.Timeout(schema.TimeoutCreate).Minutes()))
+        d.Timeout(schema.TimeoutCreate))
 
     if err != nil {
 <%      if object.custom_code.post_create_failure -%>
@@ -611,7 +611,7 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
 <%          if object.async.is_a? Api::OpAsync-%>
         err = <%= client_name_camel -%>OperationWaitTime(
             config, res, <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
-            int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+            d.Timeout(schema.TimeoutUpdate))
         if err != nil {
             return err
         }
@@ -710,7 +710,7 @@ if <%= props.map { |prop| "d.HasChange(\"#{prop.name.underscore}\")" }.join ' ||
 <%    if object.async.is_a? Api::OpAsync -%>
     err = <%= client_name_camel -%>OperationWaitTime(
         config, res, <% if has_project -%> project, <% end -%> "Updating <%= object.name -%>",
-        int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+        d.Timeout(schema.TimeoutUpdate))
 
     if err != nil {
         return err
@@ -799,7 +799,7 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
 <%  if object.async&.allow?('delete') -%>
     err = <%= client_name_camel -%>OperationWaitTime(
         config, res, <% if has_project -%> project, <% end -%> "Deleting <%= object.name -%>",
-        int(d.Timeout(schema.TimeoutDelete).Minutes()))
+        d.Timeout(schema.TimeoutDelete))
 
     if err != nil {
         return err

--- a/third_party/terraform/resources/common_operation_test.go
+++ b/third_party/terraform/resources/common_operation_test.go
@@ -55,7 +55,7 @@ func TestOperationWait_TimeoutsShouldRetry(t *testing.T) {
 	testWaiter := TestWaiter{
 		runCount: 0,
 	}
-	err := OperationWait(&testWaiter, "my-activity", 1, 0*time.Second)
+	err := OperationWait(&testWaiter, "my-activity", 1*time.Minute, 0*time.Second)
 	if err != nil {
 		t.Fatalf("unexpected error waiting for operation: got '%v', want 'nil'", err)
 	}

--- a/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -391,7 +391,7 @@ func resourceCloudFunctionsCreate(d *schema.ResourceData, meta interface{}) erro
 	d.SetId(cloudFuncId.cloudFunctionId())
 
 	err = cloudFunctionsOperationWait(config, op, "Creating CloudFunctions Function",
-		int(d.Timeout(schema.TimeoutCreate).Minutes()))
+		d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return err
 	}
@@ -556,7 +556,7 @@ func resourceCloudFunctionsUpdate(d *schema.ResourceData, meta interface{}) erro
 		}
 
 		err = cloudFunctionsOperationWait(config, op, "Updating CloudFunctions Function",
-			int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return err
 		}
@@ -579,7 +579,7 @@ func resourceCloudFunctionsDestroy(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 	err = cloudFunctionsOperationWait(config, op, "Deleting CloudFunctions Function",
-		int(d.Timeout(schema.TimeoutDelete).Minutes()))
+		d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -356,7 +356,7 @@ func resourceComposerEnvironmentCreate(d *schema.ResourceData, meta interface{})
 
 	waitErr := composerOperationWaitTime(
 		config, op, envName.Project, "Creating Environment",
-		int(d.Timeout(schema.TimeoutCreate).Minutes()))
+		d.Timeout(schema.TimeoutCreate))
 
 	if waitErr != nil {
 		// The resource didn't actually get created, remove from state.
@@ -567,7 +567,7 @@ func resourceComposerEnvironmentPatchField(updateMask string, env *composer.Envi
 
 	waitErr := composerOperationWaitTime(
 		config, op, envName.Project, "Updating newly created Environment",
-		int(d.Timeout(schema.TimeoutCreate).Minutes()))
+		d.Timeout(schema.TimeoutCreate))
 	if waitErr != nil {
 		// The resource didn't actually update.
 		return fmt.Errorf("Error waiting to update Environment: %s", waitErr)
@@ -593,7 +593,7 @@ func resourceComposerEnvironmentDelete(d *schema.ResourceData, meta interface{})
 
 	err = composerOperationWaitTime(
 		config, op, envName.Project, "Deleting Environment",
-		int(d.Timeout(schema.TimeoutDelete).Minutes()))
+		d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return err
 	}
@@ -1051,7 +1051,7 @@ func handleComposerEnvironmentCreationOpFailure(id string, envName *composerEnvi
 	waitErr := composerOperationWaitTime(
 		config, op, envName.Project,
 		fmt.Sprintf("Deleting invalid created Environment with state %q", env.State),
-		int(d.Timeout(schema.TimeoutCreate).Minutes()))
+		d.Timeout(schema.TimeoutCreate))
 	if waitErr != nil {
 		return fmt.Errorf("Error waiting to delete invalid Environment with state %q: %s", env.State, waitErr)
 	}

--- a/third_party/terraform/resources/resource_compute_attached_disk.go
+++ b/third_party/terraform/resources/resource_compute_attached_disk.go
@@ -103,7 +103,7 @@ func resourceAttachedDiskCreate(d *schema.ResourceData, meta interface{}) error 
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s/%s", zv.Project, zv.Zone, zv.Name, diskName))
 
 	waitErr := computeOperationWaitTime(config, op, zv.Project,
-		"disk to attach", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+		"disk to attach", d.Timeout(schema.TimeoutCreate))
 	if waitErr != nil {
 		d.SetId("")
 		return waitErr
@@ -184,7 +184,7 @@ func resourceAttachedDiskDelete(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	waitErr := computeOperationWaitTime(config, op, zv.Project,
-		fmt.Sprintf("Detaching disk from %s", zv.Name), int(d.Timeout(schema.TimeoutDelete).Minutes()))
+		fmt.Sprintf("Detaching disk from %s", zv.Name), d.Timeout(schema.TimeoutDelete))
 	if waitErr != nil {
 		return waitErr
 	}

--- a/third_party/terraform/resources/resource_compute_instance.go
+++ b/third_party/terraform/resources/resource_compute_instance.go
@@ -814,9 +814,6 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	// Read create timeout
-	createTimeout := int(d.Timeout(schema.TimeoutCreate).Minutes())
-
 	log.Printf("[INFO] Requesting instance creation")
 	op, err := config.clientComputeBeta.Instances.Insert(project, zone.Name, instance).Do()
 	if err != nil {
@@ -827,7 +824,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 	d.SetId(fmt.Sprintf("projects/%s/zones/%s/instances/%s", project, z, instance.Name))
 
 	// Wait for the operation to complete
-	waitErr := computeOperationWaitTime(config, op, project, "instance to create", createTimeout)
+	waitErr := computeOperationWaitTime(config, op, project, "instance to create", d.Timeout(schema.TimeoutCreate))
 	if waitErr != nil {
 		// The resource didn't actually create
 		d.SetId("")
@@ -1089,7 +1086,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 					return fmt.Errorf("Error updating metadata: %s", err)
 				}
 
-				opErr := computeOperationWaitTime(config, op, project, "metadata to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeOperationWaitTime(config, op, project, "metadata to update", d.Timeout(schema.TimeoutUpdate))
 				if opErr != nil {
 					return opErr
 				}
@@ -1117,7 +1114,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating tags: %s", err)
 		}
 
-		opErr := computeOperationWaitTime(config, op, project, "tags to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+		opErr := computeOperationWaitTime(config, op, project, "tags to update", d.Timeout(schema.TimeoutUpdate))
 		if opErr != nil {
 			return opErr
 		}
@@ -1135,7 +1132,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating labels: %s", err)
 		}
 
-		opErr := computeOperationWaitTime(config, op, project, "labels to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+		opErr := computeOperationWaitTime(config, op, project, "labels to update", d.Timeout(schema.TimeoutUpdate))
 		if opErr != nil {
 			return opErr
 		}
@@ -1157,7 +1154,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 		opErr := computeOperationWaitTime(
 			config, op, project, "scheduling policy update",
-			int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			d.Timeout(schema.TimeoutUpdate))
 		if opErr != nil {
 			return opErr
 		}
@@ -1195,7 +1192,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return fmt.Errorf("Error deleting old access_config: %s", err)
 				}
-				opErr := computeOperationWaitTime(config, op, project, "old access_config to delete", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeOperationWaitTime(config, op, project, "old access_config to delete", d.Timeout(schema.TimeoutUpdate))
 				if opErr != nil {
 					return opErr
 				}
@@ -1220,7 +1217,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return fmt.Errorf("Error adding new access_config: %s", err)
 				}
-				opErr := computeOperationWaitTime(config, op, project, "new access_config to add", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeOperationWaitTime(config, op, project, "new access_config to add", d.Timeout(schema.TimeoutUpdate))
 				if opErr != nil {
 					return opErr
 				}
@@ -1240,7 +1237,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return errwrap.Wrapf("Error removing alias_ip_range: {{err}}", err)
 				}
-				opErr := computeOperationWaitTime(config, op, project, "updating alias ip ranges", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeOperationWaitTime(config, op, project, "updating alias ip ranges", d.Timeout(schema.TimeoutUpdate))
 				if opErr != nil {
 					return opErr
 				}
@@ -1264,7 +1261,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return errwrap.Wrapf("Error adding alias_ip_range: {{err}}", err)
 				}
-				opErr := computeOperationWaitTime(config, op, project, "updating alias ip ranges", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeOperationWaitTime(config, op, project, "updating alias ip ranges", d.Timeout(schema.TimeoutUpdate))
 				if opErr != nil {
 					return opErr
 				}
@@ -1342,7 +1339,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 					return errwrap.Wrapf("Error detaching disk: %s", err)
 				}
 
-				opErr := computeOperationWaitTime(config, op, project, "detaching disk", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				opErr := computeOperationWaitTime(config, op, project, "detaching disk", d.Timeout(schema.TimeoutUpdate))
 				if opErr != nil {
 					return opErr
 				}
@@ -1357,7 +1354,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				return errwrap.Wrapf("Error attaching disk : {{err}}", err)
 			}
 
-			opErr := computeOperationWaitTime(config, op, project, "attaching disk", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeOperationWaitTime(config, op, project, "attaching disk", d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -1391,7 +1388,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			return fmt.Errorf("Error updating deletion protection flag: %s", err)
 		}
 
-		opErr := computeOperationWaitTime(config, op, project, "deletion protection to update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+		opErr := computeOperationWaitTime(config, op, project, "deletion protection to update", d.Timeout(schema.TimeoutUpdate))
 		if opErr != nil {
 			return opErr
 		}
@@ -1420,7 +1417,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			}
 			opErr := computeOperationWaitTime(
 				config, op, project, "updating status",
-				int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -1445,7 +1442,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				return errwrap.Wrapf("Error stopping instance: {{err}}", err)
 			}
 
-			opErr := computeOperationWaitTime(config, op, project, "stopping instance", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeOperationWaitTime(config, op, project, "stopping instance", d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -1463,7 +1460,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return err
 			}
-			opErr := computeOperationWaitTime(config, op, project, "updating machinetype", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeOperationWaitTime(config, op, project, "updating machinetype", d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -1485,7 +1482,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return err
 			}
-			opErr := computeOperationWaitTime(config, op, project, "updating min cpu platform", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeOperationWaitTime(config, op, project, "updating min cpu platform", d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -1504,7 +1501,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return err
 			}
-			opErr := computeOperationWaitTime(config, op, project, "updating service account", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeOperationWaitTime(config, op, project, "updating service account", d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -1520,7 +1517,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if err != nil {
 				return fmt.Errorf("Error updating display device: %s", err)
 			}
-			opErr := computeOperationWaitTime(config, op, project, "updating display device", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			opErr := computeOperationWaitTime(config, op, project, "updating display device", d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -1535,7 +1532,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			}
 
 			opErr := computeOperationWaitTime(config, op, project,
-				"starting instance", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+				"starting instance", d.Timeout(schema.TimeoutUpdate))
 			if opErr != nil {
 				return opErr
 			}
@@ -1551,7 +1548,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 
 		opErr := computeOperationWaitTime(config, op, project,
-			"shielded vm config update", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+			"shielded vm config update", d.Timeout(schema.TimeoutUpdate))
 		if opErr != nil {
 			return opErr
 		}
@@ -1775,7 +1772,7 @@ func resourceComputeInstanceDelete(d *schema.ResourceData, meta interface{}) err
 		}
 
 		// Wait for the operation to complete
-		opErr := computeOperationWaitTime(config, op, project, "instance to delete", int(d.Timeout(schema.TimeoutDelete).Minutes()))
+		opErr := computeOperationWaitTime(config, op, project, "instance to delete", d.Timeout(schema.TimeoutDelete))
 		if opErr != nil {
 			return opErr
 		}

--- a/third_party/terraform/resources/resource_compute_instance_from_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_from_template.go
@@ -163,7 +163,7 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 
 	// Wait for the operation to complete
 	waitErr := computeOperationWaitTime(config, op, project,
-		"instance to create", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+		"instance to create", d.Timeout(schema.TimeoutCreate))
 	if waitErr != nil {
 		// The resource didn't actually create
 		d.SetId("")

--- a/third_party/terraform/resources/resource_compute_instance_group_manager.go
+++ b/third_party/terraform/resources/resource_compute_instance_group_manager.go
@@ -318,8 +318,7 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 	d.SetId(id)
 
 	// Wait for the operation to complete
-	timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-	err = computeOperationWaitTime(config, op, project, "Creating InstanceGroupManager", timeoutInMinutes)
+	err = computeOperationWaitTime(config, op, project, "Creating InstanceGroupManager", d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
 		return err
 	}
@@ -495,8 +494,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 			return fmt.Errorf("Error updating managed group instances: %s", err)
 		}
 
-		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeOperationWaitTime(config, op, project, "Updating managed group instances", timeoutInMinutes)
+		err = computeOperationWaitTime(config, op, project, "Updating managed group instances", d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return err
 		}
@@ -522,8 +520,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		}
 
 		// Wait for the operation to complete:
-		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeOperationWaitTime(config, op, project, "Updating InstanceGroupManager", timeoutInMinutes)
+		err = computeOperationWaitTime(config, op, project, "Updating InstanceGroupManager", d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return err
 		}
@@ -543,8 +540,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		}
 
 		// Wait for the operation to complete
-		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeOperationWaitTime(config, op, project, "Updating InstanceGroupManager", timeoutInMinutes)
+		err = computeOperationWaitTime(config, op, project, "Updating InstanceGroupManager", d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return err
 		}
@@ -582,8 +578,7 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 	currentSize := int64(d.Get("target_size").(int))
 
 	// Wait for the operation to complete
-	timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
-	err = computeOperationWaitTime(config, op, project, "Deleting InstanceGroupManager", timeoutInMinutes)
+	err = computeOperationWaitTime(config, op, project, "Deleting InstanceGroupManager", d.Timeout(schema.TimeoutDelete))
 
 	for err != nil && currentSize > 0 {
 		if !strings.Contains(err.Error(), "timeout") {
@@ -604,8 +599,7 @@ func resourceComputeInstanceGroupManagerDelete(d *schema.ResourceData, meta inte
 
 		log.Printf("[INFO] timeout occurred, but instance group is shrinking (%d < %d)", instanceGroupSize, currentSize)
 		currentSize = instanceGroupSize
-		timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
-		err = computeOperationWaitTime(config, op, project, "Deleting InstanceGroupManager", timeoutInMinutes)
+		err = computeOperationWaitTime(config, op, project, "Deleting InstanceGroupManager", d.Timeout(schema.TimeoutDelete))
 	}
 
 	d.SetId("")

--- a/third_party/terraform/resources/resource_compute_instance_group_manager.go
+++ b/third_party/terraform/resources/resource_compute_instance_group_manager.go
@@ -318,7 +318,7 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 	d.SetId(id)
 
 	// Wait for the operation to complete
-	err = computeOperationWaitTime(config, op, project, "Creating InstanceGroupManager", d.Timeout(schema.TimeoutUpdate))
+	err = computeOperationWaitTime(config, op, project, "Creating InstanceGroupManager", d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_compute_project_metadata_item.go
+++ b/third_party/terraform/resources/resource_compute_project_metadata_item.go
@@ -63,7 +63,7 @@ func resourceComputeProjectMetadataItemCreate(d *schema.ResourceData, meta inter
 	key := d.Get("key").(string)
 	val := d.Get("value").(string)
 
-	err = updateComputeCommonInstanceMetadata(config, projectID, key, &val, int(d.Timeout(schema.TimeoutCreate).Minutes()), failIfPresent)
+	err = updateComputeCommonInstanceMetadata(config, projectID, key, &val, d.Timeout(schema.TimeoutCreate), failIfPresent)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func resourceComputeProjectMetadataItemUpdate(d *schema.ResourceData, meta inter
 		_, n := d.GetChange("value")
 		new := n.(string)
 
-		err = updateComputeCommonInstanceMetadata(config, projectID, key, &new, int(d.Timeout(schema.TimeoutUpdate).Minutes()), overwritePresent)
+		err = updateComputeCommonInstanceMetadata(config, projectID, key, &new, d.Timeout(schema.TimeoutUpdate), overwritePresent)
 		if err != nil {
 			return err
 		}
@@ -133,7 +133,7 @@ func resourceComputeProjectMetadataItemDelete(d *schema.ResourceData, meta inter
 
 	key := d.Get("key").(string)
 
-	err = updateComputeCommonInstanceMetadata(config, projectID, key, nil, int(d.Timeout(schema.TimeoutDelete).Minutes()), overwritePresent)
+	err = updateComputeCommonInstanceMetadata(config, projectID, key, nil, d.Timeout(schema.TimeoutDelete), overwritePresent)
 	if err != nil {
 		return err
 	}
@@ -142,7 +142,7 @@ func resourceComputeProjectMetadataItemDelete(d *schema.ResourceData, meta inter
 	return nil
 }
 
-func updateComputeCommonInstanceMetadata(config *Config, projectID string, key string, afterVal *string, timeout int, failIfPresent metadataPresentBehavior) error {
+func updateComputeCommonInstanceMetadata(config *Config, projectID string, key string, afterVal *string, timeout time.Duration, failIfPresent metadataPresentBehavior) error {
 	updateMD := func() error {
 		log.Printf("[DEBUG] Loading project metadata: %s", projectID)
 		project, err := config.clientCompute.Projects.Get(projectID).Do()

--- a/third_party/terraform/resources/resource_compute_region_instance_group_manager.go
+++ b/third_party/terraform/resources/resource_compute_region_instance_group_manager.go
@@ -308,8 +308,7 @@ func resourceComputeRegionInstanceGroupManagerCreate(d *schema.ResourceData, met
 	d.SetId(id)
 
 	// Wait for the operation to complete
-	timeoutInMinutes := int(d.Timeout(schema.TimeoutCreate).Minutes())
-	err = computeOperationWaitTime(config, op, project, "Creating InstanceGroupManager", timeoutInMinutes)
+	err = computeOperationWaitTime(config, op, project, "Creating InstanceGroupManager", d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return err
 	}
@@ -462,8 +461,7 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 			return fmt.Errorf("Error updating region managed group instances: %s", err)
 		}
 
-		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeOperationWaitTime(config, op, project, "Updating region managed group instances", timeoutInMinutes)
+		err = computeOperationWaitTime(config, op, project, "Updating region managed group instances", d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return err
 		}
@@ -485,8 +483,7 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 			return fmt.Errorf("Error updating RegionInstanceGroupManager: %s", err)
 		}
 
-		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeOperationWaitTime(config, op, project, "Updating RegionInstanceGroupManager", timeoutInMinutes)
+		err = computeOperationWaitTime(config, op, project, "Updating RegionInstanceGroupManager", d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return err
 		}
@@ -504,8 +501,7 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 			return fmt.Errorf("Error resizing RegionInstanceGroupManager: %s", err)
 		}
 
-		timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
-		err = computeOperationWaitTime(config, op, project, "Resizing RegionInstanceGroupManager", timeoutInMinutes)
+		err = computeOperationWaitTime(config, op, project, "Resizing RegionInstanceGroupManager", d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return err
 		}
@@ -539,8 +535,7 @@ func resourceComputeRegionInstanceGroupManagerDelete(d *schema.ResourceData, met
 	}
 
 	// Wait for the operation to complete
-	timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
-	err = computeOperationWaitTime(config, op, project, "Deleting RegionInstanceGroupManager", timeoutInMinutes)
+	err = computeOperationWaitTime(config, op, project, "Deleting RegionInstanceGroupManager", d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return fmt.Errorf("Error waiting for delete to complete: %s", err)
 	}

--- a/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -255,7 +255,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 			return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 		}
 
-		err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), d.Timeout(schema.TimeoutCreate))
+		err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return err
 		}
@@ -283,7 +283,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 					return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 				}
 
-				err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), d.Timeout(schema.TimeoutCreate))
+				err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
 					return err
 				}
@@ -295,7 +295,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 					return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 				}
 
-				err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), d.Timeout(schema.TimeoutCreate))
+				err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
 					return err
 				}
@@ -312,7 +312,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 					return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 				}
 
-				err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), d.Timeout(schema.TimeoutCreate))
+				err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), d.Timeout(schema.TimeoutUpdate))
 				if err != nil {
 					return err
 				}

--- a/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -199,7 +199,7 @@ func resourceComputeSecurityPolicyCreate(d *schema.ResourceData, meta interface{
 	}
 	d.SetId(id)
 
-	err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Creating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Creating SecurityPolicy %q", sp), d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return err
 	}
@@ -255,7 +255,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 			return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 		}
 
-		err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
+		err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), d.Timeout(schema.TimeoutCreate))
 		if err != nil {
 			return err
 		}
@@ -283,7 +283,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 					return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 				}
 
-				err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
+				err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), d.Timeout(schema.TimeoutCreate))
 				if err != nil {
 					return err
 				}
@@ -295,7 +295,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 					return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 				}
 
-				err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
+				err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), d.Timeout(schema.TimeoutCreate))
 				if err != nil {
 					return err
 				}
@@ -312,7 +312,7 @@ func resourceComputeSecurityPolicyUpdate(d *schema.ResourceData, meta interface{
 					return errwrap.Wrapf(fmt.Sprintf("Error updating SecurityPolicy %q: {{err}}", sp), err)
 				}
 
-				err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), int(d.Timeout(schema.TimeoutCreate).Minutes()))
+				err = computeOperationWaitTime(config, op, project, fmt.Sprintf("Updating SecurityPolicy %q", sp), d.Timeout(schema.TimeoutCreate))
 				if err != nil {
 					return err
 				}
@@ -337,7 +337,7 @@ func resourceComputeSecurityPolicyDelete(d *schema.ResourceData, meta interface{
 		return errwrap.Wrapf("Error deleting SecurityPolicy: {{err}}", err)
 	}
 
-	err = computeOperationWaitTime(config, op, project, "Deleting SecurityPolicy", int(d.Timeout(schema.TimeoutDelete).Minutes()))
+	err = computeOperationWaitTime(config, op, project, "Deleting SecurityPolicy", d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_compute_shared_vpc_host_project.go
+++ b/third_party/terraform/resources/resource_compute_shared_vpc_host_project.go
@@ -37,7 +37,7 @@ func resourceComputeSharedVpcHostProjectCreate(d *schema.ResourceData, meta inte
 
 	d.SetId(hostProject)
 
-	err = computeOperationWaitTime(config, op, hostProject, "Enabling Shared VPC Host", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeOperationWaitTime(config, op, hostProject, "Enabling Shared VPC Host", d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		d.SetId("")
 		return err
@@ -75,7 +75,7 @@ func resourceComputeSharedVpcHostProjectDelete(d *schema.ResourceData, meta inte
 		return fmt.Errorf("Error disabling Shared VPC Host %q: %s", hostProject, err)
 	}
 
-	err = computeOperationWaitTime(config, op, hostProject, "Disabling Shared VPC Host", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeOperationWaitTime(config, op, hostProject, "Disabling Shared VPC Host", d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_compute_shared_vpc_host_project.go
+++ b/third_party/terraform/resources/resource_compute_shared_vpc_host_project.go
@@ -37,7 +37,7 @@ func resourceComputeSharedVpcHostProjectCreate(d *schema.ResourceData, meta inte
 
 	d.SetId(hostProject)
 
-	err = computeOperationWaitTime(config, op, hostProject, "Enabling Shared VPC Host", d.Timeout(schema.TimeoutCreate))
+	err = computeOperationWait(config, op, hostProject, "Enabling Shared VPC Host")
 	if err != nil {
 		d.SetId("")
 		return err
@@ -75,7 +75,7 @@ func resourceComputeSharedVpcHostProjectDelete(d *schema.ResourceData, meta inte
 		return fmt.Errorf("Error disabling Shared VPC Host %q: %s", hostProject, err)
 	}
 
-	err = computeOperationWaitTime(config, op, hostProject, "Disabling Shared VPC Host", d.Timeout(schema.TimeoutCreate))
+	err = computeOperationWait(config, op, hostProject, "Disabling Shared VPC Host")
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_compute_shared_vpc_service_project.go
+++ b/third_party/terraform/resources/resource_compute_shared_vpc_service_project.go
@@ -52,7 +52,7 @@ func resourceComputeSharedVpcServiceProjectCreate(d *schema.ResourceData, meta i
 	if err != nil {
 		return err
 	}
-	err = computeOperationWaitTime(config, op, hostProject, "Enabling Shared VPC Resource", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeOperationWaitTime(config, op, hostProject, "Enabling Shared VPC Resource", d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func disableXpnResource(d *schema.ResourceData, config *Config, hostProject, pro
 	if err != nil {
 		return err
 	}
-	err = computeOperationWaitTime(config, op, hostProject, "Disabling Shared VPC Resource", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = computeOperationWaitTime(config, op, hostProject, "Disabling Shared VPC Resource", d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_compute_shared_vpc_service_project.go
+++ b/third_party/terraform/resources/resource_compute_shared_vpc_service_project.go
@@ -52,7 +52,7 @@ func resourceComputeSharedVpcServiceProjectCreate(d *schema.ResourceData, meta i
 	if err != nil {
 		return err
 	}
-	err = computeOperationWaitTime(config, op, hostProject, "Enabling Shared VPC Resource", d.Timeout(schema.TimeoutCreate))
+	err = computeOperationWait(config, op, hostProject, "Enabling Shared VPC Resource")
 	if err != nil {
 		return err
 	}
@@ -118,7 +118,7 @@ func disableXpnResource(d *schema.ResourceData, config *Config, hostProject, pro
 	if err != nil {
 		return err
 	}
-	err = computeOperationWaitTime(config, op, hostProject, "Disabling Shared VPC Resource", d.Timeout(schema.TimeoutCreate))
+	err = computeOperationWait(config, op, hostProject, "Disabling Shared VPC Resource")
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1181,8 +1181,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	d.SetId(containerClusterFullName(project, location, clusterName))
 
 	// Wait until it's created
-	timeoutInMinutes := int(d.Timeout(schema.TimeoutCreate).Minutes())
-	waitErr := containerOperationWait(config, op, project, location, "creating GKE cluster", timeoutInMinutes)
+	waitErr := containerOperationWait(config, op, project, location, "creating GKE cluster", d.Timeout(schema.TimeoutCreate))
 	if waitErr != nil {
 		// Check if the create operation failed because Terraform was prematurely terminated. If it was we can persist the
 		// operation id to state so that a subsequent refresh of this resource will wait until the operation has terminated
@@ -1225,7 +1224,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		if err != nil {
 			return errwrap.Wrapf("Error deleting default node pool: {{err}}", err)
 		}
-		err = containerOperationWait(config, op, project, location, "removing default node pool", timeoutInMinutes)
+		err = containerOperationWait(config, op, project, location, "removing default node pool", d.Timeout(schema.TimeoutCreate))
 		if err != nil {
 			return errwrap.Wrapf("Error while waiting to delete default node pool: {{err}}", err)
 		}
@@ -1267,7 +1266,7 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 			Name: operation,
 		}
 		d.Set("operation", "")
-		waitErr := containerOperationWait(config, op, project, location, "resuming GKE cluster", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+		waitErr := containerOperationWait(config, op, project, location, "resuming GKE cluster", d.Timeout(schema.TimeoutCreate))
 		if waitErr != nil {
 			return waitErr
 		}
@@ -1408,7 +1407,6 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	clusterName := d.Get("name").(string)
-	timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
 
 	if _, err := containerClusterAwaitRestingState(config, project, location, clusterName, d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return err
@@ -1426,7 +1424,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				return err
 			}
 			// Wait until it's updated
-			return containerOperationWait(config, op, project, location, updateDescription, timeoutInMinutes)
+			return containerOperationWait(config, op, project, location, updateDescription, d.Timeout(schema.TimeoutUpdate))
 		}
 	}
 
@@ -1551,7 +1549,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			}
 
 			// Wait until it's updated
-			err = containerOperationWait(config, op, project, location, "updating GKE Intra Node Visibility", timeoutInMinutes)
+			err = containerOperationWait(config, op, project, location, "updating GKE Intra Node Visibility", d.Timeout(schema.TimeoutUpdate))
 			log.Println("[DEBUG] done updating enable_intranode_visibility")
 			return err
 		}
@@ -1581,7 +1579,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			}
 
 			// Wait until it's updated
-			return containerOperationWait(config, op, project, location, "updating GKE cluster maintenance policy", timeoutInMinutes)
+			return containerOperationWait(config, op, project, location, "updating GKE cluster maintenance policy", d.Timeout(schema.TimeoutUpdate))
 		}
 
 		// Call update serially.
@@ -1659,7 +1657,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			}
 
 			// Wait until it's updated
-			err = containerOperationWait(config, op, project, location, "updating GKE legacy ABAC", timeoutInMinutes)
+			err = containerOperationWait(config, op, project, location, "updating GKE legacy ABAC", d.Timeout(schema.TimeoutUpdate))
 			log.Println("[DEBUG] done updating enable_legacy_abac")
 			return err
 		}
@@ -1692,7 +1690,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			}
 
 			// Wait until it's updated
-			return containerOperationWait(config, op, project, location, "updating GKE logging+monitoring service", timeoutInMinutes)
+			return containerOperationWait(config, op, project, location, "updating GKE logging+monitoring service", d.Timeout(schema.TimeoutUpdate))
 		}
 
 		// Call update serially.
@@ -1720,7 +1718,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			}
 
 			// Wait until it's updated
-			err = containerOperationWait(config, op, project, location, "updating GKE cluster network policy", timeoutInMinutes)
+			err = containerOperationWait(config, op, project, location, "updating GKE cluster network policy", d.Timeout(schema.TimeoutUpdate))
 			log.Println("[DEBUG] done updating network_policy")
 			return err
 		}
@@ -1743,7 +1741,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				return err
 			}
 
-			if err := nodePoolUpdate(d, meta, nodePoolInfo, fmt.Sprintf("node_pool.%d.", i), timeoutInMinutes); err != nil {
+			if err := nodePoolUpdate(d, meta, nodePoolInfo, fmt.Sprintf("node_pool.%d.", i), d.Timeout(schema.TimeoutUpdate)); err != nil {
 				return err
 			}
 		}
@@ -1832,7 +1830,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				}
 
 				// Wait until it's updated
-				return containerOperationWait(config, op, project, location, "updating GKE image type", timeoutInMinutes)
+				return containerOperationWait(config, op, project, location, "updating GKE image type", d.Timeout(schema.TimeoutUpdate))
 			}
 
 			// Call update serially.
@@ -1869,7 +1867,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			}
 
 			// Wait until it's updated
-			return containerOperationWait(config, op, project, location, "updating master auth", timeoutInMinutes)
+			return containerOperationWait(config, op, project, location, "updating master auth", d.Timeout(schema.TimeoutUpdate))
 		}
 
 		// Call update serially.
@@ -1917,7 +1915,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 				return err
 			}
 			// Wait until it's updated
-			return containerOperationWait(config, op, project, location, "updating GKE cluster pod security policy config", timeoutInMinutes)
+			return containerOperationWait(config, op, project, location, "updating GKE cluster pod security policy config", d.Timeout(schema.TimeoutUpdate))
 		}
 		if err := lockedCall(lockKey, updateF); err != nil {
 			return err
@@ -1972,7 +1970,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			}
 
 			// Wait until it's updated
-			return containerOperationWait(config, op, project, location, "updating GKE resource labels", timeoutInMinutes)
+			return containerOperationWait(config, op, project, location, "updating GKE resource labels", d.Timeout(schema.TimeoutUpdate))
 		}
 
 		// Call update serially.
@@ -1992,7 +1990,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			}
 			log.Printf("[WARN] Container cluster %q default node pool already removed, no change", d.Id())
 		} else {
-			err = containerOperationWait(config, op, project, location, "removing default node pool", timeoutInMinutes)
+			err = containerOperationWait(config, op, project, location, "removing default node pool", d.Timeout(schema.TimeoutUpdate))
 			if err != nil {
 				return errwrap.Wrapf("Error deleting default node pool: {{err}}", err)
 			}
@@ -2014,7 +2012,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 							return err
 					}
 					// Wait until it's updated
-					return containerOperationWait(config, op, project, location, "updating GKE cluster resource usage export config", timeoutInMinutes)
+					return containerOperationWait(config, op, project, location, "updating GKE cluster resource usage export config", d.Timeout(schema.TimeoutUpdate))
 			}
 			if err := lockedCall(lockKey, updateF); err != nil {
 					return err
@@ -2047,7 +2045,6 @@ func resourceContainerClusterDelete(d *schema.ResourceData, meta interface{}) er
 	}
 
 	clusterName := d.Get("name").(string)
-	timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
 
 	if _, err := containerClusterAwaitRestingState(config, project, location, clusterName, d.Timeout(schema.TimeoutDelete)); err != nil {
 		return err
@@ -2081,7 +2078,7 @@ func resourceContainerClusterDelete(d *schema.ResourceData, meta interface{}) er
 	}
 
 	// Wait until it's deleted
-	waitErr := containerOperationWait(config, op, project, location, "deleting GKE cluster", timeoutInMinutes)
+	waitErr := containerOperationWait(config, op, project, location, "deleting GKE cluster", d.Timeout(schema.TimeoutDelete))
 	if waitErr != nil {
 		return waitErr
 	}
@@ -2120,8 +2117,7 @@ func cleanFailedContainerCluster(d *schema.ResourceData, meta interface{}) error
 	}
 
 	// Wait until it's deleted
-	timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
-	waitErr := containerOperationWait(config, op, project, location, "deleting GKE cluster", timeoutInMinutes)
+	waitErr := containerOperationWait(config, op, project, location, "deleting GKE cluster", d.Timeout(schema.TimeoutDelete))
 	if waitErr != nil {
 		return waitErr
 	}

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -89,6 +89,7 @@ func resourceContainerCluster() *schema.Resource {
 
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(40 * time.Minute),
+			Read:   schema.DefaultTimeout(40 * time.Minute),
 			Update: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(40 * time.Minute),
 		},
@@ -1266,7 +1267,7 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 			Name: operation,
 		}
 		d.Set("operation", "")
-		waitErr := containerOperationWait(config, op, project, location, "resuming GKE cluster", d.Timeout(schema.TimeoutCreate))
+		waitErr := containerOperationWait(config, op, project, location, "resuming GKE cluster", d.Timeout(schema.TimeoutRead))
 		if waitErr != nil {
 			return waitErr
 		}

--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -293,7 +293,7 @@ func resourceContainerNodePoolCreate(d *schema.ResourceData, meta interface{}) e
 
 	waitErr := containerOperationWait(config,
 		operation, nodePoolInfo.project,
-		nodePoolInfo.location, "creating GKE NodePool", int(timeout.Minutes()))
+		nodePoolInfo.location, "creating GKE NodePool", timeout)
 
 	if waitErr != nil {
 		// The resource didn't actually create
@@ -350,7 +350,6 @@ func resourceContainerNodePoolRead(d *schema.ResourceData, meta interface{}) err
 
 func resourceContainerNodePoolUpdate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
 
 	nodePoolInfo, err := extractNodePoolInformation(d, config)
 	if err != nil {
@@ -364,7 +363,7 @@ func resourceContainerNodePoolUpdate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Partial(true)
-	if err := nodePoolUpdate(d, meta, nodePoolInfo, "", timeoutInMinutes); err != nil {
+	if err := nodePoolUpdate(d, meta, nodePoolInfo, "", d.Timeout(schema.TimeoutUpdate)); err != nil {
 		return err
 	}
 	d.Partial(false)
@@ -392,8 +391,6 @@ func resourceContainerNodePoolDelete(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
-
 	mutexKV.Lock(nodePoolInfo.lockKey())
 	defer mutexKV.Unlock(nodePoolInfo.lockKey())
 
@@ -419,7 +416,7 @@ func resourceContainerNodePoolDelete(d *schema.ResourceData, meta interface{}) e
 	}
 
 	// Wait until it's deleted
-	waitErr := containerOperationWait(config, op, nodePoolInfo.project, nodePoolInfo.location, "deleting GKE NodePool", timeoutInMinutes)
+	waitErr := containerOperationWait(config, op, nodePoolInfo.project, nodePoolInfo.location, "deleting GKE NodePool", d.Timeout(schema.TimeoutDelete))
 	if waitErr != nil {
 		return waitErr
 	}
@@ -627,7 +624,7 @@ func flattenNodePool(d *schema.ResourceData, config *Config, np *containerBeta.N
 	return nodePool, nil
 }
 
-func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *NodePoolInformation, prefix string, timeoutInMinutes int) error {
+func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *NodePoolInformation, prefix string, timeout time.Duration) error {
 	config := meta.(*Config)
 
 	name := d.Get(prefix + "name").(string)
@@ -666,7 +663,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 			return containerOperationWait(config, op,
 				nodePoolInfo.project,
 				nodePoolInfo.location, "updating GKE node pool",
-				timeoutInMinutes)
+				timeout)
 		}
 
 		// Call update serially.
@@ -700,7 +697,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 				return containerOperationWait(config, op,
 					nodePoolInfo.project,
 					nodePoolInfo.location, "updating GKE node pool",
-					timeoutInMinutes)
+					timeout)
 			}
 
 			// Call update serially.
@@ -732,7 +729,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 			return containerOperationWait(config, op,
 				nodePoolInfo.project,
 				nodePoolInfo.location, "updating GKE node pool size",
-				timeoutInMinutes)
+				timeout)
 		}
 
 		// Call update serially.
@@ -770,7 +767,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 			// Wait until it's updated
 			return containerOperationWait(config, op,
 				nodePoolInfo.project,
-				nodePoolInfo.location, "updating GKE node pool management", timeoutInMinutes)
+				nodePoolInfo.location, "updating GKE node pool management", timeout)
 		}
 
 		// Call update serially.
@@ -801,7 +798,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 			// Wait until it's updated
 			return containerOperationWait(config, op,
 				nodePoolInfo.project,
-				nodePoolInfo.location, "updating GKE node pool version", timeoutInMinutes)
+				nodePoolInfo.location, "updating GKE node pool version", timeout)
 		}
 
 		// Call update serially.
@@ -829,7 +826,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 			}
 
 			// Wait until it's updated
-			return containerOperationWait(config, op, nodePoolInfo.project, nodePoolInfo.location, "updating GKE node pool node locations", timeoutInMinutes)
+			return containerOperationWait(config, op, nodePoolInfo.project, nodePoolInfo.location, "updating GKE node pool node locations", timeout)
 		}
 
 		// Call update serially.
@@ -863,7 +860,7 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 			}
 
 			// Wait until it's updated
-			return containerOperationWait(config, op, nodePoolInfo.project, nodePoolInfo.location, "updating GKE node pool upgrade settings", timeoutInMinutes)
+			return containerOperationWait(config, op, nodePoolInfo.project, nodePoolInfo.location, "updating GKE node pool upgrade settings", timeout)
 		}
 
 		// Call update serially.

--- a/third_party/terraform/resources/resource_dataproc_cluster.go.erb
+++ b/third_party/terraform/resources/resource_dataproc_cluster.go.erb
@@ -730,8 +730,7 @@ func resourceDataprocClusterCreate(d *schema.ResourceData, meta interface{}) err
 	d.SetId(fmt.Sprintf("projects/%s/regions/%s/clusters/%s", project, region, cluster.ClusterName))
 
 	// Wait until it's created
-	timeoutInMinutes := int(d.Timeout(schema.TimeoutCreate).Minutes())
-	waitErr := dataprocClusterOperationWait(config, op, "creating Dataproc cluster", timeoutInMinutes)
+	waitErr := dataprocClusterOperationWait(config, op, "creating Dataproc cluster", d.Timeout(schema.TimeoutCreate))
 	if waitErr != nil {
 		// The resource didn't actually create
 		// Note that we do not remove the ID here - this resource tends to leave
@@ -1083,7 +1082,6 @@ func resourceDataprocClusterUpdate(d *schema.ResourceData, meta interface{}) err
 
 	region := d.Get("region").(string)
 	clusterName := d.Get("name").(string)
-	timeoutInMinutes := int(d.Timeout(schema.TimeoutUpdate).Minutes())
 
 	cluster := &dataproc.Cluster{
 		ClusterName: clusterName,
@@ -1155,7 +1153,7 @@ func resourceDataprocClusterUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 
 		// Wait until it's updated
-		waitErr := dataprocClusterOperationWait(config, op, "updating Dataproc cluster ", timeoutInMinutes)
+		waitErr := dataprocClusterOperationWait(config, op, "updating Dataproc cluster ", d.Timeout(schema.TimeoutUpdate))
 		if waitErr != nil {
 			return waitErr
 		}
@@ -1445,7 +1443,6 @@ func resourceDataprocClusterDelete(d *schema.ResourceData, meta interface{}) err
 
 	region := d.Get("region").(string)
 	clusterName := d.Get("name").(string)
-	timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
 
 	log.Printf("[DEBUG] Deleting Dataproc cluster %s", clusterName)
 	op, err := config.clientDataprocBeta.Projects.Regions.Clusters.Delete(
@@ -1455,7 +1452,7 @@ func resourceDataprocClusterDelete(d *schema.ResourceData, meta interface{}) err
 	}
 
 	// Wait until it's deleted
-	waitErr := dataprocClusterOperationWait(config, op, "deleting Dataproc cluster", timeoutInMinutes)
+	waitErr := dataprocClusterOperationWait(config, op, "deleting Dataproc cluster", d.Timeout(schema.TimeoutDelete))
 	if waitErr != nil {
 		return waitErr
 	}

--- a/third_party/terraform/resources/resource_dataproc_job.go
+++ b/third_party/terraform/resources/resource_dataproc_job.go
@@ -241,9 +241,8 @@ func resourceDataprocJobCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 	d.SetId(fmt.Sprintf("projects/%s/regions/%s/jobs/%s", project, region, job.Reference.JobId))
 
-	timeoutInMinutes := int(d.Timeout(schema.TimeoutCreate).Minutes())
 	waitErr := dataprocJobOperationWait(config, region, project, job.Reference.JobId,
-		"Creating Dataproc job", timeoutInMinutes, 1)
+		"Creating Dataproc job", d.Timeout(schema.TimeoutCreate))
 	if waitErr != nil {
 		return waitErr
 	}
@@ -310,7 +309,6 @@ func resourceDataprocJobDelete(d *schema.ResourceData, meta interface{}) error {
 
 	region := d.Get("region").(string)
 	forceDelete := d.Get("force_delete").(bool)
-	timeoutInMinutes := int(d.Timeout(schema.TimeoutDelete).Minutes())
 
 	parts := strings.Split(d.Id(), "/")
 	jobId := parts[len(parts)-1]
@@ -323,7 +321,7 @@ func resourceDataprocJobDelete(d *schema.ResourceData, meta interface{}) error {
 		_, _ = config.clientDataproc.Projects.Regions.Jobs.Cancel(project, region, jobId, &dataproc.CancelJobRequest{}).Do()
 
 		waitErr := dataprocJobOperationWait(config, region, project, jobId,
-			"Cancelling Dataproc job", timeoutInMinutes, 1)
+			"Cancelling Dataproc job", d.Timeout(schema.TimeoutDelete))
 		if waitErr != nil {
 			return waitErr
 		}
@@ -338,7 +336,7 @@ func resourceDataprocJobDelete(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	waitErr := dataprocDeleteOperationWait(config, region, project, jobId,
-		"Deleting Dataproc job", timeoutInMinutes, 1)
+		"Deleting Dataproc job", d.Timeout(schema.TimeoutDelete))
 	if waitErr != nil {
 		return waitErr
 	}

--- a/third_party/terraform/resources/resource_google_folder.go
+++ b/third_party/terraform/resources/resource_google_folder.go
@@ -161,7 +161,7 @@ func resourceGoogleFolderUpdate(d *schema.ResourceData, meta interface{}) error 
 			return err
 		}
 
-		err = resourceManagerOperationWaitTime(config, opAsMap, "move folder", d.Timeout(schema.TimeoutCreate))
+		err = resourceManagerOperationWaitTime(config, opAsMap, "move folder", d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return fmt.Errorf("Error moving folder '%s' to '%s': %s", displayName, newParent, err)
 		}

--- a/third_party/terraform/resources/resource_google_folder.go
+++ b/third_party/terraform/resources/resource_google_folder.go
@@ -3,10 +3,11 @@ package google
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	resourceManagerV2Beta1 "google.golang.org/api/cloudresourcemanager/v2beta1"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	resourceManagerV2Beta1 "google.golang.org/api/cloudresourcemanager/v2beta1"
 )
 
 func resourceGoogleFolder() *schema.Resource {
@@ -80,7 +81,7 @@ func resourceGoogleFolderCreate(d *schema.ResourceData, meta interface{}) error 
 		return err
 	}
 
-	err = resourceManagerOperationWaitTime(config, opAsMap, "creating folder", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = resourceManagerOperationWaitTime(config, opAsMap, "creating folder", d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		return fmt.Errorf("Error creating folder '%s' in '%s': %s", displayName, parent, err)
 	}
@@ -160,7 +161,7 @@ func resourceGoogleFolderUpdate(d *schema.ResourceData, meta interface{}) error 
 			return err
 		}
 
-		err = resourceManagerOperationWaitTime(config, opAsMap, "move folder", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+		err = resourceManagerOperationWaitTime(config, opAsMap, "move folder", d.Timeout(schema.TimeoutCreate))
 		if err != nil {
 			return fmt.Errorf("Error moving folder '%s' to '%s': %s", displayName, newParent, err)
 		}

--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -136,7 +136,7 @@ func resourceGoogleProjectCreate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	waitErr := resourceManagerOperationWaitTime(config, opAsMap, "creating folder", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	waitErr := resourceManagerOperationWaitTime(config, opAsMap, "creating folder", d.Timeout(schema.TimeoutCreate))
 	if waitErr != nil {
 		// The resource wasn't actually created
 		d.SetId("")

--- a/third_party/terraform/resources/resource_service_networking_connection.go
+++ b/third_party/terraform/resources/resource_service_networking_connection.go
@@ -210,7 +210,7 @@ func resourceServiceNetworkingConnectionDelete(d *schema.ResourceData, meta inte
 
 	err = computeOperationWaitTime(
 		config, op, project, "Updating Network",
-		int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+		d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_service_networking_connection.go
+++ b/third_party/terraform/resources/resource_service_networking_connection.go
@@ -208,9 +208,8 @@ func resourceServiceNetworkingConnectionDelete(d *schema.ResourceData, meta inte
 		return err
 	}
 
-	err = computeOperationWaitTime(
-		config, op, project, "Updating Network",
-		d.Timeout(schema.TimeoutUpdate))
+	err = computeOperationWait(
+		config, op, project, "Updating Network")
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -619,7 +619,7 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 	}
 	d.SetId(id)
 
-	err = sqlAdminOperationWaitTime(config, op, project, "Create Instance", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+	err = sqlAdminOperationWaitTime(config, op, project, "Create Instance", d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		d.SetId("")
 		return err
@@ -646,7 +646,7 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 				err = retry(func() error {
 					op, err = config.clientSqlAdmin.Users.Delete(project, instance.Name).Host(u.Host).Name(u.Name).Do()
 					if err == nil {
-						err = sqlAdminOperationWaitTime(config, op, project, "Delete default root User", int(d.Timeout(schema.TimeoutCreate).Minutes()))
+						err = sqlAdminOperationWaitTime(config, op, project, "Delete default root User", d.Timeout(schema.TimeoutCreate))
 					}
 					return err
 				})
@@ -914,7 +914,7 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error, failed to update instance settings for %s: %s", instance.Name, err)
 	}
 
-	err = sqlAdminOperationWaitTime(config, op, project, "Update Instance", int(d.Timeout(schema.TimeoutUpdate).Minutes()))
+	err = sqlAdminOperationWaitTime(config, op, project, "Update Instance", d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
 		return err
 	}
@@ -946,7 +946,7 @@ func resourceSqlDatabaseInstanceDelete(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error, failed to delete instance %s: %s", d.Get("name").(string), err)
 	}
 
-	err = sqlAdminOperationWaitTime(config, op, project, "Delete Instance", int(d.Timeout(schema.TimeoutDelete).Minutes()))
+	err = sqlAdminOperationWaitTime(config, op, project, "Delete Instance", d.Timeout(schema.TimeoutDelete))
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/tests/resource_dataproc_job_test.go
+++ b/third_party/terraform/tests/resource_dataproc_job_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"strings"
 	"testing"
+	"time"
 
 	// "regexp"
 
@@ -314,9 +315,9 @@ func testAccCheckDataprocJobCompletesSuccessfully(t *testing.T, n string, job *d
 			return err
 		}
 
-		jobCompleteTimeoutMins := 5
+		jobCompleteTimeoutMins := 5 * time.Minute
 		waitErr := dataprocJobOperationWait(config, region, project, job.Reference.JobId,
-			"Awaiting Dataproc job completion", jobCompleteTimeoutMins, 1)
+			"Awaiting Dataproc job completion", jobCompleteTimeoutMins)
 		if waitErr != nil {
 			return waitErr
 		}

--- a/third_party/terraform/utils/appengine_operation.go
+++ b/third_party/terraform/utils/appengine_operation.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"time"
 
 	"google.golang.org/api/appengine/v1"
 )
@@ -30,10 +31,10 @@ func (w *AppEngineOperationWaiter) QueryOp() (interface{}, error) {
 }
 
 func appEngineOperationWait(config *Config, res interface{}, appId, activity string) error {
-	return appEngineOperationWaitTime(config, res, appId, activity, 4)
+	return appEngineOperationWaitTime(config, res, appId, activity, 4*time.Minute)
 }
 
-func appEngineOperationWaitTimeWithResponse(config *Config, res interface{}, response *map[string]interface{}, appId, activity string, timeoutMinutes int) error {
+func appEngineOperationWaitTimeWithResponse(config *Config, res interface{}, response *map[string]interface{}, appId, activity string, timeout time.Duration) error {
 	op := &appengine.Operation{}
 	err := Convert(res, op)
 	if err != nil {
@@ -48,13 +49,13 @@ func appEngineOperationWaitTimeWithResponse(config *Config, res interface{}, res
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	if err := OperationWait(w, activity, timeoutMinutes, config.PollInterval); err != nil {
+	if err := OperationWait(w, activity, timeout, config.PollInterval); err != nil {
 		return err
 	}
 	return json.Unmarshal([]byte(w.CommonOperationWaiter.Op.Response), response)
 }
 
-func appEngineOperationWaitTime(config *Config, res interface{}, appId, activity string, timeoutMinutes int) error {
+func appEngineOperationWaitTime(config *Config, res interface{}, appId, activity string, timeout time.Duration) error {
 	op := &appengine.Operation{}
 	err := Convert(res, op)
 	if err != nil {
@@ -69,5 +70,5 @@ func appEngineOperationWaitTime(config *Config, res interface{}, appId, activity
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
+	return OperationWait(w, activity, timeout, config.PollInterval)
 }

--- a/third_party/terraform/utils/cloudfunctions_operation.go
+++ b/third_party/terraform/utils/cloudfunctions_operation.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"time"
 
 	"google.golang.org/api/cloudfunctions/v1"
 )
@@ -18,12 +19,12 @@ func (w *CloudFunctionsOperationWaiter) QueryOp() (interface{}, error) {
 	return w.Service.Operations.Get(w.Op.Name).Do()
 }
 
-func cloudFunctionsOperationWait(config *Config, op *cloudfunctions.Operation, activity string, timeoutMin int) error {
+func cloudFunctionsOperationWait(config *Config, op *cloudfunctions.Operation, activity string, timeout time.Duration) error {
 	w := &CloudFunctionsOperationWaiter{
 		Service: config.clientCloudFunctions,
 	}
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	return OperationWait(w, activity, timeoutMin, config.PollInterval)
+	return OperationWait(w, activity, timeout, config.PollInterval)
 }

--- a/third_party/terraform/utils/common_operation.go
+++ b/third_party/terraform/utils/common_operation.go
@@ -126,7 +126,7 @@ func CommonRefreshFunc(w Waiter) resource.StateRefreshFunc {
 	}
 }
 
-func OperationWait(w Waiter, activity string, timeoutMinutes int, pollInterval time.Duration) error {
+func OperationWait(w Waiter, activity string, timeout time.Duration, pollInterval time.Duration) error {
 	if OperationDone(w) {
 		if w.Error() != nil {
 			return w.Error()
@@ -138,7 +138,7 @@ func OperationWait(w Waiter, activity string, timeoutMinutes int, pollInterval t
 		Pending:      w.PendingStates(),
 		Target:       w.TargetStates(),
 		Refresh:      CommonRefreshFunc(w),
-		Timeout:      time.Duration(timeoutMinutes) * time.Minute,
+		Timeout:      timeout,
 		MinTimeout:   2 * time.Second,
 		PollInterval: pollInterval,
 	}

--- a/third_party/terraform/utils/composer_operation.go
+++ b/third_party/terraform/utils/composer_operation.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"time"
 
 	composer "google.golang.org/api/composer/v1beta1"
 )
@@ -18,12 +19,12 @@ func (w *ComposerOperationWaiter) QueryOp() (interface{}, error) {
 	return w.Service.Operations.Get(w.Op.Name).Do()
 }
 
-func composerOperationWaitTime(config *Config, op *composer.Operation, project, activity string, timeoutMinutes int) error {
+func composerOperationWaitTime(config *Config, op *composer.Operation, project, activity string, timeout time.Duration) error {
 	w := &ComposerOperationWaiter{
 		Service: config.clientComposer.Projects.Locations,
 	}
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
+	return OperationWait(w, activity, timeout, config.PollInterval)
 }

--- a/third_party/terraform/utils/compute_operation.go
+++ b/third_party/terraform/utils/compute_operation.go
@@ -3,6 +3,7 @@ package google
 import (
 	"bytes"
 	"fmt"
+	"time"
 
 	"google.golang.org/api/compute/v1"
 )
@@ -79,10 +80,10 @@ func (w *ComputeOperationWaiter) TargetStates() []string {
 }
 
 func computeOperationWait(config *Config, res interface{}, project, activity string) error {
-	return computeOperationWaitTime(config, res, project, activity, 4)
+	return computeOperationWaitTime(config, res, project, activity, 4*time.Minute)
 }
 
-func computeOperationWaitTime(config *Config, res interface{}, project, activity string, timeoutMinutes int) error {
+func computeOperationWaitTime(config *Config, res interface{}, project, activity string, timeout time.Duration) error {
 	op := &compute.Operation{}
 	err := Convert(res, op)
 	if err != nil {
@@ -98,7 +99,7 @@ func computeOperationWaitTime(config *Config, res interface{}, project, activity
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
+	return OperationWait(w, activity, timeout, config.PollInterval)
 }
 
 // ComputeOperationError wraps compute.OperationError and implements the

--- a/third_party/terraform/utils/container_operation.go
+++ b/third_party/terraform/utils/container_operation.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"time"
 
 	container "google.golang.org/api/container/v1beta1"
 )
@@ -96,7 +97,7 @@ func (w *ContainerOperationWaiter) TargetStates() []string {
 	return []string{"DONE"}
 }
 
-func containerOperationWait(config *Config, op *container.Operation, project, location, activity string, timeoutMinutes int) error {
+func containerOperationWait(config *Config, op *container.Operation, project, location, activity string, timeout time.Duration) error {
 	w := &ContainerOperationWaiter{
 		Service:  config.clientContainerBeta,
 		Context:  config.context,
@@ -109,5 +110,5 @@ func containerOperationWait(config *Config, op *container.Operation, project, lo
 		return err
 	}
 
-	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
+	return OperationWait(w, activity, timeout, config.PollInterval)
 }

--- a/third_party/terraform/utils/dataproc_cluster_operation.go
+++ b/third_party/terraform/utils/dataproc_cluster_operation.go
@@ -2,8 +2,9 @@ package google
 
 import (
 	"fmt"
+	"time"
 
-	"google.golang.org/api/dataproc/v1beta2"
+	dataproc "google.golang.org/api/dataproc/v1beta2"
 )
 
 type DataprocClusterOperationWaiter struct {
@@ -18,12 +19,12 @@ func (w *DataprocClusterOperationWaiter) QueryOp() (interface{}, error) {
 	return w.Service.Projects.Regions.Operations.Get(w.Op.Name).Do()
 }
 
-func dataprocClusterOperationWait(config *Config, op *dataproc.Operation, activity string, timeoutMinutes int) error {
+func dataprocClusterOperationWait(config *Config, op *dataproc.Operation, activity string, timeout time.Duration) error {
 	w := &DataprocClusterOperationWaiter{
 		Service: config.clientDataprocBeta,
 	}
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
+	return OperationWait(w, activity, timeout, config.PollInterval)
 }

--- a/third_party/terraform/utils/dataproc_job_operation.go
+++ b/third_party/terraform/utils/dataproc_job_operation.go
@@ -3,6 +3,7 @@ package google
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"google.golang.org/api/dataproc/v1"
 )
@@ -65,14 +66,14 @@ func (w *DataprocJobOperationWaiter) TargetStates() []string {
 	return []string{"CANCELLED", "DONE", "ATTEMPT_FAILURE", "ERROR"}
 }
 
-func dataprocJobOperationWait(config *Config, region, projectId, jobId string, activity string, timeoutMinutes, minTimeoutSeconds int) error {
+func dataprocJobOperationWait(config *Config, region, projectId, jobId string, activity string, timeout time.Duration) error {
 	w := &DataprocJobOperationWaiter{
 		Service:   config.clientDataproc,
 		Region:    region,
 		ProjectId: projectId,
 		JobId:     jobId,
 	}
-	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
+	return OperationWait(w, activity, timeout, config.PollInterval)
 }
 
 type DataprocDeleteJobOperationWaiter struct {
@@ -103,7 +104,7 @@ func (w *DataprocDeleteJobOperationWaiter) QueryOp() (interface{}, error) {
 	return job, err
 }
 
-func dataprocDeleteOperationWait(config *Config, region, projectId, jobId string, activity string, timeoutMinutes, minTimeoutSeconds int) error {
+func dataprocDeleteOperationWait(config *Config, region, projectId, jobId string, activity string, timeout time.Duration) error {
 	w := &DataprocDeleteJobOperationWaiter{
 		DataprocJobOperationWaiter{
 			Service:   config.clientDataproc,
@@ -112,5 +113,5 @@ func dataprocDeleteOperationWait(config *Config, region, projectId, jobId string
 			JobId:     jobId,
 		},
 	}
-	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
+	return OperationWait(w, activity, timeout, config.PollInterval)
 }

--- a/third_party/terraform/utils/deployment_manager_operation.go
+++ b/third_party/terraform/utils/deployment_manager_operation.go
@@ -3,6 +3,8 @@ package google
 import (
 	"bytes"
 	"fmt"
+	"time"
+
 	"google.golang.org/api/compute/v1"
 )
 
@@ -32,7 +34,7 @@ func (w *DeploymentManagerOperationWaiter) QueryOp() (interface{}, error) {
 	return op, nil
 }
 
-func deploymentManagerOperationWaitTime(config *Config, resp interface{}, project, activity string, timeoutMinutes int) error {
+func deploymentManagerOperationWaitTime(config *Config, resp interface{}, project, activity string, timeout time.Duration) error {
 	op := &compute.Operation{}
 	err := Convert(resp, op)
 	if err != nil {
@@ -50,7 +52,7 @@ func deploymentManagerOperationWaitTime(config *Config, resp interface{}, projec
 		return err
 	}
 
-	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
+	return OperationWait(w, activity, timeout, config.PollInterval)
 }
 
 func (w *DeploymentManagerOperationWaiter) Error() error {

--- a/third_party/terraform/utils/service_networking_operation.go
+++ b/third_party/terraform/utils/service_networking_operation.go
@@ -1,6 +1,8 @@
 package google
 
 import (
+	"time"
+
 	"google.golang.org/api/servicenetworking/v1"
 )
 
@@ -14,10 +16,10 @@ func (w *ServiceNetworkingOperationWaiter) QueryOp() (interface{}, error) {
 }
 
 func serviceNetworkingOperationWait(config *Config, op *servicenetworking.Operation, activity string) error {
-	return serviceNetworkingOperationWaitTime(config, op, activity, 10)
+	return serviceNetworkingOperationWaitTime(config, op, activity, 10*time.Minute)
 }
 
-func serviceNetworkingOperationWaitTime(config *Config, op *servicenetworking.Operation, activity string, timeoutMinutes int) error {
+func serviceNetworkingOperationWaitTime(config *Config, op *servicenetworking.Operation, activity string, timeout time.Duration) error {
 	w := &ServiceNetworkingOperationWaiter{
 		Service: config.clientServiceNetworking,
 	}
@@ -25,5 +27,5 @@ func serviceNetworkingOperationWaitTime(config *Config, op *servicenetworking.Op
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
+	return OperationWait(w, activity, timeout, config.PollInterval)
 }

--- a/third_party/terraform/utils/serviceman_operation.go
+++ b/third_party/terraform/utils/serviceman_operation.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"time"
 
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/servicemanagement/v1"
@@ -20,10 +21,10 @@ func (w *ServiceManagementOperationWaiter) QueryOp() (interface{}, error) {
 }
 
 func serviceManagementOperationWait(config *Config, op *servicemanagement.Operation, activity string) (googleapi.RawMessage, error) {
-	return serviceManagementOperationWaitTime(config, op, activity, 10)
+	return serviceManagementOperationWaitTime(config, op, activity, 10*time.Minute)
 }
 
-func serviceManagementOperationWaitTime(config *Config, op *servicemanagement.Operation, activity string, timeoutMinutes int) (googleapi.RawMessage, error) {
+func serviceManagementOperationWaitTime(config *Config, op *servicemanagement.Operation, activity string, timeout time.Duration) (googleapi.RawMessage, error) {
 	w := &ServiceManagementOperationWaiter{
 		Service: config.clientServiceMan,
 	}
@@ -32,7 +33,7 @@ func serviceManagementOperationWaitTime(config *Config, op *servicemanagement.Op
 		return nil, err
 	}
 
-	if err := OperationWait(w, activity, timeoutMinutes, config.PollInterval); err != nil {
+	if err := OperationWait(w, activity, timeout, config.PollInterval); err != nil {
 		return nil, err
 	}
 	return w.Op.Response, nil

--- a/third_party/terraform/utils/serviceusage_operation.go
+++ b/third_party/terraform/utils/serviceusage_operation.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"encoding/json"
+	"time"
 
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/serviceusage/v1"
@@ -18,7 +19,7 @@ func serviceUsageOperationWait(config *Config, op *serviceusage.Operation, proje
 	if err := json.Unmarshal(b, &m); err != nil {
 		return err
 	}
-	return serviceUsageOperationWaitTime(config, m, project, activity, 10)
+	return serviceUsageOperationWaitTime(config, m, project, activity, 10*time.Minute)
 }
 
 func handleServiceUsageRetryableError(err error) error {

--- a/third_party/terraform/utils/sqladmin_operation.go
+++ b/third_party/terraform/utils/sqladmin_operation.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"time"
 
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
@@ -100,10 +101,10 @@ func (w *SqlAdminOperationWaiter) TargetStates() []string {
 }
 
 func sqlAdminOperationWait(config *Config, res interface{}, project, activity string) error {
-	return sqlAdminOperationWaitTime(config, res, project, activity, 10)
+	return sqlAdminOperationWaitTime(config, res, project, activity, 10*time.Minute)
 }
 
-func sqlAdminOperationWaitTime(config *Config, res interface{}, project, activity string, timeoutMinutes int) error {
+func sqlAdminOperationWaitTime(config *Config, res interface{}, project, activity string, timeout time.Duration) error {
 	op := &sqladmin.Operation{}
 	err := Convert(res, op)
 	if err != nil {
@@ -118,7 +119,7 @@ func sqlAdminOperationWaitTime(config *Config, res interface{}, project, activit
 	if err := w.SetOp(op); err != nil {
 		return err
 	}
-	return OperationWait(w, activity, timeoutMinutes, config.PollInterval)
+	return OperationWait(w, activity, timeout, config.PollInterval)
 }
 
 // SqlAdminOperationError wraps sqladmin.OperationError and implements the

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -763,6 +763,7 @@ This resource provides the following
 [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
 
 - `create` - Default is 40 minutes.
+- `read`   - Default is 40 minutes.
 - `update` - Default is 60 minutes.
 - `delete` - Default is 40 minutes.
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->
Noticed this again while working on https://github.com/terraform-providers/terraform-provider-google/issues/3954, and figured this is as good a time as any to actually fix it.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
* all: fixed bug where timeouts specified in units other than minutes were getting incorrectly rounded. Also fixed several instances of timeout values being used from the wrong method.
```
