### PR TITLE
add bigquery connection with examples

### DIFF
--- a/products/bigqueryconnection/api.yaml
+++ b/products/bigqueryconnection/api.yaml
@@ -62,7 +62,8 @@ objects:
         description: |-
           The geographic location where the connection should reside.
           Cloud SQL instance must be in the same location as the connection
-          Examples: US, EU, asia-northeast1. The default value is US.
+          with following exceptions: Cloud SQL us-central1 maps to BigQuery US, Cloud SQL europe-west1 maps to BigQuery EU.
+          Examples: US, EU, asia-northeast1, us-central1, europe-west1. The default value is US.
       - !ruby/object:Api::Type::String
         name: 'friendlyName'
         description: A descriptive name for the connection
@@ -73,7 +74,7 @@ objects:
         name: 'hasCredential' 
         output: true
         description: |
-          Output only. True if the connection has credential assigned. 
+          True if the connection has credential assigned. 
       - !ruby/object:Api::Type::NestedObject
         name: cloudSql
         description: Cloud SQL properties.

--- a/products/bigqueryconnection/api.yaml
+++ b/products/bigqueryconnection/api.yaml
@@ -1,0 +1,97 @@
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: BigqueryConnection
+display_name: BigQuery Connection
+versions:
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://bigqueryconnection.googleapis.com/v1beta1/
+scopes:
+  - https://www.googleapis.com/auth/bigquery
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: BigQueryConnection API
+    url: https://console.cloud.google.com/apis/api/bigqueryconnection.googleapis.com/
+objects:
+  - !ruby/object:Api::Resource
+    name: 'Connection'
+    base_url: projects/{{project}}/locations/{{location}}/connections
+    self_link: "{{name}}"
+    create_url: projects/{{project}}/locations/{{location}}/connections?connectionId={{connection_id}}
+    update_verb: :PATCH
+    update_mask: true
+    description: |
+      A connection allows BigQuery connections to external data sources..
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        "Cloud SQL federated queries": "https://cloud.google.com/bigquery/docs/cloud-sql-federated-queries"
+      api: "https://cloud.google.com/bigquery/docs/reference/bigqueryconnection/rest/v1beta1/projects.locations.connections/create"
+    properties:
+      - !ruby/object:Api::Type::String
+        name: name
+        description: |-
+          The resource name of the connection in the form of: 
+          "projects/{project_id}/locations/{location_id}/connections/{connectionId}"
+        input: true
+        output: true
+      - !ruby/object:Api::Type::String
+        name: connection_id
+        description: |
+          Optional connection id that should be assigned to the created connection. 
+        required: false
+        input: true
+        url_param_only: true
+      - !ruby/object:Api::Type::String
+        name: 'location'
+        required: false
+        input: true
+        url_param_only: true
+        default_value: US
+        description: |-
+          The geographic location where the connection should reside.
+          Cloud SQL instance must be in the same location as the connection
+          Examples: US, EU, asia-northeast1. The default value is US.
+      - !ruby/object:Api::Type::String
+        name: 'friendlyName'
+        description: A descriptive name for the connection
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: A descriptive description for the connection
+      - !ruby/object:Api::Type::Boolean
+        name: 'hasCredential' 
+        output: true
+        description: |
+          Output only. True if the connection has credential assigned. 
+      - !ruby/object:Api::Type::NestedObject
+        name: cloudSql
+        description: Cloud SQL properties.
+        required: true
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'instanceId'
+            description: Cloud SQL instance ID in the form project:location:instance. 
+            required: true
+          - !ruby/object:Api::Type::String
+            name: 'database'
+            description: Database name. 
+            required: true
+          - !ruby/object:Api::Type::Enum
+            name: 'type'
+            description: Type of the Cloud SQL database.
+            required: true
+            values:
+              - :DATABASE_TYPE_UNSPECIFIED
+              - :POSTGRES
+              - :MYSQL

--- a/products/bigqueryconnection/terraform.yaml
+++ b/products/bigqueryconnection/terraform.yaml
@@ -1,0 +1,39 @@
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Terraform::Config
+legacy_name: bigquery
+overrides: !ruby/object:Overrides::ResourceOverrides
+  Connection: !ruby/object:Overrides::Terraform::ResourceOverride
+    id_format: "{{name}}"
+    import_format: ["{{name}}"]
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        min_version: beta
+        name: "bigquery_connection_basic"
+        primary_resource_id: "connection"
+        vars:
+          database_instance_name: "my-database-instance"
+      - !ruby/object:Provider::Terraform::Examples
+        min_version: beta
+        name: "bigquery_connection_full"
+        primary_resource_id: "connection"
+        vars:
+          database_instance_name: "my-database-instance"
+          connection_id: "my-connection"
+# This is for copying files over
+files: !ruby/object:Provider::Config::Files
+  # These files have templating (ERB) code that will be run.
+  # This is usually to add licensing info, autogeneration notices, etc.
+  compile:
+<%= lines(indent(compile('provider/terraform/product~compile.yaml'), 4)) -%>

--- a/templates/terraform/examples/bigquery_connection_basic.tf.erb
+++ b/templates/terraform/examples/bigquery_connection_basic.tf.erb
@@ -1,0 +1,26 @@
+resource "google_sql_database_instance" "instance" {
+    provider         = google-beta
+    name             = "<%= ctx[:vars]['database_instance_name'] %>"
+    database_version = "POSTGRES_11"
+    region           = "us-central1"
+    settings {
+		tier = "db-f1-micro"
+	}
+}
+
+resource "google_sql_database" "db" {
+    provider = google-beta
+    instance = google_sql_database_instance.instance.name
+    name     = "db"
+}
+
+resource "google_bigquery_connection" "<%= ctx[:primary_resource_id] %>" {
+    provider      = google-beta
+    friendly_name = "👋"
+    description   = "a riveting description"
+    cloud_sql {
+        instance_id = google_sql_database_instance.instance.connection_name
+        database    = google_sql_database.db.name
+        type        = "POSTGRES"
+    }
+}

--- a/templates/terraform/examples/bigquery_connection_full.tf.erb
+++ b/templates/terraform/examples/bigquery_connection_full.tf.erb
@@ -1,0 +1,28 @@
+resource "google_sql_database_instance" "instance" {
+    provider         = google-beta
+    name             = "<%= ctx[:vars]['database_instance_name'] %>"
+    database_version = "POSTGRES_11"
+    region           = "us-central1"
+    settings {
+		tier = "db-f1-micro"
+	}
+}
+
+resource "google_sql_database" "db" {
+    provider = google-beta
+    instance = google_sql_database_instance.instance.name
+    name     = "db"
+}
+
+resource "google_bigquery_connection" "<%= ctx[:primary_resource_id] %>" {
+    provider      = google-beta
+    connection_id = "<%= ctx[:vars]['connection_id'] %>"
+    location      = "US"
+    friendly_name = "👋"
+    description   = "a riveting description"
+    cloud_sql {
+        instance_id = google_sql_database_instance.instance.connection_name
+        database    = google_sql_database.db.name
+        type        = "POSTGRES"
+    }
+}

--- a/third_party/terraform/tests/resource_bigquery_connection_test.go.erb
+++ b/third_party/terraform/tests/resource_bigquery_connection_test.go.erb
@@ -1,0 +1,100 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccBigqueryConnectionConnection_bigqueryConnectionBasic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProvidersOiCS,
+		CheckDestroy: testAccCheckBigqueryConnectionConnectionDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigqueryConnectionConnection_bigqueryConnectionBasic(context),
+			},
+			{
+				Config: testAccBigqueryConnectionConnection_bigqueryConnectionBasicUpdate(context),
+			},
+		},
+	})
+}
+
+func testAccBigqueryConnectionConnection_bigqueryConnectionBasic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_sql_database_instance" "instance" {
+    provider         = google-beta
+    name             = "tf-test-pg-database-instance%{random_suffix}"
+    database_version = "POSTGRES_11"
+    region           = "us-central1"
+    settings {
+		tier = "db-f1-micro"
+	}
+}
+
+resource "google_sql_database" "db" {
+    provider = google-beta
+    instance = google_sql_database_instance.instance.name
+    name     = "db"
+}
+
+resource "google_bigquery_connection" "connection" {
+    provider      = google-beta
+    connection_id = "tf-test-my-connection%{random_suffix}"
+    location      = "US"
+    friendly_name = "👋"
+    description   = "a riveting description"
+    cloud_sql {
+        instance_id = google_sql_database_instance.instance.connection_name
+        database    = google_sql_database.db.name
+        type        = "POSTGRES"
+    }
+}
+`, context)
+}
+
+func testAccBigqueryConnectionConnection_bigqueryConnectionBasicUpdate(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_sql_database_instance" "instance" {
+    provider         = google-beta
+    name             = "tf-test-mysql-database-instance%{random_suffix}"
+    database_version = "MYSQL_5_6"
+    region           = "us-central1"
+    settings {
+		tier = "db-f1-micro"
+	}
+}
+
+resource "google_sql_database" "db" {
+    provider = google-beta
+    instance = google_sql_database_instance.instance.name
+    name     = "db2"
+}
+
+resource "google_bigquery_connection" "connection" {
+    provider      = google-beta
+    connection_id = "tf-test-my-connection%{random_suffix}"
+    location      = "US"
+    friendly_name = "👋👋"
+    description   = "a very riveting description"
+    cloud_sql {
+        instance_id = google_sql_database_instance.instance.connection_name
+        database    = google_sql_database.db.name
+        type        = "MYSQL"
+    }
+}
+`, context)
+}
+<% else %>
+// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
+<% end -%>


### PR DESCRIPTION
https://github.com/terraform-providers/terraform-provider-google/issues/5530

notes:
1) it's unclear on if this is ga or not to me, the api url says beta, so i went with beta.
2) I had to declare `google-beta` as the provider for everything in the examples, or the terraform go modules wouldn't build, what's the desired way to do this?
3) name vs id was not clear to me, i mapped the properties directly from the api, but this leads to the oddly reading: 
`instance_id = google_sql_database_instance.instance.connection_name`
per the docs, `connection_id` is optional (left blank a default is generated for you), which seems different from other products
4) "DATABASE_TYPE_UNSPECIFIED" when set maps to an undefined value on response (the `type` property is not present in the response) - I couldn't find any code to cargo-cult here, suggestions?

```release-note:new-resource
`google_bigquery_connection`
```
