### PR TITLE
Add contributor checker to GCB.

### DIFF
--- a/.ci/containers/contributor-checker/Dockerfile
+++ b/.ci/containers/contributor-checker/Dockerfile
@@ -1,0 +1,5 @@
+from alpine
+run apk update
+run apk add git curl jq bash
+add check-contributor.sh /main.sh
+cmd ["/main.sh"]

--- a/.ci/containers/contributor-checker/Dockerfile
+++ b/.ci/containers/contributor-checker/Dockerfile
@@ -2,4 +2,4 @@ from alpine
 run apk update
 run apk add git curl jq bash
 add check-contributor.sh /main.sh
-cmd ["/main.sh"]
+entrypoint ["/main.sh"]

--- a/.ci/containers/contributor-checker/check-contributor.sh
+++ b/.ci/containers/contributor-checker/check-contributor.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+if [ -z "$GITHUB_TOKEN" ]; then
+    echo "Did not provide GITHUB_TOKEN environment variable."
+    exit 1
+fi
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 pr-number"
+    exit 1
+fi
+PR_NUMBER=$1
+
+USER=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}" | jq .user.login)
+
+# This is where you add users who do not need to have an assignee chosen for
+# the.
+if $(echo $USER | fgrep -wq -e ndmckinley -e danawillow -e emilymye -e erjohnso -e geojaz -e megan07 -e paddcarver -e rambleraptor -e SirGitsalot -e slevenick -e c2thorn); then
+  echo "User is on the list, not assigning."
+else
+
+  # This is where you add people to the random-assignee rotation.  This list
+  # might not equal the list above.
+  ASSIGNEE=$(shuf -n 1 <(printf "danawillow\nrambleraptor\nemilymye\nrileykarson\nSirGitsalot\nslevenick\nc2thorn\nndmckinley"))
+
+  comment=$(cat << EOF
+Hello!  I am a robot who works on Magic Modules PRs.
+
+I have detected that you are a community contributor, so your PR will be assigned to someone with a commit-bit on this repo for initial review.
+
+Thanks for your contribution!  A human will be with you soon.
+
+@$ASSIGNEE, please review this PR or find an appropriate assignee.
+EOF
+)
+
+  curl -H "Authorization: token ${GITHUB_TOKEN}" \
+        -d "$(jq -r --arg comment "$comment" -n "{body: \$comment}")" \
+        "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}/comments"
+  curl -H "Authorization: token ${GITHUB_TOKEN}" \
+        -d "$(jq -r --arg assignee "$ASSIGNEE" -n "{assignees: [\$assignee]}")" \
+        "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}/assignees"
+
+fi

--- a/.ci/containers/contributor-checker/check-contributor.sh
+++ b/.ci/containers/contributor-checker/check-contributor.sh
@@ -14,7 +14,7 @@ USER=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
 
 # This is where you add users who do not need to have an assignee chosen for
 # the.
-if $(echo $USER | fgrep -wq -e ndmckinley -e danawillow -e emilymye -e erjohnso -e geojaz -e megan07 -e paddcarver -e rambleraptor -e SirGitsalot -e slevenick -e c2thorn); then
+if $(echo $USER | fgrep -wq -e ndmckinley -e danawillow -e emilymye -e erjohnso -e geojaz -e megan07 -e paddycarver -e rambleraptor -e SirGitsalot -e slevenick -e c2thorn -e rileykarson); then
   echo "User is on the list, not assigning."
 else
 

--- a/.ci/containers/contributor-checker/check-contributor.sh
+++ b/.ci/containers/contributor-checker/check-contributor.sh
@@ -14,7 +14,7 @@ USER=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
   "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}" | jq .user.login)
 
 ASSIGNEE=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
-  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}" | jq .assignee.login)
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/${PR_NUMBER}/requested_reviewers" | jq .users[0].login)
 
 # This is where you add users who do not need to have an assignee chosen for
 # the.
@@ -22,7 +22,9 @@ if $(echo $USER | fgrep -wq -e ndmckinley -e danawillow -e emilymye -e erjohnso 
   echo "User is on the list, not assigning."
   exit 0
 fi
-if [ -j "$ASSIGNEE" ] ; then 
+if [ "$ASSIGNEE" == "null" ] ; then 
+  echo "Issue is not assigned."
+else
   echo "Issue is assigned, not assigning."
   exit 0
 fi
@@ -46,5 +48,5 @@ curl -H "Authorization: token ${GITHUB_TOKEN}" \
       -d "$(jq -r --arg comment "$comment" -n "{body: \$comment}")" \
       "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}/comments"
 curl -H "Authorization: token ${GITHUB_TOKEN}" \
-      -d "$(jq -r --arg assignee "$ASSIGNEE" -n "{assignees: [\$assignee]}")" \
-      "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}/assignees"
+      -d "$(jq -r --arg assignee "$ASSIGNEE" -n "{reviewers: [\$assignee], team_reviewers: []}")" \
+      "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/${PR_NUMBER}/requested_reviewers"

--- a/.ci/containers/contributor-checker/check-contributor.sh
+++ b/.ci/containers/contributor-checker/check-contributor.sh
@@ -18,7 +18,7 @@ ASSIGNEE=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
 
 # This is where you add users who do not need to have an assignee chosen for
 # the.
-if $(echo $USER | fgrep -wq -e ndmckinley -e danawillow -e emilymye -e erjohnso -e geojaz -e megan07 -e paddycarver -e rambleraptor -e SirGitsalot -e slevenick -e c2thorn -e rileykarson); then
+if $(echo $USER | fgrep -wq -e ndmckinley -e danawillow -e emilymye -e erjohnso -e megan07 -e paddycarver -e rambleraptor -e SirGitsalot -e slevenick -e c2thorn -e rileykarson); then
   echo "User is on the list, not assigning."
   exit 0
 fi

--- a/.ci/containers/contributor-checker/check-contributor.sh
+++ b/.ci/containers/contributor-checker/check-contributor.sh
@@ -8,21 +8,30 @@ if [ $# -lt 1 ]; then
     exit 1
 fi
 PR_NUMBER=$1
+set -x
 
 USER=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
   "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}" | jq .user.login)
+
+ASSIGNEE=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}" | jq .assignee.login)
 
 # This is where you add users who do not need to have an assignee chosen for
 # the.
 if $(echo $USER | fgrep -wq -e ndmckinley -e danawillow -e emilymye -e erjohnso -e geojaz -e megan07 -e paddycarver -e rambleraptor -e SirGitsalot -e slevenick -e c2thorn -e rileykarson); then
   echo "User is on the list, not assigning."
-else
+  exit 0
+fi
+if [ -j "$ASSIGNEE" ] ; then 
+  echo "Issue is assigned, not assigning."
+  exit 0
+fi
 
-  # This is where you add people to the random-assignee rotation.  This list
-  # might not equal the list above.
-  ASSIGNEE=$(shuf -n 1 <(printf "danawillow\nrambleraptor\nemilymye\nrileykarson\nSirGitsalot\nslevenick\nc2thorn\nndmckinley"))
+# This is where you add people to the random-assignee rotation.  This list
+# might not equal the list above.
+ASSIGNEE=$(shuf -n 1 <(printf "danawillow\nrambleraptor\nemilymye\nrileykarson\nSirGitsalot\nslevenick\nc2thorn\nndmckinley"))
 
-  comment=$(cat << EOF
+comment=$(cat << EOF
 Hello!  I am a robot who works on Magic Modules PRs.
 
 I have detected that you are a community contributor, so your PR will be assigned to someone with a commit-bit on this repo for initial review.
@@ -33,11 +42,9 @@ Thanks for your contribution!  A human will be with you soon.
 EOF
 )
 
-  curl -H "Authorization: token ${GITHUB_TOKEN}" \
-        -d "$(jq -r --arg comment "$comment" -n "{body: \$comment}")" \
-        "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}/comments"
-  curl -H "Authorization: token ${GITHUB_TOKEN}" \
-        -d "$(jq -r --arg assignee "$ASSIGNEE" -n "{assignees: [\$assignee]}")" \
-        "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}/assignees"
-
-fi
+curl -H "Authorization: token ${GITHUB_TOKEN}" \
+      -d "$(jq -r --arg comment "$comment" -n "{body: \$comment}")" \
+      "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}/comments"
+curl -H "Authorization: token ${GITHUB_TOKEN}" \
+      -d "$(jq -r --arg assignee "$ASSIGNEE" -n "{assignees: [\$assignee]}")" \
+      "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}/assignees"

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -1,5 +1,10 @@
 ---
 steps:
+    - name: 'gcr.io/graphite-docker-images/contributor-checker'
+      secretEnv: ["GITHUB_TOKEN"]
+      args:
+          - $_PR_NUMBER
+
     # The GCB / GH integration doesn't satisfy our use case perfectly.
     # It doesn't check out the merge commit, and it doesn't check out the repo
     # itself - it only gives us the actual code, not the repo. So we need


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```

This fixes https://github.com/GoogleCloudPlatform/magic-modules/issues/3055.

Weirdly, this time the assignee thing works.

I'll delete concourse soon after this.