### PR TITLE
Add validation to label keys for cloud functions

### DIFF
--- a/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -63,7 +63,7 @@ func labelKeyValidator(val interface{}, key string) (warns []string, errs []erro
 	m := val.(map[string]interface{})
 	for k := range m {
 		if !labelKeyRegex.MatchString(k) {
-			errs = append(errs, fmt.Errorf("%q is an invlaid label key. See https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements", k))
+			errs = append(errs, fmt.Errorf("%q is an invalid label key. See https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements", k))
 		}
 	}
 	return

--- a/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -1,6 +1,8 @@
 package google
 
 import (
+	"regexp"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"google.golang.org/api/cloudfunctions/v1"
@@ -48,6 +50,23 @@ type cloudFunctionId struct {
 
 func (s *cloudFunctionId) cloudFunctionId() string {
 	return fmt.Sprintf("projects/%s/locations/%s/functions/%s", s.Project, s.Region, s.Name)
+}
+
+// matches all international lower case letters, number, underscores and dashes.
+var labelKeyRegex = regexp.MustCompile(`^[\p{Ll}0-9_-]+$`)
+
+func labelKeyValidator(val interface{}, key string) (warns []string, errs []error) {
+	if val == nil {
+		return
+	}
+
+	m := val.(map[string]interface{})
+	for k := range m {
+		if !labelKeyRegex.MatchString(k) {
+			errs = append(errs, fmt.Errorf("%q is an invlaid label key. See https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements", k))
+		}
+	}
+	return
 }
 
 func (s *cloudFunctionId) locationId() string {
@@ -193,8 +212,9 @@ func resourceCloudFunctionsFunction() *schema.Resource {
 			},
 
 			"labels": {
-				Type:     schema.TypeMap,
-				Optional: true,
+				Type:         schema.TypeMap,
+				ValidateFunc: labelKeyValidator,
+				Optional:     true,
 			},
 
 			"runtime": {

--- a/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
+++ b/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
@@ -70,6 +70,51 @@ func TestCloudFunctionsFunction_nameValidator(t *testing.T) {
 	}
 }
 
+func TestValidLabelKeys(t *testing.T) {
+	testCases := []struct {
+		labelKey string
+		valid    bool
+	}{
+		{
+			"test-label", true,
+		},
+		{
+			"test_label", true,
+		},
+		{
+			"MixedCase", false,
+		},
+		{
+			"number-09-dash", true,
+		},
+		{
+			"", false,
+		},
+		{
+			"test-label", true,
+		},
+		{
+			"mixed*symbol", false,
+		},
+		{
+			"intérnätional", true,
+		},
+	}
+
+	for _, tc := range testCases {
+		labels := make(map[string]interface{})
+		labels[tc.labelKey] = "test value"
+
+		_, errs := labelKeyValidator(labels, "")
+		if tc.valid && len(errs) > 0 {
+			t.Errorf("Validation failure, key: '%s' should be valid but actual errors were %q", tc.labelKey, errs)
+		}
+		if !tc.valid && len(errs) < 1 {
+			t.Errorf("Validation failure, key: '%s' should fail but actual errors were %q", tc.labelKey, errs)
+		}
+	}
+}
+
 func TestAccCloudFunctionsFunction_basic(t *testing.T) {
 	t.Parallel()
 

--- a/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
+++ b/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
@@ -125,7 +125,7 @@ Eg. `"nodejs8"`, `"nodejs10"`, `"python37"`, `"go111"`.
 
 * `ingress_settings` - (Optional) String value that controls what traffic can reach the function. Allowed values are ALLOW_ALL and ALLOW_INTERNAL_ONLY. Changes to this field will recreate the cloud function.
 
-* `labels` - (Optional) A set of key/value label pairs to assign to the function.
+* `labels` - (Optional) A set of key/value label pairs to assign to the function. Label keys must follow the requirements at https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements.
 
 * `service_account_email` - (Optional) If provided, the self-provided service account to run the function with.
 
@@ -147,7 +147,7 @@ Eg. `"nodejs8"`, `"nodejs10"`, `"python37"`, `"go111"`.
 The `event_trigger` block supports:
 
 * `event_type` - (Required) The type of event to observe. For example: `"google.storage.object.finalize"`.
-See the documentation on [calling Cloud Functions](https://cloud.google.com/functions/docs/calling/) for a 
+See the documentation on [calling Cloud Functions](https://cloud.google.com/functions/docs/calling/) for a
 full reference of accepted triggers.
 
 * `resource` - (Required) Required. The name or partial URI of the resource from


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-google/issues/6144
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudfunctions: Added validation to label keys for `google_cloudfunctions_function` as API errors aren't useful.
```
