### PR TITLE
Add different api name for screen lock

### DIFF
--- a/products/accesscontextmanager/api.yaml
+++ b/products/accesscontextmanager/api.yaml
@@ -221,6 +221,7 @@ objects:
                 properties:
                   - !ruby/object:Api::Type::Boolean
                     name: 'requireScreenLock'
+                    apiName: 'requireScreenlock'
                     description: |
                       Whether or not screenlock is required for the DevicePolicy
                       to be true. Defaults to false.

--- a/products/accesscontextmanager/api.yaml
+++ b/products/accesscontextmanager/api.yaml
@@ -221,7 +221,7 @@ objects:
                 properties:
                   - !ruby/object:Api::Type::Boolean
                     name: 'requireScreenLock'
-                    apiName: 'requireScreenlock'
+                    api_name: 'requireScreenlock'
                     description: |
                       Whether or not screenlock is required for the DevicePolicy
                       to be true. Defaults to false.

--- a/templates/terraform/examples/access_context_manager_access_level_basic.tf.erb
+++ b/templates/terraform/examples/access_context_manager_access_level_basic.tf.erb
@@ -5,7 +5,7 @@ resource "google_access_context_manager_access_level" "<%= ctx[:primary_resource
   basic {
     conditions {
       device_policy {
-        require_screen_lock = false
+        require_screen_lock = true
         os_constraints {
           os_type = "DESKTOP_CHROME_OS"
         }


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
accesscontextmanager: Fixed setting `require_screen_lock` to true for `google_access_context_manager_access_level`
```

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6195
