### PR TITLE
Make localityLbPolicy updateable

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -1109,7 +1109,6 @@ objects:
           - :INTERNAL_SELF_MANAGED
       - !ruby/object:Api::Type::Enum
         name: 'localityLbPolicy'
-        input: true
         min_version: beta
         values:
           - :ROUND_ROBIN
@@ -1940,7 +1939,6 @@ objects:
           - :INTERNAL_MANAGED
       - !ruby/object:Api::Type::Enum
         name: 'localityLbPolicy'
-        input: true
         min_version: beta
         values:
           - :ROUND_ROBIN


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: Stopped force-recreation of `google_compute_backend_service` and `google_compute_backend_service` on updating `locality_lb_policy
```
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6206