### PR TITLE
Add nil checks to stateful disk flatten

### DIFF
--- a/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
+++ b/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
@@ -767,6 +767,9 @@ func flattenAutoHealingPolicies(autoHealingPolicies []*computeBeta.InstanceGroup
 
 <% unless version == 'ga' -%>
 func flattenStatefulPolicy(statefulPolicy *computeBeta.StatefulPolicy) []map[string]interface{} {
+	if statefulPolicy == nil || statefulPolicy.PreservedState == nil || statefulPolicy.PreservedState.Disks == nil {
+		return make([]map[string]interface{}, 0, 0)
+	}
 	result := make([]map[string]interface{}, 0, len(statefulPolicy.PreservedState.Disks))
 	for deviceName, disk := range statefulPolicy.PreservedState.Disks {
 		data := map[string]interface{}{


### PR DESCRIPTION
Fix nil pointer when stateful policy unspecified in IGM/RIGM. Not currently released so no user-facing impact

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
