### PR TITLE
don't include IGM URLs that 404 in instance_group_urls

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -2172,6 +2172,10 @@ func getInstanceGroupUrlsFromManagerUrls(config *Config, igmUrls []string) ([]st
 		}
 		matches := instanceGroupManagerURL.FindStringSubmatch(u)
 		instanceGroupManager, err := config.clientCompute.InstanceGroupManagers.Get(matches[1], matches[2], matches[3]).Do()
+		if isGoogleApiErrorWithCode(err, 404) {
+			// The IGM URL is stale; don't include it
+			continue
+		}
 		if err != nil {
 			return nil, fmt.Errorf("Error reading instance group manager returned as an instance group URL: %s", err)
 		}

--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -561,6 +561,7 @@ func flattenNodePool(d *schema.ResourceData, config *Config, np *containerBeta.N
 	// instance groups instead. They should all have the same size, but in case a resize
 	// failed or something else strange happened, we'll just use the average size.
 	size := 0
+	igmUrls := []string{}
 	for _, url := range np.InstanceGroupUrls {
 		// retrieve instance group manager (InstanceGroupUrls are actually URLs for InstanceGroupManagers)
 		matches := instanceGroupManagerURL.FindStringSubmatch(url)
@@ -568,10 +569,19 @@ func flattenNodePool(d *schema.ResourceData, config *Config, np *containerBeta.N
 			return nil, fmt.Errorf("Error reading instance group manage URL '%q'", url)
 		}
 		igm, err := config.clientComputeBeta.InstanceGroupManagers.Get(matches[1], matches[2], matches[3]).Do()
+		if isGoogleApiErrorWithCode(err, 404) {
+			// The IGM URL in is stale; don't include it
+			continue
+		}
 		if err != nil {
 			return nil, fmt.Errorf("Error reading instance group manager returned as an instance group URL: %q", err)
 		}
 		size += int(igm.TargetSize)
+		igmUrls = append(igmUrls, url)
+	}
+	nodeCount := 0
+	if len(igmUrls) > 0 {
+		nodeCount = size / len(igmUrls)
 	}
 	nodePool := map[string]interface{}{
 		"name":                np.Name,
@@ -580,9 +590,9 @@ func flattenNodePool(d *schema.ResourceData, config *Config, np *containerBeta.N
 <% unless version == 'ga' -%>
 		"node_locations":      schema.NewSet(schema.HashString, convertStringArrToInterface(np.Locations)),
 <% end -%>
-		"node_count":          size / len(np.InstanceGroupUrls),
+		"node_count":          nodeCount,
 		"node_config":         flattenNodeConfig(np.Config),
-		"instance_group_urls": np.InstanceGroupUrls,
+		"instance_group_urls": igmUrls,
 		"version":             np.Version,
 	}
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4314. 

Tested by creating a cluster and node pools, deleting one of the created IGs in the cloud console, and running `terraform refresh`.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
* container: fixed issue where terraform would error if a gke instance group was deleted out-of-band
```
