### PR TITLE
fix hardcoded int timeouts

### DIFF
--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -497,7 +497,7 @@ func deleteComputeNetwork(project, network string, config *Config) error {
 		return errwrap.Wrapf("Error deleting network: {{err}}", err)
 	}
 
-	err = computeOperationWaitTime(config, op, project, "Deleting Network", 10)
+	err = computeOperationWaitTime(config, op, project, "Deleting Network", 10*time.Minute)
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_google_service_account_key.go
+++ b/third_party/terraform/resources/resource_google_service_account_key.go
@@ -3,6 +3,7 @@ package google
 import (
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -111,7 +112,7 @@ func resourceGoogleServiceAccountKeyCreate(d *schema.ResourceData, meta interfac
 	d.Set("valid_before", sak.ValidBeforeTime)
 	d.Set("private_key", sak.PrivateKeyData)
 
-	err = serviceAccountKeyWaitTime(config.clientIAM.Projects.ServiceAccounts.Keys, d.Id(), d.Get("public_key_type").(string), "Creating Service account key", 4)
+	err = serviceAccountKeyWaitTime(config.clientIAM.Projects.ServiceAccounts.Keys, d.Id(), d.Get("public_key_type").(string), "Creating Service account key", 4*time.Minute)
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -610,7 +610,7 @@ func testSweepComposerEnvironments(config *Config) error {
 				allErrors = multierror.Append(allErrors, fmt.Errorf("Unable to delete environment %q: %s", e.Name, deleteErr))
 				continue
 			}
-			waitErr := composerOperationWaitTime(config, op, config.Project, "Sweeping old test environments", 10)
+			waitErr := composerOperationWaitTime(config, op, config.Project, "Sweeping old test environments", 10*time.Minute)
 			if waitErr != nil {
 				allErrors = multierror.Append(allErrors, fmt.Errorf("Unable to delete environment %q: %s", e.Name, waitErr))
 			}

--- a/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_test.go
@@ -1877,7 +1877,7 @@ func testAccCheckComputeInstanceUpdateMachineType(t *testing.T, n string) resour
 		if err != nil {
 			return fmt.Errorf("Could not stop instance: %s", err)
 		}
-		err = computeOperationWaitTime(config, op, config.Project, "Waiting on stop", 20)
+		err = computeOperationWaitTime(config, op, config.Project, "Waiting on stop", 20*time.Minute)
 		if err != nil {
 			return fmt.Errorf("Could not stop instance: %s", err)
 		}
@@ -1891,7 +1891,7 @@ func testAccCheckComputeInstanceUpdateMachineType(t *testing.T, n string) resour
 		if err != nil {
 			return fmt.Errorf("Could not change machine type: %s", err)
 		}
-		err = computeOperationWaitTime(config, op, config.Project, "Waiting machine type change", 20)
+		err = computeOperationWaitTime(config, op, config.Project, "Waiting machine type change", 20*time.Minute)
 		if err != nil {
 			return fmt.Errorf("Could not change machine type: %s", err)
 		}

--- a/third_party/terraform/utils/bootstrap_utils_test.go
+++ b/third_party/terraform/utils/bootstrap_utils_test.go
@@ -280,7 +280,7 @@ func BootstrapSharedTestNetwork(t *testing.T, testId string) string {
 		}
 
 		log.Printf("[DEBUG] Waiting for network creation to finish")
-		err = computeOperationWaitTime(config, res, project, "Error bootstrapping shared test network", 4)
+		err = computeOperationWaitTime(config, res, project, "Error bootstrapping shared test network", 4*time.Minute)
 		if err != nil {
 			t.Fatalf("Error bootstrapping shared test network %q: %s", networkName, err)
 		}

--- a/third_party/terraform/utils/service_account_waiter.go
+++ b/third_party/terraform/utils/service_account_waiter.go
@@ -33,7 +33,7 @@ func (w *ServiceAccountKeyWaiter) RefreshFunc() resource.StateRefreshFunc {
 	}
 }
 
-func serviceAccountKeyWaitTime(client *iam.ProjectsServiceAccountsKeysService, keyName, publicKeyType, activity string, timeoutMinutes int) error {
+func serviceAccountKeyWaitTime(client *iam.ProjectsServiceAccountsKeysService, keyName, publicKeyType, activity string, timeout time.Duration) error {
 	w := &ServiceAccountKeyWaiter{
 		Service:       client,
 		PublicKeyType: publicKeyType,
@@ -44,7 +44,7 @@ func serviceAccountKeyWaitTime(client *iam.ProjectsServiceAccountsKeysService, k
 		Pending:    []string{"PENDING"},
 		Target:     []string{"DONE"},
 		Refresh:    w.RefreshFunc(),
-		Timeout:    time.Duration(timeoutMinutes) * time.Minute,
+		Timeout:    timeout,
 		MinTimeout: 2 * time.Second,
 	}
 	_, err := c.WaitForState()


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->
Fixes TestAccComputeInstance_forceChangeMachineTypeManually and TestAccProject_deleteDefaultNetwork. Found the rest by searching for `WaitTime\(.*, .*, .*, .*, .*\d\)`. It's possible there are still some left if they're split across lines or use a variable, but ~I don't know  how to find those.~  I'll do it in a follow-up if there are any, since it'll take a bit of extra work.

Either this change should get cherrypicked into the release that was cut last night, or the culprit PR should be removed from the release. Since this is just fixing an unreleased change, not adding a release note.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
