### PR TITLE
Add back requireds on stripquery

### DIFF
--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -263,6 +263,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         description: |
           The source snapshot used to create this disk. You can provide this as
           a partial or full URL to the resource.
+  RegionUrlMap: !ruby/object:Overrides::Ansible::ResourceOverride
+    properties:
+      pathMatchers.defaultUrlRedirect.stripQuery: !ruby/object:Overrides::Ansible::PropertyOverride
+        default_value: false
+      defaultUrlRedirect.stripQuery: !ruby/object:Overrides::Ansible::PropertyOverride
+        default_value: false
+      pathMatchers.pathRules.urlRedirect.stripQuery: !ruby/object:Overrides::Ansible::PropertyOverride
+        default_value: false
   Reservation: !ruby/object:Overrides::Ansible::ResourceOverride
     properties:
       specificReservation.instanceProperties.minCpuPlatform: !ruby/object:Overrides::Ansible::PropertyOverride
@@ -333,6 +341,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     exclude: true
   SecurityPolicy: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
+  UrlMap: !ruby/object:Overrides::Ansible::ResourceOverride
+    properties:
+      pathMatchers.defaultUrlRedirect.stripQuery: !ruby/object:Overrides::Ansible::PropertyOverride
+        default_value: false
+      defaultUrlRedirect.stripQuery: !ruby/object:Overrides::Ansible::PropertyOverride
+        default_value: false
+      pathMatchers.pathRules.urlRedirect.stripQuery: !ruby/object:Overrides::Ansible::PropertyOverride
+        default_value: false
   Zone: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
 files: !ruby/object:Provider::Config::Files

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -9452,7 +9452,7 @@ objects:
                           - :TEMPORARY_REDIRECT
                       - !ruby/object:Api::Type::Boolean
                         name: 'stripQuery'
-                        required: true
+                        default_value: false
                         description: |
                           If set to true, any accompanying query portion of the original URL is
                           removed prior to redirecting the request. If set to false, the query
@@ -9871,7 +9871,7 @@ objects:
                           - :TEMPORARY_REDIRECT
                       - !ruby/object:Api::Type::Boolean
                         name: 'stripQuery'
-                        required: true
+                        default_value: false
                         description: |
                           If set to true, any accompanying query portion of the original URL is removed
                           prior to redirecting the request. If set to false, the query portion of the
@@ -9935,11 +9935,11 @@ objects:
                     - :TEMPORARY_REDIRECT
                 - !ruby/object:Api::Type::Boolean
                   name: 'stripQuery'
-                  required: true
+                  default_value: false
                   description: |
                     If set to true, any accompanying query portion of the original URL is removed prior
                     to redirecting the request. If set to false, the query portion of the original URL is
-                    retained. The default value is false.
+                    retained.
       - !ruby/object:Api::Type::Array
         name: 'tests'
         description: |
@@ -10025,11 +10025,11 @@ objects:
               - :TEMPORARY_REDIRECT
           - !ruby/object:Api::Type::Boolean
             name: 'stripQuery'
-            required: true
+            default_value: false
             description: |
               If set to true, any accompanying query portion of the original URL is removed prior
               to redirecting the request. If set to false, the query portion of the original URL is
-              retained. The default value is false.
+              retained.
   - !ruby/object:Api::Resource
     name: 'RegionHealthCheck'
     kind: 'compute#healthCheck'
@@ -14437,11 +14437,11 @@ objects:
                           - :TEMPORARY_REDIRECT
                       - !ruby/object:Api::Type::Boolean
                         name: 'stripQuery'
-                        required: true
+                        default_value: false
                         description: |
                           If set to true, any accompanying query portion of the original URL is
                           removed prior to redirecting the request. If set to false, the query
-                          portion of the original URL is retained. The default value is false.
+                          portion of the original URL is retained.
             - !ruby/object:Api::Type::Array
               name: 'routeRules'
               description: |
@@ -15116,11 +15116,11 @@ objects:
                           - :TEMPORARY_REDIRECT
                       - !ruby/object:Api::Type::Boolean
                         name: 'stripQuery'
-                        required: true
+                        default_value: false
                         description: |
                           If set to true, any accompanying query portion of the original URL is removed
                           prior to redirecting the request. If set to false, the query portion of the
-                          original URL is retained. The default value is false.
+                          original URL is retained.
             - !ruby/object:Api::Type::NestedObject
               name: 'defaultUrlRedirect'
               # TODO: add defaultRouteAction.weightedBackendService here once they are supported.
@@ -15184,7 +15184,7 @@ objects:
                   description: |
                     If set to true, any accompanying query portion of the original URL is removed prior
                     to redirecting the request. If set to false, the query portion of the original URL is
-                    retained. The default is set to false.
+                    retained.
       - !ruby/object:Api::Type::Array
         name: 'tests'
         description: |

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -9452,11 +9452,11 @@ objects:
                           - :TEMPORARY_REDIRECT
                       - !ruby/object:Api::Type::Boolean
                         name: 'stripQuery'
-                        default_value: false
+                        required: true
                         description: |
                           If set to true, any accompanying query portion of the original URL is
                           removed prior to redirecting the request. If set to false, the query
-                          portion of the original URL is retained. The default is set to false.
+                          portion of the original URL is retained. The default value is false.
             - !ruby/object:Api::Type::Array
               name: 'pathRules'
               description: |
@@ -9871,11 +9871,11 @@ objects:
                           - :TEMPORARY_REDIRECT
                       - !ruby/object:Api::Type::Boolean
                         name: 'stripQuery'
-                        default_value: false
+                        required: true
                         description: |
                           If set to true, any accompanying query portion of the original URL is removed
                           prior to redirecting the request. If set to false, the query portion of the
-                          original URL is retained.
+                          original URL is retained. The default value is false.
             - !ruby/object:Api::Type::NestedObject
               name: 'defaultUrlRedirect'
               # TODO: add defaultRouteAction.weightedBackendService here once they are supported.
@@ -9935,11 +9935,11 @@ objects:
                     - :TEMPORARY_REDIRECT
                 - !ruby/object:Api::Type::Boolean
                   name: 'stripQuery'
-                  default_value: false
+                  required: true
                   description: |
                     If set to true, any accompanying query portion of the original URL is removed prior
                     to redirecting the request. If set to false, the query portion of the original URL is
-                    retained. The default is set to false.
+                    retained. The default value is false.
       - !ruby/object:Api::Type::Array
         name: 'tests'
         description: |
@@ -10025,11 +10025,11 @@ objects:
               - :TEMPORARY_REDIRECT
           - !ruby/object:Api::Type::Boolean
             name: 'stripQuery'
-            default_value: false
+            required: true
             description: |
               If set to true, any accompanying query portion of the original URL is removed prior
               to redirecting the request. If set to false, the query portion of the original URL is
-              retained. The default is set to false.
+              retained. The default value is false.
   - !ruby/object:Api::Resource
     name: 'RegionHealthCheck'
     kind: 'compute#healthCheck'
@@ -14437,11 +14437,11 @@ objects:
                           - :TEMPORARY_REDIRECT
                       - !ruby/object:Api::Type::Boolean
                         name: 'stripQuery'
-                        default_value: false
+                        required: true
                         description: |
                           If set to true, any accompanying query portion of the original URL is
                           removed prior to redirecting the request. If set to false, the query
-                          portion of the original URL is retained. The default is set to false.
+                          portion of the original URL is retained. The default value is false.
             - !ruby/object:Api::Type::Array
               name: 'routeRules'
               description: |
@@ -15116,11 +15116,11 @@ objects:
                           - :TEMPORARY_REDIRECT
                       - !ruby/object:Api::Type::Boolean
                         name: 'stripQuery'
-                        default_value: false
+                        required: true
                         description: |
                           If set to true, any accompanying query portion of the original URL is removed
                           prior to redirecting the request. If set to false, the query portion of the
-                          original URL is retained. Defaults to false.
+                          original URL is retained. The default value is false.
             - !ruby/object:Api::Type::NestedObject
               name: 'defaultUrlRedirect'
               # TODO: add defaultRouteAction.weightedBackendService here once they are supported.

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -9871,7 +9871,6 @@ objects:
                           - :TEMPORARY_REDIRECT
                       - !ruby/object:Api::Type::Boolean
                         name: 'stripQuery'
-                        default_value: false
                         description: |
                           If set to true, any accompanying query portion of the original URL is removed
                           prior to redirecting the request. If set to false, the query portion of the
@@ -9935,7 +9934,6 @@ objects:
                     - :TEMPORARY_REDIRECT
                 - !ruby/object:Api::Type::Boolean
                   name: 'stripQuery'
-                  default_value: false
                   description: |
                     If set to true, any accompanying query portion of the original URL is removed prior
                     to redirecting the request. If set to false, the query portion of the original URL is
@@ -10025,7 +10023,6 @@ objects:
               - :TEMPORARY_REDIRECT
           - !ruby/object:Api::Type::Boolean
             name: 'stripQuery'
-            default_value: false
             description: |
               If set to true, any accompanying query portion of the original URL is removed prior
               to redirecting the request. If set to false, the query portion of the original URL is
@@ -14437,7 +14434,6 @@ objects:
                           - :TEMPORARY_REDIRECT
                       - !ruby/object:Api::Type::Boolean
                         name: 'stripQuery'
-                        default_value: false
                         description: |
                           If set to true, any accompanying query portion of the original URL is
                           removed prior to redirecting the request. If set to false, the query
@@ -15120,7 +15116,7 @@ objects:
                         description: |
                           If set to true, any accompanying query portion of the original URL is removed
                           prior to redirecting the request. If set to false, the query portion of the
-                          original URL is retained.
+                          original URL is retained. Defaults to false.
             - !ruby/object:Api::Type::NestedObject
               name: 'defaultUrlRedirect'
               # TODO: add defaultRouteAction.weightedBackendService here once they are supported.
@@ -15180,7 +15176,6 @@ objects:
                     - :TEMPORARY_REDIRECT
                 - !ruby/object:Api::Type::Boolean
                   name: 'stripQuery'
-                  default_value: false
                   description: |
                     If set to true, any accompanying query portion of the original URL is removed prior
                     to redirecting the request. If set to false, the query portion of the original URL is
@@ -15273,7 +15268,6 @@ objects:
               - :TEMPORARY_REDIRECT
           - !ruby/object:Api::Type::Boolean
             name: 'stripQuery'
-            default_value: false
             description: |
               If set to true, any accompanying query portion of the original URL is removed prior
               to redirecting the request. If set to false, the query portion of the original URL is

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -9874,7 +9874,7 @@ objects:
                         description: |
                           If set to true, any accompanying query portion of the original URL is removed
                           prior to redirecting the request. If set to false, the query portion of the
-                          original URL is retained. The default value is false.
+                          original URL is retained.
             - !ruby/object:Api::Type::NestedObject
               name: 'defaultUrlRedirect'
               # TODO: add defaultRouteAction.weightedBackendService here once they are supported.

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1500,10 +1500,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       pathMatchers.defaultUrlRedirect.stripQuery: !ruby/object:Overrides::Terraform::PropertyOverride
         required: true
         description: '{{description}} This field is required to ensure an empty block is not set. The normal default value is false.'
-      pathMatchers.pathRules.urlRedirect.stripQuery: !ruby/object:Overrides::Terraform::PropertyOverride
+      defaultUrlRedirect.stripQuery: !ruby/object:Overrides::Terraform::PropertyOverride
         required: true
         description: '{{description}} This field is required to ensure an empty block is not set. The normal default value is false.'
-      pathMatchers.routeRules.urlRedirect.stripQuery: !ruby/object:Overrides::Terraform::PropertyOverride
+      pathMatchers.pathRules.urlRedirect.stripQuery: !ruby/object:Overrides::Terraform::PropertyOverride
         required: true
         description: '{{description}} This field is required to ensure an empty block is not set. The normal default value is false.'
   ResourcePolicy: !ruby/object:Overrides::Terraform::ResourceOverride
@@ -2343,10 +2343,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       pathMatchers.defaultUrlRedirect.stripQuery: !ruby/object:Overrides::Terraform::PropertyOverride
         required: true
         description: '{{description}} This field is required to ensure an empty block is not set. The normal default value is false.'
-      pathMatchers.pathRules.urlRedirect.stripQuery: !ruby/object:Overrides::Terraform::PropertyOverride
+      defaultUrlRedirect.stripQuery: !ruby/object:Overrides::Terraform::PropertyOverride
         required: true
         description: '{{description}} This field is required to ensure an empty block is not set. The normal default value is false.'
-      pathMatchers.routeRules.urlRedirect.stripQuery: !ruby/object:Overrides::Terraform::PropertyOverride
+      pathMatchers.pathRules.urlRedirect.stripQuery: !ruby/object:Overrides::Terraform::PropertyOverride
         required: true
         description: '{{description}} This field is required to ensure an empty block is not set. The normal default value is false.'
   VpnTunnel: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1497,6 +1497,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         is_set: true
       tests: !ruby/object:Overrides::Terraform::PropertyOverride
         name: "test"
+      pathMatchers.defaultUrlRedirect.stripQuery: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: true
+        description: '{{description}} This field is required to ensure an empty block is not set. The normal default value is false.'
+      pathMatchers.pathRules.urlRedirect.stripQuery: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: true
+        description: '{{description}} This field is required to ensure an empty block is not set. The normal default value is false.'
+      pathMatchers.routeRules.urlRedirect.stripQuery: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: true
+        description: '{{description}} This field is required to ensure an empty block is not set. The normal default value is false.'
   ResourcePolicy: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples
@@ -2331,6 +2340,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         description: The backend service or backend bucket link that should be matched by this test.
       tests: !ruby/object:Overrides::Terraform::PropertyOverride
         name: "test"
+      pathMatchers.defaultUrlRedirect.stripQuery: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: true
+        description: '{{description}} This field is required to ensure an empty block is not set. The normal default value is false.'
+      pathMatchers.pathRules.urlRedirect.stripQuery: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: true
+        description: '{{description}} This field is required to ensure an empty block is not set. The normal default value is false.'
+      pathMatchers.routeRules.urlRedirect.stripQuery: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: true
+        description: '{{description}} This field is required to ensure an empty block is not set. The normal default value is false.'
   VpnTunnel: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples


### PR DESCRIPTION
Reverts changes from https://github.com/GoogleCloudPlatform/magic-modules/pull/3378 to prevent empty blocks from being valid.

Adds required to the same field that was added in a duplicate object in https://github.com/GoogleCloudPlatform/magic-modules/pull/3379

This should be cherry-picked into 3.20.0

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
