### PR TITLE
Un-guard node_locations on google_container_node_pool resource

### DIFF
--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -103,14 +103,12 @@ var schemaNodePool = map[string]*schema.Schema{
 		Computed:   true,
 	},
 
-<% unless version == 'ga' -%>
 	"node_locations": {
 		Type:     schema.TypeSet,
 		Optional: true,
 		Computed: true,
 		Elem:     &schema.Schema{Type: schema.TypeString},
 	},
-<% end -%>
 
 	"upgrade_settings": {
 		Type:     schema.TypeList,
@@ -493,21 +491,16 @@ func expandNodePool(d *schema.ResourceData, prefix string) (*containerBeta.NodeP
 		nodeCount = nc.(int)
 	}
 
-
-<% unless version == 'ga' -%>
 	var locations []string
 	if v, ok := d.GetOk("node_locations"); ok && v.(*schema.Set).Len() > 0 {
 		locations = convertStringSet(v.(*schema.Set))
 	}
-<% end -%>
 
 	np := &containerBeta.NodePool{
 		Name:             name,
 		InitialNodeCount: int64(nodeCount),
 		Config:           expandNodeConfig(d.Get(prefix + "node_config")),
-<% unless version == 'ga' -%>
 		Locations:        locations,
-<% end -%>
 		Version:          d.Get(prefix + "version").(string),
 	}
 
@@ -587,9 +580,7 @@ func flattenNodePool(d *schema.ResourceData, config *Config, np *containerBeta.N
 		"name":                np.Name,
 		"name_prefix":         d.Get(prefix + "name_prefix"),
 		"initial_node_count":  np.InitialNodeCount,
-<% unless version == 'ga' -%>
 		"node_locations":      schema.NewSet(schema.HashString, convertStringArrToInterface(np.Locations)),
-<% end -%>
 		"node_count":          nodeCount,
 		"node_config":         flattenNodeConfig(np.Config),
 		"instance_group_urls": igmUrls,
@@ -823,7 +814,6 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 		}
 	}
 
-<% unless version == 'ga' -%>
 	if d.HasChange(prefix + "node_locations") {
 		req := &containerBeta.UpdateNodePoolRequest{
 			Locations: convertStringSet(d.Get(prefix + "node_locations").(*schema.Set)),
@@ -850,7 +840,6 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 			d.SetPartial("node_locations")
 		}
 	}
-<% end -%>
 
 	if d.HasChange(prefix + "upgrade_settings") {
 		upgradeSettings := &containerBeta.UpgradeSettings{}

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -32,7 +32,6 @@ func TestAccContainerNodePool_basic(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccContainerNodePool_nodeLocations(t *testing.T) {
 	t.Parallel()
 
@@ -56,7 +55,6 @@ func TestAccContainerNodePool_nodeLocations(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccContainerNodePool_maxPodsPerNode(t *testing.T) {
 	t.Parallel()
@@ -785,7 +783,6 @@ resource "google_container_node_pool" "np" {
 `, cluster, np)
 }
 
-<% unless version == 'ga' -%>
 func testAccContainerNodePool_nodeLocations(cluster, np, network string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "container_network" {
@@ -843,7 +840,6 @@ resource "google_container_node_pool" "np" {
 }
 `, network, cluster, np)
 }
-<% end -%>
 
 func testAccContainerNodePool_maxPodsPerNode(cluster, np, network string) string {
 	return fmt.Sprintf(`

--- a/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -125,7 +125,7 @@ this will force recreation of the resource.
     See the [official documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/flexible-pod-cidr)
     for more information.
 
-* `node_locations` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+* `node_locations` - (Optional)
 The list of zones in which the node pool's nodes should be located. Nodes must
 be in the region of their regional cluster or in the same region as their
 cluster's zone for zonal clusters. If unspecified, the cluster-level


### PR DESCRIPTION
As far as I can tell from the [official documentation](https://cloud.google.com/sdk/gcloud/reference/container/node-pools/create), this feature is now GA, so we can use it in the "google" provider.

This is a follow-up to #2320

@rileykarson 

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
* container: added `node_locations` to `google_container_node_pool` and `google_container_cluster.node_pool` (now available in GA)
```
