### PR TITLE
duplicate fhir version and set it to required

### DIFF
--- a/products/healthcare/api.yaml
+++ b/products/healthcare/api.yaml
@@ -207,7 +207,6 @@ objects:
         exact_version: ga
         required: true
         input: true
-        default_value: :STU3
         values:
           - :DSTU2
           - :STU3

--- a/products/healthcare/api.yaml
+++ b/products/healthcare/api.yaml
@@ -187,11 +187,25 @@ objects:
           ** Changing this property may recreate the FHIR store (removing all data) **
         required: true
         input: true
+      # Version is duplicated because it is optional in beta but required in GA.
       - !ruby/object:Api::Type::Enum
         name: version
         description: |
           The FHIR specification version.
-        required: false # TODO: Make this field required in GA.
+        exact_version: beta
+        required: false
+        input: true
+        default_value: :STU3
+        values:
+          - :DSTU2
+          - :STU3
+          - :R4
+      - !ruby/object:Api::Type::Enum
+        name: version
+        description: |
+          The FHIR specification version.
+        exact_version: ga
+        required: true
         input: true
         default_value: :STU3
         values:


### PR DESCRIPTION
cc @chrisst 

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
healthcare: Added the required option to `version` for FHIR stores to discourage users from accidentally using older versions.
```
