### PR TITLE
Allow `subnetwork` field of google_dataflow_job to accept self_links and partial URIs

### DIFF
--- a/third_party/terraform/resources/resource_dataflow_job.go
+++ b/third_party/terraform/resources/resource_dataflow_job.go
@@ -3,6 +3,7 @@ package google
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 
@@ -23,6 +24,8 @@ var dataflowTerminalStatesMap = map[string]struct{}{
 	"JOB_STATE_UPDATED":   {},
 	"JOB_STATE_DRAINED":   {},
 }
+
+var validSubnetFormatRegex = regexp.MustCompile(`regions/(?P<region>[^/]+)/subnetworks/(?P<name>[^/]+)$`)
 
 func resourceDataflowJobLabelDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	// Example Diff: "labels.goog-dataflow-provided-template-version": "word_count" => ""
@@ -135,7 +138,7 @@ func resourceDataflowJob() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				ForceNew:         true,
-				DiffSuppressFunc: compareSelfLinkOrResourceName,
+				DiffSuppressFunc: resourceDataflowJobSubnetworkDiffSuppress,
 			},
 
 			"machine_type": {
@@ -186,6 +189,11 @@ func resourceDataflowJobCreate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	subnetwork, err := getSubnetwork(d)
+	if err != nil {
+		return err
+	}
+
 	params := expandStringMap(d, "parameters")
 	labels := expandStringMap(d, "labels")
 	additionalExperiments := convertStringSet(d.Get("additional_experiments").(*schema.Set))
@@ -194,7 +202,7 @@ func resourceDataflowJobCreate(d *schema.ResourceData, meta interface{}) error {
 		MaxWorkers:            int64(d.Get("max_workers").(int)),
 		Network:               d.Get("network").(string),
 		ServiceAccountEmail:   d.Get("service_account_email").(string),
-		Subnetwork:            d.Get("subnetwork").(string),
+		Subnetwork:            subnetwork,
 		TempLocation:          d.Get("temp_gcs_location").(string),
 		MachineType:           d.Get("machine_type").(string),
 		IpConfiguration:       d.Get("ip_configuration").(string),
@@ -363,4 +371,34 @@ func resourceDataflowJobUpdateJob(config *Config, project string, region string,
 		return config.clientDataflow.Projects.Jobs.Update(project, id, job).Do()
 	}
 	return config.clientDataflow.Projects.Locations.Jobs.Update(project, region, id, job).Do()
+}
+
+func resourceDataflowJobSubnetworkDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
+	if match := validSubnetFormatRegex.FindString(new); match != "" {
+		oldMatch := validSubnetFormatRegex.FindString(old)
+		return oldMatch != "" && oldMatch == match
+	}
+	return false
+}
+
+func getSubnetwork(d *schema.ResourceData) (string, error) {
+	subnetwork := d.Get("subnetwork").(string)
+	if subnetwork == "" {
+		return "", nil
+	}
+	return toValidSubnetworkFormat(subnetwork)
+}
+
+// toValidSubnetworkFormat converts the given string to a valid subnetwork
+// string recognizable by the Dataflow API (i.e. in the format of
+// "regions/REGION/subnetworks/SUBNETWORK"). Returns an error if not possible.
+// This function exists to allow subnetworks to be specified as one of:
+// (1) self_links: https://www.googleapis.com/compute/v1/projects/PROJECT/regions/REGION/subnetworks/SUBNETWORK
+// (2) partial URIs: projects/PROJECT/regions/REGION/subnetworks/SUBNETWORK
+// (3) Dataflow subnetwork format: regions/REGION/subnetworks/SUBNETWORK
+func toValidSubnetworkFormat(subnetwork string) (string, error) {
+	if match := validSubnetFormatRegex.FindString(subnetwork); match != "" {
+		return match, nil
+	}
+	return "", fmt.Errorf("could not convert subnetwork %q to a valid format recognizable by the Dataflow API", subnetwork)
 }

--- a/third_party/terraform/tests/resource_dataflow_job_test.go
+++ b/third_party/terraform/tests/resource_dataflow_job_test.go
@@ -118,6 +118,9 @@ func TestAccDataflowJob_withSubnetwork(t *testing.T) {
 	job := "tf-test-dataflow-job-" + randStr
 	network := "tf-test-dataflow-net" + randStr
 	subnetwork := "tf-test-dataflow-subnet" + randStr
+	subnetValAsSelfLink := "${google_compute_subnetwork.subnet.self_link}"
+	subnetValAsPartialURI := fmt.Sprintf("projects/%s/regions/us-central1/subnetworks/%s", getTestProjectFromEnv(), subnetwork)
+	subnetValAsFormatAcceptedByDataflow := fmt.Sprintf("regions/us-central1/subnetworks/%s", subnetwork)
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -125,11 +128,29 @@ func TestAccDataflowJob_withSubnetwork(t *testing.T) {
 		CheckDestroy: testAccCheckDataflowJobDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataflowJob_subnetwork(bucket, job, network, subnetwork),
+				Config: testAccDataflowJob_subnetwork(bucket, job, network, subnetwork, subnetValAsSelfLink),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataflowJobExists(t, "google_dataflow_job.big_data"),
 					testAccDataflowJobHasSubnetwork(t, "google_dataflow_job.big_data", subnetwork),
 				),
+			},
+			{
+				Config:             testAccDataflowJob_subnetwork(bucket, job, network, subnetwork, subnetValAsPartialURI),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config:             testAccDataflowJob_subnetwork(bucket, job, network, subnetwork, subnetValAsFormatAcceptedByDataflow),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			// The google_dataflow_job must refer to the google_compute_subnetwork using the "google_compute_subnetwork.<name>" expression in the
+			// first and last test steps in order allow Terraform to know about the resource dependency, ensuring that the subnetwork is created
+			// before the job is created and deleted after the job is deleted.
+			{
+				Config:             testAccDataflowJob_subnetwork(bucket, job, network, subnetwork, subnetValAsSelfLink),
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
 			},
 		},
 	})
@@ -516,7 +537,7 @@ resource "google_dataflow_job" "big_data" {
 `, bucket, network, job, testDataflowJobTemplateWordCountUrl, testDataflowJobSampleFileUrl)
 }
 
-func testAccDataflowJob_subnetwork(bucket, job, network, subnet string) string {
+func testAccDataflowJob_subnetwork(bucket, job, network, subnet, subnetVal string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "temp" {
   name = "%s"
@@ -530,6 +551,7 @@ resource "google_compute_network" "net" {
 
 resource "google_compute_subnetwork" "subnet" {
   name          = "%s"
+  region        = "us-central1"
   ip_cidr_range = "10.2.0.0/16"
   network       = google_compute_network.net.self_link
 }
@@ -537,7 +559,7 @@ resource "google_compute_subnetwork" "subnet" {
 resource "google_dataflow_job" "big_data" {
   name = "%s"
 
-  subnetwork        = google_compute_subnetwork.subnet.self_link
+  subnetwork        = "%s"
 
   template_gcs_path = "%s"
   temp_gcs_location = google_storage_bucket.temp.url
@@ -547,7 +569,7 @@ resource "google_dataflow_job" "big_data" {
   }
   on_delete = "cancel"
 }
-`, bucket, network, subnet, job, testDataflowJobTemplateWordCountUrl, testDataflowJobSampleFileUrl)
+`, bucket, network, subnet, job, subnetVal, testDataflowJobTemplateWordCountUrl, testDataflowJobSampleFileUrl)
 }
 
 func testAccDataflowJob_serviceAccount(bucket, job, accountId string) string {

--- a/third_party/terraform/website/docs/r/dataflow_job.html.markdown
+++ b/third_party/terraform/website/docs/r/dataflow_job.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 * `zone` - (Optional) The zone in which the created job should run. If it is not provided, the provider zone is used.
 * `service_account_email` - (Optional) The Service Account email used to create the job.
 * `network` - (Optional) The network to which VMs will be assigned. If it is not provided, "default" will be used.
-* `subnetwork` - (Optional) The subnetwork to which VMs will be assigned. Should be of the form "regions/REGION/subnetworks/SUBNETWORK".
+* `subnetwork` - (Optional) The subnetwork to which VMs will be assigned. This can be one of: the subnetwork's `self_link`, `projects/{project}/regions/{region}/subnetworks/{subnetwork}`, or `regions/{region}/subnetworks/{subnetwork}`.
 * `machine_type` - (Optional) The machine type to use for the job.
 * `ip_configuration` - (Optional) The configuration for VM IPs.  Options are `"WORKER_IP_PUBLIC"` or `"WORKER_IP_PRIVATE"`.
 * `additional_experiments` - (Optional) List of experiments that should be used by the job. An example value is `["enable_stackdriver_agent_metrics"]`.


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
`dataflow`: Allow `google_dataflow_job.subnetwork` to accept self links or partial URIs.
```
Upstreams https://github.com/terraform-providers/terraform-provider-google/pull/5706