### PR TITLE
Upstream tpgb #1963

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -57,6 +57,7 @@ var (
 		"addons_config.0.istio_config",
 		"addons_config.0.cloudrun_config",
 		"addons_config.0.dns_cache_config",
+		"addons_config.0.kalm_config",
 		"addons_config.0.gce_persistent_disk_csi_driver_config",
 	<% end -%>
 	}
@@ -276,6 +277,21 @@ func resourceContainerCluster() *schema.Resource {
 							},
 						},
 						"dns_cache_config": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: addonsConfigKeys,
+							MaxItems:     1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+								},
+							},
+						},
+						"kalm_config": {
 							Type:         schema.TypeList,
 							Optional:     true,
 							Computed:     true,
@@ -2243,6 +2259,14 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 		}
 	}
 
+	if v, ok := config["kalm_config"]; ok && len(v.([]interface{})) > 0 {
+		addon := v.([]interface{})[0].(map[string]interface{})
+		ac.KalmConfig = &containerBeta.KalmConfig{
+			Enabled:         addon["enabled"].(bool),
+			ForceSendFields: []string{"Enabled"},
+		}
+	}
+
 	if v, ok := config["gce_persistent_disk_csi_driver_config"]; ok && len(v.([]interface{})) > 0 {
 		addon := v.([]interface{})[0].(map[string]interface{})
 		ac.GcePersistentDiskCsiDriverConfig = &containerBeta.GcePersistentDiskCsiDriverConfig{
@@ -2664,6 +2688,14 @@ func flattenClusterAddonsConfig(c *containerBeta.AddonsConfig) []map[string]inte
 		result["dns_cache_config"] = []map[string]interface{}{
 			{
 				"enabled": c.DnsCacheConfig.Enabled,
+			},
+		}
+	}
+
+	if c.KalmConfig != nil {
+		result["kalm_config"] = []map[string]interface{}{
+			{
+				"enabled": c.KalmConfig.Enabled,
 			},
 		}
 	}

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1989,6 +1989,9 @@ resource "google_container_cluster" "primary" {
     dns_cache_config {
       enabled = false
     }
+    kalm_config {
+      enabled = false
+    }
     gce_persistent_disk_csi_driver_config {
       enabled = false
     }
@@ -2027,6 +2030,9 @@ resource "google_container_cluster" "primary" {
     }
     dns_cache_config {
       enabled = true
+    }
+    kalm_config {
+      enabled = false
     }
     gce_persistent_disk_csi_driver_config {
       enabled = true

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -337,6 +337,9 @@ The `addons_config` block supports:
 
 * `gce_persistent_disk_csi_driver_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)).
     Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. Defaults to disabled; set `enabled = true` to enable. 
+    
+* `kalm_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)).
+Whether this cluster should enable the Google Compute Engine Application Delibery (KALM) addon. Defaults to disabled; set `enabled = true` to enable.
 
 This example `addons_config` disables two addons:
 


### PR DESCRIPTION
Upstreams https://github.com/terraform-providers/terraform-provider-google-beta/pull/1963.

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
`container`: Add `addons.kalm_config` to `google_container_cluster`.
```
