### PR TITLE
Make consistent hash computed

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -208,6 +208,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         is_set: true
       cdnPolicy.cacheKeyPolicy.queryStringBlacklist: !ruby/object:Overrides::Terraform::PropertyOverride
         is_set: true
+      consistentHash:  !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       connectionDraining: !ruby/object:Overrides::Terraform::PropertyOverride
         flatten_object: true
       connectionDraining.drainingTimeoutSec: !ruby/object:Overrides::Terraform::PropertyOverride
@@ -302,6 +304,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: connection_draining_timeout_sec
         default_value: 0
         send_empty_value: true
+      consistentHash:  !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       healthChecks: !ruby/object:Overrides::Terraform::PropertyOverride
         is_set: true
         set_hash_func: 'selfLinkRelativePathHash'


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: Fixed `google_compute_backend_service` and `google_compute_region_backend_service` to default to API value for `consistent_hash`
```
