### PR TITLE
add deletion_protection field for bigtable instance

### DIFF
--- a/products/bigtable/terraform.yaml
+++ b/products/bigtable/terraform.yaml
@@ -28,11 +28,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           instance_name: "bt-instance"
           app_profile_name: "bt-profile"
-          allow_destroy: "false"
+          deletion_protection: "true"
         test_vars_overrides:
-          allow_destroy: "true"
+          deletion_protection: "false"
         oics_vars_overrides:
-          allow_destroy: "true"
+          deletion_protection: "false"
         ignore_read_extra:
           - "ignore_warnings"
       - !ruby/object:Provider::Terraform::Examples
@@ -41,11 +41,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           instance_name: "bt-instance"
           app_profile_name: "bt-profile"
-          allow_destroy: "false"
+          deletion_protection: "true"
         test_vars_overrides:
-          allow_destroy: "true"
+          deletion_protection: "false"
         oics_vars_overrides:
-          allow_destroy: "true"
+          deletion_protection: "false"
         ignore_read_extra:
           - "ignore_warnings"
     properties:

--- a/products/bigtable/terraform.yaml
+++ b/products/bigtable/terraform.yaml
@@ -28,6 +28,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           instance_name: "bt-instance"
           app_profile_name: "bt-profile"
+          allow_destroy: "false"
+        test_vars_overrides:
+          allow_destroy: "true"
         ignore_read_extra:
           - "ignore_warnings"
       - !ruby/object:Provider::Terraform::Examples
@@ -36,6 +39,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           instance_name: "bt-instance"
           app_profile_name: "bt-profile"
+          allow_destroy: "false"
+        test_vars_overrides:
+          allow_destroy: "true"
         ignore_read_extra:
           - "ignore_warnings"
     properties:

--- a/products/bigtable/terraform.yaml
+++ b/products/bigtable/terraform.yaml
@@ -31,6 +31,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           allow_destroy: "false"
         test_vars_overrides:
           allow_destroy: "true"
+        oics_vars_overrides:
+          allow_destroy: "true"
         ignore_read_extra:
           - "ignore_warnings"
       - !ruby/object:Provider::Terraform::Examples
@@ -41,6 +43,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           app_profile_name: "bt-profile"
           allow_destroy: "false"
         test_vars_overrides:
+          allow_destroy: "true"
+        oics_vars_overrides:
           allow_destroy: "true"
         ignore_read_extra:
           - "ignore_warnings"

--- a/provider/terraform/examples.rb
+++ b/provider/terraform/examples.rb
@@ -81,6 +81,10 @@ module Provider
       #       }
       attr_reader :test_vars_overrides
 
+      # Hash to provider custom override values for generating oics config
+      # See test_vars_overrides for more details
+      attr_reader :oics_vars_overrides
+
       # The version name of of the example's version if it's different than the
       # resource version, eg. `beta`
       #
@@ -193,10 +197,14 @@ module Provider
 
       def config_example
         @vars ||= []
+        @oics_vars_overrides ||= {}
+
+        rand_vars = vars.map { |k, str| [k, "#{str}-${local.name_suffix}"] }.to_h
+
         # Examples with test_env_vars are skipped elsewhere
         body = lines(compile_file(
                        {
-                         vars: vars.map { |k, str| [k, "#{str}-${local.name_suffix}"] }.to_h,
+                         vars: rand_vars.merge(oics_vars_overrides),
                          primary_resource_id: primary_resource_id
                        },
                        config_path

--- a/templates/terraform/examples/bigtable_app_profile_multicluster.tf.erb
+++ b/templates/terraform/examples/bigtable_app_profile_multicluster.tf.erb
@@ -7,7 +7,7 @@ resource "google_bigtable_instance" "instance" {
     storage_type = "HDD"
   }
 
-  allow_destroy  = "<%= ctx[:vars]['allow_destroy'] %>"
+  deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
 }
 
 resource "google_bigtable_app_profile" "ap" {

--- a/templates/terraform/examples/bigtable_app_profile_multicluster.tf.erb
+++ b/templates/terraform/examples/bigtable_app_profile_multicluster.tf.erb
@@ -6,6 +6,8 @@ resource "google_bigtable_instance" "instance" {
     num_nodes    = 3
     storage_type = "HDD"
   }
+
+  allow_destroy  = "<%= ctx[:vars]['allow_destroy'] %>"
 }
 
 resource "google_bigtable_app_profile" "ap" {

--- a/templates/terraform/examples/bigtable_app_profile_singlecluster.tf.erb
+++ b/templates/terraform/examples/bigtable_app_profile_singlecluster.tf.erb
@@ -7,7 +7,7 @@ resource "google_bigtable_instance" "instance" {
     storage_type = "HDD"
   }
 
-  allow_destroy  = "<%= ctx[:vars]['allow_destroy'] %>"
+  deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
 }
 
 resource "google_bigtable_app_profile" "ap" {

--- a/templates/terraform/examples/bigtable_app_profile_singlecluster.tf.erb
+++ b/templates/terraform/examples/bigtable_app_profile_singlecluster.tf.erb
@@ -6,6 +6,8 @@ resource "google_bigtable_instance" "instance" {
     num_nodes    = 3
     storage_type = "HDD"
   }
+
+  allow_destroy  = "<%= ctx[:vars]['allow_destroy'] %>"
 }
 
 resource "google_bigtable_app_profile" "ap" {

--- a/third_party/terraform/resources/resource_bigtable_instance.go
+++ b/third_party/terraform/resources/resource_bigtable_instance.go
@@ -82,6 +82,11 @@ func resourceBigtableInstance() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"DEVELOPMENT", "PRODUCTION"}, false),
 			},
 
+			"allow_destroy": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -235,6 +240,9 @@ func resourceBigtableInstanceUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceBigtableInstanceDestroy(d *schema.ResourceData, meta interface{}) error {
+	if !d.Get("allow_destroy").(bool) {
+		return fmt.Errorf("cannot destroy instance without setting allow_destroy=true and running `terraform apply`")
+	}
 	config := meta.(*Config)
 	ctx := context.Background()
 

--- a/third_party/terraform/resources/resource_bigtable_instance_migrate.go
+++ b/third_party/terraform/resources/resource_bigtable_instance_migrate.go
@@ -1,0 +1,80 @@
+package google
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceBigtableInstanceResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"cluster": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"cluster_id": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"zone": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"num_nodes": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							// DEVELOPMENT instances could get returned with either zero or one node,
+							// so mark as computed.
+							Computed:     true,
+							ValidateFunc: validation.IntAtLeast(1),
+						},
+						"storage_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							Default:      "SSD",
+							ValidateFunc: validation.StringInSlice([]string{"SSD", "HDD"}, false),
+						},
+					},
+				},
+			},
+			"display_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"instance_type": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "PRODUCTION",
+				ValidateFunc: validation.StringInSlice([]string{"DEVELOPMENT", "PRODUCTION"}, false),
+			},
+
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceBigtableInstanceUpgradeV0(rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	log.Printf("[DEBUG] Attributes before migration: %#v", rawState)
+
+	rawState["deletion_protection"] = true
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", rawState)
+	return rawState, nil
+}

--- a/third_party/terraform/tests/resource_bigtable_app_profile_test.go
+++ b/third_party/terraform/tests/resource_bigtable_app_profile_test.go
@@ -50,7 +50,7 @@ resource "google_bigtable_instance" "instance" {
     storage_type = "HDD"
   }
 
-  allow_destroy = true
+  deletion_protection = false
 }
 
 resource "google_bigtable_app_profile" "ap" {
@@ -74,7 +74,7 @@ resource "google_bigtable_instance" "instance" {
     storage_type = "HDD"
   }
 
-  allow_destroy = true
+  deletion_protection = false
 }
 
 resource "google_bigtable_app_profile" "ap" {

--- a/third_party/terraform/tests/resource_bigtable_app_profile_test.go
+++ b/third_party/terraform/tests/resource_bigtable_app_profile_test.go
@@ -49,6 +49,8 @@ resource "google_bigtable_instance" "instance" {
     num_nodes    = 3
     storage_type = "HDD"
   }
+
+  allow_destroy = true
 }
 
 resource "google_bigtable_app_profile" "ap" {
@@ -71,6 +73,8 @@ resource "google_bigtable_instance" "instance" {
     num_nodes    = 3
     storage_type = "HDD"
   }
+
+  allow_destroy = true
 }
 
 resource "google_bigtable_app_profile" "ap" {

--- a/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -136,6 +136,7 @@ resource "google_bigtable_instance" "instance" {
   }
 
   instance_type = "DEVELOPMENT"
+  allow_destroy = "true"
 }
 
 resource "google_bigtable_table" "table" {
@@ -170,6 +171,7 @@ resource "google_bigtable_instance" "instance" {
   }
 
   instance_type = "DEVELOPMENT"
+  allow_destroy = "true"
 }
 
 resource "google_bigtable_table" "table" {

--- a/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -136,7 +136,7 @@ resource "google_bigtable_instance" "instance" {
   }
 
   instance_type = "DEVELOPMENT"
-  allow_destroy = "true"
+  deletion_protection = false
 }
 
 resource "google_bigtable_table" "table" {
@@ -171,7 +171,7 @@ resource "google_bigtable_instance" "instance" {
   }
 
   instance_type = "DEVELOPMENT"
-  allow_destroy = "true"
+  deletion_protection = false
 }
 
 resource "google_bigtable_table" "table" {

--- a/third_party/terraform/tests/resource_bigtable_instance_iam_test.go
+++ b/third_party/terraform/tests/resource_bigtable_instance_iam_test.go
@@ -209,5 +209,7 @@ resource "google_bigtable_instance" "instance" {
       zone         = "us-central1-b"
       storage_type = "HDD"
     }
+
+    allow_destroy = true
 }
 `

--- a/third_party/terraform/tests/resource_bigtable_instance_iam_test.go
+++ b/third_party/terraform/tests/resource_bigtable_instance_iam_test.go
@@ -210,6 +210,6 @@ resource "google_bigtable_instance" "instance" {
       storage_type = "HDD"
     }
 
-    allow_destroy = true
+    deletion_protection = false
 }
 `

--- a/third_party/terraform/tests/resource_bigtable_instance_test.go
+++ b/third_party/terraform/tests/resource_bigtable_instance_test.go
@@ -31,7 +31,7 @@ func TestAccBigtableInstance_basic(t *testing.T) {
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_destroy", "instance_type"}, // we don't read instance type back
+				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type"}, // we don't read instance type back
 			},
 			{
 				Config: testAccBigtableInstance(instanceName, 4),
@@ -40,7 +40,7 @@ func TestAccBigtableInstance_basic(t *testing.T) {
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_destroy", "instance_type"}, // we don't read instance type back
+				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type"}, // we don't read instance type back
 			},
 		},
 	})
@@ -67,7 +67,7 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_destroy", "instance_type"}, // we don't read instance type back
+				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type"}, // we don't read instance type back
 			},
 			{
 				Config: testAccBigtableInstance_clusterReordered(instanceName, 5),
@@ -76,7 +76,7 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_destroy", "instance_type"}, // we don't read instance type back
+				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type"}, // we don't read instance type back
 			},
 			{
 				Config: testAccBigtableInstance_clusterModified(instanceName, 5),
@@ -85,7 +85,7 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_destroy", "instance_type"}, // we don't read instance type back
+				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type"}, // we don't read instance type back
 			},
 			{
 				Config: testAccBigtableInstance_clusterReordered(instanceName, 5),
@@ -94,7 +94,7 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_destroy", "instance_type"}, // we don't read instance type back
+				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type"}, // we don't read instance type back
 			},
 		},
 	})
@@ -117,7 +117,7 @@ func TestAccBigtableInstance_development(t *testing.T) {
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_destroy", "instance_type"}, // we don't read instance type back
+				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type"}, // we don't read instance type back
 			},
 		},
 	})
@@ -140,12 +140,12 @@ func TestAccBigtableInstance_allowDestroy(t *testing.T) {
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"allow_destroy", "instance_type"}, // we don't read instance type back
+				ImportStateVerifyIgnore: []string{"deletion_protection", "instance_type"}, // we don't read instance type back
 			},
 			{
 				Config:      testAccBigtableInstance_noAllowDestroy(instanceName, 3),
 				Destroy:     true,
-				ExpectError: regexp.MustCompile("allow_destroy"),
+				ExpectError: regexp.MustCompile("deletion_protection"),
 			},
 			{
 				Config: testAccBigtableInstance(instanceName, 3),
@@ -191,7 +191,7 @@ resource "google_bigtable_instance" "instance" {
     storage_type = "HDD"
   }
 
-  allow_destroy = true
+  deletion_protection = false
 }
 `, instanceName, instanceName, numNodes)
 }
@@ -233,7 +233,7 @@ resource "google_bigtable_instance" "instance" {
     storage_type = "HDD"
   }
 
-  allow_destroy = true
+  deletion_protection = false
 }
 `, instanceName, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes)
 }
@@ -273,7 +273,7 @@ resource "google_bigtable_instance" "instance" {
     storage_type = "HDD"
   }
 
-  allow_destroy = true
+  deletion_protection = false
 }
 `, instanceName, instanceName, instanceName, instanceName, instanceName, instanceName)
 }
@@ -307,7 +307,7 @@ resource "google_bigtable_instance" "instance" {
     storage_type = "HDD"
   }
 
-  allow_destroy = true
+  deletion_protection = false
 }
 `, instanceName, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes)
 }
@@ -335,7 +335,7 @@ resource "google_bigtable_instance" "instance" {
     storage_type = "HDD"
   }
 
-  allow_destroy = true
+  deletion_protection = false
 }
 `, instanceName, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes)
 }
@@ -350,7 +350,7 @@ resource "google_bigtable_instance" "instance" {
   }
   instance_type = "DEVELOPMENT"
 
-  allow_destroy = true
+  deletion_protection = false
 }
 `, instanceName, instanceName)
 }

--- a/third_party/terraform/tests/resource_bigtable_instance_test.go
+++ b/third_party/terraform/tests/resource_bigtable_instance_test.go
@@ -31,7 +31,7 @@ func TestAccBigtableInstance_basic(t *testing.T) {
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"instance_type"}, // we don't read instance type back
+				ImportStateVerifyIgnore: []string{"allow_destroy", "instance_type"}, // we don't read instance type back
 			},
 			{
 				Config: testAccBigtableInstance(instanceName, 4),
@@ -40,7 +40,7 @@ func TestAccBigtableInstance_basic(t *testing.T) {
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"instance_type"}, // we don't read instance type back
+				ImportStateVerifyIgnore: []string{"allow_destroy", "instance_type"}, // we don't read instance type back
 			},
 		},
 	})
@@ -67,7 +67,7 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"instance_type"}, // we don't read instance type back
+				ImportStateVerifyIgnore: []string{"allow_destroy", "instance_type"}, // we don't read instance type back
 			},
 			{
 				Config: testAccBigtableInstance_clusterReordered(instanceName, 5),
@@ -76,7 +76,7 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"instance_type"}, // we don't read instance type back
+				ImportStateVerifyIgnore: []string{"allow_destroy", "instance_type"}, // we don't read instance type back
 			},
 			{
 				Config: testAccBigtableInstance_clusterModified(instanceName, 5),
@@ -85,7 +85,7 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"instance_type"}, // we don't read instance type back
+				ImportStateVerifyIgnore: []string{"allow_destroy", "instance_type"}, // we don't read instance type back
 			},
 			{
 				Config: testAccBigtableInstance_clusterReordered(instanceName, 5),
@@ -94,7 +94,7 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"instance_type"}, // we don't read instance type back
+				ImportStateVerifyIgnore: []string{"allow_destroy", "instance_type"}, // we don't read instance type back
 			},
 		},
 	})
@@ -117,7 +117,38 @@ func TestAccBigtableInstance_development(t *testing.T) {
 				ResourceName:            "google_bigtable_instance.instance",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"instance_type"}, // we don't read instance type back
+				ImportStateVerifyIgnore: []string{"allow_destroy", "instance_type"}, // we don't read instance type back
+			},
+		},
+	})
+}
+
+func TestAccBigtableInstance_allowDestroy(t *testing.T) {
+	t.Parallel()
+
+	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBigtableInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigtableInstance_noAllowDestroy(instanceName, 3),
+			},
+			{
+				ResourceName:            "google_bigtable_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"allow_destroy", "instance_type"}, // we don't read instance type back
+			},
+			{
+				Config:      testAccBigtableInstance_noAllowDestroy(instanceName, 3),
+				Destroy:     true,
+				ExpectError: regexp.MustCompile("allow_destroy"),
+			},
+			{
+				Config: testAccBigtableInstance(instanceName, 3),
 			},
 		},
 	})
@@ -159,6 +190,8 @@ resource "google_bigtable_instance" "instance" {
     num_nodes    = %d
     storage_type = "HDD"
   }
+
+  allow_destroy = true
 }
 `, instanceName, instanceName, numNodes)
 }
@@ -199,6 +232,8 @@ resource "google_bigtable_instance" "instance" {
     num_nodes    = %d
     storage_type = "HDD"
   }
+
+  allow_destroy = true
 }
 `, instanceName, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes)
 }
@@ -237,6 +272,8 @@ resource "google_bigtable_instance" "instance" {
     num_nodes    = 3
     storage_type = "HDD"
   }
+
+  allow_destroy = true
 }
 `, instanceName, instanceName, instanceName, instanceName, instanceName, instanceName)
 }
@@ -269,6 +306,8 @@ resource "google_bigtable_instance" "instance" {
     num_nodes    = %d
     storage_type = "HDD"
   }
+
+  allow_destroy = true
 }
 `, instanceName, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes)
 }
@@ -295,6 +334,8 @@ resource "google_bigtable_instance" "instance" {
     num_nodes    = %d
     storage_type = "HDD"
   }
+
+  allow_destroy = true
 }
 `, instanceName, instanceName, numNodes, instanceName, numNodes, instanceName, numNodes)
 }
@@ -308,6 +349,22 @@ resource "google_bigtable_instance" "instance" {
     zone       = "us-central1-b"
   }
   instance_type = "DEVELOPMENT"
+
+  allow_destroy = true
 }
 `, instanceName, instanceName)
+}
+
+func testAccBigtableInstance_noAllowDestroy(instanceName string, numNodes int) string {
+	return fmt.Sprintf(`
+resource "google_bigtable_instance" "instance" {
+  name = "%s"
+  cluster {
+    cluster_id   = "%s"
+    zone         = "us-central1-b"
+    num_nodes    = %d
+    storage_type = "HDD"
+  }
+}
+`, instanceName, instanceName, numNodes)
 }

--- a/third_party/terraform/tests/resource_bigtable_table_test.go
+++ b/third_party/terraform/tests/resource_bigtable_table_test.go
@@ -173,7 +173,7 @@ resource "google_bigtable_instance" "instance" {
     zone       = "us-central1-b"
   }
 
-  allow_destroy = true
+  deletion_protection = false
 }
 
 resource "google_bigtable_table" "table" {
@@ -193,7 +193,7 @@ resource "google_bigtable_instance" "instance" {
     zone       = "us-central1-b"
   }
 
-  allow_destroy = true
+  deletion_protection = false
 }
 
 resource "google_bigtable_table" "table" {
@@ -215,7 +215,7 @@ resource "google_bigtable_instance" "instance" {
   }
 
   instance_type = "DEVELOPMENT"
-  allow_destroy = true
+  deletion_protection = false
 }
 
 resource "google_bigtable_table" "table" {
@@ -240,7 +240,7 @@ resource "google_bigtable_instance" "instance" {
   }
 
   instance_type = "DEVELOPMENT"
-  allow_destroy = true
+  deletion_protection = false
 }
 
 resource "google_bigtable_table" "table" {
@@ -269,7 +269,7 @@ resource "google_bigtable_instance" "instance" {
   }
 
   instance_type = "DEVELOPMENT"
-  allow_destroy = true
+  deletion_protection = false
 }
 
 resource "google_bigtable_table" "table" {

--- a/third_party/terraform/tests/resource_bigtable_table_test.go
+++ b/third_party/terraform/tests/resource_bigtable_table_test.go
@@ -172,6 +172,8 @@ resource "google_bigtable_instance" "instance" {
     cluster_id = "%s"
     zone       = "us-central1-b"
   }
+
+  allow_destroy = true
 }
 
 resource "google_bigtable_table" "table" {
@@ -190,6 +192,8 @@ resource "google_bigtable_instance" "instance" {
     cluster_id = "%s"
     zone       = "us-central1-b"
   }
+
+  allow_destroy = true
 }
 
 resource "google_bigtable_table" "table" {
@@ -211,6 +215,7 @@ resource "google_bigtable_instance" "instance" {
   }
 
   instance_type = "DEVELOPMENT"
+  allow_destroy = true
 }
 
 resource "google_bigtable_table" "table" {
@@ -235,6 +240,7 @@ resource "google_bigtable_instance" "instance" {
   }
 
   instance_type = "DEVELOPMENT"
+  allow_destroy = true
 }
 
 resource "google_bigtable_table" "table" {
@@ -263,6 +269,7 @@ resource "google_bigtable_instance" "instance" {
   }
 
   instance_type = "DEVELOPMENT"
+  allow_destroy = true
 }
 
 resource "google_bigtable_table" "table" {

--- a/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -18,6 +18,10 @@ on instances in order to prevent accidental data loss. See
 [Terraform docs](https://www.terraform.io/docs/configuration/resources.html#prevent_destroy)
 for more information on lifecycle parameters.
 
+-> **Note**: On newer versions of the provider, you must explicitly set `allow_destroy=true`
+(and run `terraform apply` to write the field to state) in order to destroy an instance.
+It is recommended to not set this field (or set it to false) until you're ready to destroy.
+
 
 ## Example Usage - Production Instance
 
@@ -50,10 +54,6 @@ resource "google_bigtable_instance" "development-instance" {
     zone         = "us-central1-b"
     storage_type = "HDD"
   }
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 ```
 
@@ -73,6 +73,9 @@ The following arguments are supported:
 * `instance_type` - (Optional) The instance type to create. One of `"DEVELOPMENT"` or `"PRODUCTION"`. Defaults to `"PRODUCTION"`.
 
 * `display_name` - (Optional) The human-readable display name of the Bigtable instance. Defaults to the instance `name`.
+
+* `allow_destroy` - (Optional) Whether or not to allow Terraform to destroy the instance. Unless this field is set to true
+in Terraform state, a `terraform destroy` or `terraform apply` that would delete the instance will fail.
 
 
 -----

--- a/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_instance.html.markdown
@@ -18,9 +18,9 @@ on instances in order to prevent accidental data loss. See
 [Terraform docs](https://www.terraform.io/docs/configuration/resources.html#prevent_destroy)
 for more information on lifecycle parameters.
 
--> **Note**: On newer versions of the provider, you must explicitly set `allow_destroy=true`
+-> **Note**: On newer versions of the provider, you must explicitly set `deletion_protection=false`
 (and run `terraform apply` to write the field to state) in order to destroy an instance.
-It is recommended to not set this field (or set it to false) until you're ready to destroy.
+It is recommended to not set this field (or set it to true) until you're ready to destroy.
 
 
 ## Example Usage - Production Instance
@@ -74,7 +74,7 @@ The following arguments are supported:
 
 * `display_name` - (Optional) The human-readable display name of the Bigtable instance. Defaults to the instance `name`.
 
-* `allow_destroy` - (Optional) Whether or not to allow Terraform to destroy the instance. Unless this field is set to true
+* `deletion_protection` - (Optional) Whether or not to allow Terraform to destroy the instance. Unless this field is set to false
 in Terraform state, a `terraform destroy` or `terraform apply` that would delete the instance will fail.
 
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->
I called it `allow_destroy` to align with `prevent_destroy` and `terraform destroy`, but feel free to suggest a different name if you'd like.

I'm not considering this a breaking change because it doesn't affect users until they want to make a change, but let me know if you disagree.

Once this is merged, I'll follow up with the other bigtable resources.

EDIT: it's called deletion_protection now to align with the field in compute instance.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
* bigtable: added `deletion_protection` field to `google_bigtable_instance` to make deleting them require an explicit intent.
```

```release-note:note
* `google_bigtable_instance` resources now cannot be destroyed unless `deletion_protection = false` is set in state for the resource.
```
