### PR TITLE
Update PR template to request everyone write release notes.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,6 @@
 <!-- AUTOCHANGELOG for Downstream PRs.
 
-EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.
-
-INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
-for writing good release notes.
-
-NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.
-
-Otherwise, fill the template out (replace the heading).
-You can add more release notes if you want more than one CHANGELOG entry for
-this PR, but make sure not to indent notes and to leave newlines between
-code blocks for Markdown's sake.
-
-For Terraform PRs, we use the following "release-note:" headings
+Please select one of the following "release-note:" headings
     - release-note:enhancement
     - release-note:bug
     - release-note:note
@@ -21,6 +9,13 @@ For Terraform PRs, we use the following "release-note:" headings
     - release-note:deprecation
     - release-note:breaking-change
     - release-note:none
+    
+Unless you choose release-note:none, please add a release note.
+
+See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.
+
+You can add more release note blocks if you want more than one CHANGELOG
+entry for this PR.
 -->
 
 **Release Note Template for Downstream PRs (will be copied)**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- AUTOCHANGELOG for Downstream PRs.
 
-Please select one of the following "release-note:" headings
+Please select one of the following "release-note:" headings:
     - release-note:enhancement
     - release-note:bug
     - release-note:note


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```

At least the line about "NO CHANGELOG NOTE" is no longer true, so that should be removed.  While I was in here, I restructured it a bit to suggest that everyone, including external contributors, should give it a try.  :)