### PR TITLE
Fix bigquery table google_sheets_options

### DIFF
--- a/third_party/terraform/resources/resource_bigquery_table.go.erb
+++ b/third_party/terraform/resources/resource_bigquery_table.go.erb
@@ -167,14 +167,20 @@ func resourceBigQueryTable() *schema.Resource {
 									"range": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										AtLeastOneOf: []string{"external_data_configuration.0.google_sheets_options.0.range"},
+										AtLeastOneOf: []string{
+											"external_data_configuration.0.google_sheets_options.0.skip_leading_rows",
+											"external_data_configuration.0.google_sheets_options.0.range",
+										},
 									},
 									// SkipLeadingRows: [Optional] The number of rows at the top
 									// of the sheet that BigQuery will skip when reading the data.
 									"skip_leading_rows": {
 										Type:         schema.TypeInt,
 										Optional:     true,
-										AtLeastOneOf: []string{"external_data_configuration.0.google_sheets_options.0.skip_leading_rows"},
+										AtLeastOneOf: []string{
+											"external_data_configuration.0.google_sheets_options.0.skip_leading_rows",
+											"external_data_configuration.0.google_sheets_options.0.range",
+										},
 									},
 								},
 							},

--- a/third_party/terraform/tests/resource_bigquery_table_test.go.erb
+++ b/third_party/terraform/tests/resource_bigquery_table_test.go.erb
@@ -170,6 +170,30 @@ func TestAccBigQueryExternalDataTable_CSV(t *testing.T) {
 	})
 }
 
+func TestAccBigQueryDataTable_sheet(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBigQueryTableDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTableFromSheet(context),
+			},
+			{
+				ResourceName:      "google_bigquery_table.table",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckBigQueryExtData(t *testing.T, expectedQuoteChar string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
@@ -512,6 +536,60 @@ resource "google_bigquery_table" "test" {
 	}
 }
 `, datasetID, bucketName, objectName, content, tableID, format, quoteChar)
+}
+
+
+
+func testAccBigQueryTableFromSheet(context map[string]interface{}) string {
+	return Nprintf(`
+	resource "google_bigquery_table" "table" {
+		dataset_id = google_bigquery_dataset.dataset.dataset_id
+		table_id   = "tf_test_sheet_%{random_suffix}"
+
+		external_data_configuration {
+		  autodetect            = true
+		  source_format         = "GOOGLE_SHEETS"
+		  ignore_unknown_values = true
+
+		  google_sheets_options {
+			skip_leading_rows = 1
+		  }
+
+		  source_uris = [
+			"https://drive.google.com/open?id=xxxx",
+		  ]
+		}
+
+		schema = <<EOF
+	  [
+		{
+		  "name": "permalink",
+		  "type": "STRING",
+		  "mode": "NULLABLE",
+		  "description": "The Permalink"
+		},
+		{
+		  "name": "state",
+		  "type": "STRING",
+		  "mode": "NULLABLE",
+		  "description": "State where the head office is located"
+		}
+	  ]
+	  EOF
+	  }
+
+	  resource "google_bigquery_dataset" "dataset" {
+		dataset_id                  = "tf_test_ds_%{random_suffix}"
+		friendly_name               = "test"
+		description                 = "This is a test description"
+		location                    = "EU"
+		default_table_expiration_ms = 3600000
+
+		labels = {
+		  env = "default"
+		}
+	  }
+`, context)
 }
 
 var TEST_CSV = `lifelock,LifeLock,,web,Tempe,AZ,1-May-07,6850000,USD,b


### PR DESCRIPTION
The at least one of validation has been changed to actually allow at least one
of the options.

fixes https://github.com/terraform-providers/terraform-provider-google/issues/5645

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquery: Fixed the `google_sheets_options` at least one of logic.
```
