### PR TITLE
Fix metadata for storage bucket object

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_storage_bucket_object.go
+++ b/third_party/terraform/data_sources/data_source_google_storage_bucket_object.go
@@ -49,6 +49,7 @@ func dataSourceGoogleStorageBucketObjectRead(d *schema.ResourceData, meta interf
 	d.Set("self_link", res["selfLink"])
 	d.Set("storage_class", res["storageClass"])
 	d.Set("md5hash", res["md5Hash"])
+	d.Set("metadata", res["metadata"])
 
 	d.SetId(bucket + "-" + name)
 

--- a/third_party/terraform/resources/resource_storage_bucket_object.go
+++ b/third_party/terraform/resources/resource_storage_bucket_object.go
@@ -206,6 +206,10 @@ func resourceStorageBucketObjectCreate(d *schema.ResourceData, meta interface{})
 		object.ContentType = v.(string)
 	}
 
+	if v, ok := d.GetOk("metadata"); ok {
+		object.Metadata = convertStringMap(v.(map[string]interface{}))
+	}
+
 	if v, ok := d.GetOk("storage_class"); ok {
 		object.StorageClass = v.(string)
 	}
@@ -249,6 +253,7 @@ func resourceStorageBucketObjectRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("storage_class", res.StorageClass)
 	d.Set("self_link", res.SelfLink)
 	d.Set("output_name", res.Name)
+	d.Set("metadata", res.Metadata)
 
 	d.SetId(objectGetId(res))
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
storage: Fixed setting/reading `google_storage_bucket_object`  metadata on API object
```

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6256

This wasn't caught by the metadata test because the absence of the field in both create and read - resource.TestCheckResourceAttr checks against state, where metadata was never changed from the initial config value. Usually this is fixed by the import tests. 

I don't think storage bucket object is out of the range of autogenerating, so I'll probably do that in a follow-up PR. At the very least, we should support import, though I'm not sure if we avoided it because of content/source.