### PR TITLE
kalm (K8s Application lifecycle manager) addon config added

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -58,6 +58,7 @@ var (
 		"addons_config.0.cloudrun_config",
 		"addons_config.0.dns_cache_config",
 		"addons_config.0.gce_persistent_disk_csi_driver_config",
+		"addons_config.0.kalm_config",
 	<% end -%>
 	}
 )
@@ -291,6 +292,21 @@ func resourceContainerCluster() *schema.Resource {
 							},
 						},
 						"gce_persistent_disk_csi_driver_config": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: addonsConfigKeys,
+							MaxItems:     1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enabled": {
+										Type:     schema.TypeBool,
+										Required: true,
+									},
+								},
+							},
+						},
+						"kalm_config": {
 							Type:         schema.TypeList,
 							Optional:     true,
 							Computed:     true,
@@ -2250,6 +2266,14 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 			ForceSendFields: []string{"Enabled"},
 		}
 	}
+
+	if v, ok := config["kalm_config"]; ok && len(v.([]interface{})) > 0 {
+		addon := v.([]interface{})[0].(map[string]interface{})
+		ac.KalmConfig = &containerBeta.KalmConfig{
+			Enabled:         addon["enabled"].(bool),
+			ForceSendFields: []string{"Enabled"},
+		}
+	}
 <% end -%>
 
 	return ac
@@ -2672,6 +2696,14 @@ func flattenClusterAddonsConfig(c *containerBeta.AddonsConfig) []map[string]inte
 		result["gce_persistent_disk_csi_driver_config"] = []map[string]interface{}{
 			{
 				"enabled": c.GcePersistentDiskCsiDriverConfig.Enabled,
+			},
+		}
+	}
+
+	if c.KalmConfig != nil {
+		result["kalm_config"] = []map[string]interface{}{
+			{
+				"enabled": c.KalmConfig.Enabled,
 			},
 		}
 	}

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1991,10 +1991,10 @@ resource "google_container_cluster" "primary" {
     }
     gce_persistent_disk_csi_driver_config {
       enabled = false
-	}
-	kalm_config {
-		enabled = false
-	}
+     }
+     kalm_config {
+	enabled = false
+     }
 <% end -%>
   }
 }

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1991,9 +1991,9 @@ resource "google_container_cluster" "primary" {
     }
     gce_persistent_disk_csi_driver_config {
       enabled = false
-     }
-     kalm_config {
-	enabled = false
+    }
+    kalm_config {
+	  enabled = false
      }
 <% end -%>
   }
@@ -2035,7 +2035,7 @@ resource "google_container_cluster" "primary" {
       enabled = true
 	}
 	kalm_config {
-		enabled = true
+	  enabled = true
 	}
 <% end -%>
   }

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1991,7 +1991,10 @@ resource "google_container_cluster" "primary" {
     }
     gce_persistent_disk_csi_driver_config {
       enabled = false
-    }
+	}
+	kalm_config {
+		enabled = false
+	}
 <% end -%>
   }
 }
@@ -2030,7 +2033,10 @@ resource "google_container_cluster" "primary" {
     }
     gce_persistent_disk_csi_driver_config {
       enabled = true
-    }
+	}
+	kalm_config {
+		enabled = true
+	}
 <% end -%>
   }
 }

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -338,6 +338,9 @@ The `addons_config` block supports:
 * `gce_persistent_disk_csi_driver_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)).
     Whether this cluster should enable the Google Compute Engine Persistent Disk Container Storage Interface (CSI) Driver. Defaults to disabled; set `enabled = true` to enable. 
 
+* `kalm_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)).
+    Configuration for the KALM addon, which manages the lifecycle of k8s. It is disabled by default; Set `enabled = true` to enable. 
+
 This example `addons_config` disables two addons:
 
 ```hcl


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->
Application Manager addon (KALM) config added to provider.
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5960

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
* container: added `kalm_config` addon to `google_container_cluster` (beta-only)
```
