### PR TITLE
Data source for IAM Testable Permissions

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_iam_testable_permissions.go
+++ b/third_party/terraform/data_sources/data_source_google_iam_testable_permissions.go
@@ -1,0 +1,157 @@
+package google
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceGoogleIamTestablePermissions() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleIamTestablePermissionsRead,
+		Schema: map[string]*schema.Schema{
+			"full_resource_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"custom_support_level": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "SUPPORTED",
+			},
+			"stage": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "GA",
+			},
+			"permissions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"title": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"custom_support_level": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"stage": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"api_disabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGoogleIamTestablePermissionsRead(d *schema.ResourceData, meta interface{}) (err error) {
+	config := meta.(*Config)
+	body := make(map[string]interface{}, 0)
+	body["pageSize"] = 500
+	permissions := make([]map[string]interface{}, 0)
+	custom_support_level := d.Get("custom_support_level").(string)
+	if err = validatePermissionCustomSupport(custom_support_level); err != nil {
+		return err
+	}
+
+	stage := d.Get("stage").(string)
+	if err = validatePermissionStage(stage); err != nil {
+		return err
+	}
+
+	for {
+		url := "https://iam.googleapis.com/v1/permissions:queryTestablePermissions"
+		body["fullResourceName"] = d.Get("full_resource_name").(string)
+		res, err := sendRequest(config, "POST", "", url, body)
+		if err != nil {
+			return fmt.Errorf("Error retrieving permissions: %s", err)
+		}
+
+		pagePermissions := flattenTestablePermissionsList(res["permissions"], custom_support_level, stage)
+		permissions = append(permissions, pagePermissions...)
+		pToken, ok := res["nextPageToken"]
+		if ok && pToken != nil && pToken.(string) != "" {
+			body["pageToken"] = pToken.(string)
+		} else {
+			break
+		}
+	}
+
+	if err := d.Set("permissions", permissions); err != nil {
+		return fmt.Errorf("Error retrieving permissions: %s", err)
+	}
+
+	d.SetId(d.Get("full_resource_name").(string))
+	return nil
+}
+
+func flattenTestablePermissionsList(v interface{}, custom_support_level string, stage string) []map[string]interface{} {
+	if v == nil {
+		return make([]map[string]interface{}, 0)
+	}
+
+	ls := v.([]interface{})
+	permissions := make([]map[string]interface{}, 0, len(ls))
+	for _, raw := range ls {
+		p := raw.(map[string]interface{})
+
+		if _, ok := p["name"]; ok {
+			csl := true
+			if custom_support_level == "SUPPORTED" {
+				csl = p["customRolesSupportLevel"] == nil || p["customRolesSupportLevel"] == "SUPPORTED"
+			} else {
+				csl = p["customRolesSupportLevel"] == custom_support_level
+			}
+
+			if csl && p["stage"] == stage {
+				permissions = append(permissions, map[string]interface{}{
+					"name":                 p["name"],
+					"title":                p["title"],
+					"stage":                p["stage"],
+					"api_disabled":         p["apiDisabled"],
+					"custom_support_level": p["customRolesSupportLevel"],
+				})
+			}
+		}
+	}
+
+	return permissions
+}
+
+func validatePermissionCustomSupport(val string) error {
+	allowed := []string{"NOT_SUPPORTED", "SUPPORTED", "TESTING"}
+	if !sliceContainsString(allowed, val) {
+		return errors.New("custom_support_level must be one of \"NOT_SUPPORTED\", \"SUPPORTED\", \"TESTING\"")
+	}
+	return nil
+}
+
+func validatePermissionStage(val string) error {
+	allowed := []string{"ALPHA", "BETA", "GA", "DEPRECATED"}
+	if !sliceContainsString(allowed, val) {
+		return errors.New("stage must be one of \"ALPHA\", \"BETA\", \"GA\", \"DEPRECATED\"")
+	}
+	return nil
+}
+
+func sliceContainsString(slice []string, str string) bool {
+	for _, s := range slice {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}

--- a/third_party/terraform/data_sources/data_source_google_iam_testable_permissions.go
+++ b/third_party/terraform/data_sources/data_source_google_iam_testable_permissions.go
@@ -1,8 +1,8 @@
 package google
 
 import (
-	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
@@ -59,7 +59,7 @@ func dataSourceGoogleIamTestablePermissions() *schema.Resource {
 
 func dataSourceGoogleIamTestablePermissionsRead(d *schema.ResourceData, meta interface{}) (err error) {
 	config := meta.(*Config)
-	body := make(map[string]interface{}, 0)
+	body := make(map[string]interface{})
 	body["pageSize"] = 500
 	permissions := make([]map[string]interface{}, 0)
 	custom_support_level := d.Get("custom_support_level").(string)
@@ -109,7 +109,7 @@ func flattenTestablePermissionsList(v interface{}, custom_support_level string, 
 		p := raw.(map[string]interface{})
 
 		if _, ok := p["name"]; ok {
-			csl := true
+			var csl bool
 			if custom_support_level == "SUPPORTED" {
 				csl = p["customRolesSupportLevel"] == nil || p["customRolesSupportLevel"] == "SUPPORTED"
 			} else {
@@ -134,7 +134,7 @@ func flattenTestablePermissionsList(v interface{}, custom_support_level string, 
 func validatePermissionCustomSupport(val string) error {
 	allowed := []string{"NOT_SUPPORTED", "SUPPORTED", "TESTING"}
 	if !sliceContainsString(allowed, val) {
-		return errors.New("custom_support_level must be one of \"NOT_SUPPORTED\", \"SUPPORTED\", \"TESTING\"")
+		return fmt.Errorf("custom_support_level must be one of %s", strings.Join(allowed, ", "))
 	}
 	return nil
 }
@@ -142,7 +142,7 @@ func validatePermissionCustomSupport(val string) error {
 func validatePermissionStage(val string) error {
 	allowed := []string{"ALPHA", "BETA", "GA", "DEPRECATED"}
 	if !sliceContainsString(allowed, val) {
-		return errors.New("stage must be one of \"ALPHA\", \"BETA\", \"GA\", \"DEPRECATED\"")
+		return fmt.Errorf("stage must be one of %s", strings.Join(allowed, ", "))
 	}
 	return nil
 }

--- a/third_party/terraform/tests/data_source_google_iam_testable_permissions_test.go
+++ b/third_party/terraform/tests/data_source_google_iam_testable_permissions_test.go
@@ -1,0 +1,104 @@
+package google
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDataSourceGoogleIamTestablePermissions_basic(t *testing.T) {
+	t.Parallel()
+
+	project := getTestProjectFromEnv()
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+			 data "google_iam_testable_permissions" "perms" {
+				full_resource_name = "//cloudresourcemanager.googleapis.com/projects/%s"
+			}
+		`, project),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleIamTestablePermissionsMeta(
+						project,
+						"data.google_iam_testable_permissions.perms",
+						"GA",
+						"",
+					),
+				),
+			},
+			{
+				Config: fmt.Sprintf(`
+			 data "google_iam_testable_permissions" "perms" {
+				full_resource_name   = "//cloudresourcemanager.googleapis.com/projects/%s"
+				custom_support_level = "NOT_SUPPORTED"
+				stage                = "BETA"
+			}
+		`, project),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleIamTestablePermissionsMeta(
+						project,
+						"data.google_iam_testable_permissions.perms",
+						"BETA",
+						"NOT_SUPPORTED",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGoogleIamTestablePermissionsMeta(project string, n string, expectedStage string, expectedSupportLevel string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find perms data source: %s", n)
+		}
+		expectedId := fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)
+		if rs.Primary.ID != expectedId {
+			return errors.New("perms data source ID not set.")
+		}
+		attrs := rs.Primary.Attributes
+		count, ok := attrs["permissions.#"]
+		if !ok {
+			return errors.New("can't find 'permsissions' attribute")
+		}
+		permCount, err := strconv.Atoi(count)
+		if err != nil {
+			return err
+		}
+		if permCount < 2 {
+			return errors.New("count should be greater than 2")
+		}
+		foundStage := false
+		foundSupport := false
+
+		for i := 0; i < permCount; i++ {
+			stageKey := "permissions." + strconv.Itoa(i) + ".stage"
+			supportKey := "permissions." + strconv.Itoa(i) + ".custom_support_level"
+			if attrs[stageKey] == expectedStage {
+				foundStage = true
+			}
+			if attrs[supportKey] == expectedSupportLevel {
+				foundSupport = true
+			}
+			if foundSupport && foundStage {
+				return nil
+			}
+		}
+
+		if foundSupport {
+			return errors.New(fmt.Sprintf("Could not find stage %s in output", expectedStage))
+		}
+		if foundStage {
+			return errors.New(fmt.Sprintf("Could not find custom_support_level %s in output", expectedSupportLevel))
+		}
+		return errors.New("Unable to find customeSupportLevel or stage")
+	}
+}

--- a/third_party/terraform/tests/data_source_google_iam_testable_permissions_test.go
+++ b/third_party/terraform/tests/data_source_google_iam_testable_permissions_test.go
@@ -1,7 +1,6 @@
 package google
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"testing"
@@ -62,19 +61,19 @@ func testAccCheckGoogleIamTestablePermissionsMeta(project string, n string, expe
 		}
 		expectedId := fmt.Sprintf("//cloudresourcemanager.googleapis.com/projects/%s", project)
 		if rs.Primary.ID != expectedId {
-			return errors.New("perms data source ID not set.")
+			return fmt.Errorf("perms data source ID not set.")
 		}
 		attrs := rs.Primary.Attributes
 		count, ok := attrs["permissions.#"]
 		if !ok {
-			return errors.New("can't find 'permsissions' attribute")
+			return fmt.Errorf("can't find 'permsissions' attribute")
 		}
 		permCount, err := strconv.Atoi(count)
 		if err != nil {
 			return err
 		}
 		if permCount < 2 {
-			return errors.New("count should be greater than 2")
+			return fmt.Errorf("count should be greater than 2")
 		}
 		foundStage := false
 		foundSupport := false
@@ -94,11 +93,11 @@ func testAccCheckGoogleIamTestablePermissionsMeta(project string, n string, expe
 		}
 
 		if foundSupport {
-			return errors.New(fmt.Sprintf("Could not find stage %s in output", expectedStage))
+			return fmt.Errorf("Could not find stage %s in output", expectedStage)
 		}
 		if foundStage {
-			return errors.New(fmt.Sprintf("Could not find custom_support_level %s in output", expectedSupportLevel))
+			return fmt.Errorf("Could not find custom_support_level %s in output", expectedSupportLevel)
 		}
-		return errors.New("Unable to find customeSupportLevel or stage")
+		return fmt.Errorf("Unable to find customeSupportLevel or stage")
 	}
 }

--- a/third_party/terraform/tests/data_source_google_iam_testable_permissions_test.go
+++ b/third_party/terraform/tests/data_source_google_iam_testable_permissions_test.go
@@ -49,6 +49,23 @@ func TestAccDataSourceGoogleIamTestablePermissions_basic(t *testing.T) {
 					),
 				),
 			},
+			{
+				Config: fmt.Sprintf(`
+			 data "google_iam_testable_permissions" "perms" {
+				full_resource_name   = "//cloudresourcemanager.googleapis.com/projects/%s"
+				custom_support_level = "not_supported"
+				stage                = "beta"
+			}
+		`, project),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleIamTestablePermissionsMeta(
+						project,
+						"data.google_iam_testable_permissions.perms",
+						"BETA",
+						"NOT_SUPPORTED",
+					),
+				),
+			},
 		},
 	})
 }

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -181,6 +181,7 @@ func Provider() terraform.ResourceProvider {
 			"google_dns_managed_zone":                          dataSourceDnsManagedZone(),
 			"google_iam_policy":                                dataSourceGoogleIamPolicy(),
 			"google_iam_role":                                  dataSourceGoogleIamRole(),
+			"google_iam_testable_permissions":                  dataSourceGoogleIamTestablePermissions(),
 			"google_kms_crypto_key":                            dataSourceGoogleKmsCryptoKey(),
 			"google_kms_crypto_key_version":                    dataSourceGoogleKmsCryptoKeyVersion(),
 			"google_kms_key_ring":                              dataSourceGoogleKmsKeyRing(),

--- a/third_party/terraform/website/docs/d/datasource_iam_testable_permissions.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_iam_testable_permissions.html.markdown
@@ -1,0 +1,43 @@
+---
+subcategory: "Cloud Platform"
+layout: "google"
+page_title: "Google: google_projects"
+sidebar_current: "docs-google-datasource-iam-testable-permissions"
+description: |-
+  Retrieve a list of testable permissions for a resource. Testable permissions mean the permissions that user can add or remove in a role at a given resource. The resource can be referenced either via the full resource name or via a URI.
+---
+
+# google\_iam\_testable\_permissions
+
+Retrieve a list of testable permissions for a resource. Testable permissions mean the permissions that user can add or remove in a role at a given resource. The resource can be referenced either via the full resource name or via a URI.
+
+## Example Usage - searching for projects about to be deleted in an org
+
+```hcl
+data "google_iam_testable_permissions" "perms" {
+	full_resource_name = "//cloudresourcemanager.googleapis.com/projects/my-project"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `full_resource_name` - (Required) See [full resource name documentation](https://cloud.google.com/apis/design/resource_names#full_resource_name) for more detail.
+* `stage` - (Optional) The release stage of the permission in the output. Can be one of `"ALPHA"`, `"BETA"`, `"GA"`, `"DEPRECATED"`. Default is `"GA"`.
+* `custom_support_level` - (Optional) The level of support for custom roles. Can be one of `"NOT_SUPPORTED"`, `"SUPPORTED"`, `"TESTING"`. Default is `"SUPPORTED"`
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `permissions` - A list of permissions matching the provided input. Structure is defined below.
+
+The `permissions` block supports:
+
+* `name` - Name of the permission.
+* `title` - Human readable title of the permission.
+* `stage` - Release stage of the permission.
+* `custom_support_level` - The the support level of this permission for custom roles.
+* `api_disabled` - Whether the corresponding API has been enabled for the resource.
+

--- a/third_party/terraform/website/docs/d/datasource_iam_testable_permissions.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_iam_testable_permissions.html.markdown
@@ -16,6 +16,7 @@ Retrieve a list of testable permissions for a resource. Testable permissions mea
 ```hcl
 data "google_iam_testable_permissions" "perms" {
 	full_resource_name = "//cloudresourcemanager.googleapis.com/projects/my-project"
+	stages             = ["GA", "BETA"]
 }
 ```
 
@@ -24,7 +25,7 @@ data "google_iam_testable_permissions" "perms" {
 The following arguments are supported:
 
 * `full_resource_name` - (Required) See [full resource name documentation](https://cloud.google.com/apis/design/resource_names#full_resource_name) for more detail.
-* `stage` - (Optional) The release stage of the permission in the output. Can be one of `"ALPHA"`, `"BETA"`, `"GA"`, `"DEPRECATED"`. Default is `"GA"`.
+* `stages` - (Optional) The acceptable release stages of the permission in the output. Note that `BETA` does not include permissions in `GA`, but you can specify both with `["GA", "BETA"]` for example. Can be a list of `"ALPHA"`, `"BETA"`, `"GA"`, `"DEPRECATED"`. Default is `["GA"]`.
 * `custom_support_level` - (Optional) The level of support for custom roles. Can be one of `"NOT_SUPPORTED"`, `"SUPPORTED"`, `"TESTING"`. Default is `"SUPPORTED"`
 
 ## Attributes Reference


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
Add google_iam_testable_permissions data source
```

Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/6120
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/4812

Adds a new data source for IAM testable permissions.

```
data "google_iam_testable_permissions" "perms" {
	full_resource_name   = "//cloudresourcemanager.googleapis.com/projects/my-project"
        custom_support_level = "NOT_SUPPORTED"
        stages               = ["GA", "BETA"]
}

output "perms" {
	value = data.google_iam_testable_permissions.perms.permissions
}
```
Then the output will look like this:
```
$ terraform apply
data.google_iam_testable_permissions.perms: Refreshing state...

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

perms = [
  {
    "api_disabled" = false
    "custom_support_level" = "NOT_SUPPORTED"
    "name" = "appengine.runtimes.actAsAdmin"
    "stage" = "GA"
    "title" = ""
  },
  {
    "api_disabled" = false
    "custom_support_level" = "NOT_SUPPORTED"
    "name" = "cloudsql.sslCerts.createEphemeral"
    "stage" = "GA"
    "title" = ""
  },
```