### PR TITLE
VCR body comparison fixes

### DIFF
--- a/products/identityplatform/terraform.yaml
+++ b/products/identityplatform/terraform.yaml
@@ -43,7 +43,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           idp_entity_id: tf-idp
           sp_entity_id: tf-sp
         test_vars_overrides:
-          name: '"saml.tf-config-" + acctest.RandString(10)'
+          name: '"saml.tf-config-" + randString(t, 10)'
   TenantInboundSamlConfig: !ruby/object:Overrides::Terraform::ResourceOverride
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
@@ -57,7 +57,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           idp_entity_id: tf-idp
           sp_entity_id: tf-sp
         test_vars_overrides:
-          name: '"saml.tf-config-" + acctest.RandString(10)'
+          name: '"saml.tf-config-" + randString(t, 10)'
   OauthIdpConfig: !ruby/object:Overrides::Terraform::ResourceOverride
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
@@ -69,7 +69,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           name: oidc.oauth-idp-config
         test_vars_overrides:
-          name: '"oidc.oauth-idp-config-" + acctest.RandString(10)'
+          name: '"oidc.oauth-idp-config-" + randString(t, 10)'
   TenantOauthIdpConfig: !ruby/object:Overrides::Terraform::ResourceOverride
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
@@ -81,7 +81,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           name: oidc.oauth-idp-config
         test_vars_overrides:
-          name: '"oidc.oauth-idp-config-" + acctest.RandString(10)'
+          name: '"oidc.oauth-idp-config-" + randString(t, 10)'
   Tenant: !ruby/object:Overrides::Terraform::ResourceOverride
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/templates/terraform/custom_check_destroy/storage_hmac_key.go.erb
+++ b/templates/terraform/custom_check_destroy/storage_hmac_key.go.erb
@@ -1,4 +1,4 @@
-config := testAccProvider.Meta().(*Config)
+config := googleProviderConfig(t)
 
 url, err := replaceVarsForTest(config, rs, "{{StorageBasePath}}projects/{{project}}/hmacKeys/{{access_id}}")
 if err != nil {

--- a/third_party/terraform/resources/resource_sql_ssl_cert_test.go
+++ b/third_party/terraform/resources/resource_sql_ssl_cert_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -12,7 +11,7 @@ import (
 func TestAccSqlClientCert_mysql(t *testing.T) {
 	t.Parallel()
 
-	instance := acctest.RandomWithPrefix("i")
+	instance := fmt.Sprintf("tf-test-%s", randString(t, 10))
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -32,7 +31,7 @@ func TestAccSqlClientCert_mysql(t *testing.T) {
 func TestAccSqlClientCert_postgres(t *testing.T) {
 	t.Parallel()
 
-	instance := acctest.RandomWithPrefix("i")
+	instance := fmt.Sprintf("tf-test-%s", randString(t, 10))
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
+++ b/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
@@ -26,7 +26,7 @@ func TestAccFolderIamBinding_basic(t *testing.T) {
 			{
 				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(t, org, fname),
 				),
 			},
 			// Apply an IAM binding
@@ -57,7 +57,7 @@ func TestAccFolderIamBinding_multiple(t *testing.T) {
 			{
 				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(t, org, fname),
 				),
 			},
 			// Apply an IAM binding
@@ -102,7 +102,7 @@ func TestAccFolderIamBinding_multipleAtOnce(t *testing.T) {
 			{
 				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(t, org, fname),
 				),
 			},
 			// Apply an IAM binding
@@ -137,7 +137,7 @@ func TestAccFolderIamBinding_update(t *testing.T) {
 			{
 				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(t, org, fname),
 				),
 			},
 			// Apply an IAM binding
@@ -188,7 +188,7 @@ func TestAccFolderIamBinding_remove(t *testing.T) {
 			{
 				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(t, org, fname),
 				),
 			},
 			// Apply multiple IAM bindings
@@ -209,7 +209,7 @@ func TestAccFolderIamBinding_remove(t *testing.T) {
 			{
 				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(t, org, fname),
 				),
 			},
 		},

--- a/third_party/terraform/tests/resource_google_folder_iam_member_test.go
+++ b/third_party/terraform/tests/resource_google_folder_iam_member_test.go
@@ -22,7 +22,7 @@ func TestAccFolderIamMember_basic(t *testing.T) {
 			{
 				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(t, org, fname),
 				),
 			},
 			// Apply an IAM binding
@@ -53,7 +53,7 @@ func TestAccFolderIamMember_multiple(t *testing.T) {
 			{
 				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(t, org, fname),
 				),
 			},
 			// Apply an IAM binding
@@ -94,7 +94,7 @@ func TestAccFolderIamMember_remove(t *testing.T) {
 			{
 				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(t, org, fname),
 				),
 			},
 			// Apply multiple IAM bindings
@@ -111,7 +111,7 @@ func TestAccFolderIamMember_remove(t *testing.T) {
 			{
 				Config: testAccFolderIamBasic(org, fname),
 				Check: resource.ComposeTestCheckFunc(
-					testAccFolderExistingPolicy(org, fname),
+					testAccFolderExistingPolicy(t, org, fname),
 				),
 			},
 		},

--- a/third_party/terraform/tests/resource_google_folder_iam_policy_test.go
+++ b/third_party/terraform/tests/resource_google_folder_iam_policy_test.go
@@ -86,9 +86,9 @@ func testAccCheckGoogleFolderIamPolicyDestroyProducer(t *testing.T) func(s *terr
 }
 
 // Confirm that a folder has an IAM policy with at least 1 binding
-func testAccFolderExistingPolicy(org, fname string) resource.TestCheckFunc {
+func testAccFolderExistingPolicy(t *testing.T, org, fname string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		c := testAccProvider.Meta().(*Config)
+		c := googleProviderConfig(t)
 		var err error
 		originalPolicy, err = getFolderIamPolicyByParentAndDisplayName("organizations/"+org, fname, c)
 		if err != nil {

--- a/third_party/terraform/tests/resource_google_project_iam_audit_config_test.go
+++ b/third_party/terraform/tests/resource_google_project_iam_audit_config_test.go
@@ -32,7 +32,7 @@ func TestAccProjectIamAuditConfig_basic(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply an IAM audit config
@@ -61,7 +61,7 @@ func TestAccProjectIamAuditConfig_multiple(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply an IAM audit config
@@ -95,7 +95,7 @@ func TestAccProjectIamAuditConfig_multipleAtOnce(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply an IAM audit config
@@ -124,7 +124,7 @@ func TestAccProjectIamAuditConfig_update(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply an IAM audit config
@@ -165,7 +165,7 @@ func TestAccProjectIamAuditConfig_remove(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply multiple IAM audit configs
@@ -179,7 +179,7 @@ func TestAccProjectIamAuditConfig_remove(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 		},
@@ -204,7 +204,7 @@ func TestAccProjectIamAuditConfig_addFirstExemptMember(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply IAM audit config with no members
@@ -240,7 +240,7 @@ func TestAccProjectIamAuditConfig_removeLastExemptMember(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply IAM audit config with member
@@ -276,7 +276,7 @@ func TestAccProjectIamAuditConfig_updateNoExemptMembers(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply IAM audit config with DATA_READ

--- a/third_party/terraform/tests/resource_google_project_iam_binding_test.go.erb
+++ b/third_party/terraform/tests/resource_google_project_iam_binding_test.go.erb
@@ -32,7 +32,7 @@ func TestAccProjectIamBinding_basic(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply an IAM binding
@@ -61,7 +61,7 @@ func TestAccProjectIamBinding_multiple(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply an IAM binding
@@ -95,7 +95,7 @@ func TestAccProjectIamBinding_multipleAtOnce(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply an IAM binding
@@ -124,7 +124,7 @@ func TestAccProjectIamBinding_update(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply an IAM binding
@@ -165,7 +165,7 @@ func TestAccProjectIamBinding_remove(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply multiple IAM bindings
@@ -179,7 +179,7 @@ func TestAccProjectIamBinding_remove(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 		},
@@ -201,7 +201,7 @@ func TestAccProjectIamBinding_noMembers(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply an IAM binding
@@ -229,7 +229,7 @@ func TestAccProjectIamBinding_withCondition(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply an IAM binding

--- a/third_party/terraform/tests/resource_google_project_iam_member_test.go.erb
+++ b/third_party/terraform/tests/resource_google_project_iam_member_test.go.erb
@@ -34,7 +34,7 @@ func TestAccProjectIamMember_basic(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply an IAM binding
@@ -68,7 +68,7 @@ func TestAccProjectIamMember_multiple(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply an IAM binding
@@ -108,7 +108,7 @@ func TestAccProjectIamMember_remove(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 
@@ -123,7 +123,7 @@ func TestAccProjectIamMember_remove(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 		},
@@ -148,7 +148,7 @@ func TestAccProjectIamMember_withCondition(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply an IAM binding

--- a/third_party/terraform/tests/resource_google_project_iam_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_google_project_iam_policy_test.go.erb
@@ -25,7 +25,7 @@ func TestAccProjectIamPolicy_basic(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply an IAM policy from a data source. The application
@@ -92,7 +92,7 @@ func TestAccProjectIamPolicy_basicAuditConfig(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply an IAM policy from a data source. The application
@@ -142,7 +142,7 @@ func TestAccProjectIamPolicy_withCondition(t *testing.T) {
 			{
 				Config: testAccProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccProjectExistingPolicy(pid),
+					testAccProjectExistingPolicy(t, pid),
 				),
 			},
 			// Apply an IAM policy from a data source. The application
@@ -216,9 +216,9 @@ func testAccCheckGoogleProjectIamPolicyExists(projectRes, policyRes, pid string)
 }
 
 // Confirm that a project has an IAM policy with at least 1 binding
-func testAccProjectExistingPolicy(pid string) resource.TestCheckFunc {
+func testAccProjectExistingPolicy(t *testing.T, pid string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		c := testAccProvider.Meta().(*Config)
+		c := googleProviderConfig(t)
 		var err error
 		originalPolicy, err = getProjectIamPolicy(pid, c)
 		if err != nil {

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -75,6 +75,7 @@ type Config struct {
 	PollInterval time.Duration
 
 	client           *http.Client
+	wrappedBigQueryClient *http.Client
 	wrappedPubsubClient *http.Client
 	context          context.Context
 	terraformVersion string
@@ -436,6 +437,7 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 	bigQueryClientBasePath := c.BigQueryBasePath
 	log.Printf("[INFO] Instantiating Google Cloud BigQuery client for path %s", bigQueryClientBasePath)
 	wrappedBigQueryClient := ClientWithAdditionalRetries(client, retryTransport, iamMemberMissing)
+	c.wrappedBigQueryClient = wrappedBigQueryClient
 	c.clientBigQuery, err = bigquery.NewService(ctx, option.WithHTTPClient(wrappedBigQueryClient))
 	if err != nil {
 		return err

--- a/third_party/terraform/utils/iam.go.erb
+++ b/third_party/terraform/utils/iam.go.erb
@@ -266,7 +266,17 @@ func createIamBindingsMap(bindings []*cloudresourcemanager.Binding) map[iamBindi
 // Return list of Bindings for a map of role to member sets
 func listFromIamBindingMap(bm map[iamBindingKey]map[string]struct{}) []*cloudresourcemanager.Binding {
 	rb := make([]*cloudresourcemanager.Binding, 0, len(bm))
-	for key, members := range bm {
+	var keys []iamBindingKey
+	for k := range bm {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		keyI := keys[i]
+		keyJ := keys[j]
+		return fmt.Sprintf("%s%s", keyI.Role, keyI.Condition.String()) < fmt.Sprintf("%s%s", keyJ.Role, keyJ.Condition.String())
+	})
+	for _, key := range keys {
+		members := bm[key]
 		if len(members) == 0 {
 			continue
 		}

--- a/third_party/terraform/utils/metadata.go
+++ b/third_party/terraform/utils/metadata.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"sort"
 
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
@@ -144,10 +145,15 @@ func resourceInstanceMetadata(d TerraformResourceData) (*computeBeta.Metadata, e
 	}
 	if len(mdMap) > 0 {
 		m.Items = make([]*computeBeta.MetadataItems, 0, len(mdMap))
-		for key, val := range mdMap {
-			v := val.(string)
+		var keys []string
+		for k := range mdMap {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			v := mdMap[k].(string)
 			m.Items = append(m.Items, &computeBeta.MetadataItems{
-				Key:   key,
+				Key:   k,
 				Value: &v,
 			})
 		}

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -327,7 +327,7 @@ end     # products.each do
 				"google_dns_record_set":                        resourceDnsRecordSet(),
 				"google_endpoints_service":                     resourceEndpointsService(),
 				"google_folder":                                resourceGoogleFolder(),
-				"google_folder_iam_binding":                    ResourceIamBinding(IamFolderSchema, NewFolderIamUpdater, FolderIdParseFunc),
+				"google_folder_iam_binding":                    ResourceIamBindingWithBatching(IamFolderSchema, NewFolderIamUpdater, FolderIdParseFunc, IamBatchingEnabled),
 				"google_folder_iam_member":                     ResourceIamMember(IamFolderSchema, NewFolderIamUpdater, FolderIdParseFunc),
 				"google_folder_iam_policy":                     ResourceIamPolicy(IamFolderSchema, NewFolderIamUpdater, FolderIdParseFunc),
 				"google_folder_organization_policy":            resourceGoogleFolderOrganizationPolicy(),

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -180,11 +180,11 @@ func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.Resour
 		// JSON might be the same, but reordered. Try parsing json and comparing
 		if strings.Contains(contentType, "application/json") {
 			var reqJson, cassetteJson interface{}
-			if err := json.Unmarshal(byte[]{reqBody}, &reqJson); err != nil {
+			if err := json.Unmarshal([]byte(reqBody), &reqJson); err != nil {
         log.Printf("[DEBUG] Failed to unmarshall request json: %v", err)
         return false
     	}
-    	if err := json.Unmarshal(byte[]{i.Body}, &cassetteJson); err != nil {
+    	if err := json.Unmarshal([]byte(i.Body), &cassetteJson); err != nil {
         log.Printf("[DEBUG] Failed to unmarshall cassette json: %v", err)
         return false
     	}

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -181,14 +181,14 @@ func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.Resour
 		if strings.Contains(contentType, "application/json") {
 			var reqJson, cassetteJson interface{}
 			if err := json.Unmarshal([]byte(reqBody), &reqJson); err != nil {
-        log.Printf("[DEBUG] Failed to unmarshall request json: %v", err)
-        return false
-    	}
-    	if err := json.Unmarshal([]byte(i.Body), &cassetteJson); err != nil {
-        log.Printf("[DEBUG] Failed to unmarshall cassette json: %v", err)
-        return false
-    	}
-    	return reflect.DeepEqual(reqJson, cassetteJson)
+				log.Printf("[DEBUG] Failed to unmarshall request json: %v", err)
+				return false
+			}
+			if err := json.Unmarshal([]byte(i.Body), &cassetteJson); err != nil {
+				log.Printf("[DEBUG] Failed to unmarshall cassette json: %v", err)
+				return false
+			}
+			return reflect.DeepEqual(reqJson, cassetteJson)
 		}
 		return false
 	})

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -157,6 +157,12 @@ func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.Resour
 		if r.Body == nil {
 			return defaultMatch
 		}
+		contentType := r.Header.Get("Content-Type")
+		// If body contains media, don't try to compare
+		if strings.Contains(contentType, "multipart/related") {
+			return defaultMatch
+		}
+
 		var b bytes.Buffer
 		if _, err := b.ReadFrom(r.Body); err != nil {
 			log.Printf("[DEBUG] Failed to read request body from cassette: %v", err)

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -153,14 +153,16 @@ func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.Resour
 	// Defines how VCR will match requests to responses.
 	rec.SetMatcher(func(r *http.Request, i cassette.Request) bool {
 		// Default matcher compares method and URL only
-		defaultMatch := cassette.DefaultMatcher(r, i)
+		if !cassette.DefaultMatcher(r, i) {
+			return false
+		}
 		if r.Body == nil {
-			return defaultMatch
+			return true
 		}
 		contentType := r.Header.Get("Content-Type")
 		// If body contains media, don't try to compare
 		if strings.Contains(contentType, "multipart/related") {
-			return defaultMatch
+			return true
 		}
 
 		var b bytes.Buffer
@@ -169,8 +171,26 @@ func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.Resour
 			return false
 		}
 		r.Body = ioutil.NopCloser(&b)
-		// body must match recorded body
-		return defaultMatch && b.String() == i.Body
+		reqBody := b.String()
+		// If body matches identically, we are done
+		if reqBody == i.Body {
+			return true
+		}
+
+		// JSON might be the same, but reordered. Try parsing json and comparing
+		if strings.Contains(contentType, "application/json") {
+			var reqJson, cassetteJson interface{}
+			if err := json.Unmarshal(byte[]{reqBody}, &reqJson); err != nil {
+        log.Printf("[DEBUG] Failed to unmarshall request json: %v", err)
+        return false
+    	}
+    	if err := json.Unmarshal(byte[]{i.Body}, &cassetteJson); err != nil {
+        log.Printf("[DEBUG] Failed to unmarshall cassette json: %v", err)
+        return false
+    	}
+    	return reflect.DeepEqual(reqJson, cassetteJson)
+		}
+		return false
 	})
 	config.client.Transport = rec
 	config.wrappedPubsubClient.Transport = rec

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -174,6 +174,7 @@ func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.Resour
 	})
 	config.client.Transport = rec
 	config.wrappedPubsubClient.Transport = rec
+	config.wrappedBigQueryClient.Transport = rec
 	configs[testName] = config
 	return config, err
 }

--- a/third_party/terraform/utils/utils.go.erb
+++ b/third_party/terraform/utils/utils.go.erb
@@ -210,6 +210,8 @@ func convertStringSet(set *schema.Set) []string {
 	for _, v := range set.List() {
 		s = append(s, v.(string))
 	}
+	sort.Strings(s)
+
 	return s
 }
 

--- a/third_party/terraform/utils/utils.go.erb
+++ b/third_party/terraform/utils/utils.go.erb
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -226,6 +227,7 @@ func stringSliceFromGolangSet(sset map[string]struct{}) []string {
 	for s := range sset {
 		ls = append(ls, s)
 	}
+	sort.Strings(ls)
 
 	return ls
 }


### PR DESCRIPTION
Included in this PR:
Ignore request body when matching requests with multipart Content-Type. Allows VCR to work for tests that involve uploading a zip or other types of media where the content may change between VCR runs (we create the zip on-demand during the test)

Deterministic ordering of several unordered arrays during HTTP request building. For example, IAM bindings are unordered lists (both API and tf client don't care about order), and could be randomly ordered between identical runs (due to non-deterministic ordering of golang's `range` function over maps). Fix this by sorting keys when building the array from a map.

Attempt at parsing request body string as json (if application/json type) and comparing maps rather than strings

Various fixes to use cached client that were missed during earlier PRs

<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
