### PR TITLE
Change credentials to sensitive

### DIFF
--- a/third_party/terraform/data_sources/data_source_storage_object_signed_url.go
+++ b/third_party/terraform/data_sources/data_source_storage_object_signed_url.go
@@ -51,8 +51,9 @@ func dataSourceGoogleSignedUrl() *schema.Resource {
 				Default:  "",
 			},
 			"credentials": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Optional:  true,
 			},
 			"duration": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-google/issues/5599
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
storage: Marked the credentials field in `google_storage_object_signed_url` as sensitive so it doesn't expose private credentials.
```
