### PR TITLE
Make retryConfig computed for Cloud Scheduler jobs

### DIFF
--- a/products/cloudscheduler/terraform.yaml
+++ b/products/cloudscheduler/terraform.yaml
@@ -77,6 +77,16 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       region: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
         ignore_read: true
+      retryConfig.retryCount: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      retryConfig.maxRetryDuration: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      retryConfig.minBackoffDuration: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      retryConfig.maxBackoffDuration: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      retryConfig.maxDoublings: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/templates/terraform/examples/scheduler_job_app_engine.tf.erb
+++ b/templates/terraform/examples/scheduler_job_app_engine.tf.erb
@@ -5,6 +5,13 @@ resource "google_cloud_scheduler_job" "job" {
   time_zone        = "Europe/London"
   attempt_deadline = "320s"
 
+  retry_config {
+    min_backoff_duration = "1s"
+    max_retry_duration = "10s"
+    max_doublings = 2
+    retry_count = 3
+  }
+
   app_engine_http_target {
     http_method = "POST"
 

--- a/templates/terraform/examples/scheduler_job_http.tf.erb
+++ b/templates/terraform/examples/scheduler_job_http.tf.erb
@@ -5,6 +5,10 @@ resource "google_cloud_scheduler_job" "job" {
   time_zone        = "America/New_York"
   attempt_deadline = "320s"
 
+  retry_config {
+    retry_count = 1
+  }
+
   http_target {
     http_method = "POST"
     uri         = "https://example.com/ping"

--- a/third_party/terraform/tests/resource_cloud_scheduler_job_test.go
+++ b/third_party/terraform/tests/resource_cloud_scheduler_job_test.go
@@ -1,6 +1,4 @@
-<% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
 
 import (
 	"reflect"
@@ -95,6 +93,3 @@ func TestCloudScheduler_FlattenHttpHeaders(t *testing.T) {
 		}
 	}
 }
-<% else %>
-// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
-<% end -%>


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

EXTERNAL CONTRIBUTORS: Ignore please - your reviewer will handle.

INTERNAL CONTRIBUTORS AND REVIEWERS: See .ci/RELEASE_NOTES_GUIDE.md
for writing good release notes.

NO CHANGELOG NOTE: Please add "changelog: no-release-note" label to this PR.

Otherwise, fill the template out (replace the heading).
You can add more release notes if you want more than one CHANGELOG entry for
this PR, but make sure not to indent notes and to leave newlines between
code blocks for Markdown's sake.

For Terraform PRs, we use the following "release-note:" headings
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloudscheduler: Fixed permadiff for `google_cloud_scheduler_job.retry_config.*` block when API provides default values
```

Also rename the handwritten test and GA it - I missed it when I GA'd Job :S

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6204
