### PR TITLE
Fix tests requiring strip_query

### DIFF
--- a/templates/terraform/examples/region_target_http_proxy_https_redirect.tf.erb
+++ b/templates/terraform/examples/region_target_http_proxy_https_redirect.tf.erb
@@ -9,5 +9,6 @@ resource "google_compute_region_url_map" "default" {
   name            = "<%= ctx[:vars]['region_url_map_name'] %>"
   default_url_redirect {
     https_redirect = true
+    strip_query    = false
   }
 }

--- a/templates/terraform/examples/target_http_proxy_https_redirect.tf.erb
+++ b/templates/terraform/examples/target_http_proxy_https_redirect.tf.erb
@@ -7,5 +7,6 @@ resource "google_compute_url_map" "default" {
   name            = "<%= ctx[:vars]['url_map_name'] %>"
   default_url_redirect {
     https_redirect = true
+    strip_query    = false
   }
 }

--- a/third_party/terraform/tests/resource_compute_region_url_map_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_url_map_test.go.erb
@@ -850,6 +850,7 @@ resource "google_compute_region_url_map" "foobar" {
   name            = "urlmap-test-%s"
   default_url_redirect {
     https_redirect = true
+    strip_query    = false
   }
 }
 `, randomSuffix)

--- a/third_party/terraform/tests/resource_compute_url_map_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_url_map_test.go.erb
@@ -970,6 +970,7 @@ resource "google_compute_url_map" "foobar" {
   name            = "urlmap-test-%s"
   default_url_redirect {
     https_redirect = true
+    strip_query    = false
   }
 }
 `, randomSuffix)


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/6282

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
