### PR TITLE
Remove unsupported consistent hash for backend services in decoder

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -278,6 +278,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/region_backend_service.go.erb
       encoder: templates/terraform/encoders/region_backend_service.go.erb
+      decoder: templates/terraform/decoders/region_backend_service.go.erb
       resource_definition: 'templates/terraform/resource_definition/region_backend_service.go.erb'
     properties:
       region: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/templates/terraform/decoders/region_backend_service.go.erb
+++ b/templates/terraform/decoders/region_backend_service.go.erb
@@ -1,5 +1,5 @@
 <%# The license inside this block applies to this file.
-	# Copyright 2017 Google Inc.
+	# Copyright 2020 Google Inc.
 	# Licensed under the Apache License, Version 2.0 (the "License");
 	# you may not use this file except in compliance with the License.
 	# You may obtain a copy of the License at
@@ -12,18 +12,6 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-// We need to pretend IAP isn't there if it's disabled for Terraform to maintain
-// BC behaviour with the handwritten resource.
-v, ok :=  res["iap"]
-if !ok || v == nil {
-	delete(res, "iap")
-	return res, nil
-}
-m := v.(map[string]interface{})
-if ok && m["enabled"] == false {
-	delete(res, "iap")
-}
-
 // Requests with consistentHash will error for specific values of
 // localityLbPolicy. However, the API will not remove it if the backend
 // service is updated to from supporting to non-supporting localityLbPolicy


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6281 (see for context)

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: Remove permadiff or errors on update for `google_compute_backend_service` and `google_compute_region_backend_service` when `consistent_hash` values were previously set on  backend service but are not supported by updated value of `locality_lb_policy`
```
