### PR TITLE
Fix bigquery dataset access iam roles with primative equivalent

### DIFF
--- a/products/bigquery/api.yaml
+++ b/products/bigquery/api.yaml
@@ -61,7 +61,7 @@ objects:
                 member of the access object. Primitive, Predefined and custom
                 roles are supported. Predefined roles that have equivalent
                 primitive roles are swapped by the API to their Primitive
-                counterparts, and will show a diff post-create. See
+                counterparts. See
                 [official docs](https://cloud.google.com/bigquery/docs/access-control).
             - !ruby/object:Api::Type::String
               name: 'specialGroup'

--- a/products/bigquery/terraform.yaml
+++ b/products/bigquery/terraform.yaml
@@ -92,7 +92,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       datasetId: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
       role: !ruby/object:Overrides::Terraform::PropertyOverride
+        # Bigquery allows for two different formats for specific roles
+        # (IAM vs "primitive" format), but will return the primative role in API
+        # responses. We identify this fine-grained resource from a list
+        # of DatasetAccess objects by comparing role, and we must use the same
+        # format when comparing.
         diff_suppress_func: 'resourceBigQueryDatasetAccessRoleDiffSuppress'
+        # This custom expand makes sure we are correctly
+        # converting IAM roles set in state to their primitive equivalents
+        # before comparison.
         custom_expand: "templates/terraform/custom_expand/bigquery_access_role.go.erb"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/bigquery_dataset_access.go

--- a/products/bigquery/terraform.yaml
+++ b/products/bigquery/terraform.yaml
@@ -91,6 +91,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       datasetId: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
+      role: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: 'resourceBigQueryDatasetAccessRoleDiffSuppress'
+        custom_expand: "templates/terraform/custom_expand/bigquery_access_role.go.erb"
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      constants: templates/terraform/constants/bigquery_dataset_access.go
   Job: !ruby/object:Overrides::Terraform::ResourceOverride
     import_format: ["projects/{{project}}/jobs/{{job_id}}"]
     skip_delete: true

--- a/templates/terraform/constants/bigquery_dataset_access.go
+++ b/templates/terraform/constants/bigquery_dataset_access.go
@@ -1,6 +1,6 @@
 var bigqueryAccessRoleToPrimitiveMap =  map[string]string {
     "roles/bigquery.dataOwner": "OWNER",
-    "roles/bigquery.dataEditor": "EDITOR",
+    "roles/bigquery.dataEditor": "WRITER",
     "roles/bigquery.dataViewer": "VIEWER",
 }
 

--- a/templates/terraform/constants/bigquery_dataset_access.go
+++ b/templates/terraform/constants/bigquery_dataset_access.go
@@ -1,7 +1,7 @@
 var bigqueryAccessRoleToPrimitiveMap =  map[string]string {
-    "roles/bigQuery.dataOwner": "OWNER",
-    "roles/bigQuery.dataEditor": "EDITOR",
-    "roles/bigQuery.dataViewer": "VIEWER",
+    "roles/bigquery.dataOwner": "OWNER",
+    "roles/bigquery.dataEditor": "EDITOR",
+    "roles/bigquery.dataViewer": "VIEWER",
 }
 
 func resourceBigQueryDatasetAccessRoleDiffSuppress(k, old, new string, d *schema.ResourceData) bool {

--- a/templates/terraform/constants/bigquery_dataset_access.go
+++ b/templates/terraform/constants/bigquery_dataset_access.go
@@ -1,0 +1,12 @@
+var bigqueryAccessRoleToPrimitiveMap =  map[string]string {
+    "roles/bigQuery.dataOwner": "OWNER",
+    "roles/bigQuery.dataEditor": "EDITOR",
+    "roles/bigQuery.dataViewer": "VIEWER",
+}
+
+func resourceBigQueryDatasetAccessRoleDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+    if primitiveRole, ok := bigqueryAccessRoleToPrimitiveMap[new]; ok {
+        return primitiveRole == old
+    }
+    return false
+}

--- a/templates/terraform/custom_expand/bigquery_access_role.go.erb
+++ b/templates/terraform/custom_expand/bigquery_access_role.go.erb
@@ -1,0 +1,24 @@
+<%- # the license inside this block applies to this file
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	if primitiveRole, ok := bigqueryAccessRoleToPrimitiveMap[v.(string)]; ok {
+    return primitiveRole, nil
+  }
+  return v, nil
+}

--- a/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
+++ b/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
@@ -106,6 +106,37 @@ func TestAccBigQueryDatasetAccess_multiple(t *testing.T) {
 	})
 }
 
+func TestAccBigQueryDatasetAccess_predefinedRole(t *testing.T) {
+	t.Parallel()
+
+	datasetID := fmt.Sprintf("tf_test_%s", randString(t, 10))
+
+	expected1 := map[string]interface{}{
+		"role":   "EDITOR",
+		"domain": "google.com",
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryDatasetAccess_predefinedRole(datasetID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBigQueryDatasetAccessPresent(t, "google_bigquery_dataset.dataset", expected1),
+				),
+			},
+			{
+				// Destroy step instead of CheckDestroy so we can check the access is removed without deleting the dataset
+				Config: testAccBigQueryDatasetAccess_destroy(datasetID, "dataset"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBigQueryDatasetAccessAbsent(t, "google_bigquery_dataset.dataset", expected1),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckBigQueryDatasetAccessPresent(t *testing.T, n string, expected map[string]interface{}) resource.TestCheckFunc {
 	return testAccCheckBigQueryDatasetAccess(t, n, expected, true)
 }
@@ -217,6 +248,20 @@ resource "google_bigquery_dataset_access" "access2" {
   dataset_id    = google_bigquery_dataset.dataset.dataset_id
   role          = "READER"
   special_group = "projectWriters"
+}
+
+resource "google_bigquery_dataset" "dataset" {
+  dataset_id = "%s"
+}
+`, datasetID)
+}
+
+func testAccBigQueryDatasetAccess_predefinedRole(datasetID string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset_access" "access" {
+  dataset_id = google_bigquery_dataset.dataset.dataset_id
+  role       = "roles/bigquery.dataEditor"
+  domain     = "google.com"
 }
 
 resource "google_bigquery_dataset" "dataset" {

--- a/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
+++ b/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
@@ -112,7 +112,7 @@ func TestAccBigQueryDatasetAccess_predefinedRole(t *testing.T) {
 	datasetID := fmt.Sprintf("tf_test_%s", randString(t, 10))
 
 	expected1 := map[string]interface{}{
-		"role":   "EDITOR",
+		"role":   "WRITER",
 		"domain": "google.com",
 	}
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquery: Fixed error where `google_bigquery_dataset_access` resources could not be found post-creation if role was set to a predefined IAM role with an equivalent primative role (e.g. `roles/bigquery.dataOwner` and `OWNER`)
```

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6175