### PR TITLE
Move enable_shielded_nodes from beta to GA.

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -439,13 +439,11 @@ func resourceContainerCluster() *schema.Resource {
 				Default:  false,
 			},
 
-<% unless version == 'ga' -%>
 			"enable_shielded_nodes": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
 			},
-<% end -%>
 
 			"authenticator_groups_config": {
 				Type:     schema.TypeList,
@@ -1069,11 +1067,11 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			Enabled:         d.Get("enable_binary_authorization").(bool),
 			ForceSendFields: []string{"Enabled"},
 		},
-<% unless version == 'ga' -%>
 		ShieldedNodes: &containerBeta.ShieldedNodes{
 			Enabled:         d.Get("enable_shielded_nodes").(bool),
 			ForceSendFields: []string{"Enabled"},
 		},
+<% unless version == 'ga' -%>
 		ReleaseChannel:          expandReleaseChannel(d.Get("release_channel")),
 		EnableTpu:               d.Get("enable_tpu").(bool),
 		NetworkConfig: &containerBeta.NetworkConfig{
@@ -1333,10 +1331,10 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 	d.Set("enable_binary_authorization", cluster.BinaryAuthorization != nil && cluster.BinaryAuthorization.Enabled)
-<% unless version == 'ga' -%>
 	if cluster.ShieldedNodes != nil {
 		d.Set("enable_shielded_nodes", cluster.ShieldedNodes.Enabled)
 	}
+<% unless version == 'ga' -%>
 	d.Set("enable_tpu", cluster.EnableTpu)
 	d.Set("tpu_ipv4_cidr_block", cluster.TpuIpv4CidrBlock)
 
@@ -1524,7 +1522,6 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		d.SetPartial("enable_binary_authorization")
 	}
 
-<% unless version == 'ga' -%>
 	if d.HasChange("enable_shielded_nodes") {
 		enabled := d.Get("enable_shielded_nodes").(bool)
 		req := &containerBeta.UpdateClusterRequest{
@@ -1546,6 +1543,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		d.SetPartial("enable_shielded_nodes")
 	}
+<% unless version == 'ga' -%>
 
 	if d.HasChange("enable_intranode_visibility") {
 		enabled := d.Get("enable_intranode_visibility").(bool)

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1362,6 +1362,36 @@ func TestAccContainerCluster_nodeAutoprovisioningDefaults(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withShieldedNodes(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:	  func() { testAccPreCheck(t) },
+		Providers:	  testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withShieldedNodes(clusterName, true),
+			},
+			{
+				ResourceName:		 "google_container_cluster.with_shielded_nodes",
+				ImportState:		 true,
+				ImportStateVerify:	 true,
+			},
+			{
+				Config: testAccContainerCluster_withShieldedNodes(clusterName, false),
+			},
+			{
+				ResourceName:		 "google_container_cluster.with_shielded_nodes",
+				ImportState:		 true,
+				ImportStateVerify:	 true,
+			},
+		},
+	})
+}
+
 <% unless version == 'ga' -%>
 func TestAccContainerCluster_withAutoscalingProfile(t *testing.T) {
 	t.Parallel()
@@ -1507,36 +1537,6 @@ func TestAccContainerCluster_withBinaryAuthorization(t *testing.T) {
 			},
 			{
 				ResourceName:		 "google_container_cluster.with_binary_authorization",
-				ImportState:		 true,
-				ImportStateVerify:	 true,
-			},
-		},
-	})
-}
-
-func TestAccContainerCluster_withShieldedNodes(t *testing.T) {
-	t.Parallel()
-
-	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
-
-	vcrTest(t, resource.TestCase{
-		PreCheck:	  func() { testAccPreCheck(t) },
-		Providers:	  testAccProviders,
-		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccContainerCluster_withShieldedNodes(clusterName, true),
-			},
-			{
-				ResourceName:		 "google_container_cluster.with_shielded_nodes",
-				ImportState:		 true,
-				ImportStateVerify:	 true,
-			},
-			{
-				Config: testAccContainerCluster_withShieldedNodes(clusterName, false),
-			},
-			{
-				ResourceName:		 "google_container_cluster.with_shielded_nodes",
 				ImportState:		 true,
 				ImportStateVerify:	 true,
 			},

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -3392,6 +3392,20 @@ resource "google_container_cluster" "with_private_cluster" {
 }
 `, containerNetName, clusterName)
 }
+
+func testAccContainerCluster_withShieldedNodes(clusterName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_shielded_nodes" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  enable_shielded_nodes = %v
+}
+`, clusterName, enabled)
+}
+
+
 <% unless version.nil? || version == 'ga' -%>
 func testAccContainerCluster_sharedVpc(org, billingId, projectName, name string, suffix string) string {
 	return fmt.Sprintf(`
@@ -3546,18 +3560,6 @@ resource "google_container_cluster" "with_binary_authorization" {
   initial_node_count = 1
 
   enable_binary_authorization = %v
-}
-`, clusterName, enabled)
-}
-
-func testAccContainerCluster_withShieldedNodes(clusterName string, enabled bool) string {
-	return fmt.Sprintf(`
-resource "google_container_cluster" "with_shielded_nodes" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
-
-  enable_shielded_nodes = %v
 }
 `, clusterName, enabled)
 }

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -172,7 +172,7 @@ for more information.
     will have statically granted permissions beyond those provided by the RBAC configuration or IAM.
     Defaults to `false`
 
-* `enable_shielded_nodes` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Enable Shielded Nodes features on all nodes in this cluster.  Defaults to `false`.
+* `enable_shielded_nodes` - (Optional) Enable Shielded Nodes features on all nodes in this cluster.  Defaults to `false`.
 
 * `initial_node_count` - (Optional) The number of nodes to create in this
 cluster's default node pool. In regional or multi-zonal clusters, this is the


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6269.


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: Moved `google_container_cluster.enable_shielded_nodes` from beta to GA.
```