### PR TITLE
Fix node pool tests.

### DIFF
--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -568,6 +568,9 @@ func TestAccContainerNodePool_resize(t *testing.T) {
 	})
 }
 
+<%#  Re-enable this test when there is more than one acceptable node pool version
+     for the current master version.
+
 func TestAccContainerNodePool_version(t *testing.T) {
 	t.Parallel()
 
@@ -606,6 +609,7 @@ func TestAccContainerNodePool_version(t *testing.T) {
 		},
 	})
 }
+%>
 
 func TestAccContainerNodePool_regionalClusters(t *testing.T) {
 	t.Parallel()
@@ -1363,7 +1367,6 @@ resource "google_container_cluster" "cluster" {
   name               = "%s"
   location           = "us-central1-c"
   initial_node_count = 1
-  node_version       = data.google_container_engine_versions.central1c.latest_node_version
   min_master_version = data.google_container_engine_versions.central1c.latest_master_version
 }
 

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -568,11 +568,13 @@ func TestAccContainerNodePool_resize(t *testing.T) {
 	})
 }
 
-<%#  Re-enable this test when there is more than one acceptable node pool version
-     for the current master version.
 
 func TestAccContainerNodePool_version(t *testing.T) {
 	t.Parallel()
+
+	// Re-enable this test when there is more than one acceptable node pool version
+	// for the current master version
+	t.Skip()
 
 	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
 	np := fmt.Sprintf("tf-test-nodepool-%s", randString(t, 10))
@@ -609,7 +611,6 @@ func TestAccContainerNodePool_version(t *testing.T) {
 		},
 	})
 }
-%>
 
 func TestAccContainerNodePool_regionalClusters(t *testing.T) {
 	t.Parallel()
@@ -1425,9 +1426,6 @@ resource "google_container_node_pool" "np_with_node_config_scope_alias" {
 `, cluster, np)
 }
 
-<%#  Re-enable this test when there is more than one acceptable node pool version
-     for the current master version.
-
 func testAccContainerNodePool_version(cluster, np string) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
@@ -1475,7 +1473,6 @@ resource "google_container_node_pool" "np" {
 }
 `, cluster, np)
 }
-%>
 
 func testAccContainerNodePool_012_ConfigModeAttr1(cluster, np string) string {
 	return fmt.Sprintf(`

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -1425,6 +1425,9 @@ resource "google_container_node_pool" "np_with_node_config_scope_alias" {
 `, cluster, np)
 }
 
+<%#  Re-enable this test when there is more than one acceptable node pool version
+     for the current master version.
+
 func testAccContainerNodePool_version(cluster, np string) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
@@ -1472,6 +1475,7 @@ resource "google_container_node_pool" "np" {
 }
 `, cluster, np)
 }
+%>
 
 func testAccContainerNodePool_012_ConfigModeAttr1(cluster, np string) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
The core problem here is that the available node versions are such that
version (max - 1) is not compatible with the latest master version.

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6283.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```