### PR TITLE
add ability to manage firestore fields

### DIFF
--- a/products/firestore/api.yaml
+++ b/products/firestore/api.yaml
@@ -108,3 +108,95 @@ objects:
                 be specified.
               values:
                 - :CONTAINS
+  - !ruby/object:Api::Resource
+    name: 'Field'
+    base_url: 'projects/{{project}}/databases/{{database}}/collectionGroups/{{collection}}/fields'
+    self_link: 'projects/{{project}}/databases/{{database}}/collectionGroups/{{collection}}/fields/{{name}}'
+    create_verb: :PATCH
+    delete_verb: :PATCH
+    input: true
+    update_mask: true
+    description: |
+      Represents a single field in the database.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation': 'https://cloud.google.com/firestore/docs/query-data/indexing'
+      api: 'https://cloud.google.com/firestore/docs/reference/rest/v1/projects.databases.collectionGroups.fields'
+    properties:
+      - !ruby/object:Api::Type::String
+        name: database
+        default_value: '(default)'
+        description: |
+          The Firestore database id. Defaults to `"(default)"`.
+      - !ruby/object:Api::Type::String
+        name: collection
+        required: true
+        description: |
+          The collection being indexed.
+      - !ruby/object:Api::Type::String
+        name: name
+        required: true
+        description: |
+          A name of the form
+          `projects/{project_id}/databases/{database_id}/collectionGroups/{collectionId}/fields/{field_id}`
+      - !ruby/object:Api::Type::String
+        name: 'ancestorField'
+        output: true
+        description: |
+          Output only. Specifies the resource name of the Field from which this field's index configuration is set
+          (when usesAncestorConfig is true), or from which it would be set if this field had no index
+          configuration (when usesAncestorConfig is false).
+      - !ruby/object:Api::Type::NestedObject
+        name: indexConfig
+        description: |
+          The index configuration for this field. If unset, field indexing will revert to the configuration defined
+          by the ancestorField. To explicitly remove all indexes for this field, specify an index config with an empty
+          list of indexes.
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: indexes
+            description: |
+              The indexes supported for this field.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+              - !ruby/object:Api::Type::Enum
+                name: queryScope
+                description: |
+                  The scope at which a query is run. One of `"COLLECTION"` or
+                  `"COLLECTION_GROUP"`. Defaults to `"COLLECTION"`.
+                default_value: :COLLECTION
+                values:
+                  - :COLLECTION
+                  - :COLLECTION_GROUP
+              - !ruby/object:Api::Type::Array
+                name: fields
+                description: |
+                  The fields supported by this index. The last field entry is always for
+                  the field path `__name__`. If, on creation, `__name__` was not
+                  specified as the last field, it will be added automatically with the
+                  same direction as that of the last field defined. If the final field
+                  in a composite index is not directional, the `__name__` will be
+                  ordered `"ASCENDING"` (unless explicitly specified otherwise).
+                item_type: !ruby/object:Api::Type::NestedObject
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: 'fieldPath'
+                      description: |
+                        Name of the field.
+                    - !ruby/object:Api::Type::Enum
+                      name: 'order'
+                      # Exactly one of order or arrayConfig must be set
+                      description: |
+                        Indicates that this field supports ordering by the specified order or comparing using =, <, <=, >, >=.
+                        Only one of `order` and `arrayConfig` can be specified.
+                      values:
+                        - :ASCENDING
+                        - :DESCENDING
+                    - !ruby/object:Api::Type::Enum
+                      name: 'arrayConfig'
+                      # Exactly one of order or arrayConfig must be set
+                      description: |
+                        Indicates that this field supports operations on arrayValues. Only one of `order` and `arrayConfig` can
+                        be specified.
+                      values:
+                          - :CONTAINS

--- a/products/firestore/terraform.yaml
+++ b/products/firestore/terraform.yaml
@@ -43,7 +43,36 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read: true
       collection: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
-
+  Field: !ruby/object:Overrides::Terraform::ResourceOverride
+    timeouts: !ruby/object:Api::Timeouts
+      insert_minutes: 10
+      update_minutes: 10
+      delete_minutes: 10
+    autogen_async: true
+    # This resource is a child resource
+    skip_sweeper: true
+    import_format: ["{{name}}"]
+    description: |
+      {{description}} This resource manages single field indexes.
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "firestore_field_basic"
+        primary_resource_id: "my-field"
+        # This example relies on a well-known collection having been created and
+        # Firestore being enabled on the project. We can't do that automatically
+        # so we need a pre-created project.
+        test_env_vars:
+          project_id: :FIRESTORE_PROJECT_NAME
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      custom_import: templates/terraform/custom_import/field_self_link_as_name_set_project.go.erb
+      custom_delete: templates/terraform/custom_delete/firestore_field_delete.go.erb
+      encoder: templates/terraform/encoders/field.go.erb
+      post_create: templates/terraform/post_create/field.go.erb
+    properties:
+      database: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
+      collection: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.

--- a/templates/terraform/custom_delete/firestore_field_delete.go.erb
+++ b/templates/terraform/custom_delete/firestore_field_delete.go.erb
@@ -1,0 +1,55 @@
+config := meta.(*Config)
+
+obj := make(map[string]interface{})
+databaseProp, err := expandFirestoreFieldDatabase(d.Get("database"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("database"); !isEmptyValue(reflect.ValueOf(databaseProp)) && (ok || !reflect.DeepEqual(v, databaseProp)) {
+	obj["database"] = databaseProp
+}
+collectionProp, err := expandFirestoreFieldCollection(d.Get("collection"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("collection"); !isEmptyValue(reflect.ValueOf(collectionProp)) && (ok || !reflect.DeepEqual(v, collectionProp)) {
+	obj["collection"] = collectionProp
+}
+nameProp, err := expandFirestoreFieldName(d.Get("name"), d, config)
+if err != nil {
+	return err
+} else if v, ok := d.GetOkExists("name"); !isEmptyValue(reflect.ValueOf(nameProp)) && (ok || !reflect.DeepEqual(v, nameProp)) {
+	obj["name"] = nameProp
+}
+
+obj, err = resourceFirestoreFieldEncoder(d, meta, obj)
+if err != nil {
+	return err
+}
+
+url, err := replaceVars(d, config, "{{FirestoreBasePath}}{{name}}")
+if err != nil {
+	return err
+}
+
+log.Printf("[DEBUG] Deleting Field: %#v", obj)
+project, err := getProject(d, config)
+if err != nil {
+	return err
+}
+res, err := sendRequestWithTimeout(config, "PATCH", project, url, obj, d.Timeout(schema.TimeoutDelete))
+if err != nil {
+	return fmt.Errorf("Error deleting Field: %s", err)
+}
+
+// Use the resource in the operation response to populate
+// identity fields and d.Id() before read
+var opRes map[string]interface{}
+err = firestoreOperationWaitTimeWithResponse(
+	config, res, &opRes, project, "Creating Field",
+	d.Timeout(schema.TimeoutDelete))
+if err != nil {
+	return fmt.Errorf("Error waiting to delete Field: %s", err)
+}
+
+log.Printf("[DEBUG] Finished deleting Field %q: %#v", d.Id(), res)
+
+return resourceFirestoreFieldRead(d, meta)

--- a/templates/terraform/custom_import/field_self_link_as_name_set_project.go.erb
+++ b/templates/terraform/custom_import/field_self_link_as_name_set_project.go.erb
@@ -1,0 +1,22 @@
+
+	config := meta.(*Config)
+
+	// current import_formats can't import fields with forward slashes in their value
+	if err := parseImportId([]string{"(?P<field>.+)"}, d, config); err != nil {
+		return nil, err
+	}
+
+	stringParts := strings.Split(d.Get("field").(string), "/")
+	if len(stringParts) != 8 {
+		return nil, fmt.Errorf(
+				"Saw %s when the name is expected to have shape %s",
+				d.Get("field"),
+				"projects/{{project}}/databases/{{database}}/collectionGroups/{{collection}}/fields/{{name}}",
+			)
+	}
+
+	d.Set("project", stringParts[1])
+	d.Set("database", stringParts[3])
+	d.Set("collection", stringParts[5])
+	d.Set("name", stringParts[7])
+	return []*schema.ResourceData{d}, nil

--- a/templates/terraform/encoders/field.go.erb
+++ b/templates/terraform/encoders/field.go.erb
@@ -1,0 +1,20 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2019 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+
+delete(obj, "project")
+delete(obj, "database")
+delete(obj, "collection")
+delete(obj, "name")
+return obj, nil

--- a/templates/terraform/examples/firestore_field_basic.tf.erb
+++ b/templates/terraform/examples/firestore_field_basic.tf.erb
@@ -1,0 +1,74 @@
+// If the field is present, it will be ENABLED
+resource "google_firestore_field" "<%= ctx[:primary_resource_id] %>" {
+  project = "<%= ctx[:test_env_vars]['project_id'] %>"
+
+  collection = "chatrooms"
+
+  name = "projects/"<%= ctx[:test_env_vars]['project_id'] %>"/databases/{database_id}/collectionGroups/chatrooms/fields/name"
+
+  index_config {
+    indexes {
+      query_scope = "COLLECTION"
+
+      fields {
+        field_path = "name"
+        order = "ASCENDING"
+      }
+    }
+
+    indexes {
+      query_scope = "COLLECTION"
+
+      fields {
+        field_path = "name"
+        order = "DESCENDING"
+      }
+    }
+
+    indexes {
+      query_scope = "COLLECTION"
+
+      fields {
+        field_path = "name"
+        array_config = "CONTAINS"
+      }
+    }
+
+    indexes {
+      query_scope = "COLLECTION_GROUP"
+
+      fields {
+        field_path = "name"
+        order = "ASCENDING"
+      }
+    }
+
+    indexes {
+      query_scope = "COLLECTION_GROUP"
+
+      fields {
+        field_path = "name"
+        order = "DESCENDING"
+      }
+    }
+
+    indexes {
+      query_scope = "COLLECTION_GROUP"
+
+      fields {
+        field_path = "name"
+        array_config = "CONTAINS"
+      }
+    }
+  }
+}
+
+// If the field is not present, it will be DISABLED
+resource "google_firestore_field" "my_field" {
+  project = "<%= ctx[:test_env_vars]['project_id'] %>"
+  collection = "chatrooms"
+  name = "projects/"<%= ctx[:test_env_vars]['project_id'] %>"/databases/{database_id}/collectionGroups/chatrooms/fields/name"
+  index_config {
+    // An empty index_config disables every field
+  }
+}

--- a/templates/terraform/post_create/field.go.erb
+++ b/templates/terraform/post_create/field.go.erb
@@ -1,0 +1,29 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2019 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+metadata := res["metadata"].(map[string]interface{})
+name := metadata["field"].(string)
+log.Printf("[DEBUG] Setting Field name, id to %s", name)
+
+stringParts := strings.Split(name, "/")
+if len(stringParts) != 8 {
+	return fmt.Errorf(
+			"Saw %s when the name is expected to have shape %s",
+			d.Get("field"),
+			"projects/{{project}}/databases/{{database}}/collectionGroups/{{collection}}/fields/{{name}}",
+		)
+}
+
+d.Set("name", stringParts[7])
+d.SetId(name)


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

    - release-note:enhancement
    - release-note:new-resource
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
release-note:enhancement

I'm not sure which release-note to use. either enhancement or new-resource.

One TODO remains, which is to read the proper state of fields to compare and construct the terraform state.

I'd like to get initial reviews to make sure I am on the right track to add the ability to create Single field index via terraform


```
