### PR TITLE
Initial definition for metric descriptor

### DIFF
--- a/products/monitoring/api.yaml
+++ b/products/monitoring/api.yaml
@@ -693,7 +693,6 @@ objects:
         required: true
       - !ruby/object:Api::Type::Array
         name: 'notificationChannels'
-        # TODO chrisst - turn this into a resource ref
         description: |
           Identifies the notification channels to which notifications should be
           sent when incidents are opened or closed or when new violations occur
@@ -757,7 +756,6 @@ objects:
     properties:
       - !ruby/object:Api::Type::String
         name: parentName
-        # TODO chrisst - turn into self-reference if possible.
         description: |
           The name of the group's parent, if it has one. The format is
           "projects/{project_id_or_number}/groups/{group_id}". For
@@ -1320,3 +1318,127 @@ objects:
         description: Values for all of the labels listed in the associated
           monitored resource descriptor. For example, Compute Engine VM instances use
           the labels "project_id", "instance_id", and "zone".
+
+  - !ruby/object:Api::Resource
+    name: MetricDescriptor
+    input: true
+    self_link: "{{name}}"
+    base_url: projects/{{project}}/metricDescriptors
+    description: Defines a metric type and its schema. Once a metric descriptor is created,
+      deleting or altering it stops data collection and makes the metric type's existing
+      data unusable.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation': 'https://cloud.google.com/monitoring/custom-metrics/'
+      api: 'https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors'
+    properties:
+    - !ruby/object:Api::Type::String
+      name: unit
+      description: |-
+        The unit in which the metric value is reported. It is only applicable if the value_type is INT64, DOUBLE, or DISTRIBUTION.
+        The supported units are a subset of The Unified Code for Units of Measure (http://unitsofmeasure.org/ucum.html)
+        Basic units (UNIT)
+
+        bit bit
+        By byte
+        s second
+        min minute
+        h hour
+        d day
+
+        For more complex expressions see https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors#resource-metricdescriptor
+      output: false
+    - !ruby/object:Api::Type::Array
+      name: labels
+      description: The set of labels that can be used to describe a specific instance
+        of this metric type. For example, the appengine.googleapis.com/http/server/response_latencies
+        metric type has a label for the HTTP response code, response_code, so you can
+        look at latencies for successful responses or just for responses that failed.
+      item_type: !ruby/object:Api::Type::NestedObject
+        properties:
+        - !ruby/object:Api::Type::String
+          name: key
+          description: The label key.
+        - !ruby/object:Api::Type::String
+          name: description
+          description: A human-readable description for the label.
+        - !ruby/object:Api::Type::Enum
+          name: valueType
+          description: The type of data that can be assigned to the label.
+          values:
+          - :STRING
+          - :BOOL
+          - :INT64
+    - !ruby/object:Api::Type::String
+      name: name
+      description: |
+        The resource name of the metric descriptor.
+        ex: projects/<project-id>/metricDescriptors/agent.googleapis.com/apache/traffic
+      output: true
+    - !ruby/object:Api::Type::String
+      name: type
+      required: true
+      # TODO chrisst - custom validation func for 'custom.googleapis.com' prefix
+      description: |
+        The metric type, including its DNS name prefix. The type is not URL-encoded.
+        All user-defined metric types have the DNS name custom.googleapis.com or external.googleapis.com.
+        Metric types should use a natural hierarchical grouping. For example:
+        "custom.googleapis.com/invoice/paid/amount"
+        "external.googleapis.com/prometheus/up"
+        "appengine.googleapis.com/http/server/response_latencies"
+    - !ruby/object:Api::Type::NestedObject
+      name: metadata
+      description: Optional. Metadata which can be used to guide usage of the metric.
+      properties:
+      - !ruby/object:Api::Type::String
+        name: ingestDelay
+        description: The delay of data points caused by ingestion. Data points older
+          than this age are guaranteed to be ingested and available to be read, excluding
+          data loss due to errors.
+      - !ruby/object:Api::Type::Enum
+        name: launchStage
+        description: The launch stage of the metric definition.
+        # todo chrisst - can this be specifed?
+        output: false
+        values:
+        - :EARLY_ACCESS
+        - :ALPHA
+        - :BETAf
+        - :GA
+        - :DEPRECATED
+      - !ruby/object:Api::Type::String
+        name: samplePeriod
+        description: The sampling period of metric data points. For metrics which are
+          written periodically, consecutive data points are stored at this time interval,
+          excluding data loss due to errors. Metrics with a higher granularity have
+          a smaller sampling period.
+    - !ruby/object:Api::Type::Enum
+      name: valueType
+      required: true
+      description: Whether the measurement is an integer, a floating-point number, etc.
+        Some combinations of metric_kind and value_type might not be supported.
+      values:
+      - :BOOL
+      - :INT64
+      - :DOUBLE
+      - :STRING
+      - :DISTRIBUTION
+      - :MONEY
+    - !ruby/object:Api::Type::Enum
+      name: metricKind
+      required: true
+      description: Whether the metric records instantaneous values, changes to a value,
+        etc. Some combinations of metric_kind and value_type might not be supported.
+      values:
+      - :GAUGE
+      - :DELTA
+      - :CUMULATIVE
+    - !ruby/object:Api::Type::String
+      name: displayName
+      description: A concise name for the metric, which can be displayed in user interfaces.
+        Use sentence case without an ending period, for example "Request count". This
+        field is optional but it is recommended to be set for any metrics associated
+        with user-visible concepts, such as Quota.
+    - !ruby/object:Api::Type::String
+      name: description
+      description: A detailed description of the metric, which can be used in documentation.

--- a/products/monitoring/terraform.yaml
+++ b/products/monitoring/terraform.yaml
@@ -211,6 +211,23 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_expand: "templates/terraform/custom_expand/resource_from_self_link.go.erb"
         custom_flatten: "templates/terraform/custom_flatten/group_id_to_name.erb"
 
+  MetricDescriptor: !ruby/object:Provider::Terraform::ResourceOverride
+    id_format: "{{name}}"
+    import_format: ["{{name}}"]
+    # mutex: stackdriver/groups/{{project}}
+    # TODO chrisst - mutex is almost certainly needed
+    example:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "monitoring_metric_descriptor"
+        primary_resource_id: "basic"
+        vars:
+          display_name: "Test Custom Metric"
+          type: "custom.googleapis.com/terraform/test"
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      custom_import: templates/terraform/custom_import/self_link_as_name.erb
+      # post_create: templates/terraform/post_create/metric_descriptor_wait.erb
+      # TODO chrisst - need to use a poll based wait for N repeated 200 post create
+
 files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.
   # This is usually to add licensing info, autogeneration notices, etc.

--- a/templates/terraform/examples/monitoring_metric_descriptor.tf.erb
+++ b/templates/terraform/examples/monitoring_metric_descriptor.tf.erb
@@ -1,0 +1,6 @@
+resource "google_monitoring_metric_descriptor" "<%= ctx[:primary_resource_id] %>" {
+  display_name = "<%= ctx[:vars]["display_name"] %>"
+  type = "<%= ctx[:vars]["type"] %>"
+  metric_kind = "GAUGE"
+  value_type = "BOOL"
+}


### PR DESCRIPTION
Adding my WIP PR that I abandoned when I first added stackdriver monitoring endpoints. Since that time magic modules has added better support for polling non-operation async resources so I suspect this is more possible now.

re https://github.com/terraform-providers/terraform-provider-google/issues/3360

One of the issues was  this endpoint is an async and eventually consistent endpoint. Meaning that after initial create and a 200 response, the resources will 404 for ~60s. Also for a short time it will randomly 404 and 200 making it difficult to determine the state of the object reliably.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
