### PR TITLE
support for vpc connector for cloud run

### DIFF
--- a/products/cloudrun/api.yaml
+++ b/products/cloudrun/api.yaml
@@ -266,7 +266,6 @@ objects:
   - !ruby/object:Api::Type::String
     name: vpc_connector
     description: The VPC connector the cloud run instance will use
-    required: false
     min_version: beta
   - !ruby/object:Api::Type::String
     name: apiVersion

--- a/products/cloudrun/api.yaml
+++ b/products/cloudrun/api.yaml
@@ -18,6 +18,9 @@ versions:
   - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://{{location}}-run.googleapis.com/
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://{{location}}-run.googleapis.com/v1beta1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 objects:
@@ -260,6 +263,11 @@ objects:
       Is required when creating resources. Name is primarily intended
       for creation idempotence and configuration definition. Cannot be updated.
       More info: http://kubernetes.io/docs/user-guide/identifiers#names
+  - !ruby/object:Api::Type::String
+    name: vpc_connector
+    description: The VPC connector the cloud run instance will use
+    required: false
+    min_version: beta
   - !ruby/object:Api::Type::String
     name: apiVersion
     description: The API version for this call such as "serving.knative.dev/v1alpha1".

--- a/third_party/terraform/tests/resource_cloud_run_service_vpc_connector_test.go.erb
+++ b/third_party/terraform/tests/resource_cloud_run_service_vpc_connector_test.go.erb
@@ -1,0 +1,90 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccCloudRunService_cloudRunVPCServiceUpdate(t *testing.T) {
+	t.Parallel()
+
+	project := getTestProjectFromEnv()
+	name := "tfvpctest-cloudrun-" + randString(t, 6)
+	networkName := fmt.Sprintf("tf-test-net-%d", randInt(t))
+	vpcConnectorName := fmt.Sprintf("tf-test-conn-%s", randString(t, 5))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudRunService_cloudRunVPCServiceUpdate(name, project, networkName, vpcConnectorName, "10.10.0.0/28", "10"),
+			},
+			{
+				ResourceName:            "google_cloud_run_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+			},
+			{
+				Config: testAccCloudRunService_cloudRunVPCServiceUpdate(name, project, networkName, vpcConnectorName, "10.10.0.0/28", "50"),
+			},
+			{
+				ResourceName:            "google_cloud_run_service.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
+			},
+		},
+	})
+}
+
+func testAccCloudRunService_cloudRunVPCServiceUpdate(name, project, networkName, vpcConnectorName, vpcIp, concurrency string) string {
+	return fmt.Sprintf(`
+	resource "google_compute_network" "vpc" {
+		name = "%s"
+		auto_create_subnetworks = false
+	}
+	
+	resource "google_vpc_access_connector" "%s" {
+		name          = "%s"
+		region        = "us-central1"
+		ip_cidr_range = "%s"
+		network       = google_compute_network.vpc.name
+	}
+
+	resource "google_cloud_run_service" "default" {
+		name     = "%s"
+		location = "us-central1"
+    provider = google-beta
+
+		metadata {
+			namespace = "%s"
+		}
+		
+		vpc_connector	=	google_vpc_access_connector.%s.self_link
+
+		template {
+			spec {
+				containers {
+					image = "gcr.io/cloudrun/hello"
+					args  = ["arrgs"]
+				}
+			container_concurrency = %s
+			}
+		}
+
+		traffic {
+			percent         = 100
+			latest_revision = true
+		}
+	}
+`, networkName, vpcConnectorName, vpcConnectorName, vpcIp, name, project, vpcConnectorName, concurrency)
+}
+<% else %>
+// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
+<% end -%>


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

fixes https://github.com/terraform-providers/terraform-provider-google/issues/6294

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
added vpc_connector property to cloud run service resource
```
