### PR TITLE
Vcr ignore tests

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1961,14 +1961,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "ssl_certificate_basic"
         primary_resource_id: "default"
+        skip_vcr: true
         ignore_read_extra:
           - "name_prefix"
       - !ruby/object:Provider::Terraform::Examples
         name: "ssl_certificate_random_provider"
         primary_resource_id: "default"
+        skip_vcr: true
       - !ruby/object:Provider::Terraform::Examples
         name: "ssl_certificate_target_https_proxies"
         primary_resource_id: "default"
+        skip_vcr: true
         vars:
           target_https_proxy_name: "test-proxy"
           url_map_name: "url-map"
@@ -2006,14 +2009,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "region_ssl_certificate_basic"
         primary_resource_id: "default"
+        skip_vcr: true
         ignore_read_extra:
           - "name_prefix"
       - !ruby/object:Provider::Terraform::Examples
         name: "region_ssl_certificate_random_provider"
         primary_resource_id: "default"
+        skip_vcr: true
       - !ruby/object:Provider::Terraform::Examples
         name: "region_ssl_certificate_target_https_proxies"
         primary_resource_id: "default"
+        skip_vcr: true
         vars:
           region_target_https_proxy_name: "test-proxy"
           region_url_map_name: "url-map"

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1961,16 +1961,19 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "ssl_certificate_basic"
         primary_resource_id: "default"
+        # Uses resource.UniqueId
         skip_vcr: true
         ignore_read_extra:
           - "name_prefix"
       - !ruby/object:Provider::Terraform::Examples
         name: "ssl_certificate_random_provider"
         primary_resource_id: "default"
+        # Uses resource.UniqueId
         skip_vcr: true
       - !ruby/object:Provider::Terraform::Examples
         name: "ssl_certificate_target_https_proxies"
         primary_resource_id: "default"
+        # Uses resource.UniqueId
         skip_vcr: true
         vars:
           target_https_proxy_name: "test-proxy"
@@ -2009,16 +2012,19 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "region_ssl_certificate_basic"
         primary_resource_id: "default"
+        # Uses resource.UniqueId
         skip_vcr: true
         ignore_read_extra:
           - "name_prefix"
       - !ruby/object:Provider::Terraform::Examples
         name: "region_ssl_certificate_random_provider"
         primary_resource_id: "default"
+        # Uses resource.UniqueId
         skip_vcr: true
       - !ruby/object:Provider::Terraform::Examples
         name: "region_ssl_certificate_target_https_proxies"
         primary_resource_id: "default"
+        # Uses resource.UniqueId
         skip_vcr: true
         vars:
           region_target_https_proxy_name: "test-proxy"

--- a/products/dns/terraform.yaml
+++ b/products/dns/terraform.yaml
@@ -19,6 +19,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "dns_managed_zone_basic"
         primary_resource_id: "example-zone"
+        # Randomness from random provider
         skip_vcr: true
       - !ruby/object:Provider::Terraform::Examples
         name: "dns_managed_zone_private"

--- a/products/dns/terraform.yaml
+++ b/products/dns/terraform.yaml
@@ -19,6 +19,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "dns_managed_zone_basic"
         primary_resource_id: "example-zone"
+        skip_vcr: true
       - !ruby/object:Provider::Terraform::Examples
         name: "dns_managed_zone_private"
         primary_resource_id: "private-zone"

--- a/products/spanner/terraform.yaml
+++ b/products/spanner/terraform.yaml
@@ -26,6 +26,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "spanner_database_basic"
         primary_resource_id: "database"
+        # Randomness due to spanner instance
         skip_vcr: true
         vars:
           database_name: "my-database"
@@ -56,6 +57,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "spanner_instance_basic"
         primary_resource_id: "example"
+        # Randomness
         skip_vcr: true
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/products/spanner/terraform.yaml
+++ b/products/spanner/terraform.yaml
@@ -26,6 +26,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "spanner_database_basic"
         primary_resource_id: "database"
+        skip_vcr: true
         vars:
           database_name: "my-database"
     properties:
@@ -55,6 +56,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "spanner_instance_basic"
         primary_resource_id: "example"
+        skip_vcr: true
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         description: |

--- a/provider/terraform/examples.rb
+++ b/provider/terraform/examples.rb
@@ -119,6 +119,12 @@ module Provider
       # Defaults to `templates/terraform/examples/{{name}}.tf.erb`
       attr_reader :config_path
 
+      # If the example should be skipped during VCR testing.
+      # This is the case when something about the resource or config causes VCR to fail
+      # for example, a resource with a unique identifier generated within the resource via resource.UniqueId()
+      # Or a config with two fine grained resources that have a race condition during create
+      attr_reader :skip_vcr
+
       def config_documentation(pwd)
         docs_defaults = {
           PROJECT_NAME: 'my-project-name',
@@ -262,6 +268,7 @@ module Provider
         check :primary_resource_name, type: String
         check :skip_test, type: TrueClass
         check :config_path, type: String, default: "templates/terraform/examples/#{name}.tf.erb"
+        check :skip_vcr, type: TrueClass
       end
     end
   end

--- a/provider/terraform/examples.rb
+++ b/provider/terraform/examples.rb
@@ -120,8 +120,8 @@ module Provider
       attr_reader :config_path
 
       # If the example should be skipped during VCR testing.
-      # This is the case when something about the resource or config causes VCR to fail
-      # for example, a resource with a unique identifier generated within the resource via resource.UniqueId()
+      # This is the case when something about the resource or config causes VCR to fail for example
+      # a resource with a unique identifier generated within the resource via resource.UniqueId()
       # Or a config with two fine grained resources that have a race condition during create
       attr_reader :skip_vcr
 

--- a/templates/terraform/examples/base_configs/test_file.go.erb
+++ b/templates/terraform/examples/base_configs/test_file.go.erb
@@ -39,6 +39,9 @@ object.examples
 -%>
 
 func TestAcc<%= test_slug -%>(t *testing.T) {
+<% if example.skip_vcr -%>
+	skipIfVcr(t)
+<% end -%>
   t.Parallel()
 
 	context := map[string]interface{} {

--- a/third_party/terraform/data_sources/data_source_compute_network_endpoint_group_test.go
+++ b/third_party/terraform/data_sources/data_source_compute_network_endpoint_group_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -13,7 +12,7 @@ func TestAccDataSourceComputeNetworkEndpointGroup(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
-		"random_suffix": acctest.RandString(10),
+		"random_suffix": randString(t, 10),
 	}
 
 	vcrTest(t, resource.TestCase{

--- a/third_party/terraform/resources/resource_compute_instance_iam_test.go
+++ b/third_party/terraform/resources/resource_compute_instance_iam_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
@@ -16,7 +15,7 @@ func TestAccComputeInstanceIamPolicy(t *testing.T) {
 	project := getTestProjectFromEnv()
 	role := "roles/compute.osLogin"
 	zone := getTestZoneFromEnv()
-	instanceName := fmt.Sprintf("tf-test-instance-%s", acctest.RandString(10))
+	instanceName := fmt.Sprintf("tf-test-instance-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/third_party/terraform/tests/data_source_google_compute_region_instance_group_test.go.erb
+++ b/third_party/terraform/tests/data_source_google_compute_region_instance_group_test.go.erb
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccDataSourceRegionInstanceGroup(t *testing.T) {
+  skipIfVcr(t)
 	t.Parallel()
 	name := "acctest-" + randString(t, 6)
 	vcrTest(t, resource.TestCase{

--- a/third_party/terraform/tests/data_source_google_compute_region_instance_group_test.go.erb
+++ b/third_party/terraform/tests/data_source_google_compute_region_instance_group_test.go.erb
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccDataSourceRegionInstanceGroup(t *testing.T) {
+  // Randomness in instance template
   skipIfVcr(t)
 	t.Parallel()
 	name := "acctest-" + randString(t, 6)

--- a/third_party/terraform/tests/data_source_google_compute_region_instance_group_test.go.erb
+++ b/third_party/terraform/tests/data_source_google_compute_region_instance_group_test.go.erb
@@ -9,8 +9,8 @@ import (
 )
 
 func TestAccDataSourceRegionInstanceGroup(t *testing.T) {
-  // Randomness in instance template
-  skipIfVcr(t)
+	// Randomness in instance template
+	skipIfVcr(t)
 	t.Parallel()
 	name := "acctest-" + randString(t, 6)
 	vcrTest(t, resource.TestCase{

--- a/third_party/terraform/tests/resource_access_context_manager_service_perimeter_resource_test.go
+++ b/third_party/terraform/tests/resource_access_context_manager_service_perimeter_resource_test.go
@@ -12,6 +12,7 @@ import (
 // can exist, they need to be ran serially. See AccessPolicy for the test runner.
 
 func testAccAccessContextManagerServicePerimeterResource_basicTest(t *testing.T) {
+	skipIfVcr(t)
 	org := getTestOrgFromEnv(t)
 	projects := BootstrapServicePerimeterProjects(t, 2)
 	policyTitle := "my policy"

--- a/third_party/terraform/tests/resource_access_context_manager_service_perimeter_resource_test.go
+++ b/third_party/terraform/tests/resource_access_context_manager_service_perimeter_resource_test.go
@@ -12,6 +12,7 @@ import (
 // can exist, they need to be ran serially. See AccessPolicy for the test runner.
 
 func testAccAccessContextManagerServicePerimeterResource_basicTest(t *testing.T) {
+	// Multiple fine-grained resources
 	skipIfVcr(t)
 	org := getTestOrgFromEnv(t)
 	projects := BootstrapServicePerimeterProjects(t, 2)

--- a/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
+++ b/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
@@ -69,6 +69,7 @@ func TestAccBigQueryDatasetAccess_view(t *testing.T) {
 }
 
 func TestAccBigQueryDatasetAccess_multiple(t *testing.T) {
+	// Multiple fine-grained resources
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
+++ b/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
@@ -69,6 +69,7 @@ func TestAccBigQueryDatasetAccess_view(t *testing.T) {
 }
 
 func TestAccBigQueryDatasetAccess_multiple(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	datasetID := fmt.Sprintf("tf_test_%s", randString(t, 10))

--- a/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -378,6 +378,7 @@ func TestAccComputeDisk_deleteDetach(t *testing.T) {
 }
 
 func TestAccComputeDisk_deleteDetachIGM(t *testing.T) {
+	// Randomness in instance template
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -206,6 +206,8 @@ func TestAccComputeDisk_imageDiffSuppressPublicVendorsFamilyNames(t *testing.T) 
 }
 
 func TestAccComputeDisk_timeout(t *testing.T) {
+	// Vcr speeds up test, so it doesn't time out
+	skipIfVcr(t)
 	t.Parallel()
 
 	diskName := fmt.Sprintf("tf-test-disk-%d", randInt(t))
@@ -376,6 +378,7 @@ func TestAccComputeDisk_deleteDetach(t *testing.T) {
 }
 
 func TestAccComputeDisk_deleteDetachIGM(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	diskName := fmt.Sprintf("tf-test-%s", randString(t, 10))

--- a/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -97,6 +97,7 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 }
 
 func TestAccInstanceGroupManager_updateLifecycle(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	tag1 := "tag1"
@@ -129,6 +130,7 @@ func TestAccInstanceGroupManager_updateLifecycle(t *testing.T) {
 }
 
 func TestAccInstanceGroupManager_updatePolicy(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	igm := fmt.Sprintf("igm-test-%s", randString(t, 10))
@@ -176,6 +178,7 @@ func TestAccInstanceGroupManager_updatePolicy(t *testing.T) {
 }
 
 func TestAccInstanceGroupManager_separateRegions(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	igm1 := fmt.Sprintf("igm-test-%s", randString(t, 10))

--- a/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -97,6 +97,7 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 }
 
 func TestAccInstanceGroupManager_updateLifecycle(t *testing.T) {
+	// Randomness in instance template
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -130,6 +131,7 @@ func TestAccInstanceGroupManager_updateLifecycle(t *testing.T) {
 }
 
 func TestAccInstanceGroupManager_updatePolicy(t *testing.T) {
+	// Randomness in instance template
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -178,6 +180,7 @@ func TestAccInstanceGroupManager_updatePolicy(t *testing.T) {
 }
 
 func TestAccInstanceGroupManager_separateRegions(t *testing.T) {
+	// Randomness in instance template
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_compute_instance_template_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_template_test.go
@@ -511,6 +511,7 @@ func TestAccComputeInstanceTemplate_subnet_custom(t *testing.T) {
 }
 
 func TestAccComputeInstanceTemplate_subnet_xpn(t *testing.T) {
+	// Randomness
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -820,6 +821,7 @@ func TestAccComputeInstanceTemplate_invalidDiskType(t *testing.T) {
 }
 
 func TestAccComputeInstanceTemplate_imageResourceTest(t *testing.T) {
+	// Multiple fine-grained resources
 	skipIfVcr(t)
 	t.Parallel()
 	diskName := "tf-test-disk-" + randString(t, 10)

--- a/third_party/terraform/tests/resource_compute_instance_template_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_template_test.go
@@ -511,6 +511,7 @@ func TestAccComputeInstanceTemplate_subnet_custom(t *testing.T) {
 }
 
 func TestAccComputeInstanceTemplate_subnet_xpn(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	var instanceTemplate compute.InstanceTemplate
@@ -819,6 +820,7 @@ func TestAccComputeInstanceTemplate_invalidDiskType(t *testing.T) {
 }
 
 func TestAccComputeInstanceTemplate_imageResourceTest(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 	diskName := "tf-test-disk-" + randString(t, 10)
 	computeImage := "tf-test-image-" + randString(t, 10)

--- a/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_test.go
@@ -903,6 +903,7 @@ func TestAccComputeInstance_subnet_custom(t *testing.T) {
 }
 
 func TestAccComputeInstance_subnet_xpn(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	var instance compute.Instance

--- a/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_test.go
@@ -903,6 +903,7 @@ func TestAccComputeInstance_subnet_custom(t *testing.T) {
 }
 
 func TestAccComputeInstance_subnet_xpn(t *testing.T) {
+	// Multiple fine-grained resources
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_compute_network_endpoint_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_network_endpoint_test.go.erb
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccComputeNetworkEndpoint_networkEndpointsBasic(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	context := map[string]interface{}{

--- a/third_party/terraform/tests/resource_compute_network_endpoint_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_network_endpoint_test.go.erb
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccComputeNetworkEndpoint_networkEndpointsBasic(t *testing.T) {
+	// Multiple fine-grained resources
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
@@ -99,6 +99,7 @@ func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 }
 
 func TestAccRegionInstanceGroupManager_updateLifecycle(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	tag1 := "tag1"
@@ -131,6 +132,7 @@ func TestAccRegionInstanceGroupManager_updateLifecycle(t *testing.T) {
 }
 
 func TestAccRegionInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	igm := fmt.Sprintf("igm-test-%s", randString(t, 10))
@@ -166,6 +168,7 @@ func TestAccRegionInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 }
 
 func TestAccRegionInstanceGroupManager_separateRegions(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	igm1 := fmt.Sprintf("igm-test-%s", randString(t, 10))

--- a/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
@@ -99,6 +99,7 @@ func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 }
 
 func TestAccRegionInstanceGroupManager_updateLifecycle(t *testing.T) {
+	// Randomness in instance template
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -132,6 +133,7 @@ func TestAccRegionInstanceGroupManager_updateLifecycle(t *testing.T) {
 }
 
 func TestAccRegionInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
+	// Randomness in instance template
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -168,6 +170,7 @@ func TestAccRegionInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 }
 
 func TestAccRegionInstanceGroupManager_separateRegions(t *testing.T) {
+	// Randomness in instance template
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_compute_ssl_certificate_test.go
+++ b/third_party/terraform/tests/resource_compute_ssl_certificate_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccComputeSslCertificate_no_name(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	vcrTest(t, resource.TestCase{

--- a/third_party/terraform/tests/resource_compute_ssl_certificate_test.go
+++ b/third_party/terraform/tests/resource_compute_ssl_certificate_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccComputeSslCertificate_no_name(t *testing.T) {
+	// Randomness
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1068,6 +1068,8 @@ func TestAccContainerCluster_withNodePoolAutoscaling(t *testing.T) {
 }
 
 func TestAccContainerCluster_withNodePoolNamePrefix(t *testing.T) {
+	// Computed name within terraform
+	skipIfVcr()
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1068,7 +1068,7 @@ func TestAccContainerCluster_withNodePoolAutoscaling(t *testing.T) {
 }
 
 func TestAccContainerCluster_withNodePoolNamePrefix(t *testing.T) {
-	// Computed name within terraform
+	// Randomness
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1069,7 +1069,7 @@ func TestAccContainerCluster_withNodePoolAutoscaling(t *testing.T) {
 
 func TestAccContainerCluster_withNodePoolNamePrefix(t *testing.T) {
 	// Computed name within terraform
-	skipIfVcr()
+	skipIfVcr(t)
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -81,7 +81,7 @@ func TestAccContainerNodePool_maxPodsPerNode(t *testing.T) {
 }
 
 func TestAccContainerNodePool_namePrefix(t *testing.T) {
-	// Computed name within terraform
+	// Randomness
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -106,7 +106,7 @@ func TestAccContainerNodePool_namePrefix(t *testing.T) {
 }
 
 func TestAccContainerNodePool_noName(t *testing.T) {
-	// Computed name within terraform
+	// Randomness
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -81,6 +81,8 @@ func TestAccContainerNodePool_maxPodsPerNode(t *testing.T) {
 }
 
 func TestAccContainerNodePool_namePrefix(t *testing.T) {
+	// Computed name within terraform
+	skipIfVcr()
 	t.Parallel()
 
 	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
@@ -104,6 +106,8 @@ func TestAccContainerNodePool_namePrefix(t *testing.T) {
 }
 
 func TestAccContainerNodePool_noName(t *testing.T) {
+	// Computed name within terraform
+	skipIfVcr()
 	t.Parallel()
 
 	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -82,7 +82,7 @@ func TestAccContainerNodePool_maxPodsPerNode(t *testing.T) {
 
 func TestAccContainerNodePool_namePrefix(t *testing.T) {
 	// Computed name within terraform
-	skipIfVcr()
+	skipIfVcr(t)
 	t.Parallel()
 
 	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
@@ -107,7 +107,7 @@ func TestAccContainerNodePool_namePrefix(t *testing.T) {
 
 func TestAccContainerNodePool_noName(t *testing.T) {
 	// Computed name within terraform
-	skipIfVcr()
+	skipIfVcr(t)
 	t.Parallel()
 
 	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))

--- a/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -655,7 +655,7 @@ func TestAccDataprocCluster_withEndpointConfig(t *testing.T) {
 	t.Parallel()
 
 	var cluster dataproc.Cluster
-	rnd := acctest.RandString(10)
+	rnd := randString(t, 10)
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/third_party/terraform/tests/resource_dialogflow_intent_test.go.erb
+++ b/third_party/terraform/tests/resource_dialogflow_intent_test.go.erb
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -15,7 +14,7 @@ func TestAccDialogflowIntent_basic(t *testing.T) {
 	context := map[string]interface{}{
 		"org_id":          getTestOrgFromEnv(t),
 		"billing_account": getTestBillingAccountFromEnv(t),
-		"random_suffix":   acctest.RandString(10),
+		"random_suffix":   randString(t, 10),
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -40,7 +39,7 @@ func TestAccDialogflowIntent_update(t *testing.T) {
 	context := map[string]interface{}{
 		"org_id":          getTestOrgFromEnv(t),
 		"billing_account": getTestBillingAccountFromEnv(t),
-		"random_suffix":   acctest.RandString(10),
+		"random_suffix":   randString(t, 10),
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/third_party/terraform/tests/resource_firebase_web_app_test.go.erb
+++ b/third_party/terraform/tests/resource_firebase_web_app_test.go.erb
@@ -14,7 +14,7 @@ func TestAccFirebaseWebApp_firebaseWebAppFull(t *testing.T) {
 
 	context := map[string]interface{}{
 		"org_id":        getTestOrgFromEnv(t),
-		"random_suffix": acctest.RandString(10),
+		"random_suffix": randString(t, 10),
 		"display_name":  "Display Name N",
 	}
 

--- a/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
+++ b/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
@@ -90,6 +90,7 @@ func TestAccFolderIamBinding_multiple(t *testing.T) {
 
 // Test that multiple IAM bindings can be applied to a folder all at once
 func TestAccFolderIamBinding_multipleAtOnce(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)

--- a/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
+++ b/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
@@ -177,6 +177,7 @@ func TestAccFolderIamBinding_update(t *testing.T) {
 
 // Test that an IAM binding can be removed from a folder
 func TestAccFolderIamBinding_remove(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)

--- a/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
+++ b/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
@@ -90,6 +90,7 @@ func TestAccFolderIamBinding_multiple(t *testing.T) {
 
 // Test that multiple IAM bindings can be applied to a folder all at once
 func TestAccFolderIamBinding_multipleAtOnce(t *testing.T) {
+	// Multiple fine-grained resources
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -177,6 +178,7 @@ func TestAccFolderIamBinding_update(t *testing.T) {
 
 // Test that an IAM binding can be removed from a folder
 func TestAccFolderIamBinding_remove(t *testing.T) {
+	// Multiple fine-grained resources
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_google_folder_iam_member_test.go
+++ b/third_party/terraform/tests/resource_google_folder_iam_member_test.go
@@ -41,6 +41,7 @@ func TestAccFolderIamMember_basic(t *testing.T) {
 
 // Test that multiple IAM bindings can be applied to a folder
 func TestAccFolderIamMember_multiple(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -82,6 +83,7 @@ func TestAccFolderIamMember_multiple(t *testing.T) {
 
 // Test that an IAM binding can be removed from a folder
 func TestAccFolderIamMember_remove(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)

--- a/third_party/terraform/tests/resource_google_organization_iam_audit_config_test.go
+++ b/third_party/terraform/tests/resource_google_organization_iam_audit_config_test.go
@@ -69,6 +69,7 @@ func TestAccOrganizationIamAuditConfig_multiple(t *testing.T) {
 
 // Test that multiple IAM audit configs can be applied to an organization all at once
 func TestAccOrganizationIamAuditConfig_multipleAtOnce(t *testing.T) {
+	// Multiple fine-grained resources
 	skipIfVcr(t)
 	if os.Getenv(runOrgIamAuditConfigTestEnvVar) != "true" {
 		t.Skipf("Environment variable %s is not set, skipping.", runOrgIamAuditConfigTestEnvVar)
@@ -126,6 +127,7 @@ func TestAccOrganizationIamAuditConfig_update(t *testing.T) {
 
 // Test that an IAM audit config can be removed from an organization
 func TestAccOrganizationIamAuditConfig_remove(t *testing.T) {
+	// Multiple fine-grained resources
 	skipIfVcr(t)
 	if os.Getenv(runOrgIamAuditConfigTestEnvVar) != "true" {
 		t.Skipf("Environment variable %s is not set, skipping.", runOrgIamAuditConfigTestEnvVar)

--- a/third_party/terraform/tests/resource_google_organization_iam_audit_config_test.go
+++ b/third_party/terraform/tests/resource_google_organization_iam_audit_config_test.go
@@ -69,6 +69,7 @@ func TestAccOrganizationIamAuditConfig_multiple(t *testing.T) {
 
 // Test that multiple IAM audit configs can be applied to an organization all at once
 func TestAccOrganizationIamAuditConfig_multipleAtOnce(t *testing.T) {
+	skipIfVcr(t)
 	if os.Getenv(runOrgIamAuditConfigTestEnvVar) != "true" {
 		t.Skipf("Environment variable %s is not set, skipping.", runOrgIamAuditConfigTestEnvVar)
 	}
@@ -125,6 +126,7 @@ func TestAccOrganizationIamAuditConfig_update(t *testing.T) {
 
 // Test that an IAM audit config can be removed from an organization
 func TestAccOrganizationIamAuditConfig_remove(t *testing.T) {
+	skipIfVcr(t)
 	if os.Getenv(runOrgIamAuditConfigTestEnvVar) != "true" {
 		t.Skipf("Environment variable %s is not set, skipping.", runOrgIamAuditConfigTestEnvVar)
 	}

--- a/third_party/terraform/tests/resource_google_project_iam_audit_config_test.go
+++ b/third_party/terraform/tests/resource_google_project_iam_audit_config_test.go
@@ -151,7 +151,7 @@ func TestAccProjectIamAuditConfig_update(t *testing.T) {
 
 // Test that an IAM audit config can be removed from a project
 func TestAccProjectIamAuditConfig_remove(t *testing.T) {
-	skipIfVcr()
+	skipIfVcr(t)
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)

--- a/third_party/terraform/tests/resource_google_project_iam_audit_config_test.go
+++ b/third_party/terraform/tests/resource_google_project_iam_audit_config_test.go
@@ -80,6 +80,7 @@ func TestAccProjectIamAuditConfig_multiple(t *testing.T) {
 
 // Test that multiple IAM audit configs can be applied to a project all at once
 func TestAccProjectIamAuditConfig_multipleAtOnce(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -150,6 +151,7 @@ func TestAccProjectIamAuditConfig_update(t *testing.T) {
 
 // Test that an IAM audit config can be removed from a project
 func TestAccProjectIamAuditConfig_remove(t *testing.T) {
+	skipIfVcr()
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)

--- a/third_party/terraform/tests/resource_google_project_iam_audit_config_test.go
+++ b/third_party/terraform/tests/resource_google_project_iam_audit_config_test.go
@@ -80,6 +80,7 @@ func TestAccProjectIamAuditConfig_multiple(t *testing.T) {
 
 // Test that multiple IAM audit configs can be applied to a project all at once
 func TestAccProjectIamAuditConfig_multipleAtOnce(t *testing.T) {
+	// Multiple fine-grained resources
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -151,6 +152,7 @@ func TestAccProjectIamAuditConfig_update(t *testing.T) {
 
 // Test that an IAM audit config can be removed from a project
 func TestAccProjectIamAuditConfig_remove(t *testing.T) {
+	// Multiple fine-grained resources
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_google_project_iam_binding_test.go.erb
+++ b/third_party/terraform/tests/resource_google_project_iam_binding_test.go.erb
@@ -80,6 +80,7 @@ func TestAccProjectIamBinding_multiple(t *testing.T) {
 
 // Test that multiple IAM bindings can be applied to a project all at once
 func TestAccProjectIamBinding_multipleAtOnce(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -150,6 +151,7 @@ func TestAccProjectIamBinding_update(t *testing.T) {
 
 // Test that an IAM binding can be removed from a project
 func TestAccProjectIamBinding_remove(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)

--- a/third_party/terraform/tests/resource_google_project_iam_binding_test.go.erb
+++ b/third_party/terraform/tests/resource_google_project_iam_binding_test.go.erb
@@ -80,6 +80,7 @@ func TestAccProjectIamBinding_multiple(t *testing.T) {
 
 // Test that multiple IAM bindings can be applied to a project all at once
 func TestAccProjectIamBinding_multipleAtOnce(t *testing.T) {
+	// Multiple fine-grained resources
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -151,6 +152,7 @@ func TestAccProjectIamBinding_update(t *testing.T) {
 
 // Test that an IAM binding can be removed from a project
 func TestAccProjectIamBinding_remove(t *testing.T) {
+	// Multiple fine-grained resources
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_google_project_iam_member_test.go.erb
+++ b/third_party/terraform/tests/resource_google_project_iam_member_test.go.erb
@@ -48,6 +48,7 @@ func TestAccProjectIamMember_basic(t *testing.T) {
 
 // Test that multiple IAM bindings can be applied to a project
 func TestAccProjectIamMember_multiple(t *testing.T) {
+	// Multiple fine-grained resources
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -90,6 +91,7 @@ func TestAccProjectIamMember_multiple(t *testing.T) {
 
 // Test that an IAM binding can be removed from a project
 func TestAccProjectIamMember_remove(t *testing.T) {
+	// Multiple fine-grained resources
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_google_project_iam_member_test.go.erb
+++ b/third_party/terraform/tests/resource_google_project_iam_member_test.go.erb
@@ -48,6 +48,7 @@ func TestAccProjectIamMember_basic(t *testing.T) {
 
 // Test that multiple IAM bindings can be applied to a project
 func TestAccProjectIamMember_multiple(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -89,6 +90,7 @@ func TestAccProjectIamMember_multiple(t *testing.T) {
 
 // Test that an IAM binding can be removed from a project
 func TestAccProjectIamMember_remove(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)

--- a/third_party/terraform/tests/resource_google_project_service_test.go
+++ b/third_party/terraform/tests/resource_google_project_service_test.go
@@ -65,6 +65,7 @@ func TestAccProjectService_basic(t *testing.T) {
 }
 
 func TestAccProjectService_disableDependentServices(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)

--- a/third_party/terraform/tests/resource_google_project_service_test.go
+++ b/third_party/terraform/tests/resource_google_project_service_test.go
@@ -65,6 +65,7 @@ func TestAccProjectService_basic(t *testing.T) {
 }
 
 func TestAccProjectService_disableDependentServices(t *testing.T) {
+	// Multiple fine-grained resources
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_service_directory_namespace_test.go.erb
+++ b/third_party/terraform/tests/resource_service_directory_namespace_test.go.erb
@@ -17,7 +17,7 @@ func TestAccServiceDirectoryNamespace_serviceDirectoryNamespaceUpdateExample(t *
 
 	project := getTestProjectFromEnv()
 	location := "us-central1"
-	testId := fmt.Sprintf("tf-test-example-namespace%s", acctest.RandString(10))
+	testId := fmt.Sprintf("tf-test-example-namespace%s", randString(t, 10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/third_party/terraform/tests/resource_service_directory_service_test.go.erb
+++ b/third_party/terraform/tests/resource_service_directory_service_test.go.erb
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
@@ -17,7 +16,7 @@ func TestAccServiceDirectoryService_serviceDirectoryServiceUpdateExample(t *test
 
 	project := getTestProjectFromEnv()
 	location := "us-central1"
-	testId := fmt.Sprintf("tf-test-example-service%s", acctest.RandString(10))
+	testId := fmt.Sprintf("tf-test-example-service%s", randString(t, 10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/third_party/terraform/tests/resource_spanner_instance_test.go
+++ b/third_party/terraform/tests/resource_spanner_instance_test.go
@@ -72,6 +72,7 @@ func TestAccSpannerInstance_basic(t *testing.T) {
 }
 
 func TestAccSpannerInstance_basicWithAutogenName(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	displayName := fmt.Sprintf("spanner-test-%s-dname", randString(t, 10))
@@ -96,6 +97,7 @@ func TestAccSpannerInstance_basicWithAutogenName(t *testing.T) {
 }
 
 func TestAccSpannerInstance_update(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	dName1 := fmt.Sprintf("spanner-dname1-%s", randString(t, 10))

--- a/third_party/terraform/tests/resource_spanner_instance_test.go
+++ b/third_party/terraform/tests/resource_spanner_instance_test.go
@@ -72,6 +72,7 @@ func TestAccSpannerInstance_basic(t *testing.T) {
 }
 
 func TestAccSpannerInstance_basicWithAutogenName(t *testing.T) {
+	// Randomness
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -97,6 +98,7 @@ func TestAccSpannerInstance_basicWithAutogenName(t *testing.T) {
 }
 
 func TestAccSpannerInstance_update(t *testing.T) {
+	// Randomness
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -152,6 +152,7 @@ func testSweepDatabases(region string) error {
 }
 
 func TestAccSqlDatabaseInstance_basicInferredName(t *testing.T) {
+	// Randomness
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -152,6 +152,7 @@ func testSweepDatabases(region string) error {
 }
 
 func TestAccSqlDatabaseInstance_basicInferredName(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	vcrTest(t, resource.TestCase{

--- a/third_party/terraform/tests/resource_sql_user_test.go
+++ b/third_party/terraform/tests/resource_sql_user_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccSqlUser_mysql(t *testing.T) {
+	skipIfVcr(t)
 	t.Parallel()
 
 	instance := fmt.Sprintf("i-%d", randInt(t))

--- a/third_party/terraform/tests/resource_sql_user_test.go
+++ b/third_party/terraform/tests/resource_sql_user_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestAccSqlUser_mysql(t *testing.T) {
+	// Multiple fine-grained resources
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/utils/bootstrap_utils_test.go
+++ b/third_party/terraform/utils/bootstrap_utils_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"google.golang.org/api/cloudkms/v1"
 	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
 	"google.golang.org/api/iam/v1"
@@ -329,7 +328,7 @@ func BootstrapServicePerimeterProjects(t *testing.T, desiredProjects int) []*clo
 
 	projects := res.Projects
 	for len(projects) < desiredProjects {
-		pid := SharedServicePerimeterProjectPrefix + acctest.RandString(10)
+		pid := SharedServicePerimeterProjectPrefix + randString(t, 10)
 		project := &cloudresourcemanager.Project{
 			ProjectId: pid,
 			Name:      "TF Service Perimeter Test",

--- a/third_party/terraform/utils/metadata.go
+++ b/third_party/terraform/utils/metadata.go
@@ -104,7 +104,7 @@ func expandComputeMetadata(m map[string]interface{}) []*compute.MetadataItems {
 	metadata := make([]*compute.MetadataItems, len(m))
 	var keys []string
 	for key := range m {
-		keys = append(keys, k)
+		keys = append(keys, key)
 	}
 	sort.Strings(keys)
 	// Append new metadata to existing metadata

--- a/third_party/terraform/utils/metadata.go
+++ b/third_party/terraform/utils/metadata.go
@@ -102,9 +102,14 @@ func BetaMetadataUpdate(oldMDMap map[string]interface{}, newMDMap map[string]int
 
 func expandComputeMetadata(m map[string]interface{}) []*compute.MetadataItems {
 	metadata := make([]*compute.MetadataItems, len(m))
+	var keys []string
+	for key := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
 	// Append new metadata to existing metadata
-	for key, val := range m {
-		v := val.(string)
+	for _, key := range keys {
+		v := m[key].(string)
 		metadata = append(metadata, &compute.MetadataItems{
 			Key:   key,
 			Value: &v,

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -327,7 +327,7 @@ end     # products.each do
 				"google_dns_record_set":                        resourceDnsRecordSet(),
 				"google_endpoints_service":                     resourceEndpointsService(),
 				"google_folder":                                resourceGoogleFolder(),
-				"google_folder_iam_binding":                    ResourceIamBindingWithBatching(IamFolderSchema, NewFolderIamUpdater, FolderIdParseFunc, IamBatchingEnabled),
+				"google_folder_iam_binding":                    ResourceIamBinding(IamFolderSchema, NewFolderIamUpdater, FolderIdParseFunc, IamBatchingEnabled),
 				"google_folder_iam_member":                     ResourceIamMember(IamFolderSchema, NewFolderIamUpdater, FolderIdParseFunc),
 				"google_folder_iam_policy":                     ResourceIamPolicy(IamFolderSchema, NewFolderIamUpdater, FolderIdParseFunc),
 				"google_folder_organization_policy":            resourceGoogleFolderOrganizationPolicy(),

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -327,7 +327,7 @@ end     # products.each do
 				"google_dns_record_set":                        resourceDnsRecordSet(),
 				"google_endpoints_service":                     resourceEndpointsService(),
 				"google_folder":                                resourceGoogleFolder(),
-				"google_folder_iam_binding":                    ResourceIamBinding(IamFolderSchema, NewFolderIamUpdater, FolderIdParseFunc, IamBatchingEnabled),
+				"google_folder_iam_binding":                    ResourceIamBinding(IamFolderSchema, NewFolderIamUpdater, FolderIdParseFunc),
 				"google_folder_iam_member":                     ResourceIamMember(IamFolderSchema, NewFolderIamUpdater, FolderIdParseFunc),
 				"google_folder_iam_policy":                     ResourceIamPolicy(IamFolderSchema, NewFolderIamUpdater, FolderIdParseFunc),
 				"google_folder_organization_policy":            resourceGoogleFolderOrganizationPolicy(),

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -258,6 +258,7 @@ func vcrTest(t *testing.T, c resource.TestCase) {
 
 // Retrieves a unique test name used for writing files
 // replaces all `/` characters that would cause filepath issues
+// This matters during tests that dispatch multiple tests, for example TestAccLoggingFolderExclusion
 func vcrFileName(name string) string {
 	return strings.ReplaceAll(name, "/", "_")
 }

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -144,7 +144,7 @@ func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.Resour
 		log.Print("[DEBUG] No environment var set for VCR_PATH, skipping VCR")
 		return config, nil
 	}
-	path := filepath.Join(envPath, testName)
+	path := filepath.Join(envPath, vcrFileName(testName))
 
 	rec, err := recorder.NewAsMode(path, vcrMode, config.client.Transport)
 	if err != nil {
@@ -256,6 +256,12 @@ func vcrTest(t *testing.T, c resource.TestCase) {
 	resource.Test(t, c)
 }
 
+// Retrieves a unique test name used for writing files
+// replaces all `/` characters that would cause filepath issues
+func vcrFileName(name string) string {
+	return strings.ReplaceAll(name, "/", "_")
+}
+
 // Produces a rand.Source for VCR testing based on the given mode.
 // In RECORDING mode, generates a new seed and saves it to a file, using the seed for the source
 // In REPLAYING mode, reads a seed from a file and creates a source from it
@@ -263,7 +269,7 @@ func vcrSource(t *testing.T, path, mode string) (rand.Source, error) {
 	if s, ok := sources[t.Name()]; ok {
 		return s, nil
 	}
-	fileName := filepath.Join(path, fmt.Sprintf("%s.seed", t.Name()))
+	fileName := filepath.Join(path, fmt.Sprintf("%s.seed", vcrFileName(t.Name())))
 	switch mode {
 	case "RECORDING":
 		seed := rand.Int63()
@@ -439,7 +445,7 @@ func TestAccProviderBasePath_setBasePath(t *testing.T) {
 		CheckDestroy: testAccCheckComputeAddressDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccProviderBasePath_setBasePath("https://www.googleapis.com/compute/beta/", acctest.RandString(10)),
+				Config: testAccProviderBasePath_setBasePath("https://www.googleapis.com/compute/beta/", randString(t, 10)),
 			},
 			{
 				ResourceName:      "google_compute_address.default",
@@ -459,7 +465,7 @@ func TestAccProviderBasePath_setInvalidBasePath(t *testing.T) {
 		CheckDestroy: testAccCheckComputeAddressDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccProviderBasePath_setBasePath("https://www.example.com/compute/beta/", acctest.RandString(10)),
+				Config:      testAccProviderBasePath_setBasePath("https://www.example.com/compute/beta/", randString(t, 10)),
 				ExpectError: regexp.MustCompile("got HTTP response code 404 with body"),
 			},
 		},
@@ -471,9 +477,9 @@ func TestAccProviderUserProjectOverride(t *testing.T) {
 
 	org := getTestOrgFromEnv(t)
 	billing := getTestBillingAccountFromEnv(t)
-	pid := acctest.RandomWithPrefix("tf-test")
-	sa := acctest.RandomWithPrefix("tf-test")
-	topicName := "tf-test-topic-" + acctest.RandString(10)
+	pid := "tf-test-" + randString(t, 10)
+	sa := "tf-test-" + randString(t, 10)
+	topicName := "tf-test-topic-" + randString(t, 10)
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -515,8 +521,8 @@ func TestAccProviderIndirectUserProjectOverride(t *testing.T) {
 
 	org := getTestOrgFromEnv(t)
 	billing := getTestBillingAccountFromEnv(t)
-	pid := acctest.RandomWithPrefix("tf-test")
-	sa := acctest.RandomWithPrefix("tf-test")
+	pid := "tf-test-" + randString(t, 10)
+	sa := "tf-test-" + randString(t, 10)
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -855,4 +861,13 @@ func multiEnvSearch(ks []string) string {
 		}
 	}
 	return ""
+}
+
+// Some tests fail during VCR. One common case is race conditions when creating resources.
+// If a test config adds two fine-grained resources with the same parent it is undefined
+// which will be created first, causing VCR to fail ~50% of the time
+func skipIfVcr(t *testing.T) {
+	if isVcrEnabled() {
+		t.Skipf("VCR enabled, skipping test: %s", t.Name())
+	}
 }

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -80,11 +80,18 @@ var billingAccountEnvVars = []string{
 }
 
 var configs map[string]*Config
-var sources map[string]rand.Source
+
+// A source for a given VCR test with the value that seeded it
+type VcrSource struct {
+	seed int64
+	source rand.Source
+}
+
+var sources map[string]VcrSource
 
 func init() {
 	configs = make(map[string]*Config)
-	sources = make(map[string]rand.Source)
+	sources = make(map[string]VcrSource)
 	testAccProvider = Provider().(*schema.Provider)
 	testAccRandomProvider = random.Provider().(*schema.Provider)
 	<% if version == 'ga' -%>
@@ -203,9 +210,19 @@ func getCachedConfig(d *schema.ResourceData, configureFunc func(d *schema.Resour
 func closeRecorder(t *testing.T) {
 	if config, ok := configs[t.Name()]; ok {
 		// We did not cache the config if it does not use VCR
-		err := config.client.Transport.(*recorder.Recorder).Stop()
-		if err != nil {
-			t.Error(err)
+		if !t.Failed() && isVcrEnabled() {
+			// If a test succeeds, write new seed/yaml to files
+			err := config.client.Transport.(*recorder.Recorder).Stop()
+			if err != nil {
+				t.Error(err)
+			}
+			envPath := os.Getenv("VCR_PATH")
+			if vcrSource, ok := sources[t.Name()]; ok {
+				err = writeSeedToFile(vcrSource.seed, vcrSeedFile(envPath, t.Name()))
+				if err != nil {
+					t.Error(err)
+				}
+			}
 		}
 		// Clean up test config
 		delete(configs, t.Name())
@@ -259,6 +276,10 @@ func vcrTest(t *testing.T, c resource.TestCase) {
 // Retrieves a unique test name used for writing files
 // replaces all `/` characters that would cause filepath issues
 // This matters during tests that dispatch multiple tests, for example TestAccLoggingFolderExclusion
+func vcrSeedFile(path, name string) string {
+	return filepath.Join(path, fmt.Sprintf("%s.seed", vcrFileName(name)))
+}
+
 func vcrFileName(name string) string {
 	return strings.ReplaceAll(name, "/", "_")
 }
@@ -266,29 +287,26 @@ func vcrFileName(name string) string {
 // Produces a rand.Source for VCR testing based on the given mode.
 // In RECORDING mode, generates a new seed and saves it to a file, using the seed for the source
 // In REPLAYING mode, reads a seed from a file and creates a source from it
-func vcrSource(t *testing.T, path, mode string) (rand.Source, error) {
+func vcrSource(t *testing.T, path, mode string) (*VcrSource, error) {
 	if s, ok := sources[t.Name()]; ok {
-		return s, nil
+		return &s, nil
 	}
-	fileName := filepath.Join(path, fmt.Sprintf("%s.seed", vcrFileName(t.Name())))
 	switch mode {
 	case "RECORDING":
 		seed := rand.Int63()
 		s := rand.NewSource(seed)
-		err := writeSeedToFile(seed, fileName)
-		if err != nil {
-			return nil, err
-		}
-		sources[t.Name()] = s
-		return s, nil
+		vcrSource := VcrSource{seed: seed, source: s}
+		sources[t.Name()] = vcrSource
+		return &vcrSource, nil
 	case "REPLAYING":
-		seed, err := readSeedFromFile(fileName)
+		seed, err := readSeedFromFile(vcrSeedFile(path, t.Name()))
 		if err != nil {
 			return nil, err
 		}
 		s := rand.NewSource(seed)
-		sources[t.Name()] = s
-		return s, nil
+		vcrSource := VcrSource{seed: seed, source: s}
+		sources[t.Name()] = vcrSource
+		return &vcrSource, nil
 	default:
 		log.Printf("[DEBUG] No valid environment var set for VCR_MODE, expected RECORDING or REPLAYING, skipping VCR. VCR_MODE: %s", mode)
 		return nil, errors.New("No valid VCR_MODE set")
@@ -338,7 +356,7 @@ func randString(t *testing.T, length int) string {
 		t.Fatal(err)
 	}
 
-	r := rand.New(s)
+	r := rand.New(s.source)
 	result := make([]byte, length)
 	set := "abcdefghijklmnopqrstuvwxyz012346789"
 	for i := 0; i < length; i++ {
@@ -359,7 +377,7 @@ func randInt(t *testing.T) int {
 		t.Fatal(err)
 	}
 
-	return rand.New(s).Int()
+	return rand.New(s.source).Int()
 }
 
 func TestProvider(t *testing.T) {


### PR DESCRIPTION
Add support for ignoring tests during VCR test runs. Fix more tests

Move writing new seeds to the end of a test process alongside writing the cassette yaml. This prevents the seed and yaml from getting out of sync if a test fails during RECORDING mode.

~20 tests failing at this point

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
