### PR TITLE
Added support for request-based SLIs in monitoring SLO

### DIFF
--- a/products/monitoring/api.yaml
+++ b/products/monitoring/api.yaml
@@ -1043,7 +1043,9 @@ objects:
       properties:
         - !ruby/object:Api::Type::NestedObject
           name: basicSli
-          required: true
+          exactly_one_of:
+            - service_level_indicator.0.basic_sli
+            - service_level_indicator.0.request_based_sli
           description: |
             Basic Service-Level Indicator (SLI) on a well-known service type.
             Performance will be computed on the basis of pre-defined metrics.
@@ -1094,6 +1096,127 @@ objects:
                   A duration string, e.g. 10s.
                   Good service is defined to be the count of requests made to
                   this service that return in no more than threshold.
+        - !ruby/object:Api::Type::NestedObject
+          name: requestBasedSli
+          api_name: 'requestBased'
+          exactly_one_of:
+            - service_level_indicator.0.basic_sli
+            - service_level_indicator.0.request_based_sli
+          description: |
+            A request-based SLI defines a SLI for which atomic units of
+            service are counted directly.
+
+            A SLI describes a good service.
+            It is used to measure and calculate the quality of the Service's
+            performance with respect to a single aspect of service quality.
+          # If adding properties to requestBasedSli, remember to add to the
+          # custom updateMask fields in property overrides.
+          properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: goodTotalRatio
+            exactly_one_of:
+            - service_level_indicator.0.request_based_sli.0.good_total_ratio
+            - service_level_indicator.0.request_based_sli.0.distribution_cut
+            description: |
+              A means to compute a ratio of `good_service` to `total_service`.
+              Defines computing this ratio with two TimeSeries [monitoring filters](https://cloud.google.com/monitoring/api/v3/filters)
+              Must specify exactly two of good, bad, and total service filters.
+              The relationship good_service + bad_service = total_service
+              will be assumed.
+            properties:
+            - !ruby/object:Api::Type::String
+              name: goodServiceFilter
+              at_least_one_of:
+                - service_level_indicator.0.request_based_sli.0.good_total_ratio.0.good_service_filter
+                - service_level_indicator.0.request_based_sli.0.good_total_ratio.0.bad_service_filter
+                - service_level_indicator.0.request_based_sli.0.good_total_ratio.0.total_service_filter
+              description: |
+                 A TimeSeries [monitoring filter](https://cloud.google.com/monitoring/api/v3/filters)
+                 quantifying good service provided. Exactly two of
+                 good, bad, or total service filter must be defined (where
+                 good + bad = total is assumed)
+
+                 Must have ValueType = DOUBLE or ValueType = INT64 and
+                 must have MetricKind = DELTA or MetricKind = CUMULATIVE.
+            - !ruby/object:Api::Type::String
+              name: badServiceFilter
+              at_least_one_of:
+                - service_level_indicator.0.request_based_sli.0.good_total_ratio.0.good_service_filter
+                - service_level_indicator.0.request_based_sli.0.good_total_ratio.0.bad_service_filter
+                - service_level_indicator.0.request_based_sli.0.good_total_ratio.0.total_service_filter
+              description: |
+                 A TimeSeries [monitoring filter](https://cloud.google.com/monitoring/api/v3/filters)
+                 quantifying bad service provided, either demanded service that
+                 was not provided or demanded service that was of inadequate
+                 quality. Exactly two of
+                 good, bad, or total service filter must be defined (where
+                 good + bad = total is assumed)
+
+                 Must have ValueType = DOUBLE or ValueType = INT64 and
+                 must have MetricKind = DELTA or MetricKind = CUMULATIVE.
+            - !ruby/object:Api::Type::String
+              name: totalServiceFilter
+              at_least_one_of:
+                - service_level_indicator.0.request_based_sli.0.good_total_ratio.0.good_service_filter
+                - service_level_indicator.0.request_based_sli.0.good_total_ratio.0.bad_service_filter
+                - service_level_indicator.0.request_based_sli.0.good_total_ratio.0.total_service_filter
+              description: |
+                 A TimeSeries [monitoring filter](https://cloud.google.com/monitoring/api/v3/filters)
+                 quantifying total demanded service. Exactly two of
+                 good, bad, or total service filter must be defined (where
+                 good + bad = total is assumed)
+
+                 Must have ValueType = DOUBLE or ValueType = INT64 and
+                 must have MetricKind = DELTA or MetricKind = CUMULATIVE.
+          - !ruby/object:Api::Type::NestedObject
+            name: distributionCut
+            exactly_one_of:
+            - service_level_indicator.0.request_based_sli.0.good_total_ratio
+            - service_level_indicator.0.request_based_sli.0.distribution_cut
+            description: |
+              Used when good_service is defined by a count of values aggregated in a
+              Distribution that fall into a good range. The total_service is the
+              total count of all values aggregated in the Distribution.
+              Defines a distribution TimeSeries filter and thresholds used for
+              measuring good service and total service.
+            properties:
+            - !ruby/object:Api::Type::String
+              name: distributionFilter
+              required: true
+              description: |
+                 A TimeSeries [monitoring filter](https://cloud.google.com/monitoring/api/v3/filters)
+                 aggregating values to quantify the good service provided.
+
+                 Must have ValueType = DISTRIBUTION and
+                 MetricKind = DELTA or MetricKind = CUMULATIVE.
+            - !ruby/object:Api::Type::NestedObject
+              name: range
+              required: true
+              description: |
+                 Range of numerical values. The computed good_service
+                 will be the count of values x in the Distribution such
+                 that range.min <= x < range.max. inclusive of min and
+                 exclusive of max. Open ranges can be defined by setting
+                 just one of min or max.
+              properties:
+              - !ruby/object:Api::Type::Integer
+                name: min
+                at_least_one_of:
+                - service_level_indicator.0.request_based_sli.0.distribution_cut.0.range.0.min
+                - service_level_indicator.0.request_based_sli.0.distribution_cut.0.range.0.max
+                description: |
+                  Min value for the range (inclusive). If not given,
+                  will be set to "-infinity", defining an open range
+                  "< range.max"
+              - !ruby/object:Api::Type::Integer
+                name: max
+                at_least_one_of:
+                - service_level_indicator.0.request_based_sli.0.distribution_cut.0.range.0.min
+                - service_level_indicator.0.request_based_sli.0.distribution_cut.0.range.0.max
+                description: |
+                  max value for the range (inclusive). If not given,
+                  will be set to "infinity", defining an open range
+                  ">= range.min"
 
   - !ruby/object:Api::Resource
     name: UptimeCheckConfig

--- a/products/monitoring/api.yaml
+++ b/products/monitoring/api.yaml
@@ -1052,6 +1052,9 @@ objects:
 
             SLIs are used to measure and calculate the quality of the Service's
             performance with respect to a single aspect of service quality.
+
+            Exactly one of the following must be set:
+            `basic_sli`, `request_based_sli`
           properties:
             - !ruby/object:Api::Type::Array
               name: method
@@ -1109,6 +1112,8 @@ objects:
             A SLI describes a good service.
             It is used to measure and calculate the quality of the Service's
             performance with respect to a single aspect of service quality.
+            Exactly one of the following must be set:
+            `basic_sli`, `request_based_sli`
           # If adding properties to requestBasedSli, remember to add to the
           # custom updateMask fields in property overrides.
           properties:
@@ -1123,6 +1128,8 @@ objects:
               Must specify exactly two of good, bad, and total service filters.
               The relationship good_service + bad_service = total_service
               will be assumed.
+
+              Exactly one of `distribution_cut` or `good_total_ratio` can be set.
             properties:
             - !ruby/object:Api::Type::String
               name: goodServiceFilter
@@ -1132,12 +1139,12 @@ objects:
                 - service_level_indicator.0.request_based_sli.0.good_total_ratio.0.total_service_filter
               description: |
                  A TimeSeries [monitoring filter](https://cloud.google.com/monitoring/api/v3/filters)
-                 quantifying good service provided. Exactly two of
-                 good, bad, or total service filter must be defined (where
-                 good + bad = total is assumed)
-
+                 quantifying good service provided.
                  Must have ValueType = DOUBLE or ValueType = INT64 and
                  must have MetricKind = DELTA or MetricKind = CUMULATIVE.
+
+                 Exactly two of `good_service_filter`,`bad_service_filter`,`total_service_filter`
+                 must be set (good + bad = total is assumed).
             - !ruby/object:Api::Type::String
               name: badServiceFilter
               at_least_one_of:
@@ -1148,12 +1155,13 @@ objects:
                  A TimeSeries [monitoring filter](https://cloud.google.com/monitoring/api/v3/filters)
                  quantifying bad service provided, either demanded service that
                  was not provided or demanded service that was of inadequate
-                 quality. Exactly two of
-                 good, bad, or total service filter must be defined (where
-                 good + bad = total is assumed)
+                 quality.
 
                  Must have ValueType = DOUBLE or ValueType = INT64 and
                  must have MetricKind = DELTA or MetricKind = CUMULATIVE.
+
+                 Exactly two of `good_service_filter`,`bad_service_filter`,`total_service_filter`
+                 must be set (good + bad = total is assumed).
             - !ruby/object:Api::Type::String
               name: totalServiceFilter
               at_least_one_of:
@@ -1162,12 +1170,13 @@ objects:
                 - service_level_indicator.0.request_based_sli.0.good_total_ratio.0.total_service_filter
               description: |
                  A TimeSeries [monitoring filter](https://cloud.google.com/monitoring/api/v3/filters)
-                 quantifying total demanded service. Exactly two of
-                 good, bad, or total service filter must be defined (where
-                 good + bad = total is assumed)
+                 quantifying total demanded service.
 
                  Must have ValueType = DOUBLE or ValueType = INT64 and
                  must have MetricKind = DELTA or MetricKind = CUMULATIVE.
+
+                 Exactly two of `good_service_filter`,`bad_service_filter`,`total_service_filter`
+                 must be set (good + bad = total is assumed).
           - !ruby/object:Api::Type::NestedObject
             name: distributionCut
             exactly_one_of:
@@ -1179,6 +1188,8 @@ objects:
               total count of all values aggregated in the Distribution.
               Defines a distribution TimeSeries filter and thresholds used for
               measuring good service and total service.
+
+              Exactly one of `distribution_cut` or `good_total_ratio` can be set.
             properties:
             - !ruby/object:Api::Type::String
               name: distributionFilter

--- a/products/monitoring/terraform.yaml
+++ b/products/monitoring/terraform.yaml
@@ -140,6 +140,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "appeng_slo"
         vars:
           slo_id: "ae-slo"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "monitoring_slo_request_based"
+        primary_resource_id: "request_based_slo"
+        test_env_vars:
+          project: :PROJECT_NAME
+        vars:
+          service_id: "custom-srv"
+          slo_id: "consumed-api-slo"
     properties:
       rollingPeriodDays: !ruby/object:Overrides::Terraform::PropertyOverride
         api_name: rollingPeriod
@@ -164,6 +172,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         is_set: true
       serviceLevelIndicator.basicSli.version: !ruby/object:Overrides::Terraform::PropertyOverride
         is_set: true
+      serviceLevelIndicator.requestBasedSli: !ruby/object:Overrides::Terraform::PropertyOverride
+        # Force update all nested fields to allow for unsetting values.
+        update_mask_fields:
+          - "serviceLevelIndicator.requestBased.goodTotalRatio.badServiceFilter"
+          - "serviceLevelIndicator.requestBased.goodTotalRatio.goodServiceFilter"
+          - "serviceLevelIndicator.requestBased.goodTotalRatio.totalServiceFilter"
+          - "serviceLevelIndicator.requestBased.distributionCut.range.min"
+          - "serviceLevelIndicator.requestBased.distributionCut.range.max"
+          - "serviceLevelIndicator.requestBased.distributionCut.distributionFilter"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/monitoring_slo.go.erb
       custom_import: templates/terraform/custom_import/self_link_as_name.erb

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -107,13 +107,14 @@ module Provider
       mask_groups = []
       properties.each do |prop|
         if prop.flatten_object
-          mask_groups += get_property_update_masks_groups(prop.properties,
-                                          mask_prefix: "#{prop.api_name}.")
+          mask_groups += get_property_update_masks_groups(
+            prop.properties, mask_prefix: "#{prop.api_name}."
+          )
         elsif prop.update_mask_fields
-         mask_groups << [prop.name.underscore, prop.update_mask_fields]
+          mask_groups << [prop.name.underscore, prop.update_mask_fields]
         else
-         mask_groups << [prop.name.underscore, [mask_prefix + prop.api_name]]
-       end
+          mask_groups << [prop.name.underscore, [mask_prefix + prop.api_name]]
+        end
       end
       mask_groups
     end

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -100,23 +100,43 @@ module Provider
                              force_new?(property.parent, resource))))
     end
 
-    # Returns the property for a given Terraform field path (e.g.
+    # Returns tuples of (fieldName, list of update masks) for
+    #  top-level updatable fields. Schema path refers to a given Terraform
+    # field name (e.g. d.GetChange('fieldName)')
+    def get_property_update_masks_groups(properties, mask_prefix: '')
+      mask_groups = []
+      properties.each do |prop|
+        if prop.flatten_object
+          mask_groups += get_property_update_masks_groups(prop.properties,
+                                          mask_prefix: "#{prop.api_name}.")
+        elsif prop.update_mask_fields
+         mask_groups << [prop.name.underscore, prop.update_mask_fields]
+        else
+         mask_groups << [prop.name.underscore, [mask_prefix + prop.api_name]]
+       end
+      end
+      mask_groups
+    end
+
+    # Returns an updated path for a given Terraform field path (e.g.
     # 'a_field', 'parent_field.0.child_name'). Returns nil if the property
-    # is not included in the resource's properties.
-    def property_for_schema_path(schema_path, resource)
+    # is not included in the resource's properties and removes keys that have
+    # been flattened
+    # TODO(emilymye): Change format of input for
+    # xactly_one_of/at_least_one_of/etc to use camelcase, MM properities and
+    # convert to snake in this method
+    def get_property_schema_path(schema_path, resource)
       nested_props = resource.properties
       prop = nil
-
-      schema_path.split('.').each_with_index do |pname, i|
-        next if i.odd?
-
-        pname = pname.camelize(:lower)
-        prop = nested_props.find { |p| p.name == pname }
-        break if prop.nil?
+      path_tkns = schema_path.split('.0.').map do |pname|
+        camel_pname = pname.camelize(:lower)
+        prop = nested_props.find { |p| p.name == camel_pname }
+        return nil if prop.nil?
 
         nested_props = prop.nested_properties || []
+        prop.flatten_object ? nil : pname.underscore
       end
-      prop
+      path_tkns.compact.join('.0.')
     end
 
     # Transforms a format string with field markers to a regex string with

--- a/provider/terraform.rb
+++ b/provider/terraform.rb
@@ -137,7 +137,11 @@ module Provider
         nested_props = prop.nested_properties || []
         prop.flatten_object ? nil : pname.underscore
       end
-      path_tkns.compact.join('.0.')
+      if path_tkns.empty? || path_tkns[-1].nil?
+        nil
+      else
+        path_tkns.compact.join('.0.')
+      end
     end
 
     # Transforms a format string with field markers to a regex string with

--- a/spec/compiler_spec.rb
+++ b/spec/compiler_spec.rb
@@ -48,7 +48,7 @@ describe Api::Compiler do
 
     it { is_expected.to be_instance_of Api::Product }
     it { is_expected.to have_attributes(api_name: 'myproduct') }
-    it { is_expected.to have_attribute_of_length(objects: 4) }
+    it { is_expected.to have_attribute_of_length(objects: 5) }
   end
 
   context 'should only accept product' do

--- a/spec/data/good-file.yaml
+++ b/spec/data/good-file.yaml
@@ -115,6 +115,43 @@ objects:
               name: 'nv-prop1'
               description: 'the first property in my namevalues'
   - !ruby/object:Api::Resource
+    name: 'ResourceWithTerraformOverride'
+    kind: 'terraform#resourceWithTerraformOverride'
+    base_url: 'resourceWithTerraformOverride'
+    description: 'a description'
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'stringOne'
+        description: 'a string property (depth 0)'
+      - !ruby/object:Api::Type::NestedObject
+        name: 'objectOne'
+        description: 'a NestedObject property (depth 0)'
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'objectOneString'
+            description: 'a string property (depth 1)'
+          - !ruby/object:Api::Type::NestedObject
+            name: 'objectOneFlattenedObject'
+            description: 'a nested NestedObject (depth 1)'
+            properties:
+              - !ruby/object:Api::Type::Integer
+                name: 'objectOneNestedNestedInteger'
+                description: 'a nested integer (depth 2)'
+      - !ruby/object:Api::Type::NestedObject
+        name: 'objectTwoFlattened'
+        description: 'a NestedObject property that is flattened (depth 0)'
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'objectTwoString'
+            description: 'a nested string (depth 1)'
+          - !ruby/object:Api::Type::NestedObject
+            name: 'objectTwoNestedObject'
+            description: 'a nested NestedObject (depth 1)'
+            properties:
+              - !ruby/object:Api::Type::String
+                name: 'objectTwoNestedNestedString'
+                description: 'a nested String (depth 2)'
+  - !ruby/object:Api::Resource
     name: 'TerraformImportIdTest'
     description: 'Used for spec/provider_terraform_import_spec'
     base_url: "projects/{{project}}/regions/{{region}}/subnetworks"

--- a/spec/data/good-tf-override.yaml
+++ b/spec/data/good-tf-override.yaml
@@ -12,13 +12,12 @@
 # limitations under the License.
 
 --- !ruby/object:Provider::Terraform::Config
-overrides: !ruby/object:Provider::ResourceOverrides
-  AnotherResource: !ruby/object:Provider::Terraform::ResourceOverride
-    description: '{{description}} bar'
+overrides: !ruby/object:Overrides::ResourceOverrides
+  ResourceWithTerraformOverride: !ruby/object:Overrides::Terraform::ResourceOverride
     properties:
-      property1: !ruby/object:Provider::Terraform::PropertyOverride
-        description: 'foo'
-      nested-property.property1: !ruby/object:Provider::Terraform::PropertyOverride
-        description: 'bar'
-      array-property.property1: !ruby/object:Provider::Terraform::PropertyOverride
-        description: 'baz'
+      objectTwoFlattened: !ruby/object:Overrides::Terraform::PropertyOverride
+        flatten_object: true
+      objectTwoFlattened.objectTwoNestedObject: !ruby/object:Overrides::Terraform::PropertyOverride
+        update_mask_fields:
+          - 'overrideFoo'
+          - 'nested.overrideBar'

--- a/spec/data/terraform-config.yaml
+++ b/spec/data/terraform-config.yaml
@@ -13,3 +13,13 @@
 
 --- !ruby/object:Provider::Terraform::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
+  ResourceWithTerraformOverride: !ruby/object:Overrides::Terraform::ResourceOverride
+    properties:
+      objectOne.objectOneFlattenedObject: !ruby/object:Overrides::Terraform::PropertyOverride
+        flatten_object: true
+      objectTwoFlattened: !ruby/object:Overrides::Terraform::PropertyOverride
+        flatten_object: true
+      objectTwoFlattened.objectTwoString: !ruby/object:Overrides::Terraform::PropertyOverride
+        update_mask_fields:
+          - 'overrideFoo'
+          - 'nested.overrideBar'

--- a/templates/terraform/examples/monitoring_slo_request_based.tf.erb
+++ b/templates/terraform/examples/monitoring_slo_request_based.tf.erb
@@ -1,0 +1,27 @@
+resource "google_monitoring_custom_service" "customsrv" {
+  service_id = "<%= ctx[:vars]['service_id'] %>"
+  display_name = "My Custom Service"
+}
+
+resource "google_monitoring_slo" "<%= ctx[:primary_resource_id] %>" {
+  service = google_monitoring_custom_service.customsrv.service_id
+  slo_id = "<%= ctx[:vars]['slo_id'] %>"
+  display_name = "Terraform Test SLO with request based SLI (good total ratio)"
+
+  goal = 0.9
+  rolling_period_days = 30
+
+  request_based_sli {
+    distribution_cut {
+      distribution_filter = join(" AND ", [
+        "metric.type=\"serviceruntime.googleapis.com/api/request_latencies\"",
+        "resource.type=\"consumed_api\"",
+        "resource.label.\"project_id\"=\"<%= ctx[:test_env_vars]['project'] -%>\"",
+      ])
+
+      range {
+        max = 10
+      }
+    }
+  }
+}

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -157,13 +157,13 @@
 <% end -%>
 <% unless property.conflicting().empty? -%>
 <% conflicting_props = property.conflicting().map(&:name).map(&:underscore) -%>
-    ConflictsWith: <%= go_literal(conflicting_props.reject {|sp| property_for_schema_path(sp, object).nil? }) -%>,
+    ConflictsWith: <%= go_literal(conflicting_props.map {|sp| get_property_schema_path(sp, object) }.compact) -%>,
 <% end -%>
 <% unless property.at_least_one_of_list().empty? -%>
-    AtLeastOneOf: <%= go_literal(property.at_least_one_of_list.reject {|sp| property_for_schema_path(sp, object).nil? }) -%>,
+    AtLeastOneOf: <%= go_literal(property.at_least_one_of_list.map {|sp| get_property_schema_path(sp, object) }.compact) -%>,
 <% end -%>
 <% unless property.exactly_one_of_list().empty? -%>
-    ExactlyOneOf: <%= go_literal(property.exactly_one_of_list.reject {|sp| property_for_schema_path(sp, object).nil? }) -%>,
+    ExactlyOneOf: <%= go_literal(property.exactly_one_of_list.map {|sp| get_property_schema_path(sp, object) }.compact) -%>,
 <% end -%>
 },
 <% else -%>

--- a/templates/terraform/update_mask.erb
+++ b/templates/terraform/update_mask.erb
@@ -8,31 +8,13 @@
    using `update_mask_fields`.
 -%>
 updateMask := []string{}
-<% update_body_properties.each do |prop| -%>
 <%
-    mask = prop.api_name
-    if prop.update_mask_fields
-      mask = prop.update_mask_fields.join(',')
-    end
--%>
-<%  if prop.flatten_object -%>
-<%    prop.properties.each do |nested| %>
-<%
-        if nested.update_mask_fields
-          mask = nest_p.update_mask_fields.join(',')
-        end
--%>
+  masks_for_props = get_property_update_masks_groups(update_body_properties)
+  masks_for_props.each do |prop_name, masks| -%>
 
-if d.HasChange("<%= nested.name.underscore -%>") {
-  updateMask = append(updateMask, "<%= mask -%>")
+if d.HasChange("<%= prop_name %>") {
+  updateMask = append(updateMask, <%= masks.map{|m| "\"#{m}\"" }.join(",\n") %>)
 }
-<%    end # prop.properties.each do -%>
-<%  else # if !prop.flatten_object -%>
-
-if d.HasChange("<%= prop.name.underscore -%>") {
-  updateMask = append(updateMask, "<%= mask -%>")
-}
-<%  end # if prop.flatten_object  -%>
 <% end # update_body_properties.each -%>
 // updateMask is a URL parameter but not present in the schema, so replaceVars
 // won't set it


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
monitoring: Added `request_based` SLI support to `google_monitoring_slo` 
```
