### PR TITLE
Fix test with partial revert of #3467.

### DIFF
--- a/templates/terraform/examples/dns_managed_zone_private.tf.erb
+++ b/templates/terraform/examples/dns_managed_zone_private.tf.erb
@@ -10,10 +10,10 @@ resource "google_dns_managed_zone" "<%= ctx[:primary_resource_id] %>" {
 
   private_visibility_config {
     networks {
-      network_url = google_compute_network.network-1.id
+      network_url = google_compute_network.network-1.self_link
     }
     networks {
-      network_url = google_compute_network.network-2.id
+      network_url = google_compute_network.network-2.self_link
     }
   }
 }

--- a/templates/terraform/examples/dns_managed_zone_private_forwarding.tf.erb
+++ b/templates/terraform/examples/dns_managed_zone_private_forwarding.tf.erb
@@ -11,10 +11,10 @@ resource "google_dns_managed_zone" "<%= ctx[:primary_resource_id] %>" {
 
   private_visibility_config {
     networks {
-      network_url = google_compute_network.network-1.id
+      network_url = google_compute_network.network-1.self_link
     }
     networks {
-      network_url = google_compute_network.network-2.id
+      network_url = google_compute_network.network-2.self_link
     }
   }
 

--- a/templates/terraform/examples/dns_managed_zone_private_peering.tf.erb
+++ b/templates/terraform/examples/dns_managed_zone_private_peering.tf.erb
@@ -9,13 +9,13 @@ resource "google_dns_managed_zone" "<%= ctx[:primary_resource_id] %>" {
 
   private_visibility_config {
     networks {
-      network_url = google_compute_network.network-source.id
+      network_url = google_compute_network.network-source.self_link
     }
   }
 
   peering_config {
     target_network {
-      network_url = google_compute_network.network-target.id
+      network_url = google_compute_network.network-target.self_link
     }
   }
 }


### PR DESCRIPTION
In this one very specific case it actually does matter whether we use self_link or id!  :)

This is basically a docs-only change, this unit test started failing but it's not release-blocking to fix.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```