### PR TITLE
Set network_tier to forcenew.

### DIFF
--- a/third_party/terraform/resources/resource_compute_instance_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_template.go
@@ -294,6 +294,7 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 										Type:         schema.TypeString,
 										Optional:     true,
 										Computed:     true,
+										ForceNew:     true,
 										ValidateFunc: validation.StringInSlice([]string{"PREMIUM", "STANDARD"}, false),
 									},
 									// Possibly configurable- this was added so we don't break if it's inadvertently set


### PR DESCRIPTION
According to https://github.com/terraform-providers/terraform-provider-google/issues/6317, this is ForceNew.

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6317.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: Fixed permadiff in `google_compute_instance_template`'s `network_tier`.

```