### PR TITLE
Add reboot_on_source_change on the compute_instance attached disk

### DIFF
--- a/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_test.go
@@ -497,7 +497,7 @@ func TestAccComputeInstance_attachedDisk_rebootOnSourceChange(t *testing.T) {
 					testAccCheckComputeInstanceDisk(&instance, diskName2, false, false),
 				),
 			},
-			computeInstanceImportStep("us-central1-a", instanceName, []string{"attached_disk.0.reboot_on_source_change"}),
+			computeInstanceImportStep("us-central1-a", instanceName, []string{"attached_disk.0.reboot_on_source_change", "allow_stopping_for_update"}),
 		},
 	})
 }
@@ -3284,9 +3284,12 @@ resource "google_compute_instance" "foobar" {
 
   network_interface {
     network = "default"
-  }
+	}
+	
+	allow_stopping_for_update = %v
+
 }
-`, disk, instance, rebootOnSourceChange)
+`, disk, instance, rebootOnSourceChange, rebootOnSourceChange)
 }
 
 func testAccComputeInstance_attachedDisk_modeRo(disk, instance string) string {

--- a/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -223,6 +223,10 @@ The `attached_disk` block supports:
 
 * `source` - (Required) The name or self_link of the disk to attach to this instance.
 
+* `reboot_on_source_change` - (Optional) When set to true and if, and only if, the source 
+    has changed, then the instance gets rebooted. Default value is `false`.
+    **Note**: [`allow_stopping_for_update`](#allow_stopping_for_update) must be set to true or your instance must have a `desired_status` of `TERMINATED` in order to update this field.   
+
 * `device_name` - (Optional) Name with which the attached disk will be accessible
     under `/dev/disk/by-id/google-*`
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
On `google_compute_instance resource for `attached_disk`, add new field `reboot_on_source_change`
```

https://github.com/terraform-providers/terraform-provider-google/issues/6148