### PR TITLE
Remove portNames for default INTERNAL backend services in tests

### DIFF
--- a/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
@@ -451,7 +451,6 @@ resource "google_compute_region_backend_service" "foobar" {
   name          = "%s"
   health_checks = [google_compute_health_check.zero.self_link]
   region        = "us-central1"
-  port_name     = "http"
 }
 
 resource "google_compute_health_check" "zero" {
@@ -508,7 +507,6 @@ data "google_compute_image" "my_image" {
 resource "google_compute_region_backend_service" "lipsum" {
   name        = "%s"
   description = "Hello World 1234"
-  port_name   = "http"
   protocol    = "TCP"
   region      = "us-central1"
   timeout_sec = %v
@@ -578,7 +576,6 @@ data "google_compute_image" "my_image" {
 resource "google_compute_region_backend_service" "lipsum" {
   name        = "%s"
   description = "Hello World 1234"
-  port_name   = "http"
   protocol    = "TCP"
   region      = "us-central1"
   timeout_sec = %v

--- a/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
@@ -471,7 +471,6 @@ resource "google_compute_region_backend_service" "foobar" {
   name          = "%s"
   health_checks = [google_compute_health_check.one.self_link]
   region        = "us-central1"
-  port_name     = "http"
 }
 
 resource "google_compute_health_check" "zero" {


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```

Missed in reviewing https://github.com/GoogleCloudPlatform/magic-modules/pull/3265