### PR TITLE
if google_compute_region_disk_resource_policy_attachment is empty, shouldn't error

### DIFF
--- a/templates/terraform/nested_query.go.erb
+++ b/templates/terraform/nested_query.go.erb
@@ -13,9 +13,7 @@ func flattenNested<%= resource_name -%>(d *schema.ResourceData, meta interface{}
   <% end -%>
   v, ok = res["<%=object.nested_query.keys[-1]-%>"]
   if !ok || v == nil {
-    // It's possible that there is only one of these resources and
-    // that res represents that resource.
-    v = res
+    return nil,nil
   }
 
   switch v.(type) {


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6059

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed error where plan would error if `google_compute_region_disk_resource_policy_attachment` had been deleted outside of terraform.
```
