### PR TITLE
Add Cloud Run - Traffic Splitting example

### DIFF
--- a/products/cloudrun/terraform.yaml
+++ b/products/cloudrun/terraform.yaml
@@ -104,6 +104,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - "autogenerate_revision_name"
       - !ruby/object:Provider::Terraform::Examples
         name: "cloud_run_service_traffic_split"
+        skip_test: true
         primary_resource_id: "default"
         primary_resource_name: "fmt.Sprintf(\"tf-test-cloudrun-srv%s\", context[\"random_suffix\"])"
         vars:

--- a/products/cloudrun/terraform.yaml
+++ b/products/cloudrun/terraform.yaml
@@ -102,6 +102,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           project: :PROJECT_NAME
         ignore_read_extra:
           - "autogenerate_revision_name"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "cloud_run_service_traffic_split"
+        primary_resource_id: "default"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-cloudrun-srv%s\", context[\"random_suffix\"])"
+        vars:
+          cloud_run_service_name: "cloudrun-srv"
+        test_env_vars:
+          project: :PROJECT_NAME
     virtual_fields:
       - !ruby/object:Api::Type::Boolean
         name: 'autogenerate_revision_name'

--- a/templates/terraform/examples/cloud_run_service_traffic_split.tf.erb
+++ b/templates/terraform/examples/cloud_run_service_traffic_split.tf.erb
@@ -20,6 +20,7 @@ resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
 
   traffic {
     percent       = 75
+    # This revision needs to already exist
     revision_name = "<%= ctx[:vars]['cloud_run_service_name'] %>-blue"
   }
 }

--- a/templates/terraform/examples/cloud_run_service_traffic_split.tf.erb
+++ b/templates/terraform/examples/cloud_run_service_traffic_split.tf.erb
@@ -1,0 +1,25 @@
+resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
+  name     = "<%= ctx[:vars]['cloud_run_service_name'] %>"
+  location = "us-central1"
+
+  template {
+    spec {
+      containers {
+        image = "gcr.io/cloudrun/hello"
+      }
+    }
+    metadata {
+      name = "<%= ctx[:vars]['cloud_run_service_name'] %>-green"
+    }
+  }
+
+  traffic {
+    percent       = 25
+    revision_name = "<%= ctx[:vars]['cloud_run_service_name'] %>-green"
+  }
+
+  traffic {
+    percent       = 75
+    revision_name = "<%= ctx[:vars]['cloud_run_service_name'] %>-blue"
+  }
+}


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
