### PR TITLE
Add back changelog template

### DIFF
--- a/.ci/changelog.tmpl
+++ b/.ci/changelog.tmpl
@@ -1,0 +1,67 @@
+{{- $notes := newStringList -}}
+{{- $unknown := newStringList -}}
+{{- $breaking := newStringList -}}
+{{- $deprecations := newStringList -}}
+{{- $features := newStringList -}}
+{{- $improvements := newStringList -}}
+{{- $bugs := newStringList -}}
+{{- range . -}}
+	{{if eq "note" .Type -}}
+		{{$notes = append $notes (renderReleaseNote .) -}}
+	{{else if eq "breaking-change" .Type -}}
+		{{$breaking = append $breaking (renderReleaseNote .) -}}
+	{{else if eq "deprecation" .Type -}}
+		{{$deprecations = append $deprecations (renderReleaseNote .) -}}
+	{{else if or (eq "new-resource" .Type) (eq "new-datasource" .Type) (eq "feature" .Type) -}}
+		{{$features = append $features (renderReleaseNote .) -}}
+	{{else if or (eq "improvement" .Type) (eq "enhancement" .Type) -}}
+		{{$improvements = append $improvements (renderReleaseNote .) -}}
+	{{ else if eq "bug" .Type -}}
+		{{$bugs = append $bugs (renderReleaseNote .) -}}
+	{{ else if eq "none" .Type -}}
+	{{ else -}}
+		{{$unknown = append $unknown (renderReleaseNote .) -}}
+	{{end -}}
+{{- end -}}
+{{- if gt (len $unknown) 0 -}}
+UNKNOWN CHANGELOG TYPE:
+{{range $unknown | sortAlpha -}}
+* {{. }}
+{{- end -}}
+{{- end -}}
+{{- if gt (len $notes) 0 -}}
+NOTES:
+{{range $notes | sortAlpha -}}
+* {{. }}
+{{- end -}}
+{{- end -}}
+{{- if gt (len $deprecations) 0 -}}
+DEPRECATIONS:
+{{range $deprecations | sortAlpha -}}
+* {{. }}
+{{- end -}}
+{{- end -}}
+{{- if gt (len $breaking) 0 -}}
+BREAKING CHANGES:
+{{range $breaking | sortAlpha -}}
+* {{. }}
+{{- end -}}
+{{- end -}}
+{{- if gt (len $features) 0}}
+FEATURES:
+{{range $features | sortAlpha -}}
+* {{. }}
+{{- end -}}
+{{- end -}}
+{{- if gt (len $improvements) 0}}
+IMPROVEMENTS:
+{{range $improvements | sortAlpha -}}
+* {{. }}
+{{- end -}}
+{{- end -}}
+{{- if gt (len $bugs) 0}}
+BUG FIXES:
+{{range $bugs | sortAlpha -}}
+* {{. }}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
Needed for step #3 of https://github.com/terraform-providers/terraform-provider-google/wiki/Release-Process#release-manager-role
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
