### PR TITLE
Add support for GKE release channel updates

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_container_engine_versions.go.erb
+++ b/third_party/terraform/data_sources/data_source_google_container_engine_versions.go.erb
@@ -58,6 +58,14 @@ func dataSourceGoogleContainerEngineVersions() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+
+<% unless version == 'ga' -%>
+			"release_channel_default_version": {
+				Type:     schema.TypeMap,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+<% end %>
 		},
 	}
 }
@@ -109,6 +117,14 @@ func dataSourceGoogleContainerEngineVersionsRead(d *schema.ResourceData, meta in
 	}
 
 	d.Set("default_cluster_version", resp.DefaultClusterVersion)
+
+<% unless version == 'ga' -%>
+  m := map[string]string{}
+	for _, v := range resp.Channels {
+		m[v.Channel] = v.DefaultVersion
+	}
+	d.Set("release_channel_default_version", m)
+<% end %>
 
 	d.SetId(time.Now().UTC().String())
 	return nil

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -864,7 +864,6 @@ func resourceContainerCluster() *schema.Resource {
 <% unless version == 'ga' -%>
 			"release_channel": {
 				Type:     schema.TypeList,
-				ForceNew: true,
 				Optional: true,
 				Computed: true,
 				MaxItems: 1,
@@ -873,7 +872,6 @@ func resourceContainerCluster() *schema.Resource {
 						"channel": {
 							Type:             schema.TypeString,
 							Required:         true,
-							ForceNew:         true,
 							ValidateFunc:     validation.StringInSlice([]string{"UNSPECIFIED", "RAPID", "REGULAR", "STABLE"}, false),
 							DiffSuppressFunc: emptyOrDefaultStringSuppress("UNSPECIFIED"),
 						},
@@ -1544,7 +1542,6 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		d.SetPartial("enable_shielded_nodes")
 	}
 <% unless version == 'ga' -%>
-
 	if d.HasChange("enable_intranode_visibility") {
 		enabled := d.Get("enable_intranode_visibility").(bool)
 		req := &containerBeta.UpdateClusterRequest{
@@ -1579,7 +1576,37 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		d.SetPartial("enable_intranode_visibility")
 	}
 <% end -%>
+<% unless version == 'ga' -%>
+	if d.HasChange("release_channel") {
+		req := &containerBeta.UpdateClusterRequest{
+			Update: &containerBeta.ClusterUpdate{
+				DesiredReleaseChannel: expandReleaseChannel(d.Get("release_channel")),
+			},
+		}
+		updateF := func() error {
+			log.Println("[DEBUG] updating release_channel")
+			name := containerClusterFullName(project, location, clusterName)
+			op, err := config.clientContainerBeta.Projects.Locations.Clusters.Update(name, req).Do()
+			if err != nil {
+				return err
+			}
 
+			// Wait until it's updated
+			err = containerOperationWait(config, op, project, location, "updating Release Channel", d.Timeout(schema.TimeoutUpdate))
+			log.Println("[DEBUG] done updating release_channel")
+			return err
+		}
+
+		// Call update serially.
+		if err := lockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s Release Channel has been updated to %#v", d.Id(), req.Update.DesiredReleaseChannel)
+
+		d.SetPartial("release_channel")
+	}
+<% end -%>
 	if d.HasChange("maintenance_policy") {
 		req := &containerBeta.SetMaintenancePolicyRequest{
 			MaintenancePolicy: expandMaintenancePolicy(d, meta),
@@ -1764,13 +1791,14 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	// The master must be updated before the nodes
-	if d.HasChange("min_master_version") {
-		desiredMasterVersion := d.Get("min_master_version").(string)
-		currentMasterVersion := d.Get("master_version").(string)
-		des, err := version.NewVersion(desiredMasterVersion)
+	// If set to "", skip this step- any master version satisfies that minimum.
+	if ver := d.Get("min_master_version").(string); d.HasChange("min_master_version") && ver != "" {
+		des, err := version.NewVersion(ver)
 		if err != nil {
 			return err
 		}
+
+		currentMasterVersion := d.Get("master_version").(string)
 		cur, err := version.NewVersion(currentMasterVersion)
 		if err != nil {
 			return err
@@ -1780,7 +1808,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		if cur.LessThan(des) {
 			req := &containerBeta.UpdateClusterRequest{
 				Update: &containerBeta.ClusterUpdate{
-					DesiredMasterVersion: desiredMasterVersion,
+					DesiredMasterVersion: ver,
 				},
 			}
 
@@ -1789,7 +1817,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 			if err := lockedCall(lockKey, updateF); err != nil {
 				return err
 			}
-			log.Printf("[INFO] GKE cluster %s: master has been updated to %s", d.Id(), desiredMasterVersion)
+			log.Printf("[INFO] GKE cluster %s: master has been updated to %s", d.Id(), ver)
 		}
 		d.SetPartial("min_master_version")
 	}

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -350,37 +350,51 @@ func TestAccContainerCluster_withReleaseChannelEnabled(t *testing.T) {
 				Config: testAccContainerCluster_withReleaseChannelEnabled(clusterName, "STABLE"),
 			},
 			{
-				ResourceName:        "google_container_cluster.with_release_channel",
-				ImportStateIdPrefix: "us-central1-a/",
-				ImportState:         true,
-				ImportStateVerify:   true,
-			},
-			{
-				Config: testAccContainerCluster_withReleaseChannelEnabled(clusterName, "REGULAR"),
-			},
-			{
-				ResourceName:        "google_container_cluster.with_release_channel",
-				ImportStateIdPrefix: "us-central1-a/",
-				ImportState:         true,
-				ImportStateVerify:   true,
-			},
-			{
-				Config: testAccContainerCluster_withReleaseChannelEnabled(clusterName, "RAPID"),
-			},
-			{
-				ResourceName:        "google_container_cluster.with_release_channel",
-				ImportStateIdPrefix: "us-central1-a/",
-				ImportState:         true,
-				ImportStateVerify:   true,
+				ResourceName:            "google_container_cluster.with_release_channel",
+				ImportStateIdPrefix:     "us-central1-a/",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
 			},
 			{
 				Config: testAccContainerCluster_withReleaseChannelEnabled(clusterName, "UNSPECIFIED"),
 			},
 			{
-				ResourceName:        "google_container_cluster.with_release_channel",
-				ImportStateIdPrefix: "us-central1-a/",
-				ImportState:         true,
-				ImportStateVerify:   true,
+				ResourceName:            "google_container_cluster.with_release_channel",
+				ImportStateIdPrefix:     "us-central1-a/",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
+			{
+				Config: testAccContainerCluster_withReleaseChannelEnabledUpdateToChannelDefaultVersion(clusterName, "REGULAR"),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_release_channel",
+				ImportStateIdPrefix:     "us-central1-a/",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
+			{
+				Config: testAccContainerCluster_withReleaseChannelEnabled(clusterName, "REGULAR"),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_release_channel",
+				ImportStateIdPrefix:     "us-central1-a/",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
+			{
+				Config: testAccContainerCluster_withReleaseChannelEnabled(clusterName, "UNSPECIFIED"),
+			},
+			{
+				ResourceName:            "google_container_cluster.with_release_channel",
+				ImportStateIdPrefix:     "us-central1-a/",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
 			},
 		},
 	})
@@ -2139,6 +2153,22 @@ resource "google_container_cluster" "with_release_channel" {
   release_channel {
     channel = "%s"
   }
+}
+`, clusterName, channel)
+}
+
+func testAccContainerCluster_withReleaseChannelEnabledUpdateToChannelDefaultVersion(clusterName string, channel string) string {
+	return fmt.Sprintf(`
+
+data "google_container_engine_versions" "central1a" {
+  location = "us-central1-a"
+}
+
+resource "google_container_cluster" "with_release_channel" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  min_master_version = data.google_container_engine_versions.central1a.release_channel_default_version["%s"]
 }
 `, clusterName, channel)
 }

--- a/third_party/terraform/website/docs/d/google_container_engine_versions.html.markdown
+++ b/third_party/terraform/website/docs/d/google_container_engine_versions.html.markdown
@@ -21,6 +21,7 @@ support the same version.
 
 ```hcl
 data "google_container_engine_versions" "central1b" {
+  provider       = "google-beta"
   location       = "us-central1-b"
   version_prefix = "1.12."
 }
@@ -35,6 +36,10 @@ resource "google_container_cluster" "foo" {
     username = "mr.yoda"
     password = "adoy.rm"
   }
+}
+
+output "stable_channel_version" {
+  value = data.google_container_engine_versions.central1b.release_channel_default_version["STABLE"]
 }
 ```
 
@@ -66,3 +71,4 @@ The following attributes are exported:
 * `latest_master_version` - The latest version available in the given zone for use with master instances.
 * `latest_node_version` - The latest version available in the given zone for use with node instances.
 * `default_cluster_version` - Version of Kubernetes the service deploys by default.
+* `release_channel_default_version` ([Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) - A map from a release channel name to the channel's default version.

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -271,9 +271,16 @@ clusters with private nodes. Structure is documented below.
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
 
-* `release_channel` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Configuration options for the
-    [Release channel](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels)
-    feature, which provide more control over automatic upgrades of your GKE clusters. Structure is documented below.
+* `release_channel` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+Configuration options for the [Release channel](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels)
+feature, which provide more control over automatic upgrades of your GKE clusters.
+When updating this field, GKE imposes specific version requirements. See
+[Migrating between release channels](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels#migrating_between_release_channels)
+for more details; the `google_container_engine_versions` datasource can provide
+the default version for a channel. Note that removing the `release_channel`
+field from your config will cause Terraform to stop managing your cluster's
+release channel, but will not unenroll it. Instead, use the `"UNSPECIFIED"`
+channel. Structure is documented below.
 
 * `remove_default_node_pool` - (Optional) If `true`, deletes the default node
     pool upon cluster creation. If you're using `google_container_node_pool`


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5846

The field I exposed on the datasource doesn't match the API 1:1 (which is a list of objects. `repeated message` in proto, I bet), but should prove much more useful overall- as you can see in the test, it's simple to look up the version for the channel and advance to it. 

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added update support to `google_container_cluster`'s `release_channel` field (`google-beta` only)
```

```release-note:enhancement
container: added the ability to unspecify `google_container_cluster`'s `min_master_version` field
```

```release-note:enhancement
container: added `release_channel_default_version` to `data.google_container_engine_versions`, allowing you to find the default version for a release channel (`google-beta` only)
```