### PR TITLE
Allow update of node pool workload metadata config

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -83,17 +83,6 @@ func clusterSchemaNodeConfig() *schema.Schema {
 	return nodeConfigSch
 }
 
-func changeFieldSchemaToForceNew(sch *schema.Schema) {
-	sch.ForceNew = true
-	if sch.Type == schema.TypeList {
-		if nestedR, ok := sch.Elem.(*schema.Resource); ok {
-			for _, nestedSch := range nestedR.Schema {
-				changeFieldSchemaToForceNew(nestedSch)
-			}
-		}
-	}
-}
-
 func rfc5545RecurrenceDiffSuppress(k, o, n string, d *schema.ResourceData) bool {
 	// This diff gets applied in the cloud console if you specify
 	// "FREQ=DAILY" in your config and add a maintenance exclusion.

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -62,7 +62,37 @@ var (
 		"addons_config.0.config_connector_config",
 	<% end -%>
 	}
+
+	forceNewClusterNodeConfigFields = []string{
+	<% unless version == 'ga' -%>
+		"workload_metadata_config",
+	<% end -%>
+	}
 )
+
+// This uses the node pool nodeConfig schema but sets
+// node-pool-only updatable fields to ForceNew
+func clusterSchemaNodeConfig() *schema.Schema {
+	nodeConfigSch := schemaNodeConfig()
+	schemaMap := nodeConfigSch.Elem.(*schema.Resource).Schema
+	for _, k := range forceNewClusterNodeConfigFields {
+		if sch, ok := schemaMap[k]; ok {
+			changeFieldSchemaToForceNew(sch)
+		}
+	}
+	return nodeConfigSch
+}
+
+func changeFieldSchemaToForceNew(sch *schema.Schema) {
+	sch.ForceNew = true
+	if sch.Type == schema.TypeList {
+		if nestedR, ok := sch.Elem.(*schema.Resource); ok {
+			for _, nestedSch := range nestedR.Schema {
+				changeFieldSchemaToForceNew(nestedSch)
+			}
+		}
+	}
+}
 
 func rfc5545RecurrenceDiffSuppress(k, o, n string, d *schema.ResourceData) bool {
 	// This diff gets applied in the cloud console if you specify
@@ -663,7 +693,7 @@ func resourceContainerCluster() *schema.Resource {
 				},
 			},
 
-			"node_config": schemaNodeConfig,
+			"node_config": clusterSchemaNodeConfig(),
 
 			"node_pool": {
 				Type:     schema.TypeList,

--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -181,7 +181,7 @@ var schemaNodePool = map[string]*schema.Schema{
 		ForceNew: true,
 	},
 
-	"node_config": schemaNodeConfig,
+	"node_config": schemaNodeConfig(),
 
 	"node_count": {
 		Type:         schema.TypeInt,
@@ -711,7 +711,40 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 
 			log.Printf("[INFO] Updated image type in Node Pool %s", d.Id())
 		}
+<% unless version == 'ga' -%>
+		if d.HasChange(prefix + "node_config.0.workload_metadata_config") {
+			req := &containerBeta.UpdateNodePoolRequest{
+				NodePoolId: name,
+				WorkloadMetadataConfig: expandWorkloadMetadataConfig(
+					d.Get(prefix + "node_config.0.workload_metadata_config")),
+			}
+			if req.WorkloadMetadataConfig == nil {
+				req.ForceSendFields = []string{"WorkloadMetadataConfig"}
+			}
+			updateF := func() error {
+				op, err := config.clientContainerBeta.Projects.Locations.Clusters.NodePools.
+					Update(nodePoolInfo.fullyQualifiedName(name), req).Do()
+				if err != nil {
+					return err
+				}
 
+				// Wait until it's updated
+				return containerOperationWait(config, op,
+					nodePoolInfo.project,
+					nodePoolInfo.location,
+					"updating GKE node pool workload_metadata_config",
+					timeout)
+			}
+
+			// Call update serially.
+			if err := lockedCall(lockKey, updateF); err != nil {
+				return err
+			}
+
+			log.Printf("[INFO] Updated workload_metadata_config for node pool %s", name)
+		}
+
+<% end -%>
 		if prefix == "" {
 			d.SetPartial("node_config")
 		}

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -167,9 +167,10 @@ func TestAccContainerNodePool_withNodeConfig(t *testing.T) {
 }
 
 <% unless version.nil? || version == 'ga' -%>
-func TestAccContainerNodePool_withWorkloadMetadataConfig(t *testing.T) {
+func TestAccContainerNodePool_withWorkloadIdentityConfig(t *testing.T) {
 	t.Parallel()
 
+	pid := getTestProjectFromEnv()
 	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
 	np := fmt.Sprintf("tf-test-np-%s", randString(t, 10))
 
@@ -195,22 +196,6 @@ func TestAccContainerNodePool_withWorkloadMetadataConfig(t *testing.T) {
 					"node_config.0.workload_metadata_config.0.node_metadata",
 				},
 			},
-		},
-	})
-}
-
-func TestAccContainerNodePool_withWorkloadIdentityConfig(t *testing.T) {
-	t.Parallel()
-
-	pid := getTestProjectFromEnv()
-	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
-	np := fmt.Sprintf("tf-test-np-%s", randString(t, 10))
-
-	vcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
-		Steps: []resource.TestStep{
 			{
 				Config: testAccContainerNodePool_withWorkloadMetadataConfig_gkeMetadataServer(pid, cluster, np),
 				Check: resource.ComposeTestCheckFunc(

--- a/third_party/terraform/utils/node_config.go.erb
+++ b/third_party/terraform/utils/node_config.go.erb
@@ -231,6 +231,7 @@ func schemaNodeConfig() *schema.Schema {
 	<% end -%>
 					Type:       schema.TypeList,
 					Optional:   true,
+					ForceNew:   true,
 					MaxItems:   1,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{

--- a/third_party/terraform/utils/node_config.go.erb
+++ b/third_party/terraform/utils/node_config.go.erb
@@ -20,240 +20,240 @@ var defaultOauthScopes = []string{
 	"https://www.googleapis.com/auth/trace.append",
 }
 
-var schemaNodeConfig = &schema.Schema{
-	Type:     schema.TypeList,
-	Optional: true,
-	Computed: true,
-	ForceNew: true,
-	MaxItems: 1,
-	Elem: &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"disk_size_gb": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntAtLeast(10),
-			},
+func schemaNodeConfig() *schema.Schema {
+	return &schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		Computed: true,
+		ForceNew: true,
+		MaxItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"disk_size_gb": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntAtLeast(10),
+				},
 
-			"disk_type": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.StringInSlice([]string{"pd-standard", "pd-ssd"}, false),
-			},
+				"disk_type": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.StringInSlice([]string{"pd-standard", "pd-ssd"}, false),
+				},
 
-			"guest_accelerator": &schema.Schema{
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				// Legacy config mode allows removing GPU's from an existing resource
-				// See https://www.terraform.io/docs/configuration/attr-as-blocks.html
-				ConfigMode: schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"count": &schema.Schema{
-							Type:     schema.TypeInt,
-							Required: true,
-							ForceNew: true,
-						},
-						"type": &schema.Schema{
-							Type:             schema.TypeString,
-							Required:         true,
-							ForceNew:         true,
-							DiffSuppressFunc: compareSelfLinkOrResourceName,
+				"guest_accelerator": &schema.Schema{
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+					// Legacy config mode allows removing GPU's from an existing resource
+					// See https://www.terraform.io/docs/configuration/attr-as-blocks.html
+					ConfigMode: schema.SchemaConfigModeAttr,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"count": &schema.Schema{
+								Type:     schema.TypeInt,
+								Required: true,
+								ForceNew: true,
+							},
+							"type": &schema.Schema{
+								Type:             schema.TypeString,
+								Required:         true,
+								ForceNew:         true,
+								DiffSuppressFunc: compareSelfLinkOrResourceName,
+							},
 						},
 					},
 				},
-			},
 
-			"image_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-			},
-
-			"labels": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				// Computed=true because GKE Sandbox will automatically add labels to nodes that can/cannot run sandboxed pods.
-				Computed: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-
-			"local_ssd_count": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ForceNew:     true,
-				ValidateFunc: validation.IntAtLeast(0),
-			},
-
-			"machine_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-
-			"metadata": {
-				Type:     schema.TypeMap,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
-
-			"min_cpu_platform": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
-			"oauth_scopes": {
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-					StateFunc: func(v interface{}) string {
-						return canonicalizeServiceScope(v.(string))
-					},
+				"image_type": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
 				},
-				DiffSuppressFunc: containerClusterAddedScopesSuppress,
-				Set: stringScopeHashcode,
-			},
 
-			"preemptible": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				ForceNew: true,
-				Default:  false,
-			},
+				"labels": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					// Computed=true because GKE Sandbox will automatically add labels to nodes that can/cannot run sandboxed pods.
+					Computed: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
 
-			"service_account": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
+				"local_ssd_count": {
+					Type:         schema.TypeInt,
+					Optional:     true,
+					Computed:     true,
+					ForceNew:     true,
+					ValidateFunc: validation.IntAtLeast(0),
+				},
 
-			"tags": {
-				Type:     schema.TypeList,
-				Optional: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-			},
+				"machine_type": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
 
-			"shielded_instance_config": &schema.Schema{
-				Type:     schema.TypeList,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"enable_secure_boot": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							ForceNew: true,
-							Default:  false,
-						},
-						"enable_integrity_monitoring": {
-							Type:     schema.TypeBool,
-							Optional: true,
-							ForceNew: true,
-							Default:  true,
+				"metadata": {
+					Type:     schema.TypeMap,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+
+				"min_cpu_platform": {
+					Type:     schema.TypeString,
+					Optional: true,
+					ForceNew: true,
+				},
+
+				"oauth_scopes": {
+					Type:     schema.TypeSet,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+						StateFunc: func(v interface{}) string {
+							return canonicalizeServiceScope(v.(string))
 						},
 					},
+					DiffSuppressFunc: containerClusterAddedScopesSuppress,
+					Set: stringScopeHashcode,
 				},
-			},
 
-			"taint": {
-				Type:             schema.TypeList,
-				Optional:         true,
-				// Computed=true because GKE Sandbox will automatically add taints to nodes that can/cannot run sandboxed pods.
-				Computed:         true,
-				ForceNew:         true,
-				// Legacy config mode allows explicitly defining an empty taint.
-				// See https://www.terraform.io/docs/configuration/attr-as-blocks.html
-				ConfigMode: schema.SchemaConfigModeAttr,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"key": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-						"value": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-						"effect": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice([]string{"NO_SCHEDULE", "PREFER_NO_SCHEDULE", "NO_EXECUTE"}, false),
+				"preemptible": {
+					Type:     schema.TypeBool,
+					Optional: true,
+					ForceNew: true,
+					Default:  false,
+				},
+
+				"service_account": {
+					Type:     schema.TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+
+				"tags": {
+					Type:     schema.TypeList,
+					Optional: true,
+					ForceNew: true,
+					Elem:     &schema.Schema{Type: schema.TypeString},
+				},
+
+				"shielded_instance_config": &schema.Schema{
+					Type:     schema.TypeList,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"enable_secure_boot": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								ForceNew: true,
+								Default:  false,
+							},
+							"enable_integrity_monitoring": {
+								Type:     schema.TypeBool,
+								Optional: true,
+								ForceNew: true,
+								Default:  true,
+							},
 						},
 					},
 				},
-			},
 
-			"workload_metadata_config": {
-<% if version.nil? || version == 'ga' -%>
-				Removed: "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/guides/provider_versions.html for more details.",
-				Computed: true,
-<% end -%>
-				Type:       schema.TypeList,
-				Optional:   true,
-				ForceNew:   true,
-				MaxItems:   1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"node_metadata": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice([]string{"UNSPECIFIED", "SECURE", "EXPOSE", "GKE_METADATA_SERVER"}, false),
+				"taint": {
+					Type:             schema.TypeList,
+					Optional:         true,
+					// Computed=true because GKE Sandbox will automatically add taints to nodes that can/cannot run sandboxed pods.
+					Computed:         true,
+					ForceNew:         true,
+					// Legacy config mode allows explicitly defining an empty taint.
+					// See https://www.terraform.io/docs/configuration/attr-as-blocks.html
+					ConfigMode: schema.SchemaConfigModeAttr,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"key": {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
+							"value": {
+								Type:     schema.TypeString,
+								Required: true,
+								ForceNew: true,
+							},
+							"effect": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ForceNew:     true,
+								ValidateFunc: validation.StringInSlice([]string{"NO_SCHEDULE", "PREFER_NO_SCHEDULE", "NO_EXECUTE"}, false),
+							},
 						},
 					},
 				},
-			},
 
-			"sandbox_config": {
-<% if version.nil? || version == 'ga' -%>
-				Removed: "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/guides/provider_versions.html for more details.",
-				Computed: true,
-<% end -%>
-				Type:       schema.TypeList,
-				Optional:   true,
-				ForceNew:   true,
-				MaxItems:   1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"sandbox_type": {
-							Type:         schema.TypeString,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"gvisor"}, false),
+				"workload_metadata_config": {
+	<% if version.nil? || version == 'ga' -%>
+					Removed: "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/guides/provider_versions.html for more details.",
+					Computed: true,
+	<% end -%>
+					Type:       schema.TypeList,
+					Optional:   true,
+					ForceNew:   true,
+					MaxItems:   1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"node_metadata": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringInSlice([]string{"UNSPECIFIED", "SECURE", "EXPOSE", "GKE_METADATA_SERVER"}, false),
+							},
 						},
 					},
 				},
-			},
 
-<% unless version == 'ga' -%>
-			"boot_disk_kms_key": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				ForceNew:   true,
+				"sandbox_config": {
+	<% if version.nil? || version == 'ga' -%>
+					Removed: "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/guides/provider_versions.html for more details.",
+					Computed: true,
+	<% end -%>
+					Type:       schema.TypeList,
+					Optional:   true,
+					MaxItems:   1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"sandbox_type": {
+								Type:         schema.TypeString,
+								Required:     true,
+								ValidateFunc: validation.StringInSlice([]string{"gvisor"}, false),
+							},
+						},
+					},
+				},
+
+	<% unless version == 'ga' -%>
+				"boot_disk_kms_key": {
+					Type:       schema.TypeString,
+					Optional:   true,
+					ForceNew:   true,
+				},
+	<% end -%>
 			},
-<% end -%>
 		},
-	},
+	}
 }
 
 func expandNodeConfig(v interface{}) *containerBeta.NodeConfig {
@@ -376,11 +376,8 @@ func expandNodeConfig(v interface{}) *containerBeta.NodeConfig {
 	}
 
 <% unless version == 'ga' -%>
-	if v, ok := nodeConfig["workload_metadata_config"]; ok && len(v.([]interface{})) > 0 {
-		conf := v.([]interface{})[0].(map[string]interface{})
-		nc.WorkloadMetadataConfig = &containerBeta.WorkloadMetadataConfig{
-			NodeMetadata: conf["node_metadata"].(string),
-		}
+	if v, ok := nodeConfig["workload_metadata_config"]; ok {
+		nc.WorkloadMetadataConfig = expandWorkloadMetadataConfig(v)
 	}
 
 	if v, ok := nodeConfig["sandbox_config"]; ok && len(v.([]interface{})) > 0 {
@@ -398,6 +395,23 @@ func expandNodeConfig(v interface{}) *containerBeta.NodeConfig {
 	return nc
 }
 
+<% unless version == 'ga' -%>
+func expandWorkloadMetadataConfig(v interface{}) *containerBeta.WorkloadMetadataConfig {
+	if v == nil {
+		return nil
+	}
+	ls := v.([]interface{})
+	if len(ls) == 0 {
+		return nil
+	}
+
+	cfg := ls[0].(map[string]interface{})
+	return &containerBeta.WorkloadMetadataConfig{
+		NodeMetadata: cfg["node_metadata"].(string),
+	}
+}
+
+<% end -%>
 func flattenNodeConfig(c *containerBeta.NodeConfig) []map[string]interface{} {
 	config := make([]map[string]interface{}, 0, 1)
 

--- a/third_party/terraform/utils/node_config.go.erb
+++ b/third_party/terraform/utils/node_config.go.erb
@@ -212,7 +212,6 @@ func schemaNodeConfig() *schema.Schema {
 	<% end -%>
 					Type:       schema.TypeList,
 					Optional:   true,
-					ForceNew:   true,
 					MaxItems:   1,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{

--- a/third_party/terraform/utils/utils.go.erb
+++ b/third_party/terraform/utils/utils.go.erb
@@ -431,3 +431,17 @@ func migrateStateNoop(v int, is *terraform.InstanceState, meta interface{}) (*te
 func expandString(v interface{}, d TerraformResourceData, config *Config) (string, error) {
 	return v.(string), nil
 }
+
+
+func changeFieldSchemaToForceNew(sch *schema.Schema) {
+	sch.ForceNew = true
+	switch sch.Type {
+	case schema.TypeList:
+	case schema.TypeSet:
+		if nestedR, ok := sch.Elem.(*schema.Resource); ok {
+			for _, nestedSch := range nestedR.Schema {
+				changeFieldSchemaToForceNew(nestedSch)
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: Added update support for `node_config.workload_metadata_config` to `google_container_node_pool`
```

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4041

This field is only updatable on node pool, so we've chosen to only make it updatable on `node_pool` and keep it ForceNew on container cluster

In addition, because cluster.workload_identity_config and node_pool.workload_metadata_config are closely related, I decided to combine the test