### PR TITLE
Add precondition retry to node pool deletion - upstreams tpg#6334

### DIFF
--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -395,20 +395,24 @@ func resourceContainerNodePoolDelete(d *schema.ResourceData, meta interface{}) e
 	mutexKV.Lock(nodePoolInfo.lockKey())
 	defer mutexKV.Unlock(nodePoolInfo.lockKey())
 
-	var op = &containerBeta.Operation{}
-	var count = 0
-	err = resource.Retry(30*time.Second, func() *resource.RetryError {
-		count++
-		op, err = config.clientContainerBeta.Projects.Locations.
-			Clusters.NodePools.Delete(nodePoolInfo.fullyQualifiedName(name)).Do()
+
+	timeout := d.Timeout(schema.TimeoutCreate)
+	startTime := time.Now()
+
+	var operation *containerBeta.Operation
+	err = resource.Retry(timeout, func() *resource.RetryError {
+		operation, err = config.clientContainerBeta.
+			Projects.Locations.Clusters.NodePools.Delete(nodePoolInfo.fullyQualifiedName(name)).Do()
 
 		if err != nil {
-			return resource.RetryableError(err)
+			if isFailedPreconditionError(err) {
+				// We get failed precondition errors if the cluster is updating
+				// while we try to delete the node pool.
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
 		}
 
-		if count == 15 {
-			return resource.NonRetryableError(fmt.Errorf("Error retrying to delete node pool %s", name))
-		}
 		return nil
 	})
 
@@ -416,8 +420,10 @@ func resourceContainerNodePoolDelete(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error deleting NodePool: %s", err)
 	}
 
+	timeout -= time.Since(startTime)
+
 	// Wait until it's deleted
-	waitErr := containerOperationWait(config, op, nodePoolInfo.project, nodePoolInfo.location, "deleting GKE NodePool", d.Timeout(schema.TimeoutDelete))
+	waitErr := containerOperationWait(config, operation, nodePoolInfo.project, nodePoolInfo.location, "deleting GKE NodePool", timeout)
 	if waitErr != nil {
 		return waitErr
 	}

--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -396,7 +396,7 @@ func resourceContainerNodePoolDelete(d *schema.ResourceData, meta interface{}) e
 	defer mutexKV.Unlock(nodePoolInfo.lockKey())
 
 
-	timeout := d.Timeout(schema.TimeoutCreate)
+	timeout := d.Timeout(schema.TimeoutDelete)
 	startTime := time.Now()
 
 	var operation *containerBeta.Operation


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: Changed retry logic for `google_container_node_pool` deletion to use timeouts and retry errors more specifically when cluster is updating.
```

Upstreams https://github.com/terraform-providers/terraform-provider-google/pull/6335
