### PR TITLE
cloud app armor: Maximum number of src_ip_ranges is 10

### DIFF
--- a/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -83,7 +83,7 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 													Type:     schema.TypeSet,
 													Required: true,
 													MinItems: 1,
-													MaxItems: 5,
+													MaxItems: 10,
 													Elem:     &schema.Schema{Type: schema.TypeString},
 												},
 											},


### PR DESCRIPTION
```release-note:bug
google_compute_security_policy: raise limit on number of  srcIpRange values to supported 10
```

Upstreams: https://github.com/terraform-providers/terraform-provider-google/pull/6393