### PR TITLE
Add compute_route retry for "peering operation in progress"

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1680,6 +1680,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   Route: !ruby/object:Overrides::Terraform::ResourceOverride
     # Route cannot be added while a peering is on progress on the network
     mutex: 'projects/{{project}}/global/networks/{{network}}/peerings'
+    error_retry_predicates: ["isPeeringOperationInProgress"]
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "route_basic"

--- a/third_party/terraform/utils/error_retry_predicates.go
+++ b/third_party/terraform/utils/error_retry_predicates.go
@@ -248,3 +248,12 @@ func isDataflowJobUpdateRetryableError(err error) (bool, string) {
 	}
 	return false, ""
 }
+
+func isPeeringOperationInProgress(err error) (bool, string) {
+	if gerr, ok := err.(*googleapi.Error); ok {
+		if gerr.Code == 400 && strings.Contains(gerr.Body, "There is a peering operation in progress") {
+			return true, "Waiting peering operation to complete"
+		}
+	}
+	return false, ""
+}


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6361
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Fixed an issue where `google_compute_route` creation failed while VPC peering was in progress.
```
