### PR TITLE
allow bigquery job fields that reference resources in blocks to do so with one field

### DIFF
--- a/products/bigquery/terraform.yaml
+++ b/products/bigquery/terraform.yaml
@@ -117,12 +117,31 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read_extra:
           - "etag"
       - !ruby/object:Provider::Terraform::Examples
+        name: "bigquery_job_query_table_reference"
+        primary_resource_id: "job"
+        vars:
+          job_id: "job_query"
+          account_name: "bqowner"
+        ignore_read_extra:
+          - "etag"
+          - "query.0.default_dataset.0.dataset_id"
+          - "query.0.destination_table.0.table_id"
+      - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_job_load"
         primary_resource_id: "job"
         vars:
           job_id: "job_load"
         ignore_read_extra:
           - "etag"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "bigquery_job_load_table_reference"
+        primary_resource_id: "job"
+        vars:
+          job_id: "job_load"
+        ignore_read_extra:
+          - "etag"
+          - "load.0.destination_table.0.table_id"
+        skip_docs: true  # there are a lot of examples for this resource, so omitting some that are similar to others
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_job_copy"
         primary_resource_id: "job"
@@ -136,6 +155,22 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read_extra:
           - "etag"
       - !ruby/object:Provider::Terraform::Examples
+        name: "bigquery_job_copy_table_reference"
+        primary_resource_id: "job"
+        vars:
+          job_id: "job_copy"
+          account_name: "bqowner"
+          key_name: "example-key"
+          keyring_name: "example-keyring"
+        test_env_vars:
+          project: :PROJECT_NAME
+        ignore_read_extra:
+          - "etag"
+          - "copy.0.destination_table.0.table_id"
+          - "copy.0.source_tables.0.table_id"
+          - "copy.0.source_tables.1.table_id"
+        skip_docs: true  # there are a lot of examples for this resource, so omitting some that are similar to others
+      - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_job_extract"
         primary_resource_id: "job"
         vars:
@@ -143,11 +178,60 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           account_name: "bqowner"
         ignore_read_extra:
           - "etag"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "bigquery_job_extract_table_reference"
+        primary_resource_id: "job"
+        vars:
+          job_id: "job_extract"
+          account_name: "bqowner"
+        ignore_read_extra:
+          - "etag"
+          - "extract.0.source_table.0.table_id"
+        skip_docs: true  # there are a lot of examples for this resource, so omitting some that are similar to others
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
       configuration: !ruby/object:Overrides::Terraform::PropertyOverride
         flatten_object: true
+      configuration.copy.destinationTable: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/bigquery_table_ref.go.erb'
+        custom_flatten: 'templates/terraform/custom_flatten/bigquery_table_ref_copy_destinationtable.go.erb'
+      configuration.copy.destinationTable.projectId: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: false
+        default_from_api: true
+      configuration.copy.destinationTable.datasetId: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: false
+        default_from_api: true
+      configuration.copy.destinationTable.tableId: !ruby/object:Overrides::Terraform::PropertyOverride
+        description: |
+          The table. Can be specified `{{table_id}}` if `project_id` and `dataset_id` are also set,
+          or of the form `projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}` if not.
+      configuration.copy.sourceTables: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/bigquery_table_ref_array.go.erb'
+        custom_flatten: 'templates/terraform/custom_flatten/bigquery_table_ref_copy_sourcetables.go.erb'
+      configuration.copy.sourceTables.projectId: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: false
+        default_from_api: true
+      configuration.copy.sourceTables.datasetId: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: false
+        default_from_api: true
+      configuration.copy.sourceTables.tableId: !ruby/object:Overrides::Terraform::PropertyOverride
+        description: |
+          The table. Can be specified `{{table_id}}` if `project_id` and `dataset_id` are also set,
+          or of the form `projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}` if not.
+      configuration.load.destinationTable: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/bigquery_table_ref.go.erb'
+        custom_flatten: 'templates/terraform/custom_flatten/bigquery_table_ref_load_destinationtable.go.erb'
+      configuration.load.destinationTable.projectId: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: false
+        default_from_api: true
+      configuration.load.destinationTable.datasetId: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: false
+        default_from_api: true
+      configuration.load.destinationTable.tableId: !ruby/object:Overrides::Terraform::PropertyOverride
+        description: |
+          The table. Can be specified `{{table_id}}` if `project_id` and `dataset_id` are also set,
+          or of the form `projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}` if not.
       configuration.load.skipLeadingRows: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validation.IntAtLeast(0)'
@@ -159,11 +243,48 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       configuration.extract.destinationFormat: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      configuration.extract.sourceTable: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/bigquery_table_ref.go.erb'
+        custom_flatten: 'templates/terraform/custom_flatten/bigquery_table_ref_extract_sourcetable.go.erb'
+      configuration.extract.sourceTable.projectId: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: false
+        default_from_api: true
+      configuration.extract.sourceTable.datasetId: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: false
+        default_from_api: true
+      configuration.extract.sourceTable.tableId: !ruby/object:Overrides::Terraform::PropertyOverride
+        description: |
+          The table. Can be specified `{{table_id}}` if `project_id` and `dataset_id` are also set,
+          or of the form `projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}` if not.
+      configuration.query.destinationTable: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/bigquery_table_ref.go.erb'
+        custom_flatten: 'templates/terraform/custom_flatten/bigquery_table_ref_query_destinationtable.go.erb'
+      configuration.query.destinationTable.projectId: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: false
+        default_from_api: true
+      configuration.query.destinationTable.datasetId: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: false
+        default_from_api: true
+      configuration.query.destinationTable.tableId: !ruby/object:Overrides::Terraform::PropertyOverride
+        description: |
+          The table. Can be specified `{{table_id}}` if `project_id` and `dataset_id` are also set,
+          or of the form `projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}` if not.
+      configuration.query.defaultDataset: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/bigquery_dataset_ref.go.erb'
+        custom_flatten: 'templates/terraform/custom_flatten/bigquery_dataset_ref.go.erb'
+      configuration.query.defaultDataset.projectId: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: false
+        default_from_api: true
+      configuration.query.defaultDataset.datasetId: !ruby/object:Overrides::Terraform::PropertyOverride
+        description: |
+          The dataset. Can be specified `{{dataset_id}}` if `project_id` is also set,
+          or of the form `projects/{{project}}/datasets/{{dataset_id}}` if not.
       jobReference: !ruby/object:Overrides::Terraform::PropertyOverride
         flatten_object: true
       jobReference.projectId: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
+      constants: templates/terraform/constants/bigquery_job.go
       encoder: templates/terraform/encoders/bigquery_job.go.erb
   Table: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true

--- a/provider/terraform/examples.rb
+++ b/provider/terraform/examples.rb
@@ -111,6 +111,9 @@ module Provider
       # Whether to skip generating tests for this resource
       attr_reader :skip_test
 
+      # Whether to skip generating docs for this example
+      attr_reader :skip_docs
+
       # The name of the primary resource for use in IAM tests. IAM tests need
       # a reference to the primary resource to create IAM policies for
       attr_reader :primary_resource_name
@@ -267,6 +270,7 @@ module Provider
         check :ignore_read_extra, type: Array, item_type: String, default: []
         check :primary_resource_name, type: String
         check :skip_test, type: TrueClass
+        check :skip_docs, type: TrueClass
         check :config_path, type: String, default: "templates/terraform/examples/#{name}.tf.erb"
         check :skip_vcr, type: TrueClass
       end

--- a/templates/terraform/constants/bigquery_job.go
+++ b/templates/terraform/constants/bigquery_job.go
@@ -1,0 +1,18 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+var (
+	bigqueryDatasetRegexp = regexp.MustCompile("projects/(.+)/datasets/(.+)")
+	bigqueryTableRegexp = regexp.MustCompile("projects/(.+)/datasets/(.+)/tables/(.+)")
+)

--- a/templates/terraform/custom_expand/bigquery_dataset_ref.go.erb
+++ b/templates/terraform/custom_expand/bigquery_dataset_ref.go.erb
@@ -1,0 +1,40 @@
+<%# # the license inside this if block pertains to this file
+		# Copyright 2020 Google Inc.
+		# Licensed under the Apache License, Version 2.0 (the "License");
+		# you may not use this file except in compliance with the License.
+		# You may obtain a copy of the License at
+		#
+		#     http://www.apache.org/licenses/LICENSE-2.0
+		#
+		# Unless required by applicable law or agreed to in writing, software
+		# distributed under the License is distributed on an "AS IS" BASIS,
+		# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+		# See the License for the specific language governing permissions and
+		# limitations under the License.
+#%>
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+			return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
+
+	transformedProjectId := original["project_id"]
+	if val := reflect.ValueOf(transformedProjectId); val.IsValid() && !isEmptyValue(val) {
+		transformed["projectId"] = transformedProjectId
+	}
+
+	transformedDatasetId := original["dataset_id"]
+	if val := reflect.ValueOf(transformedDatasetId); val.IsValid() && !isEmptyValue(val) {
+		transformed["datasetId"] = transformedDatasetId
+	}
+
+	if parts := bigqueryDatasetRegexp.FindStringSubmatch(transformedDatasetId.(string)); parts != nil {
+		transformed["projectId"] = parts[1]
+		transformed["datasetId"] = parts[2]
+	}
+
+	return transformed, nil
+}

--- a/templates/terraform/custom_expand/bigquery_table_ref.go.erb
+++ b/templates/terraform/custom_expand/bigquery_table_ref.go.erb
@@ -1,0 +1,46 @@
+<%# # the license inside this if block pertains to this file
+		# Copyright 2020 Google Inc.
+		# Licensed under the Apache License, Version 2.0 (the "License");
+		# you may not use this file except in compliance with the License.
+		# You may obtain a copy of the License at
+		#
+		#     http://www.apache.org/licenses/LICENSE-2.0
+		#
+		# Unless required by applicable law or agreed to in writing, software
+		# distributed under the License is distributed on an "AS IS" BASIS,
+		# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+		# See the License for the specific language governing permissions and
+		# limitations under the License.
+#%>
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+			return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
+
+	transformedProjectId := original["project_id"]
+	if val := reflect.ValueOf(transformedProjectId); val.IsValid() && !isEmptyValue(val) {
+		transformed["projectId"] = transformedProjectId
+	}
+
+	transformedDatasetId := original["dataset_id"]
+	if val := reflect.ValueOf(transformedDatasetId); val.IsValid() && !isEmptyValue(val) {
+		transformed["datasetId"] = transformedDatasetId
+	}
+
+	transformedTableId := original["table_id"]
+	if val := reflect.ValueOf(transformedTableId); val.IsValid() && !isEmptyValue(val) {
+		transformed["tableId"] = transformedTableId
+	}
+
+	if parts := bigqueryTableRegexp.FindStringSubmatch(transformedTableId.(string)); parts != nil {
+		transformed["projectId"] = parts[1]
+		transformed["datasetId"] = parts[2]
+		transformed["tableId"] =  parts[3]
+	}
+
+	return transformed, nil
+}

--- a/templates/terraform/custom_expand/bigquery_table_ref_array.go.erb
+++ b/templates/terraform/custom_expand/bigquery_table_ref_array.go.erb
@@ -1,0 +1,50 @@
+<%# # the license inside this if block pertains to this file
+		# Copyright 2020 Google Inc.
+		# Licensed under the Apache License, Version 2.0 (the "License");
+		# you may not use this file except in compliance with the License.
+		# You may obtain a copy of the License at
+		#
+		#     http://www.apache.org/licenses/LICENSE-2.0
+		#
+		# Unless required by applicable law or agreed to in writing, software
+		# distributed under the License is distributed on an "AS IS" BASIS,
+		# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+		# See the License for the specific language governing permissions and
+		# limitations under the License.
+#%>
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	l := v.([]interface{})
+	req := make([]interface{}, 0, len(l))
+	for _, raw := range l {
+		if raw == nil {
+			continue
+		}
+		original := raw.(map[string]interface{})
+		transformed := make(map[string]interface{})
+
+		transformedProjectId := original["project_id"]
+		if val := reflect.ValueOf(transformedProjectId); val.IsValid() && !isEmptyValue(val) {
+			transformed["projectId"] = transformedProjectId
+		}
+
+		transformedDatasetId := original["dataset_id"]
+		if val := reflect.ValueOf(transformedDatasetId); val.IsValid() && !isEmptyValue(val) {
+			transformed["datasetId"] = transformedDatasetId
+		}
+
+		transformedTableId := original["table_id"]
+		if val := reflect.ValueOf(transformedTableId); val.IsValid() && !isEmptyValue(val) {
+			transformed["tableId"] = transformedTableId
+		}
+
+		tableRef := regexp.MustCompile("projects/(.+)/datasets/(.+)/tables/(.+)")
+		if parts := tableRef.FindStringSubmatch(transformedTableId.(string)); parts != nil {
+			transformed["projectId"] = parts[1]
+			transformed["datasetId"] = parts[2]
+			transformed["tableId"] =  parts[3]
+		}
+
+		req = append(req, transformed)
+	}
+	return req, nil
+}

--- a/templates/terraform/custom_flatten/bigquery_dataset_ref.go.erb
+++ b/templates/terraform/custom_flatten/bigquery_dataset_ref.go.erb
@@ -1,0 +1,32 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["project_id"] = original["projectId"]
+	transformed["dataset_id"] = original["datasetId"]
+
+	if bigqueryDatasetRegexp.MatchString(d.Get("query.0.default_dataset.0.dataset_id").(string)) {
+		// The user specified the dataset_id as a URL, so store it in state that way
+		transformed["dataset_id"] = fmt.Sprintf("projects/%s/datasets/%s", transformed["project_id"], transformed["dataset_id"])
+	}
+	return []interface{}{transformed}
+}

--- a/templates/terraform/custom_flatten/bigquery_table_ref.go.erb
+++ b/templates/terraform/custom_flatten/bigquery_table_ref.go.erb
@@ -1,0 +1,33 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+	transformed := make(map[string]interface{})
+	transformed["project_id"] = original["projectId"]
+	transformed["dataset_id"] = original["datasetId"]
+	transformed["table_id"] = original["tableId"]
+
+	if bigqueryTableRegexp.MatchString(d.Get("<%= prop_path -%>").(string)) {
+		// The user specified the table_id as a URL, so store it in state that way
+		transformed["table_id"] = fmt.Sprintf("projects/%s/datasets/%s/tables/%s", transformed["project_id"], transformed["dataset_id"], transformed["table_id"])
+	}
+	return []interface{}{transformed}
+}

--- a/templates/terraform/custom_flatten/bigquery_table_ref_copy_destinationtable.go.erb
+++ b/templates/terraform/custom_flatten/bigquery_table_ref_copy_destinationtable.go.erb
@@ -1,0 +1,18 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+<%= lines(compile_template(pwd + '/templates/terraform/custom_flatten/bigquery_table_ref.go.erb',
+                           prefix: prefix,
+                           property: property,
+                           prop_path: 'copy.0.destination_table.0.table_id')) -%>

--- a/templates/terraform/custom_flatten/bigquery_table_ref_copy_sourcetables.go.erb
+++ b/templates/terraform/custom_flatten/bigquery_table_ref_copy_sourcetables.go.erb
@@ -1,0 +1,41 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	if v == nil {
+		return v
+	}
+	l := v.([]interface{})
+	transformed := make([]interface{}, 0, len(l))
+	for i, raw := range l {
+		original := raw.(map[string]interface{})
+		if len(original) < 1 {
+			// Do not include empty json objects coming back from the api
+			continue
+		}
+		t := map[string]interface{}{
+			"project_id": original["projectId"],
+			"dataset_id": original["datasetId"],
+			"table_id":   original["tableId"],
+		}
+		
+		if bigqueryTableRegexp.MatchString(d.Get(fmt.Sprintf("copy.0.source_tables.%d.table_id", i)).(string)) {
+			// The user specified the table_id as a URL, so store it in state that way
+			t["table_id"] = fmt.Sprintf("projects/%s/datasets/%s/tables/%s", t["project_id"], t["dataset_id"], t["table_id"])
+		}
+		transformed = append(transformed, t)
+	}
+
+	return transformed
+}

--- a/templates/terraform/custom_flatten/bigquery_table_ref_extract_sourcetable.go.erb
+++ b/templates/terraform/custom_flatten/bigquery_table_ref_extract_sourcetable.go.erb
@@ -1,0 +1,18 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+<%= lines(compile_template(pwd + '/templates/terraform/custom_flatten/bigquery_table_ref.go.erb',
+                           prefix: prefix,
+                           property: property,
+                           prop_path: 'extract.0.source_table.0.table_id')) -%>

--- a/templates/terraform/custom_flatten/bigquery_table_ref_load_destinationtable.go.erb
+++ b/templates/terraform/custom_flatten/bigquery_table_ref_load_destinationtable.go.erb
@@ -1,0 +1,18 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+<%= lines(compile_template(pwd + '/templates/terraform/custom_flatten/bigquery_table_ref.go.erb',
+                           prefix: prefix,
+                           property: property,
+                           prop_path: 'load.0.destination_table.0.table_id')) -%>

--- a/templates/terraform/custom_flatten/bigquery_table_ref_query_destinationtable.go.erb
+++ b/templates/terraform/custom_flatten/bigquery_table_ref_query_destinationtable.go.erb
@@ -1,0 +1,18 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+<%= lines(compile_template(pwd + '/templates/terraform/custom_flatten/bigquery_table_ref.go.erb',
+                           prefix: prefix,
+                           property: property,
+                           prop_path: 'query.0.destination_table.0.table_id')) -%>

--- a/templates/terraform/examples/bigquery_job_copy_table_reference.tf.erb
+++ b/templates/terraform/examples/bigquery_job_copy_table_reference.tf.erb
@@ -1,0 +1,116 @@
+resource "google_bigquery_table" "source" {
+  count = length(google_bigquery_dataset.source)
+
+  dataset_id = google_bigquery_dataset.source[count.index].dataset_id
+  table_id   = "<%= ctx[:vars]['job_id'] %>_${count.index}_table"
+
+  schema = <<EOF
+[
+  {
+    "name": "name",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "post_abbr",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "date",
+    "type": "DATE",
+    "mode": "NULLABLE"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_dataset" "source" {
+  count = 2
+
+  dataset_id                  = "<%= ctx[:vars]['job_id'] %>_${count.index}_dataset"
+  friendly_name               = "test"
+  description                 = "This is a test description"
+  location                    = "US"
+}
+
+resource "google_bigquery_table" "dest" {
+  dataset_id = google_bigquery_dataset.dest.dataset_id
+  table_id   = "<%= ctx[:vars]['job_id'] %>_dest_table"
+
+  schema = <<EOF
+[
+  {
+    "name": "name",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "post_abbr",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "date",
+    "type": "DATE",
+    "mode": "NULLABLE"
+  }
+]
+EOF
+
+  encryption_configuration {
+    kms_key_name = google_kms_crypto_key.crypto_key.id
+  }
+
+  depends_on = ["google_project_iam_member.encrypt_role"]
+}
+
+resource "google_bigquery_dataset" "dest" {
+  dataset_id    = "<%= ctx[:vars]['job_id'] %>_dest_dataset"
+  friendly_name = "test"
+  description   = "This is a test description"
+  location      = "US"
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+  name     = "<%= ctx[:vars]['key_name'] %>"
+  key_ring = google_kms_key_ring.key_ring.id
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  name     = "<%= ctx[:vars]['keyring_name'] %>"
+  location = "global"
+}
+
+data "google_project" "project" {
+  project_id = "<%= ctx[:test_env_vars]['project'] %>"
+}
+
+resource "google_project_iam_member" "encrypt_role" {
+  role = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member = "serviceAccount:bq-${data.google_project.project.number}@bigquery-encryption.iam.gserviceaccount.com"
+}
+
+resource "google_bigquery_job" "<%= ctx[:primary_resource_id] %>" {
+  job_id     = "<%= ctx[:vars]['job_id'] %>"
+
+  copy {
+    source_tables {
+      table_id   = google_bigquery_table.source.0.id
+    }
+
+    source_tables {
+      table_id   = google_bigquery_table.source.1.id
+    }
+
+    destination_table {
+      table_id   = google_bigquery_table.dest.id
+    }
+
+    destination_encryption_configuration {
+      kms_key_name = google_kms_crypto_key.crypto_key.id
+    }
+  }
+
+  depends_on = ["google_project_iam_member.encrypt_role"]
+}

--- a/templates/terraform/examples/bigquery_job_extract_table_reference.tf.erb
+++ b/templates/terraform/examples/bigquery_job_extract_table_reference.tf.erb
@@ -1,0 +1,52 @@
+resource "google_bigquery_table" "source-one" {
+  dataset_id = google_bigquery_dataset.source-one.dataset_id
+  table_id   = "<%= ctx[:vars]['job_id'] %>_table"
+
+  schema = <<EOF
+[
+  {
+    "name": "name",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "post_abbr",
+    "type": "STRING",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "date",
+    "type": "DATE",
+    "mode": "NULLABLE"
+  }
+]
+EOF
+}
+
+resource "google_bigquery_dataset" "source-one" {
+  dataset_id    = "<%= ctx[:vars]['job_id'] %>_dataset"
+  friendly_name = "test"
+  description   = "This is a test description"
+  location      = "US"
+}
+
+resource "google_storage_bucket" "dest" {
+  name = "<%= ctx[:vars]['job_id'] %>_bucket"
+
+  force_destroy = true
+}
+
+resource "google_bigquery_job" "<%= ctx[:primary_resource_id] %>" {
+  job_id     = "<%= ctx[:vars]['job_id'] %>"
+
+  extract {
+    destination_uris = ["${google_storage_bucket.dest.url}/extract"]
+
+    source_table {
+      table_id   = google_bigquery_table.source-one.id
+    }
+
+    destination_format = "NEWLINE_DELIMITED_JSON"
+    compression = "GZIP"
+  }
+}

--- a/templates/terraform/examples/bigquery_job_load_table_reference.tf.erb
+++ b/templates/terraform/examples/bigquery_job_load_table_reference.tf.erb
@@ -1,0 +1,35 @@
+resource "google_bigquery_table" "foo" {
+  dataset_id = google_bigquery_dataset.bar.dataset_id
+  table_id   = "<%= ctx[:vars]['job_id'] %>_table"
+}
+
+resource "google_bigquery_dataset" "bar" {
+  dataset_id                  = "<%= ctx[:vars]['job_id'] %>_dataset"
+  friendly_name               = "test"
+  description                 = "This is a test description"
+  location                    = "US"
+}
+
+resource "google_bigquery_job" "<%= ctx[:primary_resource_id] %>" {
+  job_id     = "<%= ctx[:vars]['job_id'] %>"
+
+  labels = {
+    "my_job" ="load"
+  }
+
+  load {
+    source_uris = [
+      "gs://cloud-samples-data/bigquery/us-states/us-states-by-date.csv",
+    ]
+
+    destination_table {
+      table_id   = google_bigquery_table.foo.id
+    }
+
+    skip_leading_rows = 1
+    schema_update_options = ["ALLOW_FIELD_RELAXATION", "ALLOW_FIELD_ADDITION"]
+
+    write_disposition = "WRITE_APPEND"
+    autodetect = true
+  }
+}

--- a/templates/terraform/examples/bigquery_job_query_table_reference.tf.erb
+++ b/templates/terraform/examples/bigquery_job_query_table_reference.tf.erb
@@ -1,0 +1,38 @@
+resource "google_bigquery_table" "foo" {
+  dataset_id = google_bigquery_dataset.bar.dataset_id
+  table_id   = "<%= ctx[:vars]['job_id'] %>_table"
+}
+
+resource "google_bigquery_dataset" "bar" {
+  dataset_id                  = "<%= ctx[:vars]['job_id'] %>_dataset"
+  friendly_name               = "test"
+  description                 = "This is a test description"
+  location                    = "US"
+}
+
+resource "google_bigquery_job" "<%= ctx[:primary_resource_id] %>" {
+  job_id     = "<%= ctx[:vars]['job_id'] %>"
+
+  labels = {
+    "example-label" ="example-value"
+  }
+
+  query {
+    query = "SELECT state FROM [lookerdata:cdc.project_tycho_reports]"
+
+    destination_table {
+      table_id = google_bigquery_table.foo.id
+    }
+
+    default_dataset {
+      dataset_id = google_bigquery_dataset.bar.id
+    }
+
+    allow_large_results = true
+    flatten_results = true
+
+    script_options {
+      key_result_statement = "LAST"
+    }
+  }
+}

--- a/templates/terraform/flatten_property_method.erb
+++ b/templates/terraform/flatten_property_method.erb
@@ -15,7 +15,8 @@
 <% if property.custom_flatten -%>
 <%= lines(compile_template(pwd + '/' + property.custom_flatten,
                            prefix: prefix,
-                           property: property)) -%>
+                           property: property,
+                           pwd: pwd)) -%>
 <% else -%>
 <% if tf_types.include?(property.class) -%>
 func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) interface{} {

--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -95,7 +95,7 @@ state as plain-text. [Read more about sensitive data in state](/docs/state/sensi
 <%#- We over-generate examples/oics buttons here; they'll all be _valid_ just not necessarily intended for this provider version.
      Unless/Until we split our docs, this is a non-issue. -%>
 <% unless object.examples.empty? -%>
-  <%- object.examples.each do |example| -%>
+  <%- object.examples.reject(&:skip_docs).each do |example| -%>
     <%- unless example.skip_test -%>
 <div class = "oics-button" style="float: right; margin: 0 0 -15px">
   <a href="<%= example.oics_link %>" target="_blank">


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: added ability for various `table_id` fields (and one `dataset_id` field) in `google_bigquery_job` to specify a relative path instead of just the table id
```
