### PR TITLE
Fix composer resource names

### DIFF
--- a/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -16,8 +16,8 @@ import (
 	"google.golang.org/api/storage/v1"
 )
 
-const testComposerEnvironmentPrefix = "tf-cc-testenv"
-const testComposerNetworkPrefix = "tf-cc-testnet"
+const testComposerEnvironmentPrefix = "tf-test-composer-env"
+const testComposerNetworkPrefix = "tf-test-composer-net"
 
 func init() {
 	resource.AddTestSweepers("gcp_composer_environment", &resource.Sweeper{


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
