### PR TITLE
Promote DNS resources to GA

### DIFF
--- a/products/dns/ansible.yaml
+++ b/products/dns/ansible.yaml
@@ -14,6 +14,8 @@
 --- !ruby/object:Provider::Ansible::Config
 # This is where custom code would be defined eventually.
 datasources: !ruby/object:Overrides::ResourceOverrides
+  Policy: !ruby/object:Overrides::Ansible::ResourceOverride
+    exclude: true
   Project: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
   ResourceRecordSet: !ruby/object:Overrides::Ansible::ResourceOverride
@@ -33,6 +35,8 @@ datasources: !ruby/object:Overrides::ResourceOverrides
       query_options: false
       filter_api_param: dnsName
 overrides: !ruby/object:Overrides::ResourceOverrides
+  Policy: !ruby/object:Overrides::Ansible::ResourceOverride
+    exclude: true
   ResourceRecordSet: !ruby/object:Overrides::Ansible::ResourceOverride
     access_api_results: true
     imports:

--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -227,9 +227,7 @@ objects:
                   values:
                   - :default
                   - :private
-        min_version: beta
       - !ruby/object:Api::Type::NestedObject
-        min_version: beta
         name: 'peeringConfig'
         description: |
           The presence of this field indicates that DNS Peering is enabled for this
@@ -370,7 +368,6 @@ objects:
         'Using DNS server policies':
           'https://cloud.google.com/dns/zones/#using-dns-server-policies'
       api: 'https://cloud.google.com/dns/docs/reference/v1beta2/policies'
-    min_version: beta
   - !ruby/object:Api::Resource
     name: 'Project'
     kind: 'dns#project'

--- a/products/dns/terraform.yaml
+++ b/products/dns/terraform.yaml
@@ -38,7 +38,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           network_2_name: "network-2"
       - !ruby/object:Provider::Terraform::Examples
         name: "dns_managed_zone_private_peering"
-        min_version: 'beta'
         primary_resource_id: "peering-zone"
         vars:
           zone_name: "peering-zone"

--- a/templates/terraform/examples/dns_managed_zone_private_forwarding.tf.erb
+++ b/templates/terraform/examples/dns_managed_zone_private_forwarding.tf.erb
@@ -1,5 +1,4 @@
 resource "google_dns_managed_zone" "<%= ctx[:primary_resource_id] %>" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['zone_name'] %>"
   dns_name    = "private.example.com."
   description = "Example private DNS zone"

--- a/templates/terraform/examples/dns_managed_zone_private_peering.tf.erb
+++ b/templates/terraform/examples/dns_managed_zone_private_peering.tf.erb
@@ -1,6 +1,4 @@
 resource "google_dns_managed_zone" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
-
   name        = "<%= ctx[:vars]['zone_name'] %>"
   dns_name    = "peering.example.com."
   description = "Example private DNS peering zone"
@@ -21,20 +19,12 @@ resource "google_dns_managed_zone" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_compute_network" "network-source" {
-  provider = google-beta
-
   name                    = "<%= ctx[:vars]['network_source_name'] %>"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_network" "network-target" {
-  provider = google-beta
-
   name                    = "<%= ctx[:vars]['network_target_name'] %>"
   auto_create_subnetworks = false
 }
 
-provider "google-beta" {
-  region = "us-central1"
-  zone   = "us-central1-a"
-}

--- a/templates/terraform/examples/dns_policy_basic.tf.erb
+++ b/templates/terraform/examples/dns_policy_basic.tf.erb
@@ -1,6 +1,4 @@
 resource "google_dns_policy" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
-
   name                      = "<%= ctx[:vars]['policy_name'] %>"
   enable_inbound_forwarding = true
 
@@ -16,28 +14,19 @@ resource "google_dns_policy" "<%= ctx[:primary_resource_id] %>" {
   }
 
   networks {
-    network_url = google_compute_network.network-1.id
+    network_url = google_compute_network.network-1.self_link
   }
   networks {
-    network_url = google_compute_network.network-2.id
+    network_url = google_compute_network.network-2.self_link
   }
 }
 
 resource "google_compute_network" "network-1" {
-  provider = google-beta
-
   name                    = "<%= ctx[:vars]['network_1_name'] %>"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_network" "network-2" {
-  provider = google-beta
-
   name                    = "<%= ctx[:vars]['network_2_name'] %>"
   auto_create_subnetworks = false
-}
-
-provider "google-beta" {
-  region = "us-central1"
-  zone   = "us-central1-a"
 }

--- a/third_party/terraform/tests/data_source_dns_managed_zone_test.go.erb
+++ b/third_party/terraform/tests/data_source_dns_managed_zone_test.go.erb
@@ -24,9 +24,9 @@ func TestAccDataSourceDnsManagedZone_basic(t *testing.T) {
 					map[string]struct{}{
 						"dnssec_config.#":             {},
 						"private_visibility_config.#": {},
-<% unless version == "ga" -%>
 						"peering_config.#":            {},
 						"forwarding_config.#":         {},
+<% unless version == "ga" -%>
 						"reverse_lookup":         {},
 <% end -%>
 					},

--- a/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
+++ b/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
@@ -120,7 +120,6 @@ func TestAccDNSManagedZone_dnssec_empty(t *testing.T) {
 	})
 }
 
-<% unless version.nil? || version == 'ga' -%>
 func TestAccDNSManagedZone_privateForwardingUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -150,7 +149,6 @@ func TestAccDNSManagedZone_privateForwardingUpdate(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 <% unless version.nil? || version == 'ga' -%>
 func TestAccDNSManagedZone_reverseLookup(t *testing.T) {
@@ -288,7 +286,6 @@ resource "google_compute_network" "network-3" {
 `, suffix, first_network, second_network, suffix, suffix, suffix)
 }
 
-<% unless version.nil? || version == 'ga' -%>
 func testAccDnsManagedZone_privateForwardingUpdate(suffix, first_nameserver, second_nameserver, first_forwarding_path, second_forwarding_path string) string {
 	return fmt.Sprintf(`
 resource "google_dns_managed_zone" "private" {
@@ -320,7 +317,6 @@ resource "google_compute_network" "network-1" {
 }
 `, suffix, first_nameserver, first_forwarding_path, second_nameserver, second_forwarding_path, suffix)
 }
-<% end -%>
 
 <% unless version.nil? || version == 'ga' -%>
 func testAccDnsManagedZone_reverseLookup(suffix string) string {

--- a/third_party/terraform/tests/resource_dns_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_dns_policy_test.go.erb
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-<% unless version.nil? || version == 'ga' -%>
 func TestAccDNSPolicy_update(t *testing.T) {
 	t.Parallel()
 
@@ -67,4 +66,3 @@ resource "google_compute_network" "network-2" {
 }
 `, suffix, forwarding, nameserver, network, suffix, suffix)
 }
-<% end -%>


### PR DESCRIPTION
Fixes: terraform-providers/terraform-provider-google#6402

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
This change promotes to GA a few CloudDNS features that been become GA in the previous months, but had not yet been promoted out of the beta in the providers.

[CloudDNS release notes:
](https://cloud.google.com/dns/docs/release-notes)

* January 07, 2020: DNS Peering went GA
* September 24, 2019: DNS Forwarding went GA (includes the DNS policy resource)

Let me know if there's anything I missed that would prevent these resources from being promoted

**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
dns: Promoted `google_dns_policy` to GA.
```

```release-note:note
dns: Promoted the following `google_dns_managed_zone ` fields to GA: `forwarding_config`, `peering_config`
```