### PR TITLE
Check for diffs in allowed ranges set

### DIFF
--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -578,6 +578,8 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 			d.SetPartial("config")
 		}
 
+		// If web_server_network_access_control has more fields added it may require changes here.
+		// This is scoped specifically to allowed_ip_range due to https://github.com/hashicorp/terraform-plugin-sdk/issues/98
 		if d.HasChange("config.0.web_server_network_access_control.0.allowed_ip_range") {
 			patchObj := &composer.Environment{Config: &composer.EnvironmentConfig{}}
 			if config != nil {

--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -578,7 +578,7 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 			d.SetPartial("config")
 		}
 
-		if d.HasChange("config.0.web_server_network_access_control") {
+		if d.HasChange("config.0.web_server_network_access_control.0.allowed_ip_range") {
 			patchObj := &composer.Environment{Config: &composer.EnvironmentConfig{}}
 			if config != nil {
 				patchObj.Config.WebServerNetworkAccessControl = config.WebServerNetworkAccessControl


### PR DESCRIPTION
Checking the parent object for HasChange produces incorrect results.

No changes as this has not been released yet

See https://github.com/hashicorp/terraform-plugin-sdk/issues/98

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
