### PR TITLE
Use self link for DNS networks

### DIFF
--- a/templates/terraform/examples/dns_policy_basic.tf.erb
+++ b/templates/terraform/examples/dns_policy_basic.tf.erb
@@ -16,10 +16,10 @@ resource "google_dns_policy" "<%= ctx[:primary_resource_id] %>" {
   }
 
   networks {
-    network_url = google_compute_network.network-1.id
+    network_url = google_compute_network.network-1.self_link
   }
   networks {
-    network_url = google_compute_network.network-2.id
+    network_url = google_compute_network.network-2.self_link
   }
 }
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```

Was previously switched to ID but DNS requires full self link