### PR TITLE
Fix more VCR tests

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -939,6 +939,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "instance_group_named_port_gke"
         primary_resource_id: "my_port"
+        # Multiple fine-grained resources
+        skip_vcr: true
         vars:
           network_name: "container-network"
           subnetwork_name: "container-subnetwork"

--- a/third_party/terraform/data_sources/data_source_monitoring_service_test.go
+++ b/third_party/terraform/data_sources/data_source_monitoring_service_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccDataSourceMonitoringService_AppEngine(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/third_party/terraform/tests/data_source_google_kms_secret_test.go
+++ b/third_party/terraform/tests/data_source_google_kms_secret_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAccKmsSecret_basic(t *testing.T) {
+	// Nested tests confuse VCR
+	skipIfVcr(t)
 	t.Parallel()
 
 	projectOrg := getTestOrgFromEnv(t)

--- a/third_party/terraform/tests/data_source_storage_object_signed_url_test.go
+++ b/third_party/terraform/tests/data_source_storage_object_signed_url_test.go
@@ -117,6 +117,8 @@ func TestAccStorageSignedUrl_basic(t *testing.T) {
 }
 
 func TestAccStorageSignedUrl_accTest(t *testing.T) {
+	// URL includes an expires time
+	skipIfVcr(t)
 	t.Parallel()
 
 	bucketName := fmt.Sprintf("tf-test-bucket-%d", randInt(t))

--- a/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -275,7 +275,7 @@ func TestAccInstanceGroupManager_stateful(t *testing.T) {
 	igm := fmt.Sprintf("igm-test-%s", randString(t, 10))
 	hck := fmt.Sprintf("igm-test-%s", randString(t, 10))
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckInstanceGroupManagerDestroyProducer(t),

--- a/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -2866,6 +2867,7 @@ func testAccComputeInstance_disks_encryption(bootEncryptionKey string, diskNameT
 	for k := range diskNameToEncryptionKey {
 		diskNames = append(diskNames, k)
 	}
+	sort.Strings(diskNames)
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family  = "debian-9"

--- a/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_test.go
@@ -1849,7 +1849,7 @@ func TestAccComputeInstance_resourcePolicyCollocate(t *testing.T) {
 
 	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckComputeInstanceDestroyProducer(t),

--- a/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
@@ -287,7 +287,7 @@ func TestAccRegionInstanceGroupManager_stateful(t *testing.T) {
 	template := fmt.Sprintf("igm-test-%s", randString(t, 10))
 	igm := fmt.Sprintf("igm-test-%s", randString(t, 10))
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRegionInstanceGroupManagerDestroyProducer(t),

--- a/third_party/terraform/tests/resource_compute_resource_policy_test.go
+++ b/third_party/terraform/tests/resource_compute_resource_policy_test.go
@@ -10,7 +10,7 @@ import (
 func TestAccComputeResourcePolicy_attached(t *testing.T) {
 	t.Parallel()
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckComputeResourcePolicyDestroyProducer(t),

--- a/third_party/terraform/tests/resource_dataflow_job_test.go
+++ b/third_party/terraform/tests/resource_dataflow_job_test.go
@@ -19,6 +19,9 @@ const (
 )
 
 func TestAccDataflowJob_basic(t *testing.T) {
+	// Dataflow responses include serialized java classes and bash commands
+	// This makes body comparison infeasible
+	skipIfVcr(t)
 	t.Parallel()
 
 	randStr := randString(t, 10)
@@ -42,6 +45,8 @@ func TestAccDataflowJob_basic(t *testing.T) {
 }
 
 func TestAccDataflowJob_withRegion(t *testing.T) {
+	// Dataflow responses include serialized java classes and bash commands
+	// This makes body comparison infeasible
 	t.Parallel()
 
 	randStr := randString(t, 10)
@@ -64,6 +69,8 @@ func TestAccDataflowJob_withRegion(t *testing.T) {
 }
 
 func TestAccDataflowJob_withServiceAccount(t *testing.T) {
+	// Dataflow responses include serialized java classes and bash commands
+	// This makes body comparison infeasible
 	t.Parallel()
 
 	randStr := randString(t, 10)
@@ -88,6 +95,8 @@ func TestAccDataflowJob_withServiceAccount(t *testing.T) {
 }
 
 func TestAccDataflowJob_withNetwork(t *testing.T) {
+	// Dataflow responses include serialized java classes and bash commands
+	// This makes body comparison infeasible
 	t.Parallel()
 
 	randStr := randString(t, 10)
@@ -112,6 +121,8 @@ func TestAccDataflowJob_withNetwork(t *testing.T) {
 }
 
 func TestAccDataflowJob_withSubnetwork(t *testing.T) {
+	// Dataflow responses include serialized java classes and bash commands
+	// This makes body comparison infeasible
 	t.Parallel()
 
 	randStr := randString(t, 10)
@@ -137,6 +148,8 @@ func TestAccDataflowJob_withSubnetwork(t *testing.T) {
 }
 
 func TestAccDataflowJob_withLabels(t *testing.T) {
+	// Dataflow responses include serialized java classes and bash commands
+	// This makes body comparison infeasible
 	t.Parallel()
 
 	randStr := randString(t, 10)
@@ -162,6 +175,8 @@ func TestAccDataflowJob_withLabels(t *testing.T) {
 }
 
 func TestAccDataflowJob_withIpConfig(t *testing.T) {
+	// Dataflow responses include serialized java classes and bash commands
+	// This makes body comparison infeasible
 	t.Parallel()
 
 	randStr := randString(t, 10)
@@ -184,6 +199,8 @@ func TestAccDataflowJob_withIpConfig(t *testing.T) {
 }
 
 func TestAccDataflowJobWithAdditionalExperiments(t *testing.T) {
+	// Dataflow responses include serialized java classes and bash commands
+	// This makes body comparison infeasible
 	t.Parallel()
 
 	randStr := randString(t, 10)
@@ -208,6 +225,8 @@ func TestAccDataflowJobWithAdditionalExperiments(t *testing.T) {
 }
 
 func TestAccDataflowJob_streamUpdate(t *testing.T) {
+	// Dataflow responses include serialized java classes and bash commands
+	// This makes body comparison infeasible
 	t.Parallel()
 
 	suffix := randString(t, 10)

--- a/third_party/terraform/tests/resource_dataflow_job_test.go
+++ b/third_party/terraform/tests/resource_dataflow_job_test.go
@@ -47,6 +47,7 @@ func TestAccDataflowJob_basic(t *testing.T) {
 func TestAccDataflowJob_withRegion(t *testing.T) {
 	// Dataflow responses include serialized java classes and bash commands
 	// This makes body comparison infeasible
+	skipIfVcr(t)
 	t.Parallel()
 
 	randStr := randString(t, 10)
@@ -71,6 +72,7 @@ func TestAccDataflowJob_withRegion(t *testing.T) {
 func TestAccDataflowJob_withServiceAccount(t *testing.T) {
 	// Dataflow responses include serialized java classes and bash commands
 	// This makes body comparison infeasible
+	skipIfVcr(t)
 	t.Parallel()
 
 	randStr := randString(t, 10)
@@ -97,6 +99,7 @@ func TestAccDataflowJob_withServiceAccount(t *testing.T) {
 func TestAccDataflowJob_withNetwork(t *testing.T) {
 	// Dataflow responses include serialized java classes and bash commands
 	// This makes body comparison infeasible
+	skipIfVcr(t)
 	t.Parallel()
 
 	randStr := randString(t, 10)
@@ -123,6 +126,7 @@ func TestAccDataflowJob_withNetwork(t *testing.T) {
 func TestAccDataflowJob_withSubnetwork(t *testing.T) {
 	// Dataflow responses include serialized java classes and bash commands
 	// This makes body comparison infeasible
+	skipIfVcr(t)
 	t.Parallel()
 
 	randStr := randString(t, 10)
@@ -150,6 +154,7 @@ func TestAccDataflowJob_withSubnetwork(t *testing.T) {
 func TestAccDataflowJob_withLabels(t *testing.T) {
 	// Dataflow responses include serialized java classes and bash commands
 	// This makes body comparison infeasible
+	skipIfVcr(t)
 	t.Parallel()
 
 	randStr := randString(t, 10)
@@ -177,6 +182,7 @@ func TestAccDataflowJob_withLabels(t *testing.T) {
 func TestAccDataflowJob_withIpConfig(t *testing.T) {
 	// Dataflow responses include serialized java classes and bash commands
 	// This makes body comparison infeasible
+	skipIfVcr(t)
 	t.Parallel()
 
 	randStr := randString(t, 10)
@@ -201,6 +207,7 @@ func TestAccDataflowJob_withIpConfig(t *testing.T) {
 func TestAccDataflowJobWithAdditionalExperiments(t *testing.T) {
 	// Dataflow responses include serialized java classes and bash commands
 	// This makes body comparison infeasible
+	skipIfVcr(t)
 	t.Parallel()
 
 	randStr := randString(t, 10)
@@ -227,6 +234,7 @@ func TestAccDataflowJobWithAdditionalExperiments(t *testing.T) {
 func TestAccDataflowJob_streamUpdate(t *testing.T) {
 	// Dataflow responses include serialized java classes and bash commands
 	// This makes body comparison infeasible
+	skipIfVcr(t)
 	t.Parallel()
 
 	suffix := randString(t, 10)

--- a/third_party/terraform/tests/resource_dialogflow_entity_type_test.go.erb
+++ b/third_party/terraform/tests/resource_dialogflow_entity_type_test.go.erb
@@ -15,10 +15,10 @@ func TestAccDialogflowEntityType_update(t *testing.T) {
 	context := map[string]interface{}{
 		"org_id":          getTestOrgFromEnv(t),
 		"billing_account": getTestBillingAccountFromEnv(t),
-		"random_suffix":   acctest.RandString(10),
+		"random_suffix":   randString(t, 10),
 	}
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/third_party/terraform/tests/resource_dialogflow_intent_test.go.erb
+++ b/third_party/terraform/tests/resource_dialogflow_intent_test.go.erb
@@ -17,7 +17,7 @@ func TestAccDialogflowIntent_basic(t *testing.T) {
 		"random_suffix":   randString(t, 10),
 	}
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -42,7 +42,7 @@ func TestAccDialogflowIntent_update(t *testing.T) {
 		"random_suffix":   randString(t, 10),
 	}
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/third_party/terraform/tests/resource_firebase_web_app_test.go.erb
+++ b/third_party/terraform/tests/resource_firebase_web_app_test.go.erb
@@ -18,7 +18,7 @@ func TestAccFirebaseWebApp_firebaseWebAppFull(t *testing.T) {
 		"display_name":  "Display Name N",
 	}
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProvidersOiCS,
 		Steps: []resource.TestStep{

--- a/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
+++ b/third_party/terraform/tests/resource_google_folder_iam_binding_test.go
@@ -45,6 +45,8 @@ func TestAccFolderIamBinding_basic(t *testing.T) {
 
 // Test that multiple IAM bindings can be applied to a folder, one at a time
 func TestAccFolderIamBinding_multiple(t *testing.T) {
+	// Multiple fine-grained resources
+	skipIfVcr(t)
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)

--- a/third_party/terraform/tests/resource_kms_crypto_key_test.go
+++ b/third_party/terraform/tests/resource_kms_crypto_key_test.go
@@ -200,6 +200,8 @@ func TestAccKmsCryptoKey_basic(t *testing.T) {
 }
 
 func TestAccKmsCryptoKey_rotation(t *testing.T) {
+	// when rotation is set, next rotation time is set using time.Now
+	skipIfVcr(t)
 	t.Parallel()
 
 	projectId := fmt.Sprintf("tf-test-%d", randInt(t))

--- a/third_party/terraform/tests/resource_logging_bucket_config_test.go
+++ b/third_party/terraform/tests/resource_logging_bucket_config_test.go
@@ -16,7 +16,7 @@ func TestAccLoggingBucketConfigFolder_basic(t *testing.T) {
 		"org_id":        getTestOrgFromEnv(t),
 	}
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -51,7 +51,7 @@ func TestAccLoggingBucketConfigProject_basic(t *testing.T) {
 		"org_id":        getTestOrgFromEnv(t),
 	}
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -86,7 +86,7 @@ func TestAccLoggingBucketConfigBillingAccount_basic(t *testing.T) {
 		"org_id":               getTestOrgFromEnv(t),
 	}
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
@@ -120,7 +120,7 @@ func TestAccLoggingBucketConfigOrganization_basic(t *testing.T) {
 		"org_id":        getTestOrgFromEnv(t),
 	}
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{

--- a/third_party/terraform/tests/resource_monitoring_slo_test.go
+++ b/third_party/terraform/tests/resource_monitoring_slo_test.go
@@ -73,7 +73,7 @@ func TestAccMonitoringSlo_basic(t *testing.T) {
 	t.Parallel()
 
 	var generatedId string
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMonitoringSloDestroyProducer(t),

--- a/third_party/terraform/tests/resource_monitoring_slo_test.go
+++ b/third_party/terraform/tests/resource_monitoring_slo_test.go
@@ -109,7 +109,7 @@ func TestAccMonitoringSlo_requestBased(t *testing.T) {
 
 	randomSuffix := randString(t, 10)
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMonitoringSloDestroyProducer(t),
@@ -159,7 +159,7 @@ func TestAccMonitoringSlo_windowBased_updateSlis(t *testing.T) {
 
 	randomSuffix := randString(t, 10)
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMonitoringSloDestroyProducer(t),
@@ -225,7 +225,7 @@ func TestAccMonitoringSlo_windowBasedGoodTotalRatioThresholdSlis(t *testing.T) {
 
 	randomSuffix := randString(t, 10)
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMonitoringSloDestroyProducer(t),
@@ -291,7 +291,7 @@ func TestAccMonitoringSlo_windowBasedMetricMeanRangeSlis(t *testing.T) {
 
 	randomSuffix := randString(t, 10)
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMonitoringSloDestroyProducer(t),
@@ -331,7 +331,7 @@ func TestAccMonitoringSlo_windowBasedMetricSumRangeSlis(t *testing.T) {
 
 	randomSuffix := randString(t, 10)
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckMonitoringSloDestroyProducer(t),

--- a/third_party/terraform/tests/resource_service_directory_endpoint_test.go.erb
+++ b/third_party/terraform/tests/resource_service_directory_endpoint_test.go.erb
@@ -17,9 +17,9 @@ func TestAccServiceDirectoryEndpoint_serviceDirectoryEndpointUpdateExample(t *te
 
 	project := getTestProjectFromEnv()
 	location := "us-central1"
-	testId := fmt.Sprintf("tf-test-example-endpoint%s", acctest.RandString(10))
+	testId := fmt.Sprintf("tf-test-example-endpoint%s", randString(t, 10))
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceDirectoryEndpointDestroyProducer(t),

--- a/third_party/terraform/tests/resource_service_directory_namespace_test.go.erb
+++ b/third_party/terraform/tests/resource_service_directory_namespace_test.go.erb
@@ -19,7 +19,7 @@ func TestAccServiceDirectoryNamespace_serviceDirectoryNamespaceUpdateExample(t *
 	location := "us-central1"
 	testId := fmt.Sprintf("tf-test-example-namespace%s", randString(t, 10))
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceDirectoryNamespaceDestroyProducer(t),

--- a/third_party/terraform/tests/resource_service_directory_service_test.go.erb
+++ b/third_party/terraform/tests/resource_service_directory_service_test.go.erb
@@ -18,7 +18,7 @@ func TestAccServiceDirectoryService_serviceDirectoryServiceUpdateExample(t *test
 	location := "us-central1"
 	testId := fmt.Sprintf("tf-test-example-service%s", randString(t, 10))
 
-	resource.Test(t, resource.TestCase{
+	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckServiceDirectoryServiceDestroyProducer(t),

--- a/third_party/terraform/tests/resource_storage_bucket_test.go
+++ b/third_party/terraform/tests/resource_storage_bucket_test.go
@@ -749,6 +749,8 @@ func TestAccStorageBucket_defaultEventBasedHold(t *testing.T) {
 }
 
 func TestAccStorageBucket_encryption(t *testing.T) {
+	// when rotation is set, next rotation time is set using time.Now
+	skipIfVcr(t)
 	t.Parallel()
 
 	context := map[string]interface{}{

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -492,6 +492,8 @@ func TestAccProviderBasePath_setInvalidBasePath(t *testing.T) {
 }
 
 func TestAccProviderUserProjectOverride(t *testing.T) {
+	// Parallel fine-grained resource creation
+	skipIfVcr(t)
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)
@@ -536,6 +538,8 @@ func TestAccProviderUserProjectOverride(t *testing.T) {
 // Do the same thing as TestAccProviderUserProjectOverride, but using a resource that gets its project via
 // a reference to a different resource instead of a project field.
 func TestAccProviderIndirectUserProjectOverride(t *testing.T) {
+	// Parallel fine-grained resource creation
+	skipIfVcr(t)
 	t.Parallel()
 
 	org := getTestOrgFromEnv(t)


### PR DESCRIPTION
Migrate more tests (that were added recently) to use VCR.

Ignore several tests that cannot pass due to various reasons

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
