### PR TITLE
Fix fetching of app_engine_standard_app_version data

### DIFF
--- a/products/appengine/api.yaml
+++ b/products/appengine/api.yaml
@@ -225,7 +225,8 @@ objects:
     update_url: 'apps/{{project}}/services/{{service}}/versions'
     update_verb: :POST
     update_mask: false
-    self_link: 'apps/{{project}}/services/{{service}}/versions/{{version_id}}'
+    create_url: 'apps/{{project}}/services/{{service}}/versions'
+    self_link: 'apps/{{project}}/services/{{service}}/versions/{{version_id}}?view=FULL'
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Official Documentation':

--- a/products/appengine/terraform.yaml
+++ b/products/appengine/terraform.yaml
@@ -28,6 +28,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           org_id: :ORG_ID
   StandardAppVersion: !ruby/object:Overrides::Terraform::ResourceOverride
     import_format: ["apps/{{project}}/services/{{service}}/versions/{{version_id}}"]
+    id_format: "apps/{{project}}/services/{{service}}/versions/{{version_id}}"
     mutex: "apps/{{project}}"
     error_retry_predicates: ["isAppEngineRetryableError"]
     parameters:


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
appengine: added ability to fully sync `StandardAppVersion` resources
```

@megan07 I've tried to match the generated terraform output to my original PR https://github.com/terraform-providers/terraform-provider-google/pull/6388

I didn't try to add your suggested
```
      handlers: !ruby/object:Overrides::Terraform::PropertyOverride
        default_from_api: true
```
since I don't have any appengine versions with just the default handlers to try with.
Also I don't currently have `FlexibleAppVersion` resources setup in terraform to play around with.

Maybe this PR can serve as base for more changes.

**References**
 
* https://github.com/terraform-providers/terraform-provider-google/issues/6417
* https://github.com/terraform-providers/terraform-provider-google/pull/6388
