### PR TITLE
Add "inbound_services" to google_app_engine_standard_app_version

### DIFF
--- a/products/appengine/api.yaml
+++ b/products/appengine/api.yaml
@@ -457,6 +457,11 @@ objects:
             required: true
             description: |
               The format should be a shell command that can be fed to bash -c.
+      - !ruby/object:Api::Type::Array
+        name: 'inboundServices'
+        description: |
+          Before an application can receive email or XMPP messages, the application must be configured to enable the service.
+        item_type: Api::Type::String
       - !ruby/object:Api::Type::String
         name: 'instanceClass'
         description: |

--- a/products/appengine/terraform.yaml
+++ b/products/appengine/terraform.yaml
@@ -65,6 +65,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       # instanceClass defaults to a value based on the scaling method
       instanceClass: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      inboundServices: !ruby/object:Overrides::Terraform::PropertyOverride
+        is_set: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "app_engine_standard_app_version"
@@ -127,6 +129,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       handlers: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      inboundServices: !ruby/object:Overrides::Terraform::PropertyOverride
+        is_set: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "app_engine_flexible_app_version"

--- a/third_party/terraform/tests/resource_app_engine_standard_app_version_test.go
+++ b/third_party/terraform/tests/resource_app_engine_standard_app_version_test.go
@@ -84,6 +84,8 @@ resource "google_app_engine_standard_app_version" "foo" {
     }
   }
 
+  inbound_services = ["INBOUND_SERVICE_WARMUP"]
+
   env_variables = {
     port = "8000"
   }
@@ -167,6 +169,8 @@ resource "google_app_engine_standard_app_version" "foo" {
       source_url = "https://storage.googleapis.com/${google_storage_bucket.bucket.name}/${google_storage_bucket_object.requirements.name}"
     }
   }
+
+  inbound_services = []
 
   env_variables = {
     port = "8000"

--- a/third_party/terraform/tests/resource_app_engine_standard_app_version_test.go
+++ b/third_party/terraform/tests/resource_app_engine_standard_app_version_test.go
@@ -84,7 +84,7 @@ resource "google_app_engine_standard_app_version" "foo" {
     }
   }
 
-  inbound_services = ["INBOUND_SERVICE_WARMUP"]
+  inbound_services = ["INBOUND_SERVICE_WARMUP", "INBOUND_SERVICE_MAIL"]
 
   env_variables = {
     port = "8000"


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
appengine: add `inbound_services` to `StandardAppVersion` resource
```

**References**

 * https://github.com/terraform-providers/terraform-provider-google/pull/6387 /cc @slevenick
