### PR TITLE
Mark interconnect edge availability domain as computed

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -984,6 +984,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       candidateSubnets: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
+      edgeAvailabilityDomain: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/interconnect_attachment.go.erb
       post_create: templates/terraform/post_create/interconnect_attachment.go.erb


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/6400

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: Fixed `google_compute_interconnect_attachment` `edge_availability_domain` diff when the field is unspecified
```
