### PR TITLE
GA peering config and forwarding config

### DIFF
--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -227,9 +227,7 @@ objects:
                   values:
                   - :default
                   - :private
-        min_version: beta
       - !ruby/object:Api::Type::NestedObject
-        min_version: beta
         name: 'peeringConfig'
         description: |
           The presence of this field indicates that DNS Peering is enabled for this

--- a/products/dns/terraform.yaml
+++ b/products/dns/terraform.yaml
@@ -38,7 +38,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           network_2_name: "network-2"
       - !ruby/object:Provider::Terraform::Examples
         name: "dns_managed_zone_private_peering"
-        min_version: 'beta'
         primary_resource_id: "peering-zone"
         vars:
           zone_name: "peering-zone"

--- a/templates/terraform/examples/dns_managed_zone_private_peering.tf.erb
+++ b/templates/terraform/examples/dns_managed_zone_private_peering.tf.erb
@@ -1,6 +1,4 @@
 resource "google_dns_managed_zone" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
-
   name        = "<%= ctx[:vars]['zone_name'] %>"
   dns_name    = "peering.example.com."
   description = "Example private DNS peering zone"
@@ -21,20 +19,11 @@ resource "google_dns_managed_zone" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_compute_network" "network-source" {
-  provider = google-beta
-
   name                    = "<%= ctx[:vars]['network_source_name'] %>"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_network" "network-target" {
-  provider = google-beta
-
   name                    = "<%= ctx[:vars]['network_target_name'] %>"
   auto_create_subnetworks = false
-}
-
-provider "google-beta" {
-  region = "us-central1"
-  zone   = "us-central1-a"
 }

--- a/third_party/terraform/tests/data_source_dns_managed_zone_test.go.erb
+++ b/third_party/terraform/tests/data_source_dns_managed_zone_test.go.erb
@@ -24,9 +24,9 @@ func TestAccDataSourceDnsManagedZone_basic(t *testing.T) {
 					map[string]struct{}{
 						"dnssec_config.#":             {},
 						"private_visibility_config.#": {},
-<% unless version == "ga" -%>
 						"peering_config.#":            {},
 						"forwarding_config.#":         {},
+<% unless version == "ga" -%>
 						"reverse_lookup":         {},
 <% end -%>
 					},


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/6402

I noticed forwarding config is also GA
Peering config doesn't show up in the REST documentation for GA, but does work in GA

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dns: Moved `google_dns_managed_zone.peering_config` to GA
```
```release-note:enhancement
dns: Moved `google_dns_managed_zone.forwarding_config` to GA
```
