### PR TITLE
use explicit version in monitoring data sources

### DIFF
--- a/third_party/terraform/data_sources/data_source_monitoring_notification_channel.go
+++ b/third_party/terraform/data_sources/data_source_monitoring_notification_channel.go
@@ -26,7 +26,7 @@ func dataSourceMonitoringNotificationChannel() *schema.Resource {
 func dataSourceMonitoringNotificationChannelRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	url, err := replaceVars(d, config, "{{MonitoringBasePath}}projects/{{project}}/notificationChannels")
+	url, err := replaceVars(d, config, "{{MonitoringBasePath}}v3/projects/{{project}}/notificationChannels")
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/data_sources/data_source_monitoring_service.go
+++ b/third_party/terraform/data_sources/data_source_monitoring_service.go
@@ -2,8 +2,9 @@ package google
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	neturl "net/url"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 type monitoringServiceTypeStateSetter func(map[string]interface{}, *schema.ResourceData, interface{}) error
@@ -47,7 +48,7 @@ func dataSourceMonitoringServiceTypeReadFromList(listFilter string, typeStateSet
 			return err
 		}
 
-		listUrlTmpl := "{{MonitoringBasePath}}projects/{{project}}/services?filter=" + neturl.QueryEscape(filters)
+		listUrlTmpl := "{{MonitoringBasePath}}v3/projects/{{project}}/services?filter=" + neturl.QueryEscape(filters)
 		url, err := replaceVars(d, config, listUrlTmpl)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
As of https://github.com/GoogleCloudPlatform/magic-modules/pull/3490, we don't hardcode the version in the monitoring base path anymore because it has two different versions for GA products (v1 and v3)

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
