### PR TITLE
Empty reservations must ignore empty

### DIFF
--- a/templates/terraform/examples/bigquery_reservation_basic.tf.erb
+++ b/templates/terraform/examples/bigquery_reservation_basic.tf.erb
@@ -5,5 +5,5 @@ resource "google_bigquery_reservation" "<%= ctx[:primary_resource_id] %>" {
 	// Set to 0 for testing purposes
 	// In reality this would be larger than zero
 	slot_capacity  = 0
-	ignore_idle_slots = true
+	ignore_idle_slots = false
 }

--- a/third_party/terraform/tests/resource_bigquery_reservation_test.go.erb
+++ b/third_party/terraform/tests/resource_bigquery_reservation_test.go.erb
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-func TestAccBigqueryReservationReservation_bigqueryReservationUpdate(t *testing.T) {
+func TestAccBigqueryReservationReservation_bigqueryReservation(t *testing.T) {
 	t.Parallel()
 
 	location := "asia-northeast1"
@@ -33,32 +33,11 @@ func TestAccBigqueryReservationReservation_bigqueryReservationUpdate(t *testing.
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
-			{
-				Config: testAccBigqueryReservationReservation_bigqueryReservationUpdate(context),
-			},
-			{
-				ResourceName:      "google_bigquery_reservation.reservation",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
 		},
 	})
 }
 
 func testAccBigqueryReservationReservation_bigqueryReservationBasic(context map[string]interface{}) string {
-	return Nprintf(`
-resource "google_bigquery_reservation" "reservation" {
-	name           = "reservation%{random_suffix}"
-	location       = "%{location}"
-	// Set to 0 for testing purposes
-	// In reality this would be larger than zero
-	slot_capacity  = 0
-	ignore_idle_slots = true
-}
-`, context)
-}
-
-func testAccBigqueryReservationReservation_bigqueryReservationUpdate(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_bigquery_reservation" "reservation" {
 	name           = "reservation%{random_suffix}"


### PR DESCRIPTION
Fixes bigquery reservation tests. Removed update test as there is now nothing to update without a real reservation

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
