### PR TITLE
Dataset access viewer is primitive role READER not VIEWER

### DIFF
--- a/templates/terraform/constants/bigquery_dataset_access.go
+++ b/templates/terraform/constants/bigquery_dataset_access.go
@@ -1,7 +1,7 @@
 var bigqueryAccessRoleToPrimitiveMap =  map[string]string {
     "roles/bigquery.dataOwner": "OWNER",
     "roles/bigquery.dataEditor": "WRITER",
-    "roles/bigquery.dataViewer": "VIEWER",
+    "roles/bigquery.dataViewer": "READER",
 }
 
 func resourceBigQueryDatasetAccessRoleDiffSuppress(k, old, new string, d *schema.ResourceData) bool {

--- a/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
+++ b/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
@@ -118,14 +118,26 @@ func TestAccBigQueryDatasetAccess_predefinedRole(t *testing.T) {
 		"domain": "google.com",
 	}
 
+	expected2 := map[string]interface{}{
+		"role":   "READER",
+		"domain": "google.com",
+	}
+
 	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryDatasetAccess_predefinedRole(datasetID),
+				Config: testAccBigQueryDatasetAccess_predefinedRole("roles/bigquery.dataEditor", datasetID),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckBigQueryDatasetAccessPresent(t, "google_bigquery_dataset.dataset", expected1),
+				),
+			},
+			{
+				// Update role
+				Config: testAccBigQueryDatasetAccess_predefinedRole("roles/bigquery.dataViewer", datasetID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBigQueryDatasetAccessPresent(t, "google_bigquery_dataset.dataset", expected2),
 				),
 			},
 			{
@@ -258,16 +270,16 @@ resource "google_bigquery_dataset" "dataset" {
 `, datasetID)
 }
 
-func testAccBigQueryDatasetAccess_predefinedRole(datasetID string) string {
+func testAccBigQueryDatasetAccess_predefinedRole(role, datasetID string) string {
 	return fmt.Sprintf(`
 resource "google_bigquery_dataset_access" "access" {
   dataset_id = google_bigquery_dataset.dataset.dataset_id
-  role       = "roles/bigquery.dataEditor"
+  role       = "%s"
   domain     = "google.com"
 }
 
 resource "google_bigquery_dataset" "dataset" {
   dataset_id = "%s"
 }
-`, datasetID)
+`, role, datasetID)
 }


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/6425

Added a test for this role as well

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquery: Fixed an issue with `google_bigquery_dataset_access` failing for primitive role `roles/bigquery.dataViewer`
```
