### PR TITLE
Mark ssh key as force new

### DIFF
--- a/products/oslogin/api.yaml
+++ b/products/oslogin/api.yaml
@@ -60,6 +60,7 @@ objects:
         description: |
           Public key text in SSH format, defined by RFC4253 section 6.6.
         required: true
+        input: true
       - !ruby/object:Api::Type::String
         name: 'expirationTimeUsec'
         description: |


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/6399

Updating the SSH public key doesn't make sense, that would be creating a new resource

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
os_login: Fixed `google_os_login_ssh_public_key` `key` field attempting to update in-place
```
