### PR TITLE
continue updates for view=full app engine version

### DIFF
--- a/products/appengine/api.yaml
+++ b/products/appengine/api.yaml
@@ -185,7 +185,7 @@ objects:
   - !ruby/object:Api::Resource
     name: 'Service'
     description: |
-      A Service resource is a logical component of an application that can share state and communicate in a secure fashion with other services. 
+      A Service resource is a logical component of an application that can share state and communicate in a secure fashion with other services.
       For example, an application that handles customer requests might include separate services to handle tasks such as backend data analysis or API requests from mobile devices. 
       Each service has a collection of versions that define a specific set of code used to implement the functionality of that service.
     base_url: 'apps/{{project}}/services'
@@ -273,7 +273,7 @@ objects:
         name: 'runtime'
         description: |
           Desired runtime. Example python27.
-        required: true        
+        required: true
       - !ruby/object:Api::Type::Boolean
         name: 'threadsafe'
         description: |
@@ -281,19 +281,19 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'runtimeApiVersion'
         description: |
-          The version of the API in the given runtime environment. 
+          The version of the API in the given runtime environment.
           Please see the app.yaml reference for valid values at https://cloud.google.com/appengine/docs/standard//config/appref
       - !ruby/object:Api::Type::Array
         name: 'handlers'
         description: |
-          An ordered list of URL-matching patterns that should be applied to incoming requests. 
-          The first matching URL handles the request and other request handlers are not attempted. 
+          An ordered list of URL-matching patterns that should be applied to incoming requests.
+          The first matching URL handles the request and other request handlers are not attempted.
         item_type: !ruby/object:Api::Type::NestedObject
           properties:
           - !ruby/object:Api::Type::String
             name: 'urlRegex'
             description: |
-              URL prefix. Uses regular expression syntax, which means regexp special characters must be escaped, but should not contain groupings. 
+              URL prefix. Uses regular expression syntax, which means regexp special characters must be escaped, but should not contain groupings.
               All URLs that begin with this prefix are handled by this handler, using the portion of the URL after the prefix as part of the file path.
           - !ruby/object:Api::Type::Enum
             name: 'securityLevel'
@@ -336,7 +336,7 @@ objects:
             name: 'script'
             # TODO (mbang): Exactly one of script, staticFiles, or apiEndpoint must be set
             description: |
-              Executes a script to handle the requests that match this URL pattern. 
+              Executes a script to handle the requests that match this URL pattern.
               Only the auto value is supported for Node.js in the App Engine standard environment, for example "script:" "auto".
             properties:
             - !ruby/object:Api::Type::String
@@ -380,7 +380,9 @@ objects:
             - !ruby/object:Api::Type::Boolean
               name: 'applicationReadable'
               description: |
-                Whether files should also be uploaded as code data. By default, files declared in static file handlers are uploaded as static data and are only served to end users; they cannot be read by the application. If enabled, uploads are charged against both your code and static data storage resource quotas.        
+                Whether files should also be uploaded as code data. By default, files declared in static file handlers are uploaded as
+                static data and are only served to end users; they cannot be read by the application. If enabled, uploads are charged
+                against both your code and static data storage resource quotas.
       - !ruby/object:Api::Type::Array
         name: 'libraries'
         description: |
@@ -571,7 +573,7 @@ objects:
     update_url: 'apps/{{project}}/services/{{service}}/versions'
     update_verb: :POST
     update_mask: false
-    self_link: 'apps/{{project}}/services/{{service}}/versions/{{version_id}}'
+    self_link: 'apps/{{project}}/services/{{service}}/versions/{{version_id}}?view=FULL'
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Official Documentation':
@@ -743,8 +745,112 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'runtimeApiVersion'
         description: |
-          The version of the API in the given runtime environment. 
+          The version of the API in the given runtime environment.
           Please see the app.yaml reference for valid values at https://cloud.google.com/appengine/docs/standard//config/appref
+      - !ruby/object:Api::Type::Array
+        name: 'handlers'
+        description: |
+          An ordered list of URL-matching patterns that should be applied to incoming requests.
+          The first matching URL handles the request and other request handlers are not attempted.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+          - !ruby/object:Api::Type::String
+            name: 'urlRegex'
+            description: |
+              URL prefix. Uses regular expression syntax, which means regexp special characters must be escaped, but should not contain groupings.
+              All URLs that begin with this prefix are handled by this handler, using the portion of the URL after the prefix as part of the file path.
+          - !ruby/object:Api::Type::Enum
+            name: 'securityLevel'
+            required: false
+            description: |
+              Security (HTTPS) enforcement for this URL.
+            values:
+              - :SECURE_DEFAULT
+              - :SECURE_NEVER
+              - :SECURE_OPTIONAL
+              - :SECURE_ALWAYS
+          - !ruby/object:Api::Type::Enum
+            name: 'login'
+            description: |
+              Methods to restrict access to a URL based on login status.
+            required: false
+            values:
+              - :LOGIN_OPTIONAL
+              - :LOGIN_ADMIN
+              - :LOGIN_REQUIRED
+          - !ruby/object:Api::Type::Enum
+            name: 'authFailAction'
+            description: |
+              Actions to take when the user is not logged in.
+            required: false
+            values:
+              - :AUTH_FAIL_ACTION_REDIRECT
+              - :AUTH_FAIL_ACTION_UNAUTHORIZED
+          - !ruby/object:Api::Type::Enum
+            name: 'redirectHttpResponseCode'
+            description: |
+              30x code to use when performing redirects for the secure field.
+            required: false
+            values:
+              - :REDIRECT_HTTP_RESPONSE_CODE_301
+              - :REDIRECT_HTTP_RESPONSE_CODE_302
+              - :REDIRECT_HTTP_RESPONSE_CODE_303
+              - :REDIRECT_HTTP_RESPONSE_CODE_307
+          - !ruby/object:Api::Type::NestedObject
+            name: 'script'
+            # TODO (mbang): Exactly one of script, staticFiles, or apiEndpoint must be set
+            description: |
+              Executes a script to handle the requests that match this URL pattern.
+              Only the auto value is supported for Node.js in the App Engine standard environment, for example "script:" "auto".
+            properties:
+            - !ruby/object:Api::Type::String
+              name: 'scriptPath'
+              required: true
+              description: |
+                Path to the script from the application root directory.
+          - !ruby/object:Api::Type::NestedObject
+            name: 'staticFiles'
+            # TODO (mbang): Exactly one of script, staticFiles, or apiEndpoint must be set
+            description: |
+              Files served directly to the user for a given URL, such as images, CSS stylesheets, or JavaScript source files.
+              Static file handlers describe which files in the application directory are static files, and which URLs serve them.
+            properties:
+            - !ruby/object:Api::Type::String
+              name: 'path'
+              description: |
+                Path to the static files matched by the URL pattern, from the application root directory.
+                The path can refer to text matched in groupings in the URL pattern.
+            - !ruby/object:Api::Type::String
+              name: 'uploadPathRegex'
+              description: |
+                Regular expression that matches the file paths for all files that should be referenced by this handler.
+            - !ruby/object:Api::Type::KeyValuePairs
+              name: 'httpHeaders'
+              description: |
+                HTTP headers to use for all responses from these URLs.
+                An object containing a list of "key:value" value pairs.".
+            - !ruby/object:Api::Type::String
+              name: 'mimeType'
+              description: |
+                MIME type used to serve all files served by this handler.
+                Defaults to file-specific MIME types, which are derived from each file's filename extension.
+            - !ruby/object:Api::Type::String
+              name: 'expiration'
+              description: |
+                Time a static file served by this handler should be cached by web proxies and browsers.
+                A duration in seconds with up to nine fractional digits, terminated by 's'. Example "3.5s".
+                Default is '0s'
+              default_value: '0s'
+            - !ruby/object:Api::Type::Boolean
+              name: 'requireMatchingFile'
+              description: |
+                Whether this handler should match the request if the file referenced by the handler does not exist.
+            - !ruby/object:Api::Type::Boolean
+              name: 'applicationReadable'
+              description: |
+                Whether files should also be uploaded as code data. By default, files declared in static file handlers are
+                uploaded as static data and are only served to end users; they cannot be read by the application. If enabled,
+                uploads are charged against both your code and static data storage resource quotas.
       - !ruby/object:Api::Type::String
         name: 'runtimeMainExecutablePath'
         description: |
@@ -1193,7 +1299,7 @@ objects:
             description: |
               Number of instances to assign to the service at the start.
 
-              **Note:** When managing the number of instances at runtime through the App Engine Admin API or the (now deprecated) Python 2 
+              **Note:** When managing the number of instances at runtime through the App Engine Admin API or the (now deprecated) Python 2
               Modules API set_num_instances() you must use `lifecycle.ignore_changes = ["manual_scaling"[0].instances]` to prevent drift detection.
   - !ruby/object:Api::Resource
     name: 'ApplicationUrlDispatchRules'
@@ -1226,7 +1332,7 @@ objects:
         path: 'error/errors'
         message: 'message'
     properties:
-      - !ruby/object:Api::Type::Array   
+      - !ruby/object:Api::Type::Array
         name: 'dispatchRules'
         required: true
         description: |
@@ -1300,7 +1406,7 @@ objects:
         description: |
            Mapping that defines fractional HTTP traffic diversion to different versions within the service.
         required: true
-        properties:      
+        properties:
           - !ruby/object:Api::Type::Enum
             name: 'shardBy'
             description: |
@@ -1315,5 +1421,3 @@ objects:
             required: true
             description: |
               Mapping from version IDs within the service to fractional (0.000, 1] allocations of traffic for that version. Each version can be specified only once, but some versions in the service may not have any traffic allocation. Services that have traffic allocated cannot be deleted until either the service is deleted or their traffic allocation is removed. Allocations must sum to 1. Up to two decimal place precision is supported for IP-based splits and up to three decimal places is supported for cookie-based splits.           
-              
-              

--- a/products/appengine/terraform.yaml
+++ b/products/appengine/terraform.yaml
@@ -60,6 +60,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read: true
       threadsafe: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
+      handlers: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       # instanceClass defaults to a value based on the scaling method
       instanceClass: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
@@ -77,6 +79,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           org_id: :ORG_ID
   FlexibleAppVersion: !ruby/object:Overrides::Terraform::ResourceOverride
     import_format: ["apps/{{project}}/services/{{service}}/versions/{{version_id}}"]
+    id_format: "apps/{{project}}/services/{{service}}/versions/{{version_id}}"
     mutex: "apps/{{project}}"
     error_retry_predicates: ["isAppEngineRetryableError"]
     parameters:
@@ -121,6 +124,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       # runtimeApiVersion defaults to a runtime-specific value
       runtimeApiVersion: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      handlers: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
+++ b/templates/terraform/examples/app_engine_flexible_app_version.tf.erb
@@ -51,6 +51,18 @@ resource "google_app_engine_flexible_app_version" "<%= ctx[:primary_resource_id]
     port = "8080"
   }
 
+  handlers {
+    url_regex        = ".*\\/my-path\\/*"
+    security_level   = "SECURE_ALWAYS"
+    login            = "LOGIN_REQUIRED"
+    auth_fail_action = "AUTH_FAIL_ACTION_REDIRECT"
+
+    static_files {
+      path = "my-other-path"
+      upload_path_regex = ".*\\/my-path\\/*"
+    }
+  }
+
   automatic_scaling {
     cool_down_period = "120s"
     cpu_utilization {


### PR DESCRIPTION
More changes to follow https://github.com/GoogleCloudPlatform/magic-modules/pull/3536

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6417

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
appengine: added `handlers` to `google_flexible_app_version`
```
