### PR TITLE
Add credentials to bigquery connection.

### DIFF
--- a/products/bigqueryconnection/api.yaml
+++ b/products/bigqueryconnection/api.yaml
@@ -88,6 +88,19 @@ objects:
             name: 'database'
             description: Database name. 
             required: true
+          - !ruby/object:Api::Type::NestedObject
+            name: credential
+            description: Cloud SQL properties.
+            required: true
+            properties:
+              - !ruby/object:Api::Type::String
+                name: username
+                description: Username for database.
+                required: true
+              - !ruby/object:Api::Type::String
+                name: password
+                description: Password for database.
+                required: true
           - !ruby/object:Api::Type::Enum
             name: 'type'
             description: Type of the Cloud SQL database.

--- a/products/bigqueryconnection/terraform.yaml
+++ b/products/bigqueryconnection/terraform.yaml
@@ -21,7 +21,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           credential: !ruby/object:Overrides::Terraform::PropertyOverride
             ignore_read: true
             properties:
+              username: !ruby/object:Overrides::Terraform::PropertyOverride
+                ignore_read: true
               password: !ruby/object:Overrides::Terraform::PropertyOverride
+                ignore_read: true
                 sensitive: true
     id_format: "{{name}}"
     import_format: ["{{name}}"]

--- a/products/bigqueryconnection/terraform.yaml
+++ b/products/bigqueryconnection/terraform.yaml
@@ -32,6 +32,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "connection"
         vars:
           database_instance_name: "my-database-instance"
+          username: "user"
       - !ruby/object:Provider::Terraform::Examples
         min_version: beta
         name: "bigquery_connection_full"

--- a/products/bigqueryconnection/terraform.yaml
+++ b/products/bigqueryconnection/terraform.yaml
@@ -19,6 +19,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       cloudSql: !ruby/object:Overrides::Terraform::PropertyOverride
         properties:
           credential: !ruby/object:Overrides::Terraform::PropertyOverride
+            ignore_read: true
             properties:
               password: !ruby/object:Overrides::Terraform::PropertyOverride
                 sensitive: true

--- a/products/bigqueryconnection/terraform.yaml
+++ b/products/bigqueryconnection/terraform.yaml
@@ -17,6 +17,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   Connection: !ruby/object:Overrides::Terraform::ResourceOverride
     properties:
       cloudSql: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
         properties:
           credential: !ruby/object:Overrides::Terraform::PropertyOverride
             ignore_read: true

--- a/products/bigqueryconnection/terraform.yaml
+++ b/products/bigqueryconnection/terraform.yaml
@@ -19,7 +19,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       cloudSql: !ruby/object:Overrides::Terraform::PropertyOverride
         properties:
           credential: !ruby/object:Overrides::Terraform::PropertyOverride
-            custom_flatten: 'templates/terraform/custom_flatten/bigquery_connection_flatten.erb'
+            custom_flatten: 'templates/terraform/custom_flatten/bigquery_connection_flatten.go.erb'
             properties:
               password: !ruby/object:Overrides::Terraform::PropertyOverride
                 sensitive: true

--- a/products/bigqueryconnection/terraform.yaml
+++ b/products/bigqueryconnection/terraform.yaml
@@ -16,13 +16,10 @@ legacy_name: bigquery
 overrides: !ruby/object:Overrides::ResourceOverrides
   Connection: !ruby/object:Overrides::Terraform::ResourceOverride
     properties:
-      cloudSql: !ruby/object:Overrides::Terraform::PropertyOverride
-        properties:
-          credential: !ruby/object:Overrides::Terraform::PropertyOverride
-            custom_flatten: 'templates/terraform/custom_flatten/bigquery_connection_flatten.go.erb'
-            properties:
-              password: !ruby/object:Overrides::Terraform::PropertyOverride
-                sensitive: true
+      cloudSql.credential: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_flatten: 'templates/terraform/custom_flatten/bigquery_connection_flatten.go.erb'
+      cloudSql.credential.password: !ruby/object:Overrides::Terraform::PropertyOverride
+        sensitive: true
     id_format: "{{name}}"
     import_format: ["{{name}}"]
     examples:

--- a/products/bigqueryconnection/terraform.yaml
+++ b/products/bigqueryconnection/terraform.yaml
@@ -17,15 +17,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   Connection: !ruby/object:Overrides::Terraform::ResourceOverride
     properties:
       cloudSql: !ruby/object:Overrides::Terraform::PropertyOverride
-        ignore_read: true
         properties:
           credential: !ruby/object:Overrides::Terraform::PropertyOverride
-            ignore_read: true
+            custom_flatten: 'templates/terraform/custom_flatten/bigquery_connection_flatten.erb'
             properties:
-              username: !ruby/object:Overrides::Terraform::PropertyOverride
-                ignore_read: true
               password: !ruby/object:Overrides::Terraform::PropertyOverride
-                ignore_read: true
                 sensitive: true
     id_format: "{{name}}"
     import_format: ["{{name}}"]

--- a/products/bigqueryconnection/terraform.yaml
+++ b/products/bigqueryconnection/terraform.yaml
@@ -15,6 +15,13 @@
 legacy_name: bigquery
 overrides: !ruby/object:Overrides::ResourceOverrides
   Connection: !ruby/object:Overrides::Terraform::ResourceOverride
+    properties:
+      cloudSql: !ruby/object:Overrides::Terraform::PropertyOverride
+        properties:
+          credential: !ruby/object:Overrides::Terraform::PropertyOverride
+            properties:
+              password: !ruby/object:Overrides::Terraform::PropertyOverride
+                sensitive: true
     id_format: "{{name}}"
     import_format: ["{{name}}"]
     examples:
@@ -30,6 +37,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "connection"
         vars:
           database_instance_name: "my-database-instance"
+          username: "user"
           connection_id: "my-connection"
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/templates/terraform/custom_flatten/bigquery_connection_flatten.go.erb
+++ b/templates/terraform/custom_flatten/bigquery_connection_flatten.go.erb
@@ -13,9 +13,6 @@
 	# limitations under the License.
 -%>
 func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) interface{} {
-	if v == nil {
-		return nil
-	}
 	return []interface{}{
 		map[string]interface{}{
 			"username": d.Get("cloud_sql.0.credential.0.username"),

--- a/templates/terraform/custom_flatten/bigquery_connection_flatten.go.erb
+++ b/templates/terraform/custom_flatten/bigquery_connection_flatten.go.erb
@@ -1,0 +1,25 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	return []interface{}{
+		map[string]interface{}{
+			"username": d.Get("cloud_sql.0.credentials.0.username"),
+			"password": d.Get("cloud_sql.0.credentials.0.password"),
+		},
+	}
+}

--- a/templates/terraform/custom_flatten/bigquery_connection_flatten.go.erb
+++ b/templates/terraform/custom_flatten/bigquery_connection_flatten.go.erb
@@ -18,8 +18,8 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
 	}
 	return []interface{}{
 		map[string]interface{}{
-			"username": d.Get("cloud_sql.0.credentials.0.username"),
-			"password": d.Get("cloud_sql.0.credentials.0.password"),
+			"username": d.Get("cloud_sql.0.credential.0.username"),
+			"password": d.Get("cloud_sql.0.credential.0.password"),
 		},
 	}
 }

--- a/templates/terraform/examples/bigquery_connection_basic.tf.erb
+++ b/templates/terraform/examples/bigquery_connection_basic.tf.erb
@@ -14,6 +14,18 @@ resource "google_sql_database" "db" {
     name     = "db"
 }
 
+resource "random_password" "pwd" {
+    length = 16
+    special = false
+}
+
+resource "google_sql_user" "user" {
+    provider = google-beta
+    name = "<%= ctx[:vars]['username'] %>"
+    instance = google_sql_database_instance.instance.name
+    password = random_password.pwd.result
+}
+
 resource "google_bigquery_connection" "<%= ctx[:primary_resource_id] %>" {
     provider      = google-beta
     friendly_name = "👋"
@@ -22,5 +34,9 @@ resource "google_bigquery_connection" "<%= ctx[:primary_resource_id] %>" {
         instance_id = google_sql_database_instance.instance.connection_name
         database    = google_sql_database.db.name
         type        = "POSTGRES"
+        credential {
+          username = google_sql_user.user.name
+          password = google_sql_user.user.password
+        }
     }
 }

--- a/templates/terraform/examples/bigquery_connection_full.tf.erb
+++ b/templates/terraform/examples/bigquery_connection_full.tf.erb
@@ -14,6 +14,18 @@ resource "google_sql_database" "db" {
     name     = "db"
 }
 
+resource "random_password" "pwd" {
+    length = 16
+    special = false
+}
+
+resource "google_sql_user" "user" {
+    provider = google-beta
+    name = "<%= ctx[:vars]['username'] %>"
+    instance = google_sql_database_instance.instance.name
+    password = random_password.pwd.result
+}
+
 resource "google_bigquery_connection" "<%= ctx[:primary_resource_id] %>" {
     provider      = google-beta
     connection_id = "<%= ctx[:vars]['connection_id'] %>"
@@ -24,5 +36,9 @@ resource "google_bigquery_connection" "<%= ctx[:primary_resource_id] %>" {
         instance_id = google_sql_database_instance.instance.connection_name
         database    = google_sql_database.db.name
         type        = "POSTGRES"
+        credentials {
+          username = google_sql_user.user.name
+          password = google_sql_user.user.password
+        }
     }
 }

--- a/templates/terraform/examples/bigquery_connection_full.tf.erb
+++ b/templates/terraform/examples/bigquery_connection_full.tf.erb
@@ -36,7 +36,7 @@ resource "google_bigquery_connection" "<%= ctx[:primary_resource_id] %>" {
         instance_id = google_sql_database_instance.instance.connection_name
         database    = google_sql_database.db.name
         type        = "POSTGRES"
-        credentials {
+        credential {
           username = google_sql_user.user.name
           password = google_sql_user.user.password
         }

--- a/third_party/terraform/tests/resource_bigquery_connection_test.go.erb
+++ b/third_party/terraform/tests/resource_bigquery_connection_test.go.erb
@@ -48,6 +48,18 @@ resource "google_sql_database" "db" {
     name     = "db"
 }
 
+resource "random_password" "pwd" {
+    length = 16
+    special = false
+}
+
+resource "google_sql_user" "user" {
+    provider = google-beta
+    name = "username"
+    instance = google_sql_database_instance.instance.name
+    password = random_password.pwd.result
+}
+
 resource "google_bigquery_connection" "connection" {
     provider      = google-beta
     connection_id = "tf-test-my-connection%{random_suffix}"
@@ -58,6 +70,10 @@ resource "google_bigquery_connection" "connection" {
         instance_id = google_sql_database_instance.instance.connection_name
         database    = google_sql_database.db.name
         type        = "POSTGRES"
+        credential {
+            username = google_sql_user.user.name
+            password = google_sql_user.user.password
+        }
     }
 }
 `, context)
@@ -81,6 +97,18 @@ resource "google_sql_database" "db" {
     name     = "db2"
 }
 
+resource "random_password" "pwd" {
+    length = 16
+    special = false
+}
+
+resource "google_sql_user" "user" {
+    provider = google-beta
+    name = "username"
+    instance = google_sql_database_instance.instance.name
+    password = random_password.pwd.result
+}
+
 resource "google_bigquery_connection" "connection" {
     provider      = google-beta
     connection_id = "tf-test-my-connection%{random_suffix}"
@@ -91,6 +119,10 @@ resource "google_bigquery_connection" "connection" {
         instance_id = google_sql_database_instance.instance.connection_name
         database    = google_sql_database.db.name
         type        = "MYSQL"
+        credential {
+            username = google_sql_user.user.name
+            password = google_sql_user.user.password
+        }
     }
 }
 `, context)


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
bigquery: Add ability to manage credentials to `google_bigquery_connection`.  This field is required as the resource is not useful without them.
```