### PR TITLE
If a review is already submitted, the GH API thinks that no reviewer exists

### DIFF
--- a/.ci/containers/contributor-checker/check-contributor.sh
+++ b/.ci/containers/contributor-checker/check-contributor.sh
@@ -10,22 +10,28 @@ fi
 PR_NUMBER=$1
 set -x
 
-USER=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
-  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}" | jq .user.login)
-
 ASSIGNEE=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
   "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/${PR_NUMBER}/requested_reviewers" | jq .users[0].login)
-
-# This is where you add users who do not need to have an assignee chosen for
-# the.
-if $(echo $USER | fgrep -wq -e ndmckinley -e danawillow -e emilymye -e erjohnso -e megan07 -e paddycarver -e rambleraptor -e SirGitsalot -e slevenick -e c2thorn -e rileykarson); then
-  echo "User is on the list, not assigning."
-  exit 0
+  
+if [ "$ASSIGNEE" == "null" || -z "$ASSIGNEE" ]; then 
+  ASSIGNEE=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
+    "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/${PR_NUMBER}/reviews" | jq .[0].user.login)
 fi
-if [ "$ASSIGNEE" == "null" ] ; then 
+
+if [ "$ASSIGNEE" == "null" || -z "$ASSIGNEE" ] ; then 
   echo "Issue is not assigned."
 else
   echo "Issue is assigned, not assigning."
+  exit 0
+fi
+
+USER=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}" | jq .user.login)
+
+# This is where you add users who do not need to have an assignee chosen for
+# them.
+if $(echo $USER | fgrep -wq -e ndmckinley -e danawillow -e emilymye -e erjohnso -e megan07 -e paddycarver -e rambleraptor -e SirGitsalot -e slevenick -e c2thorn -e rileykarson); then
+  echo "User is on the list, not assigning."
   exit 0
 fi
 

--- a/.ci/containers/contributor-checker/check-contributor.sh
+++ b/.ci/containers/contributor-checker/check-contributor.sh
@@ -30,7 +30,7 @@ USER=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
 
 # This is where you add users who do not need to have an assignee chosen for
 # them.
-if $(echo $USER | fgrep -wq -e ndmckinley -e danawillow -e emilymye -e erjohnso -e megan07 -e paddycarver -e rambleraptor -e SirGitsalot -e slevenick -e c2thorn -e rileykarson); then
+if $(echo $USER | fgrep -wq -e ndmckinley -e danawillow -e emilymye -e megan07 -e paddycarver -e rambleraptor -e SirGitsalot -e slevenick -e c2thorn -e rileykarson); then
   echo "User is on the list, not assigning."
   exit 0
 fi


### PR DESCRIPTION


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
