### PR TITLE
adding id for exported attributes in more manual docs

### DIFF
--- a/third_party/terraform/website/docs/r/logging_billing_account_bucket_config.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_billing_account_bucket_config.html.markdown
@@ -49,6 +49,8 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
+* `id` - an identifier for the resource with format `projects/{{project}}/locations/{{location}}/buckets/{{bucket}}`
+
 * `name` -  The resource name of the bucket. For example: "projects/my-project-id/locations/my-location/buckets/my-bucket-id"
 
 * `lifecycle_state` -  The bucket's lifecycle such as active or deleted. See [LifecycleState](https://cloud.google.com/logging/docs/reference/v2/rest/v2/billingAccounts.buckets#LogBucket.LifecycleState).

--- a/third_party/terraform/website/docs/r/logging_billing_account_exclusion.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_billing_account_exclusion.html.markdown
@@ -47,6 +47,12 @@ The following arguments are supported:
     See [Advanced Log Filters](https://cloud.google.com/logging/docs/view/advanced-filters) for information on how to
     write a filter.
 
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `id` - an identifier for the resource with format `billingAccounts/{{billing_account}}/exclusions/{{name}}`
+
 ## Import
 
 Billing account logging exclusions can be imported using their URI, e.g.

--- a/third_party/terraform/website/docs/r/logging_billing_account_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_billing_account_sink.html.markdown
@@ -77,6 +77,8 @@ The `bigquery_options` block supports:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
+* `id` - an identifier for the resource with format `billingAccounts/{{billing_account_id}}/sinks/{{sink_id}}`
+
 * `writer_identity` - The identity associated with this sink. This identity must be granted write access to the
     configured `destination`.
 

--- a/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
@@ -50,6 +50,8 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
+* `id` - an identifier for the resource with format `folders/{{folder}}/locations/{{location}}/buckets/{{bucket_id}}`
+
 * `name` -  The resource name of the bucket. For example: "folders/my-folder-id/locations/my-location/buckets/my-bucket-id"
 
 * `lifecycle_state` -  The bucket's lifecycle such as active or deleted. See [LifecycleState](https://cloud.google.com/logging/docs/reference/v2/rest/v2/billingAccounts.buckets#LogBucket.LifecycleState).

--- a/third_party/terraform/website/docs/r/logging_folder_exclusion.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_folder_exclusion.html.markdown
@@ -53,6 +53,12 @@ The following arguments are supported:
     See [Advanced Log Filters](https://cloud.google.com/logging/docs/view/advanced-filters) for information on how to
     write a filter.
 
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `id` - an identifier for the resource with format `folders/{{folder}}/exclusions/{{name}}`
+
 ## Import
 
 Folder-level logging exclusions can be imported using their URI, e.g.

--- a/third_party/terraform/website/docs/r/logging_folder_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_folder_sink.html.markdown
@@ -87,6 +87,8 @@ The `bigquery_options` block supports:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
+* `id` - an identifier for the resource with format `folders/{{folder_id}}/sinks/{{name}}`
+
 * `writer_identity` - The identity associated with this sink. This identity must be granted write access to the
     configured `destination`.
 
@@ -95,5 +97,5 @@ exported:
 Folder-level logging sinks can be imported using this format:
 
 ```
-$ terraform import google_logging_folder_sink.my_sink folders/{{folder_id}}/sinks/{{sink_id}}
+$ terraform import google_logging_folder_sink.my_sink folders/{{folder_id}}/sinks/{{name}}
 ```

--- a/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
@@ -49,6 +49,8 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
+* `id` - an identifier for the resource with format `organizations/{{organization}}/locations/{{location}}/buckets/{{bucket_id}}`
+
 * `name` -  The resource name of the bucket. For example: "organizations/my-organization-id/locations/my-location/buckets/my-bucket-id"
 
 * `lifecycle_state` -  The bucket's lifecycle such as active or deleted. See [LifecycleState](https://cloud.google.com/logging/docs/reference/v2/rest/v2/billingAccounts.buckets#LogBucket.LifecycleState).

--- a/third_party/terraform/website/docs/r/logging_organization_exclusion.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_organization_exclusion.html.markdown
@@ -47,10 +47,16 @@ The following arguments are supported:
     See [Advanced Log Filters](https://cloud.google.com/logging/docs/view/advanced-filters) for information on how to
     write a filter.
 
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `id` - an identifier for the resource with format `organizations/{{organization}}/exclusions/{{name}}`
+
 ## Import
 
 Organization-level logging exclusions can be imported using their URI, e.g.
 
 ```
-$ terraform import google_logging_organization_exclusion.my_exclusion organizations/my-organization/exclusions/my-exclusion
+$ terraform import google_logging_organization_exclusion.my_exclusion organizations/{{organization}}/exclusions/{{name}}
 ```

--- a/third_party/terraform/website/docs/r/logging_organization_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_organization_sink.html.markdown
@@ -79,6 +79,8 @@ The `bigquery_options` block supports:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
+* `id` - an identifier for the resource with format `organizations/{{organization}}/sinks/{{name}}`
+
 * `writer_identity` - The identity associated with this sink. This identity must be granted write access to the
     configured `destination`.
 

--- a/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_project_bucket_config.html.markdown
@@ -51,6 +51,8 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
+* `id` - an identifier for the resource with format `projects/{{project}}/locations/{{location}}/buckets/{{bucket_id}}`
+
 * `name` -  The resource name of the bucket. For example: "projects/my-project-id/locations/my-location/buckets/my-bucket-id"
 
 * `lifecycle_state` -  The bucket's lifecycle such as active or deleted. See [LifecycleState](https://cloud.google.com/logging/docs/reference/v2/rest/v2/billingAccounts.buckets#LogBucket.LifecycleState).

--- a/third_party/terraform/website/docs/r/logging_project_exclusion.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_project_exclusion.html.markdown
@@ -47,6 +47,12 @@ The following arguments are supported:
 * `project` - (Optional) The project to create the exclusion in. If omitted, the project associated with the provider is
     used.
 
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `id` - an identifier for the resource with format `projects/{{project}}/exclusions/{{name}}`
+
 ## Import
 
 Project-level logging exclusions can be imported using their URI, e.g.

--- a/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -127,6 +127,8 @@ The `bigquery_options` block supports:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
+* `id` - an identifier for the resource with format `projects/{{project}}/sinks/{{name}}`
+
 * `writer_identity` - The identity associated with this sink. This identity must be granted write access to the
     configured `destination`.
 

--- a/third_party/terraform/website/docs/r/runtimeconfig_config.html.markdown
+++ b/third_party/terraform/website/docs/r/runtimeconfig_config.html.markdown
@@ -39,6 +39,12 @@ is not provided, the provider project is used.
 * `description` - (Optional) The description to associate with the runtime
 config.
 
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `id` - an identifier for the resource with format `projects/{{project}}/configs/{{name}}`
+
 ## Import
 
 Runtime Configs can be imported using the `name` or full config name, e.g.

--- a/third_party/terraform/website/docs/r/runtimeconfig_variable.html.markdown
+++ b/third_party/terraform/website/docs/r/runtimeconfig_variable.html.markdown
@@ -74,6 +74,8 @@ is specified, it must be base64 encoded and less than 4096 bytes in length.
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
+* `id` - an identifier for the resource with format `projects/{{project}}/configs/{{config}}/variables/{{name}}`
+
 * `update_time` - (Computed) The timestamp in RFC3339 UTC "Zulu" format,
 accurate to nanoseconds, representing when the variable was last updated.
 Example: "2016-10-09T12:33:37.578138407Z".


### PR DESCRIPTION
Part of https://github.com/terraform-providers/terraform-provider-google/issues/5542

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
