### PR TITLE
Skip instance migrate tests, they handle config directly

### DIFF
--- a/third_party/terraform/tests/resource_bigtable_app_profile_test.go
+++ b/third_party/terraform/tests/resource_bigtable_app_profile_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAccBigtableAppProfile_update(t *testing.T) {
+	// bigtable does not use the shared HTTP client
+	skipIfVcr(t)
 	t.Parallel()
 
 	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))

--- a/third_party/terraform/tests/resource_bigtable_app_profile_test.go
+++ b/third_party/terraform/tests/resource_bigtable_app_profile_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccBigtableAppProfile_update(t *testing.T) {
-	// bigtable does not use the shared HTTP client
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccBigtableGCPolicy_basic(t *testing.T) {
-	// bigtable does not use the shared HTTP client
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -35,7 +35,7 @@ func TestAccBigtableGCPolicy_basic(t *testing.T) {
 }
 
 func TestAccBigtableGCPolicy_union(t *testing.T) {
-	// bigtable does not use the shared HTTP client
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccBigtableGCPolicy_basic(t *testing.T) {
+	// bigtable does not use the shared HTTP client
+	skipIfVcr(t)
 	t.Parallel()
 
 	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
@@ -33,6 +35,8 @@ func TestAccBigtableGCPolicy_basic(t *testing.T) {
 }
 
 func TestAccBigtableGCPolicy_union(t *testing.T) {
+	// bigtable does not use the shared HTTP client
+	skipIfVcr(t)
 	t.Parallel()
 
 	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))

--- a/third_party/terraform/tests/resource_bigtable_instance_iam_test.go
+++ b/third_party/terraform/tests/resource_bigtable_instance_iam_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestAccBigtableInstanceIamBinding(t *testing.T) {
+	// bigtable does not use the shared HTTP client
+	skipIfVcr(t)
 	t.Parallel()
 
 	instance := "tf-bigtable-iam-" + randString(t, 10)
@@ -51,6 +53,8 @@ func TestAccBigtableInstanceIamBinding(t *testing.T) {
 }
 
 func TestAccBigtableInstanceIamMember(t *testing.T) {
+	// bigtable does not use the shared HTTP client
+	skipIfVcr(t)
 	t.Parallel()
 
 	instance := "tf-bigtable-iam-" + randString(t, 10)
@@ -89,6 +93,8 @@ func TestAccBigtableInstanceIamMember(t *testing.T) {
 }
 
 func TestAccBigtableInstanceIamPolicy(t *testing.T) {
+	// bigtable does not use the shared HTTP client
+	skipIfVcr(t)
 	t.Parallel()
 
 	instance := "tf-bigtable-iam-" + randString(t, 10)

--- a/third_party/terraform/tests/resource_bigtable_instance_iam_test.go
+++ b/third_party/terraform/tests/resource_bigtable_instance_iam_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccBigtableInstanceIamBinding(t *testing.T) {
-	// bigtable does not use the shared HTTP client
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -53,7 +53,7 @@ func TestAccBigtableInstanceIamBinding(t *testing.T) {
 }
 
 func TestAccBigtableInstanceIamMember(t *testing.T) {
-	// bigtable does not use the shared HTTP client
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -93,7 +93,7 @@ func TestAccBigtableInstanceIamMember(t *testing.T) {
 }
 
 func TestAccBigtableInstanceIamPolicy(t *testing.T) {
-	// bigtable does not use the shared HTTP client
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_bigtable_instance_test.go
+++ b/third_party/terraform/tests/resource_bigtable_instance_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestAccBigtableInstance_basic(t *testing.T) {
+	// bigtable does not use the shared HTTP client
+	skipIfVcr(t)
 	t.Parallel()
 
 	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
@@ -47,6 +49,8 @@ func TestAccBigtableInstance_basic(t *testing.T) {
 }
 
 func TestAccBigtableInstance_cluster(t *testing.T) {
+	// bigtable does not use the shared HTTP client
+	skipIfVcr(t)
 	t.Parallel()
 
 	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
@@ -101,6 +105,8 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 }
 
 func TestAccBigtableInstance_development(t *testing.T) {
+	// bigtable does not use the shared HTTP client
+	skipIfVcr(t)
 	t.Parallel()
 
 	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
@@ -124,6 +130,8 @@ func TestAccBigtableInstance_development(t *testing.T) {
 }
 
 func TestAccBigtableInstance_allowDestroy(t *testing.T) {
+	// bigtable does not use the shared HTTP client
+	skipIfVcr(t)
 	t.Parallel()
 
 	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))

--- a/third_party/terraform/tests/resource_bigtable_instance_test.go
+++ b/third_party/terraform/tests/resource_bigtable_instance_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAccBigtableInstance_basic(t *testing.T) {
-	// bigtable does not use the shared HTTP client
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -49,7 +49,7 @@ func TestAccBigtableInstance_basic(t *testing.T) {
 }
 
 func TestAccBigtableInstance_cluster(t *testing.T) {
-	// bigtable does not use the shared HTTP client
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -105,7 +105,7 @@ func TestAccBigtableInstance_cluster(t *testing.T) {
 }
 
 func TestAccBigtableInstance_development(t *testing.T) {
-	// bigtable does not use the shared HTTP client
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -130,7 +130,7 @@ func TestAccBigtableInstance_development(t *testing.T) {
 }
 
 func TestAccBigtableInstance_allowDestroy(t *testing.T) {
-	// bigtable does not use the shared HTTP client
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_bigtable_table_test.go
+++ b/third_party/terraform/tests/resource_bigtable_table_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccBigtableTable_basic(t *testing.T) {
-	// bigtable does not use the shared HTTP client
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -35,7 +35,7 @@ func TestAccBigtableTable_basic(t *testing.T) {
 }
 
 func TestAccBigtableTable_splitKeys(t *testing.T) {
-	// bigtable does not use the shared HTTP client
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -61,7 +61,7 @@ func TestAccBigtableTable_splitKeys(t *testing.T) {
 }
 
 func TestAccBigtableTable_family(t *testing.T) {
-	// bigtable does not use the shared HTTP client
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -87,7 +87,7 @@ func TestAccBigtableTable_family(t *testing.T) {
 }
 
 func TestAccBigtableTable_familyMany(t *testing.T) {
-	// bigtable does not use the shared HTTP client
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	skipIfVcr(t)
 	t.Parallel()
 
@@ -113,7 +113,7 @@ func TestAccBigtableTable_familyMany(t *testing.T) {
 }
 
 func TestAccBigtableTable_familyUpdate(t *testing.T) {
-	// bigtable does not use the shared HTTP client
+	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	skipIfVcr(t)
 	t.Parallel()
 

--- a/third_party/terraform/tests/resource_bigtable_table_test.go
+++ b/third_party/terraform/tests/resource_bigtable_table_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestAccBigtableTable_basic(t *testing.T) {
+	// bigtable does not use the shared HTTP client
+	skipIfVcr(t)
 	t.Parallel()
 
 	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
@@ -33,6 +35,8 @@ func TestAccBigtableTable_basic(t *testing.T) {
 }
 
 func TestAccBigtableTable_splitKeys(t *testing.T) {
+	// bigtable does not use the shared HTTP client
+	skipIfVcr(t)
 	t.Parallel()
 
 	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
@@ -57,6 +61,8 @@ func TestAccBigtableTable_splitKeys(t *testing.T) {
 }
 
 func TestAccBigtableTable_family(t *testing.T) {
+	// bigtable does not use the shared HTTP client
+	skipIfVcr(t)
 	t.Parallel()
 
 	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
@@ -81,6 +87,8 @@ func TestAccBigtableTable_family(t *testing.T) {
 }
 
 func TestAccBigtableTable_familyMany(t *testing.T) {
+	// bigtable does not use the shared HTTP client
+	skipIfVcr(t)
 	t.Parallel()
 
 	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
@@ -105,6 +113,8 @@ func TestAccBigtableTable_familyMany(t *testing.T) {
 }
 
 func TestAccBigtableTable_familyUpdate(t *testing.T) {
+	// bigtable does not use the shared HTTP client
+	skipIfVcr(t)
 	t.Parallel()
 
 	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))

--- a/third_party/terraform/tests/resource_compute_instance_migrate_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_migrate_test.go
@@ -930,6 +930,8 @@ func cleanUpDisk(config *Config, diskName, zone string) {
 }
 
 func getInitializedConfig(t *testing.T) *Config {
+	// Migrate tests are non standard and handle the config directly
+	skipIfVcr(t)
 	// Check that all required environment variables are set
 	testAccPreCheck(t)
 


### PR DESCRIPTION
Because these tests don't use `resource.Test` and instead manually create `*Config` objects they never properly call the `ConfigureFunc` on the config, preventing VCR transport swapping

Skip Bigtable tests that use a client factory that takes the raw TokenSource to produce new clients on demand within the resource rather than using the shared HTTP client

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
