### PR TITLE
Create the MachineImage resource

### DIFF
--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -325,6 +325,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     exclude: true
   MachineType: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
+  MachineImage: !ruby/object:Overrides::Ansible::ResourceOverride
+    exclude: true
   NetworkEndpoint: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
   GlobalNetworkEndpoint: !ruby/object:Overrides::Ansible::ResourceOverride

--- a/products/compute/ansible.yaml
+++ b/products/compute/ansible.yaml
@@ -31,6 +31,8 @@ datasources: !ruby/object:Overrides::ResourceOverrides
     exclude: true
   License: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
+  MachineImage: !ruby/object:Overrides::Ansible::ResourceOverride
+    exclude: true
   MachineType: !ruby/object:Overrides::Ansible::ResourceOverride
     exclude: true
   NetworkEndpoint: !ruby/object:Overrides::Ansible::ResourceOverride

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -6937,6 +6937,7 @@ objects:
       guides:
         'Official Documentation': 'https://cloud.google.com/compute/docs/machine-images'
       api: 'https://cloud.google.com/compute/docs/reference/rest/beta/machineImages'
+    min_version: beta
 
     properties:
       - !ruby/object:Api::Type::String

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -6924,6 +6924,35 @@ objects:
           The IEEE 802.1Q VLAN tag for this attachment, in the range 2-4094. When
           using PARTNER type this will be managed upstream.
   - !ruby/object:Api::Resource
+    name: 'MachineImage'
+    kind: 'compute#machineImage'
+    base_url: projects/{{project}}/global/machineImages
+    collection_url_key: 'items'
+    has_self_link: true
+    description: |
+      Represents a MachineImage resource. Machine images store all the configuration,
+      metadata, permissions, and data from one or more disks required to create a
+      Virtual machine (VM) instance.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation': 'https://cloud.google.com/compute/docs/machine-images'
+      api: 'https://cloud.google.com/compute/docs/reference/rest/beta/machineImages'
+
+    properties:
+      - !ruby/object:Api::Type::String
+        name: name
+        description: 'Name of the resource.'
+        required: true
+      - !ruby/object:Api::Type::String
+        name: description
+        description: 'A text description of the resource.'
+      - !ruby/object:Api::Type::ResourceRef
+        name: sourceInstance
+        description: 'The source instance used to create the machine image. You can provide this as a partial or full URL to the resource.'
+        resource: 'Instance'
+        imports: 'selfLink'
+        required: true
+  - !ruby/object:Api::Resource
     name: 'MachineType'
     kind: 'compute#machineType'
     base_url: projects/{{project}}/zones/{{zone}}/machineTypes

--- a/products/compute/inspec.yaml
+++ b/products/compute/inspec.yaml
@@ -93,6 +93,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     exclude: true
   MachineType: !ruby/object:Overrides::Inspec::ResourceOverride
     exclude: true
+  MachineImage: !ruby/object:Overrides::Inspec::ResourceOverride
+    exclude: true
   ManagedSslCertificate: !ruby/object:Overrides::Inspec::ResourceOverride
     exclude: true
   Network: !ruby/object:Overrides::Inspec::ResourceOverride

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -994,6 +994,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       pre_delete: templates/terraform/pre_delete/interconnect_attachment.go.erb
   License: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true
+  MachineImage: !ruby/object:Overrides::Terraform::ResourceOverride
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "machine_image_basic"
+        primary_resource_id: "image"
+        vars:
+          vm_name: "vm"
+          image_name: "image"
+
   MachineType: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true
   Network: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/templates/terraform/examples/machine_image_basic.tf.erb
+++ b/templates/terraform/examples/machine_image_basic.tf.erb
@@ -1,0 +1,19 @@
+resource "google_compute_instance" "vm" {
+  name         = "<%= ctx[:vars]['vm_name'] %>"
+  machine_type = "n1-standard-1"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+
+resource "google_compute_machine_image" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['image_name'] %>"
+  source_instance = google_compute_instance.vm.self_link
+}

--- a/templates/terraform/examples/machine_image_basic.tf.erb
+++ b/templates/terraform/examples/machine_image_basic.tf.erb
@@ -1,4 +1,5 @@
 resource "google_compute_instance" "vm" {
+  provider     = google-beta
   name         = "<%= ctx[:vars]['vm_name'] %>"
   machine_type = "n1-standard-1"
 
@@ -14,6 +15,7 @@ resource "google_compute_instance" "vm" {
 }
 
 resource "google_compute_machine_image" "<%= ctx[:primary_resource_id] %>" {
-  name = "<%= ctx[:vars]['image_name'] %>"
+  provider        = google-beta
+  name            = "<%= ctx[:vars]['image_name'] %>"
   source_instance = google_compute_instance.vm.self_link
 }


### PR DESCRIPTION
This does not yet support the creation of instances from MachineImages, but you can create machine images from existing instances - the test passes.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_compute_machine_image`
```
