### PR TITLE
Make dataflow on_delete a virtual field

### DIFF
--- a/third_party/terraform/resources/resource_dataflow_job.go
+++ b/third_party/terraform/resources/resource_dataflow_job.go
@@ -171,12 +171,12 @@ func resourceDataflowJobTypeCustomizeDiff(d *schema.ResourceDiff, meta interface
 	// All non-virtual fields are ForceNew for batch jobs
 	if d.Get("type") == "JOB_TYPE_BATCH" {
 		resourceSchema := resourceDataflowJob().Schema
-		for field, fieldSchema := range resourceSchema {
+		for field := range resourceSchema {
 			if field == "on_delete" {
 				continue
 			}
-			// Each key within a map must be checked for a change
-			if fieldSchema.Type == schema.TypeMap {
+			// Labels map will likely have suppressed changes, so we check each key instead of the parent field
+			if field == "labels" {
 				resourceDataflowJobIterateMapForceNew(field, d)
 			} else if d.HasChange(field) {
 				d.ForceNew(field)
@@ -483,13 +483,13 @@ func resourceDataflowJobIsVirtualUpdate(d *schema.ResourceData) bool {
 	if d.HasChange("on_delete") {
 		// Check if other fields have changes, which would require an actual update request
 		resourceSchema := resourceDataflowJob().Schema
-		for field, fieldSchema := range resourceSchema {
+		for field := range resourceSchema {
 			if field == "on_delete" {
 				continue
 			}
-			// Each key within a map must be checked for a change
-			if (fieldSchema.Type == schema.TypeMap && resourceDataflowJobIterateMapHasChange(field, d)) ||
-				(fieldSchema.Type != schema.TypeMap && d.HasChange(field)) {
+			// Labels map will likely have suppressed changes, so we check each key instead of the parent field
+			if (field == "labels" && resourceDataflowJobIterateMapHasChange(field, d)) ||
+				(field != "labels" && d.HasChange(field)) {
 				return false
 			}
 		}

--- a/third_party/terraform/resources/resource_dataflow_job.go
+++ b/third_party/terraform/resources/resource_dataflow_job.go
@@ -85,6 +85,8 @@ func resourceDataflowJob() *schema.Resource {
 			"max_workers": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				// ForceNew applies to both stream and batch jobs
+				ForceNew: true,
 			},
 
 			"parameters": {
@@ -166,10 +168,13 @@ func resourceDataflowJob() *schema.Resource {
 }
 
 func resourceDataflowJobTypeCustomizeDiff(d *schema.ResourceDiff, meta interface{}) error {
-	// All changes are ForceNew for batch jobs
+	// All non-virtual fields are ForceNew for batch jobs
 	if d.Get("type") == "JOB_TYPE_BATCH" {
 		resourceSchema := resourceDataflowJob().Schema
 		for field, fieldSchema := range resourceSchema {
+			if field == "on_delete" {
+				continue
+			}
 			// Each key within a map must be checked for a change
 			if fieldSchema.Type == schema.TypeMap {
 				resourceDataflowJobIterateMapForceNew(field, d)
@@ -265,6 +270,11 @@ func resourceDataflowJobRead(d *schema.ResourceData, meta interface{}) error {
 
 // Stream update method. Batch job changes should have been set to ForceNew via custom diff
 func resourceDataflowJobUpdateByReplacement(d *schema.ResourceData, meta interface{}) error {
+	// Don't send an update request if only virtual fields have changes
+	if resourceDataflowJobIsVirtualUpdate(d) {
+		return nil
+	}
+
 	config := meta.(*Config)
 
 	project, err := getProject(d, config)
@@ -455,4 +465,37 @@ func resourceDataflowJobIterateMapForceNew(mapKey string, d *schema.ResourceDiff
 			break
 		}
 	}
+}
+
+func resourceDataflowJobIterateMapHasChange(mapKey string, d *schema.ResourceData) bool {
+	obj := d.Get(mapKey).(map[string]interface{})
+	for k := range obj {
+		entrySchemaKey := mapKey + "." + k
+		if d.HasChange(entrySchemaKey) {
+			return true
+		}
+	}
+	return false
+}
+
+func resourceDataflowJobIsVirtualUpdate(d *schema.ResourceData) bool {
+	// on_delete is the only virtual field
+	if d.HasChange("on_delete") {
+		// Check if other fields have changes, which would require an actual update request
+		resourceSchema := resourceDataflowJob().Schema
+		for field, fieldSchema := range resourceSchema {
+			if field == "on_delete" {
+				continue
+			}
+			// Each key within a map must be checked for a change
+			if (fieldSchema.Type == schema.TypeMap && resourceDataflowJobIterateMapHasChange(field, d)) ||
+				(fieldSchema.Type != schema.TypeMap && d.HasChange(field)) {
+				return false
+			}
+		}
+		// on_delete is changing, but nothing else
+		return true
+	}
+
+	return false
 }

--- a/third_party/terraform/tests/resource_dataflow_job_test.go
+++ b/third_party/terraform/tests/resource_dataflow_job_test.go
@@ -285,6 +285,7 @@ func TestAccDataflowJob_virtualUpdate(t *testing.T) {
 				Config: testAccDataflowJob_virtualUpdate(suffix, "cancel"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataflowCheckId(t, "google_dataflow_job.pubsub_stream", &id),
+					resource.TestCheckResourceAttr("google_dataflow_job.pubsub_stream", "on_delete", "cancel"),
 				),
 			},
 		},

--- a/third_party/terraform/tests/resource_dataflow_job_test.go
+++ b/third_party/terraform/tests/resource_dataflow_job_test.go
@@ -363,8 +363,6 @@ func testAccDataflowSetId(t *testing.T, resource string, id *string) resource.Te
 			return fmt.Errorf("resource %q not in state", resource)
 		}
 
-		// copyID := rs.Primary.ID
-		// *id = copyID
 		*id = rs.Primary.ID
 		return nil
 	}

--- a/third_party/terraform/tests/resource_dataflow_job_test.go
+++ b/third_party/terraform/tests/resource_dataflow_job_test.go
@@ -259,6 +259,36 @@ func TestAccDataflowJob_streamUpdate(t *testing.T) {
 	})
 }
 
+func TestAccDataflowJob_virtualUpdate(t *testing.T) {
+	// Dataflow responses include serialized java classes and bash commands
+	// This makes body comparison infeasible
+	skipIfVcr(t)
+	t.Parallel()
+
+	suffix := randString(t, 10)
+	var id string
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDataflowJobDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataflowJob_virtualUpdate(suffix, "drain"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataflowJobExists(t, "google_dataflow_job.pubsub_stream"),
+					testAccDataflowSetId(t, "google_dataflow_job.pubsub_stream", &id),
+				),
+			},
+			{
+				Config: testAccDataflowJob_virtualUpdate(suffix, "cancel"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataflowCheckId(t, "google_dataflow_job.pubsub_stream", &id),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDataflowJobDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
@@ -319,6 +349,34 @@ func testAccDataflowJobExists(t *testing.T, resource string) resource.TestCheckF
 			return fmt.Errorf("could not confirm Dataflow Job %q exists: %v", rs.Primary.ID, err)
 		}
 
+		return nil
+	}
+}
+
+func testAccDataflowSetId(t *testing.T, resource string, id *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resource]
+		if !ok {
+			return fmt.Errorf("resource %q not in state", resource)
+		}
+
+		// copyID := rs.Primary.ID
+		// *id = copyID
+		*id = rs.Primary.ID
+		return nil
+	}
+}
+
+func testAccDataflowCheckId(t *testing.T, resource string, id *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resource]
+		if !ok {
+			return fmt.Errorf("resource %q not in state", resource)
+		}
+
+		if rs.Primary.ID != *id {
+			return fmt.Errorf("ID did not match. Expected %s, received %s", *id, rs.Primary.ID)
+		}
 		return nil
 	}
 }
@@ -771,4 +829,26 @@ resource "google_dataflow_job" "pubsub_stream" {
 	on_delete = "cancel"
 }
   `, suffix, suffix, suffix, suffix, testDataflowJobTemplateTextToPubsub, tempLocation)
+}
+
+func testAccDataflowJob_virtualUpdate(suffix, onDelete string) string {
+	return fmt.Sprintf(`
+resource "google_pubsub_topic" "topic" {
+	name     = "tf-test-dataflow-job-%s"
+}
+resource "google_storage_bucket" "bucket" {
+	name = "tf-test-bucket-%s"
+	force_destroy = true
+}
+resource "google_dataflow_job" "pubsub_stream" {
+	name = "tf-test-dataflow-job-%s"
+	template_gcs_path = "%s"
+	temp_gcs_location = google_storage_bucket.bucket.url
+	parameters = {
+	  inputFilePattern = "${google_storage_bucket.bucket.url}/*.json"
+	  outputTopic    = google_pubsub_topic.topic.id
+	}
+	on_delete = "%s"
+}
+  `, suffix, suffix, suffix, testDataflowJobTemplateTextToPubsub, onDelete)
 }

--- a/third_party/terraform/tests/resource_dataflow_job_test.go
+++ b/third_party/terraform/tests/resource_dataflow_job_test.go
@@ -266,6 +266,8 @@ func TestAccDataflowJob_virtualUpdate(t *testing.T) {
 	t.Parallel()
 
 	suffix := randString(t, 10)
+
+	// If the update is virtual-only, the ID should remain the same after updating.
 	var id string
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6301 
updating `on_delete` would either cause the batch job to be destroyed or the stream to be updated-by-replacement. To prevent this, we need to check if `on_delete` is our only change by update time. 
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
`dataflow`: fixed an issue where `google_dataflow_job` would try to update `max_workers`
```
```release-note:bug
`dataflow`: fixed an issue where updating `on_delete` in `google_dataflow_job` would cause the job to be replaced
```
