### PR TITLE
Remove credentials from error message in TF

### DIFF
--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -638,7 +638,7 @@ func (c *Config) getTokenSource(clientScopes []string) (oauth2.TokenSource, erro
 
 		creds, err := googleoauth.CredentialsFromJSON(context.Background(), []byte(contents), clientScopes...)
 		if err != nil {
-			return nil, fmt.Errorf("Unable to parse credentials from '%s': %s", contents, err)
+			return nil, fmt.Errorf("Unable to parse credentials: %s", err)
 		}
 
 		log.Printf("[INFO] Authenticating using configured Google JSON 'credentials'...")


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
provider: Removed credentials from output error when provider cannot parse given credentials
```

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6414
