### PR TITLE
Move workload identity to GA

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -903,6 +903,19 @@ func resourceContainerCluster() *schema.Resource {
 					},
 				},
 			},
+			"workload_identity_config": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"identity_namespace": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
 
 <% unless version == 'ga' -%>
 			"release_channel": {
@@ -917,20 +930,6 @@ func resourceContainerCluster() *schema.Resource {
 							Required:         true,
 							ValidateFunc:     validation.StringInSlice([]string{"UNSPECIFIED", "RAPID", "REGULAR", "STABLE"}, false),
 							DiffSuppressFunc: emptyOrDefaultStringSuppress("UNSPECIFIED"),
-						},
-					},
-				},
-			},
-
-			"workload_identity_config": {
-				Type:     schema.TypeList,
-				MaxItems: 1,
-				Optional: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"identity_namespace": {
-							Type:     schema.TypeString,
-							Required: true,
 						},
 					},
 				},
@@ -1208,10 +1207,11 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		cluster.DatabaseEncryption = expandDatabaseEncryption(v)
 	}
 
+<% end -%>
+
 	if v, ok := d.GetOk("workload_identity_config"); ok {
 		cluster.WorkloadIdentityConfig = expandWorkloadIdentityConfig(v)
 	}
-<% end -%>
 
 	if v, ok := d.GetOk("resource_usage_export_config"); ok {
 		cluster.ResourceUsageExportConfig = expandResourceUsageExportConfig(v)
@@ -1425,10 +1425,10 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-<% unless version == 'ga' -%>
 	if err := d.Set("workload_identity_config", flattenWorkloadIdentityConfig(cluster.WorkloadIdentityConfig)); err != nil {
 		return err
 	}
+<% unless version == 'ga' -%>
 
 	if err := d.Set("pod_security_policy_config", flattenPodSecurityPolicyConfig(cluster.PodSecurityPolicyConfig)); err != nil {
 		return err
@@ -2010,6 +2010,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		d.SetPartial("pod_security_policy_config")
 	}
+<% end -%>
 
 	if d.HasChange("workload_identity_config") {
 		// Because GKE uses a non-RESTful update function, when removing the
@@ -2039,7 +2040,6 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		d.SetPartial("workload_identity_config")
 	}
-<% end -%>
 
 	if d.HasChange("resource_labels") {
 		resourceLabels := d.Get("resource_labels").(map[string]interface{})
@@ -2639,6 +2639,7 @@ func expandDatabaseEncryption(configured interface{}) *containerBeta.DatabaseEnc
 	}
 }
 
+<% end -%>
 func expandWorkloadIdentityConfig(configured interface{}) *containerBeta.WorkloadIdentityConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
@@ -2649,7 +2650,6 @@ func expandWorkloadIdentityConfig(configured interface{}) *containerBeta.Workloa
 		IdentityNamespace: config["identity_namespace"].(string),
 	}
 }
-<% end -%>
 
 func expandPodSecurityPolicyConfig(configured interface{}) *containerBeta.PodSecurityPolicyConfig {
 <% unless version == 'ga' -%>
@@ -2872,6 +2872,7 @@ func flattenReleaseChannel(c *containerBeta.ReleaseChannel) []map[string]interfa
 	return result
 }
 
+<% end -%>
 func flattenWorkloadIdentityConfig(c *containerBeta.WorkloadIdentityConfig) []map[string]interface{} {
 	if c == nil {
 		return nil
@@ -2882,7 +2883,6 @@ func flattenWorkloadIdentityConfig(c *containerBeta.WorkloadIdentityConfig) []ma
 		},
 	}
 }
-<% end -%>
 
 func flattenIPAllocationPolicy(c *containerBeta.Cluster, d *schema.ResourceData, config *Config) []map[string]interface{} {
 	// If IP aliasing isn't enabled, none of the values in this block can be set.

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2723,31 +2723,6 @@ resource "google_container_cluster" "with_workload_metadata_config" {
 `, clusterName)
 }
 
-func testAccContainerCluster_updateWorkloadMetadataConfig(projectID string, clusterName string, workloadMetadataConfig string) string {
-	return fmt.Sprintf(`
-data "google_project" "project" {
-  project_id = "%s"
-}
-
-resource "google_container_cluster" "with_workload_identity_config" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
-
-  node_config {
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-    ]
-
-    workload_metadata_config {
-      node_metadata = "%s"
-    }
-  }
-}
-`, projectID, clusterName, workloadMetadataConfig)
-}
-
 func testAccContainerCluster_withSandboxConfig(clusterName string) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1413,6 +1413,49 @@ func TestAccContainerCluster_withShieldedNodes(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withWorkloadIdentityConfig(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	pid := getTestProjectFromEnv()
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_withWorkloadIdentityConfigEnabled(pid, clusterName),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_workload_identity_config",
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateVerifyIgnore: []string{"remove_default_node_pool"},
+			},
+			{
+				Config: testAccContainerCluster_updateWorkloadIdentityConfig(pid, clusterName, false),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_workload_identity_config",
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateVerifyIgnore: []string{"remove_default_node_pool"},
+			},
+			{
+				Config: testAccContainerCluster_updateWorkloadIdentityConfig(pid, clusterName, true),
+			},
+			{
+				ResourceName:        "google_container_cluster.with_workload_identity_config",
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateVerifyIgnore: []string{"remove_default_node_pool"},
+			},
+		},
+	})
+
+}
+
 <% unless version == 'ga' -%>
 // consider merging this test with TestAccContainerCluster_nodeAutoprovisioningDefaults
 // once the feature is GA
@@ -1522,53 +1565,6 @@ func TestAccContainerCluster_sharedVpc(t *testing.T) {
 	})
 }
 
-func TestAccContainerCluster_withWorkloadIdentityConfig(t *testing.T) {
-	t.Parallel()
-
-	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
-	pid := getTestProjectFromEnv()
-
-	vcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccContainerCluster_withWorkloadIdentityConfigEnabled(pid, clusterName),
-			},
-			{
-				ResourceName:        "google_container_cluster.with_workload_identity_config",
-				ImportState:         true,
-				ImportStateVerify:   true,
-			},
-			{
-				Config: testAccContainerCluster_updateWorkloadMetadataConfig(pid, clusterName, "SECURE"),
-			},
-			{
-				ResourceName:        "google_container_cluster.with_workload_identity_config",
-				ImportState:         true,
-				ImportStateVerify:   true,
-			},
-			{
-				Config: testAccContainerCluster_updateWorkloadIdentityConfig(pid, clusterName, false),
-			},
-			{
-				ResourceName:        "google_container_cluster.with_workload_identity_config",
-				ImportState:         true,
-				ImportStateVerify:   true,
-			},
-			{
-				Config: testAccContainerCluster_updateWorkloadIdentityConfig(pid, clusterName, true),
-			},
-			{
-				ResourceName:        "google_container_cluster.with_workload_identity_config",
-				ImportState:         true,
-				ImportStateVerify:   true,
-			},
-		},
-	})
-
-}
 
 func TestAccContainerCluster_withBinaryAuthorization(t *testing.T) {
 	t.Parallel()
@@ -2028,11 +2024,9 @@ resource "google_container_cluster" "primary" {
 
   min_master_version = "latest"
 
-<% unless version == 'ga' -%>
   workload_identity_config {
     identity_namespace = "${data.google_project.project.project_id}.svc.id.goog"
   }
-<% end -%>
 
   addons_config {
     http_load_balancing {
@@ -2083,11 +2077,9 @@ resource "google_container_cluster" "primary" {
 
   min_master_version = "latest"
 
-<% unless version == 'ga' -%>
   workload_identity_config {
     identity_namespace = "${data.google_project.project.project_id}.svc.id.goog"
   }
-<% end -%>
 
   addons_config {
     http_load_balancing {
@@ -3542,6 +3534,55 @@ resource "google_container_cluster" "with_shielded_nodes" {
 `, clusterName, enabled)
 }
 
+func testAccContainerCluster_withWorkloadIdentityConfigEnabled(projectID string, clusterName string) string {
+	return fmt.Sprintf(`
+data "google_project" "project" {
+  project_id = "%s"
+}
+
+resource "google_container_cluster" "with_workload_identity_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  workload_identity_config {
+    identity_namespace = "${data.google_project.project.project_id}.svc.id.goog"
+  }
+  remove_default_node_pool = true
+
+}
+`, projectID, clusterName)
+}
+
+func testAccContainerCluster_updateWorkloadIdentityConfig(projectID string, clusterName string, enable bool) string {
+	workloadIdentityConfig := ""
+	if enable {
+		workloadIdentityConfig = `
+			workload_identity_config {
+			identity_namespace = "${data.google_project.project.project_id}.svc.id.goog"
+		}`
+        } else {
+		workloadIdentityConfig = `
+			workload_identity_config {
+			identity_namespace = ""
+		}`
+        }
+	return fmt.Sprintf(`
+data "google_project" "project" {
+  project_id = "%s"
+}
+
+resource "google_container_cluster" "with_workload_identity_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  remove_default_node_pool = true
+  %s
+}
+`, projectID, clusterName, workloadIdentityConfig)
+}
+
+
 
 <% unless version.nil? || version == 'ga' -%>
 func testAccContainerCluster_sharedVpc(org, billingId, projectName, name string, suffix string) string {
@@ -3647,46 +3688,6 @@ resource "google_container_cluster" "shared_vpc_cluster" {
   ]
 }
 `, projectName, org, billingId, projectName, org, billingId, suffix, suffix, name)
-}
-
-func testAccContainerCluster_withWorkloadIdentityConfigEnabled(projectID string, clusterName string) string {
-	return fmt.Sprintf(`
-data "google_project" "project" {
-  project_id = "%s"
-}
-
-resource "google_container_cluster" "with_workload_identity_config" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
-
-  workload_identity_config {
-    identity_namespace = "${data.google_project.project.project_id}.svc.id.goog"
-  }
-}
-`, projectID, clusterName)
-}
-
-func testAccContainerCluster_updateWorkloadIdentityConfig(projectID string, clusterName string, enable bool) string {
-	workloadIdentityConfig := ""
-	if enable {
-		workloadIdentityConfig = `
-			workload_identity_config {
-			identity_namespace = "${data.google_project.project.project_id}.svc.id.goog"
-		}`
-	}
-	return fmt.Sprintf(`
-data "google_project" "project" {
-  project_id = "%s"
-}
-
-resource "google_container_cluster" "with_workload_identity_config" {
-  name               = "%s"
-  location           = "us-central1-a"
-  initial_node_count = 1
-  %s
-}
-`, projectID, clusterName, workloadIdentityConfig)
 }
 
 func testAccContainerCluster_withBinaryAuthorization(clusterName string, enabled bool) string {


### PR DESCRIPTION
This entails some test changes - the metadata that the test used to depend on is still beta - but the test passes in beta and GA.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Promoted `google_container_cluster.workload_identity_config` to GA.
```

This replaces https://github.com/GoogleCloudPlatform/magic-modules/pull/3453 because I have now written most of the code, so it deserves a second review.  :)