### PR TITLE
Add monitoring group mutex to uptime check config

### DIFF
--- a/products/monitoring/terraform.yaml
+++ b/products/monitoring/terraform.yaml
@@ -16,7 +16,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     id_format: "{{name}}"
     import_format: ["{{name}}"]
     mutex: alertPolicy/{{project}}
-    error_retry_predicates: ["isMonitoringRetryableError"]
+    error_retry_predicates: ["isMonitoringConcurrentEditError"]
     examples:
       - !ruby/object:Provider::Terraform::Examples
         # skipping tests because the API is full of race conditions
@@ -35,7 +35,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     id_format: "{{name}}"
     import_format: ["{{name}}"]
     mutex: stackdriver/groups/{{project}}
-    error_retry_predicates: ["isMonitoringRetryableError"]
+    error_retry_predicates: ["isMonitoringConcurrentEditError"]
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "monitoring_group_basic"
@@ -59,7 +59,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     id_format: "{{name}}"
     import_format: ["{{name}}"]
     mutex: stackdriver/notifications/{{project}}
-    error_retry_predicates: ["isMonitoringRetryableError"]
+    error_retry_predicates: ["isMonitoringConcurrentEditError"]
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "notification_channel_basic"
@@ -111,7 +111,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     legacy_name: 'google_monitoring_custom_service'
     id_format: "{{name}}"
     import_format: ["{{name}}"]
-    error_retry_predicates: ["isMonitoringRetryableError"]
+    error_retry_predicates: ["isMonitoringConcurrentEditError"]
     properties:
       serviceId: !ruby/object:Overrides::Terraform::PropertyOverride
         api_name: 'name'
@@ -235,7 +235,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   UptimeCheckConfig: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: "{{name}}"
     import_format: ["{{name}}"]
-    error_retry_predicates: ["isMonitoringRetryableError"]
+    error_retry_predicates: ["isMonitoringConcurrentEditError"]
+    mutex: stackdriver/groups/{{project}}
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "uptime_check_config_http"

--- a/third_party/terraform/data_sources/data_source_monitoring_service.go
+++ b/third_party/terraform/data_sources/data_source_monitoring_service.go
@@ -54,7 +54,7 @@ func dataSourceMonitoringServiceTypeReadFromList(listFilter string, typeStateSet
 			return err
 		}
 
-		resp, err := sendRequest(config, "GET", project, url, nil, isMonitoringRetryableError)
+		resp, err := sendRequest(config, "GET", project, url, nil, isMonitoringConcurrentEditError)
 		if err != nil {
 			return fmt.Errorf("unable to list Monitoring Service for data source: %v", err)
 		}

--- a/third_party/terraform/resources/resource_monitoring_dashboard.go
+++ b/third_party/terraform/resources/resource_monitoring_dashboard.go
@@ -86,7 +86,7 @@ func resourceMonitoringDashboardCreate(d *schema.ResourceData, meta interface{})
 	if err != nil {
 		return err
 	}
-	res, err := sendRequestWithTimeout(config, "POST", project, url, obj, d.Timeout(schema.TimeoutCreate), isMonitoringRetryableError)
+	res, err := sendRequestWithTimeout(config, "POST", project, url, obj, d.Timeout(schema.TimeoutCreate), isMonitoringConcurrentEditError)
 	if err != nil {
 		return fmt.Errorf("Error creating Dashboard: %s", err)
 	}
@@ -110,7 +110,7 @@ func resourceMonitoringDashboardRead(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	res, err := sendRequest(config, "GET", project, url, nil, isMonitoringRetryableError)
+	res, err := sendRequest(config, "GET", project, url, nil, isMonitoringConcurrentEditError)
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("MonitoringDashboard %q", d.Id()))
 	}
@@ -151,7 +151,7 @@ func resourceMonitoringDashboardUpdate(d *schema.ResourceData, meta interface{})
 	}
 
 	url := config.MonitoringBasePath + "v1/" + d.Id()
-	_, err = sendRequestWithTimeout(config, "PATCH", project, url, nObj, d.Timeout(schema.TimeoutUpdate), isMonitoringRetryableError)
+	_, err = sendRequestWithTimeout(config, "PATCH", project, url, nObj, d.Timeout(schema.TimeoutUpdate), isMonitoringConcurrentEditError)
 	if err != nil {
 		return fmt.Errorf("Error updating Dashboard %q: %s", d.Id(), err)
 	}
@@ -169,7 +169,7 @@ func resourceMonitoringDashboardDelete(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	_, err = sendRequestWithTimeout(config, "DELETE", project, url, nil, d.Timeout(schema.TimeoutDelete), isMonitoringRetryableError)
+	_, err = sendRequestWithTimeout(config, "DELETE", project, url, nil, d.Timeout(schema.TimeoutDelete), isMonitoringConcurrentEditError)
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("MonitoringDashboard %q", d.Id()))
 	}

--- a/third_party/terraform/tests/resource_monitoring_dashboard_test.go
+++ b/third_party/terraform/tests/resource_monitoring_dashboard_test.go
@@ -132,7 +132,7 @@ func testAccCheckMonitoringDashboardDestroyProducer(t *testing.T) func(s *terraf
 				return err
 			}
 
-			_, err = sendRequest(config, "GET", "", url, nil, isMonitoringRetryableError)
+			_, err = sendRequest(config, "GET", "", url, nil, isMonitoringConcurrentEditError)
 			if err == nil {
 				return fmt.Errorf("MonitoringDashboard still exists at %s", url)
 			}

--- a/third_party/terraform/utils/error_retry_predicates.go
+++ b/third_party/terraform/utils/error_retry_predicates.go
@@ -192,7 +192,7 @@ func isSqlOperationInProgressError(err error) (bool, string) {
 
 // Retry if Monitoring operation returns a 429 with a specific message for
 // concurrent operations.
-func isMonitoringRetryableError(err error) (bool, string) {
+func isMonitoringConcurrentEditError(err error) (bool, string) {
 	if gerr, ok := err.(*googleapi.Error); ok {
 		if gerr.Code == 409 && strings.Contains(strings.ToLower(gerr.Body), "too many concurrent edits") {
 			return true, "Waiting for other Monitoring changes to finish"

--- a/third_party/terraform/utils/utils.go.erb
+++ b/third_party/terraform/utils/utils.go.erb
@@ -79,7 +79,7 @@ func getRouterLockName(region string, router string) string {
 }
 
 func handleNotFoundError(err error, d *schema.ResourceData, resource string) error {
-	if isGoogleApiErrorWithCode(err, 404) {
+		if isGoogleApiErrorWithCode(err, 404) {
 		log.Printf("[WARN] Removing %s because it's gone", resource)
 		// The resource doesn't exist anymore
 		d.SetId("")
@@ -87,7 +87,8 @@ func handleNotFoundError(err error, d *schema.ResourceData, resource string) err
 		return nil
 	}
 
-	return fmt.Errorf("Error reading %s: %s", resource, err)
+	return errwrap.Wrapf(
+		fmt.Sprintf("Error when reading or editing %s: {{err}}", resource), err)
 }
 
 func isGoogleApiErrorWithCode(err error, errCode int) bool {

--- a/third_party/terraform/utils/utils.go.erb
+++ b/third_party/terraform/utils/utils.go.erb
@@ -79,7 +79,7 @@ func getRouterLockName(region string, router string) string {
 }
 
 func handleNotFoundError(err error, d *schema.ResourceData, resource string) error {
-		if isGoogleApiErrorWithCode(err, 404) {
+	if isGoogleApiErrorWithCode(err, 404) {
 		log.Printf("[WARN] Removing %s because it's gone", resource)
 		// The resource doesn't exist anymore
 		d.SetId("")
@@ -416,7 +416,7 @@ func calcAddRemove(from []string, to []string) (add, remove []string) {
 }
 
 func stringInSlice(arr []string, str string) bool {
-	for _,i := range arr {
+	for _, i := range arr {
 		if i == str {
 			return true
 		}
@@ -426,13 +426,12 @@ func stringInSlice(arr []string, str string) bool {
 }
 
 func migrateStateNoop(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
-		return is, nil
+	return is, nil
 }
 
 func expandString(v interface{}, d TerraformResourceData, config *Config) (string, error) {
 	return v.(string), nil
 }
-
 
 func changeFieldSchemaToForceNew(sch *schema.Schema) {
 	sch.ForceNew = true


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6452



Related:
* b/157746942