### PR TITLE
add default_route_action to compute_url_map

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -14043,7 +14043,6 @@ objects:
         output: true
       - !ruby/object:Api::Type::ResourceRef
         name: 'defaultService'
-        # TODO: add defaultRouteAction.weightedBackendService here once they are supported.
         exactly_one_of:
           - default_service
           - default_url_redirect
@@ -14202,11 +14201,14 @@ objects:
           properties:
             - !ruby/object:Api::Type::ResourceRef
               name: 'defaultService'
-              # TODO: (mbang) won't work for array path matchers yet, uncomment here once they are supported.
+              # TODO: (mbang) won't work for array path matchers yet, uncomment here and remove conflicts once they are supported.
+              # (github.com/hashicorp/terraform-plugin-sdk/issues/470)
               # exactly_one_of:
               #   - path_matchers.0.default_service
               #   - path_matchers.0.default_url_redirect
               #   - path_matchers.0.default_route_action.0.weighted_backend_services
+              conflicts:
+                - defaultUrlRedirect
               resource: 'BackendService'
               imports: 'selfLink'
               description: |
@@ -15402,12 +15404,14 @@ objects:
                           original URL is retained. Defaults to false.
             - !ruby/object:Api::Type::NestedObject
               name: 'defaultUrlRedirect'
-              # TODO: (mbang) won't work for array path matchers yet, uncomment here once they are supported.
+              # TODO: (mbang) won't work for array path matchers yet, uncomment here and remove conflicts once they are supported.
+              # (github.com/hashicorp/terraform-plugin-sdk/issues/470)
               # exactly_one_of:
               #   - path_matchers.0.default_service
               #   - path_matchers.0.default_url_redirect
-              #   - path_matchers.0.default_route_action.0.weighted_backend_services
+              #   - path_matchers.0.default_route_action
               conflicts:
+                - defaultService
                 - defaultRouteAction
               description: |
                 When none of the specified hostRules match, the request is redirected to a URL specified
@@ -15481,9 +15485,9 @@ objects:
                 - !ruby/object:Api::Type::Array
                   name: 'weightedBackendServices'
                   # TODO: (mbang) won't work for array path matchers yet, uncomment here once they are supported.
+                  # (github.com/hashicorp/terraform-plugin-sdk/issues/470)
                   # exactly_one_of:
                   #   - path_matchers.0.default_service
-                  #   - path_matchers.0.default_url_redirect
                   #   - path_matchers.0.default_route_action.0.weighted_backend_services
                   description: |
                     A list of weighted backend services to send traffic to when a route match occurs.
@@ -15806,13 +15810,10 @@ objects:
                 Expected BackendService resource the given URL should be mapped to.
       - !ruby/object:Api::Type::NestedObject
         name: 'defaultUrlRedirect'
-        # TODO: add defaultRouteAction.weightedBackendService here once they are supported.
         exactly_one_of:
           - default_service
           - default_url_redirect
-          - default_route_action.0.weighted_backend_services
-        conflicts:
-          - defaultRouteAction
+          - default_route_action
         description: |
           When none of the specified hostRules match, the request is redirected to a URL specified
           by defaultUrlRedirect. If defaultUrlRedirect is specified, defaultService or
@@ -15887,7 +15888,6 @@ objects:
             exactly_one_of:
               - default_service
               - default_route_action.0.weighted_backend_services
-              - default_url_redirect
             description: |
               A list of weighted backend services to send traffic to when a route match occurs.
               The weights determine the fraction of traffic that flows to their corresponding backend service.

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -15404,12 +15404,12 @@ objects:
                           original URL is retained. Defaults to false.
             - !ruby/object:Api::Type::NestedObject
               name: 'defaultUrlRedirect'
-              # TODO: (mbang) won't work for array path matchers yet, uncomment here and remove conflicts once they are supported.
+              # TODO: (mbang) won't work for array path matchers yet, uncomment here and remove defaultService conflict once they are supported.
               # (github.com/hashicorp/terraform-plugin-sdk/issues/470)
               # exactly_one_of:
               #   - path_matchers.0.default_service
               #   - path_matchers.0.default_url_redirect
-              #   - path_matchers.0.default_route_action
+              #   - path_matchers.0.default_route_action.0.weighted_backend_services
               conflicts:
                 - defaultService
                 - defaultRouteAction
@@ -15488,6 +15488,7 @@ objects:
                   # (github.com/hashicorp/terraform-plugin-sdk/issues/470)
                   # exactly_one_of:
                   #   - path_matchers.0.default_service
+                  #   - path_matchers.0.default_url_redirect
                   #   - path_matchers.0.default_route_action.0.weighted_backend_services
                   description: |
                     A list of weighted backend services to send traffic to when a route match occurs.
@@ -15813,7 +15814,9 @@ objects:
         exactly_one_of:
           - default_service
           - default_url_redirect
-          - default_route_action
+          - default_route_action.0.weighted_backend_services
+        conflicts:
+          - defaultRouteAction
         description: |
           When none of the specified hostRules match, the request is redirected to a URL specified
           by defaultUrlRedirect. If defaultUrlRedirect is specified, defaultService or
@@ -15887,6 +15890,7 @@ objects:
             name: 'weightedBackendServices'
             exactly_one_of:
               - default_service
+              - default_url_redirect
               - default_route_action.0.weighted_backend_services
             description: |
               A list of weighted backend services to send traffic to when a route match occurs.

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -14047,6 +14047,7 @@ objects:
         exactly_one_of:
           - default_service
           - default_url_redirect
+          - default_route_action.0.weighted_backend_services
         resource: 'BackendService'
         imports: 'selfLink'
         description: |
@@ -14201,10 +14202,11 @@ objects:
           properties:
             - !ruby/object:Api::Type::ResourceRef
               name: 'defaultService'
-              # TODO: add defaultRouteAction.weightedBackendService here once they are supported.
-              exactly_one_of:
-                - path_matchers.0.default_service
-                - path_matchers.0.default_url_redirect
+              # TODO: (mbang) won't work for array path matchers yet, uncomment here once they are supported.
+              # exactly_one_of:
+              #   - path_matchers.0.default_service
+              #   - path_matchers.0.default_url_redirect
+              #   - path_matchers.0.default_route_action.0.weighted_backend_services
               resource: 'BackendService'
               imports: 'selfLink'
               description: |
@@ -15400,10 +15402,13 @@ objects:
                           original URL is retained. Defaults to false.
             - !ruby/object:Api::Type::NestedObject
               name: 'defaultUrlRedirect'
-              # TODO: add defaultRouteAction.weightedBackendService here once they are supported.
-              exactly_one_of:
-                - path_matchers.0.default_service
-                - path_matchers.0.default_url_redirect
+              # TODO: (mbang) won't work for array path matchers yet, uncomment here once they are supported.
+              # exactly_one_of:
+              #   - path_matchers.0.default_service
+              #   - path_matchers.0.default_url_redirect
+              #   - path_matchers.0.default_route_action.0.weighted_backend_services
+              conflicts:
+                - defaultRouteAction
               description: |
                 When none of the specified hostRules match, the request is redirected to a URL specified
                 by defaultUrlRedirect. If defaultUrlRedirect is specified, defaultService or
@@ -15461,6 +15466,315 @@ objects:
                     If set to true, any accompanying query portion of the original URL is removed prior
                     to redirecting the request. If set to false, the query portion of the original URL is
                     retained.
+            - !ruby/object:Api::Type::NestedObject
+              name: 'defaultRouteAction'
+              conflicts:
+                - defaultUrlRedirect
+              description: |
+                defaultRouteAction takes effect when none of the pathRules or routeRules match. The load balancer performs
+                advanced routing actions like URL rewrites, header transformations, etc. prior to forwarding the request
+                to the selected backend. If defaultRouteAction specifies any weightedBackendServices, defaultService must not be set.
+                Conversely if defaultService is set, defaultRouteAction cannot contain any weightedBackendServices.
+
+                Only one of defaultRouteAction or defaultUrlRedirect must be set.
+              properties:
+                - !ruby/object:Api::Type::Array
+                  name: 'weightedBackendServices'
+                  # TODO: (mbang) won't work for array path matchers yet, uncomment here once they are supported.
+                  # exactly_one_of:
+                  #   - path_matchers.0.default_service
+                  #   - path_matchers.0.default_url_redirect
+                  #   - path_matchers.0.default_route_action.0.weighted_backend_services
+                  description: |
+                    A list of weighted backend services to send traffic to when a route match occurs.
+                    The weights determine the fraction of traffic that flows to their corresponding backend service.
+                    If all traffic needs to go to a single backend service, there must be one weightedBackendService
+                    with weight set to a non 0 number.
+
+                    Once a backendService is identified and before forwarding the request to the backend service,
+                    advanced routing actions like Url rewrites and header transformations are applied depending on
+                    additional settings specified in this HttpRouteAction.
+                  item_type: !ruby/object:Api::Type::NestedObject
+                    properties:
+                      - !ruby/object:Api::Type::ResourceRef
+                        name: 'backendService'
+                        resource: 'BackendService'
+                        imports: 'selfLink'
+                        description: |
+                          The full or partial URL to the default BackendService resource. Before forwarding the
+                          request to backendService, the loadbalancer applies any relevant headerActions
+                          specified as part of this backendServiceWeight.
+                      - !ruby/object:Api::Type::Integer
+                        name: 'weight'
+                        description: |
+                          Specifies the fraction of traffic sent to backendService, computed as
+                          weight / (sum of all weightedBackendService weights in routeAction) .
+
+                          The selection of a backend service is determined only for new traffic. Once a user's request
+                          has been directed to a backendService, subsequent requests will be sent to the same backendService
+                          as determined by the BackendService's session affinity policy.
+
+                          The value must be between 0 and 1000
+                      - !ruby/object:Api::Type::NestedObject
+                        name: 'headerAction'
+                        description: |
+                          Specifies changes to request and response headers that need to take effect for
+                          the selected backendService.
+
+                          headerAction specified here take effect before headerAction in the enclosing
+                          HttpRouteRule, PathMatcher and UrlMap.
+                        properties:
+                          - !ruby/object:Api::Type::Array
+                            name: 'requestHeadersToRemove'
+                            description: |
+                              A list of header names for headers that need to be removed from the request prior to
+                              forwarding the request to the backendService.
+                            item_type: Api::Type::String
+                          - !ruby/object:Api::Type::Array
+                            name: 'requestHeadersToAdd'
+                            description: |
+                              Headers to add to a matching request prior to forwarding the request to the backendService.
+                            item_type: !ruby/object:Api::Type::NestedObject
+                              properties:
+                                - !ruby/object:Api::Type::String
+                                  name: 'headerName'
+                                  description: |
+                                    The name of the header to add.
+                                - !ruby/object:Api::Type::String
+                                  name: 'headerValue'
+                                  description: |
+                                    The value of the header to add.
+                                - !ruby/object:Api::Type::Boolean
+                                  name: 'replace'
+                                  description: |
+                                    If false, headerValue is appended to any values that already exist for the header.
+                                    If true, headerValue is set for the header, discarding any values that were set for that header.
+                                  default_value: false
+                          - !ruby/object:Api::Type::Array
+                            name: 'responseHeadersToRemove'
+                            description: |
+                              A list of header names for headers that need to be removed from the response prior to sending the
+                              response back to the client.
+                            item_type: Api::Type::String
+                          - !ruby/object:Api::Type::Array
+                            name: 'responseHeadersToAdd'
+                            description: |
+                              Headers to add the response prior to sending the response back to the client.
+                            item_type: !ruby/object:Api::Type::NestedObject
+                              properties:
+                                - !ruby/object:Api::Type::String
+                                  name: 'headerName'
+                                  description: |
+                                    The name of the header to add.
+                                - !ruby/object:Api::Type::String
+                                  name: 'headerValue'
+                                  description: |
+                                    The value of the header to add.
+                                - !ruby/object:Api::Type::Boolean
+                                  name: 'replace'
+                                  description: |
+                                    If false, headerValue is appended to any values that already exist for the header.
+                                    If true, headerValue is set for the header, discarding any values that were set for that header.
+                                  default_value: false
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'urlRewrite'
+                  description: |
+                    The spec to modify the URL of the request, prior to forwarding the request to the matched service.
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: 'pathPrefixRewrite'
+                      description: |
+                        Prior to forwarding the request to the selected backend service, the matching portion of the
+                        request's path is replaced by pathPrefixRewrite.
+
+                        The value must be between 1 and 1024 characters.
+                    - !ruby/object:Api::Type::String
+                      name: 'hostRewrite'
+                      description: |
+                        Prior to forwarding the request to the selected service, the request's host header is replaced
+                        with contents of hostRewrite.
+
+                        The value must be between 1 and 255 characters.
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'timeout'
+                  description: |
+                    Specifies the timeout for the selected route. Timeout is computed from the time the request has been
+                    fully processed (i.e. end-of-stream) up until the response has been completely processed. Timeout includes all retries.
+
+                    If not specified, will use the largest timeout among all backend services associated with the route.
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: 'seconds'
+                      description: |
+                        Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                        Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                    - !ruby/object:Api::Type::Integer
+                      name: 'nanos'
+                      description: |
+                        Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are represented
+                        with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'retryPolicy'
+                  description: |
+                    Specifies the retry policy associated with this route.
+                  properties:
+                    - !ruby/object:Api::Type::Array
+                      name: 'retryConditions'
+                      description: |
+                        Specfies one or more conditions when this retry rule applies. Valid values are:
+
+                        5xx: Loadbalancer will attempt a retry if the backend service responds with any 5xx response code,
+                        or if the backend service does not respond at all, example: disconnects, reset, read timeout,
+                        connection failure, and refused streams.
+                        gateway-error: Similar to 5xx, but only applies to response codes 502, 503 or 504.
+                        connect-failure: Loadbalancer will retry on failures connecting to backend services,
+                        for example due to connection timeouts.
+                        retriable-4xx: Loadbalancer will retry for retriable 4xx response codes.
+                        Currently the only retriable error supported is 409.
+                        refused-stream:Loadbalancer will retry if the backend service resets the stream with a REFUSED_STREAM error code.
+                        This reset type indicates that it is safe to retry.
+                        cancelled: Loadbalancer will retry if the gRPC status code in the response header is set to cancelled
+                        deadline-exceeded: Loadbalancer will retry if the gRPC status code in the response header is set to deadline-exceeded
+                        resource-exhausted: Loadbalancer will retry if the gRPC status code in the response header is set to resource-exhausted
+                        unavailable: Loadbalancer will retry if the gRPC status code in the response header is set to unavailable
+                      item_type: Api::Type::String
+                    - !ruby/object:Api::Type::Integer
+                      name: 'numRetries'
+                      description: |
+                        Specifies the allowed number retries. This number must be > 0. If not specified, defaults to 1.
+                      default_value: 1
+                    - !ruby/object:Api::Type::NestedObject
+                      name: 'perTryTimeout'
+                      description: |
+                        Specifies a non-zero timeout per retry attempt.
+
+                        If not specified, will use the timeout set in HttpRouteAction. If timeout in HttpRouteAction is not set,
+                        will use the largest timeout among all backend services associated with the route.
+                      properties:
+                        - !ruby/object:Api::Type::String
+                          name: 'seconds'
+                          description: |
+                            Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                            Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                        - !ruby/object:Api::Type::Integer
+                          name: 'nanos'
+                          description: |
+                            Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are
+                            represented with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'requestMirrorPolicy'
+                  description: |
+                    Specifies the policy on how requests intended for the route's backends are shadowed to a separate mirrored backend service.
+                    Loadbalancer does not wait for responses from the shadow service. Prior to sending traffic to the shadow service,
+                    the host / authority header is suffixed with -shadow.
+                  properties:
+                    - !ruby/object:Api::Type::ResourceRef
+                      name: 'backendService'
+                      resource: 'BackendService'
+                      imports: 'selfLink'
+                      description: |
+                        The full or partial URL to the BackendService resource being mirrored to.
+                      required: true
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'corsPolicy'
+                  description: |
+                    The specification for allowing client side cross-origin requests. Please see
+                    [W3C Recommendation for Cross Origin Resource Sharing](https://www.w3.org/TR/cors/)
+                  properties:
+                    - !ruby/object:Api::Type::Array
+                      name: 'allowOrigins'
+                      description: |
+                        Specifies the list of origins that will be allowed to do CORS requests.
+                        An origin is allowed if it matches either an item in allowOrigins or an item in allowOriginRegexes.
+                      item_type: Api::Type::String
+                    - !ruby/object:Api::Type::Array
+                      name: 'allowOriginRegexes'
+                      description: |
+                        Specifies the regualar expression patterns that match allowed origins. For regular expression grammar
+                        please see en.cppreference.com/w/cpp/regex/ecmascript
+                        An origin is allowed if it matches either an item in allowOrigins or an item in allowOriginRegexes.
+                      item_type: Api::Type::String
+                    - !ruby/object:Api::Type::Array
+                      name: 'allowMethods'
+                      description: |
+                        Specifies the content for the Access-Control-Allow-Methods header.
+                      item_type: Api::Type::String
+                    - !ruby/object:Api::Type::Array
+                      name: 'allowHeaders'
+                      description: |
+                        Specifies the content for the Access-Control-Allow-Headers header.
+                      item_type: Api::Type::String
+                    - !ruby/object:Api::Type::Array
+                      name: 'exposeHeaders'
+                      description: |
+                        Specifies the content for the Access-Control-Expose-Headers header.
+                      item_type: Api::Type::String
+                    - !ruby/object:Api::Type::Integer
+                      name: 'maxAge'
+                      description: |
+                        Specifies how long results of a preflight request can be cached in seconds.
+                        This translates to the Access-Control-Max-Age header.
+                    - !ruby/object:Api::Type::Boolean
+                      name: 'allowCredentials'
+                      description: |
+                        In response to a preflight request, setting this to true indicates that the actual request can include user credentials.
+                        This translates to the Access-Control-Allow-Credentials header.
+                      default_value: false
+                    - !ruby/object:Api::Type::Boolean
+                      name: 'disabled'
+                      description: |
+                        If true, specifies the CORS policy is disabled. The default value is false, which indicates that the CORS policy is in effect.
+                      default_value: false
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'faultInjectionPolicy'
+                  description: |
+                    The specification for fault injection introduced into traffic to test the resiliency of clients to backend service failure.
+                    As part of fault injection, when clients send requests to a backend service, delays can be introduced by Loadbalancer on a
+                    percentage of requests before sending those request to the backend service. Similarly requests from clients can be aborted
+                    by the Loadbalancer for a percentage of requests.
+
+                    timeout and retryPolicy will be ignored by clients that are configured with a faultInjectionPolicy.
+                  properties:
+                    - !ruby/object:Api::Type::NestedObject
+                      name: 'delay'
+                      description: |
+                        The specification for how client requests are delayed as part of fault injection, before being sent to a backend service.
+                      properties:
+                        - !ruby/object:Api::Type::NestedObject
+                          name: 'fixedDelay'
+                          description: |
+                            Specifies the value of the fixed delay interval.
+                          properties:
+                            - !ruby/object:Api::Type::String
+                              name: 'seconds'
+                              description: |
+                                Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                                Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                            - !ruby/object:Api::Type::Integer
+                              name: 'nanos'
+                              description: |
+                                Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are
+                                represented with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+                        - !ruby/object:Api::Type::Double
+                          name: 'percentage'
+                          description: |
+                            The percentage of traffic (connections/operations/requests) on which delay will be introduced as part of fault injection.
+                            The value must be between 0.0 and 100.0 inclusive.
+                    - !ruby/object:Api::Type::NestedObject
+                      name: 'abort'
+                      description: |
+                        The specification for how client requests are aborted as part of fault injection.
+                      properties:
+                        - !ruby/object:Api::Type::Integer
+                          name: 'httpStatus'
+                          description: |
+                            The HTTP status code used to abort the request.
+                            The value must be between 200 and 599 inclusive.
+                        - !ruby/object:Api::Type::Double
+                          name: 'percentage'
+                          description: |
+                            The percentage of traffic (connections/operations/requests) which will be aborted as part of fault injection.
+                            The value must be between 0.0 and 100.0 inclusive.
       - !ruby/object:Api::Type::Array
         name: 'tests'
         description: |
@@ -15496,6 +15810,9 @@ objects:
         exactly_one_of:
           - default_service
           - default_url_redirect
+          - default_route_action.0.weighted_backend_services
+        conflicts:
+          - defaultRouteAction
         description: |
           When none of the specified hostRules match, the request is redirected to a URL specified
           by defaultUrlRedirect. If defaultUrlRedirect is specified, defaultService or
@@ -15553,6 +15870,496 @@ objects:
               If set to true, any accompanying query portion of the original URL is removed prior
               to redirecting the request. If set to false, the query portion of the original URL is
               retained. The default is set to false.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'defaultRouteAction'
+        conflicts:
+          - defaultUrlRedirect
+        description: |
+          defaultRouteAction takes effect when none of the hostRules match. The load balancer performs advanced routing actions
+          like URL rewrites, header transformations, etc. prior to forwarding the request to the selected backend.
+          If defaultRouteAction specifies any weightedBackendServices, defaultService must not be set. Conversely if defaultService
+          is set, defaultRouteAction cannot contain any weightedBackendServices.
+
+          Only one of defaultRouteAction or defaultUrlRedirect must be set.
+        properties:
+          - !ruby/object:Api::Type::Array
+            name: 'weightedBackendServices'
+            exactly_one_of:
+              - default_service
+              - default_route_action.0.weighted_backend_services
+              - default_url_redirect
+            description: |
+              A list of weighted backend services to send traffic to when a route match occurs.
+              The weights determine the fraction of traffic that flows to their corresponding backend service.
+              If all traffic needs to go to a single backend service, there must be one weightedBackendService
+              with weight set to a non 0 number.
+
+              Once a backendService is identified and before forwarding the request to the backend service,
+              advanced routing actions like Url rewrites and header transformations are applied depending on
+              additional settings specified in this HttpRouteAction.
+            at_least_one_of:
+              - default_route_action.0.weighted_backend_services
+              - default_route_action.0.url_rewrite
+              - default_route_action.0.timeout
+              - default_route_action.0.retry_policy
+              - default_route_action.0.request_mirror_policy
+              - default_route_action.0.cors_policy
+              - default_route_action.0.fault_injection_policy
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::ResourceRef
+                  name: 'backendService'
+                  resource: 'BackendService'
+                  imports: 'selfLink'
+                  description: |
+                    The full or partial URL to the default BackendService resource. Before forwarding the
+                    request to backendService, the loadbalancer applies any relevant headerActions
+                    specified as part of this backendServiceWeight.
+                - !ruby/object:Api::Type::Integer
+                  name: 'weight'
+                  description: |
+                    Specifies the fraction of traffic sent to backendService, computed as
+                    weight / (sum of all weightedBackendService weights in routeAction) .
+
+                    The selection of a backend service is determined only for new traffic. Once a user's request
+                    has been directed to a backendService, subsequent requests will be sent to the same backendService
+                    as determined by the BackendService's session affinity policy.
+
+                    The value must be between 0 and 1000
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'headerAction'
+                  description: |
+                    Specifies changes to request and response headers that need to take effect for
+                    the selected backendService.
+
+                    headerAction specified here take effect before headerAction in the enclosing
+                    HttpRouteRule, PathMatcher and UrlMap.
+                  properties:
+                    - !ruby/object:Api::Type::Array
+                      name: 'requestHeadersToRemove'
+                      description: |
+                        A list of header names for headers that need to be removed from the request prior to
+                        forwarding the request to the backendService.
+                      item_type: Api::Type::String
+                    - !ruby/object:Api::Type::Array
+                      name: 'requestHeadersToAdd'
+                      description: |
+                        Headers to add to a matching request prior to forwarding the request to the backendService.
+                      item_type: !ruby/object:Api::Type::NestedObject
+                        properties:
+                          - !ruby/object:Api::Type::String
+                            name: 'headerName'
+                            description: |
+                              The name of the header to add.
+                          - !ruby/object:Api::Type::String
+                            name: 'headerValue'
+                            description: |
+                              The value of the header to add.
+                          - !ruby/object:Api::Type::Boolean
+                            name: 'replace'
+                            description: |
+                              If false, headerValue is appended to any values that already exist for the header.
+                              If true, headerValue is set for the header, discarding any values that were set for that header.
+                            default_value: false
+                    - !ruby/object:Api::Type::Array
+                      name: 'responseHeadersToRemove'
+                      description: |
+                        A list of header names for headers that need to be removed from the response prior to sending the
+                        response back to the client.
+                      item_type: Api::Type::String
+                    - !ruby/object:Api::Type::Array
+                      name: 'responseHeadersToAdd'
+                      description: |
+                        Headers to add the response prior to sending the response back to the client.
+                      item_type: !ruby/object:Api::Type::NestedObject
+                        properties:
+                          - !ruby/object:Api::Type::String
+                            name: 'headerName'
+                            description: |
+                              The name of the header to add.
+                          - !ruby/object:Api::Type::String
+                            name: 'headerValue'
+                            description: |
+                              The value of the header to add.
+                          - !ruby/object:Api::Type::Boolean
+                            name: 'replace'
+                            description: |
+                              If false, headerValue is appended to any values that already exist for the header.
+                              If true, headerValue is set for the header, discarding any values that were set for that header.
+                            default_value: false
+          - !ruby/object:Api::Type::NestedObject
+            name: 'urlRewrite'
+            description: |
+              The spec to modify the URL of the request, prior to forwarding the request to the matched service.
+            at_least_one_of:
+              - default_route_action.0.weighted_backend_services
+              - default_route_action.0.url_rewrite
+              - default_route_action.0.timeout
+              - default_route_action.0.retry_policy
+              - default_route_action.0.request_mirror_policy
+              - default_route_action.0.cors_policy
+              - default_route_action.0.fault_injection_policy
+            properties:
+              - !ruby/object:Api::Type::String
+                name: 'pathPrefixRewrite'
+                description: |
+                  Prior to forwarding the request to the selected backend service, the matching portion of the
+                  request's path is replaced by pathPrefixRewrite.
+
+                  The value must be between 1 and 1024 characters.
+                at_least_one_of:
+                  - default_route_action.0.url_rewrite.0.path_prefix_rewrite
+                  - default_route_action.0.url_rewrite.0.host_rewrite
+              - !ruby/object:Api::Type::String
+                name: 'hostRewrite'
+                description: |
+                  Prior to forwarding the request to the selected service, the request's host header is replaced
+                  with contents of hostRewrite.
+
+                  The value must be between 1 and 255 characters.
+                at_least_one_of:
+                  - default_route_action.0.url_rewrite.0.path_prefix_rewrite
+                  - default_route_action.0.url_rewrite.0.host_rewrite
+          - !ruby/object:Api::Type::NestedObject
+            name: 'timeout'
+            description: |
+              Specifies the timeout for the selected route. Timeout is computed from the time the request has been
+              fully processed (i.e. end-of-stream) up until the response has been completely processed. Timeout includes all retries.
+
+              If not specified, will use the largest timeout among all backend services associated with the route.
+            at_least_one_of:
+              - default_route_action.0.weighted_backend_services
+              - default_route_action.0.url_rewrite
+              - default_route_action.0.timeout
+              - default_route_action.0.retry_policy
+              - default_route_action.0.request_mirror_policy
+              - default_route_action.0.cors_policy
+              - default_route_action.0.fault_injection_policy
+            properties:
+              - !ruby/object:Api::Type::String
+                name: 'seconds'
+                description: |
+                  Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                  Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                at_least_one_of:
+                  - default_route_action.0.timeout.0.seconds
+                  - default_route_action.0.timeout.0.nanos
+              - !ruby/object:Api::Type::Integer
+                name: 'nanos'
+                description: |
+                  Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are represented
+                  with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+                at_least_one_of:
+                  - default_route_action.0.timeout.0.seconds
+                  - default_route_action.0.timeout.0.nanos
+          - !ruby/object:Api::Type::NestedObject
+            name: 'retryPolicy'
+            description: |
+              Specifies the retry policy associated with this route.
+            at_least_one_of:
+              - default_route_action.0.weighted_backend_services
+              - default_route_action.0.url_rewrite
+              - default_route_action.0.timeout
+              - default_route_action.0.retry_policy
+              - default_route_action.0.request_mirror_policy
+              - default_route_action.0.cors_policy
+              - default_route_action.0.fault_injection_policy
+            properties:
+              - !ruby/object:Api::Type::Array
+                name: 'retryConditions'
+                description: |
+                  Specfies one or more conditions when this retry rule applies. Valid values are:
+
+                  5xx: Loadbalancer will attempt a retry if the backend service responds with any 5xx response code,
+                  or if the backend service does not respond at all, example: disconnects, reset, read timeout,
+                  connection failure, and refused streams.
+                  gateway-error: Similar to 5xx, but only applies to response codes 502, 503 or 504.
+                  connect-failure: Loadbalancer will retry on failures connecting to backend services,
+                  for example due to connection timeouts.
+                  retriable-4xx: Loadbalancer will retry for retriable 4xx response codes.
+                  Currently the only retriable error supported is 409.
+                  refused-stream:Loadbalancer will retry if the backend service resets the stream with a REFUSED_STREAM error code.
+                  This reset type indicates that it is safe to retry.
+                  cancelled: Loadbalancer will retry if the gRPC status code in the response header is set to cancelled
+                  deadline-exceeded: Loadbalancer will retry if the gRPC status code in the response header is set to deadline-exceeded
+                  resource-exhausted: Loadbalancer will retry if the gRPC status code in the response header is set to resource-exhausted
+                  unavailable: Loadbalancer will retry if the gRPC status code in the response header is set to unavailable
+                at_least_one_of:
+                  - default_route_action.0.retry_policy.0.retry_conditions
+                  - default_route_action.0.retry_policy.0.num_retries
+                  - default_route_action.0.retry_policy.0.per_try_timeout
+                item_type: Api::Type::String
+              - !ruby/object:Api::Type::Integer
+                name: 'numRetries'
+                description: |
+                  Specifies the allowed number retries. This number must be > 0. If not specified, defaults to 1.
+                at_least_one_of:
+                  - default_route_action.0.retry_policy.0.retry_conditions
+                  - default_route_action.0.retry_policy.0.num_retries
+                  - default_route_action.0.retry_policy.0.per_try_timeout
+                default_value: 1
+              - !ruby/object:Api::Type::NestedObject
+                name: 'perTryTimeout'
+                description: |
+                  Specifies a non-zero timeout per retry attempt.
+
+                  If not specified, will use the timeout set in HttpRouteAction. If timeout in HttpRouteAction is not set,
+                  will use the largest timeout among all backend services associated with the route.
+                at_least_one_of:
+                  - default_route_action.0.retry_policy.0.retry_conditions
+                  - default_route_action.0.retry_policy.0.num_retries
+                  - default_route_action.0.retry_policy.0.per_try_timeout
+                properties:
+                  - !ruby/object:Api::Type::String
+                    name: 'seconds'
+                    description: |
+                      Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                      Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                    at_least_one_of:
+                      - default_route_action.0.retry_policy.0.per_try_timeout.0.seconds
+                      - default_route_action.0.retry_policy.0.per_try_timeout.0.nanos
+                  - !ruby/object:Api::Type::Integer
+                    name: 'nanos'
+                    description: |
+                      Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are
+                      represented with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+                    at_least_one_of:
+                      - default_route_action.0.retry_policy.0.per_try_timeout.0.seconds
+                      - default_route_action.0.retry_policy.0.per_try_timeout.0.nanos
+          - !ruby/object:Api::Type::NestedObject
+            name: 'requestMirrorPolicy'
+            description: |
+              Specifies the policy on how requests intended for the route's backends are shadowed to a separate mirrored backend service.
+              Loadbalancer does not wait for responses from the shadow service. Prior to sending traffic to the shadow service,
+              the host / authority header is suffixed with -shadow.
+            at_least_one_of:
+              - default_route_action.0.weighted_backend_services
+              - default_route_action.0.url_rewrite
+              - default_route_action.0.timeout
+              - default_route_action.0.retry_policy
+              - default_route_action.0.request_mirror_policy
+              - default_route_action.0.cors_policy
+              - default_route_action.0.fault_injection_policy
+            properties:
+              - !ruby/object:Api::Type::ResourceRef
+                name: 'backendService'
+                resource: 'BackendService'
+                imports: 'selfLink'
+                description: |
+                  The full or partial URL to the BackendService resource being mirrored to.
+                required: true
+          - !ruby/object:Api::Type::NestedObject
+            name: 'corsPolicy'
+            description: |
+              The specification for allowing client side cross-origin requests. Please see
+              [W3C Recommendation for Cross Origin Resource Sharing](https://www.w3.org/TR/cors/)
+            at_least_one_of:
+              - default_route_action.0.weighted_backend_services
+              - default_route_action.0.url_rewrite
+              - default_route_action.0.timeout
+              - default_route_action.0.retry_policy
+              - default_route_action.0.request_mirror_policy
+              - default_route_action.0.cors_policy
+              - default_route_action.0.fault_injection_policy
+            properties:
+              - !ruby/object:Api::Type::Array
+                name: 'allowOrigins'
+                description: |
+                  Specifies the list of origins that will be allowed to do CORS requests.
+                  An origin is allowed if it matches either an item in allowOrigins or an item in allowOriginRegexes.
+                at_least_one_of:
+                  - default_route_action.0.cors_policy.0.allow_origins
+                  - default_route_action.0.cors_policy.0.allow_origin_regexes
+                  - default_route_action.0.cors_policy.0.allow_methods
+                  - default_route_action.0.cors_policy.0.allow_headers
+                  - default_route_action.0.cors_policy.0.expose_headers
+                  - default_route_action.0.cors_policy.0.max_age
+                  - default_route_action.0.cors_policy.0.allow_credentials
+                  - default_route_action.0.cors_policy.0.disabled
+                item_type: Api::Type::String
+              - !ruby/object:Api::Type::Array
+                name: 'allowOriginRegexes'
+                description: |
+                  Specifies the regualar expression patterns that match allowed origins. For regular expression grammar
+                  please see en.cppreference.com/w/cpp/regex/ecmascript
+                  An origin is allowed if it matches either an item in allowOrigins or an item in allowOriginRegexes.
+                at_least_one_of:
+                  - default_route_action.0.cors_policy.0.allow_origins
+                  - default_route_action.0.cors_policy.0.allow_origin_regexes
+                  - default_route_action.0.cors_policy.0.allow_methods
+                  - default_route_action.0.cors_policy.0.allow_headers
+                  - default_route_action.0.cors_policy.0.expose_headers
+                  - default_route_action.0.cors_policy.0.max_age
+                  - default_route_action.0.cors_policy.0.allow_credentials
+                  - default_route_action.0.cors_policy.0.disabled
+                item_type: Api::Type::String
+              - !ruby/object:Api::Type::Array
+                name: 'allowMethods'
+                description: |
+                  Specifies the content for the Access-Control-Allow-Methods header.
+                at_least_one_of:
+                  - default_route_action.0.cors_policy.0.allow_origins
+                  - default_route_action.0.cors_policy.0.allow_origin_regexes
+                  - default_route_action.0.cors_policy.0.allow_methods
+                  - default_route_action.0.cors_policy.0.allow_headers
+                  - default_route_action.0.cors_policy.0.expose_headers
+                  - default_route_action.0.cors_policy.0.max_age
+                  - default_route_action.0.cors_policy.0.allow_credentials
+                  - default_route_action.0.cors_policy.0.disabled
+                item_type: Api::Type::String
+              - !ruby/object:Api::Type::Array
+                name: 'allowHeaders'
+                description: |
+                  Specifies the content for the Access-Control-Allow-Headers header.
+                at_least_one_of:
+                  - default_route_action.0.cors_policy.0.allow_origins
+                  - default_route_action.0.cors_policy.0.allow_origin_regexes
+                  - default_route_action.0.cors_policy.0.allow_methods
+                  - default_route_action.0.cors_policy.0.allow_headers
+                  - default_route_action.0.cors_policy.0.expose_headers
+                  - default_route_action.0.cors_policy.0.max_age
+                  - default_route_action.0.cors_policy.0.allow_credentials
+                  - default_route_action.0.cors_policy.0.disabled
+                item_type: Api::Type::String
+              - !ruby/object:Api::Type::Array
+                name: 'exposeHeaders'
+                description: |
+                  Specifies the content for the Access-Control-Expose-Headers header.
+                at_least_one_of:
+                  - default_route_action.0.cors_policy.0.allow_origins
+                  - default_route_action.0.cors_policy.0.allow_origin_regexes
+                  - default_route_action.0.cors_policy.0.allow_methods
+                  - default_route_action.0.cors_policy.0.allow_headers
+                  - default_route_action.0.cors_policy.0.expose_headers
+                  - default_route_action.0.cors_policy.0.max_age
+                  - default_route_action.0.cors_policy.0.allow_credentials
+                  - default_route_action.0.cors_policy.0.disabled
+                item_type: Api::Type::String
+              - !ruby/object:Api::Type::Integer
+                name: 'maxAge'
+                description: |
+                  Specifies how long results of a preflight request can be cached in seconds.
+                  This translates to the Access-Control-Max-Age header.
+                at_least_one_of:
+                  - default_route_action.0.cors_policy.0.allow_origins
+                  - default_route_action.0.cors_policy.0.allow_origin_regexes
+                  - default_route_action.0.cors_policy.0.allow_methods
+                  - default_route_action.0.cors_policy.0.allow_headers
+                  - default_route_action.0.cors_policy.0.expose_headers
+                  - default_route_action.0.cors_policy.0.max_age
+                  - default_route_action.0.cors_policy.0.allow_credentials
+                  - default_route_action.0.cors_policy.0.disabled
+              - !ruby/object:Api::Type::Boolean
+                name: 'allowCredentials'
+                description: |
+                  In response to a preflight request, setting this to true indicates that the actual request can include user credentials.
+                  This translates to the Access-Control-Allow-Credentials header.
+                default_value: false
+                at_least_one_of:
+                  - default_route_action.0.cors_policy.0.allow_origins
+                  - default_route_action.0.cors_policy.0.allow_origin_regexes
+                  - default_route_action.0.cors_policy.0.allow_methods
+                  - default_route_action.0.cors_policy.0.allow_headers
+                  - default_route_action.0.cors_policy.0.expose_headers
+                  - default_route_action.0.cors_policy.0.max_age
+                  - default_route_action.0.cors_policy.0.allow_credentials
+                  - default_route_action.0.cors_policy.0.disabled
+              - !ruby/object:Api::Type::Boolean
+                name: 'disabled'
+                description: |
+                  If true, specifies the CORS policy is disabled. The default value is false, which indicates that the CORS policy is in effect.
+                default_value: false
+                at_least_one_of:
+                  - default_route_action.0.cors_policy.0.allow_origins
+                  - default_route_action.0.cors_policy.0.allow_origin_regexes
+                  - default_route_action.0.cors_policy.0.allow_methods
+                  - default_route_action.0.cors_policy.0.allow_headers
+                  - default_route_action.0.cors_policy.0.expose_headers
+                  - default_route_action.0.cors_policy.0.max_age
+                  - default_route_action.0.cors_policy.0.allow_credentials
+                  - default_route_action.0.cors_policy.0.disabled
+          - !ruby/object:Api::Type::NestedObject
+            name: 'faultInjectionPolicy'
+            description: |
+              The specification for fault injection introduced into traffic to test the resiliency of clients to backend service failure.
+              As part of fault injection, when clients send requests to a backend service, delays can be introduced by Loadbalancer on a
+              percentage of requests before sending those request to the backend service. Similarly requests from clients can be aborted
+              by the Loadbalancer for a percentage of requests.
+
+              timeout and retryPolicy will be ignored by clients that are configured with a faultInjectionPolicy.
+            at_least_one_of:
+              - default_route_action.0.weighted_backend_services
+              - default_route_action.0.url_rewrite
+              - default_route_action.0.timeout
+              - default_route_action.0.retry_policy
+              - default_route_action.0.request_mirror_policy
+              - default_route_action.0.cors_policy
+              - default_route_action.0.fault_injection_policy
+            properties:
+              - !ruby/object:Api::Type::NestedObject
+                name: 'delay'
+                description: |
+                  The specification for how client requests are delayed as part of fault injection, before being sent to a backend service.
+                at_least_one_of:
+                  - default_route_action.0.fault_injection_policy.0.delay
+                  - default_route_action.0.fault_injection_policy.0.abort
+                properties:
+                  - !ruby/object:Api::Type::NestedObject
+                    name: 'fixedDelay'
+                    description: |
+                      Specifies the value of the fixed delay interval.
+                    at_least_one_of:
+                      - default_route_action.0.fault_injection_policy.0.delay.0.delay
+                      - default_route_action.0.fault_injection_policy.0.delay.0.percentage
+                    properties:
+                      - !ruby/object:Api::Type::String
+                        name: 'seconds'
+                        description: |
+                          Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive.
+                          Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
+                        at_least_one_of:
+                          - default_route_action.0.fault_injection_policy.0.delay.0.fixed_delay.0.seconds
+                          - default_route_action.0.fault_injection_policy.0.delay.0.fixed_delay.0.nanos
+                      - !ruby/object:Api::Type::Integer
+                        name: 'nanos'
+                        description: |
+                          Span of time that's a fraction of a second at nanosecond resolution. Durations less than one second are
+                          represented with a 0 seconds field and a positive nanos field. Must be from 0 to 999,999,999 inclusive.
+                        at_least_one_of:
+                          - default_route_action.0.fault_injection_policy.0.delay.0.fixed_delay.0.seconds
+                          - default_route_action.0.fault_injection_policy.0.delay.0.fixed_delay.0.nanos
+                  - !ruby/object:Api::Type::Double
+                    name: 'percentage'
+                    description: |
+                      The percentage of traffic (connections/operations/requests) on which delay will be introduced as part of fault injection.
+                      The value must be between 0.0 and 100.0 inclusive.
+                    at_least_one_of:
+                      - default_route_action.0.fault_injection_policy.0.delay.0.delay
+                      - default_route_action.0.fault_injection_policy.0.delay.0.percentage
+              - !ruby/object:Api::Type::NestedObject
+                name: 'abort'
+                description: |
+                  The specification for how client requests are aborted as part of fault injection.
+                at_least_one_of:
+                  - default_route_action.0.fault_injection_policy.0.delay
+                  - default_route_action.0.fault_injection_policy.0.abort
+                properties:
+                  - !ruby/object:Api::Type::Integer
+                    name: 'httpStatus'
+                    description: |
+                      The HTTP status code used to abort the request.
+                      The value must be between 200 and 599 inclusive.
+                    at_least_one_of:
+                      - default_route_action.0.fault_injection_policy.0.abort.0.http_status
+                      - default_route_action.0.fault_injection_policy.0.abort.0.percentage
+                  - !ruby/object:Api::Type::Double
+                    name: 'percentage'
+                    description: |
+                      The percentage of traffic (connections/operations/requests) which will be aborted as part of fault injection.
+                      The value must be between 0.0 and 100.0 inclusive.
+                    at_least_one_of:
+                      - default_route_action.0.fault_injection_policy.0.abort.0.http_status
+                      - default_route_action.0.fault_injection_policy.0.abort.0.percentage
   - !ruby/object:Api::Resource
     name: 'VpnTunnel'
     kind: 'compute#vpnTunnel'

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -2499,6 +2499,40 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       pathMatchers.pathRules.urlRedirect.stripQuery: !ruby/object:Overrides::Terraform::PropertyOverride
         required: true
         description: '{{description}} This field is required to ensure an empty block is not set. The normal default value is false.'
+      pathMatchers.defaultRouteAction.weightedBackendServices.weight: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.IntBetween(0, 1000)'
+      pathMatchers.defaultRouteAction.timeout: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      pathMatchers.defaultRouteAction.retryPolicy.numRetries: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.IntAtLeast(1)'
+      pathMatchers.defaultRouteAction.faultInjectionPolicy.delay.percentage: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.FloatBetween(0, 100)'
+      pathMatchers.defaultRouteAction.faultInjectionPolicy.abort.httpStatus: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.IntBetween(200, 599)'
+      pathMatchers.defaultRouteAction.faultInjectionPolicy.abort.percentage: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.FloatBetween(0, 100)'
+      defaultRouteAction.weightedBackendServices.weight: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.IntBetween(0, 1000)'
+      defaultRouteAction.timeout: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      defaultRouteAction.retryPolicy.numRetries: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.IntAtLeast(1)'
+      defaultRouteAction.faultInjectionPolicy.delay.percentage: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.FloatBetween(0, 100)'
+      defaultRouteAction.faultInjectionPolicy.abort.httpStatus: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.IntBetween(200, 599)'
+      defaultRouteAction.faultInjectionPolicy.abort.percentage: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.FloatBetween(0, 100)'
   VpnTunnel: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/third_party/terraform/tests/resource_compute_url_map_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_url_map_test.go.erb
@@ -66,6 +66,59 @@ func TestAccComputeUrlMap_advanced(t *testing.T) {
 	})
 }
 
+func TestAccComputeUrlMap_defaultRouteActionPathUrlRewrite(t *testing.T) {
+  t.Parallel()
+
+  vcrTest(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testAccCheckComputeUrlMapDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccComputeUrlMap_defaultRouteActionPathUrlRewrite(randString(t, 10)),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckComputeUrlMapExists(
+            t, "google_compute_url_map.foobar"),
+        ),
+      },
+      {
+        Config: testAccComputeUrlMap_defaultRouteActionPathUrlRewrite_update(randString(t, 10)),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckComputeUrlMapExists(
+            t, "google_compute_url_map.foobar"),
+        ),
+      },
+    },
+  })
+}
+
+func TestAccComputeUrlMap_defaultRouteActionUrlRewrite(t *testing.T) {
+  t.Parallel()
+
+  vcrTest(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testAccCheckComputeUrlMapDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccComputeUrlMap_defaultRouteActionUrlRewrite(randString(t, 10)),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckComputeUrlMapExists(
+            t, "google_compute_url_map.foobar"),
+        ),
+      },
+
+      {
+        Config: testAccComputeUrlMap_defaultRouteActionUrlRewrite_update(randString(t, 10)),
+        Check: resource.ComposeTestCheckFunc(
+          testAccCheckComputeUrlMapExists(
+            t, "google_compute_url_map.foobar"),
+        ),
+      },
+    },
+  })
+}
+
 func TestAccComputeUrlMap_noPathRulesWithUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -120,6 +173,72 @@ func testAccCheckComputeUrlMapExists(t *testing.T, n string) resource.TestCheckF
 		}
 		return nil
 	}
+}
+
+func TestAccComputeUrlMap_defaultRouteActionTrafficDirectorPathUpdate(t *testing.T) {
+  t.Parallel()
+
+  randString := randString(t, 10)
+
+  bsName := fmt.Sprintf("urlmap-test-%s", randString)
+  hcName := fmt.Sprintf("urlmap-test-%s", randString)
+  umName := fmt.Sprintf("urlmap-test-%s", randString)
+  vcrTest(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testAccCheckComputeUrlMapDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccComputeUrlMap_defaultRouteActionTrafficDirectorPath(bsName, hcName, umName),
+      },
+      {
+        ResourceName:      "google_compute_url_map.foobar",
+        ImportState:       true,
+        ImportStateVerify: true,
+      },
+      {
+        Config: testAccComputeUrlMap_defaultRouteActionTrafficDirectorPathUpdate(bsName, hcName, umName),
+      },
+      {
+        ResourceName:      "google_compute_url_map.foobar",
+        ImportState:       true,
+        ImportStateVerify: true,
+      },
+    },
+  })
+}
+
+func TestAccComputeUrlMap_defaultRouteActionTrafficDirectorUpdate(t *testing.T) {
+  t.Parallel()
+
+  randString := randString(t, 10)
+
+  bsName := fmt.Sprintf("urlmap-test-%s", randString)
+  hcName := fmt.Sprintf("urlmap-test-%s", randString)
+  umName := fmt.Sprintf("urlmap-test-%s", randString)
+  vcrTest(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testAccCheckComputeUrlMapDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccComputeUrlMap_defaultRouteActionTrafficDirector(bsName, hcName, umName),
+      },
+      {
+        ResourceName:      "google_compute_url_map.foobar",
+        ImportState:       true,
+        ImportStateVerify: true,
+      },
+      {
+        Config: testAccComputeUrlMap_defaultRouteActionTrafficDirectorUpdate(bsName, hcName, umName),
+      },
+      {
+        ResourceName:      "google_compute_url_map.foobar",
+        ImportState:       true,
+        ImportStateVerify: true,
+      },
+    },
+  })
 }
 
 func TestAccComputeUrlMap_trafficDirectorUpdate(t *testing.T) {
@@ -443,6 +562,158 @@ resource "google_compute_url_map" "foobar" {
     path_rule {
       paths   = ["/*", "/home"]
       service = google_compute_backend_service.foobar.self_link
+    }
+  }
+}
+`, suffix, suffix, suffix)
+}
+
+func testAccComputeUrlMap_defaultRouteActionPathUrlRewrite(suffix string) string {
+  return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name          = "urlmap-test-%s"
+  health_checks = [google_compute_http_health_check.zero.self_link]
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "urlmap-test-%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_compute_url_map" "foobar" {
+  name            = "urlmap-test-%s"
+  default_service = google_compute_backend_service.foobar.self_link
+
+  host_rule {
+    hosts        = ["mysite.com", "myothersite.com"]
+    path_matcher = "blep"
+  }
+
+  path_matcher {
+    default_service = google_compute_backend_service.foobar.self_link
+    name            = "blep"
+
+    path_rule {
+      paths   = ["/home"]
+      service = google_compute_backend_service.foobar.self_link
+    }
+
+    path_rule {
+      paths   = ["/login"]
+      service = google_compute_backend_service.foobar.self_link
+    }
+
+    default_route_action {
+      url_rewrite {
+        host_rewrite = "my-new-host"
+        path_prefix_rewrite = "my-new-path"
+      }
+    }
+  }
+}
+`, suffix, suffix, suffix)
+}
+
+func testAccComputeUrlMap_defaultRouteActionPathUrlRewrite_update(suffix string) string {
+  return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name          = "urlmap-test-%s"
+  health_checks = [google_compute_http_health_check.zero.self_link]
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "urlmap-test-%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_compute_url_map" "foobar" {
+  name            = "urlmap-test-%s"
+  default_service = google_compute_backend_service.foobar.self_link
+
+  host_rule {
+    hosts        = ["mysite.com", "myothersite.com"]
+    path_matcher = "blep"
+  }
+
+  path_matcher {
+    default_service = google_compute_backend_service.foobar.self_link
+    name            = "blep"
+
+    path_rule {
+      paths   = ["/home"]
+      service = google_compute_backend_service.foobar.self_link
+    }
+
+    path_rule {
+      paths   = ["/login"]
+      service = google_compute_backend_service.foobar.self_link
+    }
+
+    default_route_action {
+      url_rewrite {
+        host_rewrite = "a-different-host"
+        path_prefix_rewrite = "a-different-path"
+      }
+    }
+  }
+}
+`, suffix, suffix, suffix)
+}
+
+func testAccComputeUrlMap_defaultRouteActionUrlRewrite(suffix string) string {
+  return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name          = "urlmap-test-%s"
+  health_checks = [google_compute_http_health_check.zero.self_link]
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "urlmap-test-%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_compute_url_map" "foobar" {
+  name            = "urlmap-test-%s"
+  default_service = google_compute_backend_service.foobar.self_link
+
+  default_route_action {
+    url_rewrite {
+      host_rewrite = "my-new-host"
+      path_prefix_rewrite = "my-new-path"
+    }
+  }
+}
+`, suffix, suffix, suffix)
+}
+
+func testAccComputeUrlMap_defaultRouteActionUrlRewrite_update(suffix string) string {
+  return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name          = "urlmap-test-%s"
+  health_checks = [google_compute_http_health_check.zero.self_link]
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "urlmap-test-%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+
+resource "google_compute_url_map" "foobar" {
+  name            = "urlmap-test-%s"
+  default_service = google_compute_backend_service.foobar.self_link
+
+  default_route_action {
+    url_rewrite {
+      host_rewrite = "a-different-host"
+      path_prefix_rewrite = "a-different-path"
     }
   }
 }
@@ -952,6 +1223,445 @@ resource "google_compute_backend_service" "home2" {
   timeout_sec = 10
 
   health_checks = ["${google_compute_health_check.default.self_link}"]
+  load_balancing_scheme = "INTERNAL_SELF_MANAGED"
+}
+
+resource "google_compute_health_check" "default" {
+  name               = "%s"
+  http_health_check {
+    port = 80
+  }
+}
+`, umName, bsName, bsName, hcName)
+}
+
+func testAccComputeUrlMap_defaultRouteActionTrafficDirectorPath(bsName, hcName, umName string) string {
+  return fmt.Sprintf(`
+resource "google_compute_url_map" "foobar" {
+  name        = "%s"
+  description = "a description"
+  default_service = google_compute_backend_service.home.self_link
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name = "allpaths"
+
+    default_route_action {
+      cors_policy {
+        allow_credentials = true
+        allow_headers = ["Allowed content"]
+        allow_methods = ["GET"]
+        allow_origin_regexes = ["abc.*"]
+        allow_origins = ["Allowed origin"]
+        expose_headers = ["Exposed header"]
+        max_age = 30
+        disabled = true
+      }
+      fault_injection_policy {
+        abort {
+          http_status = 234
+          percentage = 5.6
+        }
+        delay {
+          fixed_delay {
+            seconds = 0
+            nanos = 50000
+          }
+          percentage = 7.8
+        }
+      }
+      request_mirror_policy {
+        backend_service = google_compute_backend_service.home.self_link
+      }
+      retry_policy {
+        num_retries = 4
+        per_try_timeout {
+          seconds = 30
+        }
+        retry_conditions = ["5xx", "deadline-exceeded"]
+      }
+      timeout {
+        seconds = 20
+        nanos = 750000000
+      }
+      url_rewrite {
+        host_rewrite = "A replacement header"
+        path_prefix_rewrite = "A replacement path"
+      }
+      weighted_backend_services {
+        backend_service = google_compute_backend_service.home.self_link
+        weight = 400
+        header_action {
+          request_headers_to_remove = ["RemoveMe"]
+          request_headers_to_add {
+            header_name = "AddMe"
+            header_value = "MyValue"
+            replace = true
+          }
+          response_headers_to_remove = ["RemoveMe"]
+          response_headers_to_add {
+            header_name = "AddMe"
+            header_value = "MyValue"
+            replace = false
+          }
+        }
+      }
+    }
+  }
+
+  test {
+    service = google_compute_backend_service.home.self_link
+    host    = "hi.com"
+    path    = "/home"
+  }
+}
+
+resource "google_compute_backend_service" "home" {
+  name        = "%s"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.default.self_link]
+  load_balancing_scheme = "INTERNAL_SELF_MANAGED"
+}
+
+resource "google_compute_backend_service" "home2" {
+  name        = "%s-2"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.default.self_link]
+  load_balancing_scheme = "INTERNAL_SELF_MANAGED"
+}
+
+resource "google_compute_health_check" "default" {
+  name               = "%s"
+  http_health_check {
+    port = 80
+  }
+}
+
+`, umName, bsName, bsName, hcName)
+}
+
+func testAccComputeUrlMap_defaultRouteActionTrafficDirectorPathUpdate(bsName, hcName, umName string) string {
+  return fmt.Sprintf(`
+resource "google_compute_url_map" "foobar" {
+  name        = "%s"
+  description = "a description"
+  default_service = google_compute_backend_service.home2.self_link
+
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths2"
+  }
+
+  path_matcher {
+    name = "allpaths2"
+
+    default_route_action {
+      cors_policy {
+        allow_credentials = false
+        allow_headers = ["Allowed content updated"]
+        allow_methods = ["PUT"]
+        allow_origin_regexes = ["abcdef.*"]
+        allow_origins = ["Allowed origin updated"]
+        expose_headers = ["Exposed header updated"]
+        max_age = 31
+        disabled = false
+      }
+      fault_injection_policy {
+        abort {
+          http_status = 235
+          percentage = 6.7
+        }
+        delay {
+          fixed_delay {
+            seconds = 1
+            nanos = 40000
+          }
+          percentage = 8.9
+        }
+      }
+      request_mirror_policy {
+        backend_service = google_compute_backend_service.home.self_link
+      }
+      retry_policy {
+        num_retries = 5
+        per_try_timeout {
+          seconds = 31
+        }
+        retry_conditions = ["5xx"]
+      }
+      timeout {
+        seconds = 21
+        nanos = 760000000
+      }
+      url_rewrite {
+        host_rewrite = "A replacement header updated"
+        path_prefix_rewrite = "A replacement path updated"
+      }
+      weighted_backend_services {
+        backend_service = google_compute_backend_service.home.self_link
+        weight = 400
+        header_action {
+          request_headers_to_remove = ["RemoveMeUpdated"]
+          request_headers_to_add {
+            header_name = "AddMeUpdated"
+            header_value = "MyValueUpdated"
+            replace = false
+          }
+          response_headers_to_remove = ["RemoveMeUpdated"]
+          response_headers_to_add {
+            header_name = "AddMeUpdated"
+            header_value = "MyValueUpdated"
+            replace = true
+          }
+        }
+      }
+    }
+  }
+
+  test {
+    service = google_compute_backend_service.home.self_link
+    host    = "hi.com"
+    path    = "/home"
+  }
+}
+
+resource "google_compute_backend_service" "home" {
+  name        = "%s"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.default.self_link]
+  load_balancing_scheme = "INTERNAL_SELF_MANAGED"
+}
+
+resource "google_compute_backend_service" "home2" {
+  name        = "%s-2"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.default.self_link]
+  load_balancing_scheme = "INTERNAL_SELF_MANAGED"
+}
+
+resource "google_compute_health_check" "default" {
+  name               = "%s"
+  http_health_check {
+    port = 80
+  }
+}
+`, umName, bsName, bsName, hcName)
+}
+
+
+func testAccComputeUrlMap_defaultRouteActionTrafficDirector(bsName, hcName, umName string) string {
+  return fmt.Sprintf(`
+resource "google_compute_url_map" "foobar" {
+  name        = "%s"
+  description = "a description"
+
+  default_route_action {
+    cors_policy {
+      allow_credentials = true
+      allow_headers = ["Allowed content"]
+      allow_methods = ["GET"]
+      allow_origin_regexes = ["abc.*"]
+      allow_origins = ["Allowed origin"]
+      expose_headers = ["Exposed header"]
+      max_age = 30
+      disabled = true
+    }
+    fault_injection_policy {
+      abort {
+        http_status = 234
+        percentage = 5.6
+      }
+      delay {
+        fixed_delay {
+          seconds = 0
+          nanos = 50000
+        }
+        percentage = 7.8
+      }
+    }
+    request_mirror_policy {
+      backend_service = google_compute_backend_service.home.self_link
+    }
+    retry_policy {
+      num_retries = 4
+      per_try_timeout {
+        seconds = 30
+      }
+      retry_conditions = ["5xx", "deadline-exceeded"]
+    }
+    timeout {
+      seconds = 20
+      nanos = 750000000
+    }
+    url_rewrite {
+      host_rewrite = "A replacement header"
+      path_prefix_rewrite = "A replacement path"
+    }
+    weighted_backend_services {
+      backend_service = google_compute_backend_service.home.self_link
+      weight = 400
+      header_action {
+        request_headers_to_remove = ["RemoveMe"]
+        request_headers_to_add {
+          header_name = "AddMe"
+          header_value = "MyValue"
+          replace = true
+        }
+        response_headers_to_remove = ["RemoveMe"]
+        response_headers_to_add {
+          header_name = "AddMe"
+          header_value = "MyValue"
+          replace = false
+        }
+      }
+    }
+  }
+
+  test {
+    service = google_compute_backend_service.home.self_link
+    host    = "hi.com"
+    path    = "/home"
+  }
+}
+
+resource "google_compute_backend_service" "home" {
+  name        = "%s"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.default.self_link]
+  load_balancing_scheme = "INTERNAL_SELF_MANAGED"
+}
+
+resource "google_compute_backend_service" "home2" {
+  name        = "%s-2"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.default.self_link]
+  load_balancing_scheme = "INTERNAL_SELF_MANAGED"
+}
+
+resource "google_compute_health_check" "default" {
+  name               = "%s"
+  http_health_check {
+    port = 80
+  }
+}
+
+`, umName, bsName, bsName, hcName)
+}
+
+func testAccComputeUrlMap_defaultRouteActionTrafficDirectorUpdate(bsName, hcName, umName string) string {
+  return fmt.Sprintf(`
+resource "google_compute_url_map" "foobar" {
+  name        = "%s"
+  description = "a description"
+
+  default_route_action {
+    cors_policy {
+      allow_credentials = false
+      allow_headers = ["Allowed content updated"]
+      allow_methods = ["PUT"]
+      allow_origin_regexes = ["abcdef.*"]
+      allow_origins = ["Allowed origin updated"]
+      expose_headers = ["Exposed header updated"]
+      max_age = 31
+      disabled = false
+    }
+    fault_injection_policy {
+      abort {
+        http_status = 235
+        percentage = 6.7
+      }
+      delay {
+        fixed_delay {
+          seconds = 1
+          nanos = 40000
+        }
+        percentage = 8.9
+      }
+    }
+    request_mirror_policy {
+      backend_service = google_compute_backend_service.home2.self_link
+    }
+    retry_policy {
+      num_retries = 5
+      per_try_timeout {
+        seconds = 31
+      }
+      retry_conditions = ["5xx"]
+    }
+    timeout {
+      seconds = 21
+      nanos = 760000000
+    }
+    url_rewrite {
+      host_rewrite = "A replacement header updated"
+      path_prefix_rewrite = "A replacement path updated"
+    }
+    weighted_backend_services {
+      backend_service = google_compute_backend_service.home2.self_link
+      weight = 400
+      header_action {
+        request_headers_to_remove = ["RemoveMeUpdated"]
+        request_headers_to_add {
+          header_name = "AddMeUpdated"
+          header_value = "MyValueUpdated"
+          replace = false
+        }
+        response_headers_to_remove = ["RemoveMeUpdated"]
+        response_headers_to_add {
+          header_name = "AddMeUpdated"
+          header_value = "MyValueUpdated"
+          replace = true
+        }
+      }
+    }
+  }
+
+  test {
+    service = google_compute_backend_service.home2.self_link
+    host    = "hi.com"
+    path    = "/home"
+  }
+}
+
+resource "google_compute_backend_service" "home" {
+  name        = "%s"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.default.self_link]
+  load_balancing_scheme = "INTERNAL_SELF_MANAGED"
+}
+
+resource "google_compute_backend_service" "home2" {
+  name        = "%s-2"
+  port_name   = "http"
+  protocol    = "HTTP"
+  timeout_sec = 10
+
+  health_checks = [google_compute_health_check.default.self_link]
   load_balancing_scheme = "INTERNAL_SELF_MANAGED"
 }
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6205 
And adds the extra fields in default_route_action as well.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `default_route_action` to `compute_url_map` and `compute_url_map.path_matchers`
```
