### PR TITLE
enable google_dns_managed_zone to accept network id for two attributes

### DIFF
--- a/products/dns/terraform.yaml
+++ b/products/dns/terraform.yaml
@@ -89,6 +89,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           and apply an incorrect update to the resource. If you encounter this issue, remove all `networks`
           blocks in an update and then apply another update adding all of them back simultaneously.
       privateVisibilityConfig.networks.networkUrl: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/network_full_url.erb'
         diff_suppress_func: 'compareSelfLinkOrResourceName'
       forwardingConfig.targetNameServers: !ruby/object:Overrides::Terraform::PropertyOverride
         is_set: true
@@ -114,6 +115,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       visibility: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'caseDiffSuppress'
         custom_flatten: templates/terraform/custom_flatten/default_if_empty.erb
+      peeringConfig.targetNetwork.networkUrl: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: templates/terraform/custom_expand/network_full_url.erb
       reverseLookup: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/object_to_bool.go.erb
         custom_expand: templates/terraform/custom_expand/bool_to_object.go.erb

--- a/products/dns/terraform.yaml
+++ b/products/dns/terraform.yaml
@@ -117,6 +117,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_flatten: templates/terraform/custom_flatten/default_if_empty.erb
       peeringConfig.targetNetwork.networkUrl: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_expand: templates/terraform/custom_expand/network_full_url.erb
+        diff_suppress_func: 'compareSelfLinkOrResourceName'
       reverseLookup: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/object_to_bool.go.erb
         custom_expand: templates/terraform/custom_expand/bool_to_object.go.erb

--- a/templates/terraform/custom_expand/network_full_url.erb
+++ b/templates/terraform/custom_expand/network_full_url.erb
@@ -1,0 +1,12 @@
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+  if v == nil || v.(string) == "" {
+    return "", nil
+  } else if strings.HasPrefix(v.(string), "https://") {
+    return v, nil
+  }
+  url, err := replaceVars(d, config, "{{ComputeBasePath}}" + v.(string))
+  if err != nil {
+    return "", err
+  }
+  return ConvertSelfLinkToV1(url), nil
+}

--- a/templates/terraform/examples/dns_managed_zone_private.tf.erb
+++ b/templates/terraform/examples/dns_managed_zone_private.tf.erb
@@ -10,10 +10,10 @@ resource "google_dns_managed_zone" "<%= ctx[:primary_resource_id] %>" {
 
   private_visibility_config {
     networks {
-      network_url = google_compute_network.network-1.self_link
+      network_url = google_compute_network.network-1.id
     }
     networks {
-      network_url = google_compute_network.network-2.self_link
+      network_url = google_compute_network.network-2.id
     }
   }
 }

--- a/templates/terraform/examples/dns_managed_zone_private_peering.tf.erb
+++ b/templates/terraform/examples/dns_managed_zone_private_peering.tf.erb
@@ -7,13 +7,13 @@ resource "google_dns_managed_zone" "<%= ctx[:primary_resource_id] %>" {
 
   private_visibility_config {
     networks {
-      network_url = google_compute_network.network-source.self_link
+      network_url = google_compute_network.network-source.id
     }
   }
 
   peering_config {
     target_network {
-      network_url = google_compute_network.network-target.self_link
+      network_url = google_compute_network.network-target.id
     }
   }
 }


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-google/issues/6498

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
