### PR TITLE
Code with reviews does not need an assigned reviewer

### DIFF
--- a/.ci/containers/contributor-checker/check-contributor.sh
+++ b/.ci/containers/contributor-checker/check-contributor.sh
@@ -29,6 +29,16 @@ else
   exit 0
 fi
 
+# If there is already somebody reviewing the code, we do not need to assign any reviewer.
+# This person will not appear as a requested_reviewer, but they will appear as the user of the first review.
+ASSIGNEE=$(curl -H 'Authorization: token ea48e8665505b29e1ed550d1ae64f264eccd29a0' https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/3585/reviews | jq '.[0].user.login')
+if [ "$ASSIGNEE" == "null" ] ; then 
+  echo "No reviews on this issue."
+else
+  echo "Issue is reviewed, not assigning."
+  exit 0
+fi
+
 # This is where you add people to the random-assignee rotation.  This list
 # might not equal the list above.
 ASSIGNEE=$(shuf -n 1 <(printf "danawillow\nrambleraptor\nemilymye\nrileykarson\nSirGitsalot\nslevenick\nc2thorn\nndmckinley"))


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
If you look at https://github.com/GoogleCloudPlatform/magic-modules/pull/3585#issuecomment-637775773, you'll see that Dana was reviewing code but I was assigned as a reviewer even after her review. This has happened a couple times to me and I imagine it's been happening to everyone.

This is because Dana was never a "requested reviewer", so the list of requested reviewers appeared empty.

The Magician will now assign reviewers only if there is no requested reviewer and there is no ongoing reviews.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
