### PR TITLE
make subnetwork region forcenew and update its description

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -12902,7 +12902,7 @@ objects:
         resource: 'Region'
         imports: 'name'
         description: |
-          URL of the GCP region for this subnetwork.
+          The GCP region for this subnetwork.
         required: true
         input: true
       - !ruby/object:Api::Type::NestedObject

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -2167,7 +2167,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           function: 'validateIpCidrRange'
       region: !ruby/object:Overrides::Terraform::PropertyOverride
         required: false
-        input: false
         default_from_api: true
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
       purpose: !ruby/object:Overrides::Terraform::PropertyOverride


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6470

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed issue where trying to update the region of `google_compute_subnetwork` would fail instead of destroying/recreating the subnetwork
```
