### PR TITLE
Advanced logging config options in google_compute_subnetwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ often minor differences- the naming of a field, or whether it's required or not.
 You can find them under the folder for a product, with the name `{{tool}}.yaml`.
 For example, Ansible's overrides for Cloud SQL are present at `products/sql/ansible.yaml`
 
-You can find a full reference for each tool under `provider/{{tool}}/resource_override.rb`
-and `provider/{{tool}}/property_override.rb`, as well as some other tool-specific
+You can find a full reference for each tool under `overrides/{{tool}}/resource_override.rb`
+and `overrides/{{tool}}/property_override.rb`, as well as some other tool-specific
 functionality.
 
 #### Making changes to handwritten files

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -12971,7 +12971,7 @@ objects:
           - !ruby/object:Api::Type::Array
             name: 'metadataFields'
             description: |
-              Can only be specified if VPC flow logs for this subnetwork is enabled and "metadata" was set to CUSTOM_METADATA.
+              Can only be specified if VPC flow logs for this subnetwork is enabled and "metadata" is set to CUSTOM_METADATA.
             item_type: Api::Type::String
           - !ruby/object:Api::Type::String
             name: 'filterExpr'

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -12966,14 +12966,24 @@ objects:
             values:
               - :EXCLUDE_ALL_METADATA
               - :INCLUDE_ALL_METADATA
+              - :CUSTOM_METADATA
             default_value: :INCLUDE_ALL_METADATA
+          - !ruby/object:Api::Type::Array
+            name: 'metadataFields'
+            description: |
+              Can only be specified if VPC flow logs for this subnetwork is enabled and "metadata" was set to CUSTOM_METADATA.
+            item_type: Api::Type::String
+          - !ruby/object:Api::Type::String
+            name: 'filterExpr'
+            description: |
+              Can only be specified if VPC flow logs for this subnetwork is enabled. Export filter used to define which VPC flow logs should be logged.
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Private Google Access':
           'https://cloud.google.com/vpc/docs/configure-private-google-access'
         'Cloud Networking':
           'https://cloud.google.com/vpc/docs/using-vpc'
-      api: 'https://cloud.google.com/compute/docs/reference/rest/beta/subnetworks'
+      api: 'https://cloud.google.com/compute/docs/reference/rest/v1/subnetworks'
   - !ruby/object:Api::Resource
     name: 'TargetHttpProxy'
     kind: 'compute#targetHttpProxy'

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -12976,7 +12976,7 @@ objects:
           - !ruby/object:Api::Type::String
             name: 'filterExpr'
             description: |
-              Can only be specified if VPC flow logs for this subnetwork is enabled. Export filter used to define which VPC flow logs should be logged.
+              Export filter used to define which VPC flow logs should be logged.
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Private Google Access':

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -12977,6 +12977,7 @@ objects:
             name: 'filterExpr'
             description: |
               Export filter used to define which VPC flow logs should be logged.
+            default_value: "true"
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Private Google Access':

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -12985,7 +12985,8 @@ objects:
               - log_config.0.metadata
               - log_config.0.filterExpr
             description: |
-              Export filter used to define which VPC flow logs should be logged.
+              Export filter used to define which VPC flow logs should be logged, as as CEL expression. See
+              https://cloud.google.com/vpc/docs/flow-logs#filtering for details on how to format this field.
             default_value: "true"
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -12925,6 +12925,7 @@ objects:
               - log_config.0.aggregation_interval
               - log_config.0.flow_sampling
               - log_config.0.metadata
+              - log_config.0.filterExpr
             description: |
               Can only be specified if VPC flow logging for this subnetwork is enabled.
               Toggles the aggregation interval for collecting flow logs. Increasing the
@@ -12946,6 +12947,7 @@ objects:
               - log_config.0.aggregation_interval
               - log_config.0.flow_sampling
               - log_config.0.metadata
+              - log_config.0.filterExpr
             description: |
               Can only be specified if VPC flow logging for this subnetwork is enabled.
               The value of the field must be in [0, 1]. Set the sampling rate of VPC
@@ -12959,6 +12961,7 @@ objects:
               - log_config.0.aggregation_interval
               - log_config.0.flow_sampling
               - log_config.0.metadata
+              - log_config.0.filterExpr
             description: |
               Can only be specified if VPC flow logging for this subnetwork is enabled.
               Configures whether metadata fields should be added to the reported VPC
@@ -12971,10 +12974,16 @@ objects:
           - !ruby/object:Api::Type::Array
             name: 'metadataFields'
             description: |
+              List of metadata fields that should be added to reported logs.
               Can only be specified if VPC flow logs for this subnetwork is enabled and "metadata" is set to CUSTOM_METADATA.
             item_type: Api::Type::String
           - !ruby/object:Api::Type::String
             name: 'filterExpr'
+            at_least_one_of:
+              - log_config.0.aggregation_interval
+              - log_config.0.flow_sampling
+              - log_config.0.metadata
+              - log_config.0.filterExpr
             description: |
               Export filter used to define which VPC flow logs should be logged.
             default_value: "true"

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -2162,6 +2162,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_flatten: 'templates/terraform/custom_flatten/subnetwork_log_config.go.erb'
       logConfig.enable: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
+      logConfig.metadataFields: !ruby/object:Overrides::Terraform::PropertyOverride
+        is_set: true
       ipCidrRange: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateIpCidrRange'

--- a/templates/terraform/custom_expand/subnetwork_log_config.go.erb
+++ b/templates/terraform/custom_expand/subnetwork_log_config.go.erb
@@ -35,6 +35,14 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d T
 	transformed["aggregationInterval"] = original["aggregation_interval"]
 	transformed["flowSampling"] = original["flow_sampling"]
 	transformed["metadata"] = original["metadata"]
+	
+	// make it JSON marshallable
+	transformed["metadataFields"] = original["metadata_fields"].(*schema.Set).List()
+
+	// allow a null default (must eval to true otherwise)
+	if val := reflect.ValueOf(original["filter_expr"]); val.IsValid() && !isEmptyValue(val) {
+		transformed["filterExpr"] = original["filter_expr"]
+	}
 
 	return transformed, nil
 }

--- a/templates/terraform/custom_expand/subnetwork_log_config.go.erb
+++ b/templates/terraform/custom_expand/subnetwork_log_config.go.erb
@@ -35,14 +35,10 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d T
 	transformed["aggregationInterval"] = original["aggregation_interval"]
 	transformed["flowSampling"] = original["flow_sampling"]
 	transformed["metadata"] = original["metadata"]
+	transformed["filterExpr"] = original["filter_expr"]
 	
 	// make it JSON marshallable
 	transformed["metadataFields"] = original["metadata_fields"].(*schema.Set).List()
-
-	// allow a null default (must eval to true otherwise)
-	if val := reflect.ValueOf(original["filter_expr"]); val.IsValid() && !isEmptyValue(val) {
-		transformed["filterExpr"] = original["filter_expr"]
-	}
 
 	return transformed, nil
 }

--- a/templates/terraform/custom_flatten/subnetwork_log_config.go.erb
+++ b/templates/terraform/custom_flatten/subnetwork_log_config.go.erb
@@ -30,5 +30,8 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
 	transformed["flow_sampling"] = original["flowSampling"]
 	transformed["aggregation_interval"] = original["aggregationInterval"]
 	transformed["metadata"] = original["metadata"]
+	transformed["metadata_fields"] = original["metadataFields"]
+	transformed["filter_expr"] = original["filterExpr"]
+	
 	return []interface{}{transformed}
 }

--- a/templates/terraform/custom_flatten/subnetwork_log_config.go.erb
+++ b/templates/terraform/custom_flatten/subnetwork_log_config.go.erb
@@ -30,7 +30,16 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
 	transformed["flow_sampling"] = original["flowSampling"]
 	transformed["aggregation_interval"] = original["aggregationInterval"]
 	transformed["metadata"] = original["metadata"]
-	transformed["metadata_fields"] = original["metadataFields"]
+	if original["metadata"].(string) == "CUSTOM_METADATA" {
+		transformed["metadata_fields"] = original["metadataFields"]
+	} else {
+		// MetadataFields can only be set when metadata is CUSTOM_METADATA. However, when updating
+		// from custom to include/exclude, the API will return the previous values of the metadata fields,
+		// despite not actually having any custom fields at the moment. The API team has confirmed
+		// this as WAI (b/162771344), so we work around it by clearing the response if metadata is
+		// not custom.
+		transformed["metadata_fields"] = nil
+	}
 	transformed["filter_expr"] = original["filterExpr"]
 	
 	return []interface{}{transformed}

--- a/third_party/terraform/tests/resource_compute_subnetwork_test.go
+++ b/third_party/terraform/tests/resource_compute_subnetwork_test.go
@@ -604,12 +604,12 @@ resource "google_compute_subnetwork" "network-with-flow-logs" {
   log_config {
     aggregation_interval = "INTERVAL_30_SEC"
     flow_sampling        = 0.8
-	metadata             = "CUSTOM_METADATA"
-	metadata_fields      = [
-		"src_gke_details",
-		"dest_gke_details",
-	]
-	filter_expr          = "inIpRange(connection.src_ip, '10.0.0.0/8')"
+    metadata             = "CUSTOM_METADATA"
+    metadata_fields      = [
+        "src_gke_details",
+        "dest_gke_details",
+    ]
+    filter_expr          = "inIpRange(connection.src_ip, '10.0.0.0/8')"
   }
 }
 `, cnName, subnetworkName)

--- a/third_party/terraform/tests/resource_compute_subnetwork_test.go
+++ b/third_party/terraform/tests/resource_compute_subnetwork_test.go
@@ -225,7 +225,19 @@ func TestAccComputeSubnetwork_flowLogs(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeSubnetwork_flowLogsUpdate(cnName, subnetworkName),
+				Config: testAccComputeSubnetwork_flowLogsUpdate1(cnName, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSubnetworkExists(
+						t, "google_compute_subnetwork.network-with-flow-logs", &subnetwork),
+				),
+			},
+			{
+				ResourceName:      "google_compute_subnetwork.network-with-flow-logs",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeSubnetwork_flowLogsUpdate2(cnName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeSubnetworkExists(
 						t, "google_compute_subnetwork.network-with-flow-logs", &subnetwork),
@@ -556,7 +568,7 @@ resource "google_compute_subnetwork" "network-with-flow-logs" {
 `, cnName, subnetworkName)
 }
 
-func testAccComputeSubnetwork_flowLogsUpdate(cnName, subnetworkName string) string {
+func testAccComputeSubnetwork_flowLogsUpdate1(cnName, subnetworkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "custom-test" {
   name                    = "%s"
@@ -572,6 +584,32 @@ resource "google_compute_subnetwork" "network-with-flow-logs" {
     aggregation_interval = "INTERVAL_30_SEC"
     flow_sampling        = 0.8
     metadata             = "EXCLUDE_ALL_METADATA"
+  }
+}
+`, cnName, subnetworkName)
+}
+
+func testAccComputeSubnetwork_flowLogsUpdate2(cnName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "custom-test" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "network-with-flow-logs" {
+  name          = "%s"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.custom-test.self_link
+  log_config {
+    aggregation_interval = "INTERVAL_30_SEC"
+    flow_sampling        = 0.8
+	metadata             = "CUSTOM_METADATA"
+	metadata_fields      = [
+		"src_gke_details",
+		"dest_gke_details",
+	]
+	filter_expr          = "inIpRange(connection.src_ip, '10.0.0.0/8')"
   }
 }
 `, cnName, subnetworkName)

--- a/third_party/terraform/tests/resource_compute_subnetwork_test.go
+++ b/third_party/terraform/tests/resource_compute_subnetwork_test.go
@@ -249,6 +249,18 @@ func TestAccComputeSubnetwork_flowLogs(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
+				Config: testAccComputeSubnetwork_flowLogsUpdate3(cnName, subnetworkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSubnetworkExists(
+						t, "google_compute_subnetwork.network-with-flow-logs", &subnetwork),
+				),
+			},
+			{
+				ResourceName:      "google_compute_subnetwork.network-with-flow-logs",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccComputeSubnetwork_flowLogsDelete(cnName, subnetworkName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeSubnetworkExists(
@@ -610,6 +622,27 @@ resource "google_compute_subnetwork" "network-with-flow-logs" {
         "dest_gke_details",
     ]
     filter_expr          = "inIpRange(connection.src_ip, '10.0.0.0/8')"
+  }
+}
+`, cnName, subnetworkName)
+}
+
+func testAccComputeSubnetwork_flowLogsUpdate3(cnName, subnetworkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "custom-test" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "network-with-flow-logs" {
+  name          = "%s"
+  ip_cidr_range = "10.0.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.custom-test.self_link
+  log_config {
+    aggregation_interval = "INTERVAL_30_SEC"
+    flow_sampling        = 0.8
+    metadata             = "INCLUDE_ALL_METADATA"
   }
 }
 `, cnName, subnetworkName)


### PR DESCRIPTION
 Added custom metadata fields and filter expressions to subnetwork flow log configuration. Fixes https://github.com/hashicorp/terraform-provider-google/issues/6500

Signed-off-by: Dustin Decker <dustin.decker@getcruise.com>

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:note
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added custom metadata fields and filter expressions to `google_compute_subnetwork` flow log configuration
```
