### PR TITLE
Fix nodepool management tests with new default for autoRepair

### DIFF
--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -171,14 +171,14 @@ var schemaNodePool = map[string]*schema.Schema{
 				"auto_repair": {
 					Type:        schema.TypeBool,
 					Optional:    true,
-					Default:     true,
+					Default:     false,
 					Description: `Whether the nodes will be automatically repaired.`,
 				},
 
 				"auto_upgrade": {
 					Type:        schema.TypeBool,
 					Optional:    true,
-					Default:     true,
+					Default:     false,
 					Description: `Whether the nodes will be automatically upgraded.`,
 				},
 			},

--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -171,14 +171,14 @@ var schemaNodePool = map[string]*schema.Schema{
 				"auto_repair": {
 					Type:        schema.TypeBool,
 					Optional:    true,
-					Default:     false,
+					Default:     true,
 					Description: `Whether the nodes will be automatically repaired.`,
 				},
 
 				"auto_upgrade": {
 					Type:        schema.TypeBool,
 					Optional:    true,
-					Default:     false,
+					Default:     true,
 					Description: `Whether the nodes will be automatically upgraded.`,
 				},
 			},

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -343,8 +343,8 @@ func TestAccContainerNodePool_withManagement(t *testing.T) {
 	nodePool := fmt.Sprintf("tf-test-nodepool-%s", randString(t, 10))
 	management := `
 	management {
-		auto_repair = "true"
-		auto_upgrade = "true"
+		auto_repair = "false"
+		auto_upgrade = "false"
 	}`
 
 	vcrTest(t, resource.TestCase{
@@ -358,9 +358,9 @@ func TestAccContainerNodePool_withManagement(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"google_container_node_pool.np_with_management", "management.#", "1"),
 					resource.TestCheckResourceAttr(
-						"google_container_node_pool.np_with_management", "management.0.auto_repair", "false"),
+						"google_container_node_pool.np_with_management", "management.0.auto_repair", "true"),
 					resource.TestCheckResourceAttr(
-						"google_container_node_pool.np_with_management", "management.0.auto_repair", "false"),
+						"google_container_node_pool.np_with_management", "management.0.auto_upgrade", "true"),
 				),
 			},
 			resource.TestStep{
@@ -374,9 +374,9 @@ func TestAccContainerNodePool_withManagement(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"google_container_node_pool.np_with_management", "management.#", "1"),
 					resource.TestCheckResourceAttr(
-						"google_container_node_pool.np_with_management", "management.0.auto_repair", "true"),
+						"google_container_node_pool.np_with_management", "management.0.auto_repair", "false"),
 					resource.TestCheckResourceAttr(
-						"google_container_node_pool.np_with_management", "management.0.auto_repair", "true"),
+						"google_container_node_pool.np_with_management", "management.0.auto_repair", "false"),
 				),
 			},
 			resource.TestStep{

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -376,7 +376,7 @@ func TestAccContainerNodePool_withManagement(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"google_container_node_pool.np_with_management", "management.0.auto_repair", "false"),
 					resource.TestCheckResourceAttr(
-						"google_container_node_pool.np_with_management", "management.0.auto_repair", "false"),
+						"google_container_node_pool.np_with_management", "management.0.auto_upgrade", "false"),
 				),
 			},
 			resource.TestStep{


### PR DESCRIPTION
The API previously omitted the autoRepair option from the management block
if it wasn't provided, however as of June 3rd it is now returning true. Also
autoUpdate would default to true, but there was a bug in the test that
wasn't asserting that it was coming back false.

I believe this only would have affected people who specified the `management` block and did not explicitly set one of the two fields. If the block was missing the API defaults were being set in state.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
