### PR TITLE
add matcher attribute to contentmatchers

### DIFF
--- a/products/monitoring/api.yaml
+++ b/products/monitoring/api.yaml
@@ -1632,7 +1632,6 @@ objects:
             - :NOT_CONTAINS_STRING
             - :MATCHES_REGEX
             - :NON_MATCHES_REGEX
-          required: true
     - !ruby/object:Api::Type::Array
       name: selectedRegions
       description: The list of regions from which the check will be run. Some regions

--- a/products/monitoring/api.yaml
+++ b/products/monitoring/api.yaml
@@ -1623,6 +1623,16 @@ objects:
           name: content
           description: String or regex content to match (max 1024 bytes)
           required: true
+        - !ruby/object:Api::Type::Enum
+          name: matcher
+          description: The type of content matcher that will be applied to the server output,
+            compared to the content string when the check is run.
+          values:
+            - :CONTAINS_STRING
+            - :NOT_CONTAINS_STRING
+            - :MATCHES_REGEX
+            - :NON_MATCHES_REGEX
+          required: true
     - !ruby/object:Api::Type::Array
       name: selectedRegions
       description: The list of regions from which the check will be run. Some regions

--- a/third_party/terraform/tests/resource_monitoring_uptime_check_config_test.go
+++ b/third_party/terraform/tests/resource_monitoring_uptime_check_config_test.go
@@ -106,6 +106,7 @@ resource "google_monitoring_uptime_check_config" "http" {
 
   content_matchers {
     content = "example"
+	matcher = "CONTAINS_STRING"
   }
 }
 `, suffix, path, project, pwd, host,

--- a/third_party/terraform/tests/resource_monitoring_uptime_check_config_test.go
+++ b/third_party/terraform/tests/resource_monitoring_uptime_check_config_test.go
@@ -106,7 +106,7 @@ resource "google_monitoring_uptime_check_config" "http" {
 
   content_matchers {
     content = "example"
-	matcher = "CONTAINS_STRING"
+    matcher = "CONTAINS_STRING"
   }
 }
 `, suffix, path, project, pwd, host,


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
monitoring: added `matcher` attribute to `content_matchers` block for 
 `google_monitoring_uptime_check_config`
```
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/4591
