### PR TITLE
Add note on iap client that only internal org clients can be created

### DIFF
--- a/products/iap/api.yaml
+++ b/products/iap/api.yaml
@@ -182,6 +182,10 @@ objects:
     input: true
     description: |
       Contains the data that describes an Identity Aware Proxy owned client.
+
+      ~> **Note:** Only internal org clients can be created via declarative tools. Other types of clients must be
+      manually created via the GCP console. This restriction is due to the existing APIs and not lack of support
+      in this tool.
     parameters:
       - !ruby/object:Api::Type::String
         name: 'clientId'


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
