### PR TITLE
Send empty value for range_partitioning.range.start in google_bigquery_table

### DIFF
--- a/third_party/terraform/resources/resource_bigquery_table.go
+++ b/third_party/terraform/resources/resource_bigquery_table.go
@@ -992,9 +992,10 @@ func expandRangePartitioning(configured interface{}) (*bigquery.RangePartitionin
 
 		rangeJson := rangeLs[0].(map[string]interface{})
 		rp.Range = &bigquery.RangePartitioningRange{
-			Start:    int64(rangeJson["start"].(int)),
-			End:      int64(rangeJson["end"].(int)),
-			Interval: int64(rangeJson["interval"].(int)),
+			Start:           int64(rangeJson["start"].(int)),
+			End:             int64(rangeJson["end"].(int)),
+			Interval:        int64(rangeJson["interval"].(int)),
+			ForceSendFields: []string{"Start"},
 		}
 	}
 

--- a/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -428,7 +428,7 @@ func testAccBigQueryTableRangePartitioning(datasetID, tableID string) string {
 		range_partitioning {
 			field = "id"
 			range {
-				start    = 1
+				start    = 0
 				end      = 10000
 				interval = 100
 			}


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6525

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquery: Fixed range_partitioning.range.start so that the value `0` is sent in `google_bigquery_table`
```
