### PR TITLE
Add timeoutSeconds to cloud run

### DIFF
--- a/products/cloudrun/api.yaml
+++ b/products/cloudrun/api.yaml
@@ -540,6 +540,10 @@ objects:
                 the default value.
             - `1` not-thread-safe. Single concurrency
             - `2-N` thread-safe, max concurrency of N
+        - !ruby/object:Api::Type::Integer
+          name: timeoutSeconds
+          description: |-
+            TimeoutSeconds holds the max duration the instance is allowed for responding to a request.
         - !ruby/object:Api::Type::String
           name: serviceAccountName
           description:  |-

--- a/products/cloudrun/terraform.yaml
+++ b/products/cloudrun/terraform.yaml
@@ -152,6 +152,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       spec.template.spec.containerConcurrency: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      spec.template.spec.timeoutSeconds: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       spec.template.spec.containers: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       spec.template.spec.containers.resources: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/third_party/terraform/tests/resource_cloud_run_service_test.go
+++ b/third_party/terraform/tests/resource_cloud_run_service_test.go
@@ -18,7 +18,7 @@ func TestAccCloudRunService_cloudRunServiceUpdate(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "10"),
+				Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "10", "600"),
 			},
 			{
 				ResourceName:            "google_cloud_run_service.default",
@@ -27,7 +27,7 @@ func TestAccCloudRunService_cloudRunServiceUpdate(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"metadata.0.resource_version", "status.0.conditions"},
 			},
 			{
-				Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "50"),
+				Config: testAccCloudRunService_cloudRunServiceUpdate(name, project, "50", "300"),
 			},
 			{
 				ResourceName:            "google_cloud_run_service.default",
@@ -39,7 +39,7 @@ func TestAccCloudRunService_cloudRunServiceUpdate(t *testing.T) {
 	})
 }
 
-func testAccCloudRunService_cloudRunServiceUpdate(name, project, concurrency string) string {
+func testAccCloudRunService_cloudRunServiceUpdate(name, project, concurrency, timeoutSeconds string) string {
 	return fmt.Sprintf(`
 resource "google_cloud_run_service" "default" {
   name     = "%s"
@@ -56,6 +56,7 @@ resource "google_cloud_run_service" "default" {
         args  = ["arrgs"]
       }
 	  container_concurrency = %s
+	  timeout_seconds = %s
     }
   }
 
@@ -64,5 +65,5 @@ resource "google_cloud_run_service" "default" {
     latest_revision = true
   }
 }
-`, name, project, concurrency)
+`, name, project, concurrency, timeoutSeconds)
 }


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5924

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrun: added `template.spec.timeout_seconds` to `google_cloud_run_service`
```
