### PR TITLE
Added support for redis instance data source

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_redis_instance.go
+++ b/third_party/terraform/data_sources/data_source_google_redis_instance.go
@@ -1,0 +1,29 @@
+package google
+
+import "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+
+func dataSourceGoogleRedisInstance() *schema.Resource {
+	// Generate datasource schema from resource
+	dsSchema := datasourceSchemaFromResourceSchema(resourceRedisInstance().Schema)
+
+	// Set 'Required' schema elements
+	addRequiredFieldsToSchema(dsSchema, "name")
+
+	// Set 'Optional' schema elements
+	addOptionalFieldsToSchema(dsSchema, "project", "region")
+
+	return &schema.Resource{
+		Read:   dataSourceGoogleRedisInstanceRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceGoogleRedisInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	id, err := replaceVars(d, meta.(*Config), "projects/{{project}}/locations/{{region}}/instances/{{name}}")
+	if err != nil {
+		return err
+	}
+	d.SetId(id)
+
+	return resourceRedisInstanceRead(d, meta)
+}

--- a/third_party/terraform/tests/data_source_google_redis_instance_test.go
+++ b/third_party/terraform/tests/data_source_google_redis_instance_test.go
@@ -1,0 +1,38 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccRedisInstanceDatasource_basic(t *testing.T) {
+	t.Parallel()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRedisInstanceDatasourceConfig(randString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceStateMatchesResourceState("data.google_redis_instance.redis", "google_redis_instance.redis"),
+				),
+			},
+		},
+	})
+}
+
+func testAccRedisInstanceDatasourceConfig(suffix string) string {
+	return fmt.Sprintf(`
+resource "google_redis_instance" "redis" {
+  name               = "redis-test-%s"
+  memory_size_gb     = 1
+}
+
+data "google_redis_instance" "redis" {
+  name = "${google_redis_instance.redis.name}"
+}
+`, suffix)
+}

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -210,6 +210,7 @@ func Provider() terraform.ResourceProvider {
 			"google_storage_project_service_account":           dataSourceGoogleStorageProjectServiceAccount(),
 			"google_storage_transfer_project_service_account":  dataSourceGoogleStorageTransferProjectServiceAccount(),
 			"google_tpu_tensorflow_versions":                   dataSourceTpuTensorflowVersions(),
+			"google_redis_instance":                            dataSourceGoogleRedisInstance(),
 		},
 
 		ResourcesMap: ResourceMap(),

--- a/third_party/terraform/website/docs/d/datasource_google_redis_instance.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_redis_instance.html.markdown
@@ -35,12 +35,80 @@ The following arguments are supported:
 * `region` - (Optional) The region in which the resource belongs. If it
     is not provided, the provider region is used.
 
-
 ## Attributes Reference
 
-The following attributes are exported:
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `memory_size_gb` -
+  Redis memory size in GiB.
+
+* `alternative_location_id` -
+  Only applicable to STANDARD_HA tier which protects the instance
+  against zonal failures by provisioning it across two zones.
+  If provided, it must be a different zone from the one provided in
+  [locationId].
+
+* `authorized_network` -
+  The full name of the Google Compute Engine network to which the
+  instance is connected. If left unspecified, the default network
+  will be used.
+
+* `connect_mode` -
+  The connection mode of the Redis instance.
+
+* `display_name` -
+  An arbitrary and optional user-provided name for the instance.
+
+* `labels` -
+  Resource labels to represent user provided metadata.
+
+* `redis_configs` -
+  Redis configuration parameters, according to http://redis.io/topics/config.
+  Please check Memorystore documentation for the list of supported parameters:
+  https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Instance.FIELDS.redis_configs
+
+* `location_id` -
+  The zone where the instance will be provisioned. If not provided,
+  the service will choose a zone for the instance. For STANDARD_HA tier,
+  instances will be created across two zones for protection against
+  zonal failures. If [alternativeLocationId] is also provided, it must
+  be different from [locationId].
+
+* `redis_version` -
+  The version of Redis software. If not provided, latest supported
+  version will be used. Currently, the supported values are:
+  - REDIS_4_0 for Redis 4.0 compatibility
+  - REDIS_3_2 for Redis 3.2 compatibility
+
+* `reserved_ip_range` -
+  The CIDR range of internal addresses that are reserved for this
+  instance. If not provided, the service will choose an unused /29
+  block, for example, 10.0.0.0/29 or 192.168.0.0/29. Ranges must be
+  unique and non-overlapping with existing subnets in an authorized
+  network.
+
+* `tier` -
+  The service tier of the instance. Must be one of these values:
+  - BASIC: standalone instance
+  - STANDARD_HA: highly available primary/replica instances
+
+  Default value: `BASIC`
+  Possible values are:
+  * `BASIC`
+  * `STANDARD_HA`
 
 * `host` - Hostname or IP address of the exposed Redis endpoint used by clients
   to connect to the service.
 
 * `port` - The port number of the exposed Redis endpoint.
+
+* `create_time` -
+  The time the instance was created in RFC3339 UTC "Zulu" format,
+  accurate to nanoseconds.
+
+* `current_location_id` -
+  The current zone where the Redis endpoint is placed.
+  For Basic Tier instances, this will always be the same as the
+  [locationId] provided by the user at creation time. For Standard Tier
+  instances, this can be either [locationId] or [alternativeLocationId]
+  and can change after a failover event.

--- a/third_party/terraform/website/docs/d/datasource_google_redis_instance.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_redis_instance.html.markdown
@@ -1,0 +1,46 @@
+---
+subcategory: "Memorystore (Redis)"
+layout: "google"
+page_title: "Google: google_redis_instance"
+sidebar_current: "docs-google-datasource-redis-instance"
+description: |-
+  Get information about a Google Cloud Redis instance.
+---
+
+# google\_redis\_instance
+
+Get information about a Google Cloud Redis instance. For more information see
+the [official documentation](https://cloud.google.com/memorystore/docs/redis)
+and [API](https://cloud.google.com/memorystore/docs/redis/apis).
+
+## Example Usage
+
+```hcl
+data "google_redis_instance" "default" {
+  name = "my-redis-instance"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of a Redis instance.
+
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `region` - (Optional) The region in which the resource belongs. If it
+    is not provided, the provider region is used.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `host` - Hostname or IP address of the exposed Redis endpoint used by clients
+  to connect to the service.
+
+* `port` - The port number of the exposed Redis endpoint.


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
`google_redis_instance`
```
