### PR TITLE
Fix and document id format for google_kms_crypto_key_version.

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_kms_crypto_key_version.go
+++ b/third_party/terraform/data_sources/data_source_google_kms_crypto_key_version.go
@@ -117,7 +117,7 @@ func dataSourceGoogleKmsCryptoKeyVersionRead(d *schema.ResourceData, meta interf
 			return fmt.Errorf("Error reading CryptoKeyVersion public key: %s", err)
 		}
 	}
-	d.SetId(fmt.Sprintf("//cloudkms.googleapis.com/%s/cryptoKeyVersions/%d", d.Get("crypto_key"), d.Get("version")))
+	d.SetId(fmt.Sprintf("//cloudkms.googleapis.com/v1/%s/cryptoKeyVersions/%d", d.Get("crypto_key"), d.Get("version")))
 
 	return nil
 }

--- a/third_party/terraform/website/docs/d/google_kms_crypto_key_version.html.markdown
+++ b/third_party/terraform/website/docs/d/google_kms_crypto_key_version.html.markdown
@@ -47,6 +47,8 @@ The following arguments are supported:
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
+* `id` - an identifier for the resource with format `//cloudkms.googleapis.com/v1/{{crypto_key}}/cryptoKeyVersions/{{version}}`
+
 * `state` - The current state of the CryptoKeyVersion. See the [state reference](https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys.cryptoKeyVersions#CryptoKeyVersion.CryptoKeyVersionState) for possible outputs.
 
 * `protection_level` - The ProtectionLevel describing how crypto operations are performed with this CryptoKeyVersion. See the [protection_level reference](https://cloud.google.com/kms/docs/reference/rest/v1/ProtectionLevel) for possible outputs.


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6538

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
kms: fixed the `id` value in the `google_kms_crypto_key_version` datasource to include an `/v1` part following `//cloudkms.googleapis.com/`, making it useful for interpolation into Binary Authorization.
```
