### PR TITLE
Add cloudbuild invert regex option

### DIFF
--- a/products/cloudbuild/api.yaml
+++ b/products/cloudbuild/api.yaml
@@ -133,6 +133,11 @@ objects:
               This must be a relative path. If a step's dir is specified and
               is an absolute path, this value is ignored for that step's
               execution.
+
+          - !ruby/object:Api::Type::Boolean
+            name: 'invertRegex'
+            description: |
+              Only trigger a build if the revision regex does NOT match the revision regex.
           - !ruby/object:Api::Type::String
             name: 'branchName'
             description: |
@@ -198,6 +203,10 @@ objects:
                 values:
                   - :COMMENTS_DISABLED
                   - :COMMENTS_ENABLED
+              - !ruby/object:Api::Type::Boolean
+                name: 'invertRegex'
+                description: |
+                    If true, branches that do NOT match the git_ref will trigger a build.
           - !ruby/object:Api::Type::NestedObject
             name: 'push'
             description: |
@@ -206,6 +215,10 @@ objects:
               - github.0.pull_request
               - github.0.push
             properties:
+              - !ruby/object:Api::Type::Boolean
+                name: 'invertRegex'
+                description: |
+                    When true, only trigger a build if the revision regex does NOT match the git_ref regex.
               - !ruby/object:Api::Type::String
                 name: 'branch'
                 description: |

--- a/third_party/terraform/tests/resource_cloudbuild_trigger_test.go
+++ b/third_party/terraform/tests/resource_cloudbuild_trigger_test.go
@@ -194,6 +194,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
   trigger_template {
     branch_name = "master"
     repo_name   = "some-repo"
+	invertRegex = false
   }
   build {
     images = ["gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA"]
@@ -221,6 +222,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
   trigger_template {
     branch_name = "master-updated"
     repo_name   = "some-repo-updated"
+	invertRegex = true
   }
   build {
     images = ["gcr.io/$PROJECT_ID/$REPO_NAME:$SHORT_SHA"]

--- a/third_party/terraform/tests/resource_cloudbuild_trigger_test.go
+++ b/third_party/terraform/tests/resource_cloudbuild_trigger_test.go
@@ -194,7 +194,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
   trigger_template {
     branch_name = "master"
     repo_name   = "some-repo"
-	invertRegex = false
+	invert_regex = false
   }
   build {
     images = ["gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA"]
@@ -222,7 +222,7 @@ resource "google_cloudbuild_trigger" "build_trigger" {
   trigger_template {
     branch_name = "master-updated"
     repo_name   = "some-repo-updated"
-	invertRegex = true
+	invert_regex = true
   }
   build {
     images = ["gcr.io/$PROJECT_ID/$REPO_NAME:$SHORT_SHA"]


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**PR Description**

```release-note:enhancement
cloudbuild: Added invert_regex flag in Github PullRequestFilter and PushFilter + in triggerTemplate
```
