### PR TITLE
Add SHARED_LOADBALANCER_VIP as option for google_compute_address.purpose

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -138,7 +138,7 @@ objects:
           The purpose of this resource, which can be one of the following values:
           - GCE_ENDPOINT for addresses that are used by VM instances, alias IP ranges, internal load balancers, and similar resources.
           This should only be set when using an Internal address.
-          - SHARED_LOADBALANCER_VIP for address that can be used by multiple internal load balancers
+          - SHARED_LOADBALANCER_VIP for an address that can be used by multiple internal load balancers
         values:
           - :GCE_ENDPOINT
           - :SHARED_LOADBALANCER_VIP

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -122,6 +122,7 @@ objects:
         required: true
       - !ruby/object:Api::Type::Enum
         name: purpose
+        exact_version: ga
         description: |
           The purpose of this resource, which can be one of the following values:
 
@@ -130,6 +131,17 @@ objects:
           This should only be set when using an Internal address.
         values:
           - :GCE_ENDPOINT
+      - !ruby/object:Api::Type::Enum
+        name: purpose
+        exact_version: beta
+        description: |
+          The purpose of this resource, which can be one of the following values:
+          - GCE_ENDPOINT for addresses that are used by VM instances, alias IP ranges, internal load balancers, and similar resources.
+          This should only be set when using an Internal address.
+          - SHARED_LOADBALANCER_VIP for address that can be used by multiple internal load balancers
+        values:
+          - :GCE_ENDPOINT
+          - :SHARED_LOADBALANCER_VIP
       - !ruby/object:Api::Type::Enum
         name: 'networkTier'
         description: |

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -137,8 +137,8 @@ objects:
         description: |
           The purpose of this resource, which can be one of the following values:
           - GCE_ENDPOINT for addresses that are used by VM instances, alias IP ranges, internal load balancers, and similar resources.
-          This should only be set when using an Internal address.
           - SHARED_LOADBALANCER_VIP for an address that can be used by multiple internal load balancers
+          This should only be set when using an Internal address.
         values:
           - :GCE_ENDPOINT
           - :SHARED_LOADBALANCER_VIP

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -38,6 +38,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         min_version: 'beta'
         vars:
           address_name: "my-internal-address"
+        skip_docs: true  # It is almost identical to internal_with_gce_endpoint 
       # TODO(rileykarson): Remove this example when instance is supported
       - !ruby/object:Provider::Terraform::Examples
         name: "instance_with_ip"

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -32,6 +32,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "internal_with_gce_endpoint"
         vars:
           address_name: "my-internal-address-"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "address_with_shared_loadbalancer_vip"
+        primary_resource_id: "internal_with_shared_loadbalancer_vip"
+        min_version: 'beta'
+        vars:
+          address_name: "my-internal-address"
       # TODO(rileykarson): Remove this example when instance is supported
       - !ruby/object:Provider::Terraform::Examples
         name: "instance_with_ip"

--- a/templates/terraform/examples/address_with_shared_loadbalancer_vip.tf.erb
+++ b/templates/terraform/examples/address_with_shared_loadbalancer_vip.tf.erb
@@ -1,0 +1,6 @@
+resource "google_compute_address" "<%= ctx[:primary_resource_id] %>" {
+  provider     = google-beta 
+  name         = "<%= ctx[:vars]['address_name'] %>"
+  address_type = "INTERNAL"
+  purpose      = "SHARED_LOADBALANCER_VIP"
+}


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6499

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Add SHARED_LOADBALANCER_VIP as option for google_compute_address.purpose (beta only)
```
