### PR TITLE
Add HA requirements to SQL docs

### DIFF
--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -147,7 +147,10 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 							// configuration.
 							Computed:     true,
 							ValidateFunc: validation.StringInSlice([]string{"REGIONAL", "ZONAL"}, false),
-							Description:  `The availability type of the Cloud SQL instance, high availability (REGIONAL) or single zone (ZONAL).'`,
+							Description:  `The availability type of the Cloud SQL instance, high availability
+(REGIONAL) or single zone (ZONAL). For MySQL instances, ensure that
+settings.backup_configuration.enabled and
+settings.backup_configuration.binary_log_enabled are both set to true.`,
 						},
 						"backup_configuration": {
 							Type:     schema.TypeList,

--- a/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -240,7 +240,10 @@ The required `settings` block supports:
     for information on how to upgrade to Second Generation instances.
     A list of Google App Engine (GAE) project names that are allowed to access this instance.
 
-* `availability_type` - (Optional) The availability type of the Cloud SQL instance, high availability (`REGIONAL`) or single zone (`ZONAL`).'
+* `availability_type` - (Optional) The availability type of the Cloud SQL
+instance, high availability (`REGIONAL`) or single zone (`ZONAL`).' For MySQL
+instances, ensure that `settings.backup_configuration.enabled` and
+`settings.backup_configuration.binary_log_enabled` are both set to `true`.
 
 * `crash_safe_replication` - (Optional, Deprecated) This property is only applicable to First Generation instances.
     First Generation instances are now deprecated, see [here](https://cloud.google.com/sql/docs/mysql/upgrade-2nd-gen)


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6573

There's no great authoritative doc, but I've ran into users hitting this issue a few times. Sending a request with either field disabled results in a cryptic error message about sending an invalid request.

Actually, this _contradicts_ the docs by my read: https://cloud.google.com/sql/docs/mysql/high-availability#backups-and-restores

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
