### PR TITLE
add min_node_cpus to compute_instance.scheduling

### DIFF
--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -116,7 +116,7 @@ module Provider
                        ['google/compute_shared_operation.go',
                         'third_party/terraform/utils/compute_shared_operation.go'],
                        ['google/compute_instance_helpers.go',
-                        'third_party/terraform/utils/compute_instance_helpers.go'],
+                        'third_party/terraform/utils/compute_instance_helpers.go.erb'],
                        ['google/convert.go',
                         'third_party/terraform/utils/convert.go'],
                        ['google/metadata.go',

--- a/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -1,3 +1,5 @@
+// <% autogen_exception -%>
+
 package google
 
 import (
@@ -42,6 +44,9 @@ var (
 		"scheduling.0.automatic_restart",
 		"scheduling.0.preemptible",
 		"scheduling.0.node_affinities",
+<% unless version == 'ga' -%>
+		"scheduling.0.min_node_cpus",
+<% end -%>
 	}
 
 	shieldedInstanceConfigKeys = []string{
@@ -458,6 +463,13 @@ func resourceComputeInstance() *schema.Resource {
 							Elem:             instanceSchedulingNodeAffinitiesElemSchema(),
 							DiffSuppressFunc: emptyOrDefaultStringSuppress(""),
 						},
+<% unless version == 'ga' -%>
+						"min_node_cpus": {
+							Type:             schema.TypeInt,
+							Optional:         true,
+							AtLeastOneOf:     schedulingKeys,
+						},
+<% end -%>
 					},
 				},
 			},

--- a/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -1,3 +1,5 @@
+// <% autogen_exception -%>
+
 package google
 
 import (
@@ -21,6 +23,9 @@ var (
 		"scheduling.0.automatic_restart",
 		"scheduling.0.preemptible",
 		"scheduling.0.node_affinities",
+<% unless version == 'ga' -%>
+		"scheduling.0.min_node_cpus",
+<% end -%>
 	}
 
 	shieldedInstanceTemplateConfigKeys = []string{
@@ -384,6 +389,13 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 							Elem:             instanceSchedulingNodeAffinitiesElemSchema(),
 							DiffSuppressFunc: emptyOrDefaultStringSuppress(""),
 						},
+<% unless version == 'ga' -%>
+						"min_node_cpus": {
+							Type:             schema.TypeInt,
+							Optional:         true,
+							AtLeastOneOf:     schedulingInstTemplateKeys,
+						},
+<% end -%>
 					},
 				},
 			},

--- a/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
@@ -1,3 +1,5 @@
+// <% autogen_exception -%>
+
 package google
 
 import (
@@ -1960,7 +1962,7 @@ data "google_compute_image" "my_image" {
 
 resource "google_compute_instance_template" "foobar" {
   name         = "instancet-test-%s"
-  machine_type = "n1-standard-1"
+  machine_type = "n1-standard-4"
 
   disk {
     source_image = data.google_compute_image.my_image.self_link
@@ -1980,6 +1982,10 @@ resource "google_compute_instance_template" "foobar" {
       operator = "IN"
       values   = ["testinstancetemplate"]
     }
+
+<% unless version == 'ga' -%>
+    min_node_cpus = 2
+<% end -%>
   }
 
   service_account {

--- a/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -1,3 +1,5 @@
+// <% autogen_exception -%>
+
 package google
 
 import (
@@ -4303,7 +4305,7 @@ data "google_compute_image" "my_image" {
 
 resource "google_compute_instance" "foobar" {
   name         = "%s"
-  machine_type = "n1-standard-2"
+  machine_type = "n1-standard-8"
   zone         = "us-central1-a"
 
   boot_disk {
@@ -4334,6 +4336,10 @@ resource "google_compute_instance" "foobar" {
       operator = "IN"
       values   = [google_compute_node_group.nodes.name]
     }
+
+<% unless version == 'ga' -%>
+    min_node_cpus = 4
+<% end -%>
   }
 }
 
@@ -4349,7 +4355,7 @@ resource "google_compute_node_template" "nodetmpl" {
     tfacc = "test"
   }
 
-  node_type = data.google_compute_node_types.central1a.names[0]
+  node_type = data.google_compute_node_types.central1a.names[1]
 }
 
 resource "google_compute_node_group" "nodes" {
@@ -4371,7 +4377,7 @@ data "google_compute_image" "my_image" {
 
 resource "google_compute_instance" "foobar" {
   name         = "%s"
-  machine_type = "n1-standard-2"
+  machine_type = "n1-standard-8"
   zone         = "us-central1-a"
 
   boot_disk {
@@ -4402,6 +4408,10 @@ resource "google_compute_instance" "foobar" {
       operator = "IN"
       values   = [google_compute_node_group.nodes.name]
     }
+
+<% unless version == 'ga' -%>
+    min_node_cpus = 6
+<% end -%>
   }
 }
 
@@ -4417,7 +4427,7 @@ resource "google_compute_node_template" "nodetmpl" {
     tfacc = "test"
   }
 
-  node_type = data.google_compute_node_types.central1a.names[0]
+  node_type = data.google_compute_node_types.central1a.names[1]
 }
 
 resource "google_compute_node_group" "nodes" {

--- a/third_party/terraform/utils/compute_instance_helpers.go.erb
+++ b/third_party/terraform/utils/compute_instance_helpers.go.erb
@@ -1,3 +1,5 @@
+// <% autogen_exception -%>
+
 package google
 
 import (
@@ -91,7 +93,6 @@ func expandScheduling(v interface{}) (*computeBeta.Scheduling, error) {
 	if v, ok := original["preemptible"]; ok {
 		scheduling.Preemptible = v.(bool)
 		scheduling.ForceSendFields = append(scheduling.ForceSendFields, "Preemptible")
-
 	}
 
 	if v, ok := original["on_host_maintenance"]; ok {
@@ -117,6 +118,12 @@ func expandScheduling(v interface{}) (*computeBeta.Scheduling, error) {
 		}
 	}
 
+<% unless version == 'ga' -%>
+	if v, ok := original["min_node_cpus"]; ok {
+		scheduling.MinNodeCpus = int64(v.(int))
+	}
+<% end -%>
+
 	return scheduling, nil
 }
 
@@ -124,6 +131,9 @@ func flattenScheduling(resp *computeBeta.Scheduling) []map[string]interface{} {
 	schedulingMap := map[string]interface{}{
 		"on_host_maintenance": resp.OnHostMaintenance,
 		"preemptible":         resp.Preemptible,
+<% unless version == 'ga' -%>
+		"min_node_cpus":       resp.MinNodeCpus,
+<% end -%>
 	}
 
 	if resp.AutomaticRestart != nil {
@@ -373,6 +383,12 @@ func schedulingHasChange(d *schema.ResourceData) bool {
 	if oScheduling["on_host_maintenance"] != newScheduling["on_host_maintenance"] {
 		return true
 	}
+
+<% unless version == 'ga' -%>
+	if oScheduling["min_node_cpus"] != newScheduling["min_node_cpus"] {
+		return true
+	}
+<% end -%>
 
 	return reflect.DeepEqual(newNa, originalNa)
 }


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5416

Add `min_node_cpus` to `compute_instance.scheduling` and `compute_instance_template.scheduling`

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `min_node_cpus` to the `scheduling` blocks on `compute_instance` and `compute_instance_template`
```
