### PR TITLE
Per instance config delete underlying instance

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1323,11 +1323,19 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - :REFRESH
           - :NONE
         default_value: :REPLACE
+      - !ruby/object:Api::Type::Boolean
+        name: 'remove_instance_state_on_destroy'
+        description: |
+          When true, deleting this config will immediately remove any specified state from the underlying instance.
+          When false, deleting this config will *not* immediately remove any state from the underlying instance.
+          State will be removed on the next instance recreation or update.
+        default_value: false
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       encoder: templates/terraform/encoders/compute_per_instance_config.go.erb
       update_encoder: templates/terraform/update_encoder/compute_per_instance_config.go.erb
       pre_delete: templates/terraform/pre_delete/compute_per_instance_config.go.erb
       post_update: templates/terraform/post_update/compute_per_instance_config.go.erb
+      custom_delete: templates/terraform/custom_delete/per_instance_config.go.erb
   RegionPerInstanceConfig: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: "{{project}}/{{region}}/{{region_instance_group_manager}}/{{name}}"
     mutex: instangeGroupManager/{{project}}/{{region}}/{{region_instance_group_manager}}
@@ -1387,7 +1395,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       update_encoder: templates/terraform/update_encoder/compute_per_instance_config.go.erb
       pre_delete: templates/terraform/pre_delete/compute_per_instance_config.go.erb
       post_update: templates/terraform/post_update/compute_region_per_instance_config.go.erb
-
+      custom_delete: templates/terraform/custom_delete/region_per_instance_config.go.erb
   ProjectInfo: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true
   Region: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1271,7 +1271,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
 
   PerInstanceConfig: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: "{{project}}/{{zone}}/{{instance_group_manager}}/{{name}}"
-    mutex: instangeGroupManager/{{project}}/{{zone}}/{{instance_group_manager}}
+    mutex: instanceGroupManager/{{project}}/{{zone}}/{{instance_group_manager}}
     # Fine-grained resources don't actually exist as standalone GCP resource
     # in Cloud Asset Inventory
     exclude_validator: true
@@ -1338,7 +1338,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       custom_delete: templates/terraform/custom_delete/per_instance_config.go.erb
   RegionPerInstanceConfig: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: "{{project}}/{{region}}/{{region_instance_group_manager}}/{{name}}"
-    mutex: instangeGroupManager/{{project}}/{{region}}/{{region_instance_group_manager}}
+    mutex: instanceGroupManager/{{project}}/{{region}}/{{region_instance_group_manager}}
     # Fine-grained resources don't actually exist as standalone GCP resource
     # in Cloud Asset Inventory
     exclude_validator: true
@@ -1390,6 +1390,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - :REFRESH
           - :NONE
         default_value: :REPLACE
+      - !ruby/object:Api::Type::Boolean
+        name: 'remove_instance_state_on_destroy'
+        description: |
+          When true, deleting this config will immediately remove any specified state from the underlying instance.
+          When false, deleting this config will *not* immediately remove any state from the underlying instance.
+          State will be removed on the next instance recreation or update.
+        default_value: false
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       encoder: templates/terraform/encoders/compute_per_instance_config.go.erb
       update_encoder: templates/terraform/update_encoder/compute_per_instance_config.go.erb

--- a/templates/terraform/custom_delete/per_instance_config.go.erb
+++ b/templates/terraform/custom_delete/per_instance_config.go.erb
@@ -1,0 +1,69 @@
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	lockName, err := replaceVars(d, config, "instangeGroupManager/{{project}}/{{zone}}/{{instance_group_manager}}")
+	if err != nil {
+		return err
+	}
+	mutexKV.Lock(lockName)
+	defer mutexKV.Unlock(lockName)
+
+	url, err := replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{instance_group_manager}}/deletePerInstanceConfigs")
+	if err != nil {
+		return err
+	}
+
+	var obj map[string]interface{}
+	obj = map[string]interface{}{
+		"names": [1]string{d.Get("name").(string)},
+	}
+	log.Printf("[DEBUG] Deleting PerInstanceConfig %q", d.Id())
+
+	res, err := sendRequestWithTimeout(config, "POST", project, url, obj, d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return handleNotFoundError(err, d, "PerInstanceConfig")
+	}
+
+	err = computeOperationWaitTime(
+		config, res, project, "Deleting PerInstanceConfig",
+		d.Timeout(schema.TimeoutDelete))
+
+	if err != nil {
+		return err
+	}
+
+	// Potentially delete the state managed by this config
+	if d.Get("remove_instance_state_on_destroy").(bool) {
+		// Instance name in applyUpdatesToInstances request must include zone
+		instanceName, err := replaceVars(d, config, "zones/{{zone}}/instances/{{name}}")
+		if err != nil {
+			return err
+		}
+
+		obj = make(map[string]interface{})
+		obj["instances"] = []string{instanceName}
+
+		// The deletion must be applied to the instance after the PerInstanceConfig is deleted
+		url, err = replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{instance_group_manager}}/applyUpdatesToInstances")
+		if err != nil {
+			return err
+		}
+
+		log.Printf("[DEBUG] Applying updates to PerInstanceConfig %q: %#v", d.Id(), obj)
+		res, err = sendRequestWithTimeout(config, "POST", project, url, obj, d.Timeout(schema.TimeoutUpdate))
+
+		if err != nil {
+			return fmt.Errorf("Error updating PerInstanceConfig %q: %s", d.Id(), err)
+		}
+
+		err = computeOperationWaitTime(
+			config, res, project, "Applying update to PerInstanceConfig",
+			d.Timeout(schema.TimeoutUpdate))
+	}
+
+	log.Printf("[DEBUG] Finished deleting PerInstanceConfig %q: %#v", d.Id(), res)
+	return nil

--- a/templates/terraform/custom_delete/per_instance_config.go.erb
+++ b/templates/terraform/custom_delete/per_instance_config.go.erb
@@ -5,7 +5,7 @@
 		return err
 	}
 
-	lockName, err := replaceVars(d, config, "instangeGroupManager/{{project}}/{{zone}}/{{instance_group_manager}}")
+	lockName, err := replaceVars(d, config, "instanceGroupManager/{{project}}/{{zone}}/{{instance_group_manager}}")
 	if err != nil {
 		return err
 	}
@@ -57,12 +57,21 @@
 		res, err = sendRequestWithTimeout(config, "POST", project, url, obj, d.Timeout(schema.TimeoutUpdate))
 
 		if err != nil {
-			return fmt.Errorf("Error updating PerInstanceConfig %q: %s", d.Id(), err)
+			return fmt.Errorf("Error deleting PerInstanceConfig %q: %s", d.Id(), err)
 		}
 
 		err = computeOperationWaitTime(
 			config, res, project, "Applying update to PerInstanceConfig",
 			d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return fmt.Errorf("Error deleting PerInstanceConfig %q: %s", d.Id(), err)
+		}
+
+		// PerInstanceConfig goes into "DELETING" state while the instance is actually deleted
+		err = PollingWaitTime(resourceComputePerInstanceConfigPollRead(d, meta), PollCheckInstanceConfigDeleted, "Deleting PerInstanceConfig", d.Timeout(schema.TimeoutDelete))
+		if err != nil {
+			return fmt.Errorf("Error waiting for delete on PerInstanceConfig %q: %s", d.Id(), err)
+		}		
 	}
 
 	log.Printf("[DEBUG] Finished deleting PerInstanceConfig %q: %#v", d.Id(), res)

--- a/templates/terraform/custom_delete/region_per_instance_config.go.erb
+++ b/templates/terraform/custom_delete/region_per_instance_config.go.erb
@@ -5,7 +5,7 @@
 		return err
 	}
 
-	lockName, err := replaceVars(d, config, "instangeGroupManager/{{project}}/{{region}}/{{region_instance_group_manager}}")
+	lockName, err := replaceVars(d, config, "instanceGroupManager/{{project}}/{{region}}/{{region_instance_group_manager}}")
 	if err != nil {
 		return err
 	}
@@ -38,8 +38,8 @@
 
 	// Potentially delete the state managed by this config
 	if d.Get("remove_instance_state_on_destroy").(bool) {
-		// Instance name in applyUpdatesToInstances request must include region
-		instanceName, err := replaceVars(d, config, "regoins/{{region}}/instances/{{name}}")
+		// Instance name in applyUpdatesToInstances request must include zone
+		instanceName, err := findInstanceName(d, config)
 		if err != nil {
 			return err
 		}
@@ -48,7 +48,7 @@
 		obj["instances"] = []string{instanceName}
 
 		// Updates must be applied to the instance after deleting the PerInstanceConfig
-		url, err = replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{instance_group_manager}}/applyUpdatesToInstances")
+		url, err = replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceGroupManagers/{{region_instance_group_manager}}/applyUpdatesToInstances")
 		if err != nil {
 			return err
 		}
@@ -63,6 +63,16 @@
 		err = computeOperationWaitTime(
 			config, res, project, "Applying update to PerInstanceConfig",
 			d.Timeout(schema.TimeoutUpdate))
+
+		if err != nil {
+			return fmt.Errorf("Error deleting PerInstanceConfig %q: %s", d.Id(), err)
+		}
+
+		// RegionPerInstanceConfig goes into "DELETING" state while the instance is actually deleted
+		err = PollingWaitTime(resourceComputeRegionPerInstanceConfigPollRead(d, meta), PollCheckInstanceConfigDeleted, "Deleting RegionPerInstanceConfig", d.Timeout(schema.TimeoutDelete))
+		if err != nil {
+			return fmt.Errorf("Error waiting for delete on RegionPerInstanceConfig %q: %s", d.Id(), err)
+		}	
 	}
 
 	log.Printf("[DEBUG] Finished deleting RegionPerInstanceConfig %q: %#v", d.Id(), res)

--- a/templates/terraform/custom_delete/region_per_instance_config.go.erb
+++ b/templates/terraform/custom_delete/region_per_instance_config.go.erb
@@ -1,0 +1,69 @@
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	lockName, err := replaceVars(d, config, "instangeGroupManager/{{project}}/{{region}}/{{region_instance_group_manager}}")
+	if err != nil {
+		return err
+	}
+	mutexKV.Lock(lockName)
+	defer mutexKV.Unlock(lockName)
+
+	url, err := replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceGroupManagers/{{region_instance_group_manager}}/deletePerInstanceConfigs")
+	if err != nil {
+		return err
+	}
+
+	var obj map[string]interface{}
+	obj = map[string]interface{}{
+		"names": [1]string{d.Get("name").(string)},
+	}
+	log.Printf("[DEBUG] Deleting RegionPerInstanceConfig %q", d.Id())
+
+	res, err := sendRequestWithTimeout(config, "POST", project, url, obj, d.Timeout(schema.TimeoutDelete))
+	if err != nil {
+		return handleNotFoundError(err, d, "RegionPerInstanceConfig")
+	}
+
+	err = computeOperationWaitTime(
+		config, res, project, "Deleting RegionPerInstanceConfig",
+		d.Timeout(schema.TimeoutDelete))
+
+	if err != nil {
+		return err
+	}
+
+	// Potentially delete the state managed by this config
+	if d.Get("remove_instance_state_on_destroy").(bool) {
+		// Instance name in applyUpdatesToInstances request must include region
+		instanceName, err := replaceVars(d, config, "regoins/{{region}}/instances/{{name}}")
+		if err != nil {
+			return err
+		}
+
+		obj = make(map[string]interface{})
+		obj["instances"] = []string{instanceName}
+
+		// Updates must be applied to the instance after deleting the PerInstanceConfig
+		url, err = replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{instance_group_manager}}/applyUpdatesToInstances")
+		if err != nil {
+			return err
+		}
+
+		log.Printf("[DEBUG] Applying updates to PerInstanceConfig %q: %#v", d.Id(), obj)
+		res, err = sendRequestWithTimeout(config, "POST", project, url, obj, d.Timeout(schema.TimeoutUpdate))
+
+		if err != nil {
+			return fmt.Errorf("Error updating PerInstanceConfig %q: %s", d.Id(), err)
+		}
+
+		err = computeOperationWaitTime(
+			config, res, project, "Applying update to PerInstanceConfig",
+			d.Timeout(schema.TimeoutUpdate))
+	}
+
+	log.Printf("[DEBUG] Finished deleting RegionPerInstanceConfig %q: %#v", d.Id(), res)
+	return nil

--- a/templates/terraform/post_update/compute_region_per_instance_config.go.erb
+++ b/templates/terraform/post_update/compute_region_per_instance_config.go.erb
@@ -1,5 +1,5 @@
-// Instance name in applyUpdatesToInstances request must include region
-instanceName, err := replaceVars(d, config, "regoins/{{region}}/instances/{{name}}")
+// Instance name in applyUpdatesToInstances request must include zone
+instanceName, err := findInstanceName(d, config)
 if err != nil {
 	return err
 }

--- a/third_party/terraform/tests/resource_compute_per_instance_config_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_per_instance_config_test.go.erb
@@ -76,7 +76,7 @@ func TestAccComputePerInstanceConfig_statefulBasic(t *testing.T) {
 				// delete all configs
 				Config: testAccComputePerInstanceConfig_igm(context),
 				Check: resource.ComposeTestCheckFunc(
-					// Config with remove_instance_state_on_destroy = false won't be destroyed (config2)
+					// Config with remove_instance_state_on_destroy = false won't be destroyed (config4)
 					testAccCheckComputePerInstanceConfigDestroyed(t, igmId, context["config_name2"].(string)),
 					testAccCheckComputePerInstanceConfigDestroyed(t, igmId, context["config_name3"].(string)),
 				),

--- a/third_party/terraform/tests/resource_compute_per_instance_config_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_per_instance_config_test.go.erb
@@ -85,6 +85,42 @@ func TestAccComputePerInstanceConfig_statefulBasic(t *testing.T) {
 	})
 }
 
+func TestAccComputePerInstanceConfig_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+		"config_name" : fmt.Sprintf("instance-%s", randString(t, 10)),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Create one config
+				Config: testAccComputePerInstanceConfig_statefulBasic(context),
+			},
+			{
+				ResourceName:      "google_compute_per_instance_config.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
+			},
+			{
+				// Update an existing config
+				Config: testAccComputePerInstanceConfig_update(context),
+			},
+			{
+				ResourceName:      "google_compute_per_instance_config.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
+			},
+		},
+	})
+}
+
 func testAccComputePerInstanceConfig_statefulBasic(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_compute_per_instance_config" "default" {
@@ -95,6 +131,23 @@ resource "google_compute_per_instance_config" "default" {
 	preserved_state {
 		metadata = {
 			asdf = "asdf"
+		}
+	}
+}
+`, context) + testAccComputePerInstanceConfig_igm(context)
+}
+
+func testAccComputePerInstanceConfig_update(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_compute_per_instance_config" "default" {
+	zone = google_compute_instance_group_manager.igm.zone
+	instance_group_manager = google_compute_instance_group_manager.igm.name
+	name = "%{config_name}"
+	remove_instance_state_on_destroy = true
+	preserved_state {
+		metadata = {
+			asdf = "asdf"
+			update = "12345"
 		}
 	}
 }

--- a/third_party/terraform/tests/resource_compute_per_instance_config_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_per_instance_config_test.go.erb
@@ -35,6 +35,7 @@ func TestAccComputePerInstanceConfig_statefulBasic(t *testing.T) {
 				ResourceName:      "google_compute_per_instance_config.default",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
 				// Force-recreate old config
@@ -47,6 +48,7 @@ func TestAccComputePerInstanceConfig_statefulBasic(t *testing.T) {
 				ResourceName:      "google_compute_per_instance_config.default",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
 				// Add two new endpoints
@@ -56,24 +58,27 @@ func TestAccComputePerInstanceConfig_statefulBasic(t *testing.T) {
 				ResourceName:      "google_compute_per_instance_config.default",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
 				ResourceName:            "google_compute_per_instance_config.with_disks",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"most_disruptive_allowed_action", "minimal_action"},
+				ImportStateVerifyIgnore: []string{"most_disruptive_allowed_action", "minimal_action", "remove_instance_state_on_destroy"},
 			},
 			{
 				ResourceName:      "google_compute_per_instance_config.add2",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
 				// delete all configs
 				Config: testAccComputePerInstanceConfig_igm(context),
 				Check: resource.ComposeTestCheckFunc(
+					// Config with remove_instance_state_on_destroy = false won't be destroyed (config2)
 					testAccCheckComputePerInstanceConfigDestroyed(t, igmId, context["config_name2"].(string)),
-					testAccCheckComputePerInstanceConfigDestroyed(t, igmId, context["config_name4"].(string)),
+					testAccCheckComputePerInstanceConfigDestroyed(t, igmId, context["config_name3"].(string)),
 				),
 			},
 		},
@@ -132,6 +137,7 @@ resource "google_compute_per_instance_config" "with_disks" {
 	name = "%{config_name3}"
 	most_disruptive_allowed_action = "REFRESH"
 	minimal_action = "REFRESH"
+	remove_instance_state_on_destroy = true
 	preserved_state {
 		metadata = {
 			meta = "123"
@@ -158,7 +164,6 @@ resource "google_compute_per_instance_config" "add2" {
 	zone = google_compute_instance_group_manager.igm.zone
 	instance_group_manager = google_compute_instance_group_manager.igm.name
 	name = "%{config_name4}"
-	remove_instance_state_on_destroy = true
 	preserved_state {
 		metadata = {
 			foo = "abc"

--- a/third_party/terraform/tests/resource_compute_per_instance_config_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_per_instance_config_test.go.erb
@@ -73,7 +73,6 @@ func TestAccComputePerInstanceConfig_statefulBasic(t *testing.T) {
 				Config: testAccComputePerInstanceConfig_igm(context),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputePerInstanceConfigDestroyed(t, igmId, context["config_name2"].(string)),
-					testAccCheckComputePerInstanceConfigDestroyed(t, igmId, context["config_name3"].(string)),
 					testAccCheckComputePerInstanceConfigDestroyed(t, igmId, context["config_name4"].(string)),
 				),
 			},
@@ -87,6 +86,7 @@ resource "google_compute_per_instance_config" "default" {
 	zone = google_compute_instance_group_manager.igm.zone
 	instance_group_manager = google_compute_instance_group_manager.igm.name
 	name = "%{config_name}"
+	remove_instance_state_on_destroy = true
 	preserved_state {
 		metadata = {
 			asdf = "asdf"
@@ -102,6 +102,7 @@ resource "google_compute_per_instance_config" "default" {
 	zone = google_compute_instance_group_manager.igm.zone
 	instance_group_manager = google_compute_instance_group_manager.igm.name
 	name = "%{config_name2}"
+	remove_instance_state_on_destroy = true
 	preserved_state {
 		metadata = {
 			asdf = "asdf"
@@ -117,6 +118,7 @@ resource "google_compute_per_instance_config" "default" {
 	zone = google_compute_instance_group_manager.igm.zone
 	instance_group_manager = google_compute_instance_group_manager.igm.name
 	name = "%{config_name2}"
+	remove_instance_state_on_destroy = true
 	preserved_state {
 		metadata = {
 			asdf = "asdf"
@@ -156,6 +158,7 @@ resource "google_compute_per_instance_config" "add2" {
 	zone = google_compute_instance_group_manager.igm.zone
 	instance_group_manager = google_compute_instance_group_manager.igm.name
 	name = "%{config_name4}"
+	remove_instance_state_on_destroy = true
 	preserved_state {
 		metadata = {
 			foo = "abc"

--- a/third_party/terraform/tests/resource_compute_region_per_instance_config_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_per_instance_config_test.go.erb
@@ -35,6 +35,7 @@ func TestAccComputeRegionPerInstanceConfig_statefulBasic(t *testing.T) {
 				ResourceName:      "google_compute_region_per_instance_config.default",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
 				// Force-recreate old config
@@ -47,6 +48,7 @@ func TestAccComputeRegionPerInstanceConfig_statefulBasic(t *testing.T) {
 				ResourceName:      "google_compute_region_per_instance_config.default",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
 				// Add two new endpoints
@@ -56,25 +58,27 @@ func TestAccComputeRegionPerInstanceConfig_statefulBasic(t *testing.T) {
 				ResourceName:      "google_compute_region_per_instance_config.default",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
 				ResourceName:            "google_compute_region_per_instance_config.with_disks",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"most_disruptive_allowed_action", "minimal_action"},
+				ImportStateVerifyIgnore: []string{"most_disruptive_allowed_action", "minimal_action", "remove_instance_state_on_destroy"},
 			},
 			{
 				ResourceName:      "google_compute_region_per_instance_config.add2",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
 				// delete all configs
 				Config: testAccComputeRegionPerInstanceConfig_rigm(context),
 				Check: resource.ComposeTestCheckFunc(
+					// Config with remove_instance_state_on_destroy = false won't be destroyed (config4)
 					testAccCheckComputeRegionPerInstanceConfigDestroyed(t, rigmId, context["config_name2"].(string)),
 					testAccCheckComputeRegionPerInstanceConfigDestroyed(t, rigmId, context["config_name3"].(string)),
-					testAccCheckComputeRegionPerInstanceConfigDestroyed(t, rigmId, context["config_name4"].(string)),
 				),
 			},
 		},
@@ -87,6 +91,7 @@ resource "google_compute_region_per_instance_config" "default" {
 	region = google_compute_region_instance_group_manager.rigm.region
 	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
 	name = "%{config_name}"
+	remove_instance_state_on_destroy = true
 	preserved_state {
 		metadata = {
 			asdf = "asdf"
@@ -102,6 +107,7 @@ resource "google_compute_region_per_instance_config" "default" {
 	region = google_compute_region_instance_group_manager.rigm.region
 	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
 	name = "%{config_name2}"
+	remove_instance_state_on_destroy = true
 	preserved_state {
 		metadata = {
 			asdf = "asdf"
@@ -117,6 +123,7 @@ resource "google_compute_region_per_instance_config" "default" {
 	region = google_compute_region_instance_group_manager.rigm.region
 	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
 	name = "%{config_name2}"
+	remove_instance_state_on_destroy = true
 	preserved_state {
 		metadata = {
 			asdf = "asdf"
@@ -130,6 +137,7 @@ resource "google_compute_region_per_instance_config" "with_disks" {
 	name = "%{config_name3}"
 	most_disruptive_allowed_action = "REFRESH"
 	minimal_action = "REFRESH"
+	remove_instance_state_on_destroy = true
 	preserved_state {
 		metadata = {
 			meta = "123"

--- a/third_party/terraform/tests/resource_compute_region_per_instance_config_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_per_instance_config_test.go.erb
@@ -85,6 +85,42 @@ func TestAccComputeRegionPerInstanceConfig_statefulBasic(t *testing.T) {
 	})
 }
 
+func TestAccComputeRegionPerInstanceConfig_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+		"config_name" : fmt.Sprintf("instance-%s", randString(t, 10)),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// Create one config
+				Config: testAccComputeRegionPerInstanceConfig_statefulBasic(context),
+			},
+			{
+				ResourceName:      "google_compute_region_per_instance_config.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
+			},
+			{
+				// Update an existing config
+				Config: testAccComputeRegionPerInstanceConfig_update(context),
+			},
+			{
+				ResourceName:      "google_compute_region_per_instance_config.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
+			},
+		},
+	})
+}
+
 func testAccComputeRegionPerInstanceConfig_statefulBasic(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_compute_region_per_instance_config" "default" {
@@ -95,6 +131,23 @@ resource "google_compute_region_per_instance_config" "default" {
 	preserved_state {
 		metadata = {
 			asdf = "asdf"
+		}
+	}
+}
+`, context) + testAccComputeRegionPerInstanceConfig_rigm(context)
+}
+
+func testAccComputeRegionPerInstanceConfig_update(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_compute_region_per_instance_config" "default" {
+	region = google_compute_region_instance_group_manager.rigm.region
+	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
+	name = "%{config_name}"
+	remove_instance_state_on_destroy = true
+	preserved_state {
+		metadata = {
+			asdf = "foo"
+			updated = "12345"
 		}
 	}
 }

--- a/third_party/terraform/utils/stateful_mig_polling.go.erb
+++ b/third_party/terraform/utils/stateful_mig_polling.go.erb
@@ -82,7 +82,12 @@ func findInstanceName(d *schema.ResourceData, config *Config) (string, error) {
 
 	token := ""
 	for paginate := true; paginate; {
-		urlWithToken := fmt.Sprintf("%s?pageToken=%s", url, token)
+		urlWithToken := ""
+		if token != "" {
+			urlWithToken = fmt.Sprintf("%s?maxResults=1&pageToken=%s", url, token)
+		} else {
+			urlWithToken = fmt.Sprintf("%s?maxResults=1", url)
+		}
 		res, err := sendRequest(config, "POST", project, urlWithToken, nil)
 		if err != nil {
 			return "", err

--- a/third_party/terraform/utils/stateful_mig_polling.go.erb
+++ b/third_party/terraform/utils/stateful_mig_polling.go.erb
@@ -1,0 +1,135 @@
+<% autogen_exception -%>
+package google
+
+<% unless version == 'ga' -%>
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/errwrap"
+)
+
+// PerInstanceConfig needs both regular operation polling AND custom polling for deletion which is why this is not generated
+func resourceComputePerInstanceConfigPollRead(d *schema.ResourceData, meta interface{}) PollReadFunc {
+	return func() (map[string]interface{}, error) {
+		config := meta.(*Config)
+
+		url, err := replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{instance_group_manager}}/listPerInstanceConfigs")
+		if err != nil {
+			return nil, err
+		}
+
+		project, err := getProject(d, config)
+		if err != nil {
+			return nil, err
+		}
+		res, err := sendRequest(config, "POST", project, url, nil)
+		if err != nil {
+			return res, err
+		}
+		res, err = flattenNestedComputePerInstanceConfig(d, meta, res)
+		if err != nil {
+			return nil, err
+		}
+
+		// Returns nil res if nested object is not found
+		return res, nil
+	}
+}
+
+// RegionPerInstanceConfig needs both regular operation polling AND custom polling for deletion which is why this is not generated
+func resourceComputeRegionPerInstanceConfigPollRead(d *schema.ResourceData, meta interface{}) PollReadFunc {
+	return func() (map[string]interface{}, error) {
+		config := meta.(*Config)
+
+		url, err := replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceGroupManagers/{{region_instance_group_manager}}/listPerInstanceConfigs")
+		if err != nil {
+			return nil, err
+		}
+
+		project, err := getProject(d, config)
+		if err != nil {
+			return nil, err
+		}
+		res, err := sendRequest(config, "POST", project, url, nil)
+		if err != nil {
+			return res, err
+		}
+		res, err = flattenNestedComputeRegionPerInstanceConfig(d, meta, res)
+		if err != nil {
+			return nil, err
+		}
+
+		// Returns nil res if nested object is not found
+		return res, nil
+	}
+}
+
+// Returns an instance name in the form zones/{zone}/instances/{instance} for the managed
+// instance matching the name of a PerInstanceConfig
+func findInstanceName(d *schema.ResourceData, config *Config) (string, error) {
+	url, err := replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/regions/{{region}}/instanceGroupManagers/{{region_instance_group_manager}}/listManagedInstances")
+
+	if err != nil {
+		return "", err
+	}
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return "", err
+	}
+	instanceNameToFind := fmt.Sprintf("/%s", d.Get("name").(string))
+
+	token := ""
+	for paginate := true; paginate; {
+		urlWithToken := fmt.Sprintf("%s?pageToken=%s", url, token)
+		res, err := sendRequest(config, "POST", project, urlWithToken, nil)
+		if err != nil {
+			return "", err
+		}
+
+		managedInstances, ok := res["managedInstances"]
+		if !ok {
+			return "", fmt.Errorf("Failed to parse response for listManagedInstances for %s", d.Id())
+		}
+
+		managedInstancesArr := managedInstances.([]interface{})
+		for _, managedInstanceRaw := range managedInstancesArr {
+			instance := managedInstanceRaw.(map[string]interface{})
+			name, ok := instance["instance"]
+			if !ok {
+				return "", fmt.Errorf("Failed to read instance name for managed instance: %#v", instance)
+			}
+			if strings.HasSuffix(name.(string), instanceNameToFind) {
+				return name.(string), nil
+			}
+		}
+
+		tokenRaw, paginate := res["nextPageToken"]
+		if paginate {
+			token = tokenRaw.(string)
+		}
+	}
+
+	return "", fmt.Errorf("Failed to find managed instance with name: %s", instanceNameToFind)
+}
+
+func PollCheckInstanceConfigDeleted(resp map[string]interface{}, respErr error) PollResult {
+	if respErr != nil {
+		return ErrorPollResult(respErr)
+	}
+
+	// Nested object 404 appears as nil response
+	if resp == nil {
+		// Config no longer exists
+		return SuccessPollResult()
+	}
+
+	// Read status
+	status := resp["status"].(string)
+	if status == "DELETING" {
+		return PendingStatusPollResult("Still deleting")
+	}
+	return ErrorPollResult(fmt.Errorf("Expected PerInstanceConfig to be deleting but status is: %s", status))
+}
+<% end -%>


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/6548
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added `remove_instance_state_on_destroy` to `google_compute_region_per_instance_config` to control deletion of underlying instance state. (beta only)
```
```release-note:enhancement
compute: Added `remove_instance_state_on_destroy` to `google_compute_per_instance_config` to control deletion of underlying instance state. (beta only)
```