### PR TITLE
enable google_dns_policy to accept network id

### DIFF
--- a/products/dns/terraform.yaml
+++ b/products/dns/terraform.yaml
@@ -171,6 +171,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
             schema.SerializeResourceForHash(&buf, raw, dnsPolicyNetworksSchema())
             return hashcode.String(buf.String())
           }
+      networks.networkUrl: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: templates/terraform/custom_expand/network_full_url.erb
+        diff_suppress_func: 'compareSelfLinkOrResourceName'
+        description: |
+          The id or fully qualified URL of the VPC network to forward queries to.
+          This should be formatted like `projects/{project}/global/networks/{network}` or
+          `https://www.googleapis.com/compute/v1/projects/{project}/global/networks/{network}`
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_delete: templates/terraform/pre_delete/detach_network.erb
   ResourceRecordSet: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/templates/terraform/examples/dns_managed_zone_private_forwarding.tf.erb
+++ b/templates/terraform/examples/dns_managed_zone_private_forwarding.tf.erb
@@ -10,10 +10,10 @@ resource "google_dns_managed_zone" "<%= ctx[:primary_resource_id] %>" {
 
   private_visibility_config {
     networks {
-      network_url = google_compute_network.network-1.self_link
+      network_url = google_compute_network.network-1.id
     }
     networks {
-      network_url = google_compute_network.network-2.self_link
+      network_url = google_compute_network.network-2.id
     }
   }
 

--- a/templates/terraform/examples/dns_policy_basic.tf.erb
+++ b/templates/terraform/examples/dns_policy_basic.tf.erb
@@ -14,10 +14,10 @@ resource "google_dns_policy" "<%= ctx[:primary_resource_id] %>" {
   }
 
   networks {
-    network_url = google_compute_network.network-1.self_link
+    network_url = google_compute_network.network-1.id
   }
   networks {
-    network_url = google_compute_network.network-2.self_link
+    network_url = google_compute_network.network-2.id
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6577

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
enable google_dns_policy to accept network id #6577
```
