### PR TITLE
Resource google_sql_database_instance root_password (MS SQL) for GA

### DIFF
--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -372,7 +372,6 @@ settings.backup_configuration.binary_log_enabled are both set to true.`,
             <% end -%>
 
 
-			<% unless version == 'ga' -%>
 			"root_password": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -380,7 +379,6 @@ settings.backup_configuration.binary_log_enabled are both set to true.`,
 				Sensitive:   true,
 				Description: `Initial root password. Required for MS SQL Server, ignored by MySQL and PostgreSQL.`,
 			},
-			<% end -%>
 
 			"ip_address": {
 				Type:     schema.TypeList,
@@ -641,12 +639,10 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 		ReplicaConfiguration: expandReplicaConfiguration(d.Get("replica_configuration").([]interface{})),
 	}
 
-	<% unless version == 'ga' -%>
 	// MSSQL Server require rootPassword to be set
 	if strings.Contains(instance.DatabaseVersion, "SQLSERVER") {
 		instance.RootPassword = d.Get("root_password").(string)
 	}
-	<% end -%>
 
 	// Modifying a replica during Create can cause problems if the master is
 	// modified at the same time. Lock the master until we're done in order

--- a/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -197,7 +197,6 @@ func TestAccSqlDatabaseInstance_basicSecondGen(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccSqlDatabaseInstance_basicMSSQL(t *testing.T) {
 	t.Parallel()
 
@@ -222,7 +221,6 @@ func TestAccSqlDatabaseInstance_basicMSSQL(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccSqlDatabaseInstance_dontDeleteDefaultUserOnReplica(t *testing.T) {
 	t.Parallel()
@@ -677,7 +675,6 @@ resource "google_sql_database_instance" "instance" {
 }
 `
 
-<% unless version == 'ga' -%>
 var testGoogleSqlDatabaseInstance_basic_mssql = `
 resource "google_sql_database_instance" "instance" {
   name             = "%s"
@@ -688,7 +685,6 @@ resource "google_sql_database_instance" "instance" {
   }
 }
 `
-<% end -%>
 
 func testGoogleSqlDatabaseInstanceConfig_withoutReplica(instanceName string) string {
 	return fmt.Sprintf(`

--- a/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -214,7 +214,7 @@ includes an up-to-date reference of supported versions.
 * `replica_configuration` - (Optional) The configuration for replication. The
     configuration is detailed below.
     
-* `root_password` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Initial root password. Required for MS SQL Server, ignored by MySQL and PostgreSQL.
+* `root_password` - (Optional) Initial root password. Required for MS SQL Server, ignored by MySQL and PostgreSQL.
 
 * `encryption_key_name` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
     The full path to the encryption key used for the CMEK disk encryption.  Setting


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/5870

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
sql: Moved `google_sql_database_instance` `root_password` (MS SQL) to GA
```
