### PR TITLE
adding cpu_overcommit_type and updating tests

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -7786,6 +7786,14 @@ objects:
             values:
               - :RESTART_NODE_ON_ANY_SERVER
               - :RESTART_NODE_ON_MINIMAL_SERVERS
+      - !ruby/object:Api::Type::Enum
+        name: 'cpuOvercommitType'
+        description: |
+          CPU overcommit.
+        min_version: beta
+        values:
+          - :ENABLED
+          - :DISABLED
   - !ruby/object:Api::Resource
     name: 'PacketMirroring'
     min_version: beta

--- a/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -4343,10 +4343,6 @@ resource "google_compute_instance" "foobar" {
   }
 }
 
-data "google_compute_node_types" "central1a" {
-  zone = "us-central1-a"
-}
-
 resource "google_compute_node_template" "nodetmpl" {
   name   = "%s"
   region = "us-central1"
@@ -4355,7 +4351,11 @@ resource "google_compute_node_template" "nodetmpl" {
     tfacc = "test"
   }
 
-  node_type = data.google_compute_node_types.central1a.names[1]
+  node_type = "n1-node-96-624"
+
+<% unless version == 'ga' -%>
+  cpu_overcommit_type = "ENABLED"
+<% end -%>
 }
 
 resource "google_compute_node_group" "nodes" {
@@ -4415,10 +4415,6 @@ resource "google_compute_instance" "foobar" {
   }
 }
 
-data "google_compute_node_types" "central1a" {
-  zone = "us-central1-a"
-}
-
 resource "google_compute_node_template" "nodetmpl" {
   name   = "%s"
   region = "us-central1"
@@ -4427,7 +4423,11 @@ resource "google_compute_node_template" "nodetmpl" {
     tfacc = "test"
   }
 
-  node_type = data.google_compute_node_types.central1a.names[1]
+  node_type = "n1-node-96-624"
+
+<% unless version == 'ga' -%>
+  cpu_overcommit_type = "DISABLED"
+<% end -%>
 }
 
 resource "google_compute_node_group" "nodes" {

--- a/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -4426,7 +4426,7 @@ resource "google_compute_node_template" "nodetmpl" {
   node_type = "n1-node-96-624"
 
 <% unless version == 'ga' -%>
-  cpu_overcommit_type = "DISABLED"
+  cpu_overcommit_type = "ENABLED"
 <% end -%>
 }
 


### PR DESCRIPTION
I think this should have been implemented as part of https://github.com/terraform-providers/terraform-provider-google/issues/5416

I also hard-coded the tests because the need to be type `n1`/`n2` and this will guarantee that they are.

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6591

Also, I put the test for this in `ComputeInstance` tests because it made sense, but if you think i should have a separate test in the node template tests, I can do that too.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `cpu_over_commit_type` to `google_compute_node_template`
```
