### PR TITLE
Document updating resource policies attachment in disk

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -469,6 +469,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       resourcePolicies: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+        description: |
+          {{description}}
+
+          ~>**NOTE** This value does not support updating the
+          resource policy, as resource policies can not be updated more than
+          one at a time. Use
+          [`google_compute_disk_resource_policy_attachment`](https://www.terraform.io/docs/providers/google/r/compute_disk_resource_policy_attachment.html)
+          to allow for updating the resource policy attached to the disk.
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_delete: templates/terraform/pre_delete/detach_disk.erb
       constants: templates/terraform/constants/disk.erb


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```

Related to https://github.com/terraform-providers/terraform-provider-google/issues/6600
