### PR TITLE
add the ability to specify app engine database type

### DIFF
--- a/third_party/terraform/tests/resource_app_engine_application_test.go
+++ b/third_party/terraform/tests/resource_app_engine_application_test.go
@@ -101,6 +101,7 @@ resource "google_app_engine_application" "acceptance" {
   project        = google_project.acceptance.project_id
   auth_domain    = "hashicorptest.com"
   location_id    = "us-central"
+  database_type  = "CLOUD_DATASTORE_COMPATIBILITY"
   serving_status = "SERVING"
 }
 `, pid, pid, org)
@@ -118,6 +119,7 @@ resource "google_app_engine_application" "acceptance" {
   project        = google_project.acceptance.project_id
   auth_domain    = "tf-test.club"
   location_id    = "us-central"
+  database_type  = "CLOUD_DATASTORE_COMPATIBILITY"
   serving_status = "USER_DISABLED"
 }
 `, pid, pid, org)

--- a/third_party/terraform/website/docs/r/app_engine_application.html.markdown
+++ b/third_party/terraform/website/docs/r/app_engine_application.html.markdown
@@ -47,6 +47,8 @@ The following arguments are supported:
 
 * `auth_domain` - (Optional) The domain to authenticate users with when using App Engine's User API.
 
+* `database_type` - (Optional) The type of the Cloud Firestore or Cloud Datastore database associated with this application.
+
 * `serving_status` - (Optional) The serving status of the app.
 
 * `feature_settings` - (Optional) A block of optional settings to configure specific App Engine features:


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-google/issues/3657

```release-note:enhancement
app_engine: added the option to specify `database_type` in `google_app_engine_application`
```
