### PR TITLE
Sweepable names for router+ tests 

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -585,6 +585,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           region_url_map_name: "website-map"
           region_backend_service_name: "website-backend"
           region_health_check_name: "website-hc"
+          rigm_name: "website-rigm"
           network_name: "website-net"
           fw_name: "website-fw"
     custom_code: !ruby/object:Provider::Terraform::CustomCode

--- a/templates/terraform/examples/forwarding_rule_http_lb.tf.erb
+++ b/templates/terraform/examples/forwarding_rule_http_lb.tf.erb
@@ -58,7 +58,7 @@ data "google_compute_image" "debian_image" {
 resource "google_compute_region_instance_group_manager" "rigm" {
   provider = google-beta
   region   = "us-central1"
-  name     = "rigm-internal"
+  name     = "<%= ctx[:vars]['rigm_name'] %>"
   version {
     instance_template = google_compute_instance_template.instance_template.id
     name              = "primary"

--- a/third_party/terraform/tests/data_source_google_compute_router_test.go
+++ b/third_party/terraform/tests/data_source_google_compute_router_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAccDataSourceComputeRouter(t *testing.T) {
 	t.Parallel()
-	name := fmt.Sprintf("router-test-%d", randInt(t))
+	name := fmt.Sprintf("tf-test-router-%d", randInt(t))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -12,10 +12,10 @@ import (
 func TestAccInstanceGroupManager_basic(t *testing.T) {
 	t.Parallel()
 
-	template := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	target := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	igm1 := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	igm2 := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	template := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
+	target := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
+	igm1 := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
+	igm2 := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -42,8 +42,8 @@ func TestAccInstanceGroupManager_basic(t *testing.T) {
 func TestAccInstanceGroupManager_targetSizeZero(t *testing.T) {
 	t.Parallel()
 
-	templateName := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	igmName := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	templateName := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
+	igmName := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -65,11 +65,11 @@ func TestAccInstanceGroupManager_targetSizeZero(t *testing.T) {
 func TestAccInstanceGroupManager_update(t *testing.T) {
 	t.Parallel()
 
-	template1 := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	target1 := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	target2 := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	template2 := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	igm := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	template1 := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
+	target1 := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
+	target2 := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
+	template2 := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
+	igm := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -111,7 +111,7 @@ func TestAccInstanceGroupManager_updateLifecycle(t *testing.T) {
 
 	tag1 := "tag1"
 	tag2 := "tag2"
-	igm := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	igm := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -143,7 +143,7 @@ func TestAccInstanceGroupManager_updatePolicy(t *testing.T) {
 	skipIfVcr(t)
 	t.Parallel()
 
-	igm := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	igm := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -192,8 +192,8 @@ func TestAccInstanceGroupManager_separateRegions(t *testing.T) {
 	skipIfVcr(t)
 	t.Parallel()
 
-	igm1 := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	igm2 := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	igm1 := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
+	igm2 := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -220,9 +220,9 @@ func TestAccInstanceGroupManager_separateRegions(t *testing.T) {
 func TestAccInstanceGroupManager_versions(t *testing.T) {
 	t.Parallel()
 
-	primaryTemplate := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	canaryTemplate := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	igm := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	primaryTemplate := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
+	canaryTemplate := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
+	igm := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -244,10 +244,10 @@ func TestAccInstanceGroupManager_versions(t *testing.T) {
 func TestAccInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 	t.Parallel()
 
-	template := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	target := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	igm := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	hck := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	template := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
+	target := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
+	igm := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
+	hck := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -278,10 +278,10 @@ func TestAccInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 func TestAccInstanceGroupManager_stateful(t *testing.T) {
 	t.Parallel()
 
-	template := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	target := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	igm := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	hck := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	template := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
+	target := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
+	igm := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
+	hck := fmt.Sprintf("tf-test-igm-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
@@ -14,10 +14,10 @@ import (
 func TestAccRegionInstanceGroupManager_basic(t *testing.T) {
 	t.Parallel()
 
-	template := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	target := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	igm1 := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	igm2 := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	template := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
+	target := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
+	igm1 := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
+	igm2 := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -44,8 +44,8 @@ func TestAccRegionInstanceGroupManager_basic(t *testing.T) {
 func TestAccRegionInstanceGroupManager_targetSizeZero(t *testing.T) {
 	t.Parallel()
 
-	templateName := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	igmName := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	templateName := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
+	igmName := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -67,11 +67,11 @@ func TestAccRegionInstanceGroupManager_targetSizeZero(t *testing.T) {
 func TestAccRegionInstanceGroupManager_update(t *testing.T) {
 	t.Parallel()
 
-	template1 := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	target1 := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	target2 := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	template2 := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	igm := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	template1 := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
+	target1 := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
+	target2 := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
+	template2 := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
+	igm := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -113,7 +113,7 @@ func TestAccRegionInstanceGroupManager_updateLifecycle(t *testing.T) {
 
 	tag1 := "tag1"
 	tag2 := "tag2"
-	igm := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	igm := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -145,7 +145,7 @@ func TestAccRegionInstanceGroupManager_rollingUpdatePolicy(t *testing.T) {
 	skipIfVcr(t)
 	t.Parallel()
 
-	igm := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	igm := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -182,8 +182,8 @@ func TestAccRegionInstanceGroupManager_separateRegions(t *testing.T) {
 	skipIfVcr(t)
 	t.Parallel()
 
-	igm1 := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	igm2 := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	igm1 := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
+	igm2 := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -210,9 +210,9 @@ func TestAccRegionInstanceGroupManager_separateRegions(t *testing.T) {
 func TestAccRegionInstanceGroupManager_versions(t *testing.T) {
 	t.Parallel()
 
-	primaryTemplate := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	canaryTemplate := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	igm := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	primaryTemplate := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
+	canaryTemplate := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
+	igm := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -234,10 +234,10 @@ func TestAccRegionInstanceGroupManager_versions(t *testing.T) {
 func TestAccRegionInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 	t.Parallel()
 
-	template := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	target := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	igm := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	hck := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	template := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
+	target := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
+	igm := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
+	hck := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -267,8 +267,8 @@ func TestAccRegionInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 func TestAccRegionInstanceGroupManager_distributionPolicy(t *testing.T) {
 	t.Parallel()
 
-	template := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	igm := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	template := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
+	igm := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
 	zones := []string{"us-central1-a", "us-central1-b"}
 
 	vcrTest(t, resource.TestCase{
@@ -292,8 +292,8 @@ func TestAccRegionInstanceGroupManager_distributionPolicy(t *testing.T) {
 func TestAccRegionInstanceGroupManager_stateful(t *testing.T) {
 	t.Parallel()
 
-	template := fmt.Sprintf("igm-test-%s", randString(t, 10))
-	igm := fmt.Sprintf("igm-test-%s", randString(t, 10))
+	template := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
+	igm := fmt.Sprintf("tf-test-rigm-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
@@ -17,40 +17,42 @@ func TestAccComputeRouterNat_basic(t *testing.T) {
 	region := getTestRegionFromEnv()
 
 	testId := randString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-nat-%s", testId)
+
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckComputeRouterNatDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeRouterNatBasic(testId),
+				Config: testAccComputeRouterNatBasic(routerName),
 			},
 			{
+				// implicitly full ImportStateId
 				ResourceName: "google_compute_router_nat.foobar",
-				// implicitly: ImportStateId:     fmt.Sprintf("%s/%s/router-nat-test-%s/router-nat-test-%s", project, region, testId, testId),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
 				ResourceName:      "google_compute_router_nat.foobar",
-				ImportStateId:     fmt.Sprintf("%s/%s/router-nat-test-%s/router-nat-test-%s", project, region, testId, testId),
+				ImportStateId:     fmt.Sprintf("%s/%s/%s/%s", project, region, routerName, routerName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
 				ResourceName:      "google_compute_router_nat.foobar",
-				ImportStateId:     fmt.Sprintf("%s/router-nat-test-%s/router-nat-test-%s", region, testId, testId),
+				ImportStateId:     fmt.Sprintf("%s/%s/%s", region, routerName, routerName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
 				ResourceName:      "google_compute_router_nat.foobar",
-				ImportStateId:     fmt.Sprintf("router-nat-test-%s/router-nat-test-%s", testId, testId),
+				ImportStateId:     fmt.Sprintf("%s/%s", routerName, routerName),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeRouterNatKeepRouter(testId),
+				Config: testAccComputeRouterNatKeepRouter(routerName),
 				Check: testAccCheckComputeRouterNatDelete(
 					t, "google_compute_router_nat.foobar"),
 			},
@@ -62,13 +64,15 @@ func TestAccComputeRouterNat_update(t *testing.T) {
 	t.Parallel()
 
 	testId := randString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-nat-%s", testId)
+
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckComputeRouterNatDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeRouterNatBasicBeforeUpdate(testId),
+				Config: testAccComputeRouterNatBasicBeforeUpdate(routerName),
 			},
 			{
 				ResourceName:      "google_compute_router_nat.foobar",
@@ -76,7 +80,7 @@ func TestAccComputeRouterNat_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeRouterNatUpdated(testId),
+				Config: testAccComputeRouterNatUpdated(routerName),
 			},
 			{
 				ResourceName:      "google_compute_router_nat.foobar",
@@ -84,7 +88,7 @@ func TestAccComputeRouterNat_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeRouterNatBasicBeforeUpdate(testId),
+				Config: testAccComputeRouterNatBasicBeforeUpdate(routerName),
 			},
 			{
 				ResourceName:      "google_compute_router_nat.foobar",
@@ -99,13 +103,15 @@ func TestAccComputeRouterNat_withManualIpAndSubnetConfiguration(t *testing.T) {
 	t.Parallel()
 
 	testId := randString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-nat-%s", testId)
+
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckComputeRouterNatDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeRouterNatWithManualIpAndSubnetConfiguration(testId),
+				Config: testAccComputeRouterNatWithManualIpAndSubnetConfiguration(routerName),
 			},
 			{
 				ResourceName:      "google_compute_router_nat.foobar",
@@ -121,6 +127,8 @@ func TestAccComputeRouterNat_withNatIpsAndDrainNatIps(t *testing.T) {
 	t.Parallel()
 
 	testId := randString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-nat-%s", testId)
+
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -128,12 +136,12 @@ func TestAccComputeRouterNat_withNatIpsAndDrainNatIps(t *testing.T) {
 		Steps: []resource.TestStep{
 			// (ERROR): Creation with drain nat IPs should fail
 			{
-				Config:      testAccComputeRouterNatWithOneDrainOneRemovedNatIps(testId),
+				Config:      testAccComputeRouterNatWithOneDrainOneRemovedNatIps(routerName),
 				ExpectError: regexp.MustCompile("New RouterNat cannot have drain_nat_ips"),
 			},
 			// Create NAT with three nat IPs
 			{
-				Config: testAccComputeRouterNatWithNatIps(testId),
+				Config: testAccComputeRouterNatWithNatIps(routerName),
 			},
 			{
 				ResourceName:      "google_compute_router_nat.foobar",
@@ -142,12 +150,12 @@ func TestAccComputeRouterNat_withNatIpsAndDrainNatIps(t *testing.T) {
 			},
 			// (ERROR) - Should not allow draining IPs still in natIps
 			{
-				Config:      testAccComputeRouterNatWithInvalidDrainNatIpsStillInNatIps(testId),
+				Config:      testAccComputeRouterNatWithInvalidDrainNatIpsStillInNatIps(routerName),
 				ExpectError: regexp.MustCompile("cannot be drained if still set in nat_ips"),
 			},
 			// natIps #1, #2, #3--> natIp #2, drainNatIp #3
 			{
-				Config: testAccComputeRouterNatWithOneDrainOneRemovedNatIps(testId),
+				Config: testAccComputeRouterNatWithOneDrainOneRemovedNatIps(routerName),
 			},
 			{
 				ResourceName:      "google_compute_router_nat.foobar",
@@ -156,7 +164,7 @@ func TestAccComputeRouterNat_withNatIpsAndDrainNatIps(t *testing.T) {
 			},
 			// (ERROR): Should not be able to drain previously removed natIps (#1)
 			{
-				Config:      testAccComputeRouterNatWithInvalidDrainMissingNatIp(testId),
+				Config:      testAccComputeRouterNatWithInvalidDrainMissingNatIp(routerName),
 				ExpectError: regexp.MustCompile("was not previously set in nat_ips"),
 			},
 		},
@@ -241,27 +249,27 @@ func testAccCheckComputeRouterNatDelete(t *testing.T, n string) resource.TestChe
 	}
 }
 
-func testAccComputeRouterNatBasic(testId string) string {
+func testAccComputeRouterNatBasic(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-  name = "router-nat-test-%s"
+  name = "%s-net"
 }
 
 resource "google_compute_subnetwork" "foobar" {
-  name          = "router-nat-test-subnetwork-%s"
+  name          = "%s-subnet"
   network       = google_compute_network.foobar.self_link
   ip_cidr_range = "10.0.0.0/16"
   region        = "us-central1"
 }
 
 resource "google_compute_router" "foobar" {
-  name    = "router-nat-test-%s"
+  name    = "%s"
   region  = google_compute_subnetwork.foobar.region
   network = google_compute_network.foobar.self_link
 }
 
 resource "google_compute_router_nat" "foobar" {
-  name                               = "router-nat-test-%s"
+  name                               = "%s"
   router                             = google_compute_router.foobar.name
   region                             = google_compute_router.foobar.region
   nat_ip_allocate_option             = "AUTO_ONLY"
@@ -271,36 +279,36 @@ resource "google_compute_router_nat" "foobar" {
     filter = "ERRORS_ONLY"
   }
 }
-`, testId, testId, testId, testId)
+`, routerName, routerName, routerName, routerName)
 }
 
 // Like basic but with extra resources
-func testAccComputeRouterNatBasicBeforeUpdate(randPrefix string) string {
+func testAccComputeRouterNatBasicBeforeUpdate(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_router" "foobar" {
-  name    = "router-nat-test-%s"
+  name    = "%s"
   region  = google_compute_subnetwork.foobar.region
   network = google_compute_network.foobar.self_link
 }
 
 resource "google_compute_network" "foobar" {
-  name = "router-nat-test-%s"
+  name = "%s-net"
 }
 
 resource "google_compute_subnetwork" "foobar" {
-  name          = "router-nat-test-subnetwork-%s"
+  name          = "%s-subnet"
   network       = google_compute_network.foobar.self_link
   ip_cidr_range = "10.0.0.0/16"
   region        = "us-central1"
 }
 
 resource "google_compute_address" "foobar" {
-  name   = "router-nat-test-%s"
+  name   = "%s-addr"
   region = google_compute_subnetwork.foobar.region
 }
 
 resource "google_compute_router_nat" "foobar" {
-  name                               = "router-nat-test-%s"
+  name                               = "%s"
   router                             = google_compute_router.foobar.name
   region                             = google_compute_router.foobar.region
   nat_ip_allocate_option             = "AUTO_ONLY"
@@ -311,35 +319,35 @@ resource "google_compute_router_nat" "foobar" {
     filter = "ERRORS_ONLY"
   }
 }
-`, randPrefix, randPrefix, randPrefix, randPrefix, randPrefix)
+`, routerName, routerName, routerName, routerName, routerName)
 }
 
-func testAccComputeRouterNatUpdated(randPrefix string) string {
+func testAccComputeRouterNatUpdated(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_router" "foobar" {
-  name    = "router-nat-test-%s"
+  name    = "%s"
   region  = google_compute_subnetwork.foobar.region
   network = google_compute_network.foobar.self_link
 }
 
 resource "google_compute_network" "foobar" {
-  name = "router-nat-test-%s"
+  name = "%s-net"
 }
 
 resource "google_compute_subnetwork" "foobar" {
-  name          = "router-nat-test-subnetwork-%s"
+  name          = "%s-subnet"
   network       = google_compute_network.foobar.self_link
   ip_cidr_range = "10.0.0.0/16"
   region        = "us-central1"
 }
 
 resource "google_compute_address" "foobar" {
-  name   = "router-nat-test-%s"
+  name   = "%s-addr"
   region = google_compute_subnetwork.foobar.region
 }
 
 resource "google_compute_router_nat" "foobar" {
-  name   = "router-nat-test-%s"
+  name   = "%s"
   router = google_compute_router.foobar.name
   region = google_compute_router.foobar.region
 
@@ -363,30 +371,30 @@ resource "google_compute_router_nat" "foobar" {
     filter = "TRANSLATIONS_ONLY"
   }
 }
-`, randPrefix, randPrefix, randPrefix, randPrefix, randPrefix)
+`, routerName, routerName, routerName, routerName, routerName)
 }
 
-func testAccComputeRouterNatWithManualIpAndSubnetConfiguration(testId string) string {
+func testAccComputeRouterNatWithManualIpAndSubnetConfiguration(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-  name                    = "router-nat-test-%s"
+  name                    = "%s-net"
   auto_create_subnetworks = "false"
 }
 
 resource "google_compute_subnetwork" "foobar" {
-  name          = "router-nat-test-subnetwork-%s"
+  name          = "%s-subnet"
   network       = google_compute_network.foobar.self_link
   ip_cidr_range = "10.0.0.0/16"
   region        = "us-central1"
 }
 
 resource "google_compute_address" "foobar" {
-  name   = "router-nat-test-%s"
+  name   = "router-nat-%s-addr"
   region = google_compute_subnetwork.foobar.region
 }
 
 resource "google_compute_router" "foobar" {
-  name    = "router-nat-test-%s"
+  name    = "%s"
   region  = google_compute_subnetwork.foobar.region
   network = google_compute_network.foobar.self_link
   bgp {
@@ -395,7 +403,7 @@ resource "google_compute_router" "foobar" {
 }
 
 resource "google_compute_router_nat" "foobar" {
-  name                               = "router-nat-test-%s"
+  name                               = "%s"
   router                             = google_compute_router.foobar.name
   region                             = google_compute_router.foobar.region
   nat_ip_allocate_option             = "MANUAL_ONLY"
@@ -406,53 +414,53 @@ resource "google_compute_router_nat" "foobar" {
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
   }
 }
-`, testId, testId, testId, testId, testId)
+`, routerName, routerName, routerName, routerName, routerName)
 }
 
 <% unless version == 'ga' -%>
-func testAccComputeRouterNatBaseResourcesWithNatIps(testId string) string {
+func testAccComputeRouterNatBaseResourcesWithNatIps(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-  name                    = "router-nat-test-%s"
+  name                    = "%s-net"
   auto_create_subnetworks = "false"
 }
 
 resource "google_compute_subnetwork" "foobar" {
-  name          = "router-nat-test-subnetwork-%s"
+  name          = "%s-subnet"
   network       = google_compute_network.foobar.self_link
   ip_cidr_range = "10.0.0.0/16"
   region        = "us-central1"
 }
 
 resource "google_compute_address" "addr1" {
-  name   = "router-nat-test-%s-1"
+  name   = "%s-addr1"
   region = google_compute_subnetwork.foobar.region
 }
 
 resource "google_compute_address" "addr2" {
-  name   = "router-nat-test-%s-2"
+  name   = "%s-addr2"
   region = google_compute_subnetwork.foobar.region
 }
 
 resource "google_compute_address" "addr3" {
-  name   = "router-nat-test-%s-3"
+  name   = "%s-addr3"
   region = google_compute_subnetwork.foobar.region
 }
 
 resource "google_compute_router" "foobar" {
-  name     = "router-nat-test-%s"
+  name     = "%s"
   region   = google_compute_subnetwork.foobar.region
   network  = google_compute_network.foobar.self_link
 }
-`, testId, testId, testId, testId, testId, testId)
+`, routerName, routerName, routerName, routerName, routerName, routerName)
 }
 
-func testAccComputeRouterNatWithNatIps(testId string) string {
+func testAccComputeRouterNatWithNatIps(routerName string) string {
 	return fmt.Sprintf(`
 %s
 
 resource "google_compute_router_nat" "foobar" {
-  name     = "router-nat-test-%s"
+  name     = "%s"
   router   = google_compute_router.foobar.name
   region   = google_compute_router.foobar.region
 
@@ -469,15 +477,15 @@ resource "google_compute_router_nat" "foobar" {
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
   }
 }
-`, testAccComputeRouterNatBaseResourcesWithNatIps(testId), testId)
+`, testAccComputeRouterNatBaseResourcesWithNatIps(routerName), routerName)
 }
 
-func testAccComputeRouterNatWithOneDrainOneRemovedNatIps(testId string) string {
+func testAccComputeRouterNatWithOneDrainOneRemovedNatIps(routerName string) string {
 	return fmt.Sprintf(`
 %s
 
 resource "google_compute_router_nat" "foobar" {
-  name     = "router-nat-test-%s"
+  name     = "%s"
   router   = google_compute_router.foobar.name
   region   = google_compute_router.foobar.region
 
@@ -496,15 +504,15 @@ resource "google_compute_router_nat" "foobar" {
     google_compute_address.addr3.self_link,
   ]
 }
-`, testAccComputeRouterNatBaseResourcesWithNatIps(testId), testId)
+`, testAccComputeRouterNatBaseResourcesWithNatIps(routerName), routerName)
 }
 
-func testAccComputeRouterNatWithInvalidDrainMissingNatIp(testId string) string {
+func testAccComputeRouterNatWithInvalidDrainMissingNatIp(routerName string) string {
 	return fmt.Sprintf(`
 %s
 
 resource "google_compute_router_nat" "foobar" {
-  name     = "router-nat-test-%s"
+  name     = "%s"
   router   = google_compute_router.foobar.name
   region   = google_compute_router.foobar.region
 
@@ -524,15 +532,15 @@ resource "google_compute_router_nat" "foobar" {
     google_compute_address.addr3.self_link,
   ]
 }
-`, testAccComputeRouterNatBaseResourcesWithNatIps(testId), testId)
+`, testAccComputeRouterNatBaseResourcesWithNatIps(routerName), routerName)
 }
 
-func testAccComputeRouterNatWithInvalidDrainNatIpsStillInNatIps(testId string) string {
+func testAccComputeRouterNatWithInvalidDrainNatIpsStillInNatIps(routerName string) string {
 	return fmt.Sprintf(`
 %s
 
 resource "google_compute_router_nat" "foobar" {
-  name     = "router-nat-test-%s"
+  name     = "%s"
   router   = google_compute_router.foobar.name
   region   = google_compute_router.foobar.region
 
@@ -553,29 +561,29 @@ resource "google_compute_router_nat" "foobar" {
     google_compute_address.addr3.self_link,
   ]
 }
-`, testAccComputeRouterNatBaseResourcesWithNatIps(testId), testId)
+`, testAccComputeRouterNatBaseResourcesWithNatIps(routerName), routerName)
 }
 
 <% end -%>
 
-func testAccComputeRouterNatKeepRouter(testId string) string {
+func testAccComputeRouterNatKeepRouter(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-  name                    = "router-nat-test-%s"
+  name                    = "%s"
   auto_create_subnetworks = "false"
 }
 
 resource "google_compute_subnetwork" "foobar" {
-  name          = "router-nat-test-subnetwork-%s"
+  name          = "%s"
   network       = google_compute_network.foobar.self_link
   ip_cidr_range = "10.0.0.0/16"
   region        = "us-central1"
 }
 
 resource "google_compute_router" "foobar" {
-  name    = "router-nat-test-%s"
+  name    = "%s"
   region  = google_compute_subnetwork.foobar.region
   network = google_compute_network.foobar.self_link
 }
-`, testId, testId, testId)
+`, routerName, routerName, routerName)
 }

--- a/third_party/terraform/tests/resource_compute_router_test.go
+++ b/third_party/terraform/tests/resource_compute_router_test.go
@@ -11,6 +11,7 @@ func TestAccComputeRouter_basic(t *testing.T) {
 	t.Parallel()
 
 	testId := randString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-%s", testId)
 	resourceRegion := "europe-west1"
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -18,7 +19,7 @@ func TestAccComputeRouter_basic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeRouterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeRouterBasic(testId, resourceRegion),
+				Config: testAccComputeRouterBasic(routerName, resourceRegion),
 			},
 			{
 				ResourceName:      "google_compute_router.foobar",
@@ -33,6 +34,7 @@ func TestAccComputeRouter_noRegion(t *testing.T) {
 	t.Parallel()
 
 	testId := randString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-%s", testId)
 	providerRegion := "us-central1"
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -40,7 +42,7 @@ func TestAccComputeRouter_noRegion(t *testing.T) {
 		CheckDestroy: testAccCheckComputeRouterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeRouterNoRegion(testId, providerRegion),
+				Config: testAccComputeRouterNoRegion(routerName, providerRegion),
 			},
 			{
 				ResourceName:      "google_compute_router.foobar",
@@ -55,13 +57,14 @@ func TestAccComputeRouter_full(t *testing.T) {
 	t.Parallel()
 
 	testId := randString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-%s", testId)
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckComputeRouterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeRouterFull(testId),
+				Config: testAccComputeRouterFull(routerName),
 			},
 			{
 				ResourceName:      "google_compute_router.foobar",
@@ -76,6 +79,7 @@ func TestAccComputeRouter_update(t *testing.T) {
 	t.Parallel()
 
 	testId := randString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-%s", testId)
 	region := getTestRegionFromEnv()
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -83,7 +87,7 @@ func TestAccComputeRouter_update(t *testing.T) {
 		CheckDestroy: testAccCheckComputeRouterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeRouterBasic(testId, region),
+				Config: testAccComputeRouterBasic(routerName, region),
 			},
 			{
 				ResourceName:      "google_compute_router.foobar",
@@ -91,7 +95,7 @@ func TestAccComputeRouter_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeRouterFull(testId),
+				Config: testAccComputeRouterFull(routerName),
 			},
 			{
 				ResourceName:      "google_compute_router.foobar",
@@ -99,7 +103,7 @@ func TestAccComputeRouter_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeRouterBasic(testId, region),
+				Config: testAccComputeRouterBasic(routerName, region),
 			},
 			{
 				ResourceName:      "google_compute_router.foobar",
@@ -114,6 +118,7 @@ func TestAccComputeRouter_updateAddRemoveBGP(t *testing.T) {
 	t.Parallel()
 
 	testId := randString(t, 10)
+	routerName := fmt.Sprintf("tf-test-router-%s", testId)
 	region := getTestRegionFromEnv()
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -121,7 +126,7 @@ func TestAccComputeRouter_updateAddRemoveBGP(t *testing.T) {
 		CheckDestroy: testAccCheckComputeRouterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeRouterBasic(testId, region),
+				Config: testAccComputeRouterBasic(routerName, region),
 			},
 			{
 				ResourceName:      "google_compute_router.foobar",
@@ -129,7 +134,7 @@ func TestAccComputeRouter_updateAddRemoveBGP(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeRouter_noBGP(testId, region),
+				Config: testAccComputeRouter_noBGP(routerName, region),
 			},
 			{
 				ResourceName:      "google_compute_router.foobar",
@@ -137,7 +142,7 @@ func TestAccComputeRouter_updateAddRemoveBGP(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeRouterBasic(testId, region),
+				Config: testAccComputeRouterBasic(routerName, region),
 			},
 			{
 				ResourceName:      "google_compute_router.foobar",
@@ -148,64 +153,64 @@ func TestAccComputeRouter_updateAddRemoveBGP(t *testing.T) {
 	})
 }
 
-func testAccComputeRouterBasic(testId, resourceRegion string) string {
+func testAccComputeRouterBasic(routerName, resourceRegion string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-  name                    = "router-test-%s"
+  name                    = "%s-net"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "foobar" {
-  name          = "router-test-subnetwork-%s"
+  name          = "%s-subnet"
   network       = google_compute_network.foobar.self_link
   ip_cidr_range = "10.0.0.0/16"
   region        = "%s"
 }
 
 resource "google_compute_router" "foobar" {
-  name    = "router-test-%s"
+  name    = "%s"
   region  = google_compute_subnetwork.foobar.region
   network = google_compute_network.foobar.name
   bgp {
     asn = 4294967294
   }
 }
-`, testId, testId, resourceRegion, testId)
+`, routerName, routerName, resourceRegion, routerName)
 }
 
-func testAccComputeRouterNoRegion(testId, providerRegion string) string {
+func testAccComputeRouterNoRegion(routerName, providerRegion string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-  name                    = "router-test-%s"
+  name                    = "%s-net"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "foobar" {
-  name          = "router-test-subnetwork-%s"
+  name          = "%s-subnet"
   network       = google_compute_network.foobar.self_link
   ip_cidr_range = "10.0.0.0/16"
   region        = "%s"
 }
 
 resource "google_compute_router" "foobar" {
-  name    = "router-test-%s"
+  name    = "%s"
   network = google_compute_network.foobar.name
   bgp {
     asn = 64514
   }
 }
-`, testId, testId, providerRegion, testId)
+`, routerName, routerName, providerRegion, routerName)
 }
 
-func testAccComputeRouterFull(testId string) string {
+func testAccComputeRouterFull(routerName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-  name                    = "router-test-%s"
+  name                    = "%s-net"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_router" "foobar" {
-  name    = "router-test-%s"
+  name    = "%s"
   network = google_compute_network.foobar.name
   bgp {
     asn               = 64514
@@ -219,27 +224,27 @@ resource "google_compute_router" "foobar" {
     }
   }
 }
-`, testId, testId)
+`, routerName, routerName)
 }
 
-func testAccComputeRouter_noBGP(testId, resourceRegion string) string {
+func testAccComputeRouter_noBGP(routerName, resourceRegion string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
-  name                    = "router-test-%s"
+  name                    = "%s-net"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "foobar" {
-  name          = "router-test-subnetwork-%s"
+  name          = "%s-subnet"
   network       = google_compute_network.foobar.self_link
   ip_cidr_range = "10.0.0.0/16"
   region        = "%s"
 }
 
 resource "google_compute_router" "foobar" {
-  name    = "router-test-%s"
+  name    = "%s"
   region  = google_compute_subnetwork.foobar.region
   network = google_compute_network.foobar.name
 }
-`, testId, testId, resourceRegion, testId)
+`, routerName, routerName, resourceRegion, routerName)
 }

--- a/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -393,7 +393,7 @@ func TestAccDataprocCluster_withStagingBucket(t *testing.T) {
 
 	rnd := randString(t, 10)
 	var cluster dataproc.Cluster
-	clusterName := fmt.Sprintf("dproc-cluster-test-%s", rnd)
+	clusterName := fmt.Sprintf("tf-test-dproc-%s", rnd)
 	bucketName := fmt.Sprintf("%s-bucket", clusterName)
 
 	vcrTest(t, resource.TestCase{
@@ -425,7 +425,7 @@ func TestAccDataprocCluster_withInitAction(t *testing.T) {
 
 	rnd := randString(t, 10)
 	var cluster dataproc.Cluster
-	bucketName := fmt.Sprintf("dproc-cluster-test-%s-init-bucket", rnd)
+	bucketName := fmt.Sprintf("tf-test-dproc-%s-init-bucket", rnd)
 	objectName := "msg.txt"
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -920,7 +920,7 @@ func testAccCheckDataprocClusterExists(t *testing.T, n string, cluster *dataproc
 func testAccCheckDataproc_missingZoneGlobalRegion1(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
-  name   = "dproc-cluster-test-%s"
+  name   = "tf-test-dproc-%s"
   region = "global"
 }
 `, rnd)
@@ -929,7 +929,7 @@ resource "google_dataproc_cluster" "basic" {
 func testAccCheckDataproc_missingZoneGlobalRegion2(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
-  name   = "dproc-cluster-test-%s"
+  name   = "tf-test-dproc-%s"
   region = "global"
 
   cluster_config {
@@ -944,7 +944,7 @@ resource "google_dataproc_cluster" "basic" {
 func testAccDataprocCluster_basic(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
-  name   = "dproc-cluster-test-%s"
+  name   = "tf-test-dproc-%s"
   region = "us-central1"
 }
 `, rnd)
@@ -953,7 +953,7 @@ resource "google_dataproc_cluster" "basic" {
 func testAccDataprocCluster_withAccelerators(rnd, acceleratorType, zone string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "accelerated_cluster" {
-  name   = "dproc-cluster-test-%s"
+  name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
@@ -986,7 +986,7 @@ variable "subnetwork_cidr" {
 }
 
 resource "google_compute_network" "dataproc_network" {
-  name                    = "dataproc-internalip-network-%s"
+  name                    = "tf-test-dproc-net-%s"
   auto_create_subnetworks = false
 }
 
@@ -995,7 +995,7 @@ resource "google_compute_network" "dataproc_network" {
 # deploying a Dataproc cluster with Internal IP Only enabled.
 #
 resource "google_compute_subnetwork" "dataproc_subnetwork" {
-  name                     = "dataproc-internalip-subnetwork-%s"
+  name                     = "tf-test-dproc-subnet-%s"
   ip_cidr_range            = var.subnetwork_cidr
   network                  = google_compute_network.dataproc_network.self_link
   region                   = "us-central1"
@@ -1010,7 +1010,7 @@ resource "google_compute_subnetwork" "dataproc_subnetwork" {
 # internally as part of their configuration or this will just hang.
 #
 resource "google_compute_firewall" "dataproc_network_firewall" {
-  name        = "dproc-cluster-test-allow-internal"
+  name        = "tf-test-dproc-firewall-%s"
   description = "Firewall rules for dataproc Terraform acceptance testing"
   network     = google_compute_network.dataproc_network.name
 
@@ -1032,7 +1032,7 @@ resource "google_compute_firewall" "dataproc_network_firewall" {
 }
 
 resource "google_dataproc_cluster" "basic" {
-  name       = "dproc-cluster-test-%s"
+  name       = "tf-test-dproc-%s"
   region     = "us-central1"
   depends_on = [google_compute_firewall.dataproc_network_firewall]
 
@@ -1043,13 +1043,13 @@ resource "google_dataproc_cluster" "basic" {
     }
   }
 }
-`, rnd, rnd, rnd)
+`, rnd, rnd, rnd, rnd)
 }
 
 func testAccDataprocCluster_withMetadataAndTags(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "basic" {
-  name   = "dproc-cluster-test-%s"
+  name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
@@ -1068,7 +1068,7 @@ resource "google_dataproc_cluster" "basic" {
 func testAccDataprocCluster_singleNodeCluster(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "single_node_cluster" {
-  name   = "dproc-cluster-test-%s"
+  name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
@@ -1086,7 +1086,7 @@ resource "google_dataproc_cluster" "single_node_cluster" {
 func testAccDataprocCluster_withConfigOverrides(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_config_overrides" {
-  name     = "dproc-cluster-test-%s"
+  name     = "tf-test-dproc-%s"
   region   = "us-central1"
 
   cluster_config {
@@ -1144,7 +1144,7 @@ EOL
 }
 
 resource "google_dataproc_cluster" "with_init_action" {
-  name   = "dproc-cluster-test-%s"
+  name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
@@ -1177,7 +1177,7 @@ resource "google_dataproc_cluster" "with_init_action" {
 func testAccDataprocCluster_updatable(rnd string, w, p int) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "updatable" {
-  name   = "dproc-cluster-test-%s"
+  name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
@@ -1249,7 +1249,7 @@ resource "google_dataproc_cluster" "with_bucket" {
 func testAccDataprocCluster_withLabels(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_labels" {
-  name   = "dproc-cluster-test-%s"
+  name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   labels = {
@@ -1285,7 +1285,7 @@ resource "google_dataproc_cluster" "with_endpoint_config" {
 func testAccDataprocCluster_withImageVersion(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_image_version" {
-  name   = "dproc-cluster-test-%s"
+  name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
@@ -1300,7 +1300,7 @@ resource "google_dataproc_cluster" "with_image_version" {
 func testAccDataprocCluster_withOptionalComponents(rnd string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_opt_components" {
-  name   = "dproc-cluster-test-%s"
+  name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
@@ -1316,7 +1316,7 @@ resource "google_dataproc_cluster" "with_opt_components" {
 func testAccDataprocCluster_withLifecycleConfigIdleDeleteTtl(rnd, tm string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_lifecycle_config" {
-  name   = "dproc-cluster-test-%s"
+  name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
@@ -1331,7 +1331,7 @@ resource "google_dataproc_cluster" "with_lifecycle_config" {
 func testAccDataprocCluster_withLifecycleConfigAutoDeletionTime(rnd, tm string) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "with_lifecycle_config" {
- name   = "dproc-cluster-test-%s"
+ name   = "tf-test-dproc-%s"
  region = "us-central1"
 
  cluster_config {
@@ -1411,7 +1411,7 @@ resource "google_compute_network" "dataproc_network" {
 # internally as part of their configuration or this will just hang.
 #
 resource "google_compute_firewall" "dataproc_network_firewall" {
-  name          = "dproc-cluster-test-%s-allow-internal"
+  name          = "tf-test-dproc-%s"
   description   = "Firewall rules for dataproc Terraform acceptance testing"
   network       = google_compute_network.dataproc_network.name
   source_ranges = ["192.168.0.0/16"]
@@ -1432,7 +1432,7 @@ resource "google_compute_firewall" "dataproc_network_firewall" {
 }
 
 resource "google_dataproc_cluster" "with_net_ref_by_name" {
-  name       = "dproc-cluster-test-%s-name"
+  name       = "tf-test-dproc-%s"
   region     = "us-central1"
   depends_on = [google_compute_firewall.dataproc_network_firewall]
 
@@ -1458,7 +1458,7 @@ resource "google_dataproc_cluster" "with_net_ref_by_name" {
 }
 
 resource "google_dataproc_cluster" "with_net_ref_by_url" {
-  name       = "dproc-cluster-test-%s-url"
+  name       = "tf-test-dproc-%s"
   region     = "us-central1"
   depends_on = [google_compute_firewall.dataproc_network_firewall]
 
@@ -1500,7 +1500,7 @@ resource "google_project_iam_member" "kms-project-binding" {
 resource "google_dataproc_cluster" "kms" {
   depends_on = [google_project_iam_member.kms-project-binding]
 
-  name   = "dproc-cluster-test-%s"
+  name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {
@@ -1515,7 +1515,7 @@ resource "google_dataproc_cluster" "kms" {
 func testAccDataprocCluster_withKerberos(rnd, kmsKey string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
-  name = "dproc-cluster-test-%s"
+  name = "tf-test-dproc-%s"
 }
 resource "google_storage_bucket_object" "password" {
   name = "dataproc-password-%s"
@@ -1524,7 +1524,7 @@ resource "google_storage_bucket_object" "password" {
 }
 
 resource "google_dataproc_cluster" "kerb" {
-  name   = "dproc-cluster-test-%s"
+  name   = "tf-test-dproc-%s"
   region = "us-central1"
 
   cluster_config {

--- a/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
+++ b/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
@@ -270,12 +270,12 @@ resource "google_dns_managed_zone" "private" {
 }
 
 resource "google_compute_network" "network-1" {
-  name                    = "network-1-%s"
+  name                    = "tf-test-net-1-%s"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_network" "network-2" {
-  name                    = "network-2-%s"
+  name                    = "tf-test-net-2-%s"
   auto_create_subnetworks = false
 }
 
@@ -312,7 +312,7 @@ resource "google_dns_managed_zone" "private" {
 }
 
 resource "google_compute_network" "network-1" {
-  name                    = "network-1-%s"
+  name                    = "tf-test-net-1-%s"
   auto_create_subnetworks = false
 }
 `, suffix, first_nameserver, first_forwarding_path, second_nameserver, second_forwarding_path, suffix)
@@ -331,7 +331,7 @@ resource "google_dns_managed_zone" "reverse" {
 }
 
 resource "google_compute_network" "network-1" {
-  name                    = "network-1-%s"
+  name                    = "tf-test-net-1-%s"
   auto_create_subnetworks = false
 }
 `, suffix, suffix)


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```

This should help with the routes quota