### PR TITLE
Add custom access level to access context manager

### DIFF
--- a/products/accesscontextmanager/api.yaml
+++ b/products/accesscontextmanager/api.yaml
@@ -148,6 +148,8 @@ objects:
         name: 'basic'
         description: |
           A set of predefined conditions for the access level and a combining function.
+        conflicts:
+          - custom
         properties:
           - !ruby/object:Api::Type::Enum
             name: 'combiningFunction'
@@ -294,6 +296,34 @@ objects:
                   countries/regions.
                   Format: A valid ISO 3166-1 alpha-2 code.
                 item_type: Api::Type::String
+      - !ruby/object:Api::Type::NestedObject
+        name: 'custom'
+        description: |
+          Custom access level conditions are set using the Cloud Common Expression Language to represent the necessary conditions for the level to apply to a request. 
+          See CEL spec at: https://github.com/google/cel-spec
+        conflicts:
+          - basic  
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: 'expr'
+            required: true
+            description: |
+              Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. 
+              The syntax and semantics of CEL are documented at https://github.com/google/cel-spec.
+            properties:
+            - !ruby/object:Api::Type::String
+              name: 'expression'
+              required: true
+              description: Textual representation of an expression in Common Expression Language syntax.
+            - !ruby/object:Api::Type::String
+              name: 'title'
+              description: Title for the expression, i.e. a short string describing its purpose.
+            - !ruby/object:Api::Type::String
+              name: 'description'
+              description: Description of the expression 
+            - !ruby/object:Api::Type::String
+              name: 'location'
+              description: String indicating the location of the expression for error reporting, e.g. a file name and a position in the file      
   - !ruby/object:Api::Resource
     name: 'ServicePerimeter'
     # This is an unusual API, so we need to use a few fields to map the methods

--- a/products/accesscontextmanager/api.yaml
+++ b/products/accesscontextmanager/api.yaml
@@ -300,7 +300,7 @@ objects:
         name: 'custom'
         description: |
           Custom access level conditions are set using the Cloud Common Expression Language to represent the necessary conditions for the level to apply to a request. 
-          See CEL spec at: https://github.com/google/cel-spec
+          See CEL spec at: https://github.com/google/cel-spec.
         conflicts:
           - basic  
         properties:
@@ -308,8 +308,9 @@ objects:
             name: 'expr'
             required: true
             description: |
-              Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language. 
-              The syntax and semantics of CEL are documented at https://github.com/google/cel-spec.
+              Represents a textual expression in the Common Expression Language (CEL) syntax. CEL is a C-like expression language.
+              This page details the objects and attributes that are used to the build the CEL expressions for 
+              custom access levels - https://cloud.google.com/access-context-manager/docs/custom-access-level-spec.
             properties:
             - !ruby/object:Api::Type::String
               name: 'expression'

--- a/third_party/terraform/tests/resource_access_context_manager_access_level_test.go.erb
+++ b/third_party/terraform/tests/resource_access_context_manager_access_level_test.go.erb
@@ -84,6 +84,26 @@ func testAccCheckAccessContextManagerAccessLevelDestroyProducer(t *testing.T) fu
 	}
 }
 
+func testAccAccessContextManagerAccessLevel_customTest(t *testing.T) {
+	org := getTestOrgFromEnv(t)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAccessContextManagerAccessLevelDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccessContextManagerAccessLevel_custom(org, "my policy", "level"),
+			},
+			{
+				ResourceName:      "google_access_context_manager_access_level.test-access",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccAccessContextManagerAccessLevel_basic(org, policyTitle, levelTitleName string) string {
 	return fmt.Sprintf(`
 resource "google_access_context_manager_access_policy" "test-access" {
@@ -101,6 +121,27 @@ resource "google_access_context_manager_access_level" "test-access" {
     conditions {
       ip_subnetworks = ["192.0.4.0/24"]
     }
+  }
+}
+`, org, policyTitle, levelTitleName, levelTitleName)
+}
+
+func testAccAccessContextManagerAccessLevel_custom(org, policyTitle, levelTitleName string) string {
+	return fmt.Sprintf(`
+resource "google_access_context_manager_access_policy" "test-access" {
+  parent = "organizations/%s"
+  title  = "%s"
+}
+
+resource "google_access_context_manager_access_level" "test-access" {
+  parent      = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}"
+  name        = "accessPolicies/${google_access_context_manager_access_policy.test-access.name}/accessLevels/%s"
+  title       = "%s"
+  description = "hello"
+    custom {
+		expr {
+			expression = "device.os_type == OsType.DESKTOP_MAC"
+		}
   }
 }
 `, org, policyTitle, levelTitleName, levelTitleName)

--- a/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
@@ -84,6 +84,7 @@ func TestAccAccessContextManager(t *testing.T) {
 		"service_perimeter_resource": testAccAccessContextManagerServicePerimeterResource_basicTest,
 		"access_level":               testAccAccessContextManagerAccessLevel_basicTest,
 		"access_level_full":          testAccAccessContextManagerAccessLevel_fullTest,
+		"access_level_custom":        testAccAccessContextManagerAccessLevel_customTest,
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
access_context_manager: custom access level added to `google_access_context_manager_access_level`

```
fixes : https://github.com/terraform-providers/terraform-provider-google/issues/6527