### PR TITLE
Fix names for dataproc cluster test

### DIFF
--- a/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -1432,7 +1432,7 @@ resource "google_compute_firewall" "dataproc_network_firewall" {
 }
 
 resource "google_dataproc_cluster" "with_net_ref_by_name" {
-  name       = "tf-test-dproc-%s"
+  name       = "tf-test-dproc-net-%s"
   region     = "us-central1"
   depends_on = [google_compute_firewall.dataproc_network_firewall]
 
@@ -1458,7 +1458,7 @@ resource "google_dataproc_cluster" "with_net_ref_by_name" {
 }
 
 resource "google_dataproc_cluster" "with_net_ref_by_url" {
-  name       = "tf-test-dproc-%s"
+  name       = "tf-test-dproc-url-%s"
   region     = "us-central1"
   depends_on = [google_compute_firewall.dataproc_network_firewall]
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
In #3650 I accidently made these two clusters have the same name - fixing
