### PR TITLE
Add memcache, gke release channel, sql ca cert

### DIFF
--- a/products/container/api.yaml
+++ b/products/container/api.yaml
@@ -687,6 +687,21 @@ objects:
           - !ruby/object:Api::Type::Boolean
             name: 'enabled'
             description: If enabled, all container images will be validated by Binary Authorization.
+      - !ruby/object:Api::Type::NestedObject
+        min_version: beta
+        name: 'releaseChannel'
+        description: |
+          ReleaseChannel indicates which release channel a cluster is subscribed to.
+          Release channels are arranged in order of risk and frequency of updates.
+        properties:
+          - !ruby/object:Api::Type::Enum
+            name: 'channel'
+            description: 'Which release channel the cluster is subscribed to.'
+            values: 
+              - UNSPECIFIED
+              - RAPID
+              - REGULAR
+              - STABLE
   - !ruby/object:Api::Resource
     name: 'NodePool'
     base_url: projects/{{project}}/locations/{{location}}/clusters/{{cluster}}/nodePools

--- a/products/memcache/api.yaml
+++ b/products/memcache/api.yaml
@@ -17,9 +17,6 @@ versions:
   - !ruby/object:Api::Product::Version
     name: beta
     base_url: https://memcache.googleapis.com/v1beta2/
-  - !ruby/object:Api::Product::Version
-    name: ga
-    base_url: https://memcache.googleapis.com/v1beta2/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 async: !ruby/object:Api::OpAsync

--- a/products/memcache/api.yaml
+++ b/products/memcache/api.yaml
@@ -17,6 +17,9 @@ versions:
   - !ruby/object:Api::Product::Version
     name: beta
     base_url: https://memcache.googleapis.com/v1beta2/
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://memcache.googleapis.com/v1beta2/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 async: !ruby/object:Api::OpAsync

--- a/products/memcache/inspec.yaml
+++ b/products/memcache/inspec.yaml
@@ -1,0 +1,17 @@
+# Copyright 2019 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Inspec::Config
+overrides: !ruby/object:Overrides::ResourceOverrides
+  Instance: !ruby/object:Overrides::Inspec::ResourceOverride
+    collection_url_key: resources

--- a/products/sql/api.yaml
+++ b/products/sql/api.yaml
@@ -435,6 +435,34 @@ objects:
             name: 'kmsKeyVersionName'
             description: |
               The KMS key version used to encrypt the Cloud SQL instance
+      - !ruby/object:Api::Type::NestedObject
+        name: 'serverCaCert'
+        description: 'SSL configuration'
+        output: true
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'cert'
+            description: 'PEM representation of the X.509 certificate.'
+          - !ruby/object:Api::Type::String
+            name: 'certSerialNumber'
+            description: 'Serial number, as extracted from the certificate.'
+          - !ruby/object:Api::Type::String
+            name: 'commonName'
+            description: 'User supplied name. Constrained to [a-zA-Z.-_ ]+.'
+          - !ruby/object:Api::Type::Time
+            name: 'createTime'
+            description: |
+              The time when the certificate was created in RFC 3339 format, for
+              example 2012-11-15T16:19:00.094Z.
+          - !ruby/object:Api::Type::Time
+            name: 'expirationTime'
+            description: |
+              The time when the certificate expires in RFC 3339 format, for example
+              2012-11-15T16:19:00.094Z.
+          - !ruby/object:Api::Type::Time
+            name: 'sha1Fingerprint'
+            description: |
+              SHA-1 fingerprint of the certificate.
   - !ruby/object:Api::Resource
     name: 'Database'
     kind: 'sql#database'

--- a/products/sql/api.yaml
+++ b/products/sql/api.yaml
@@ -459,7 +459,7 @@ objects:
             description: |
               The time when the certificate expires in RFC 3339 format, for example
               2012-11-15T16:19:00.094Z.
-          - !ruby/object:Api::Type::Time
+          - !ruby/object:Api::Type::String
             name: 'sha1Fingerprint'
             description: |
               SHA-1 fingerprint of the certificate.

--- a/provider/inspec.rb
+++ b/provider/inspec.rb
@@ -393,8 +393,11 @@ module Provider
     end
 
     def ga_api_url(object)
-      ga_version = object.__product.version_obj_or_closest('ga')
-      object.product_url || ga_version.base_url
+      if object.__product.exists_at_version('ga')
+        ga_version = object.__product.version_obj_or_closest('ga')
+        return object.product_url || ga_version.base_url
+      end
+      beta_api_url(object)
     end
   end
 end

--- a/templates/inspec/examples/google_container_cluster/google_container_cluster.erb
+++ b/templates/inspec/examples/google_container_cluster/google_container_cluster.erb
@@ -15,3 +15,8 @@ end
 describe google_container_cluster(project: <%= gcp_project_id -%>, location: <%= gcp_kube_cluster_zone -%>, name: 'nonexistent') do
   it { should_not exist }
 end
+
+describe google_container_cluster(project: <%= gcp_project_id -%>, location: <%= gcp_kube_cluster_zone -%>, name: <%= gcp_kube_cluster_name -%>, beta: true) do
+  it { should exist }
+  its('release_channel.channel') { should cmp "RAPID" }
+end

--- a/templates/inspec/examples/google_memcache_instance/google_memcache_instance.erb
+++ b/templates/inspec/examples/google_memcache_instance/google_memcache_instance.erb
@@ -1,0 +1,11 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+<% gcp_location = "#{external_attribute(pwd, 'gcp_location', doc_generation)}" -%>
+<% memcache_instance = grab_attributes(pwd)['memcache_instance'] -%>
+describe google_memcache_instance(project: <%= gcp_project_id -%>, region: <%= gcp_location %>, name: <%= doc_generation ? "'#{memcache_instance['name']}'" : "memcache_instance['name']" -%>) do
+  it { should exist }
+  its('node_count') { should cmp 1 }
+end
+
+describe google_memcache_instance(project: <%= gcp_project_id -%>, region: <%= gcp_location %>, name: "nonexistent") do
+  it { should_not exist }
+end

--- a/templates/inspec/examples/google_memcache_instance/google_memcache_instance_attributes.erb
+++ b/templates/inspec/examples/google_memcache_instance/google_memcache_instance_attributes.erb
@@ -1,3 +1,3 @@
 gcp_project_id = attribute(:gcp_project_id, default: '<%= external_attribute(pwd, 'gcp_project_id') -%>', description: 'The GCP project identifier.')
 gcp_location = attribute(:gcp_location, default: '<%= external_attribute(pwd, 'gcp_location') -%>', description: 'The GCP project region.')
-memcache_instance = attribute('rigm', default: <%= JSON.pretty_generate(grab_attributes(pwd)['memcache_instance']) -%>, description: 'Memcache settings')
+memcache_instance = attribute('memcache_instance', default: <%= JSON.pretty_generate(grab_attributes(pwd)['memcache_instance']) -%>, description: 'Memcache settings')

--- a/templates/inspec/examples/google_memcache_instance/google_memcache_instance_attributes.erb
+++ b/templates/inspec/examples/google_memcache_instance/google_memcache_instance_attributes.erb
@@ -1,0 +1,3 @@
+gcp_project_id = attribute(:gcp_project_id, default: '<%= external_attribute(pwd, 'gcp_project_id') -%>', description: 'The GCP project identifier.')
+gcp_location = attribute(:gcp_location, default: '<%= external_attribute(pwd, 'gcp_location') -%>', description: 'The GCP project region.')
+memcache_instance = attribute('rigm', default: <%= JSON.pretty_generate(grab_attributes(pwd)['memcache_instance']) -%>, description: 'Memcache settings')

--- a/templates/inspec/examples/google_memcache_instance/google_memcache_instances.erb
+++ b/templates/inspec/examples/google_memcache_instance/google_memcache_instances.erb
@@ -2,6 +2,6 @@
 <% gcp_location = "#{external_attribute(pwd, 'gcp_location', doc_generation)}" -%>
 <% memcache_instance = grab_attributes(pwd)['memcache_instance'] -%>
 describe google_memcache_instances(project: <%= gcp_project_id -%>, region: <%= gcp_location %>) do
-	its('size') { should be >= 1 }
-  its('names') { should include <%= doc_generation ? "'#{memcache_instance['name']}'" : "memcache_instance['name']" -%> }
+	its('count') { should be >= 1 }
+  its('node_counts') { should include 1 }
 end

--- a/templates/inspec/examples/google_memcache_instance/google_memcache_instances.erb
+++ b/templates/inspec/examples/google_memcache_instance/google_memcache_instances.erb
@@ -1,0 +1,7 @@
+<% gcp_project_id = "#{external_attribute(pwd, 'gcp_project_id', doc_generation)}" -%>
+<% gcp_location = "#{external_attribute(pwd, 'gcp_location', doc_generation)}" -%>
+<% memcache_instance = grab_attributes(pwd)['memcache_instance'] -%>
+describe google_memcache_instances(project: <%= gcp_project_id -%>, region: <%= gcp_location %>) do
+	its('size') { should be >= 1 }
+  its('names') { should include <%= doc_generation ? "'#{memcache_instance['name']}'" : "memcache_instance['name']" -%> }
+end

--- a/templates/inspec/tests/integration/build/gcp-mm.tf
+++ b/templates/inspec/tests/integration/build/gcp-mm.tf
@@ -1262,9 +1262,33 @@ variable "memcache_instance" {
   type = any
 }
 
+resource "google_compute_network" "memcache_network" {
+  provider = google-beta
+  project = var.gcp_project_id
+  name = "inspec-gcp-memcache"
+}
+
+resource "google_compute_global_address" "service_range" {
+  provider = google-beta
+  project = var.gcp_project_id
+  name          = "inspec-gcp-memcache"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.memcache_network.id
+}
+
+resource "google_service_networking_connection" "private_service_connection" {
+  provider = google-beta
+  project = var.gcp_project_id
+  network                 = google_compute_network.memcache_network.id
+  service                 = "servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.service_range.name]
+}
+
 resource "google_memcache_instance" "instance" {
   provider = google-beta
-  name = "test-instance"
+  name = var.memcache_instance["name"]
   project = var.gcp_project_id
   region = var.gcp_location
 

--- a/templates/inspec/tests/integration/build/gcp-mm.tf
+++ b/templates/inspec/tests/integration/build/gcp-mm.tf
@@ -1280,7 +1280,6 @@ resource "google_compute_global_address" "service_range" {
 
 resource "google_service_networking_connection" "private_service_connection" {
   provider = google-beta
-  project = var.gcp_project_id
   network                 = google_compute_network.memcache_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.service_range.name]
@@ -1291,6 +1290,7 @@ resource "google_memcache_instance" "instance" {
   name = var.memcache_instance["name"]
   project = var.gcp_project_id
   region = var.gcp_location
+  authorized_network = google_service_networking_connection.private_service_connection.network
 
   node_config {
     cpu_count      = 1

--- a/templates/inspec/tests/integration/build/gcp-mm.tf
+++ b/templates/inspec/tests/integration/build/gcp-mm.tf
@@ -1257,3 +1257,20 @@ resource "google_compute_security_policy" "policy" {
     description = "default rule"
   }
 }
+
+variable "memcache_instance" {
+  type = any
+}
+
+resource "google_memcache_instance" "instance" {
+  provider = google-beta
+  name = "test-instance"
+  project = var.gcp_project_id
+  region = var.gcp_location
+
+  node_config {
+    cpu_count      = 1
+    memory_size_mb = 1024
+  }
+  node_count = 1
+}

--- a/templates/inspec/tests/integration/configuration/mm-attributes.yml
+++ b/templates/inspec/tests/integration/configuration/mm-attributes.yml
@@ -444,3 +444,6 @@ security_policy:
   priority: "1000"
   ip_range: "9.9.9.0/24"
   description: my description
+
+memcache_instance:
+  name: mem-instance

--- a/third_party/inspec/custom_functions/google_compute_instance.erb
+++ b/third_party/inspec/custom_functions/google_compute_instance.erb
@@ -107,8 +107,8 @@ def service_account_scopes
 end
 
 def block_project_ssh_keys
-  return false if !defined?(@metadata.items) || @metadata.items.nil?
-  @metadata.items.each do |element|
+  return false if !defined?(@metadata['items']) || @metadata['items'].nil?
+  @metadata['items'].each do |element|
     return true if element.key=='block-project-ssh-keys' and element.value.casecmp('true').zero?
     return true if element.key=='block-project-ssh-keys' and element.value=='1'
   end
@@ -116,8 +116,8 @@ def block_project_ssh_keys
 end
 
 def has_serial_port_disabled?
-  return false if !defined?(@metadata.items) || @metadata.items.nil?
-  @metadata.items.each do |element|
+  return false if !defined?(@metadata['items']) || @metadata['items'].nil?
+  @metadata['items'].each do |element|
     return true if element.key=='serial-port-enable' and element.value.casecmp('false').zero?
     return true if element.key=='serial-port-enable' and element.value=='0'
   end


### PR DESCRIPTION
Add memcache instance to inspec,

SQL instance ssl ca cert

GKE release channel (beta)

Fixes for handwritten functions

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
