### PR TITLE
Fetch Google netblock from JSON on gstatic domain

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_netblock_ip_ranges.go
+++ b/third_party/terraform/data_sources/data_source_google_netblock_ip_ranges.go
@@ -17,8 +17,8 @@ type googRanges struct {
 }
 
 type prefixes struct {
-	Ipv4Prefix string `json:ipv4Prefix`
-	Ipv6Prefix string `json:ipv6Prefix`
+	Ipv4Prefix string `json:"ipv4Prefix"`
+	Ipv6Prefix string `json:"ipv6Prefix"`
 }
 
 func dataSourceGoogleNetblockIpRanges() *schema.Resource {

--- a/third_party/terraform/data_sources/data_source_google_netblock_ip_ranges.go
+++ b/third_party/terraform/data_sources/data_source_google_netblock_ip_ranges.go
@@ -1,12 +1,25 @@
 package google
 
 import (
+	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"io/ioutil"
 	"net/http"
 	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
+
+type googRanges struct {
+	SyncToken    string     `json:"syncToken"`
+	CreationTime string     `json:"creationTime"`
+	Prefixes     []prefixes `json:"prefixes"`
+}
+
+type prefixes struct {
+	Ipv4Prefix string `json:ipv4Prefix`
+	Ipv6Prefix string `json:ipv6Prefix`
+}
 
 func dataSourceGoogleNetblockIpRanges() *schema.Resource {
 	return &schema.Resource{
@@ -47,7 +60,7 @@ func dataSourceGoogleNetblockIpRangesRead(d *schema.ResourceData, meta interface
 	case "cloud-netblocks":
 		// https://cloud.google.com/compute/docs/faq#where_can_i_find_product_name_short_ip_ranges
 		const CLOUD_NETBLOCK_DNS = "_cloud-netblocks.googleusercontent.com"
-		CidrBlocks, err := getCidrBlocks(CLOUD_NETBLOCK_DNS)
+		CidrBlocks, err := getCidrBlocksFromDns(CLOUD_NETBLOCK_DNS)
 
 		if err != nil {
 			return err
@@ -56,9 +69,9 @@ func dataSourceGoogleNetblockIpRangesRead(d *schema.ResourceData, meta interface
 		d.Set("cidr_blocks_ipv4", CidrBlocks["cidr_blocks_ipv4"])
 		d.Set("cidr_blocks_ipv6", CidrBlocks["cidr_blocks_ipv6"])
 	case "google-netblocks":
-		// https://support.google.com/a/answer/33786?hl=en
-		const GOOGLE_NETBLOCK_DNS = "_spf.google.com"
-		CidrBlocks, err := getCidrBlocks(GOOGLE_NETBLOCK_DNS)
+		// https://cloud.google.com/vpc/docs/configure-private-google-access?hl=en#ip-addr-defaults
+		const GOOGLE_NETBLOCK_URL = "http://www.gstatic.com/ipranges/goog.json"
+		CidrBlocks, err := getCidrBlocksFromUrl(GOOGLE_NETBLOCK_URL)
 
 		if err != nil {
 			return err
@@ -132,7 +145,7 @@ func netblock_request(name string) (string, error) {
 	return string(body), nil
 }
 
-func getCidrBlocks(netblock string) (map[string][]string, error) {
+func getCidrBlocksFromDns(netblock string) (map[string][]string, error) {
 	var dnsNetblockList []string
 	cidrBlocks := make(map[string][]string)
 
@@ -182,6 +195,43 @@ func getCidrBlocks(netblock string) (map[string][]string, error) {
 				dnsNetblockList = append(dnsNetblockList, cidr_block)
 			}
 		}
+	}
+
+	return cidrBlocks, nil
+}
+
+func getCidrBlocksFromUrl(url string) (map[string][]string, error) {
+	cidrBlocks := make(map[string][]string)
+
+	response, err := http.Get(url)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error: %s", err)
+	}
+
+	defer response.Body.Close()
+	body, err := ioutil.ReadAll(response.Body)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error to retrieve the CIDR list: %s", err)
+	}
+
+	ranges := googRanges{}
+	jsonErr := json.Unmarshal(body, &ranges)
+	if jsonErr != nil {
+		return nil, fmt.Errorf("Error reading JSON list: %s", jsonErr)
+	}
+
+	for _, element := range ranges.Prefixes {
+
+		if len(element.Ipv4Prefix) > 0 {
+			cidrBlocks["cidr_blocks_ipv4"] = append(cidrBlocks["cidr_blocks_ipv4"], element.Ipv4Prefix)
+			cidrBlocks["cidr_blocks"] = append(cidrBlocks["cidr_blocks"], element.Ipv4Prefix)
+		} else if len(element.Ipv6Prefix) > 0 {
+			cidrBlocks["cidr_blocks_ipv6"] = append(cidrBlocks["cidr_blocks_ipv6"], element.Ipv6Prefix)
+			cidrBlocks["cidr_blocks"] = append(cidrBlocks["cidr_blocks"], element.Ipv6Prefix)
+		}
+
 	}
 
 	return cidrBlocks, nil

--- a/third_party/terraform/website/docs/d/datasource_google_netblock_ip_ranges.html.markdown
+++ b/third_party/terraform/website/docs/d/datasource_google_netblock_ip_ranges.html.markdown
@@ -64,7 +64,7 @@ The following arguments are supported:
 
   * `cloud-netblocks` - Corresponds to the IP addresses used for resources on Google Cloud Platform. [More details.](https://cloud.google.com/compute/docs/faq#where_can_i_find_product_name_short_ip_ranges)
 
-  * `google-netblocks` - Corresponds to IP addresses used for Google services. [More details.](https://support.google.com/a/answer/33786?hl=en)
+  * `google-netblocks` - Corresponds to IP addresses used for Google services. [More details.](https://cloud.google.com/compute/docs/faq#where_can_i_find_product_name_short_ip_ranges)
 
   * `restricted-googleapis` - Corresponds to the IP addresses used for Private Google Access only for services that support VPC Service Controls API access. [More details.](https://cloud.google.com/vpc/docs/private-access-options#domain-vips)
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
netblock: fixed the google netblock ranges returned by the `google_netblock_ip_ranges` by targeting json on gstatic domain instead of reading SPF dns records (solution provided by network team)
```

We experienced the issue after seeing that some google domains are outside of the IPs provided by the SPF records.
For example : 
```
ig datastudio.google.com
; <<>> DiG 9.10.6 <<>> datastudio.google.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 39814
;; flags: qr rd ra; QUERY: 1, ANSWER: 6, AUTHORITY: 0, ADDITIONAL: 1
;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4000
;; QUESTION SECTION:
;datastudio.google.com.		IN	A
;; ANSWER SECTION:
datastudio.google.com.	299	IN	A	142.250.31.101
datastudio.google.com.	299	IN	A	142.250.31.102
datastudio.google.com.	299	IN	A	142.250.31.138
datastudio.google.com.	299	IN	A	142.250.31.113
datastudio.google.com.	299	IN	A	142.250.31.100
datastudio.google.com.	299	IN	A	142.250.31.139
;; Query time: 96 msec
;; SERVER: 10.114.228.14#53(10.114.228.14)
;; WHEN: Fri Jun 12 11:33:54 CEST 2020
;; MSG SIZE  rcvd: 146
```

Currently the datasource return:
```
data.google_netblock_ip_ranges.netblock: Refreshing state...

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

cidr_blocks = [
  "35.190.247.0/24",
  "64.233.160.0/19",
  "66.102.0.0/20",
  "66.249.80.0/20",
  "72.14.192.0/18",
  "74.125.0.0/16",
  "108.177.8.0/21",
  "173.194.0.0/16",
  "209.85.128.0/17",
  "216.58.192.0/19",
  "216.239.32.0/19",
  "2001:4860:4000::/36",
  "2404:6800:4000::/36",
  "2607:f8b0:4000::/36",
  "2800:3f0:4000::/36",
  "2a00:1450:4000::/36",
  "2c0f:fb50:4000::/36",
  "172.217.0.0/19",
  "172.217.32.0/20",
  "172.217.128.0/19",
  "172.217.160.0/20",
  "172.217.192.0/19",
  "172.253.56.0/21",
  "172.253.112.0/20",
  "108.177.96.0/19",
  "35.191.0.0/16",
  "130.211.0.0/22",
]
```

With the changes proposed it return:
```
data.google_netblock_ip_ranges.netblock: Refreshing state...

Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

cidr_blocks = [
  "8.8.4.0/24",
  "8.8.8.0/24",
  "8.34.208.0/20",
  "8.35.192.0/20",
  "23.236.48.0/20",
  "23.251.128.0/19",
  "34.64.0.0/10",
  "35.184.0.0/13",
  "35.192.0.0/14",
  "35.196.0.0/15",
  "35.198.0.0/16",
  "35.199.0.0/17",
  "35.199.128.0/18",
  "35.200.0.0/13",
  "35.208.0.0/12",
  "35.224.0.0/12",
  "35.240.0.0/13",
  "64.15.112.0/20",
  "64.233.160.0/19",
  "66.102.0.0/20",
  "66.249.64.0/19",
  "70.32.128.0/19",
  "72.14.192.0/18",
  "74.114.24.0/21",
  "74.125.0.0/16",
  "104.154.0.0/15",
  "104.196.0.0/14",
  "104.237.160.0/19",
  "107.167.160.0/19",
  "107.178.192.0/18",
  "108.59.80.0/20",
  "108.170.192.0/18",
  "108.177.0.0/17",
  "130.211.0.0/16",
  "136.112.0.0/12",
  "142.250.0.0/15",
  "146.148.0.0/17",
  "162.216.148.0/22",
  "162.222.176.0/21",
  "172.110.32.0/21",
  "172.217.0.0/16",
  "172.253.0.0/16",
  "173.194.0.0/16",
  "173.255.112.0/20",
  "192.158.28.0/22",
  "192.178.0.0/15",
  "199.36.154.0/23",
  "199.36.156.0/24",
  "199.192.112.0/22",
  "199.223.232.0/21",
  "207.223.160.0/20",
  "208.65.152.0/22",
  "208.68.108.0/22",
  "208.81.188.0/22",
  "208.117.224.0/19",
  "209.85.128.0/17",
  "216.58.192.0/19",
  "216.73.80.0/20",
  "216.239.32.0/19",
  "2001:4860::/32",
  "2404:6800::/32",
  "2404:f340::/32",
  "2600:1900::/28",
  "2607:f8b0::/32",
  "2620:11a:a000::/40",
  "2620:120:e000::/40",
  "2800:3f0::/32",
  "2a00:1450::/32",
  "2c0f:fb50::/32",
]
```
The solution has been provided by the GCP support (networking team).