### PR TITLE
Add mode enum and scale down controls for Compute AutoScaler

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -301,6 +301,14 @@ objects:
               instance may take to initialize. To do this, create an instance
               and time the startup process.
             default_value: 60
+          - !ruby/object:Api::Type::Enum
+            name: 'mode'
+            description: |
+              Defines operating mode for this policy.
+            values:
+              - :OFF
+              - :ONLY_UP
+              - :ON
           - !ruby/object:Api::Type::NestedObject
             name: 'scaleDownControl'
             min_version: beta
@@ -8505,14 +8513,6 @@ objects:
               instance may take to initialize. To do this, create an instance
               and time the startup process.
             default_value: 60
-          - !ruby/object:Api::Type::Enum
-            name: 'mode'
-            description: |
-              Defines operating mode for this policy.
-            values:
-              - :OFF
-              - :ONLY_UP
-              - :ON
           - !ruby/object:Api::Type::NestedObject
             name: 'cpuUtilization'
             description: |

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -313,12 +313,18 @@ objects:
           - !ruby/object:Api::Type::NestedObject
             name: 'scaleDownControl'
             min_version: beta
+            at_least_one_of:
+             - scale_down_control.0.max_scaled_down_replicas
+             - scale_down_control.0.time_window_sec
             description: |
               Defines scale down controls to reduce the risk of response latency
               and outages due to abrupt scale-in events
             properties:
             - !ruby/object:Api::Type::NestedObject
               name: 'maxScaledDownReplicas'
+              at_least_one_of:
+              - scale_down_control.0.max_scaled_down_replicas.0.fixed
+              - scale_down_control.0.max_scaled_down_replicas.0.percent
               properties:
               - !ruby/object:Api::Type::Integer
                 name: 'fixed'

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -303,6 +303,7 @@ objects:
             default_value: 60
           - !ruby/object:Api::Type::Enum
             name: 'mode'
+            default_value: :ON
             description: |
               Defines operating mode for this policy.
             values:

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -302,6 +302,31 @@ objects:
               and time the startup process.
             default_value: 60
           - !ruby/object:Api::Type::NestedObject
+            name: 'scaleDownControl'
+            min_version: beta
+            description: |
+              Defines scale down controls to reduce the risk of response latency
+              and outages due to abrupt scale-in events
+            properties:
+            - !ruby/object:Api::Type::NestedObject
+              name: 'maxScaledDownReplicas'
+              properties:
+              - !ruby/object:Api::Type::Integer
+                name: 'fixed'
+                description: |
+                  Specifies a fixed number of VM instances. This must be a positive
+                  integer.
+              - !ruby/object:Api::Type::Integer
+                name: 'percent'
+                description: |
+                  Specifies a percentage of instances between 0 to 100%, inclusive.
+                  For example, specify 80 for 80%.
+            - !ruby/object:Api::Type::Integer
+              name: 'timeWindowSec'
+              description: |
+                How long back autoscaling should look when computing recommendations
+                to include directives regarding slower scale down, as described above.
+          - !ruby/object:Api::Type::NestedObject
             name: 'cpuUtilization'
             description: |
               Defines the CPU utilization policy that allows the autoscaler to
@@ -7590,8 +7615,8 @@ objects:
               The autoscaling mode. Set to one of the following:
                 - OFF: Disables the autoscaler.
                 - ON: Enables scaling in and scaling out.
-                - ONLY_SCALE_OUT: Enables only scaling out. 
-                You must use this mode if your node groups are configured to 
+                - ONLY_SCALE_OUT: Enables only scaling out.
+                You must use this mode if your node groups are configured to
                 restart their hosted VMs on minimal servers.
             values:
               - :OFF
@@ -7600,7 +7625,7 @@ objects:
           - !ruby/object:Api::Type::Integer
             name: 'minNodes'
             description: |
-              Minimum size of the node group. Must be less 
+              Minimum size of the node group. Must be less
               than or equal to max-nodes. The default value is 0.
           - !ruby/object:Api::Type::Integer
             name: 'maxNodes'
@@ -7846,7 +7871,7 @@ objects:
         description: The name of the packet mirroring rule
         required: true
       - !ruby/object:Api::Type::String
-        name: description 
+        name: description
         description: A human-readable description of the rule.
         input: true
       - !ruby/object:Api::Type::String
@@ -7890,7 +7915,7 @@ objects:
             imports: 'selfLink'
             description: The URL of the forwarding rule.
       - !ruby/object:Api::Type::NestedObject
-        name: filter 
+        name: filter
         description: |
             A filter for mirrored traffic.  If unset, all traffic is mirrored.
         properties:
@@ -8480,6 +8505,14 @@ objects:
               instance may take to initialize. To do this, create an instance
               and time the startup process.
             default_value: 60
+          - !ruby/object:Api::Type::Enum
+            name: 'mode'
+            description: |
+              Defines operating mode for this policy.
+            values:
+              - :OFF
+              - :ONLY_UP
+              - :ON
           - !ruby/object:Api::Type::NestedObject
             name: 'cpuUtilization'
             description: |

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -38,7 +38,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         min_version: 'beta'
         vars:
           address_name: "my-internal-address"
-        skip_docs: true  # It is almost identical to internal_with_gce_endpoint 
+        skip_docs: true  # It is almost identical to internal_with_gce_endpoint
       # TODO(rileykarson): Remove this example when instance is supported
       - !ruby/object:Provider::Terraform::Examples
         name: "instance_with_ip"
@@ -114,6 +114,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: maxReplicas
       autoscalingPolicy.coolDownPeriodSec: !ruby/object:Overrides::Terraform::PropertyOverride
         name: cooldownPeriod
+      autoscalingPolicy.scaleDownControl: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: false
+        default_from_api: true
       autoscalingPolicy.cpuUtilization: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       autoscalingPolicy.cpuUtilization.utilizationTarget: !ruby/object:Overrides::Terraform::PropertyOverride
@@ -352,7 +355,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       Adds existing resource policies to a disk. You can only add one policy
       which will be applied to this disk for scheduling snapshot creation.
 
-      ~> **Note:** This resource does not support zonal disks (`google_compute_disk`). For zonal disks, please refer to [`google_compute_disk_resource_policy_attachment`](https://www.terraform.io/docs/providers/google/r/compute_disk_resource_policy_attachment.html) 
+      ~> **Note:** This resource does not support zonal disks (`google_compute_disk`). For zonal disks, please refer to [`google_compute_disk_resource_policy_attachment`](https://www.terraform.io/docs/providers/google/r/compute_disk_resource_policy_attachment.html)
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "region_disk_resource_policy_attachment_basic"

--- a/third_party/terraform/tests/resource_compute_autoscaler_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_autoscaler_test.go.erb
@@ -70,6 +70,33 @@ func TestAccComputeAutoscaler_multicondition(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
+func TestAccComputeAutoscaler_scaleDownControl(t *testing.T) {
+	t.Parallel()
+
+	var it_name = fmt.Sprintf("autoscaler-test-%s", randString(t, 10))
+	var tp_name = fmt.Sprintf("autoscaler-test-%s", randString(t, 10))
+	var igm_name = fmt.Sprintf("autoscaler-test-%s", randString(t, 10))
+	var autoscaler_name = fmt.Sprintf("autoscaler-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeAutoscalerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeAutoscaler_scaleDownControl(it_name, tp_name, igm_name, autoscaler_name),
+			},
+			resource.TestStep{
+				ResourceName:      "google_compute_autoscaler.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+<% end -%>
+
 func testAccComputeAutoscaler_scaffolding(it_name, tp_name, igm_name string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -188,3 +215,30 @@ resource "google_compute_autoscaler" "foobar" {
 }
 `, autoscaler_name)
 }
+
+<% unless version == 'ga' -%>
+func testAccComputeAutoscaler_scaleDownControl(it_name, tp_name, igm_name, autoscaler_name string) string {
+	return testAccComputeAutoscaler_scaffolding(it_name, tp_name, igm_name) + fmt.Sprintf(`
+resource "google_compute_autoscaler" "foobar" {
+  description = "Resource created for Terraform acceptance testing"
+  name        = "%s"
+  zone        = "us-central1-a"
+  target      = google_compute_instance_group_manager.foobar.self_link
+  autoscaling_policy {
+    max_replicas    = 10
+    min_replicas    = 1
+    cooldown_period = 60
+    cpu_utilization {
+      target = 0.5
+    }
+    scale_down_control {
+      max_scaled_down_replicas {
+        percent = 80
+      }
+      time_window_sec = 300
+    }
+  }
+}
+`, autoscaler_name)
+}
+<% end -%>


### PR DESCRIPTION
Resolves the following two issues
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/6363
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/6636
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/5521

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added `mode` to `google_compute_autoscaler` `autoscaling_policy`
```

```release-note:enhancement
compute: Added `scale_down_control` for `google_compute_autoscaler` `autoscaling_policy` (beta only)
```