### PR TITLE
Fix check for serial port disabled

### DIFF
--- a/third_party/inspec/custom_functions/google_compute_instance.erb
+++ b/third_party/inspec/custom_functions/google_compute_instance.erb
@@ -118,10 +118,10 @@ end
 def has_serial_port_disabled?
   return false if !defined?(@metadata['items']) || @metadata['items'].nil?
   @metadata['items'].each do |element|
-    return true if element.key=='serial-port-enable' and element.value.casecmp('false').zero?
-    return true if element.key=='serial-port-enable' and element.value=='0'
+    return false if element['key']=='serial-port-enable' and element['value'].casecmp('true').zero?
+    return false if element['key']=='serial-port-enable' and element['value']=='0'
   end
-  false
+  true
 end
 
 def has_disks_encrypted_with_csek?

--- a/third_party/inspec/custom_functions/google_compute_instance.erb
+++ b/third_party/inspec/custom_functions/google_compute_instance.erb
@@ -109,8 +109,8 @@ end
 def block_project_ssh_keys
   return false if !defined?(@metadata['items']) || @metadata['items'].nil?
   @metadata['items'].each do |element|
-    return true if element.key=='block-project-ssh-keys' and element.value.casecmp('true').zero?
-    return true if element.key=='block-project-ssh-keys' and element.value=='1'
+    return true if element['key']=='block-project-ssh-keys' and element['value'].casecmp('true').zero?
+    return true if element['key']=='block-project-ssh-keys' and element['value']=='1'
   end
   false
 end
@@ -119,7 +119,7 @@ def has_serial_port_disabled?
   return false if !defined?(@metadata['items']) || @metadata['items'].nil?
   @metadata['items'].each do |element|
     return false if element['key']=='serial-port-enable' and element['value'].casecmp('true').zero?
-    return false if element['key']=='serial-port-enable' and element['value']=='0'
+    return false if element['key']=='serial-port-enable' and element['value']=='1'
   end
   true
 end


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

    - release-note:bug
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Method has_serial_port_disabled on google_compute_instance resource kept returning false, independent of setting on instance.
```
