### PR TITLE
documentation: resource composer_environment typo

### DIFF
--- a/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -293,7 +293,7 @@ The `software_config` block supports:
   The major version of Python used to run the Apache Airflow scheduler, worker, and webserver processes.
   Can be set to '2' or '3'. If not specified, the default is '2'. Cannot be updated.
 
-See [documentation](https://cloud.google.com/composer/docs/how-to/managing/configuring-private-ip) for seting up private environments. The `private_environment_config` block supports:
+See [documentation](https://cloud.google.com/composer/docs/how-to/managing/configuring-private-ip) for setting up private environments. The `private_environment_config` block supports:
 
 * `enable_private_endpoint` -
   If true, access to the public endpoint of the GKE cluster is denied.


### PR DESCRIPTION
Upstreams: https://github.com/terraform-providers/terraform-provider-google/pull/6654

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
