### PR TITLE
promote GKE database encryption to ga

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1031,6 +1031,32 @@ func resourceContainerCluster() *schema.Resource {
 				},
 			},
 
+      "database_encryption": {
+        Type:        schema.TypeList,
+        MaxItems:    1,
+        Optional:    true,
+        ForceNew:    true,
+        Computed:    true,
+        Description: `Application-layer Secrets Encryption settings. The object format is {state = string, key_name = string}. Valid values of state are: "ENCRYPTED"; "DECRYPTED". key_name is the name of a CloudKMS key.`,
+        Elem: &schema.Resource{
+          Schema: map[string]*schema.Schema{
+            "state": {
+              Type:         schema.TypeString,
+              ForceNew:     true,
+              Required:     true,
+              ValidateFunc: validation.StringInSlice([]string{"ENCRYPTED", "DECRYPTED"}, false),
+              Description:  `ENCRYPTED or DECRYPTED.`,
+            },
+            "key_name": {
+              Type:        schema.TypeString,
+              ForceNew:    true,
+              Optional:    true,
+              Description: `The key to use to encrypt/decrypt secrets.`,
+            },
+          },
+        },
+      },
+
 <% unless version == 'ga' -%>
 			"release_channel": {
 				Type:        schema.TypeList,
@@ -1058,31 +1084,7 @@ func resourceContainerCluster() *schema.Resource {
 				Description: `The IP address range of the Cloud TPUs in this cluster, in CIDR notation (e.g. 1.2.3.4/29).`,
 			},
 
-			"database_encryption": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				ForceNew:    true,
-				Computed:    true,
-				Description: `Application-layer Secrets Encryption settings. The object format is {state = string, key_name = string}. Valid values of state are: "ENCRYPTED"; "DECRYPTED". key_name is the name of a CloudKMS key.`,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"state": {
-							Type:         schema.TypeString,
-							ForceNew:     true,
-							Required:     true,
-							ValidateFunc: validation.StringInSlice([]string{"ENCRYPTED", "DECRYPTED"}, false),
-							Description:  `ENCRYPTED or DECRYPTED.`,
-						},
-						"key_name": {
-							Type:        schema.TypeString,
-							ForceNew:    true,
-							Optional:    true,
-							Description: `The key to use to encrypt/decrypt secrets.`,
-						},
-					},
-				},
-			},
+
 
 			"cluster_telemetry": {
 				Type:     schema.TypeList,
@@ -1099,7 +1101,7 @@ func resourceContainerCluster() *schema.Resource {
 					},
 				},
 			},
-			
+
 <% end -%>
 
 			"resource_usage_export_config": {
@@ -1347,12 +1349,9 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		cluster.VerticalPodAutoscaling = expandVerticalPodAutoscaling(v)
 	}
 
-<% unless version == 'ga' -%>
 	if v, ok := d.GetOk("database_encryption"); ok {
 		cluster.DatabaseEncryption = expandDatabaseEncryption(v)
 	}
-
-<% end -%>
 
 	if v, ok := d.GetOk("workload_identity_config"); ok {
 		cluster.WorkloadIdentityConfig = expandWorkloadIdentityConfig(v)
@@ -1573,13 +1572,14 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	if err := d.Set("workload_identity_config", flattenWorkloadIdentityConfig(cluster.WorkloadIdentityConfig)); err != nil {
 		return err
 	}
-<% unless version == 'ga' -%>
 
-	if err := d.Set("pod_security_policy_config", flattenPodSecurityPolicyConfig(cluster.PodSecurityPolicyConfig)); err != nil {
+	if err := d.Set("database_encryption", flattenDatabaseEncryption(cluster.DatabaseEncryption)); err != nil {
 		return err
 	}
 
-	if err := d.Set("database_encryption", flattenDatabaseEncryption(cluster.DatabaseEncryption)); err != nil {
+<% unless version == 'ga' -%>
+
+	if err := d.Set("pod_security_policy_config", flattenPodSecurityPolicyConfig(cluster.PodSecurityPolicyConfig)); err != nil {
 		return err
 	}
 
@@ -2815,18 +2815,6 @@ func expandVerticalPodAutoscaling(configured interface{}) *containerBeta.Vertica
 	}
 }
 
-<% unless version == 'ga' -%>
-func expandReleaseChannel(configured interface{}) *containerBeta.ReleaseChannel {
-	l := configured.([]interface{})
-	if len(l) == 0 || l[0] == nil {
-		return nil
-	}
-	config := l[0].(map[string]interface{})
-	return &containerBeta.ReleaseChannel{
-		Channel: config["channel"].(string),
-	}
-}
-
 func expandDatabaseEncryption(configured interface{}) *containerBeta.DatabaseEncryption {
 	l := configured.([]interface{})
 	if len(l) == 0 {
@@ -2836,6 +2824,18 @@ func expandDatabaseEncryption(configured interface{}) *containerBeta.DatabaseEnc
 	return &containerBeta.DatabaseEncryption{
 		State:   config["state"].(string),
 		KeyName: config["key_name"].(string),
+	}
+}
+
+<% unless version == 'ga' -%>
+func expandReleaseChannel(configured interface{}) *containerBeta.ReleaseChannel {
+	l := configured.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+	config := l[0].(map[string]interface{})
+	return &containerBeta.ReleaseChannel{
+		Channel: config["channel"].(string),
 	}
 }
 
@@ -3105,7 +3105,7 @@ func flattenClusterTelemetry(c *containerBeta.ClusterTelemetry) []map[string]int
 		result = append(result, map[string]interface{}{
 			"type": c.Type,
 		})
-	} 
+	}
 	return result
 }
 
@@ -3291,7 +3291,6 @@ func flattenResourceUsageExportConfig(c *containerBeta.ResourceUsageExportConfig
 	}
 }
 
-<% unless version == 'ga' -%>
 func flattenDatabaseEncryption(c *containerBeta.DatabaseEncryption) []map[string]interface{} {
 	if c == nil {
 		return nil
@@ -3303,8 +3302,6 @@ func flattenDatabaseEncryption(c *containerBeta.DatabaseEncryption) []map[string
 		},
 	}
 }
-
-<% end -%>
 
 func resourceContainerClusterStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1716,7 +1716,6 @@ func TestAccContainerCluster_errorNoClusterCreated(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccContainerCluster_withDatabaseEncryption(t *testing.T) {
 	t.Parallel()
 
@@ -1745,7 +1744,6 @@ func TestAccContainerCluster_withDatabaseEncryption(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccContainerCluster_withResourceUsageExportConfig(t *testing.T) {
 	t.Parallel()
@@ -2110,7 +2108,7 @@ func testAccContainerCluster_updateAddons(projectID string, clusterName string) 
 	return fmt.Sprintf(`
 data "google_project" "project" {
   project_id = "%s"
-}	
+}
 
 resource "google_container_cluster" "primary" {
   name               = "%s"
@@ -3853,7 +3851,6 @@ resource "google_container_cluster" "with_resource_labels" {
 `, location)
 }
 
-<% unless version == 'ga' -%>
 func testAccContainerCluster_withDatabaseEncryption(clusterName string, kmsData bootstrappedKMS) string {
 	return fmt.Sprintf(`
 data "google_project" "project" {
@@ -3886,7 +3883,6 @@ resource "google_container_cluster" "with_database_encryption" {
 }
 `, kmsData.KeyRing.Name, kmsData.CryptoKey.Name, clusterName)
 }
-<% end -%>
 
 func testAccContainerCluster_withMasterAuthorizedNetworksDisabled(containerNetName string, clusterName string) string {
 	return fmt.Sprintf(`

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -147,7 +147,7 @@ on the current needs of the cluster's workload. See the
 [guide to using Node Auto-Provisioning](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning)
 for more details. Structure is documented below.
 
-* `database_encryption` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)).
+* `database_encryption` - (Optional)
     Structure is documented below.
 
 * `description` - (Optional) Description of the cluster.


### PR DESCRIPTION
As of October 31, GKE database encryption is GA, see https://cloud.google.com/blog/products/containers-kubernetes/exploring-container-security-use-your-own-keys-to-protect-your-data-on-gke

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: Promoted `google_container_cluster` `database_encryption` to GA.
```
