### PR TITLE
Add mode and scaleDownControls for Compute Region AutoScaler

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -8520,6 +8520,46 @@ objects:
               instance may take to initialize. To do this, create an instance
               and time the startup process.
             default_value: 60
+          - !ruby/object:Api::Type::Enum
+            name: 'mode'
+            default_value: :ON
+            description: |
+              Defines operating mode for this policy.
+            values:
+              - :OFF
+              - :ONLY_UP
+              - :ON
+          - !ruby/object:Api::Type::NestedObject
+            name: 'scaleDownControl'
+            min_version: beta
+            at_least_one_of:
+             - scale_down_control.0.max_scaled_down_replicas
+             - scale_down_control.0.time_window_sec
+            description: |
+              Defines scale down controls to reduce the risk of response latency
+              and outages due to abrupt scale-in events
+            properties:
+            - !ruby/object:Api::Type::NestedObject
+              name: 'maxScaledDownReplicas'
+              at_least_one_of:
+              - scale_down_control.0.max_scaled_down_replicas.0.fixed
+              - scale_down_control.0.max_scaled_down_replicas.0.percent
+              properties:
+              - !ruby/object:Api::Type::Integer
+                name: 'fixed'
+                description: |
+                  Specifies a fixed number of VM instances. This must be a positive
+                  integer.
+              - !ruby/object:Api::Type::Integer
+                name: 'percent'
+                description: |
+                  Specifies a percentage of instances between 0 to 100%, inclusive.
+                  For example, specify 80 for 80%.
+            - !ruby/object:Api::Type::Integer
+              name: 'timeWindowSec'
+              description: |
+                How long back autoscaling should look when computing recommendations
+                to include directives regarding slower scale down, as described above.
           - !ruby/object:Api::Type::NestedObject
             name: 'cpuUtilization'
             description: |

--- a/third_party/terraform/tests/resource_compute_region_autoscaler_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_autoscaler_test.go.erb
@@ -42,7 +42,34 @@ func TestAccComputeRegionAutoscaler_update(t *testing.T) {
 	})
 }
 
-func testAccComputeRegionAutoscaler_basic(it_name, tp_name, igm_name, autoscaler_name string) string {
+<% unless version == 'ga' -%>
+func TestAccComputeRegionAutoscaler_scaleDownControl(t *testing.T) {
+	t.Parallel()
+
+	var it_name = fmt.Sprintf("region-autoscaler-test-%s", randString(t, 10))
+	var tp_name = fmt.Sprintf("region-autoscaler-test-%s", randString(t, 10))
+	var igm_name = fmt.Sprintf("region-autoscaler-test-%s", randString(t, 10))
+	var autoscaler_name = fmt.Sprintf("region-autoscaler-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeRegionAutoscalerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeRegionAutoscaler_scaleDownControl(it_name, tp_name, igm_name, autoscaler_name),
+			},
+			resource.TestStep{
+				ResourceName:      "google_compute_region_autoscaler.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+<% end -%>
+
+func testAccComputeRegionAutoscaler_scaffolding(it_name, tp_name, igm_name string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family  = "debian-9"
@@ -88,6 +115,11 @@ resource "google_compute_region_instance_group_manager" "foobar" {
   region             = "us-central1"
 }
 
+`, it_name, tp_name, igm_name)
+}
+
+func testAccComputeRegionAutoscaler_basic(it_name, tp_name, igm_name, autoscaler_name string) string {
+	return testAccComputeRegionAutoscaler_scaffolding(it_name, tp_name, igm_name) + fmt.Sprintf(`
 resource "google_compute_region_autoscaler" "foobar" {
   description = "Resource created for Terraform acceptance testing"
   name        = "%s"
@@ -102,55 +134,11 @@ resource "google_compute_region_autoscaler" "foobar" {
     }
   }
 }
-`, it_name, tp_name, igm_name, autoscaler_name)
+`, autoscaler_name)
 }
 
 func testAccComputeRegionAutoscaler_update(it_name, tp_name, igm_name, autoscaler_name string) string {
-	return fmt.Sprintf(`
-data "google_compute_image" "my_image" {
-  family  = "debian-9"
-  project = "debian-cloud"
-}
-
-resource "google_compute_instance_template" "foobar" {
-  name           = "%s"
-  machine_type   = "n1-standard-1"
-  can_ip_forward = false
-  tags           = ["foo", "bar"]
-
-  disk {
-    source_image = data.google_compute_image.my_image.self_link
-    auto_delete  = true
-    boot         = true
-  }
-
-  network_interface {
-    network = "default"
-  }
-
-  service_account {
-    scopes = ["userinfo-email", "compute-ro", "storage-ro"]
-  }
-}
-
-resource "google_compute_target_pool" "foobar" {
-  description      = "Resource created for Terraform acceptance testing"
-  name             = "%s"
-  session_affinity = "CLIENT_IP_PROTO"
-}
-
-resource "google_compute_region_instance_group_manager" "foobar" {
-  description = "Terraform test instance group manager"
-  name        = "%s"
-  version {
-    instance_template = google_compute_instance_template.foobar.self_link
-    name              = "primary"
-  }
-  target_pools       = [google_compute_target_pool.foobar.self_link]
-  base_instance_name = "foobar"
-  region             = "us-central1"
-}
-
+	return testAccComputeRegionAutoscaler_scaffolding(it_name, tp_name, igm_name) + fmt.Sprintf(`
 resource "google_compute_region_autoscaler" "foobar" {
   description = "Resource created for Terraform acceptance testing"
   name        = "%s"
@@ -165,5 +153,32 @@ resource "google_compute_region_autoscaler" "foobar" {
     }
   }
 }
-`, it_name, tp_name, igm_name, autoscaler_name)
+`, autoscaler_name)
 }
+
+<% unless version == 'ga' -%>
+func testAccComputeRegionAutoscaler_scaleDownControl(it_name, tp_name, igm_name, autoscaler_name string) string {
+	return testAccComputeRegionAutoscaler_scaffolding(it_name, tp_name, igm_name) + fmt.Sprintf(`
+resource "google_compute_region_autoscaler" "foobar" {
+  description = "Resource created for Terraform acceptance testing"
+  name        = "%s"
+  region      = "us-central1"
+  target      = google_compute_region_instance_group_manager.foobar.self_link
+  autoscaling_policy {
+    max_replicas    = 10
+    min_replicas    = 1
+    cooldown_period = 60
+    cpu_utilization {
+      target = 0.5
+    }
+    scale_down_control {
+      max_scaled_down_replicas {
+        percent = 80
+      }
+      time_window_sec = 300
+    }
+  }
+}
+`, autoscaler_name)
+}
+<% end -%>


### PR DESCRIPTION
Related to https://github.com/GoogleCloudPlatform/magic-modules/pull/3693. 
Adds support for `mode` and `scaleDownControls` for ComputeRegionAutoScaler

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added `mode` to `google_compute_region_autoscaler` `autoscaling_policy`
```
```release-note:enhancement
compute: Added `scale_down_control ` to `google_compute_region_autoscaler` `autoscaling_policy` (beta only)
```