### PR TITLE
Monitoring add content type

### DIFF
--- a/products/monitoring/api.yaml
+++ b/products/monitoring/api.yaml
@@ -1648,6 +1648,16 @@ objects:
         - http_check
         - tcp_check
       properties:
+      - !ruby/object:Api::Type::Enum
+        name: requestMethod
+        input: true
+        description: The HTTP request method to use for the check. If set to 
+          METHOD_UNSPECIFIED then requestMethod defaults to GET.
+        default_value: :GET
+        values:
+          - :METHOD_UNSPECIFIED
+          - :GET
+          - :POST
       - !ruby/object:Api::Type::NestedObject
         name: authInfo
         at_least_one_of:

--- a/products/monitoring/api.yaml
+++ b/products/monitoring/api.yaml
@@ -1658,6 +1658,12 @@ objects:
           - :METHOD_UNSPECIFIED
           - :GET
           - :POST
+      - !ruby/object:Api::Type::Enum
+        name: contentType
+        description: The content type to use for the check.
+        values:
+          - :TYPE_UNSPECIFIED
+          - :URL_ENCODED
       - !ruby/object:Api::Type::NestedObject
         name: authInfo
         at_least_one_of:
@@ -1748,6 +1754,15 @@ objects:
           you do not wish to be seen when retrieving the configuration. The server will
           be responsible for encrypting the headers. On Get/List calls, if mask_headers
           is set to True then the headers will be obscured with ******.
+      - !ruby/object:Api::Type::String
+        name: body
+        description: The request body associated with the HTTP POST request. If contentType
+          is URL_ENCODED, the body passed in must be URL-encoded. Users can provide a
+          Content-Length header via the headers field or the API will do so. If the
+          requestMethod is GET and body is not empty, the API will return an error. The
+          maximum byte size is 1 megabyte. Note - As with all bytes fields JSON
+          representations are base64 encoded. e.g. "foo=bar" in URL-encoded form is
+          "foo%3Dbar" and in base64 encoding is "Zm9vJTI1M0RiYXI=".
     - !ruby/object:Api::Type::NestedObject
       name: tcpCheck
       description: Contains information needed to make a TCP check.

--- a/products/monitoring/terraform.yaml
+++ b/products/monitoring/terraform.yaml
@@ -271,6 +271,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_flatten: "templates/terraform/custom_flatten/uptime_check_http_password.erb"
       httpCheck.port: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      httpCheck.headers: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       resourceGroup.groupId: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_expand: "templates/terraform/custom_expand/resource_from_self_link.go.erb"
         custom_flatten: "templates/terraform/custom_flatten/group_id_to_name.erb"

--- a/templates/terraform/examples/uptime_check_config_http.tf.erb
+++ b/templates/terraform/examples/uptime_check_config_http.tf.erb
@@ -5,7 +5,9 @@ resource "google_monitoring_uptime_check_config" "<%= ctx[:primary_resource_id] 
   http_check {
     path = "/some-path"
     port = "8010"
-    request_method = "GET"
+    request_method = "POST"
+    content_type = "URL_ENCODED"
+    body = "Zm9vJTI1M0RiYXI="
   }
 
   monitored_resource {

--- a/templates/terraform/examples/uptime_check_config_http.tf.erb
+++ b/templates/terraform/examples/uptime_check_config_http.tf.erb
@@ -5,6 +5,7 @@ resource "google_monitoring_uptime_check_config" "<%= ctx[:primary_resource_id] 
   http_check {
     path = "/some-path"
     port = "8010"
+    request_method = "GET"
   }
 
   monitored_resource {

--- a/third_party/terraform/tests/resource_monitoring_uptime_check_config_test.go
+++ b/third_party/terraform/tests/resource_monitoring_uptime_check_config_test.go
@@ -90,6 +90,7 @@ resource "google_monitoring_uptime_check_config" "http" {
   http_check {
     path = "/%s"
     port = "8010"
+    request_method = "GET"
     auth_info {
       username = "name"
       password = "%s"


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/6495

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
monitoring: added `request_method`, `content_type`, and `body` fields within the `http_check` object to `google_monitoring_uptime_check_config` resource
```
