### PR TITLE
Add hourly partitioning to bigquery table (upstream PR)

### DIFF
--- a/third_party/terraform/resources/resource_bigquery_table.go
+++ b/third_party/terraform/resources/resource_bigquery_table.go
@@ -336,13 +336,14 @@ func resourceBigQueryTable() *schema.Resource {
 							Description: `Number of milliseconds for which to keep the storage for a partition.`,
 						},
 
-						// Type: [Required] The only type supported is DAY, which will generate
-						// one partition per day based on data loading time.
+            // TODO: check https://github.com/googleapis/google-cloud-go/commit/8618bf3d044f4da30b144689b870354c0071cfb0
+						// Type: [Required] The supported types are DAY and HOUR, which will generate
+						// one partition per day or hour based on data loading time.
 						"type": {
 							Type:         schema.TypeString,
 							Required:     true,
-							Description:  `The only type supported is DAY, which will generate one partition per day based on data loading time.`,
-							ValidateFunc: validation.StringInSlice([]string{"DAY"}, false),
+							Description:  `The supported types are DAY and HOUR, which will generate one partition per day or hour based on data loading time`,
+							ValidateFunc: validation.StringInSlice([]string{"DAY", "HOUR"}, false),
 						},
 
 						// Field: [Optional] The field used to determine how to create a time-based

--- a/third_party/terraform/resources/resource_bigquery_table.go
+++ b/third_party/terraform/resources/resource_bigquery_table.go
@@ -341,7 +341,7 @@ func resourceBigQueryTable() *schema.Resource {
 						"type": {
 							Type:         schema.TypeString,
 							Required:     true,
-							Description:  `The supported types are DAY and HOUR, which will generate one partition per day or hour based on data loading time`,
+							Description:  `The supported types are DAY and HOUR, which will generate one partition per day or hour based on data loading time.`,
 							ValidateFunc: validation.StringInSlice([]string{"DAY", "HOUR"}, false),
 						},
 

--- a/third_party/terraform/resources/resource_bigquery_table.go
+++ b/third_party/terraform/resources/resource_bigquery_table.go
@@ -336,7 +336,6 @@ func resourceBigQueryTable() *schema.Resource {
 							Description: `Number of milliseconds for which to keep the storage for a partition.`,
 						},
 
-            // TODO: check https://github.com/googleapis/google-cloud-go/commit/8618bf3d044f4da30b144689b870354c0071cfb0
 						// Type: [Required] The supported types are DAY and HOUR, which will generate
 						// one partition per day or hour based on data loading time.
 						"type": {

--- a/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -20,7 +20,7 @@ func TestAccBigQueryTable_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckBigQueryTableDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigQueryTable(datasetID, tableID),
+				Config: testAccBigQueryTableDailyTimePartitioning(datasetID, tableID),
 			},
 			{
 				ResourceName:      "google_bigquery_table.test",
@@ -57,6 +57,37 @@ func TestAccBigQueryTable_Kms(t *testing.T) {
 			},
 			{
 				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccBigQueryTable_HourlyTimePartitioning(t *testing.T) {
+	t.Parallel()
+
+	datasetID := fmt.Sprintf("tf_test_%s", randString(t, 10))
+	tableID := fmt.Sprintf("tf_test_%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBigQueryTableDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTableHourlyTimePartitioning(datasetID, tableID),
+			},
+			{
+				ResourceName:      "google_bigquery_table.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBigQueryTableUpdated(datasetID, tableID),
+			},
+			{
+				ResourceName:      "google_bigquery_table.test",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -261,7 +292,7 @@ func testAccCheckBigQueryTableDestroyProducer(t *testing.T) func(s *terraform.St
 	}
 }
 
-func testAccBigQueryTable(datasetID, tableID string) string {
+func testAccBigQueryTableDailyTimePartitioning(datasetID, tableID string) string {
 	return fmt.Sprintf(`
 resource "google_bigquery_dataset" "test" {
 	dataset_id = "%s"
@@ -273,6 +304,63 @@ resource "google_bigquery_table" "test" {
 
 	time_partitioning {
 		type                     = "DAY"
+		field                    = "ts"
+		require_partition_filter = true
+	}
+	clustering = ["some_int", "some_string"]
+	schema     = <<EOH
+[
+	{
+		"name": "ts",
+		"type": "TIMESTAMP"
+	},
+	{
+		"name": "some_string",
+		"type": "STRING"
+	},
+	{
+		"name": "some_int",
+		"type": "INTEGER"
+	},
+	{
+		"name": "city",
+		"type": "RECORD",
+		"fields": [
+	{
+		"name": "id",
+		"type": "INTEGER"
+	},
+	{
+		"name": "coord",
+		"type": "RECORD",
+		"fields": [
+		{
+		"name": "lon",
+		"type": "FLOAT"
+		}
+		]
+	}
+		]
+	}
+]
+EOH
+
+}
+`, datasetID, tableID)
+}
+
+func testAccBigQueryTableHourlyTimePartitioning(datasetID, tableID string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset" "test" {
+	dataset_id = "%s"
+}
+
+resource "google_bigquery_table" "test" {
+	table_id   = "%s"
+	dataset_id = google_bigquery_dataset.test.dataset_id
+
+	time_partitioning {
+		type                     = "HOUR"
 		field                    = "ts"
 		require_partition_filter = true
 	}
@@ -338,7 +426,7 @@ resource "google_bigquery_table" "test" {
 	dataset_id = "${google_bigquery_dataset.test.dataset_id}"
 
 	time_partitioning {
-		type = "HOUR"
+		type = "DAY"
 		field = "ts"
 	}
 

--- a/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -338,7 +338,7 @@ resource "google_bigquery_table" "test" {
 	dataset_id = "${google_bigquery_dataset.test.dataset_id}"
 
 	time_partitioning {
-		type = "DAY"
+		type = "HOUR"
 		field = "ts"
 	}
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: Added `"HOUR"` option for `google_bigquery_table` time partitioning (`type`)
```

Upstreams https://github.com/terraform-providers/terraform-provider-google/pull/6675
