### PR TITLE
Another typo in contributor checking script.

### DIFF
--- a/.ci/containers/contributor-checker/check-contributor.sh
+++ b/.ci/containers/contributor-checker/check-contributor.sh
@@ -13,12 +13,12 @@ set -x
 ASSIGNEE=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
   "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/${PR_NUMBER}/requested_reviewers" | jq .users[0].login)
   
-if [ "$ASSIGNEE" == "null" || -z "$ASSIGNEE" ]; then 
+if [ "$ASSIGNEE" == "null" ] || [ -z "$ASSIGNEE" ] ; then 
   ASSIGNEE=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
     "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/${PR_NUMBER}/reviews" | jq .[0].user.login)
 fi
 
-if [ "$ASSIGNEE" == "null" || -z "$ASSIGNEE" ] ; then 
+if [ "$ASSIGNEE" == "null" ] || [ -z "$ASSIGNEE" ] ; then 
   echo "Issue is not assigned."
 else
   echo "Issue is assigned, not assigning."

--- a/.ci/containers/contributor-checker/check-contributor.sh
+++ b/.ci/containers/contributor-checker/check-contributor.sh
@@ -13,7 +13,7 @@ set -x
 ASSIGNEE=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
   "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/${PR_NUMBER}/requested_reviewers" | jq .users[0].login)
   
-if [ "$ASSIGNEE" == "null" ] || [ -z "$ASSIGNEE" ] ; then 
+if [[ "$ASSIGNEE" == "null" || -z "$ASSIGNEE" ]] ; then 
   ASSIGNEE=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
     "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/${PR_NUMBER}/reviews" | jq .[0].user.login)
 fi

--- a/.ci/containers/contributor-checker/check-contributor.sh
+++ b/.ci/containers/contributor-checker/check-contributor.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
-if [ -z "$GITHUB_TOKEN" ]; then
+if [[ -z "$GITHUB_TOKEN" ]]; then
     echo "Did not provide GITHUB_TOKEN environment variable."
     exit 1
 fi
-if [ $# -lt 1 ]; then
+if [[ $# -lt 1 ]]; then
     echo "Usage: $0 pr-number"
     exit 1
 fi
 PR_NUMBER=$1
+
 set -x
 
 ASSIGNEE=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
@@ -18,7 +19,7 @@ if [[ "$ASSIGNEE" == "null" || -z "$ASSIGNEE" ]] ; then
     "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/pulls/${PR_NUMBER}/reviews" | jq .[0].user.login)
 fi
 
-if [ "$ASSIGNEE" == "null" ] || [ -z "$ASSIGNEE" ] ; then 
+if [[ "$ASSIGNEE" == "null"  || -z "$ASSIGNEE" ]] ; then 
   echo "Issue is not assigned."
 else
   echo "Issue is assigned, not assigning."


### PR DESCRIPTION
CI change only.
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
