### PR TITLE
add networking_mode to google_container_cluster

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -912,9 +912,9 @@ func resourceContainerCluster() *schema.Resource {
 			"networking_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,
+				Computed:     true,
 				ForceNew:     true,
 				ValidateFunc: validation.StringInSlice([]string{"VPC_NATIVE", "ROUTES"}, false),
-				Default:      "ROUTES",
 				Description:  `Determines whether alias IPs or routes will be used for pod IPs in the cluster.`,
 			},
 <% end -%>

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -908,6 +908,17 @@ func resourceContainerCluster() *schema.Resource {
 				},
 			},
 
+<% unless version == 'ga' -%>
+			"networking_mode": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"VPC_NATIVE", "ROUTES"}, false),
+				Default:      "ROUTES",
+				Description:  `Determines whether alias IPs or routes will be used for pod IPs in the cluster.`,
+			},
+<% end -%>
+
 			"remove_default_node_pool": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -1229,6 +1240,18 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 
 	clusterName := d.Get("name").(string)
 
+<% unless version == 'ga' -%>
+	ipAllocationBlock, err := expandIPAllocationPolicy(d.Get("ip_allocation_policy"), d.Get("networking_mode").(string))
+	if err != nil {
+		return err
+	}
+<% else -%>
+	ipAllocationBlock, err := expandIPAllocationPolicy(d.Get("ip_allocation_policy"))
+	if err != nil {
+		return err
+	}
+<% end -%>
+
 	cluster := &containerBeta.Cluster{
 		Name:                           clusterName,
 		InitialNodeCount:               int64(d.Get("initial_node_count").(int)),
@@ -1246,7 +1269,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		NetworkPolicy:           expandNetworkPolicy(d.Get("network_policy")),
 		AddonsConfig:            expandClusterAddonsConfig(d.Get("addons_config")),
 		EnableKubernetesAlpha:   d.Get("enable_kubernetes_alpha").(bool),
-		IpAllocationPolicy:      expandIPAllocationPolicy(d.Get("ip_allocation_policy")),
+		IpAllocationPolicy:      ipAllocationBlock,
 		PodSecurityPolicyConfig: expandPodSecurityPolicyConfig(d.Get("pod_security_policy_config")),
 		Autoscaling:             expandClusterAutoscaling(d.Get("cluster_autoscaling"), d),
 		BinaryAuthorization: &containerBeta.BinaryAuthorization{
@@ -2536,25 +2559,41 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 	return ac
 }
 
-func expandIPAllocationPolicy(configured interface{}) *containerBeta.IPAllocationPolicy {
+<% unless version == 'ga' -%>
+func expandIPAllocationPolicy(configured interface{}, networking_mode string) (*containerBeta.IPAllocationPolicy, error) {
+<% else -%>
+func expandIPAllocationPolicy(configured interface{}) (*containerBeta.IPAllocationPolicy, error) {
+<% end -%>
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
+<% unless version == 'ga' -%>
+		if networking_mode == "VPC_NATIVE" {
+			return nil, fmt.Errorf("`ip_allocation_policy` block is required for VPC_NATIVE clusters.")
+		}
+<% end -%>
 		return &containerBeta.IPAllocationPolicy{
 			UseIpAliases:    false,
 			ForceSendFields: []string{"UseIpAliases"},
-		}
+		}, nil
 	}
 
 	config := l[0].(map[string]interface{})
 	return &containerBeta.IPAllocationPolicy{
+<% unless version == 'ga' -%>
+		UseIpAliases:          networking_mode == "VPC_NATIVE",
+<% else -%>
 		UseIpAliases:          true,
+<% end -%>
 		ClusterIpv4CidrBlock:  config["cluster_ipv4_cidr_block"].(string),
 		ServicesIpv4CidrBlock: config["services_ipv4_cidr_block"].(string),
 
 		ClusterSecondaryRangeName:  config["cluster_secondary_range_name"].(string),
 		ServicesSecondaryRangeName: config["services_secondary_range_name"].(string),
 		ForceSendFields:            []string{"UseIpAliases"},
-	}
+<% unless version == 'ga' -%>
+		UseRoutes:              networking_mode == "ROUTES",
+<% end -%>
+	}, nil
 }
 
 func expandMaintenancePolicy(d *schema.ResourceData, meta interface{}) *containerBeta.MaintenancePolicy {
@@ -3124,8 +3163,14 @@ func flattenWorkloadIdentityConfig(c *containerBeta.WorkloadIdentityConfig) []ma
 func flattenIPAllocationPolicy(c *containerBeta.Cluster, d *schema.ResourceData, config *Config) []map[string]interface{} {
 	// If IP aliasing isn't enabled, none of the values in this block can be set.
 	if c == nil || c.IpAllocationPolicy == nil || !c.IpAllocationPolicy.UseIpAliases {
+<% unless version == 'ga' -%>
+		d.Set("networking_mode", "ROUTES")
+<% end -%>
 		return nil
 	}
+<% unless version == 'ga' -%>
+		d.Set("networking_mode", "VPC_NATIVE")
+<% end -%>
 
 	p := c.IpAllocationPolicy
 	return []map[string]interface{}{

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2372,6 +2372,9 @@ resource "google_container_cluster" "with_authenticator_groups" {
     security_group = "gke-security-groups@mydomain.tld"
   }
 
+<% unless version == 'ga' -%>
+  networking_mode = "VPC_NATIVE"
+<% end -%>
   ip_allocation_policy {
     cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
     services_secondary_range_name = google_compute_subnetwork.container_subnetwork.secondary_ip_range[1].range_name
@@ -2505,8 +2508,9 @@ resource "google_container_cluster" "with_tpu" {
 
   enable_tpu = true
 
-  network    = google_compute_network.container_network.name
-  subnetwork = google_compute_subnetwork.container_subnetwork.name
+  network         = google_compute_network.container_network.name
+  subnetwork      = google_compute_subnetwork.container_subnetwork.name
+  networking_mode = "VPC_NATIVE"
 
   private_cluster_config {
     enable_private_endpoint = true
@@ -3349,6 +3353,9 @@ resource "google_container_cluster" "with_ip_allocation_policy" {
   network    = google_compute_network.container_network.name
   subnetwork = google_compute_subnetwork.container_subnetwork.name
 
+<% unless version == 'ga' -%>
+  networking_mode = "VPC_NATIVE"
+<% end -%>
   initial_node_count = 1
   ip_allocation_policy {
     cluster_secondary_range_name  = "pods"
@@ -3380,6 +3387,10 @@ resource "google_container_cluster" "with_ip_allocation_policy" {
   subnetwork = google_compute_subnetwork.container_subnetwork.name
 
   initial_node_count = 1
+
+<% unless version == 'ga' -%>
+  networking_mode = "VPC_NATIVE"
+<% end -%>
   ip_allocation_policy {
     cluster_ipv4_cidr_block  = "10.0.0.0/16"
     services_ipv4_cidr_block = "10.1.0.0/16"
@@ -3410,6 +3421,10 @@ resource "google_container_cluster" "with_ip_allocation_policy" {
   subnetwork = google_compute_subnetwork.container_subnetwork.name
 
   initial_node_count = 1
+
+<% unless version == 'ga' -%>
+  networking_mode = "VPC_NATIVE"
+<% end -%>
   ip_allocation_policy {
     cluster_ipv4_cidr_block  = "/16"
     services_ipv4_cidr_block = "/22"
@@ -3487,6 +3502,9 @@ resource "google_container_cluster" "with_private_cluster" {
   location           = "us-central1-a"
   initial_node_count = 1
 
+<% unless version == 'ga' -%>
+  networking_mode = "VPC_NATIVE"
+<% end -%>
   network    = google_compute_network.container_network.name
   subnetwork = google_compute_subnetwork.container_subnetwork.name
 
@@ -3534,6 +3552,9 @@ resource "google_container_cluster" "with_private_cluster" {
   location           = "us-central1-a"
   initial_node_count = 1
 
+<% unless version == 'ga' -%>
+  networking_mode = "VPC_NATIVE"
+<% end -%>
   network    = google_compute_network.container_network.name
   subnetwork = google_compute_subnetwork.container_subnetwork.name
 
@@ -3708,8 +3729,9 @@ resource "google_container_cluster" "shared_vpc_cluster" {
   initial_node_count = 1
   project            = google_compute_shared_vpc_service_project.service_project.service_project
 
-  network    = google_compute_network.shared_network.self_link
-  subnetwork = google_compute_subnetwork.shared_subnetwork.self_link
+  networking_mode = "VPC_NATIVE"
+  network         = google_compute_network.shared_network.self_link
+  subnetwork      = google_compute_subnetwork.shared_subnetwork.self_link
 
   ip_allocation_policy {
     cluster_secondary_range_name  = google_compute_subnetwork.shared_subnetwork.secondary_ip_range[0].range_name
@@ -3767,8 +3789,9 @@ resource "google_container_cluster" "with_flexible_cidr" {
   location           = "us-central1-a"
   initial_node_count = 3
 
-  network    = google_compute_network.container_network.name
-  subnetwork = google_compute_subnetwork.container_subnetwork.name
+  networking_mode = "VPC_NATIVE"
+  network         = google_compute_network.container_network.name
+  subnetwork      = google_compute_subnetwork.container_subnetwork.name
 
   private_cluster_config {
     enable_private_endpoint = true
@@ -3807,6 +3830,9 @@ resource "google_container_cluster" "cidr_error_preempt" {
   name     = "%s"
   location = "us-central1-a"
 
+<% unless version == 'ga' -%>
+  networking_mode = "VPC_NATIVE"
+<% end -%>
   network    = google_compute_network.container_network.name
   subnetwork = google_compute_subnetwork.container_subnetwork.name
 
@@ -3833,6 +3859,9 @@ resource "google_container_cluster" "cidr_error_overlap" {
 
   initial_node_count = 1
 
+<% unless version == 'ga' -%>
+  networking_mode = "VPC_NATIVE"
+<% end -%>
   ip_allocation_policy {
     cluster_ipv4_cidr_block  = "10.0.0.0/16"
     services_ipv4_cidr_block = "10.1.0.0/16"
@@ -3914,6 +3943,9 @@ resource "google_container_cluster" "with_private_cluster" {
   location           = "us-central1-a"
   initial_node_count = 1
 
+<% unless version == 'ga' -%>
+  networking_mode = "VPC_NATIVE"
+<% end -%>
   network    = google_compute_network.container_network.name
   subnetwork = google_compute_subnetwork.container_subnetwork.name
 

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -186,6 +186,10 @@ VPC-native clusters. Adding this block enables [IP aliasing](https://cloud.googl
 making the cluster VPC-native instead of routes-based. Structure is documented
 below.
 
+* `networking_mode` - (Optional, [Beta]) Determines whether alias IPs or routes will be used for pod IPs in the cluster.
+Options are `VPC_NATIVE` or `ROUTES`. `VPC_NATIVE` enables [IP aliasing](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-aliases),
+and requires the `ip_allocation_policy` block to be defined. The default value is `ROUTES`, making the cluster routes-based.
+
 * `logging_service` - (Optional) The logging service that the cluster should
     write logs to. Available options include `logging.googleapis.com`(Legacy Stackdriver),
     `logging.googleapis.com/kubernetes`(Stackdriver Kubernetes Engine Logging), and `none`. Defaults to `logging.googleapis.com/kubernetes`

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -188,7 +188,7 @@ below.
 
 * `networking_mode` - (Optional, [Beta]) Determines whether alias IPs or routes will be used for pod IPs in the cluster.
 Options are `VPC_NATIVE` or `ROUTES`. `VPC_NATIVE` enables [IP aliasing](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-aliases),
-and requires the `ip_allocation_policy` block to be defined. The default value is `ROUTES`, making the cluster routes-based.
+and requires the `ip_allocation_policy` block to be defined. By default when this field is unspecified, GKE will create a `ROUTES`-based cluster.
 
 * `logging_service` - (Optional) The logging service that the cluster should
     write logs to. Available options include `logging.googleapis.com`(Legacy Stackdriver),


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6268

add `networking_mode` to `google_container_cluster`

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `networking_mode` to `google_container_cluster` (TPGB-only)
```
