### PR TITLE
Fix absoluteDomainSuppress to check more than one domain

### DIFF
--- a/third_party/terraform/utils/common_diff_suppress.go.erb
+++ b/third_party/terraform/utils/common_diff_suppress.go.erb
@@ -81,7 +81,7 @@ func rfc3339TimeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 <% unless version == 'ga' -%>
 // For managed SSL certs, if new is an absolute FQDN (trailing '.') but old isn't, treat them as equals.
 func absoluteDomainSuppress(k, old, new string, _ *schema.ResourceData) bool {
-	if k == "managed.0.domains.0" {
+	if strings.HasPrefix(k, "managed.0.domains.") {
 		return old == strings.TrimRight(new, ".")
 	}
 	return old == new


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6658
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: Fixed an issue in `google_compute_managed_ssl_certificate` where multiple fully qualified domain names would cause a permadiff
```
