### PR TITLE
Add longer timeouts to support polling on VCR builds

### DIFF
--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -199,6 +199,7 @@ steps:
       id: tpg-vcr-test
       secretEnv: ["TEAMCITY_TOKEN", "GITHUB_TOKEN"]
       waitFor: ["diff"]
+      timeout: 1800s
       args:
           - $_PR_NUMBER
 
@@ -208,6 +209,8 @@ steps:
       args:
           - $_PR_NUMBER
 
+# Long timeout to enable waiting on VCR test
+timeout: 2400s
 options:
     machineType: 'N1_HIGHCPU_32'
 


### PR DESCRIPTION
Separate PR to enable testing via CI

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
