### PR TITLE
Make workload_metadata_config computed

### DIFF
--- a/third_party/terraform/utils/node_config.go.erb
+++ b/third_party/terraform/utils/node_config.go.erb
@@ -208,8 +208,8 @@ func schemaNodeConfig() *schema.Schema {
 				"workload_metadata_config": {
 	<% if version.nil? || version == 'ga' -%>
 					Removed: "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/guides/provider_versions.html for more details.",
-					Computed: true,
 	<% end -%>
+					Computed: true,
 					Type:       schema.TypeList,
 					Optional:   true,
 					MaxItems:   1,


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6652

`workload_metadata_config` is returned from the API and persisted to state while Terraform thinks it's a non-computed field.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: fixed an issue in `google_container_cluster` where `workload_metadata_config` would cause a permadiff
```
