### PR TITLE
service is part of the URL and therefore is required.

### DIFF
--- a/products/appengine/api.yaml
+++ b/products/appengine/api.yaml
@@ -256,6 +256,7 @@ objects:
         url_param_only: true
         resource: 'Service'
         imports: 'name'
+        required: true
         description: |
           AppEngine service resource
     properties:
@@ -609,6 +610,7 @@ objects:
     parameters:
       - !ruby/object:Api::Type::ResourceRef
         name: 'service'
+        required: true
         url_param_only: true
         resource: 'Service'
         imports: 'name'


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:breaking-change
`app_engine_flexible_app_version` and `app_engine_standard_app_version` now require `service` to be set.  Before this change, leaving the value empty would have passed validation but failed during apply.

```

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6711