### PR TITLE
Use different port in global FR test

### DIFF
--- a/third_party/terraform/tests/resource_compute_global_forwarding_rule_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_global_forwarding_rule_test.go.erb
@@ -387,7 +387,7 @@ func testAccComputeGlobalForwardingRule_internalLoadBalancing(fr, proxy, backend
 resource "google_compute_global_forwarding_rule" "forwarding_rule" {
   name                  = "%s"
   target                = google_compute_target_http_proxy.default.self_link
-  port_range            = "80"
+  port_range            = "8080"
   load_balancing_scheme = "INTERNAL_SELF_MANAGED"
   ip_address            = "0.0.0.0"
   metadata_filters {
@@ -491,7 +491,7 @@ func testAccComputeGlobalForwardingRule_internalLoadBalancingUpdate(fr, proxy, b
 resource "google_compute_global_forwarding_rule" "forwarding_rule" {
   name                  = "%s"
   target                = google_compute_target_http_proxy.default.self_link
-  port_range            = "80"
+  port_range            = "8080"
   load_balancing_scheme = "INTERNAL_SELF_MANAGED"
   ip_address            = "0.0.0.0"
   metadata_filters {


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6657

Using the next viable port listed in https://cloud.google.com/compute/docs/reference/rest/v1/globalForwardingRules portRanges

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
