### PR TITLE
Project warning

### DIFF
--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -218,7 +218,7 @@ func resourceGoogleProjectRead(d *schema.ResourceData, meta interface{}) error {
 	p, err := readGoogleProject(d, config)
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 403 && strings.Contains(gerr.Message, "caller does not have permission") {
-			return fmt.Errorf("Error: The user does not have permission to access Project %q or it may not exist", pid)
+			return fmt.Errorf("The user does not have permission to access Project %q or it may not exist", pid)
 		}
 		return handleNotFoundError(err, d, fmt.Sprintf("Project %q", pid))
 	}

--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -218,7 +218,7 @@ func resourceGoogleProjectRead(d *schema.ResourceData, meta interface{}) error {
 	p, err := readGoogleProject(d, config)
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 403 && strings.Contains(gerr.Message, "caller does not have permission") {
-			return fmt.Errorf("The user does not have permission to access Project %q or it may not exist", pid)
+			return fmt.Errorf("the user does not have permission to access Project %q or it may not exist", pid)
 		}
 		return handleNotFoundError(err, d, fmt.Sprintf("Project %q", pid))
 	}

--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -217,6 +217,9 @@ func resourceGoogleProjectRead(d *schema.ResourceData, meta interface{}) error {
 
 	p, err := readGoogleProject(d, config)
 	if err != nil {
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 403 && strings.Contains(gerr.Message, "caller does not have permission") {
+			return fmt.Errorf("Error: The user does not have permission to access Project %q or it may not exist", pid)
+		}
 		return handleNotFoundError(err, d, fmt.Sprintf("Project %q", pid))
 	}
 


### PR DESCRIPTION
fixes https://github.com/terraform-providers/terraform-provider-google/issues/6677

when the gcp project API attempts to read a project that doesn't exist at all (instead of simply a non-active state), it returns a 403.

gcloud wraps their error output here:
```
gcloud projects describe some-project
ERROR: (gcloud.projects.describe) User [some-user] does not have permission to access project [some-project] (or it may not exist): The caller does not have permission
```

So it makes sense to change the provider error output from:

```
Error: Error when reading or editing Project "some-project": googleapi: Error 403: The caller does not have permission, forbidden
```

to:

```
Error: The user does not have permission to access Project "some-test" or it may not exist
```

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
