### PR TITLE
make database_encryption updateable

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1046,21 +1046,18 @@ func resourceContainerCluster() *schema.Resource {
         Type:        schema.TypeList,
         MaxItems:    1,
         Optional:    true,
-        ForceNew:    true,
         Computed:    true,
         Description: `Application-layer Secrets Encryption settings. The object format is {state = string, key_name = string}. Valid values of state are: "ENCRYPTED"; "DECRYPTED". key_name is the name of a CloudKMS key.`,
         Elem: &schema.Resource{
           Schema: map[string]*schema.Schema{
             "state": {
               Type:         schema.TypeString,
-              ForceNew:     true,
               Required:     true,
               ValidateFunc: validation.StringInSlice([]string{"ENCRYPTED", "DECRYPTED"}, false),
               Description:  `ENCRYPTED or DECRYPTED.`,
             },
             "key_name": {
               Type:        schema.TypeString,
-              ForceNew:    true,
               Optional:    true,
               Description: `The key to use to encrypt/decrypt secrets.`,
             },
@@ -2155,6 +2152,31 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 			d.SetPartial("vertical_pod_autoscaling")
 		}
+	}
+
+	if d.HasChange("database_encryption") {
+		c := d.Get("database_encryption")
+		req := &containerBeta.UpdateClusterRequest{
+			Update: &containerBeta.ClusterUpdate{
+				DesiredDatabaseEncryption: expandDatabaseEncryption(c),
+			},
+		}
+
+		updateF := func() error {
+			name := containerClusterFullName(project, location, clusterName)
+			op, err := config.clientContainerBeta.Projects.Locations.Clusters.Update(name, req).Do()
+			if err != nil {
+				return err
+			}
+			// Wait until it's updated
+			return containerOperationWait(config, op, project, location, "updating GKE cluster database encryption config", d.Timeout(schema.TimeoutUpdate))
+		}
+		if err := lockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+		log.Printf("[INFO] GKE cluster %s database encryption config has been updated", d.Id())
+
+		d.SetPartial("database_encryption")
 	}
 
 <% unless version == 'ga' -%>

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1737,7 +1737,15 @@ func TestAccContainerCluster_withDatabaseEncryption(t *testing.T) {
 				Config: testAccContainerCluster_withDatabaseEncryption(clusterName, kmsData),
 			},
 			{
-				ResourceName:        "google_container_cluster.with_database_encryption",
+				ResourceName:        "google_container_cluster.primary",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+			{
+				Config: testAccContainerCluster_basic(clusterName),
+			},
+			{
+				ResourceName:        "google_container_cluster.primary",
 				ImportState:         true,
 				ImportStateVerify:   true,
 			},
@@ -3900,7 +3908,7 @@ resource "google_kms_key_ring_iam_policy" "test_key_ring_iam_policy" {
   policy_data = data.google_iam_policy.test_kms_binding.policy_data
 }
 
-resource "google_container_cluster" "with_database_encryption" {
+resource "google_container_cluster" "primary" {
   name               = "%[3]s"
   location           = "us-central1-a"
   initial_node_count = 1


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6733

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: added the ability to update `database_encryption` without recreating the cluster.
```
