### PR TITLE
handle notfound error for runtime config

### DIFF
--- a/third_party/terraform/resources/resource_runtimeconfig_config.go
+++ b/third_party/terraform/resources/resource_runtimeconfig_config.go
@@ -81,7 +81,7 @@ func resourceRuntimeconfigConfigRead(d *schema.ResourceData, meta interface{}) e
 	fullName := d.Id()
 	runConfig, err := config.clientRuntimeconfig.Projects.Configs.Get(fullName).Do()
 	if err != nil {
-		return err
+		return handleNotFoundError(err, d, fmt.Sprintf("RuntimeConfig %q", d.Id()))
 	}
 
 	project, name, err := resourceRuntimeconfigParseFullName(runConfig.Name)


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6740

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
runtimeconfig: fixed `Requested entity was not found.` error when config was deleted outside of terraform.
```
