### PR TITLE
fix memcache_parameters

### DIFF
--- a/products/memcache/api.yaml
+++ b/products/memcache/api.yaml
@@ -136,7 +136,7 @@ objects:
               Memory size in Mebibytes for each memcache node.
             required: true
       - !ruby/object:Api::Type::NestedObject
-        name: memcacheParameters
+        name: parameters
         description: |
           User-specified parameters for this memcache instance.
         input: true

--- a/products/memcache/terraform.yaml
+++ b/products/memcache/terraform.yaml
@@ -36,6 +36,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         is_set: true
       region: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
+      parameters: !ruby/object:Overrides::Terraform::PropertyOverride
+        name: memcacheParameters
 
 
 # This is for copying files over

--- a/templates/terraform/examples/memcache_instance_basic.tf.erb
+++ b/templates/terraform/examples/memcache_instance_basic.tf.erb
@@ -30,11 +30,4 @@ resource "google_memcache_instance" "<%= ctx[:primary_resource_id] %>" {
     memory_size_mb = 1024
   }
   node_count = 1
-
-  parameters {
-    params = {
-      "listen-backlog" = "2048"
-      "max-item-size" = "8388608"
-    }
-  }
 }

--- a/templates/terraform/examples/memcache_instance_basic.tf.erb
+++ b/templates/terraform/examples/memcache_instance_basic.tf.erb
@@ -30,4 +30,11 @@ resource "google_memcache_instance" "<%= ctx[:primary_resource_id] %>" {
     memory_size_mb = 1024
   }
   node_count = 1
+
+  parameters {
+    params = {
+      "listen-backlog" = "2048"
+      "max-item-size" = "8388608"
+    }
+  }
 }

--- a/third_party/terraform/tests/resource_memcache_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_memcache_instance_test.go.erb
@@ -70,6 +70,13 @@ resource "google_memcache_instance" "test" {
     memory_size_mb = 1024
   }
   node_count = 1
+
+  memcache_parameters {
+    params = {
+      "listen-backlog" = "2048"
+      "max-item-size" = "8388608"
+    }
+  }
 }
 `, prefix, prefix, name)
 }
@@ -104,6 +111,13 @@ resource "google_memcache_instance" "test" {
     memory_size_mb = 1024
   }
   node_count = 2
+
+  memcache_parameters {
+    params = {
+      "listen-backlog" = "2048"
+      "max-item-size" = "8388608"
+    }
+  }
 }
 `, prefix, prefix, name)
 }


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6759

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
memcache: fixed field `memcache_parameters` to work correctly on `google_memcache_instance`
```
