### PR TITLE
add datafusion versioning for terraform

### DIFF
--- a/products/datafusion/api.yaml
+++ b/products/datafusion/api.yaml
@@ -147,7 +147,7 @@ objects:
           Endpoint on which the Data Fusion UI and REST APIs are accessible.
       - !ruby/object:Api::Type::String
         name: 'version'
-        output: true
+        input: true
         description: |
           Current version of the Data Fusion.
       - !ruby/object:Api::Type::String

--- a/products/datafusion/terraform.yaml
+++ b/products/datafusion/terraform.yaml
@@ -37,6 +37,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read: true
         required: false
         default_from_api: true
+      version: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/shortname_to_url.go.erb'
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'

--- a/templates/terraform/examples/data_fusion_instance_full.tf.erb
+++ b/templates/terraform/examples/data_fusion_instance_full.tf.erb
@@ -14,4 +14,5 @@ resource "google_data_fusion_instance" "<%= ctx[:primary_resource_id] %>" {
     network = "default"
     ip_allocation = "10.89.48.0/22"
   }
+  version = "6.1.1"
 }

--- a/third_party/terraform/tests/resource_data_fusion_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_data_fusion_instance_test.go.erb
@@ -45,6 +45,7 @@ resource "google_data_fusion_instance" "foobar" {
   name   = "%s"
   region = "us-central1"
   type   = "BASIC"
+  version = "6.1.1"
 }
 `, instanceName)
 }
@@ -62,6 +63,7 @@ resource "google_data_fusion_instance" "foobar" {
     label1 = "value1"
     label2 = "value2"
   }
+  version = "6.1.1"
 }
 `, instanceName)
 }


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
datafusion: changed `version` field to selectable in `google_data_fusion_instance` resource
```
Changed datafusion version to be an input type to allow selection of versioning upon creation in TF. Note that resource needs to be recreated upon an update to the version field as current API: https://cloud.google.com/data-fusion/docs/reference/rest/ only allows a POST upgrade method which uplifts to latest release, the PATCH update instance does not allow changing of version. This has been tested in Terraform Beta provider where it is designed to be used.
