### PR TITLE
update google_compute_image id to match its resource

### DIFF
--- a/templates/terraform/examples/autoscaler_basic.tf.erb
+++ b/templates/terraform/examples/autoscaler_basic.tf.erb
@@ -22,7 +22,7 @@ resource "google_compute_instance_template" "foobar" {
   tags = ["foo", "bar"]
 
   disk {
-    source_image = data.google_compute_image.debian_9.self_link
+    source_image = data.google_compute_image.debian_9.id
   }
 
   network_interface {

--- a/templates/terraform/examples/autoscaler_single_instance.tf.erb
+++ b/templates/terraform/examples/autoscaler_single_instance.tf.erb
@@ -28,7 +28,7 @@ resource "google_compute_instance_template" "default" {
   tags = ["foo", "bar"]
 
   disk {
-    source_image = data.google_compute_image.debian_9.self_link
+    source_image = data.google_compute_image.debian_9.id
   }
 
   network_interface {

--- a/templates/terraform/examples/network_management_connectivity_test_instances.tf.erb
+++ b/templates/terraform/examples/network_management_connectivity_test_instances.tf.erb
@@ -17,7 +17,7 @@ resource "google_compute_instance" "source" {
 
   boot_disk {
     initialize_params {
-      image = data.google_compute_image.debian_9.self_link
+      image = data.google_compute_image.debian_9.id
     }
   }
 
@@ -34,7 +34,7 @@ resource "google_compute_instance" "destination" {
 
   boot_disk {
     initialize_params {
-      image = data.google_compute_image.debian_9.self_link
+      image = data.google_compute_image.debian_9.id
     }
   }
 

--- a/templates/terraform/examples/region_autoscaler_basic.tf.erb
+++ b/templates/terraform/examples/region_autoscaler_basic.tf.erb
@@ -22,7 +22,7 @@ resource "google_compute_instance_template" "foobar" {
   tags = ["foo", "bar"]
 
   disk {
-    source_image = data.google_compute_image.debian_9.self_link
+    source_image = data.google_compute_image.debian_9.id
   }
 
   network_interface {

--- a/third_party/terraform/data_sources/data_source_google_compute_image.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_image.go
@@ -112,15 +112,12 @@ func dataSourceGoogleComputeImageRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	params := []string{project}
 	var image *compute.Image
 	if v, ok := d.GetOk("name"); ok {
-		params = append(params, v.(string))
 		log.Printf("[DEBUG] Fetching image %s", v.(string))
 		image, err = config.clientCompute.Images.Get(project, v.(string)).Do()
 		log.Printf("[DEBUG] Fetched image %s", v.(string))
 	} else if v, ok := d.GetOk("family"); ok {
-		params = append(params, "family", v.(string))
 		log.Printf("[DEBUG] Fetching latest non-deprecated image from family %s", v.(string))
 		image, err = config.clientCompute.Images.GetFromFamily(project, v.(string)).Do()
 		log.Printf("[DEBUG] Fetched latest non-deprecated image from family %s", v.(string))

--- a/third_party/terraform/data_sources/data_source_google_compute_image.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_image.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"strconv"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	compute "google.golang.org/api/compute/v1"
@@ -162,7 +161,11 @@ func dataSourceGoogleComputeImageRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("source_image_id", image.SourceImageId)
 	d.Set("status", image.Status)
 
-	d.SetId(strings.Join(params, "/"))
+	id, err := replaceVars(d, config, "projects/{{project}}/global/images/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
 
 	return nil
 }

--- a/third_party/terraform/tests/resource_network_management_connectivity_test_resource_test.go
+++ b/third_party/terraform/tests/resource_network_management_connectivity_test_resource_test.go
@@ -96,7 +96,7 @@ resource "google_compute_instance" "vm1" {
 	machine_type = "n1-standard-1"
 	boot_disk {
 	  initialize_params {
-	    image = data.google_compute_image.debian_9.self_link
+	    image = data.google_compute_image.debian_9.id
 	  }
 	}	
 	network_interface {
@@ -110,7 +110,7 @@ resource "google_compute_instance" "vm2" {
   
 	boot_disk {
 	  initialize_params {
-		image = data.google_compute_image.debian_9.self_link
+		image = data.google_compute_image.debian_9.id
 	  }
 	}
   

--- a/third_party/terraform/website/docs/d/compute_image.html.markdown
+++ b/third_party/terraform/website/docs/d/compute_image.html.markdown
@@ -51,6 +51,7 @@ that is part of an image family and is not deprecated.
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
+* `id` - an identifier for the data source  with format `projects/{{project}}/global/images/{{name}}`
 * `self_link` - The URI of the image.
 * `name` - The name of the image.
 * `family` - The family name of the image.


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6792

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
