### PR TITLE
Add support for cloudrun ports

### DIFF
--- a/products/cloudrun/api.yaml
+++ b/products/cloudrun/api.yaml
@@ -509,6 +509,21 @@ objects:
                     references will never be expanded, regardless of whether the variable
                     exists or not.
                     Defaults to "".
+            - !ruby/object:Api::Type::Array
+              name: ports
+              description: |-
+                List of open ports in the container.
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                - !ruby/object:Api::Type::String
+                  name: name
+                  description: Name of the port
+                - !ruby/object:Api::Type::String
+                  name: protocol
+                  description: Protocol used on port. Defaults to http.
+                - !ruby/object:Api::Type::Integer
+                  name: containerPort
+                  description: Port number.  Defaults to 8080.
             - !ruby/object:Api::Type::NestedObject
               name: resources
               description: |-

--- a/products/cloudrun/api.yaml
+++ b/products/cloudrun/api.yaml
@@ -525,7 +525,7 @@ objects:
                   description: Protocol used on port. Defaults to TCP.
                 - !ruby/object:Api::Type::Integer
                   name: containerPort
-                  description: Port number.  Defaults to 8080.
+                  description: Port number.
                   required: true
             - !ruby/object:Api::Type::NestedObject
               name: resources

--- a/products/cloudrun/api.yaml
+++ b/products/cloudrun/api.yaml
@@ -517,7 +517,7 @@ objects:
                 properties:
                 - !ruby/object:Api::Type::String
                   name: name
-                  description: Name of the port
+                  description: Name of the port.
                 - !ruby/object:Api::Type::String
                   name: protocol
                   description: Protocol used on port. Defaults to http.

--- a/products/cloudrun/api.yaml
+++ b/products/cloudrun/api.yaml
@@ -522,7 +522,7 @@ objects:
                   description: Name of the port.
                 - !ruby/object:Api::Type::String
                   name: protocol
-                  description: Protocol used on port. Defaults to http.
+                  description: Protocol used on port. Defaults to TCP.
                 - !ruby/object:Api::Type::Integer
                   name: containerPort
                   description: Port number.  Defaults to 8080.

--- a/products/cloudrun/api.yaml
+++ b/products/cloudrun/api.yaml
@@ -526,6 +526,7 @@ objects:
                 - !ruby/object:Api::Type::Integer
                   name: containerPort
                   description: Port number.  Defaults to 8080.
+                  required: true
             - !ruby/object:Api::Type::NestedObject
               name: resources
               description: |-

--- a/products/cloudrun/api.yaml
+++ b/products/cloudrun/api.yaml
@@ -513,7 +513,8 @@ objects:
               name: ports
               description: |-
                 List of open ports in the container.
-                More Info: https://cloud.google.com/run/docs/reference/rest/v1/RevisionSpec#ContainerPort
+                More Info: 
+                https://cloud.google.com/run/docs/reference/rest/v1/RevisionSpec#ContainerPort
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
                 - !ruby/object:Api::Type::String

--- a/products/cloudrun/api.yaml
+++ b/products/cloudrun/api.yaml
@@ -513,6 +513,7 @@ objects:
               name: ports
               description: |-
                 List of open ports in the container.
+                More Info: https://cloud.google.com/run/docs/reference/rest/v1/RevisionSpec#ContainerPort
               item_type: !ruby/object:Api::Type::NestedObject
                 properties:
                 - !ruby/object:Api::Type::String

--- a/products/cloudrun/terraform.yaml
+++ b/products/cloudrun/terraform.yaml
@@ -156,6 +156,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       spec.template.spec.containers: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      spec.template.spec.containers.ports: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       spec.template.spec.containers.resources: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       spec.template.spec.containers.resources.limits: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/third_party/terraform/tests/resource_cloud_run_service_test.go
+++ b/third_party/terraform/tests/resource_cloud_run_service_test.go
@@ -54,6 +54,9 @@ resource "google_cloud_run_service" "default" {
       containers {
         image = "gcr.io/cloudrun/hello"
         args  = ["arrgs"]
+        ports {
+          container_port = 8080
+        }
       }
 	  container_concurrency = %s
 	  timeout_seconds = %s


### PR DESCRIPTION
Fixes: terraform-providers/terraform-provider-google#5539

API Reference:
https://cloud.google.com/run/docs/reference/rest/v1/RevisionSpec#ContainerPort
https://cloud.google.com/run/docs/reference/rest/v1/RevisionSpec#Container

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrun: added `ports` field to `google_cloud_run_service` `templates.spec.containers`
```