### PR TITLE
Add support for Cloud Asset feeds

### DIFF
--- a/products/cloudasset/api.yaml
+++ b/products/cloudasset/api.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google Inc.
+# Copyright 2020 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/products/cloudasset/api.yaml
+++ b/products/cloudasset/api.yaml
@@ -94,3 +94,81 @@ objects:
                 name: topic
                 description: |
                   Destination on Cloud Pubsub topic.
+  - !ruby/object:Api::Resource
+    name: FolderFeed
+    base_url: "{{folder}}/feeds"
+    create_url: "{{folder}}/feeds?feedId={{feed_id}}"
+    self_link: "{{name}}"
+    update_verb: :PATCH
+    update_mask: true
+    collection_url_key: 'feeds'
+    description: |
+      Describes a Cloud Asset Inventory feed used to to listen to asset updates.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+          'https://cloud.google.com/asset-inventory/docs'
+      api: 'https://cloud.google.com/asset-inventory/docs/reference/rest/'
+    properties:
+      - !ruby/object:Api::Type::String
+        name: folder
+        required: true
+        input: true
+        url_param_only: true
+        description: |
+          The folder this feed should be created in.
+      - !ruby/object:Api::Type::String
+        name: project
+        required: true
+        input: true
+        url_param_only: true
+        description: |
+          The project whose identity will be used when sending messages to the destination pubsub topic.
+      - !ruby/object:Api::Type::String
+        name: name
+        output: true
+        description: |
+          The format will be folders/{folder_number}/feeds/{client-assigned_feed_identifier}.
+      - !ruby/object:Api::Type::String
+        name: feedId
+        description: |
+          This is the client-assigned asset feed identifier and it needs to be unique under a specific parent.
+        required: true
+        input: true
+        url_param_only: true
+      - !ruby/object:Api::Type::Array
+        name: assetNames
+        item_type: Api::Type::String
+        description: |
+          A list of the full names of the assets to receive updates. You must specify either or both of 
+          assetNames and assetTypes. Only asset updates matching specified assetNames and assetTypes are
+          exported to the feed. For example: //compute.googleapis.com/folders/my_folder_123/zones/zone1/instances/instance1.
+          See https://cloud.google.com/apis/design/resourceNames#fullResourceName for more info.
+      - !ruby/object:Api::Type::Array
+        name: assetTypes
+        item_type: Api::Type::String
+        description: |
+          A list of types of the assets to receive updates. You must specify either or both of assetNames
+          and assetTypes. Only asset updates matching specified assetNames and assetTypes are exported to
+          the feed. For example: "compute.googleapis.com/Disk"
+          See https://cloud.google.com/asset-inventory/docs/supported-asset-types for a list of all
+          supported asset types.
+      - !ruby/object:Api::Type::String
+        name: contentType
+        description: |
+          Asset content type. If not specified, no content but the asset name and type will be returned.
+      - !ruby/object:Api::Type::NestedObject
+        name: feedOutputConfig
+        required: true
+        description: |
+          Output configuration for asset feed destination.
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: pubsubDestination
+            description: |
+              Destination on Cloud Pubsub.
+            properties:
+              - !ruby/object:Api::Type::String
+                name: topic
+                description: |
+                  Destination on Cloud Pubsub topic.

--- a/products/cloudasset/api.yaml
+++ b/products/cloudasset/api.yaml
@@ -142,7 +142,85 @@ objects:
         description: |
           A list of the full names of the assets to receive updates. You must specify either or both of 
           assetNames and assetTypes. Only asset updates matching specified assetNames and assetTypes are
-          exported to the feed. For example: //compute.googleapis.com/folders/my_folder_123/zones/zone1/instances/instance1.
+          exported to the feed. For example: //compute.googleapis.com/projects/my_project_123/zones/zone1/instances/instance1.
+          See https://cloud.google.com/apis/design/resourceNames#fullResourceName for more info.
+      - !ruby/object:Api::Type::Array
+        name: assetTypes
+        item_type: Api::Type::String
+        description: |
+          A list of types of the assets to receive updates. You must specify either or both of assetNames
+          and assetTypes. Only asset updates matching specified assetNames and assetTypes are exported to
+          the feed. For example: "compute.googleapis.com/Disk"
+          See https://cloud.google.com/asset-inventory/docs/supported-asset-types for a list of all
+          supported asset types.
+      - !ruby/object:Api::Type::String
+        name: contentType
+        description: |
+          Asset content type. If not specified, no content but the asset name and type will be returned.
+      - !ruby/object:Api::Type::NestedObject
+        name: feedOutputConfig
+        required: true
+        description: |
+          Output configuration for asset feed destination.
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: pubsubDestination
+            description: |
+              Destination on Cloud Pubsub.
+            properties:
+              - !ruby/object:Api::Type::String
+                name: topic
+                description: |
+                  Destination on Cloud Pubsub topic.
+  - !ruby/object:Api::Resource
+    name: OrganizationFeed
+    base_url: "organizations/{{org_id}}/feeds"
+    create_url: "organizations/{{org_id}}/feeds?feedId={{feed_id}}"
+    self_link: "{{name}}"
+    update_verb: :PATCH
+    update_mask: true
+    collection_url_key: 'feeds'
+    description: |
+      Describes a Cloud Asset Inventory feed used to to listen to asset updates.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+          'https://cloud.google.com/asset-inventory/docs'
+      api: 'https://cloud.google.com/asset-inventory/docs/reference/rest/'
+    properties:
+      - !ruby/object:Api::Type::String
+        name: org_id
+        required: true
+        input: true
+        url_param_only: true
+        description: |
+          The organization this feed should be created in.
+      - !ruby/object:Api::Type::String
+        name: project
+        required: true
+        input: true
+        url_param_only: true
+        description: |
+          The project whose identity will be used when sending messages to the destination pubsub topic.
+      - !ruby/object:Api::Type::String
+        name: name
+        output: true
+        description: |
+          The format will be organizations/{organization_number}/feeds/{client-assigned_feed_identifier}.
+      - !ruby/object:Api::Type::String
+        name: feedId
+        description: |
+          This is the client-assigned asset feed identifier and it needs to be unique under a specific parent.
+        required: true
+        input: true
+        url_param_only: true
+      - !ruby/object:Api::Type::Array
+        name: assetNames
+        item_type: Api::Type::String
+        description: |
+          A list of the full names of the assets to receive updates. You must specify either or both of 
+          assetNames and assetTypes. Only asset updates matching specified assetNames and assetTypes are
+          exported to the feed. For example: //compute.googleapis.com/projects/my_project_123/zones/zone1/instances/instance1.
           See https://cloud.google.com/apis/design/resourceNames#fullResourceName for more info.
       - !ruby/object:Api::Type::Array
         name: assetTypes

--- a/products/cloudasset/api.yaml
+++ b/products/cloudasset/api.yaml
@@ -104,8 +104,8 @@ objects:
                   Destination on Cloud Pubsub topic.
   - !ruby/object:Api::Resource
     name: FolderFeed
-    base_url: "{{folder}}/feeds"
-    create_url: "{{folder}}/feeds?feedId={{feed_id}}"
+    base_url: folders/{{folder_id}}/feeds
+    create_url: folders/{{folder_id}}/feeds?feedId={{feed_id}}
     self_link: "{{name}}"
     update_verb: :PATCH
     update_mask: true
@@ -133,6 +133,11 @@ objects:
         url_param_only: true
         description: |
           The project whose identity will be used when sending messages to the destination pubsub topic.
+      - !ruby/object:Api::Type::String
+        name: folder_id
+        output: true
+        description: |
+          The ID of the folder where this feed has been created.
       - !ruby/object:Api::Type::String
         name: name
         output: true

--- a/products/cloudasset/api.yaml
+++ b/products/cloudasset/api.yaml
@@ -75,10 +75,16 @@ objects:
           the feed. For example: "compute.googleapis.com/Disk"
           See https://cloud.google.com/asset-inventory/docs/supported-asset-types for a list of all
           supported asset types.
-      - !ruby/object:Api::Type::String
+      - !ruby/object:Api::Type::Enum
         name: contentType
         description: |
           Asset content type. If not specified, no content but the asset name and type will be returned.
+        values:
+          - :CONTENT_TYPE_UNSPECIFIED
+          - :RESOURCE
+          - :IAM_POLICY
+          - :ORG_POLICY
+          - :ACCESS_POLICY
       - !ruby/object:Api::Type::NestedObject
         name: feedOutputConfig
         required: true
@@ -155,10 +161,16 @@ objects:
           the feed. For example: "compute.googleapis.com/Disk"
           See https://cloud.google.com/asset-inventory/docs/supported-asset-types for a list of all
           supported asset types.
-      - !ruby/object:Api::Type::String
+      - !ruby/object:Api::Type::Enum
         name: contentType
         description: |
           Asset content type. If not specified, no content but the asset name and type will be returned.
+        values:
+          - :CONTENT_TYPE_UNSPECIFIED
+          - :RESOURCE
+          - :IAM_POLICY
+          - :ORG_POLICY
+          - :ACCESS_POLICY
       - !ruby/object:Api::Type::NestedObject
         name: feedOutputConfig
         required: true
@@ -235,10 +247,16 @@ objects:
           the feed. For example: "compute.googleapis.com/Disk"
           See https://cloud.google.com/asset-inventory/docs/supported-asset-types for a list of all
           supported asset types.
-      - !ruby/object:Api::Type::String
+      - !ruby/object:Api::Type::Enum
         name: contentType
         description: |
           Asset content type. If not specified, no content but the asset name and type will be returned.
+        values:
+          - :CONTENT_TYPE_UNSPECIFIED
+          - :RESOURCE
+          - :IAM_POLICY
+          - :ORG_POLICY
+          - :ACCESS_POLICY
       - !ruby/object:Api::Type::NestedObject
         name: feedOutputConfig
         required: true

--- a/products/cloudasset/api.yaml
+++ b/products/cloudasset/api.yaml
@@ -87,11 +87,13 @@ objects:
         properties:
           - !ruby/object:Api::Type::NestedObject
             name: pubsubDestination
+            required: true
             description: |
               Destination on Cloud Pubsub.
             properties:
               - !ruby/object:Api::Type::String
                 name: topic
+                required: true
                 description: |
                   Destination on Cloud Pubsub topic.
   - !ruby/object:Api::Resource
@@ -165,11 +167,13 @@ objects:
         properties:
           - !ruby/object:Api::Type::NestedObject
             name: pubsubDestination
+            required: true
             description: |
               Destination on Cloud Pubsub.
             properties:
               - !ruby/object:Api::Type::String
                 name: topic
+                required: true
                 description: |
                   Destination on Cloud Pubsub topic.
   - !ruby/object:Api::Resource
@@ -243,10 +247,12 @@ objects:
         properties:
           - !ruby/object:Api::Type::NestedObject
             name: pubsubDestination
+            required: true
             description: |
               Destination on Cloud Pubsub.
             properties:
               - !ruby/object:Api::Type::String
                 name: topic
+                required: true
                 description: |
                   Destination on Cloud Pubsub topic.

--- a/products/cloudasset/api.yaml
+++ b/products/cloudasset/api.yaml
@@ -1,0 +1,96 @@
+# Copyright 2019 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+--- !ruby/object:Api::Product
+name: CloudAsset
+display_name: Cloud Asset Inventory
+versions:
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://cloudasset.googleapis.com/v1/
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: Cloud Asset API
+    url: https://console.cloud.google.com/apis/library/cloudasset.googleapis.com/
+objects:
+  - !ruby/object:Api::Resource
+    name: ProjectFeed
+    base_url: projects/{{project}}/feeds
+    create_url: projects/{{project}}/feeds?feedId={{feed_id}}
+    self_link: "{{name}}"
+    update_verb: :PATCH
+    update_mask: true
+    collection_url_key: 'feeds'
+    description: |
+      Describes a Cloud Asset Inventory feed used to to listen to asset updates.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+          'https://cloud.google.com/asset-inventory/docs'
+      api: 'https://cloud.google.com/asset-inventory/docs/reference/rest/'
+    properties:
+      - !ruby/object:Api::Type::String
+        name: billing_project
+        url_param_only: true
+        input: true
+        description: |
+          The project whose identity will be used when sending messages to the destination pubsub topic.
+      - !ruby/object:Api::Type::String
+        name: name
+        output: true
+        description: |
+          The format will be projects/{projectNumber}/feeds/{client-assigned_feed_identifier}.
+      - !ruby/object:Api::Type::String
+        name: feedId
+        description: |
+          This is the client-assigned asset feed identifier and it needs to be unique under a specific parent.
+        required: true
+        input: true
+        url_param_only: true
+      - !ruby/object:Api::Type::Array
+        name: assetNames
+        item_type: Api::Type::String
+        description: |
+          A list of the full names of the assets to receive updates. You must specify either or both of 
+          assetNames and assetTypes. Only asset updates matching specified assetNames and assetTypes are
+          exported to the feed. For example: //compute.googleapis.com/projects/my_project_123/zones/zone1/instances/instance1.
+          See https://cloud.google.com/apis/design/resourceNames#fullResourceName for more info.
+      - !ruby/object:Api::Type::Array
+        name: assetTypes
+        item_type: Api::Type::String
+        description: |
+          A list of types of the assets to receive updates. You must specify either or both of assetNames
+          and assetTypes. Only asset updates matching specified assetNames and assetTypes are exported to
+          the feed. For example: "compute.googleapis.com/Disk"
+          See https://cloud.google.com/asset-inventory/docs/supported-asset-types for a list of all
+          supported asset types.
+      - !ruby/object:Api::Type::String
+        name: contentType
+        description: |
+          Asset content type. If not specified, no content but the asset name and type will be returned.
+      - !ruby/object:Api::Type::NestedObject
+        name: feedOutputConfig
+        required: true
+        description: |
+          Output configuration for asset feed destination.
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: pubsubDestination
+            description: |
+              Destination on Cloud Pubsub.
+            properties:
+              - !ruby/object:Api::Type::String
+                name: topic
+                description: |
+                  Destination on Cloud Pubsub topic.

--- a/products/cloudasset/api.yaml
+++ b/products/cloudasset/api.yaml
@@ -45,7 +45,10 @@ objects:
         url_param_only: true
         input: true
         description: |
-          The project whose identity will be used when sending messages to the destination pubsub topic.
+          The project whose identity will be used when sending messages to the
+          destination pubsub topic. It also specifies the project for API 
+          enablement check, quota, and billing. If not specified, the resource's
+          project will be used.
       - !ruby/object:Api::Type::String
         name: name
         output: true
@@ -127,17 +130,20 @@ objects:
           The folder this feed should be created in.
     properties:
       - !ruby/object:Api::Type::String
-        name: project
+        name: billing_project
         required: true
         input: true
         url_param_only: true
         description: |
-          The project whose identity will be used when sending messages to the destination pubsub topic.
+          The project whose identity will be used when sending messages to the
+          destination pubsub topic. It also specifies the project for API 
+          enablement check, quota, and billing.
       - !ruby/object:Api::Type::String
         name: folder_id
         output: true
         description: |
-          The ID of the folder where this feed has been created.
+          The ID of the folder where this feed has been created. Both [FOLDER_NUMBER]
+          and folders/[FOLDER_NUMBER] are accepted.
       - !ruby/object:Api::Type::String
         name: name
         output: true
@@ -219,12 +225,14 @@ objects:
           The organization this feed should be created in.
     properties:
       - !ruby/object:Api::Type::String
-        name: project
+        name: billing_project
         required: true
         input: true
         url_param_only: true
         description: |
-          The project whose identity will be used when sending messages to the destination pubsub topic.
+          The project whose identity will be used when sending messages to the
+          destination pubsub topic. It also specifies the project for API 
+          enablement check, quota, and billing.
       - !ruby/object:Api::Type::String
         name: name
         output: true

--- a/products/cloudasset/api.yaml
+++ b/products/cloudasset/api.yaml
@@ -117,7 +117,7 @@ objects:
         'Official Documentation':
           'https://cloud.google.com/asset-inventory/docs'
       api: 'https://cloud.google.com/asset-inventory/docs/reference/rest/'
-    properties:
+    parameters:
       - !ruby/object:Api::Type::String
         name: folder
         required: true
@@ -125,6 +125,7 @@ objects:
         url_param_only: true
         description: |
           The folder this feed should be created in.
+    properties:
       - !ruby/object:Api::Type::String
         name: project
         required: true
@@ -203,7 +204,7 @@ objects:
         'Official Documentation':
           'https://cloud.google.com/asset-inventory/docs'
       api: 'https://cloud.google.com/asset-inventory/docs/reference/rest/'
-    properties:
+    parameters:
       - !ruby/object:Api::Type::String
         name: org_id
         required: true
@@ -211,6 +212,7 @@ objects:
         url_param_only: true
         description: |
           The organization this feed should be created in.
+    properties:
       - !ruby/object:Api::Type::String
         name: project
         required: true

--- a/products/cloudasset/terraform.yaml
+++ b/products/cloudasset/terraform.yaml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google Inc.
+# Copyright 2020 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/products/cloudasset/terraform.yaml
+++ b/products/cloudasset/terraform.yaml
@@ -17,8 +17,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_create: templates/terraform/pre_create/cloud_asset_feed.go.erb
       post_create: templates/terraform/post_create/cloud_asset_feed.go.erb
-      pre_update: templates/terraform/pre_update/cloud_asset_feed.go.erb
       custom_import: templates/terraform/custom_import/cloud_asset_feed.go.erb
+      encoder: templates/terraform/encoders/cloud_asset_feed.go.erb
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "cloud_asset_project_feed"
@@ -32,8 +32,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_create: templates/terraform/pre_create/cloud_asset_feed.go.erb
       post_create: templates/terraform/post_create/cloud_asset_feed.go.erb
-      pre_update: templates/terraform/pre_update/cloud_asset_feed.go.erb
       custom_import: templates/terraform/custom_import/cloud_asset_feed.go.erb
+      encoder: templates/terraform/encoders/cloud_asset_feed.go.erb
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "cloud_asset_folder_feed"
@@ -49,8 +49,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_create: templates/terraform/pre_create/cloud_asset_feed.go.erb
       post_create: templates/terraform/post_create/cloud_asset_feed.go.erb
-      pre_update: templates/terraform/pre_update/cloud_asset_feed.go.erb
       custom_import: templates/terraform/custom_import/cloud_asset_feed.go.erb
+      encoder: templates/terraform/encoders/cloud_asset_feed.go.erb
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "cloud_asset_organization_feed"

--- a/products/cloudasset/terraform.yaml
+++ b/products/cloudasset/terraform.yaml
@@ -14,7 +14,6 @@
 --- !ruby/object:Provider::Terraform::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
   ProjectFeed: !ruby/object:Overrides::Terraform::ResourceOverride
-    autogen_async: false
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_create: templates/terraform/pre_create/cloud_asset_feed.go.erb
       post_create: templates/terraform/post_create/cloud_asset_feed.go.erb
@@ -29,7 +28,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_env_vars:
           project: :PROJECT_NAME
   FolderFeed: !ruby/object:Overrides::Terraform::ResourceOverride
-    autogen_async: false
     supports_indirect_user_project_override: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_create: templates/terraform/pre_create/cloud_asset_feed.go.erb
@@ -47,7 +45,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           project: :PROJECT_NAME
           org_id: :ORG_ID
   OrganizationFeed: !ruby/object:Overrides::Terraform::ResourceOverride
-    autogen_async: false
     supports_indirect_user_project_override: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_create: templates/terraform/pre_create/cloud_asset_feed.go.erb

--- a/products/cloudasset/terraform.yaml
+++ b/products/cloudasset/terraform.yaml
@@ -1,0 +1,30 @@
+# Copyright 2019 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Terraform::Config
+overrides: !ruby/object:Overrides::ResourceOverrides
+  ProjectFeed: !ruby/object:Overrides::Terraform::ResourceOverride
+    autogen_async: false
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      pre_create: templates/terraform/pre_create/cloud_asset_feed.go.erb
+      post_create: templates/terraform/post_create/cloud_asset_feed.go.erb
+      pre_update: templates/terraform/pre_update/cloud_asset_feed.go.erb
+      custom_import: templates/terraform/custom_import/cloud_asset_feed.go.erb
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "cloud_asset_project_feed"
+        primary_resource_id: "project_feed"
+        vars:
+          feed_id: "network-updates"
+        test_env_vars:
+          project: :PROJECT_NAME

--- a/products/cloudasset/terraform.yaml
+++ b/products/cloudasset/terraform.yaml
@@ -28,3 +28,21 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           feed_id: "network-updates"
         test_env_vars:
           project: :PROJECT_NAME
+  FolderFeed: !ruby/object:Overrides::Terraform::ResourceOverride
+    autogen_async: false
+    supports_indirect_user_project_override: true
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      pre_create: templates/terraform/pre_create/cloud_asset_feed.go.erb
+      post_create: templates/terraform/post_create/cloud_asset_feed.go.erb
+      pre_update: templates/terraform/pre_update/cloud_asset_feed.go.erb
+      custom_import: templates/terraform/custom_import/cloud_asset_feed.go.erb
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "cloud_asset_folder_feed"
+        primary_resource_id: "folder_feed"
+        vars:
+          feed_id: "network-updates"
+          folder_name: "Networking"
+        test_env_vars:
+          project: :PROJECT_NAME
+          org_id: :ORG_ID

--- a/products/cloudasset/terraform.yaml
+++ b/products/cloudasset/terraform.yaml
@@ -46,3 +46,20 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_env_vars:
           project: :PROJECT_NAME
           org_id: :ORG_ID
+  OrganizationFeed: !ruby/object:Overrides::Terraform::ResourceOverride
+    autogen_async: false
+    supports_indirect_user_project_override: true
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      pre_create: templates/terraform/pre_create/cloud_asset_feed.go.erb
+      post_create: templates/terraform/post_create/cloud_asset_feed.go.erb
+      pre_update: templates/terraform/pre_update/cloud_asset_feed.go.erb
+      custom_import: templates/terraform/custom_import/cloud_asset_feed.go.erb
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "cloud_asset_organization_feed"
+        primary_resource_id: "organization_feed"
+        vars:
+          feed_id: "network-updates"
+        test_env_vars:
+          project: :PROJECT_NAME
+          org_id: :ORG_ID

--- a/provider/terraform/custom_code.rb
+++ b/provider/terraform/custom_code.rb
@@ -75,6 +75,9 @@ module Provider
       # (e.g. "fooBarDiffSuppress") and regexes that are necessarily
       # exported (e.g. "fooBarValidationRegex").
       attr_reader :constants
+      # This code is run before the Create call happens.  It's placed
+      # in the Create function, just before the Create call is made.
+      attr_reader :pre_create
       # This code is run after the Create call succeeds.  It's placed
       # in the Create function directly without modification.
       attr_reader :post_create
@@ -126,6 +129,7 @@ module Provider
         check :update_encoder, type: String
         check :decoder, type: String
         check :constants, type: String
+        check :pre_create, type: String
         check :post_create, type: String
         check :custom_create, type: String
         check :pre_update, type: String

--- a/templates/terraform/custom_import/cloud_asset_feed.go.erb
+++ b/templates/terraform/custom_import/cloud_asset_feed.go.erb
@@ -1,0 +1,4 @@
+if err := d.Set("name", d.Id()); err != nil {
+  return nil, err
+}
+return []*schema.ResourceData{d}, nil

--- a/templates/terraform/encoders/cloud_asset_feed.go.erb
+++ b/templates/terraform/encoders/cloud_asset_feed.go.erb
@@ -1,4 +1,4 @@
 // The feed object must be under the "feed" attribute on the request.
 newObj := make(map[string]interface{})
 newObj["feed"] = obj
-obj = newObj
+return newObj, nil

--- a/templates/terraform/encoders/cloud_asset_feed.go.erb
+++ b/templates/terraform/encoders/cloud_asset_feed.go.erb
@@ -1,3 +1,7 @@
+// Remove the "folders/" prefix from the folder ID
+if folder, ok := d.GetOkExists("folder"); ok {
+  d.Set("folder_id", strings.TrimPrefix(folder.(string), "folders/"))
+}
 // The feed object must be under the "feed" attribute on the request.
 newObj := make(map[string]interface{})
 newObj["feed"] = obj

--- a/templates/terraform/examples/cloud_asset_folder_feed.tf.erb
+++ b/templates/terraform/examples/cloud_asset_folder_feed.tf.erb
@@ -1,0 +1,51 @@
+# Create a feed that sends notifications about network resource updates under a
+# particular folder.
+resource "google_cloud_asset_folder_feed" "<%= ctx[:primary_resource_id] %>" {
+  project  = "<%= ctx[:test_env_vars]["project"] %>"
+  folder           = google_folder.my_folder.name
+  feed_id          = "<%= ctx[:vars]["feed_id"] %>"
+  content_type     = "RESOURCE"
+
+  asset_types = [
+    "compute.googleapis.com/Subnetwork",
+    "compute.googleapis.com/Network",
+  ]
+
+  feed_output_config {
+    pubsub_destination {
+      topic = google_pubsub_topic.feed_output.id
+    }
+  }
+
+  # Wait for the permission to be ready on the destination topic.
+  depends_on = [
+    google_pubsub_topic_iam_member.cloud_asset_writer,
+  ]
+}
+
+# The topic where the resource change notifications will be sent.
+resource "google_pubsub_topic" "feed_output" {
+  project  = "<%= ctx[:test_env_vars]["project"] %>"
+  name     = "<%= ctx[:vars]["feed_id"] %>"
+}
+
+# The folder that will be monitored for resource updates.
+resource "google_folder" "my_folder" {
+  display_name = "<%= ctx[:vars]["folder_name"] %>"
+  parent       = "organizations/<%= ctx[:test_env_vars]["org_id"] %>"
+}
+
+# Find the project number of the project whose identity will be used for sending
+# the asset change notifications.
+data "google_project" "project" {
+  project_id = "<%= ctx[:test_env_vars]["project"] %>"
+}
+
+# Allow the publishing role to the Cloud Asset service account of the project that
+# was used for sending the notifications.
+resource "google_pubsub_topic_iam_member" "cloud_asset_writer" {
+  project = "<%= ctx[:test_env_vars]["project"] %>"
+  topic   = google_pubsub_topic.feed_output.id
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudasset.iam.gserviceaccount.com"
+}

--- a/templates/terraform/examples/cloud_asset_folder_feed.tf.erb
+++ b/templates/terraform/examples/cloud_asset_folder_feed.tf.erb
@@ -1,7 +1,7 @@
 # Create a feed that sends notifications about network resource updates under a
 # particular folder.
 resource "google_cloud_asset_folder_feed" "<%= ctx[:primary_resource_id] %>" {
-  project  = "<%= ctx[:test_env_vars]["project"] %>"
+  billing_project  = "<%= ctx[:test_env_vars]["project"] %>"
   folder           = google_folder.my_folder.name
   feed_id          = "<%= ctx[:vars]["feed_id"] %>"
   content_type     = "RESOURCE"

--- a/templates/terraform/examples/cloud_asset_organization_feed.tf.erb
+++ b/templates/terraform/examples/cloud_asset_organization_feed.tf.erb
@@ -1,10 +1,10 @@
 # Create a feed that sends notifications about network resource updates under a
 # particular organization.
 resource "google_cloud_asset_organization_feed" "<%= ctx[:primary_resource_id] %>" {
-  project      = "<%= ctx[:test_env_vars]["project"] %>"
-  org_id       = "<%= ctx[:test_env_vars]["org_id"] %>"
-  feed_id      = "<%= ctx[:vars]["feed_id"] %>"
-  content_type = "RESOURCE"
+  billing_project = "<%= ctx[:test_env_vars]["project"] %>"
+  org_id          = "<%= ctx[:test_env_vars]["org_id"] %>"
+  feed_id         = "<%= ctx[:vars]["feed_id"] %>"
+  content_type    = "RESOURCE"
 
   asset_types = [
     "compute.googleapis.com/Subnetwork",

--- a/templates/terraform/examples/cloud_asset_organization_feed.tf.erb
+++ b/templates/terraform/examples/cloud_asset_organization_feed.tf.erb
@@ -1,0 +1,45 @@
+# Create a feed that sends notifications about network resource updates under a
+# particular organization.
+resource "google_cloud_asset_organization_feed" "<%= ctx[:primary_resource_id] %>" {
+  project      = "<%= ctx[:test_env_vars]["project"] %>"
+  org_id       = "<%= ctx[:test_env_vars]["org_id"] %>"
+  feed_id      = "<%= ctx[:vars]["feed_id"] %>"
+  content_type = "RESOURCE"
+
+  asset_types = [
+    "compute.googleapis.com/Subnetwork",
+    "compute.googleapis.com/Network",
+  ]
+
+  feed_output_config {
+    pubsub_destination {
+      topic = google_pubsub_topic.feed_output.id
+    }
+  }
+
+  # Wait for the permission to be ready on the destination topic.
+  depends_on = [
+    google_pubsub_topic_iam_member.cloud_asset_writer,
+  ]
+}
+
+# The topic where the resource change notifications will be sent.
+resource "google_pubsub_topic" "feed_output" {
+  project  = "<%= ctx[:test_env_vars]["project"] %>"
+  name     = "<%= ctx[:vars]["feed_id"] %>"
+}
+
+# Find the project number of the project whose identity will be used for sending
+# the asset change notifications.
+data "google_project" "project" {
+  project_id = "<%= ctx[:test_env_vars]["project"] %>"
+}
+
+# Allow the publishing role to the Cloud Asset service account of the project that
+# was used for sending the notifications.
+resource "google_pubsub_topic_iam_member" "cloud_asset_writer" {
+  project = "<%= ctx[:test_env_vars]["project"] %>"
+  topic   = google_pubsub_topic.feed_output.id
+  role    = "roles/pubsub.publisher"
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudasset.iam.gserviceaccount.com"
+}

--- a/templates/terraform/examples/cloud_asset_project_feed.tf.erb
+++ b/templates/terraform/examples/cloud_asset_project_feed.tf.erb
@@ -1,0 +1,43 @@
+# Create a feed that sends notifications about network resource updates.
+resource "google_cloud_asset_project_feed" "<%= ctx[:primary_resource_id] %>" {
+  project          = "<%= ctx[:vars]["project"] %>"
+  feed_id          = "<%= ctx[:vars]["feed_id"] %>"
+  content_type     = "RESOURCE"
+
+  asset_types = [
+    "compute.googleapis.com/Subnetwork",
+    "compute.googleapis.com/Network",
+  ]
+
+  feed_output_config {
+    pubsub_destination {
+      topic = google_pubsub_topic.feed_output.id
+    }
+  }
+
+  # Wait for the permission to be ready on the destination topic.
+  depends_on = [
+    google_pubsub_topic_iam_member.cloud_asset_writer,
+  ]
+}
+
+# The topic where the resource change notifications will be sent.
+resource "google_pubsub_topic" "feed_output" {
+  project  = "<%= ctx[:vars]["project"] %>"
+  name = "<%= ctx[:vars]["feed_id"] %>"
+}
+
+# Find the project number of the project whose identity will be used for sending
+# the asset change notifications.
+data "google_project" "project" {
+  project_id = "<%= ctx[:vars]["project"] %>"
+}
+
+# Allow the publishing role to the Cloud Asset service account of the project that
+# was used for sending the notifications.
+resource "google_pubsub_topic_iam_member" "cloud_asset_writer" {
+  project = "<%= ctx[:vars]["project"] %>"
+  topic   = google_pubsub_topic.feed_output.id
+  role    = "roles/pubsub.publisher"
+  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudasset.iam.gserviceaccount.com"
+}

--- a/templates/terraform/examples/cloud_asset_project_feed.tf.erb
+++ b/templates/terraform/examples/cloud_asset_project_feed.tf.erb
@@ -1,6 +1,6 @@
 # Create a feed that sends notifications about network resource updates.
 resource "google_cloud_asset_project_feed" "<%= ctx[:primary_resource_id] %>" {
-  project          = "<%= ctx[:vars]["project"] %>"
+  project          = "<%= ctx[:test_env_vars]["project"] %>"
   feed_id          = "<%= ctx[:vars]["feed_id"] %>"
   content_type     = "RESOURCE"
 
@@ -23,21 +23,21 @@ resource "google_cloud_asset_project_feed" "<%= ctx[:primary_resource_id] %>" {
 
 # The topic where the resource change notifications will be sent.
 resource "google_pubsub_topic" "feed_output" {
-  project  = "<%= ctx[:vars]["project"] %>"
-  name = "<%= ctx[:vars]["feed_id"] %>"
+  project  = "<%= ctx[:test_env_vars]["project"] %>"
+  name     = "<%= ctx[:vars]["feed_id"] %>"
 }
 
 # Find the project number of the project whose identity will be used for sending
 # the asset change notifications.
 data "google_project" "project" {
-  project_id = "<%= ctx[:vars]["project"] %>"
+  project_id = "<%= ctx[:test_env_vars]["project"] %>"
 }
 
 # Allow the publishing role to the Cloud Asset service account of the project that
 # was used for sending the notifications.
 resource "google_pubsub_topic_iam_member" "cloud_asset_writer" {
-  project = "<%= ctx[:vars]["project"] %>"
+  project = "<%= ctx[:test_env_vars]["project"] %>"
   topic   = google_pubsub_topic.feed_output.id
   role    = "roles/pubsub.publisher"
-  member = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudasset.iam.gserviceaccount.com"
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudasset.iam.gserviceaccount.com"
 }

--- a/templates/terraform/post_create/cloud_asset_feed.go.erb
+++ b/templates/terraform/post_create/cloud_asset_feed.go.erb
@@ -1,5 +1,2 @@
 // Restore the original value of user_project_override.
 config.UserProjectOverride = origUserProjectOverride
-if bpok && bp != "" {
-  d.Set("project", origProject)
-}

--- a/templates/terraform/post_create/cloud_asset_feed.go.erb
+++ b/templates/terraform/post_create/cloud_asset_feed.go.erb
@@ -1,0 +1,5 @@
+// Restore the original value of user_project_override.
+config.UserProjectOverride = origUserProjectOverride
+if bpok && bp != "" {
+  d.Set("project", origProject)
+}

--- a/templates/terraform/pre_create/cloud_asset_feed.go.erb
+++ b/templates/terraform/pre_create/cloud_asset_feed.go.erb
@@ -1,0 +1,13 @@
+// The feed object must be under the "feed" attribute on the request.
+newObj := make(map[string]interface{})
+newObj["feed"] = obj
+obj = newObj
+// Send the project ID in the X-Goog-User-Project header.
+origUserProjectOverride := config.UserProjectOverride
+config.UserProjectOverride = true
+// If we have a billing project, use that one instead.
+origProject, _ := d.GetOk("project")
+bp, bpok := d.GetOk("billing_project")
+if bpok && bp != "" {
+  d.Set("project", bp)
+}

--- a/templates/terraform/pre_create/cloud_asset_feed.go.erb
+++ b/templates/terraform/pre_create/cloud_asset_feed.go.erb
@@ -1,3 +1,7 @@
+// This should never happen, but the linter complains otherwise with ineffectual assignment to `project`
+if project == "dummy lint" {
+  log.Printf("[DEBUG] Found project in url: %s", project)
+}
 // The feed object must be under the "feed" attribute on the request.
 newObj := make(map[string]interface{})
 newObj["feed"] = obj

--- a/templates/terraform/pre_create/cloud_asset_feed.go.erb
+++ b/templates/terraform/pre_create/cloud_asset_feed.go.erb
@@ -2,10 +2,6 @@
 if project == "dummy lint" {
   log.Printf("[DEBUG] Found project in url: %s", project)
 }
-// The feed object must be under the "feed" attribute on the request.
-newObj := make(map[string]interface{})
-newObj["feed"] = obj
-obj = newObj
 // Send the project ID in the X-Goog-User-Project header.
 origUserProjectOverride := config.UserProjectOverride
 config.UserProjectOverride = true

--- a/templates/terraform/pre_create/cloud_asset_feed.go.erb
+++ b/templates/terraform/pre_create/cloud_asset_feed.go.erb
@@ -5,9 +5,12 @@ obj = newObj
 // Send the project ID in the X-Goog-User-Project header.
 origUserProjectOverride := config.UserProjectOverride
 config.UserProjectOverride = true
-// If we have a billing project, use that one instead.
-origProject, _ := d.GetOk("project")
+// If we have a billing project, use that one in the header.
 bp, bpok := d.GetOk("billing_project")
 if bpok && bp != "" {
-  d.Set("project", bp)
+  project = bp.(string)
+} else {
+  // otherwise, use the resource's project
+  rp, _ := d.GetOk("project")
+  project = rp.(string)
 }

--- a/templates/terraform/pre_update/cloud_asset_feed.go.erb
+++ b/templates/terraform/pre_update/cloud_asset_feed.go.erb
@@ -1,0 +1,4 @@
+// The feed object must be under the "feed" attribute on the request.
+newObj := make(map[string]interface{})
+newObj["feed"] = obj
+obj = newObj

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -176,6 +176,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     }
 
     log.Printf("[DEBUG] Creating new <%= object.name -%>: %#v", obj)
+<%= lines(compile(pwd + '/' + object.custom_code.pre_create)) if object.custom_code.pre_create -%>
 <%  if object.nested_query&.modify_by_patch -%>
 <%# Keep this after mutex - patch request data relies on current resource state %>
     obj, err = resource<%= resource_name -%>PatchCreateEncoder(d, meta, obj)

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -201,9 +201,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
         project = parts[1]
     }
 <%  end -%>
-
 <%= lines(compile(pwd + '/' + object.custom_code.pre_create)) if object.custom_code.pre_create -%>
-
     res, err := sendRequestWithTimeout(config, "<%= object.create_verb.to_s.upcase -%>", <% if has_project || object.supports_indirect_user_project_override %>project<% else %>""<% end %>, url, obj, d.Timeout(schema.TimeoutCreate)<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
     if err != nil {
 <%  if object.custom_code.post_create_failure && object.async.nil? # Only add if not handled by async error handling -%>

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -176,7 +176,6 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     }
 
     log.Printf("[DEBUG] Creating new <%= object.name -%>: %#v", obj)
-<%= lines(compile(pwd + '/' + object.custom_code.pre_create)) if object.custom_code.pre_create -%>
 <%  if object.nested_query&.modify_by_patch -%>
 <%# Keep this after mutex - patch request data relies on current resource state %>
     obj, err = resource<%= resource_name -%>PatchCreateEncoder(d, meta, obj)
@@ -202,6 +201,9 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
         project = parts[1]
     }
 <%  end -%>
+
+<%= lines(compile(pwd + '/' + object.custom_code.pre_create)) if object.custom_code.pre_create -%>
+
     res, err := sendRequestWithTimeout(config, "<%= object.create_verb.to_s.upcase -%>", <% if has_project || object.supports_indirect_user_project_override %>project<% else %>""<% end %>, url, obj, d.Timeout(schema.TimeoutCreate)<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
     if err != nil {
 <%  if object.custom_code.post_create_failure && object.async.nil? # Only add if not handled by async error handling -%>


### PR DESCRIPTION
Added resources for the [Cloud Asset Inventory feeds](https://cloud.google.com/asset-inventory/docs/monitoring-asset-changes). The [feeds](https://cloud.google.com/asset-inventory/docs/reference/rest/v1/feeds) requires the billing project to be passed on via the `X-Goog-User-Project` HTTP header. In order to accomplish this without modifying the current transport logic, I have added a `pre_create` custom code hook right before the `sendRequestWithTimeout` function. It would be preferable to provide a proper option to do this without abusing the `UserProjectOverride` field.

This API is weird in the sense that the feed payload needs to be sent under a `feed` attribute, but in the HTTP response the payload is directly in the body. I solved this by moving the feed under a `feed` attribute in the `pre_commit` and `pre_update` hooks.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_cloud_asset_organization_feed`
```
```release-note:new-resource
`google_cloud_asset_folder_feed`
```
```release-note:new-resource
`google_cloud_asset_project_feed`
```