### PR TITLE
add diff suppress for big query table schema

### DIFF
--- a/third_party/terraform/resources/resource_bigquery_table.go
+++ b/third_party/terraform/resources/resource_bigquery_table.go
@@ -15,6 +15,7 @@ import (
 )
 
 // JSONBytesEqual compares the JSON in two byte slices.
+// Reference: https://stackoverflow.com/questions/32408890/how-to-compare-two-json-requests
 func JSONBytesEqual(a, b []byte) (bool, error) {
 	var j, j2 interface{}
 	if err := json.Unmarshal(a, &j); err != nil {
@@ -34,7 +35,7 @@ func JSONBytesEqual(a, b []byte) (bool, error) {
 	return reflect.DeepEqual(j2List, jList), nil
 }
 
-// Compare only the resource name of two self links/paths.
+// Compare the JSON strings are equal
 func bigQueryTableSchemaDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 	oldBytes := []byte(old)
 	newBytes := []byte(new)

--- a/third_party/terraform/resources/resource_bigquery_table.go
+++ b/third_party/terraform/resources/resource_bigquery_table.go
@@ -5,12 +5,47 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"reflect"
+	"sort"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"google.golang.org/api/bigquery/v2"
 )
+
+// JSONBytesEqual compares the JSON in two byte slices.
+func JSONBytesEqual(a, b []byte) (bool, error) {
+	var j, j2 interface{}
+	if err := json.Unmarshal(a, &j); err != nil {
+		return false, err
+	}
+	jList := j.([]interface{})
+	sort.Slice(jList, func(i, k int) bool {
+		return jList[i].(map[string]interface{})["name"].(string) < jList[k].(map[string]interface{})["name"].(string)
+	})
+	if err := json.Unmarshal(b, &j2); err != nil {
+		return false, err
+	}
+	j2List := j2.([]interface{})
+	sort.Slice(j2List, func(i, k int) bool {
+		return j2List[i].(map[string]interface{})["name"].(string) < j2List[k].(map[string]interface{})["name"].(string)
+	})
+	return reflect.DeepEqual(j2List, jList), nil
+}
+
+// Compare only the resource name of two self links/paths.
+func bigQueryTableSchemaDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
+	oldBytes := []byte(old)
+	newBytes := []byte(new)
+
+	eq, err := JSONBytesEqual(oldBytes, newBytes)
+	if err != nil {
+		log.Printf("[DEBUG] Error comparing JSON bytes: %v, %v", old, new)
+	}
+
+	return eq
+}
 
 func resourceBigQueryTable() *schema.Resource {
 	return &schema.Resource{
@@ -299,7 +334,8 @@ func resourceBigQueryTable() *schema.Resource {
 					json, _ := structure.NormalizeJsonString(v)
 					return json
 				},
-				Description: `A JSON schema for the table.`,
+				DiffSuppressFunc: bigQueryTableSchemaDiffSuppress,
+				Description:      `A JSON schema for the table.`,
 			},
 
 			// View: [Optional] If specified, configures this table as a view.


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/4143

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquery: fixed bug where a permadiff would show up when adding a column to the middle of a `bigquery_table.schema`
```
