### PR TITLE
Add the Go 1.13 runtime

### DIFF
--- a/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
+++ b/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
@@ -107,7 +107,7 @@ The following arguments are supported:
 * `name` - (Required) A user-defined name of the function. Function names must be unique globally.
 
 * `runtime` - (Required) The runtime in which the function is going to run.
-Eg. `"nodejs8"`, `"nodejs10"`, `"python37"`, `"go111"`.
+Eg. `"nodejs8"`, `"nodejs10"`, `"python37"`, `"go111"`, `"go113"`.
 
 - - -
 


### PR DESCRIPTION
Upstreams: https://github.com/terraform-providers/terraform-provider-google/pull/6804

We received an email from Gcloud saying they are deprecating the Cloud Functions + Go 1.11 runtime soon:

> We are writing to inform you that the Go 1.11 runtime on Cloud Functions will be deprecated on August 5, 2020. You have been identified as having used it in the past six months and may be affected by this change.
>
> To avoid any potential disruptions or security risks, we recommend you update your functions to use the Go 1.13 GA runtime.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
