### PR TITLE
use {product}.googleapis.com endpoints

### DIFF
--- a/products/bigquery/api.yaml
+++ b/products/bigquery/api.yaml
@@ -17,7 +17,7 @@ display_name: BigQuery
 versions:
   - !ruby/object:Api::Product::Version
     name: ga
-    base_url: https://www.googleapis.com/bigquery/v2/
+    base_url: https://bigquery.googleapis.com/v2/
 scopes:
   - https://www.googleapis.com/auth/bigquery
 apis_required:

--- a/products/bigquery/api.yaml
+++ b/products/bigquery/api.yaml
@@ -17,7 +17,7 @@ display_name: BigQuery
 versions:
   - !ruby/object:Api::Product::Version
     name: ga
-    base_url: https://bigquery.googleapis.com/v2/
+    base_url: https://bigquery.googleapis.com/bigquery/v2/
 scopes:
   - https://www.googleapis.com/auth/bigquery
 apis_required:

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -19,10 +19,10 @@ display_name: Compute Engine
 versions:
   - !ruby/object:Api::Product::Version
     name: ga
-    base_url: https://www.googleapis.com/compute/v1/
+    base_url: https://compute.googleapis.com/v1/
   - !ruby/object:Api::Product::Version
     name: beta
-    base_url: https://www.googleapis.com/compute/beta/
+    base_url: https://compute.googleapis.com/beta/
 scopes:
   - https://www.googleapis.com/auth/compute
 apis_required:

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -19,10 +19,10 @@ display_name: Compute Engine
 versions:
   - !ruby/object:Api::Product::Version
     name: ga
-    base_url: https://compute.googleapis.com/v1/
+    base_url: https://compute.googleapis.com/compute/v1/
   - !ruby/object:Api::Product::Version
     name: beta
-    base_url: https://compute.googleapis.com/beta/
+    base_url: https://compute.googleapis.com/compute/beta/
 scopes:
   - https://www.googleapis.com/auth/compute
 apis_required:

--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -17,10 +17,10 @@ display_name: Cloud DNS
 versions:
   - !ruby/object:Api::Product::Version
     name: ga
-    base_url: https://www.googleapis.com/dns/v1/
+    base_url: https://dns.googleapis.com/v1/
   - !ruby/object:Api::Product::Version
     name: beta
-    base_url: https://www.googleapis.com/dns/v1beta2/
+    base_url: https://dns.googleapis.com/v1beta2/
 scopes:
   - https://www.googleapis.com/auth/ndev.clouddns.readwrite
 apis_required:

--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -17,10 +17,10 @@ display_name: Cloud DNS
 versions:
   - !ruby/object:Api::Product::Version
     name: ga
-    base_url: https://dns.googleapis.com/v1/
+    base_url: https://dns.googleapis.com/dns/v1/
   - !ruby/object:Api::Product::Version
     name: beta
-    base_url: https://dns.googleapis.com/v1beta2/
+    base_url: https://dns.googleapis.com/dns/v1beta2/
 scopes:
   - https://www.googleapis.com/auth/ndev.clouddns.readwrite
 apis_required:

--- a/products/storage/api.yaml
+++ b/products/storage/api.yaml
@@ -17,7 +17,7 @@ display_name: Cloud Storage
 versions:
   - !ruby/object:Api::Product::Version
     name: ga
-    base_url: https://storage.googleapis.com/v1/
+    base_url: https://storage.googleapis.com/storage/v1/
 scopes:
   - https://www.googleapis.com/auth/devstorage.full_control
 apis_required:

--- a/products/storage/api.yaml
+++ b/products/storage/api.yaml
@@ -17,7 +17,7 @@ display_name: Cloud Storage
 versions:
   - !ruby/object:Api::Product::Version
     name: ga
-    base_url: https://www.googleapis.com/storage/v1/
+    base_url: https://storage.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/devstorage.full_control
 apis_required:

--- a/third_party/terraform/data_sources/data_source_google_compute_zones.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_zones.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -51,30 +52,28 @@ func dataSourceGoogleComputeZonesRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	// we want to share exactly the same base path as the compute client or the
-	// region string may mismatch, giving us no results
-	// note that the client's BasePath includes a `projects/` suffix, so that'll
-	// need to be added to the URL below if the source changes
-	computeClientBasePath := config.clientCompute.BasePath
-
-	regionUrl, err := replaceVars(d, config, fmt.Sprintf("%s%s/regions/%s", computeClientBasePath, project, region))
-	if err != nil {
-		return err
-	}
-	filter := fmt.Sprintf("(region eq %s)", regionUrl)
-
+	filter := ""
 	if s, ok := d.GetOk("status"); ok {
 		filter += fmt.Sprintf(" (status eq %s)", s)
 	}
 
-	call := config.clientCompute.Zones.List(project).Filter(filter)
+	zones := []string{}
+	err = config.clientCompute.Zones.List(project).Filter(filter).Pages(config.context, func(zl *compute.ZoneList) error {
+		for _, zone := range zl.Items {
+			// We have no way to guarantee a specific base path for the region, but the built-in API-level filtering
+			// only lets us query on exact matches, so we do our own filtering here.
+			if strings.HasSuffix(zone.Region, "/"+region) {
+				zones = append(zones, zone.Name)
+			}
+		}
+		return nil
+	})
 
-	resp, err := call.Do()
 	if err != nil {
 		return err
 	}
 
-	zones := flattenZones(resp.Items)
+	sort.Strings(zones)
 	log.Printf("[DEBUG] Received Google Compute Zones: %q", zones)
 
 	d.Set("names", zones)
@@ -83,13 +82,4 @@ func dataSourceGoogleComputeZonesRead(d *schema.ResourceData, meta interface{}) 
 	d.SetId(time.Now().UTC().String())
 
 	return nil
-}
-
-func flattenZones(zones []*compute.Zone) []string {
-	result := make([]string, len(zones))
-	for i, zone := range zones {
-		result[i] = zone.Name
-	}
-	sort.Strings(result)
-	return result
 }

--- a/third_party/terraform/resources/resource_compute_network_peering.go
+++ b/third_party/terraform/resources/resource_compute_network_peering.go
@@ -257,17 +257,22 @@ func resourceComputeNetworkPeeringImport(d *schema.ResourceData, meta interface{
 	if len(splits) != 3 {
 		return nil, fmt.Errorf("Error parsing network peering import format, expected: {project}/{network}/{name}")
 	}
+	project := splits[0]
+	network := splits[1]
+	name := splits[2]
 
-	// Build the template for the network self_link
-	urlTemplate, err := replaceVars(d, config, "{{ComputeBasePath}}projects/%s/global/networks/%s")
+	// Since the format of the network URL in the peering might be different depending on the ComputeBasePath,
+	// just read the network self link from the API.
+	net, err := config.clientCompute.Networks.Get(project, network).Do()
 	if err != nil {
-		return nil, err
+		return nil, handleNotFoundError(err, d, fmt.Sprintf("Network %q", splits[1]))
 	}
-	d.Set("network", ConvertSelfLinkToV1(fmt.Sprintf(urlTemplate, splits[0], splits[1])))
-	d.Set("name", splits[2])
+
+	d.Set("network", ConvertSelfLinkToV1(net.SelfLink))
+	d.Set("name", name)
 
 	// Replace import id for the resource id
-	id := fmt.Sprintf("%s/%s", splits[1], splits[2])
+	id := fmt.Sprintf("%s/%s", network, name)
 	d.SetId(id)
 
 	return []*schema.ResourceData{d}, nil

--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -429,14 +429,16 @@ func resourceProjectImportState(d *schema.ResourceData, meta interface{}) ([]*sc
 
 // Delete a compute network along with the firewall rules inside it.
 func forceDeleteComputeNetwork(d *schema.ResourceData, config *Config, projectId, networkName string) error {
-	networkLink, err := replaceVars(d, config, fmt.Sprintf("{{ComputeBasePath}}projects/%s/global/networks/%s", projectId, networkName))
+	// Read the network from the API so we can get the correct self link format. We can't construct it from the
+	// base path because it might not line up exactly (compute.googleapis.com vs www.googleapis.com)
+	net, err := config.clientCompute.Networks.Get(projectId, networkName).Do()
 	if err != nil {
 		return err
 	}
 
 	token := ""
 	for paginate := true; paginate; {
-		filter := fmt.Sprintf("network eq %s", networkLink)
+		filter := fmt.Sprintf("network eq %s", net.SelfLink)
 		resp, err := config.clientCompute.Firewalls.List(projectId).Filter(filter).Do()
 		if err != nil {
 			return errwrap.Wrapf("Error listing firewall rules in proj: {{err}}", err)

--- a/third_party/terraform/tests/data_source_google_compute_zones_test.go
+++ b/third_party/terraform/tests/data_source_google_compute_zones_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -18,9 +19,27 @@ func TestAccComputeZones_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckGoogleComputeZonesConfig,
+				Config: testAccComputeZones_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGoogleComputeZonesMeta("data.google_compute_zones.available"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeZones_filter(t *testing.T) {
+	t.Parallel()
+	region := "us-central1"
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeZones_filter(region),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleComputeZonesRegion("data.google_compute_zones.available", region),
 				),
 			},
 		},
@@ -67,6 +86,51 @@ func testAccCheckGoogleComputeZonesMeta(n string) resource.TestCheckFunc {
 	}
 }
 
-var testAccCheckGoogleComputeZonesConfig = `
+func testAccCheckGoogleComputeZonesRegion(n, region string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find zones data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("zones data source ID not set.")
+		}
+
+		count, ok := rs.Primary.Attributes["names.#"]
+		if !ok {
+			return errors.New("can't find 'names' attribute")
+		}
+
+		noOfNames, err := strconv.Atoi(count)
+		if err != nil {
+			return errors.New("failed to read number of zones")
+		}
+
+		for i := 0; i < noOfNames; i++ {
+			idx := "names." + strconv.Itoa(i)
+			v, ok := rs.Primary.Attributes[idx]
+			if !ok {
+				return fmt.Errorf("zone list is corrupt (%q not found), this is definitely a bug", idx)
+			}
+			if !strings.Contains(v, region) {
+				return fmt.Errorf("zone name %q does not contain region %q", v, region)
+			}
+		}
+
+		return nil
+	}
+}
+
+var testAccComputeZones_basic = `
 data "google_compute_zones" "available" {}
 `
+
+func testAccComputeZones_filter(region string) string {
+	return fmt.Sprintf(`
+data "google_compute_zones" "available" {
+  region = "%s"
+  status = "UP"
+}
+`, region)
+}


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6783. Holding off on submitting until I find out whether we need to update deployment manager as well, since that's the only one that'll still be using the old syntax for endpoints after this.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
all: updated base urls for compute, dns, storage, and bigquery APIs to their recommended endpoints
```
