### PR TITLE
The server doesn't send back a block if this value is false - assume false if nil.

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -3326,7 +3326,7 @@ func flattenMasterAuthorizedNetworksConfig(c *containerBeta.MasterAuthorizedNetw
 <% unless version == 'ga' -%>
 func flattenPodSecurityPolicyConfig(c *containerBeta.PodSecurityPolicyConfig) []map[string]interface{} {
 	if c == nil {
-		[]map[string]interface{}{
+		return []map[string]interface{}{
 			{
 				"enabled": false,
 			},

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -3327,10 +3327,10 @@ func flattenMasterAuthorizedNetworksConfig(c *containerBeta.MasterAuthorizedNetw
 func flattenPodSecurityPolicyConfig(c *containerBeta.PodSecurityPolicyConfig) []map[string]interface{} {
 	if c == nil {
 		[]map[string]interface{}{
-		{
-			"enabled": false,
-		},
-	}
+			{
+				"enabled": false,
+			},
+		}
 	}
 	return []map[string]interface{}{
 		{

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -3326,7 +3326,11 @@ func flattenMasterAuthorizedNetworksConfig(c *containerBeta.MasterAuthorizedNetw
 <% unless version == 'ga' -%>
 func flattenPodSecurityPolicyConfig(c *containerBeta.PodSecurityPolicyConfig) []map[string]interface{} {
 	if c == nil {
-		return nil
+		[]map[string]interface{}{
+		{
+			"enabled": false,
+		},
+	}
 	}
 	return []map[string]interface{}{
 		{


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6730.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: Fixed google_container_cluster.pod_security_policy_config not being set when disabled. (beta only)

```