### PR TITLE
default_snat_status attribute added

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1109,8 +1109,34 @@ func resourceContainerCluster() *schema.Resource {
 					},
 				},
 			},
-
+			
+			"default_snat_status": {
+				Type: schema.TypeList,
+				MaxItems: 1,
+				Optional: true,
+				Description: `Whether the cluster disables default in-node sNAT rules. In-node sNAT rules will be disabled when defaultSnatStatus is disabled.`,
+				Elem: &schema.Resource {
+					Schema: map[string]*schema.Schema {
+						"disabled": {
+							Type: schema.TypeBool,
+							Optional: true,
+							Description: `When disabled is set to false, default IP masquerade rules will be applied to the nodes to prevent sNAT on cluster internal traffic.`,
+						},	
+					},
+				},
+			},
 <% end -%>
+			"enable_intranode_visibility": {
+			   Type: schema.TypeBool,
+			   Optional: true,
+			   Description: `Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network.`,
+<% if version == 'ga' -%>
+			   Removed:  "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/guides/provider_versions.html for more details.",
+			   Computed: true,
+<% else -%>
+			   Default: false,
+<% end -%>
+			}, 
 
 			"resource_usage_export_config": {
 				Type:        schema.TypeList,
@@ -1150,17 +1176,6 @@ func resourceContainerCluster() *schema.Resource {
 				},
 			},
 
-			"enable_intranode_visibility": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Description: `Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network.`,
-<% if version == 'ga' -%>
-				Removed:  "This field is in beta. Use it in the the google-beta provider instead. See https://terraform.io/docs/providers/google/guides/provider_versions.html for more details.",
-				Computed: true,
-<% else -%>
-				Default: false,
-<% end -%>
-			},
 		},
 	}
 }
@@ -1283,8 +1298,9 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		EnableTpu:               d.Get("enable_tpu").(bool),
 		NetworkConfig: &containerBeta.NetworkConfig{
 			EnableIntraNodeVisibility: d.Get("enable_intranode_visibility").(bool),
-		},
-<% end -%>
+			DefaultSnatStatus:         expandDefaultSnatStatus(d.Get("default_snat_status")),
+	    },	
+<% end -%>	
 		MasterAuth:     expandMasterAuth(d.Get("master_auth")),
 		ResourceLabels: expandStringMap(d, "resource_labels"),
 	}
@@ -1546,8 +1562,12 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	if err := d.Set("release_channel", flattenReleaseChannel(cluster.ReleaseChannel)); err != nil {
 		return err
 	}
+
+	if err := d.Set("default_snat_status", flattenDefaultSnatStatus(cluster.NetworkConfig.DefaultSnatStatus)); err != nil {
+		return err
+	}
 	d.Set("enable_intranode_visibility", cluster.NetworkConfig.EnableIntraNodeVisibility)
-<% end -%>
+<% end -%>	
 	if err := d.Set("authenticator_groups_config", flattenAuthenticatorGroupsConfig(cluster.AuthenticatorGroupsConfig)); err != nil {
 		return err
 	}
@@ -1753,6 +1773,7 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		d.SetPartial("enable_shielded_nodes")
 	}
+
 <% unless version == 'ga' -%>
 	if d.HasChange("enable_intranode_visibility") {
 		enabled := d.Get("enable_intranode_visibility").(bool)
@@ -1787,8 +1808,37 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 
 		d.SetPartial("enable_intranode_visibility")
 	}
-<% end -%>
-<% unless version == 'ga' -%>
+
+	if d.HasChange("default_snat_status") {
+		req := &containerBeta.UpdateClusterRequest{
+			Update: &containerBeta.ClusterUpdate{
+				DesiredDefaultSnatStatus: expandDefaultSnatStatus(d.Get("default_snat_status")),
+			},
+		}
+		updateF := func() error {
+			log.Println("[DEBUG] updating default_snat_status")
+			name := containerClusterFullName(project, location, clusterName)
+			op, err := config.clientContainerBeta.Projects.Locations.Clusters.Update(name, req).Do()
+			if err != nil {
+				return err
+			}
+
+			// Wait until it's updated
+			err = containerOperationWait(config, op, project, location, "updating GKE Default SNAT status", d.Timeout(schema.TimeoutUpdate))
+			log.Println("[DEBUG] done updating default_snat_status")
+			return err
+		}
+
+		// Call update serially.
+		if err := lockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s Default SNAT status has been updated", d.Id())
+
+		d.SetPartial("default_snat_status")
+	}
+
 	if d.HasChange("release_channel") {
 		req := &containerBeta.UpdateClusterRequest{
 			Update: &containerBeta.ClusterUpdate{
@@ -2911,7 +2961,21 @@ func expandClusterTelemetry(configured interface{}) *containerBeta.ClusterTeleme
 	}
 }
 
+func expandDefaultSnatStatus(configured interface{}) *containerBeta.DefaultSnatStatus {
+	l := configured.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+	config := l[0].(map[string]interface{})
+	return &containerBeta.DefaultSnatStatus{
+		Disabled:        config["disabled"].(bool),
+		ForceSendFields: []string{"Disabled"},
+	}
+
+}
+
 <% end -%>
+
 func expandWorkloadIdentityConfig(configured interface{}) *containerBeta.WorkloadIdentityConfig {
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
@@ -3165,6 +3229,16 @@ func flattenClusterTelemetry(c *containerBeta.ClusterTelemetry) []map[string]int
 	if c != nil {
 		result = append(result, map[string]interface{}{
 			"type": c.Type,
+		})
+	}
+	return result
+}
+
+func flattenDefaultSnatStatus(c *containerBeta.DefaultSnatStatus) []map[string]interface{} {
+	result := []map[string]interface{}{}
+	if c != nil {
+		result = append(result, map[string]interface{}{
+			"disabled": c.Disabled,
 		})
 	}
 	return result

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -3520,6 +3520,9 @@ resource "google_container_cluster" "with_private_cluster" {
     enable_private_endpoint = true
     enable_private_nodes    = true
   }
+  default_snat_status{
+    disabled = false	  
+  }
   master_authorized_networks_config {
   }
   ip_allocation_policy {
@@ -3562,6 +3565,9 @@ resource "google_container_cluster" "with_private_cluster" {
 
 <% unless version == 'ga' -%>
   networking_mode = "VPC_NATIVE"
+  default_snat_status {
+    disabled = true
+  }
 <% end -%>
   network    = google_compute_network.container_network.name
   subnetwork = google_compute_subnetwork.container_subnetwork.name
@@ -3573,7 +3579,7 @@ resource "google_container_cluster" "with_private_cluster" {
 <% unless version == 'ga' -%>
     master_global_access_config {
       enabled = true
-    }
+	}
 <% end -%>
   }
   master_authorized_networks_config {

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -316,8 +316,13 @@ subnetwork in which the cluster's instances are launched.
 * `enable_intranode_visibility` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
     Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network.
 
-The `cluster_telemetry` blocks supports
+* `default_snat_status` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  [GKE SNAT](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-masquerade-agent#how_ipmasq_works) DefaultSnatStatus contains the desired state of whether default sNAT should be disabled on the cluster, [API doc](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#networkconfig).
 
+The `default_snat_status` block supports
+*  `disabled` - Whether the cluster disables default in-node sNAT rules. In-node sNAT rules will be disabled when defaultSnatStatus is disabled.When disabled is set to false, default IP masquerade rules will be applied to the nodes to prevent sNAT on cluster internal traffic
+
+The `cluster_telemetry` block supports
 * `type` - Telemetry integration for the cluster. Supported values (`ENABLE, DISABLE, SYSTEM_ONLY`);
    `SYSTEM_ONLY` (Only system components are monitored and logged) is only available in GKE versions 1.15 and later.
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Cluster: added default_snat_status for `google_container_cluster` resource

```
reference: https://github.com/terraform-providers/terraform-provider-google/issues/6465
