### PR TITLE
Upstream support for Kubelet and Linux Node configurations in GKE

### DIFF
--- a/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -773,6 +773,73 @@ func nodePoolUpdate(d *schema.ResourceData, meta interface{}, nodePoolInfo *Node
 		}
 
 <% end -%>
+
+<% unless version == 'ga' -%>
+		if d.HasChange(prefix + "node_config.0.kubelet_config") {
+			req := &containerBeta.UpdateNodePoolRequest{
+				NodePoolId: name,
+				KubeletConfig: expandKubeletConfig(
+					d.Get(prefix + "node_config.0.kubelet_config")),
+			}
+			if req.KubeletConfig == nil {
+				req.ForceSendFields = []string{"KubeletConfig"}
+			}
+			updateF := func() error {
+				op, err := config.clientContainerBeta.Projects.Locations.Clusters.NodePools.
+					Update(nodePoolInfo.fullyQualifiedName(name), req).Do()
+				if err != nil {
+					return err
+				}
+
+				// Wait until it's updated
+				return containerOperationWait(config, op,
+					nodePoolInfo.project,
+					nodePoolInfo.location,
+					"updating GKE node pool kubelet_config",
+					timeout)
+			}
+
+			// Call update serially.
+			if err := lockedCall(lockKey, updateF); err != nil {
+				return err
+			}
+
+			log.Printf("[INFO] Updated kubelet_config for node pool %s", name)
+		}
+		if d.HasChange(prefix + "node_config.0.linux_node_config") {
+			req := &containerBeta.UpdateNodePoolRequest{
+				NodePoolId: name,
+				LinuxNodeConfig: expandLinuxNodeConfig(
+					d.Get(prefix + "node_config.0.linux_node_config")),
+			}
+			if req.LinuxNodeConfig == nil {
+				req.ForceSendFields = []string{"LinuxNodeConfig"}
+			}
+			updateF := func() error {
+				op, err := config.clientContainerBeta.Projects.Locations.Clusters.NodePools.
+					Update(nodePoolInfo.fullyQualifiedName(name), req).Do()
+				if err != nil {
+					return err
+				}
+
+				// Wait until it's updated
+				return containerOperationWait(config, op,
+					nodePoolInfo.project,
+					nodePoolInfo.location,
+					"updating GKE node pool linux_node_config",
+					timeout)
+			}
+
+			// Call update serially.
+			if err := lockedCall(lockKey, updateF); err != nil {
+				return err
+			}
+
+			log.Printf("[INFO] Updated linux_node_config for node pool %s", name)
+		}
+
+<% end -%>
+
 		if prefix == "" {
 			d.SetPartial("node_config")
 		}

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -253,7 +253,15 @@ func TestAccContainerNodePool_withKubeletConfig(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "static"),
+				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "static", "300ms", false),
+			},
+			{
+				ResourceName:      "google_container_node_pool.with_kubelet_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "default", "200ms", true),
 			},
 			{
 				ResourceName:      "google_container_node_pool.with_kubelet_config",
@@ -1348,7 +1356,7 @@ resource "google_container_node_pool" "with_sandbox_config" {
 <% end -%>
 
 <% unless version.nil? || version == 'ga' -%>
-func testAccContainerNodePool_withKubeletConfig(cluster, np, policy string) string {
+func testAccContainerNodePool_withKubeletConfig(cluster, np, policy, period string, quota bool) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {
   location = "us-central1-a"
@@ -1367,9 +1375,9 @@ resource "google_container_node_pool" "with_kubelet_config" {
   node_config {
     image_type = "COS_CONTAINERD"
     kubelet_config {
-      cpu_manager_policy   = "%s"
-      cpu_cfs_quota        = true
-      cpu_cfs_quota_period = "100us"
+      cpu_manager_policy   = %q
+      cpu_cfs_quota        = %v
+      cpu_cfs_quota_period = %q
     }
     oauth_scopes = [
       "https://www.googleapis.com/auth/logging.write",
@@ -1377,7 +1385,7 @@ resource "google_container_node_pool" "with_kubelet_config" {
     ]
   }
 }
-`, cluster, np, policy)
+`, cluster, np, policy, quota, period)
 }
 
 func testAccContainerNodePool_withLinuxNodeConfig(cluster, np string, maxBacklog, soMaxConn int, tcpMem string, twReuse int) string {

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -238,7 +238,85 @@ func TestAccContainerNodePool_withSandboxConfig(t *testing.T) {
 		},
 	})
 }
+<% end -%>
 
+<% unless version.nil? || version == 'ga' -%>
+func TestAccContainerNodePool_withKubeletConfig(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	np := fmt.Sprintf("tf-test-np-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "static"),
+			},
+			{
+				ResourceName:      "google_container_node_pool.with_kubelet_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccContainerNodePool_withInvalidKubeletCpuManagerPolicy(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	np := fmt.Sprintf("tf-test-np-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccContainerNodePool_withKubeletConfig(cluster, np, "dontexist"),
+				ExpectError: regexp.MustCompile(`.*to be one of \[static default\].*`),
+			},
+		},
+	})
+}
+
+func TestAccContainerNodePool_withLinuxNodeConfig(t *testing.T) {
+	t.Parallel()
+
+	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	np := fmt.Sprintf("tf-test-np-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerNodePool_withLinuxNodeConfig(cluster, np, 10000, 12800, "1000 20000 100000", 1),
+			},
+			{
+				ResourceName:      "google_container_node_pool.with_linux_node_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Perform an update.
+			{
+				Config: testAccContainerNodePool_withLinuxNodeConfig(cluster, np, 10000, 12800, "1000 20000 200000", 1),
+			},
+			{
+				ResourceName:      "google_container_node_pool.with_linux_node_config",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+<% end -%>
+
+<% unless version.nil? || version == 'ga' -%>
 func TestAccContainerNodePool_withBootDiskKmsKey(t *testing.T) {
 	t.Parallel()
 
@@ -1267,7 +1345,83 @@ resource "google_container_node_pool" "with_sandbox_config" {
 }
 `, cluster, np)
 }
+<% end -%>
 
+<% unless version.nil? || version == 'ga' -%>
+func testAccContainerNodePool_withKubeletConfig(cluster, np, policy string) string {
+	return fmt.Sprintf(`
+data "google_container_engine_versions" "central1a" {
+  location = "us-central1-a"
+}
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+}
+resource "google_container_node_pool" "with_kubelet_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 1
+  node_config {
+    image_type = "COS_CONTAINERD"
+    kubelet_config {
+      cpu_manager_policy   = "%s"
+      cpu_cfs_quota        = true
+      cpu_cfs_quota_period = "100us"
+    }
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+}
+`, cluster, np, policy)
+}
+
+func testAccContainerNodePool_withLinuxNodeConfig(cluster, np string, maxBacklog, soMaxConn int, tcpMem string, twReuse int) string {
+	return fmt.Sprintf(`
+data "google_container_engine_versions" "central1a" {
+  location = "us-central1-a"
+}
+resource "google_container_cluster" "cluster" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  min_master_version = data.google_container_engine_versions.central1a.latest_master_version
+}
+resource "google_container_node_pool" "with_linux_node_config" {
+  name               = "%s"
+  location           = "us-central1-a"
+  cluster            = google_container_cluster.cluster.name
+  initial_node_count = 1
+  node_config {
+    image_type = "COS_CONTAINERD"
+    linux_node_config {
+      sysctls = {
+        "net.core.netdev_max_backlog" = "%d"
+        "net.core.rmem_max"           = 10000
+        "net.core.wmem_default"       = 10000
+        "net.core.wmem_max"           = 20000
+        "net.core.optmem_max"         = 10000
+        "net.core.somaxconn"          = %d
+        "net.ipv4.tcp_rmem"           = "%s"
+        "net.ipv4.tcp_wmem"           = "%s"
+        "net.ipv4.tcp_tw_reuse"       = %d
+      }
+    }
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+}
+`, cluster, np, maxBacklog, soMaxConn, tcpMem, tcpMem, twReuse)
+}
+<% end -%>
+
+<% unless version.nil? || version == 'ga' -%>
 func testAccContainerNodePool_withBootDiskKmsKey(project, cluster, np string) string {
 	return fmt.Sprintf(`
 data "google_container_engine_versions" "central1a" {

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -284,7 +284,7 @@ func TestAccContainerNodePool_withInvalidKubeletCpuManagerPolicy(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccContainerNodePool_withKubeletConfig(cluster, np, "dontexist"),
+				Config:      testAccContainerNodePool_withKubeletConfig(cluster, np, "dontexist", "100us", true),
 				ExpectError: regexp.MustCompile(`.*to be one of \[static default\].*`),
 			},
 		},

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -253,7 +253,7 @@ func TestAccContainerNodePool_withKubeletConfig(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "static", "300ms", false),
+				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "static", "100us", false),
 			},
 			{
 				ResourceName:      "google_container_node_pool.with_kubelet_config",
@@ -261,7 +261,7 @@ func TestAccContainerNodePool_withKubeletConfig(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "default", "200ms", true),
+				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "default", "200us", true),
 			},
 			{
 				ResourceName:      "google_container_node_pool.with_kubelet_config",

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -1361,12 +1361,14 @@ func testAccContainerNodePool_withKubeletConfig(cluster, np, policy, period stri
 data "google_container_engine_versions" "central1a" {
   location = "us-central1-a"
 }
+
 resource "google_container_cluster" "cluster" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1
   min_master_version = data.google_container_engine_versions.central1a.latest_master_version
 }
+
 resource "google_container_node_pool" "with_kubelet_config" {
   name               = "%s"
   location           = "us-central1-a"
@@ -1393,12 +1395,14 @@ func testAccContainerNodePool_withLinuxNodeConfig(cluster, np string, maxBacklog
 data "google_container_engine_versions" "central1a" {
   location = "us-central1-a"
 }
+
 resource "google_container_cluster" "cluster" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1
   min_master_version = data.google_container_engine_versions.central1a.latest_master_version
 }
+
 resource "google_container_node_pool" "with_linux_node_config" {
   name               = "%s"
   location           = "us-central1-a"

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -261,7 +261,7 @@ func TestAccContainerNodePool_withKubeletConfig(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "default", "200us", true),
+				Config: testAccContainerNodePool_withKubeletConfig(cluster, np, "static", "200us", true),
 			},
 			{
 				ResourceName:      "google_container_node_pool.with_kubelet_config",

--- a/third_party/terraform/utils/node_config.go.erb
+++ b/third_party/terraform/utils/node_config.go.erb
@@ -251,6 +251,45 @@ func schemaNodeConfig() *schema.Schema {
 					ForceNew:   true,
 				},
 	<% end -%>
+	<% unless version == 'ga' -%>
+				"kubelet_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"cpu_manager_policy": {
+								Type:         schema.TypeString,
+								Optional:     true,
+								ValidateFunc: validation.StringInSlice([]string{"static", "default"}, false),
+							},
+							"cpu_cfs_quota": {
+								Type:     schema.TypeBool,
+								Optional: true,
+							},
+							"cpu_cfs_quota_period": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+
+				"linux_node_config": {
+					Type:     schema.TypeList,
+					Optional: true,
+					MaxItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"sysctls": {
+								Type:     schema.TypeMap,
+								Required: true,
+								Elem:     &schema.Schema{Type: schema.TypeString},
+							},
+						},
+					},
+				},
+	<% end -%>
 			},
 		},
 	}
@@ -390,8 +429,18 @@ func expandNodeConfig(v interface{}) *containerBeta.NodeConfig {
 	if v, ok := nodeConfig["boot_disk_kms_key"]; ok {
 		nc.BootDiskKmsKey = v.(string)
 	}
-<% end -%>
 
+<% end -%>
+<% unless version == 'ga' -%>
+	if v, ok := nodeConfig["kubelet_config"]; ok {
+		nc.KubeletConfig = expandKubeletConfig(v)
+	}
+
+	if v, ok := nodeConfig["linux_node_config"]; ok {
+		nc.LinuxNodeConfig = expandLinuxNodeConfig(v)
+	}
+
+<% end -%>
 	return nc
 }
 
@@ -412,6 +461,54 @@ func expandWorkloadMetadataConfig(v interface{}) *containerBeta.WorkloadMetadata
 }
 
 <% end -%>
+
+<% unless version == 'ga' -%>
+func expandKubeletConfig(v interface{}) *containerBeta.NodeKubeletConfig {
+	if v == nil {
+		return nil
+	}
+	ls := v.([]interface{})
+	if len(ls) == 0 {
+		return nil
+	}
+	cfg := ls[0].(map[string]interface{})
+	kConfig := &containerBeta.NodeKubeletConfig{}
+	if cpuManagerPolicy, ok := cfg["cpu_manager_policy"]; ok {
+		kConfig.CpuManagerPolicy = cpuManagerPolicy.(string)
+	}
+	if cpuCfsQuota, ok := cfg["cpu_cfs_quota"]; ok {
+		kConfig.CpuCfsQuota = cpuCfsQuota.(bool)
+	}
+	if cpuCfsQuotaPeriod, ok := cfg["cpu_cfs_quota_period"]; ok {
+		kConfig.CpuCfsQuotaPeriod = cpuCfsQuotaPeriod.(string)
+	}
+	return kConfig
+}
+
+func expandLinuxNodeConfig(v interface{}) *containerBeta.LinuxNodeConfig {
+	if v == nil {
+		return nil
+	}
+	ls := v.([]interface{})
+	if len(ls) == 0 {
+		return nil
+	}
+	cfg := ls[0].(map[string]interface{})
+	sysCfgRaw, ok := cfg["sysctls"]
+	if !ok {
+		return nil
+	}
+	m := make(map[string]string)
+	for k, v := range sysCfgRaw.(map[string]interface{}) {
+		m[k] = v.(string)
+	}
+	return &containerBeta.LinuxNodeConfig{
+		Sysctls: m,
+	}
+}
+
+<% end -%>
+
 func flattenNodeConfig(c *containerBeta.NodeConfig) []map[string]interface{} {
 	config := make([]map[string]interface{}, 0, 1)
 
@@ -438,6 +535,10 @@ func flattenNodeConfig(c *containerBeta.NodeConfig) []map[string]interface{} {
 		"workload_metadata_config": flattenWorkloadMetadataConfig(c.WorkloadMetadataConfig),
 		"sandbox_config": 			flattenSandboxConfig(c.SandboxConfig),
 		"boot_disk_kms_key": 		c.BootDiskKmsKey,
+<% end -%>
+<% unless version == 'ga' -%>
+		"kubelet_config":           flattenKubeletConfig(c.KubeletConfig),
+		"linux_node_config":        flattenLinuxNodeConfig(c.LinuxNodeConfig),
 <% end -%>
 	})
 
@@ -498,6 +599,30 @@ func flattenSandboxConfig(c *containerBeta.SandboxConfig) []map[string]interface
 	if c != nil {
 		result = append(result, map[string]interface{}{
 			"sandbox_type": c.SandboxType,
+		})
+	}
+	return result
+}
+<% end -%>
+
+<% unless version == 'ga' -%>
+func flattenKubeletConfig(c *containerBeta.NodeKubeletConfig) []map[string]interface{} {
+	result := []map[string]interface{}{}
+	if c != nil {
+		result = append(result, map[string]interface{}{
+			"cpu_cfs_quota":        c.CpuCfsQuota,
+			"cpu_cfs_quota_period": c.CpuCfsQuotaPeriod,
+			"cpu_manager_policy":   c.CpuManagerPolicy,
+		})
+	}
+	return result
+}
+
+func flattenLinuxNodeConfig(c *containerBeta.LinuxNodeConfig) []map[string]interface{} {
+	result := []map[string]interface{}{}
+	if c != nil {
+		result = append(result, map[string]interface{}{
+			"sysctls": c.Sysctls,
 		})
 	}
 	return result

--- a/third_party/terraform/utils/node_config.go.erb
+++ b/third_party/terraform/utils/node_config.go.erb
@@ -262,7 +262,7 @@ func schemaNodeConfig() *schema.Schema {
 						Schema: map[string]*schema.Schema{
 							"cpu_manager_policy": {
 								Type:         schema.TypeString,
-								Optional:     true,
+								Required:     true,
 								ValidateFunc: validation.StringInSlice([]string{"static", "none"}, false),
 							},
 							"cpu_cfs_quota": {

--- a/third_party/terraform/utils/node_config.go.erb
+++ b/third_party/terraform/utils/node_config.go.erb
@@ -263,7 +263,7 @@ func schemaNodeConfig() *schema.Schema {
 							"cpu_manager_policy": {
 								Type:         schema.TypeString,
 								Optional:     true,
-								ValidateFunc: validation.StringInSlice([]string{"static", "default"}, false),
+								ValidateFunc: validation.StringInSlice([]string{"static", "none"}, false),
 							},
 							"cpu_cfs_quota": {
 								Type:     schema.TypeBool,

--- a/third_party/terraform/utils/node_config.go.erb
+++ b/third_party/terraform/utils/node_config.go.erb
@@ -252,6 +252,8 @@ func schemaNodeConfig() *schema.Schema {
 				},
 	<% end -%>
 	<% unless version == 'ga' -%>
+				// Note that AtLeastOneOf can't be set because this schema is reused by
+				// two different resources.
 				"kubelet_config": {
 					Type:     schema.TypeList,
 					Optional: true,

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -794,7 +794,7 @@ The `kubelet_config` block supports:
 
 * `cpu_manager_policy` - (Optional) The CPU management policy on the node. See
 [K8S CPU Management Policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/).
-One of `"default"` or `"static"`.
+One of `"none"` or `"static"`. Defaults to `none` when unset.
 
 * `cpu_cfs_quota` - (Optional) If true, enables CPU CFS quota enforcement for
 containers that specify CPU limits.
@@ -803,6 +803,11 @@ containers that specify CPU limits.
 as a sequence of decimal numbers, each with optional fraction and a unit suffix,
 such as `"300ms"`. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
 "h". The value must be a positive duration.
+
+-> Note: At the time of writing (2020/08/18) the GKE API rejects the `none`
+value and accepts an invalid `default` value. While this remains true, not
+specifying the `kubelet_config` block should be the equivalent of specifying
+`none`.
 
 The `linux_node_config` block supports:
 

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -632,6 +632,32 @@ recommended. Structure is documented below.
 
 * `workload_metadata_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Metadata configuration to expose to workloads on the node pool.
     Structure is documented below.
+    
+* `kubelet_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+Kubelet configuration, currently supported attributes can be found [here](https://cloud.google.com/sdk/gcloud/reference/beta/container/node-pools/create#--system-config-from-file).
+Structure is documented below.
+
+```
+kubelet_config {
+  cpu_manager_policy   = "static"
+  cpu_cfs_quota        = true
+  cpu_cfs_quota_period = "100us"
+}
+```
+
+* `linux_node_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+Linux node configuration, currently supported attributes can be found [here](https://cloud.google.com/sdk/gcloud/reference/beta/container/node-pools/create#--system-config-from-file).
+Note that validations happen all server side. All attributes are optional.
+Structure is documented below.
+
+```hcl
+linux_node_config {
+  sysctls = {
+    "net.core.netdev_max_backlog" = "10000"
+    "net.core.rmem_max"           = "10000"
+  }
+}
+```
 
 The `guest_accelerator` block supports:
 
@@ -763,6 +789,26 @@ The `workload_metadata_config` block supports:
     * SECURE: Prevent workloads not in hostNetwork from accessing certain VM metadata, specifically kube-env, which contains Kubelet credentials, and the instance identity token. See [Metadata Concealment](https://cloud.google.com/kubernetes-engine/docs/how-to/metadata-proxy) documentation.
     * EXPOSE: Expose all VM metadata to pods.
     * GKE_METADATA_SERVER: Enables [workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) on the node.
+
+The `kubelet_config` block supports:
+
+* `cpu_manager_policy` (Optional): The CPU management policy on the node. See
+[K8S CPU Management Policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/).
+One of `"default"` or `"static"`.
+
+* `cpu_cfs_quota` (Optional): If true, enables CPU CFS quota enforcement for
+containers that specify CPU limits.
+
+* `cpu_cfs_quota_period` (Optional): The CPU CFS quota period value. Specified
+as a sequence of decimal numbers, each with optional fraction and a unit suffix,
+such as `"300ms"`. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
+"h". The value must be a positive duration.
+
+The `linux_node_config` block supports:
+
+* `sysctls` (Required): The Linux kernel parameters to be applied to the nodes
+and all pods running on the nodes. Specified as a map from the key, such as
+`net.core.wmem_max`, to a string value. 
 
 The `vertical_pod_autoscaling` block supports:
 

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -792,21 +792,21 @@ The `workload_metadata_config` block supports:
 
 The `kubelet_config` block supports:
 
-* `cpu_manager_policy` (Optional): The CPU management policy on the node. See
+* `cpu_manager_policy` - (Optional) The CPU management policy on the node. See
 [K8S CPU Management Policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/).
 One of `"default"` or `"static"`.
 
-* `cpu_cfs_quota` (Optional): If true, enables CPU CFS quota enforcement for
+* `cpu_cfs_quota` - (Optional) If true, enables CPU CFS quota enforcement for
 containers that specify CPU limits.
 
-* `cpu_cfs_quota_period` (Optional): The CPU CFS quota period value. Specified
+* `cpu_cfs_quota_period` - (Optional) The CPU CFS quota period value. Specified
 as a sequence of decimal numbers, each with optional fraction and a unit suffix,
 such as `"300ms"`. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
 "h". The value must be a positive duration.
 
 The `linux_node_config` block supports:
 
-* `sysctls` (Required): The Linux kernel parameters to be applied to the nodes
+* `sysctls` - (Required)  The Linux kernel parameters to be applied to the nodes
 and all pods running on the nodes. Specified as a map from the key, such as
 `net.core.wmem_max`, to a string value. 
 

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -792,9 +792,9 @@ The `workload_metadata_config` block supports:
 
 The `kubelet_config` block supports:
 
-* `cpu_manager_policy` - (Optional) The CPU management policy on the node. See
+* `cpu_manager_policy` - (Required) The CPU management policy on the node. See
 [K8S CPU Management Policies](https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/).
-One of `"none"` or `"static"`. Defaults to `none` when unset.
+One of `"none"` or `"static"`. Defaults to `none` when `kubelet_config` is unset.
 
 * `cpu_cfs_quota` - (Optional) If true, enables CPU CFS quota enforcement for
 containers that specify CPU limits.
@@ -805,8 +805,8 @@ such as `"300ms"`. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m",
 "h". The value must be a positive duration.
 
 -> Note: At the time of writing (2020/08/18) the GKE API rejects the `none`
-value and accepts an invalid `default` value. While this remains true, not
-specifying the `kubelet_config` block should be the equivalent of specifying
+value and accepts an invalid `default` value instead. While this remains true,
+not specifying the `kubelet_config` block should be the equivalent of specifying
 `none`.
 
 The `linux_node_config` block supports:


### PR DESCRIPTION
Upstreams https://github.com/terraform-providers/terraform-provider-google-beta/pull/2279, fixes https://github.com/terraform-providers/terraform-provider-google/issues/6773

I took some liberty with upstreaming the docs- I added documentation for the nested types, which I'd missed were absent in the original PR.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added support for `kubelet_config` and `linux_node_config` to GKE node pools (beta)
```
