### PR TITLE
several fixes for notebook instance

### DIFF
--- a/products/notebooks/api.yaml
+++ b/products/notebooks/api.yaml
@@ -141,8 +141,7 @@ objects:
     create_url: projects/{{project}}/locations/{{location}}/instances?instanceId={{name}}
     self_link: projects/{{project}}/locations/{{location}}/instances/{{name}}
     create_verb: :POST
-    update_verb: :PATCH
-    update_mask: true
+    input: true
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Official Documentation':
@@ -171,7 +170,11 @@ objects:
         description: |
             A reference to a machine type which defines VM kind.
         required: true
-        input: true
+        # Machine Type is updatable, but requires the instance to be stopped, just like
+        # for compute instances.
+        # TODO: Implement allow_stopping_for_update here and for acceleratorConfig
+        # update_verb: :PATCH
+        # update_url: 'projects/{{project}}/locations/{{location}}/instances/{{name}}:setMachineType'
         pattern: projects/{{project}}/zones/{{location}}/machineTypes/{{name}}
       - !ruby/object:Api::Type::String
         name: 'postStartupScript'
@@ -206,6 +209,11 @@ objects:
             The hardware accelerator used on this instance. If you use accelerators, 
             make sure that your configuration has enough vCPUs and memory to support the 
             machineType you have selected.
+        # AcceleratorConfig is updatable, but requires the instance to be stopped, just like
+        # for compute instances.
+        # TODO: Implement allow_stopping_for_update here and for machineType
+        # update_verb: :PATCH
+        # update_url: 'projects/{{project}}/locations/{{location}}/instances/{{name}}:setAccelerator'
         properties:
           - !ruby/object:Api::Type::Enum
             name: 'type'
@@ -322,6 +330,8 @@ objects:
         description: |
             Labels to apply to this instance. These can be later modified by the setLabels method.
             An object containing a list of "key": value pairs. Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+        update_verb: :PATCH
+        update_url: 'projects/{{project}}/locations/{{location}}/instances/{{name}}:setLabels'
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'metadata'
         description: |

--- a/products/notebooks/terraform.yaml
+++ b/products/notebooks/terraform.yaml
@@ -39,23 +39,62 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "instance"
         vars:
           instance_name: "notebooks-instance"
+      - !ruby/object:Provider::Terraform::Examples
+        min_version: beta
+        name: "notebook_instance_basic_container"
+        primary_resource_id: "instance"
+        vars:
+          instance_name: "notebooks-instance"
+      - !ruby/object:Provider::Terraform::Examples
+        min_version: beta
+        name: "notebook_instance_basic_gpu"
+        primary_resource_id: "instance"
+        vars:
+          instance_name: "notebooks-instance"
+      - !ruby/object:Provider::Terraform::Examples
+        min_version: beta
+        name: "notebook_instance_full"
+        primary_resource_id: "instance"
+        vars:
+          instance_name: "notebooks-instance"
+        test_env_vars:
+          service_account: :SERVICE_ACCT
+    description: |
+      {{description}}
+
+      ~> **Note:** Due to limitations of the Notebooks Instance API, many fields
+      in this resource do not properly detect drift. These fields will also not
+      appear in state once imported.
     properties:
+      bootDiskSizeGb: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
+      bootDiskType: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
       createTime: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       containerImage: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
+      dataDiskSizeGb: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
+      instanceOwners: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
       machineType: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'compareSelfLinkOrResourceName'
         custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
       metadata: !ruby/object:Overrides::Terraform::PropertyOverride
+        # This is not a traditional ignore_read. Metadata is returned from the API,
+        # but it gets merged with metadata that the server sets. This prevents us
+        # from detecting drift.
         ignore_read: true
       name: !ruby/object:Overrides::Terraform::PropertyOverride      
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
       network: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: compareSelfLinkOrResourceName
         default_from_api: true     
       serviceAccount: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       subnet: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: compareSelfLinkOrResourceName
         default_from_api: true
       updateTime: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true

--- a/templates/terraform/examples/notebook_instance_full.tf.erb
+++ b/templates/terraform/examples/notebook_instance_full.tf.erb
@@ -1,0 +1,43 @@
+resource "google_notebooks_instance" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+  name = "<%= ctx[:vars]["instance_name"] %>"
+  location = "us-central1-a"
+  machine_type = "n1-standard-1"
+
+  vm_image {
+    project      = "deeplearning-platform-release"
+    image_family = "tf-latest-cpu"
+  }
+
+  instance_owners = "admin@hashicorptest.com"
+  service_account = "<%= ctx[:test_env_vars]["service_account"] %>"
+
+  install_gpu_driver = true
+  boot_disk_type = "PD_SSD"
+  boot_disk_size_gb = 110
+
+  no_public_ip = true
+  no_proxy_access = true
+
+  network = data.google_compute_network.my_network.id
+  subnet = data.google_compute_subnetwork.my_subnetwork.id
+
+  labels = {
+  	k = "val"
+  }
+
+  metadata = {
+    terraform = "true"
+  }
+}
+
+data "google_compute_network" "my_network" {
+  provider = google-beta
+  name = "default"
+}
+
+data "google_compute_subnetwork" "my_subnetwork" {
+  provider = google-beta
+  name   = "default"
+  region = "us-central1"
+}

--- a/templates/terraform/examples/notebook_instance_full.tf.erb
+++ b/templates/terraform/examples/notebook_instance_full.tf.erb
@@ -23,7 +23,7 @@ resource "google_notebooks_instance" "<%= ctx[:primary_resource_id] %>" {
   subnet = data.google_compute_subnetwork.my_subnetwork.id
 
   labels = {
-  	k = "val"
+    k = "val"
   }
 
   metadata = {

--- a/third_party/terraform/tests/resource_notebooks_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_notebooks_instance_test.go.erb
@@ -2,6 +2,7 @@
 package google
 
 <% unless version == 'ga' %>
+
 import (
 	"fmt"
 	"testing"
@@ -16,17 +17,55 @@ func TestAccNotebooksInstance_create_vm_image(t *testing.T) {
 	name := fmt.Sprintf("tf-%s", prefix)
 
 	vcrTest(t, resource.TestCase{
-		Providers:    testAccProviders,
+		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccNotebooksInstance_create_vm_image(name),
 			},
 			{
-				ResourceName:      "google_notebooks_instance.test",
-				ImportState:        true,
-				ImportStateVerify:  true,
-				ExpectNonEmptyPlan: true,
-				ImportStateVerifyIgnore: []string{"container_image", "metadata", "vm_image"},
+				ResourceName:            "google_notebooks_instance.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"vm_image", "metadata"},
+			},
+		},
+	})
+}
+
+func TestAccNotebooksInstance_update(t *testing.T) {
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNotebooksInstance_basic(context),
+			},
+			{
+				ResourceName:            "google_notebooks_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"vm_image"},
+			},
+			{
+				Config: testAccNotebooksInstance_update(context),
+			},
+			{
+				ResourceName:            "google_notebooks_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"vm_image"},
+			},
+			{
+				Config: testAccNotebooksInstance_basic(context),
+			},
+			{
+				ResourceName:            "google_notebooks_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"vm_image"},
 			},
 		},
 	})
@@ -50,4 +89,40 @@ resource "google_notebooks_instance" "test" {
 }
 `, name)
 }
+
+func testAccNotebooksInstance_basic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_notebooks_instance" "instance" {
+  name = "tf-test-notebooks-instance%{random_suffix}"
+  location = "us-central1-a"
+  machine_type = "n1-standard-1"
+
+  vm_image {
+    project      = "deeplearning-platform-release"
+    image_family = "tf-latest-cpu"
+  }
+}
+`, context)
+}
+
+func testAccNotebooksInstance_update(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_notebooks_instance" "instance" {
+  name = "tf-test-notebooks-instance%{random_suffix}"
+  location = "us-central1-a"
+  machine_type = "n1-standard-1"
+
+  vm_image {
+    project      = "deeplearning-platform-release"
+    image_family = "tf-latest-cpu"
+  }
+
+  labels = {
+    key = "value"
+  }
+}
+`, context)
+}
+
+
 <% end -%>


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6798. Tests are also more comprehensive now.
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
notebook: fixed bug where updating certain fields would result in a no-op update call instead of a create/destroy. Now, the only field that is updatable in place is `labels`
```

```release-note:bug
notebook: fixed bug where many fields were being written as empty to state, causing a diff on the next plan
```

```release-note:bug
notebook: fixed bug where setting `network` or `subnet` to a full URL would succeed, but cause a diff on the next plan
```