### PR TITLE
separate default version update from release channel test

### DIFF
--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -367,8 +367,20 @@ func TestAccContainerCluster_withReleaseChannelEnabled(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"min_master_version"},
 			},
+		},
+	})
+}
+
+func TestAccContainerCluster_withReleaseChannelEnabledDefaultVersion(t *testing.T) {
+	t.Parallel()
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
 			{
-				Config: testAccContainerCluster_withReleaseChannelEnabledUpdateToChannelDefaultVersion(clusterName, "REGULAR"),
+				Config: testAccContainerCluster_withReleaseChannelEnabledDefaultVersion(clusterName, "REGULAR"),
 			},
 			{
 				ResourceName:            "google_container_cluster.with_release_channel",
@@ -2265,7 +2277,7 @@ resource "google_container_cluster" "with_release_channel" {
 `, clusterName, channel)
 }
 
-func testAccContainerCluster_withReleaseChannelEnabledUpdateToChannelDefaultVersion(clusterName string, channel string) string {
+func testAccContainerCluster_withReleaseChannelEnabledDefaultVersion(clusterName string, channel string) string {
 	return fmt.Sprintf(`
 
 data "google_container_engine_versions" "central1a" {


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6593

Separate the default version test from the release enabled tests as we can't update over 2 minor versions.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
