### PR TITLE
add folder_id as output to folder datasource and resource

### DIFF
--- a/templates/terraform/examples/cloud_asset_folder_feed.tf.erb
+++ b/templates/terraform/examples/cloud_asset_folder_feed.tf.erb
@@ -2,7 +2,7 @@
 # particular folder.
 resource "google_cloud_asset_folder_feed" "<%= ctx[:primary_resource_id] %>" {
   billing_project  = "<%= ctx[:test_env_vars]["project"] %>"
-  folder           = google_folder.my_folder.name
+  folder           = google_folder.my_folder.folder_id
   feed_id          = "<%= ctx[:vars]["feed_id"] %>"
   content_type     = "RESOURCE"
 

--- a/third_party/terraform/data_sources/data_source_google_folder.go
+++ b/third_party/terraform/data_sources/data_source_google_folder.go
@@ -15,6 +15,10 @@ func dataSourceGoogleFolder() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"folder_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Computed: true,

--- a/third_party/terraform/resources/resource_google_folder.go
+++ b/third_party/terraform/resources/resource_google_folder.go
@@ -41,7 +41,11 @@ func resourceGoogleFolder() *schema.Resource {
 				Required:    true,
 				Description: `The folder's display name. A folder's display name must be unique amongst its siblings, e.g. no two folders with the same parent can share the same display name. The display name must start and end with a letter or digit, may contain letters, digits, spaces, hyphens and underscores and can be no longer than 30 characters.`,
 			},
-
+			"folder_id": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `The folder id from the name "folders/{folder_id}"`,
+			},
 			// Format is 'folders/{folder_id}.
 			// The terraform id holds the same value.
 			"name": {
@@ -119,6 +123,8 @@ func resourceGoogleFolderRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("name", folder.Name)
+	folderId := strings.TrimPrefix(folder.Name, "folders/")
+	d.Set("folder_id", folderId)
 	d.Set("parent", folder.Parent)
 	d.Set("display_name", folder.DisplayName)
 	d.Set("lifecycle_state", folder.LifecycleState)


### PR DESCRIPTION
While reviewing the Cloud Asset Feed resources, we found that `folder_id` might be a helpful output of `google_folder`

https://github.com/GoogleCloudPlatform/magic-modules/pull/3750#discussion_r455980025

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
resourcemanager: added `folder_id` as computed attribute to `google_folder` resource and datasource.
```
