### PR TITLE
add tiers and nfs_export_options

### DIFF
--- a/products/filestore/api.yaml
+++ b/products/filestore/api.yaml
@@ -23,6 +23,9 @@ versions:
   - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://file.googleapis.com/v1/
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://file.googleapis.com/v1beta1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 async: !ruby/object:Api::OpAsync
@@ -104,9 +107,12 @@ objects:
         required: true
         input: true
         values:
-          - TIER_UNSPECIFIED
-          - STANDARD
-          - PREMIUM
+          - :TIER_UNSPECIFIED
+          - :STANDARD
+          - :PREMIUM
+          - :BASIC_HDD
+          - :BASIC_SSD
+          - :HIGH_SCALE_SSD
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: |
@@ -132,6 +138,52 @@ objects:
                 File share capacity in GiB. This must be at least 1024 GiB
                 for the standard tier, or 2560 GiB for the premium tier.
               required: true
+            - !ruby/object:Api::Type::Array
+              name: 'nfsExportOptions'
+              description: |
+                Nfs Export Options. There is a limit of 10 export options per file share.
+              max_size: 10
+              min_version: beta
+              item_type: !ruby/object:Api::Type::NestedObject
+                properties:
+                  - !ruby/object:Api::Type::Array
+                    name: 'ipRanges'
+                    description: |
+                      List of either an IPv4 addresses in the format {octet 1}.{octet 2}.{octet 3}.{octet 4} or CIDR ranges
+                      in the format {octet 1}.{octet 2}.{octet 3}.{octet 4}/{mask size} which may mount the file share.
+                      Overlapping IP ranges are not allowed, both within and across NfsExportOptions. An error will be returned.
+                      The limit is 64 IP ranges/addresses for each FileShareConfig among all NfsExportOptions.
+                    item_type: Api::Type::String
+                  - !ruby/object:Api::Type::Enum
+                    name: 'accessMode'
+                    description: |
+                      Either READ_ONLY, for allowing only read requests on the exported directory,
+                      or READ_WRITE, for allowing both read and write requests. The default is READ_WRITE.
+                    default_value: :READ_WRITE
+                    values:
+                      - :READ_ONLY
+                      - :READ_WRITE
+                  - !ruby/object:Api::Type::Enum
+                    name: 'squashMode'
+                    description: |
+                      Either NO_ROOT_SQUASH, for allowing root access on the exported directory, or ROOT_SQUASH,
+                      for not allowing root access. The default is NO_ROOT_SQUASH.
+                    default_value: :NO_ROOT_SQUASH
+                    values:
+                      - :NO_ROOT_SQUASH
+                      - :ROOT_SQUASH
+                  - !ruby/object:Api::Type::Integer
+                    name: 'anonUid'
+                    description: |
+                      An integer representing the anonymous user id with a default value of 65534.
+                      Anon_uid may only be set with squashMode of ROOT_SQUASH. An error will be returned
+                      if this field is specified for other squashMode settings.
+                  - !ruby/object:Api::Type::Integer
+                    name: 'anonGid'
+                    description: |
+                      An integer representing the anonymous group id with a default value of 65534.
+                      Anon_gid may only be set with squashMode of ROOT_SQUASH. An error will be returned
+                      if this field is specified for other squashMode settings.
       - !ruby/object:Api::Type::Array
         name: 'networks'
         description: |

--- a/products/filestore/api.yaml
+++ b/products/filestore/api.yaml
@@ -149,8 +149,7 @@ objects:
                   - !ruby/object:Api::Type::Array
                     name: 'ipRanges'
                     description: |
-                      List of either an IPv4 addresses in the format {octet 1}.{octet 2}.{octet 3}.{octet 4} or CIDR ranges
-                      in the format {octet 1}.{octet 2}.{octet 3}.{octet 4}/{mask size} which may mount the file share.
+                      List of either IPv4 addresses, or ranges in CIDR notation which may mount the file share.
                       Overlapping IP ranges are not allowed, both within and across NfsExportOptions. An error will be returned.
                       The limit is 64 IP ranges/addresses for each FileShareConfig among all NfsExportOptions.
                     item_type: Api::Type::String

--- a/products/filestore/terraform.yaml
+++ b/products/filestore/terraform.yaml
@@ -27,6 +27,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           instance_name: "test-instance"
       - !ruby/object:Provider::Terraform::Examples
         name: "filestore_instance_full"
+        min_version: beta
         primary_resource_id: "instance"
         vars:
           instance_name: "test-instance"

--- a/products/filestore/terraform.yaml
+++ b/products/filestore/terraform.yaml
@@ -25,6 +25,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "instance"
         vars:
           instance_name: "test-instance"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "filestore_instance_full"
+        primary_resource_id: "instance"
+        vars:
+          instance_name: "test-instance"
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'

--- a/templates/terraform/examples/filestore_instance_full.tf.erb
+++ b/templates/terraform/examples/filestore_instance_full.tf.erb
@@ -1,0 +1,29 @@
+resource "google_filestore_instance" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]["instance_name"] %>"
+  zone = "us-central1-b"
+  tier = "BASIC_SSD"
+
+  file_shares {
+    capacity_gb = 2660
+    name        = "share1"
+
+    nfs_export_options {
+      ip_ranges = ["10.0.0.0/24"]
+      access_mode = "READ_WRITE"
+      squash_mode = "NO_ROOT_SQUASH"
+   }
+
+   nfs_export_options {
+      ip_ranges = ["10.10.0.0/24"]
+      access_mode = "READ_ONLY"
+      squash_mode = "ROOT_SQUASH"
+      anon_uid = 123
+      anon_gid = 456
+   }
+  }
+
+  networks {
+    network = "default"
+    modes   = ["MODE_IPV4"]
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6572


**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
filestore: added support for filestore high scale tier.
```

```release-note:enhancement
filestore: added `nfs_export_options` field on `google_filestore_instance.file_shares`. (beta-only)
```
