### PR TITLE
Add skip enum value generation

### DIFF
--- a/api/type.rb
+++ b/api/type.rb
@@ -461,7 +461,7 @@ module Api
       def validate
         super
         check :values, type: ::Array, item_type: [Symbol, ::String, ::Integer], required: true
-        check :skip_docs_values, type :boolean, default: false
+        check :skip_docs_values, type: :boolean
       end
     end
 

--- a/api/type.rb
+++ b/api/type.rb
@@ -456,7 +456,7 @@ module Api
     # Represents an enum, and store is valid values
     class Enum < Primitive
       attr_reader :values
-      attr_reader :display_values_in_docs
+      attr_reader :skip_docs_values
 
       def validate
         super

--- a/api/type.rb
+++ b/api/type.rb
@@ -456,10 +456,12 @@ module Api
     # Represents an enum, and store is valid values
     class Enum < Primitive
       attr_reader :values
+      attr_reader :display_values_in_docs
 
       def validate
         super
         check :values, type: ::Array, item_type: [Symbol, ::String, ::Integer], required: true
+        check :skip_docs_values, type :boolean, default: false
       end
     end
 

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -9819,13 +9819,19 @@ objects:
                         name: 'redirectResponseCode'
                         description: |
                           The HTTP Status code to use for this RedirectAction. Supported values are:
-                          - MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
-                          - FOUND, which corresponds to 302.
-                          - SEE_OTHER which corresponds to 303.
-                          - TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+
+                          * MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+                          
+                          * FOUND, which corresponds to 302.
+                          
+                          * SEE_OTHER which corresponds to 303.
+                          
+                          * TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
                           will be retained.
-                          - PERMANENT_REDIRECT, which corresponds to 308. In this case,
+                          
+                          * PERMANENT_REDIRECT, which corresponds to 308. In this case,
                           the request method will be retained.
+                        skip_docs_values: true
                         values:
                           - :FOUND
                           - :MOVED_PERMANENTLY_DEFAULT
@@ -10238,13 +10244,19 @@ objects:
                         name: 'redirectResponseCode'
                         description: |
                           The HTTP Status code to use for this RedirectAction. Supported values are:
-                          - MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
-                          - FOUND, which corresponds to 302.
-                          - SEE_OTHER which corresponds to 303.
-                          - TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+
+                          * MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+                          
+                          * FOUND, which corresponds to 302.
+                          
+                          * SEE_OTHER which corresponds to 303.
+                          
+                          * TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
                           will be retained.
-                          - PERMANENT_REDIRECT, which corresponds to 308. In this case,
+                          
+                          * PERMANENT_REDIRECT, which corresponds to 308. In this case,
                           the request method will be retained.
+                        skip_docs_values: true
                         values:
                           - :FOUND
                           - :MOVED_PERMANENTLY_DEFAULT
@@ -10301,13 +10313,19 @@ objects:
                   name: 'redirectResponseCode'
                   description: |
                     The HTTP Status code to use for this RedirectAction. Supported values are:
-                    - MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
-                    - FOUND, which corresponds to 302.
-                    - SEE_OTHER which corresponds to 303.
-                    - TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+                    
+                    * MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+                    
+                    * FOUND, which corresponds to 302.
+                    
+                    * SEE_OTHER which corresponds to 303.
+                    
+                    * TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
                     will be retained.
-                    - PERMANENT_REDIRECT, which corresponds to 308. In this case,
+                    
+                    * PERMANENT_REDIRECT, which corresponds to 308. In this case,
                     the request method will be retained.
+                  skip_docs_values: true
                   values:
                     - :FOUND
                     - :MOVED_PERMANENTLY_DEFAULT
@@ -10390,13 +10408,19 @@ objects:
             name: 'redirectResponseCode'
             description: |
               The HTTP Status code to use for this RedirectAction. Supported values are:
-              - MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
-              - FOUND, which corresponds to 302.
-              - SEE_OTHER which corresponds to 303.
-              - TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+              
+              * MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+
+              * FOUND, which corresponds to 302.
+
+              * SEE_OTHER which corresponds to 303.
+              
+              * TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
               will be retained.
-              - PERMANENT_REDIRECT, which corresponds to 308. In this case,
+              
+              * PERMANENT_REDIRECT, which corresponds to 308. In this case,
               the request method will be retained.
+            skip_docs_values: true
             values:
               - :FOUND
               - :MOVED_PERMANENTLY_DEFAULT
@@ -14803,13 +14827,19 @@ objects:
                         name: 'redirectResponseCode'
                         description: |
                           The HTTP Status code to use for this RedirectAction. Supported values are:
-                          - MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
-                          - FOUND, which corresponds to 302.
-                          - SEE_OTHER which corresponds to 303.
-                          - TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+
+                          * MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+
+                          * FOUND, which corresponds to 302.
+
+                          * SEE_OTHER which corresponds to 303.
+
+                          * TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
                           will be retained.
-                          - PERMANENT_REDIRECT, which corresponds to 308. In this case,
+
+                          * PERMANENT_REDIRECT, which corresponds to 308. In this case,
                           the request method will be retained.
+                        skip_docs_values: true
                         values:
                           - :FOUND
                           - :MOVED_PERMANENTLY_DEFAULT
@@ -15482,12 +15512,18 @@ objects:
                       - !ruby/object:Api::Type::Enum
                         name: 'redirectResponseCode'
                         description: |
-                          The HTTP Status code to use for this RedirectAction. Supported values are:   -
-                          MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.  -
-                          FOUND, which corresponds to 302.  - SEE_OTHER which corresponds to 303.  -
-                          TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
-                          will be retained.  - PERMANENT_REDIRECT, which corresponds to 308. In this case,
-                          the request method will be retained.
+                          The HTTP Status code to use for this RedirectAction. Supported values are:
+
+                          * MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+
+                          * FOUND, which corresponds to 302.
+
+                          * SEE_OTHER which corresponds to 303.
+                          
+                          * TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method will be retained.
+
+                          * PERMANENT_REDIRECT, which corresponds to 308. In this case, the request method will be retained.
+                        skip_docs_values: true
                         values:
                           - :FOUND
                           - :MOVED_PERMANENTLY_DEFAULT
@@ -15547,13 +15583,19 @@ objects:
                   name: 'redirectResponseCode'
                   description: |
                     The HTTP Status code to use for this RedirectAction. Supported values are:
-                    - MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
-                    - FOUND, which corresponds to 302.
-                    - SEE_OTHER which corresponds to 303.
-                    - TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+                    
+                    * MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+                    
+                    * FOUND, which corresponds to 302.
+                    
+                    * SEE_OTHER which corresponds to 303.
+                    
+                    * TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
                     will be retained.
-                    - PERMANENT_REDIRECT, which corresponds to 308. In this case,
+                    
+                    * PERMANENT_REDIRECT, which corresponds to 308. In this case,
                     the request method will be retained.
+                  skip_docs_values: true
                   values:
                     - :FOUND
                     - :MOVED_PERMANENTLY_DEFAULT
@@ -15952,13 +15994,19 @@ objects:
             name: 'redirectResponseCode'
             description: |
               The HTTP Status code to use for this RedirectAction. Supported values are:
-              - MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
-              - FOUND, which corresponds to 302.
-              - SEE_OTHER which corresponds to 303.
-              - TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
+
+              * MOVED_PERMANENTLY_DEFAULT, which is the default value and corresponds to 301.
+              
+              * FOUND, which corresponds to 302.
+              
+              * SEE_OTHER which corresponds to 303.
+              
+              * TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method
               will be retained.
-              - PERMANENT_REDIRECT, which corresponds to 308. In this case,
+              
+              * PERMANENT_REDIRECT, which corresponds to 308. In this case,
               the request method will be retained.
+            skip_docs_values: true
             values:
               - :FOUND
               - :MOVED_PERMANENTLY_DEFAULT

--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -14,7 +14,7 @@
 <%   end -%>
 <% end -%>
 <%= indent(property.description.strip.gsub("\n\n", "\n"), 2) -%>
-<% if property.is_a?(Api::Type::Enum) && !property.output -%>
+<% if property.is_a?(Api::Type::Enum) && !property.output && !property.skip_docs_values -%>
 
 
 <% unless property.default_value.nil? || property.default_value == "" -%>

--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -19,6 +19,7 @@
 
 <% unless property.default_value.nil? || property.default_value == "" -%>
   Default value: `<%= property.default_value %>`
+
 <% end -%>
   Possible values are:
 <% property.values.select { |v| v != "" }.each do |v| -%>


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/6807

Clean up some enum values lists

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
