### PR TITLE
Add namespacing on metric descriptor so tests can run in parallel

### DIFF
--- a/products/monitoring/terraform.yaml
+++ b/products/monitoring/terraform.yaml
@@ -304,9 +304,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "monitoring_metric_descriptor_basic"
         primary_resource_id: "basic"
+        vars:
+          display_name: "metric-descriptor"
       - !ruby/object:Provider::Terraform::Examples
         name: "monitoring_metric_descriptor_alert"
         primary_resource_id: "with_alert"
+        vars:
+          display_name: "metric-descriptor"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/self_link_as_name.erb
     

--- a/products/monitoring/terraform.yaml
+++ b/products/monitoring/terraform.yaml
@@ -306,11 +306,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "basic"
         vars:
           display_name: "metric-descriptor"
+          type: "daily_sales"
       - !ruby/object:Provider::Terraform::Examples
         name: "monitoring_metric_descriptor_alert"
         primary_resource_id: "with_alert"
         vars:
           display_name: "metric-descriptor"
+          type: "daily_sales"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/self_link_as_name.erb
     

--- a/templates/terraform/examples/monitoring_metric_descriptor_alert.tf.erb
+++ b/templates/terraform/examples/monitoring_metric_descriptor_alert.tf.erb
@@ -1,7 +1,7 @@
 resource "google_monitoring_metric_descriptor" "<%= ctx[:primary_resource_id] %>" {
   description = "Daily sales records from all branch stores."
   display_name = "<%= ctx[:vars]["display_name"] %>"
-  type = "custom.googleapis.com/stores/daily_sales"
+  type = "custom.googleapis.com/stores/<%= ctx[:vars]["type"] %>"
   metric_kind = "GAUGE"
   value_type = "DOUBLE"
   unit = "{USD}"

--- a/templates/terraform/examples/monitoring_metric_descriptor_alert.tf.erb
+++ b/templates/terraform/examples/monitoring_metric_descriptor_alert.tf.erb
@@ -1,6 +1,6 @@
 resource "google_monitoring_metric_descriptor" "<%= ctx[:primary_resource_id] %>" {
   description = "Daily sales records from all branch stores."
-  display_name = "Daily sales"
+  display_name = "<%= ctx[:vars]["display_name"] %>"
   type = "custom.googleapis.com/stores/daily_sales"
   metric_kind = "GAUGE"
   value_type = "DOUBLE"
@@ -8,7 +8,7 @@ resource "google_monitoring_metric_descriptor" "<%= ctx[:primary_resource_id] %>
 }
 
 resource "google_monitoring_alert_policy" "alert_policy" {
-  display_name = "Alert on daily sales"
+  display_name = "<%= ctx[:vars]["display_name"] %>"
   combiner     = "OR"
   conditions {
     display_name = "test condition"

--- a/templates/terraform/examples/monitoring_metric_descriptor_basic.tf.erb
+++ b/templates/terraform/examples/monitoring_metric_descriptor_basic.tf.erb
@@ -1,6 +1,6 @@
 resource "google_monitoring_metric_descriptor" "<%= ctx[:primary_resource_id] %>" {
   description = "Daily sales records from all branch stores."
-  display_name = "Daily sales"
+  display_name = "<%= ctx[:vars]["display_name"] %>"
   type = "custom.googleapis.com/stores/daily_sales"
   metric_kind = "GAUGE"
   value_type = "DOUBLE"

--- a/templates/terraform/examples/monitoring_metric_descriptor_basic.tf.erb
+++ b/templates/terraform/examples/monitoring_metric_descriptor_basic.tf.erb
@@ -1,7 +1,7 @@
 resource "google_monitoring_metric_descriptor" "<%= ctx[:primary_resource_id] %>" {
   description = "Daily sales records from all branch stores."
   display_name = "<%= ctx[:vars]["display_name"] %>"
-  type = "custom.googleapis.com/stores/daily_sales"
+  type = "custom.googleapis.com/stores/<%= ctx[:vars]["type"] %>"
   metric_kind = "GAUGE"
   value_type = "DOUBLE"
   unit = "{USD}"


### PR DESCRIPTION
Using vars from the `terraform.yaml` automatically adds random strings to the end, letting us run these tests at the same time without running into namespace issues

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
