### PR TITLE
Add the `google_dataflow_flex_template_job` resource

### DIFF
--- a/third_party/terraform/resources/resource_dataflow_flex_template_job.go.erb
+++ b/third_party/terraform/resources/resource_dataflow_flex_template_job.go.erb
@@ -65,7 +65,6 @@ func resourceDataflowFlexTemplateJob() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				// ForceNew applies to both stream and batch jobs
 				ForceNew: true,
 			},
 

--- a/third_party/terraform/resources/resource_dataflow_flex_template_job.go.erb
+++ b/third_party/terraform/resources/resource_dataflow_flex_template_job.go.erb
@@ -1,0 +1,155 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	dataflow "google.golang.org/api/dataflow/v1b3"
+)
+
+// NOTE: resource_dataflow_flex_template currently does not support updating existing jobs.
+// Changing any non-computed field will result in the job being deleted (according to its
+// on_delete policy) and recreated with the updated parameters.
+
+// resourceDataflowFlexTemplateJob defines the schema for Dataflow FlexTemplate jobs.
+func resourceDataflowFlexTemplateJob() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDataflowFlexTemplateJobCreate,
+		Read:   resourceDataflowFlexTemplateJobRead,
+		Update: resourceDataflowFlexTemplateJobUpdateByReplacement,
+		Delete: resourceDataflowJobDelete,
+		Schema: map[string]*schema.Schema{
+
+			"container_spec_gcs_path": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"on_delete": {
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringInSlice([]string{"cancel", "drain"}, false),
+				Optional:     true,
+				Default:      "drain",
+			},
+
+			"labels": {
+				Type:             schema.TypeMap,
+				Optional:         true,
+				DiffSuppressFunc: resourceDataflowJobLabelDiffSuppress,
+				ForceNew: true,
+			},
+
+			"parameters": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"project": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				// ForceNew applies to both stream and batch jobs
+				ForceNew: true,
+			},
+
+			"job_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// resourceDataflowFlexTemplateJobCreate creates a Flex Template Job from TF code.
+func resourceDataflowFlexTemplateJobCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	request := dataflow.LaunchFlexTemplateRequest{
+		LaunchParameter: &dataflow.LaunchFlexTemplateParameter{
+			ContainerSpecGcsPath: d.Get("container_spec_gcs_path").(string),
+			JobName:              d.Get("name").(string),
+			Parameters:           expandStringMap(d, "parameters"),
+		},
+	}
+	response, err := config.clientDataflow.Projects.Locations.FlexTemplates.Launch(project, region, &request).Do()
+	if err != nil {
+		return err
+	}
+	job := response.Job
+	d.SetId(job.Id)
+	d.Set("job_id", job.Id)
+
+	return resourceDataflowFlexTemplateJobRead(d, meta)
+}
+
+// resourceDataflowFlexTemplateJobRead reads a Flex Template Job resource.
+func resourceDataflowFlexTemplateJobRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	jobId := d.Id()
+
+	job, err := resourceDataflowJobGetJob(config, project, region, jobId)
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("Dataflow job %s", jobId))
+	}
+
+	d.Set("state", job.CurrentState)
+	d.Set("name", job.Name)
+	d.Set("project", project)
+	d.Set("labels", job.Labels)
+
+	if _, ok := dataflowTerminalStatesMap[job.CurrentState]; ok {
+		log.Printf("[DEBUG] Removing resource '%s' because it is in state %s.\n", job.Name, job.CurrentState)
+		d.SetId("")
+		return nil
+	}
+	d.SetId(job.Id)
+	d.Set("job_id", job.Id)
+
+	return nil
+}
+
+// resourceDataflowFlexTemplateJobUpdateByReplacement will be the method for updating Flex-Template jobs
+func resourceDataflowFlexTemplateJobUpdateByReplacement(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+<% end -%>

--- a/third_party/terraform/resources/resource_dataflow_flex_template_job.go.erb
+++ b/third_party/terraform/resources/resource_dataflow_flex_template_job.go.erb
@@ -5,7 +5,11 @@ package google
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"google.golang.org/api/googleapi"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -21,8 +25,8 @@ func resourceDataflowFlexTemplateJob() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceDataflowFlexTemplateJobCreate,
 		Read:   resourceDataflowFlexTemplateJobRead,
-		Update: resourceDataflowFlexTemplateJobUpdateByReplacement,
-		Delete: resourceDataflowJobDelete,
+		Update: resourceDataflowFlexTemplateJobUpdate,
+		Delete: resourceDataflowFlexTemplateJobDelete,
 		Schema: map[string]*schema.Schema{
 
 			"container_spec_gcs_path": {
@@ -41,14 +45,14 @@ func resourceDataflowFlexTemplateJob() *schema.Resource {
 				Type:         schema.TypeString,
 				ValidateFunc: validation.StringInSlice([]string{"cancel", "drain"}, false),
 				Optional:     true,
-				Default:      "drain",
+				Default:      "cancel",
 			},
 
 			"labels": {
 				Type:             schema.TypeMap,
 				Optional:         true,
 				DiffSuppressFunc: resourceDataflowJobLabelDiffSuppress,
-				ForceNew: true,
+				ForceNew:         true,
 			},
 
 			"parameters": {
@@ -99,10 +103,12 @@ func resourceDataflowFlexTemplateJobCreate(d *schema.ResourceData, meta interfac
 			Parameters:           expandStringMap(d, "parameters"),
 		},
 	}
+
 	response, err := config.clientDataflow.Projects.Locations.FlexTemplates.Launch(project, region, &request).Do()
 	if err != nil {
 		return err
 	}
+
 	job := response.Job
 	d.SetId(job.Id)
 	d.Set("job_id", job.Id)
@@ -141,15 +147,91 @@ func resourceDataflowFlexTemplateJobRead(d *schema.ResourceData, meta interface{
 		d.SetId("")
 		return nil
 	}
-	d.SetId(job.Id)
-	d.Set("job_id", job.Id)
 
 	return nil
 }
 
-// resourceDataflowFlexTemplateJobUpdateByReplacement will be the method for updating Flex-Template jobs
-func resourceDataflowFlexTemplateJobUpdateByReplacement(d *schema.ResourceData, meta interface{}) error {
+// resourceDataflowFlexTemplateJobUpdate is a blank method to enable updating
+// the on_delete virtual field
+func resourceDataflowFlexTemplateJobUpdate(d *schema.ResourceData, meta interface{}) error {
 	return nil
+}
+
+func resourceDataflowFlexTemplateJobDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	id := d.Id()
+
+	requestedState, err := resourceDataflowJobMapRequestedState(d.Get("on_delete").(string))
+	if err != nil {
+		return err
+	}
+
+	// Retry updating the state while the job is not ready to be canceled/drained.
+	err = resource.Retry(time.Minute*time.Duration(15), func() *resource.RetryError {
+		// To terminate a dataflow job, we update the job with a requested
+		// terminal state.
+		job := &dataflow.Job{
+			RequestedState: requestedState,
+		}
+
+		_, updateErr := resourceDataflowJobUpdateJob(config, project, region, id, job)
+		if updateErr != nil {
+			gerr, isGoogleErr := updateErr.(*googleapi.Error)
+			if !isGoogleErr {
+				// If we have an error and it's not a google-specific error, we should go ahead and return.
+				return resource.NonRetryableError(updateErr)
+			}
+
+			if strings.Contains(gerr.Message, "not yet ready for canceling") {
+				// Retry cancelling job if it's not ready.
+				// Sleep to avoid hitting update quota with repeated attempts.
+				time.Sleep(5 * time.Second)
+				return resource.RetryableError(updateErr)
+			}
+
+			if strings.Contains(gerr.Message, "Job has terminated") {
+				// Job has already been terminated, skip.
+				return nil
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Wait for state to reach terminal state (canceled/drained/done)
+	_, ok := dataflowTerminalStatesMap[d.Get("state").(string)]
+	for !ok {
+		log.Printf("[DEBUG] Waiting for job with job state %q to terminate...", d.Get("state").(string))
+		time.Sleep(5 * time.Second)
+
+		err = resourceDataflowFlexTemplateJobRead(d, meta)
+		if err != nil {
+			return fmt.Errorf("Error while reading job to see if it was properly terminated: %v", err)
+		}
+		_, ok = dataflowTerminalStatesMap[d.Get("state").(string)]
+	}
+
+	// Only remove the job from state if it's actually successfully canceled.
+	if _, ok := dataflowTerminalStatesMap[d.Get("state").(string)]; ok {
+		log.Printf("[DEBUG] Removing dataflow job with final state %q", d.Get("state").(string))
+		d.SetId("")
+		return nil
+	}
+	return fmt.Errorf("Unable to cancel the dataflow job '%s' - final state was %q.", d.Id(), d.Get("state").(string))
 }
 
 <% end -%>

--- a/third_party/terraform/tests/resource_dataflow_flex_template_job_test.go.erb
+++ b/third_party/terraform/tests/resource_dataflow_flex_template_job_test.go.erb
@@ -1,0 +1,84 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataflowFlexTemplateJob_simple(t *testing.T) {
+	t.Parallel()
+
+	randStr := randString(t, 10)
+	bucket := "tf-test-dataflow-gcs-" + randStr
+	job := "tf-test-dataflow-job-" + randStr
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDataflowJobDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataflowFlowFlexTemplateJob_basic(bucket, job),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataflowJobExists(t, "google_dataflow_job.big_data"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataflowFlowFlexTemplateJob_basic(bucket, job string) string {
+	return fmt.Sprintf(`
+resource "google_storage_bucket" "temp" {
+  name = "%s"
+  force_destroy = true
+}
+
+resource "google_storage_bucket_object" "flex_template" {
+	name   = "flex_template.json"
+	bucket = "%s"
+	content = "%s"
+}
+
+resource "google_dataflow_flex_template_job" "big_data" {
+  name = "%s"
+  container_spec_gcs_path = "%s"
+  on_delete = "cancel"
+}
+`, bucket, bucket, flexTemplateContent(), bucket, job)
+}
+
+func flexTemplateContent() string {
+	return `
+<<EOF
+{
+	"name": "Streaming Beam SQL",
+	"description": "An Apache Beam streaming pipeline that reads JSON encoded messages from Pub/Sub, uses Beam SQL to transform the message data, and writes the results to a BigQuery",
+	"parameters": [
+		{
+		"name": "inputSubscription",
+		"label": "Pub/Sub input subscription.",
+		"helpText": "Pub/Sub subscription to read from.",
+		"regexes": [
+			"[-_.a-zA-Z0-9]+"
+		]
+		},
+		{
+		"name": "outputTable",
+		"label": "BigQuery output table",
+		"helpText": "BigQuery table spec to write to, in the form 'project:dataset.table'.",
+		"is_optional": true,
+		"regexes": [
+			"[^:]+:[^.]+[.].+"
+		]
+		}
+	]
+}
+EOF
+`
+}
+<% end -%>

--- a/third_party/terraform/tests/resource_dataflow_flex_template_job_test.go.erb
+++ b/third_party/terraform/tests/resource_dataflow_flex_template_job_test.go.erb
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 )
 
-func TestAccDataflowFlexTemplateJob_simple(t *testing.T) {
+func TestAccDataflowFlexTemplateJob_basic(t *testing.T) {
 	t.Parallel()
 
 	randStr := randString(t, 10)

--- a/third_party/terraform/tests/resource_dataflow_flex_template_job_test.go.erb
+++ b/third_party/terraform/tests/resource_dataflow_flex_template_job_test.go.erb
@@ -24,13 +24,14 @@ func TestAccDataflowFlexTemplateJob_simple(t *testing.T) {
 			{
 				Config: testAccDataflowFlowFlexTemplateJob_basic(bucket, job),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataflowJobExists(t, "google_dataflow_job.big_data"),
+					testAccDataflowJobExists(t, "google_dataflow_flex_template_job.big_data"),
 				),
 			},
 		},
 	})
 }
 
+// note: this config creates a job that doesn't actually do anything
 func testAccDataflowFlowFlexTemplateJob_basic(bucket, job string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "temp" {
@@ -40,45 +41,50 @@ resource "google_storage_bucket" "temp" {
 
 resource "google_storage_bucket_object" "flex_template" {
 	name   = "flex_template.json"
-	bucket = "%s"
-	content = "%s"
+	bucket = google_storage_bucket.temp.name
+	content = <<EOF
+{
+    "image": "my-image",
+    "metadata": {
+        "description": "An Apache Beam streaming pipeline that reads JSON encoded messages from Pub/Sub, uses Beam SQL to transform the message data, and writes the results to a BigQuery",
+        "name": "Streaming Beam SQL",
+        "parameters": [
+            {
+                "helpText": "Pub/Sub subscription to read from.",
+                "label": "Pub/Sub input subscription.",
+                "name": "inputSubscription",
+                "regexes": [
+                    "[-_.a-zA-Z0-9]+"
+                ]
+            },
+            {
+                "helpText": "BigQuery table spec to write to, in the form 'project:dataset.table'.",
+                "is_optional": true,
+                "label": "BigQuery output table",
+                "name": "outputTable",
+                "regexes": [
+                    "[^:]+:[^.]+[.].+"
+                ]
+            }
+        ]
+    },
+    "sdkInfo": {
+        "language": "JAVA"
+    }
+}
+EOF
 }
 
 resource "google_dataflow_flex_template_job" "big_data" {
   name = "%s"
-  container_spec_gcs_path = "%s"
+  container_spec_gcs_path = "${google_storage_bucket.temp.url}/${google_storage_bucket_object.flex_template.name}"
   on_delete = "cancel"
+  parameters = {
+    inputSubscription = "my-subscription"
+    outputTable  = "my-project:my-dataset.my-table"
+  }
 }
-`, bucket, bucket, flexTemplateContent(), bucket, job)
+`, bucket, job)
 }
 
-func flexTemplateContent() string {
-	return `
-<<EOF
-{
-	"name": "Streaming Beam SQL",
-	"description": "An Apache Beam streaming pipeline that reads JSON encoded messages from Pub/Sub, uses Beam SQL to transform the message data, and writes the results to a BigQuery",
-	"parameters": [
-		{
-		"name": "inputSubscription",
-		"label": "Pub/Sub input subscription.",
-		"helpText": "Pub/Sub subscription to read from.",
-		"regexes": [
-			"[-_.a-zA-Z0-9]+"
-		]
-		},
-		{
-		"name": "outputTable",
-		"label": "BigQuery output table",
-		"helpText": "BigQuery table spec to write to, in the form 'project:dataset.table'.",
-		"is_optional": true,
-		"regexes": [
-			"[^:]+:[^.]+[.].+"
-		]
-		}
-	]
-}
-EOF
-`
-}
 <% end -%>

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -326,6 +326,9 @@ end     # products.each do
 				"google_container_node_pool":                   resourceContainerNodePool(),
 				"google_container_registry":                    resourceContainerRegistry(),
 				"google_dataflow_job":                          resourceDataflowJob(),
+				<% unless version == 'ga' -%>
+				"google_dataflow_flex_template_job":            resourceDataflowFlexTemplateJob(), 
+				<% end -%>
 				"google_dataproc_cluster":                      resourceDataprocCluster(),
 				"google_dataproc_cluster_iam_binding":          ResourceIamBinding(IamDataprocClusterSchema, NewDataprocClusterUpdater, DataprocClusterIdParseFunc),
 				"google_dataproc_cluster_iam_member":           ResourceIamMember(IamDataprocClusterSchema, NewDataprocClusterUpdater, DataprocClusterIdParseFunc),

--- a/third_party/terraform/website/docs/r/dataflow_flex_template_job.html.markdown
+++ b/third_party/terraform/website/docs/r/dataflow_flex_template_job.html.markdown
@@ -1,0 +1,59 @@
+---
+subcategory: "Dataflow"
+layout: "google"
+page_title: "Google: google_dataflow_flex_template_job"
+sidebar_current: "docs-google-dataflow-flex-template-job"
+description: |-
+  Creates a job in Dataflow based on a Flex Template.
+---
+
+# google\_dataflow\_flex\_template\_job
+
+Creates a [Flex Template](https://cloud.google.com/dataflow/docs/guides/templates/using-flex-templates) job on Dataflow, which is an implementation of Apache Beam running on Google Compute Engine. For more information see
+the official documentation for
+[Beam](https://beam.apache.org) and [Dataflow](https://cloud.google.com/dataflow/).
+
+## Example Usage
+
+```hcl
+resource "google_dataflow_flex_template_job" "big_data_job" {
+  provider                = google-beta
+  name                    = "dataflow-flextemplates-job"
+  container_spec_gcs_path = "gs://my-bucket/templates/template.json"
+  parameters = {
+    inputSubscription = "messages"
+  }
+}
+```
+
+[ To Come ...]
+## Note on "destroy" / "apply"
+There are many types of Dataflow jobs.  Some Dataflow jobs run constantly, getting new data from (e.g.) a GCS bucket, and outputting data continuously.  Some jobs process a set amount of data then terminate.  All jobs can fail while running due to programming errors or other issues.  In this way, Dataflow jobs are different from most other Terraform / Google resources.
+
+The Dataflow resource is considered 'existing' while it is in a nonterminal state.  If it reaches a terminal state (e.g. 'FAILED', 'COMPLETE', 'CANCELLED'), it will be recreated on the next 'apply'.  This is as expected for jobs which run continuously, but may surprise users who use this resource for other kinds of Dataflow jobs.
+
+A Dataflow job which is 'destroyed' may be "cancelled" or "drained".  If "cancelled", the job terminates - any data written remains where it is, but no new data will be processed.  If "drained", no new data will enter the pipeline, but any data currently in the pipeline will finish being processed.  The default is "cancelled", but if a user sets `on_delete` to `"drain"` in the configuration, you may experience a long wait for your `terraform destroy` to complete.
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) A unique name for the resource, required by Dataflow.
+* `container_spec_gcs_path` - (Required) The GCS path to the Dataflow job Flex Template.
+
+- - -
+
+* `parameters` - (Optional) Key/Value pairs to be passed to the Dataflow job (as used in the template).
+* `labels` - (Optional) User labels to be specified for the job. Keys and values should follow the restrictions
+   specified in the [labeling restrictions](https://cloud.google.com/compute/docs/labeling-resources#restrictions) page.
+   **NOTE**: Google-provided Dataflow templates often provide default labels that begin with `goog-dataflow-provided`.
+   Unless explicitly set in config, these labels will be ignored to prevent diffs on re-apply. 
+* `on_delete` - (Optional) One of "drain" or "cancel".  Specifies behavior of deletion during `terraform destroy`.  See above note.
+* `project` - (Optional) The project in which the resource belongs. If it is not provided, the provider project is used.
+
+## Attributes Reference
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `job_id` - The unique ID of this job.
+* `type` - The type of this job, selected from the [JobType enum](https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.jobs#Job.JobType)
+* `state` - The current state of the resource, selected from the [JobState enum](https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.jobs#Job.JobState)

--- a/third_party/terraform/website/docs/r/dataflow_flex_template_job.html.markdown
+++ b/third_party/terraform/website/docs/r/dataflow_flex_template_job.html.markdown
@@ -27,7 +27,6 @@ resource "google_dataflow_flex_template_job" "big_data_job" {
 }
 ```
 
-[ To Come ...]
 ## Note on "destroy" / "apply"
 There are many types of Dataflow jobs.  Some Dataflow jobs run constantly,
 getting new data from (e.g.) a GCS bucket, and outputting data continuously. 

--- a/third_party/terraform/website/docs/r/dataflow_flex_template_job.html.markdown
+++ b/third_party/terraform/website/docs/r/dataflow_flex_template_job.html.markdown
@@ -9,9 +9,10 @@ description: |-
 
 # google\_dataflow\_flex\_template\_job
 
-Creates a [Flex Template](https://cloud.google.com/dataflow/docs/guides/templates/using-flex-templates) job on Dataflow, which is an implementation of Apache Beam running on Google Compute Engine. For more information see
-the official documentation for
-[Beam](https://beam.apache.org) and [Dataflow](https://cloud.google.com/dataflow/).
+Creates a [Flex Template](https://cloud.google.com/dataflow/docs/guides/templates/using-flex-templates)
+job on Dataflow, which is an implementation of Apache Beam running on Google
+Compute Engine. For more information see the official documentation for [Beam](https://beam.apache.org)
+and [Dataflow](https://cloud.google.com/dataflow/).
 
 ## Example Usage
 
@@ -28,32 +29,55 @@ resource "google_dataflow_flex_template_job" "big_data_job" {
 
 [ To Come ...]
 ## Note on "destroy" / "apply"
-There are many types of Dataflow jobs.  Some Dataflow jobs run constantly, getting new data from (e.g.) a GCS bucket, and outputting data continuously.  Some jobs process a set amount of data then terminate.  All jobs can fail while running due to programming errors or other issues.  In this way, Dataflow jobs are different from most other Terraform / Google resources.
+There are many types of Dataflow jobs.  Some Dataflow jobs run constantly,
+getting new data from (e.g.) a GCS bucket, and outputting data continuously. 
+Some jobs process a set amount of data then terminate. All jobs can fail while
+running due to programming errors or other issues. In this way, Dataflow jobs
+are different from most other Terraform / Google resources.
 
-The Dataflow resource is considered 'existing' while it is in a nonterminal state.  If it reaches a terminal state (e.g. 'FAILED', 'COMPLETE', 'CANCELLED'), it will be recreated on the next 'apply'.  This is as expected for jobs which run continuously, but may surprise users who use this resource for other kinds of Dataflow jobs.
+The Dataflow resource is considered 'existing' while it is in a nonterminal
+state.  If it reaches a terminal state (e.g. 'FAILED', 'COMPLETE',
+'CANCELLED'), it will be recreated on the next 'apply'.  This is as expected for 
+jobs which run continuously, but may surprise users who use this resource for
+other kinds of Dataflow jobs.
 
-A Dataflow job which is 'destroyed' may be "cancelled" or "drained".  If "cancelled", the job terminates - any data written remains where it is, but no new data will be processed.  If "drained", no new data will enter the pipeline, but any data currently in the pipeline will finish being processed.  The default is "cancelled", but if a user sets `on_delete` to `"drain"` in the configuration, you may experience a long wait for your `terraform destroy` to complete.
+A Dataflow job which is 'destroyed' may be "cancelled" or "drained".  If
+"cancelled", the job terminates - any data written remains where it is, but no
+new data will be processed.  If "drained", no new data will enter the pipeline,
+but any data currently in the pipeline will finish being processed.  The default
+is "cancelled", but if a user sets `on_delete` to `"drain"` in the
+configuration, you may experience a long wait for your `terraform destroy` to
+complete.
 
 ## Argument Reference
 
 The following arguments are supported:
 
 * `name` - (Required) A unique name for the resource, required by Dataflow.
-* `container_spec_gcs_path` - (Required) The GCS path to the Dataflow job Flex Template.
+
+* `container_spec_gcs_path` - (Required) The GCS path to the Dataflow job Flex
+Template.
 
 - - -
 
-* `parameters` - (Optional) Key/Value pairs to be passed to the Dataflow job (as used in the template).
-* `labels` - (Optional) User labels to be specified for the job. Keys and values should follow the restrictions
-   specified in the [labeling restrictions](https://cloud.google.com/compute/docs/labeling-resources#restrictions) page.
-   **NOTE**: Google-provided Dataflow templates often provide default labels that begin with `goog-dataflow-provided`.
-   Unless explicitly set in config, these labels will be ignored to prevent diffs on re-apply. 
-* `on_delete` - (Optional) One of "drain" or "cancel".  Specifies behavior of deletion during `terraform destroy`.  See above note.
-* `project` - (Optional) The project in which the resource belongs. If it is not provided, the provider project is used.
+* `parameters` - (Optional) Key/Value pairs to be passed to the Dataflow job (as
+used in the template).
+
+* `labels` - (Optional) User labels to be specified for the job. Keys and values
+should follow the restrictions specified in the [labeling restrictions](https://cloud.google.com/compute/docs/labeling-resources#restrictions)
+page. **NOTE**: Google-provided Dataflow templates often provide default labels
+that begin with `goog-dataflow-provided`. Unless explicitly set in config, these
+labels will be ignored to prevent diffs on re-apply. 
+
+* `on_delete` - (Optional) One of "drain" or "cancel". Specifies behavior of
+deletion during `terraform destroy`.  See above note.
+
+* `project` - (Optional) The project in which the resource belongs. If it is not
+provided, the provider project is used.
 
 ## Attributes Reference
 In addition to the arguments listed above, the following computed attributes are exported:
 
 * `job_id` - The unique ID of this job.
-* `type` - The type of this job, selected from the [JobType enum](https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.jobs#Job.JobType)
+
 * `state` - The current state of the resource, selected from the [JobState enum](https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.jobs#Job.JobState)


### PR DESCRIPTION
Supersedes https://github.com/GoogleCloudPlatform/magic-modules/pull/3520, fixes https://github.com/terraform-providers/terraform-provider-google/issues/6656

I squashed the original PR into a single commit and overlayed on top to keep the commit count manageable. I got this to a passing test, but spent most of my time getting that inline template right- the example linked from the docs was broken and there was some manual work with `gcloud` involved with getting a properly formatted template. I don't believe we need to document that part- it's already covered by [Using Flex Templates](https://cloud.google.com/dataflow/docs/guides/templates/using-flex-templates).

I reviewed the original PR over a fairly long period of time and lost context several times throughout. A fresh look at most of the changes would be appreciated- most aren't mine, I made targeted changes to get this to a passing state.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_dataflow_flex_template_job`
```