### PR TITLE
Remove fingerprint check from Image test

### DIFF
--- a/third_party/terraform/tests/resource_compute_image_test.go
+++ b/third_party/terraform/tests/resource_compute_image_test.go
@@ -48,7 +48,6 @@ func TestAccComputeImage_update(t *testing.T) {
 						t, "google_compute_image.foobar", &image),
 					testAccCheckComputeImageContainsLabel(&image, "my-label", "my-label-value"),
 					testAccCheckComputeImageContainsLabel(&image, "empty-label", ""),
-					testAccCheckComputeImageHasComputedFingerprint(&image, "google_compute_image.foobar"),
 				),
 			},
 			{
@@ -59,7 +58,6 @@ func TestAccComputeImage_update(t *testing.T) {
 					testAccCheckComputeImageDoesNotContainLabel(&image, "my-label"),
 					testAccCheckComputeImageContainsLabel(&image, "empty-label", "oh-look-theres-a-label-now"),
 					testAccCheckComputeImageContainsLabel(&image, "new-field", "only-shows-up-when-updated"),
-					testAccCheckComputeImageHasComputedFingerprint(&image, "google_compute_image.foobar"),
 				),
 			},
 			{
@@ -232,28 +230,6 @@ func testAccCheckComputeImageDoesNotContainLabel(image *compute.Image, key strin
 	return func(s *terraform.State) error {
 		if v, ok := image.Labels[key]; ok {
 			return fmt.Errorf("Expected no label for key '%s' but found one with value '%s'", key, v)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckComputeImageHasComputedFingerprint(image *compute.Image, resource string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		// First ensure we actually have a fingerprint
-		if image.LabelFingerprint == "" {
-			return fmt.Errorf("No fingerprint set in API read result")
-		}
-
-		state := s.RootModule().Resources[resource]
-		if state == nil {
-			return fmt.Errorf("Unable to find resource named %s in resources", resource)
-		}
-
-		storedFingerprint := state.Primary.Attributes["label_fingerprint"]
-		if storedFingerprint != image.LabelFingerprint {
-			return fmt.Errorf("Stored fingerprint doesn't match fingerprint found on server; stored '%s', server '%s'",
-				storedFingerprint, image.LabelFingerprint)
 		}
 
 		return nil


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```

This removes checking the Fingerprint from the TPG Image Test.
