### PR TITLE
Add nil check on bq destination array contents

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -3032,8 +3032,9 @@ func expandResourceUsageExportConfig(configured interface{}) *containerBeta.Reso
 		ForceSendFields: []string{"EnableNetworkEgressMetering"},
 	}
 	if _, ok := resourceUsageConfig["bigquery_destination"]; ok {
-		if len(resourceUsageConfig["bigquery_destination"].([]interface{})) > 0 {
-			bigqueryDestination := resourceUsageConfig["bigquery_destination"].([]interface{})[0].(map[string]interface{})
+		destinationArr := resourceUsageConfig["bigquery_destination"].([]interface{})
+		if len(destinationArr) > 0 && destinationArr[0] != nil {
+			bigqueryDestination := destinationArr[0].(map[string]interface{})
 			if _, ok := bigqueryDestination["dataset_id"]; ok {
 				result.BigqueryDestination = &containerBeta.BigQueryDestination{
 					DatasetId: bigqueryDestination["dataset_id"].(string),


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/6814

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
`container`: Fixed a crash in `google_container_cluster` when `""` was specified for `resource_usage_export_config.bigquery_destination.dataset_id`.
```
