### PR TITLE
Upstream changes to google_compute_global_network_endpoint docs

### DIFF
--- a/templates/terraform/examples/global_network_endpoint.tf.erb
+++ b/templates/terraform/examples/global_network_endpoint.tf.erb
@@ -1,18 +1,13 @@
 resource "google_compute_global_network_endpoint" "<%= ctx[:primary_resource_id] %>" {
-  global_network_endpoint_group = google_compute_network_endpoint_group.neg.name
+  global_network_endpoint_group = google_compute_global_network_endpoint_group.neg.name
 
   fqdn       = "www.example.com"
-  port       = google_compute_network_endpoint_group.neg.default_port
-  ip_address = google_compute_instance.endpoint-instance.network_interface[0].network_ip
+  port       = 90
+  ip_address = "8.8.8.8"
 }
 
-resource "google_compute_global_network_endpoint_group" "group" {
-  name         = "<%= ctx[:vars]['neg_name'] %>"
-  network      = google_compute_network.default.id
-  default_port = "90"
-}
-
-resource "google_compute_network" "default" {
-  name                    = "<%= ctx[:vars]['network_name'] %>"
-  auto_create_subnetworks = false
+resource "google_compute_global_network_endpoint_group" "neg" {
+  name                  = "<%= ctx[:vars]['neg_name'] %>"
+  default_port          = "90"
+  network_endpoint_type = "INTERNET_IP_PORT"
 }


### PR DESCRIPTION
Upstream https://github.com/terraform-providers/terraform-provider-google/pull/6827, also make some minor changes so they resemble the real configs in our tests more closely.

`skip_test` is applied here due to the `CheckDestroy` not working correctly for FGRs.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
