### PR TITLE
remove a confusing form of dataset id in a doc

### DIFF
--- a/third_party/terraform/website/docs/r/bigquery_dataset_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/bigquery_dataset_iam.html.markdown
@@ -27,7 +27,7 @@ These resources are intended to convert the permissions system for BigQuery data
 
 ~> **Note:** `google_bigquery_dataset_iam_binding` resources **can be** used in conjunction with `google_bigquery_dataset_iam_member` resources **only if** they do not grant privilege to the same role.
 
-## google\bigquery\_dataset\_iam\_policy
+## google\_bigquery\_dataset\_iam\_policy
 
 ```hcl
 data "google_iam_policy" "owner" {
@@ -73,7 +73,7 @@ resource "google_bigquery_dataset_iam_member" "editor" {
 
 The following arguments are supported:
 
-* `dataset_id` - (Required) The dataset ID, in the form `projects/{project}/datasets/{dataset_id}`
+* `dataset_id` - (Required) The dataset ID.
 
 * `member/members` - (Required) Identities that will be granted the privilege in `role`.
   Each entry can have one of the following values:


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6843

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
