### PR TITLE
add firewall logging controls

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -3085,13 +3085,6 @@ objects:
           not enforced and the network behaves as if it did not exist. If this
           is unspecified, the firewall rule will be enabled.
         send_empty_value: true
-      - !ruby/object:Api::Type::Boolean
-        name: 'enableLogging'
-        deprecation_message: 'Deprecated in favor of enable in LogConfig'
-        description: |
-          This field denotes whether to enable logging for a particular
-          firewall rule. If logging is enabled, logs will be exported to
-          Stackdriver.
       - !ruby/object:Api::Type::NestedObject
         name: 'logConfig'
         description: |

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -3085,20 +3085,32 @@ objects:
           not enforced and the network behaves as if it did not exist. If this
           is unspecified, the firewall rule will be enabled.
         send_empty_value: true
-      - !ruby/object:Api::Type::NestedObject
-        name: 'logConfig'
+      - !ruby/object:Api::Type::Boolean
+        name: 'enableLogging'
+        deprecation_message: 'Deprecated in favor of enable in LogConfig'
         description: |
           This field denotes whether to enable logging for a particular
           firewall rule. If logging is enabled, logs will be exported to
           Stackdriver.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'logConfig'
+        description: |
+          This field denotes the logging options for a particular firewall rule.
+          If logging is enabled, logs will be exported to Cloud Logging.
         properties:
           - !ruby/object:Api::Type::Boolean
-            name: 'enableLogging'
-            api_name: enable
+            name: 'enable'
             description: |
               This field denotes whether to enable logging for a particular
               firewall rule. If logging is enabled, logs will be exported to
               Stackdriver.
+          - !ruby/object:Api::Type::Enum
+            name: 'metadata'
+            description: |
+              This field denotes whether to include or exclude metadata for firewall logs.
+            values:
+              - :EXCLUDE_ALL_METADATA
+              - :INCLUDE_ALL_METADATA
       - !ruby/object:Api::Type::Integer
         name: 'id'
         description: 'The unique identifier for the resource.'

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -502,6 +502,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   DiskType: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true
   Firewall: !ruby/object:Overrides::Terraform::ResourceOverride
+    docs: !ruby/object:Provider::Terraform::Docs
+      optional_properties: |+
+        * `enable_logging` - (Optional, Deprecated) This field denotes whether to enable logging for a particular firewall rule.
+        If logging is enabled, logs will be exported to Stackdriver. Deprecated in favor of `log_config`
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "firewall_basic"

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -539,10 +539,24 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         # being ingress to egress without examining the diff carefully.
         # See terraform issue #2713 for more context.
         input: true
+      enableLogging: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+        deprecation_message: 'Deprecated in favor of LogConfig'
+        description: |
+          This field denotes whether to enable logging for a particular
+          firewall rule. If logging is enabled, logs will be exported to
+          Stackdriver.
       logConfig: !ruby/object:Overrides::Terraform::PropertyOverride
-        flatten_object: true
-      logConfig.enableLogging: !ruby/object:Overrides::Terraform::PropertyOverride
+        description: |
+          This field denotes the logging options for a particular firewall rule.
+          If defined, logging is enabled, and logs will be exported to Cloud Logging.
         send_empty_value: true
+        custom_expand: 'templates/terraform/custom_expand/firewall_log_config.go.erb'
+        custom_flatten: 'templates/terraform/custom_flatten/firewall_log_config.go.erb'
+      logConfig.enable: !ruby/object:Overrides::Terraform::PropertyOverride
+        exclude: true
+      logConfig.metadata: !ruby/object:Overrides::Terraform::PropertyOverride
+        required: true
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateGCPName'

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -512,6 +512,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/firewall.erb
       resource_definition: templates/terraform/resource_definition/firewall.erb
+      extra_schema_entry: templates/terraform/extra_schema_entry/firewall.erb
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
@@ -539,13 +540,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         # being ingress to egress without examining the diff carefully.
         # See terraform issue #2713 for more context.
         input: true
-      enableLogging: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
-        deprecation_message: 'Deprecated in favor of LogConfig'
-        description: |
-          This field denotes whether to enable logging for a particular
-          firewall rule. If logging is enabled, logs will be exported to
-          Stackdriver.
       logConfig: !ruby/object:Overrides::Terraform::PropertyOverride
         description: |
           This field denotes the logging options for a particular firewall rule.
@@ -553,6 +547,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         send_empty_value: true
         custom_expand: 'templates/terraform/custom_expand/firewall_log_config.go.erb'
         custom_flatten: 'templates/terraform/custom_flatten/firewall_log_config.go.erb'
+        diff_suppress_func: 'diffSuppressEnableLogging'
       logConfig.enable: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
       logConfig.metadata: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/templates/terraform/constants/firewall.erb
+++ b/templates/terraform/constants/firewall.erb
@@ -34,3 +34,27 @@ func resourceComputeFirewallRuleHash(v interface{}) int {
 func compareCaseInsensitive(k, old, new string, d *schema.ResourceData) bool {
 	return strings.ToLower(old) == strings.ToLower(new)
 }
+
+func diffSuppressEnableLogging(k, old, new string, d *schema.ResourceData) bool {
+	if k == "log_config.#" {
+		if new == "0" && d.Get("enable_logging").(bool) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func resourceComputeFirewallEnableLoggingCustomizeDiff(diff *schema.ResourceDiff, v interface{}) error {
+	enableLogging, enableExists := diff.GetOkExists("enable_logging")
+	if !enableExists {
+		return nil
+	}
+
+	logConfigExists := diff.Get("log_config.#").(int) != 0
+	if logConfigExists && enableLogging == false {
+		return fmt.Errorf("log_config cannot be defined when enable_logging is false")
+	}
+
+	return nil
+}

--- a/templates/terraform/custom_expand/firewall_log_config.go.erb
+++ b/templates/terraform/custom_expand/firewall_log_config.go.erb
@@ -15,9 +15,14 @@
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
 	l := v.([]interface{})
 	transformed := make(map[string]interface{})
-	if len(l) == 0 || l[0] == nil {
+
+	if d.Get("enable_logging").(bool) != true {
 		// send enable = false to ensure logging is disabled if there is no config
 		transformed["enable"] = false
+		return transformed, nil
+	} else if len(l) == 0 || l[0] == nil {
+		// send enable = true to ensure logging is enabled if there is no config, but enable_logging = true
+		transformed["enable"] = true
 		return transformed, nil
 	}
 

--- a/templates/terraform/custom_expand/firewall_log_config.go.erb
+++ b/templates/terraform/custom_expand/firewall_log_config.go.erb
@@ -1,0 +1,32 @@
+<%- # the license inside this block applies to this file
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	l := v.([]interface{})
+	transformed := make(map[string]interface{})
+	if len(l) == 0 || l[0] == nil {
+		// send enable = false to ensure logging is disabled if there is no config
+		transformed["enable"] = false
+		return transformed, nil
+	}
+
+	raw := l[0]
+	original := raw.(map[string]interface{})
+
+	// The log_config block is specified, so logging should be enabled
+	transformed["enable"] = true
+	transformed["metadata"] = original["metadata"]
+
+	return transformed, nil
+}

--- a/templates/terraform/custom_expand/firewall_log_config.go.erb
+++ b/templates/terraform/custom_expand/firewall_log_config.go.erb
@@ -16,13 +16,9 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d T
 	l := v.([]interface{})
 	transformed := make(map[string]interface{})
 
-	if d.Get("enable_logging").(bool) != true {
-		// send enable = false to ensure logging is disabled if there is no config
-		transformed["enable"] = false
-		return transformed, nil
-	} else if len(l) == 0 || l[0] == nil {
-		// send enable = true to ensure logging is enabled if there is no config, but enable_logging = true
-		transformed["enable"] = true
+	if len(l) == 0 || l[0] == nil {
+		// send enable = enable_logging value to ensure correct logging status if there is no config
+		transformed["enable"] = d.Get("enable_logging").(bool)
 		return transformed, nil
 	}
 

--- a/templates/terraform/custom_flatten/firewall_log_config.go.erb
+++ b/templates/terraform/custom_flatten/firewall_log_config.go.erb
@@ -1,0 +1,32 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	if v == nil {
+		return nil
+	}
+	original := v.(map[string]interface{})
+	if len(original) == 0 {
+		return nil
+	}
+
+	v, ok := original["enable"]
+	if ok && !v.(bool) {
+		return nil
+	}
+
+	transformed := make(map[string]interface{})
+	transformed["metadata"] = original["metadata"]
+	return []interface{}{transformed}
+}

--- a/templates/terraform/extra_schema_entry/firewall.erb
+++ b/templates/terraform/extra_schema_entry/firewall.erb
@@ -1,5 +1,5 @@
 <%# The license inside this block applies to this file.
-	# Copyright 2017 Google Inc.
+	# Copyright 2020 Google Inc.
 	# Licensed under the Apache License, Version 2.0 (the "License");
 	# you may not use this file except in compliance with the License.
 	# You may obtain a copy of the License at
@@ -12,6 +12,10 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
-SchemaVersion: 1,
-MigrateState:  resourceComputeFirewallMigrateState,
-CustomizeDiff: resourceComputeFirewallEnableLoggingCustomizeDiff,
+"enable_logging": {
+	Type:       schema.TypeBool,
+	Optional:   true,
+	Computed:   true,
+	Deprecated: "Deprecated in favor of log_config",
+	Description: "This field denotes whether to enable logging for a particular firewall rule. If logging is enabled, logs will be exported to Stackdriver.",
+},

--- a/third_party/terraform/tests/resource_compute_firewall_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_firewall_test.go.erb
@@ -208,7 +208,7 @@ func TestAccComputeFirewall_enableLogging(t *testing.T) {
 		CheckDestroy: testAccCheckComputeFirewallDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeFirewall_enableLogging(networkName, firewallName, false),
+				Config: testAccComputeFirewall_enableLogging(networkName, firewallName, ""),
 			},
 			{
 				ResourceName:      "google_compute_firewall.foobar",
@@ -216,7 +216,7 @@ func TestAccComputeFirewall_enableLogging(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeFirewall_enableLogging(networkName, firewallName, true),
+				Config: testAccComputeFirewall_enableLogging(networkName, firewallName, "INCLUDE_ALL_METADATA"),
 			},
 			{
 				ResourceName:      "google_compute_firewall.foobar",
@@ -224,7 +224,15 @@ func TestAccComputeFirewall_enableLogging(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeFirewall_enableLogging(networkName, firewallName, false),
+				Config: testAccComputeFirewall_enableLogging(networkName, firewallName, "EXCLUDE_ALL_METADATA"),
+			},
+			{
+				ResourceName:      "google_compute_firewall.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeFirewall_enableLogging(networkName, firewallName, ""),
 			},
 			{
 				ResourceName:      "google_compute_firewall.foobar",
@@ -412,10 +420,13 @@ resource "google_compute_firewall" "foobar" {
 `, network, firewall)
 }
 
-func testAccComputeFirewall_enableLogging(network, firewall string, enableLogging bool) string {
+func testAccComputeFirewall_enableLogging(network, firewall, logging string) string {
 	enableLoggingCfg := ""
-	if enableLogging {
-		enableLoggingCfg = "enable_logging= true"
+	if logging != "" {
+		enableLoggingCfg = fmt.Sprintf(`log_config {
+		  metadata = "%s"
+		}
+		`, logging)
 	}
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6596

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `logConfig.metadata` to `google_compute_firewall`, defining this will enable logging.
```

```release-note:deprecation
compute: deprecated `enableLogging` on `google_compute_firewall`, define `logConfig.metadata` to enable logging instead.
```