### PR TITLE
Add error checking to location load in endpoints service

### DIFF
--- a/third_party/terraform/resources/resource_endpoints_service.go
+++ b/third_party/terraform/resources/resource_endpoints_service.go
@@ -153,7 +153,11 @@ func predictServiceId(d *schema.ResourceDiff, meta interface{}) error {
 	if !d.HasChange("openapi_config") && !d.HasChange("grpc_config") && !d.HasChange("protoc_output_base64") {
 		return nil
 	}
-	loc, _ := time.LoadLocation("America/Los_Angeles")
+	loc, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		// Timezone data may not be present on some machines, in that case skip
+		return nil
+	}
 	baseDate := time.Now().In(loc).Format("2006-01-02")
 	oldConfigId := d.Get("config_id").(string)
 	if match, err := regexp.MatchString(`\d\d\d\d-\d\d-\d\dr\d*`, oldConfigId); !match || err != nil {


### PR DESCRIPTION
Fixes: https://github.com/terraform-providers/terraform-provider-google/issues/6840

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
endpoints: Fixed a crash when `google_endpoints_service` is used on a machine without timezone data
```
