### PR TITLE
Fix collapsed markdown for enum values on Terraform website

### DIFF
--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -15,16 +15,10 @@
 <% end -%>
 <%= indent(property.description.strip.gsub("\n\n", "\n"), 2) -%>
 <% if property.is_a?(Api::Type::Enum) && !property.output && !property.skip_docs_values -%>
-
-
 <% unless property.default_value.nil? || property.default_value == "" -%>
-  Default value: `<%= property.default_value %>`
-
+  Default value is `<%= property.default_value %>`.
 <% end -%>
-  Possible values are:
-<% property.values.select { |v| v != "" }.each do |v| -%>
-  * `<%= v %>`
-<% end -%>
+  Possible values are <%= property.values.select { |v| v != "" }.map { |v| "`#{v}`" }.to_sentence %>.
 <% end -%>
 <% if property.sensitive -%>
   **Note**: This property is sensitive and will not be displayed in the plan.

--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -13,7 +13,7 @@
   (Optional<% if property.deprecated? -%>, Deprecated<% end -%>)
 <%   end -%>
 <% end -%>
-<%= indent(property.description.strip.gsub("\n\n", "\n"), 2) -%>
+<%= indent(property.description.strip.gsub("\n\n", "\n"), 2) %>
 <% if property.is_a?(Api::Type::Enum) && !property.output && !property.skip_docs_values -%>
 <% unless property.default_value.nil? || property.default_value == "" -%>
   Default value is `<%= property.default_value %>`.


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Fix markdown for enum values
```

I fixed a collapsed markdown for enum values on the Terraform website.

Current docs are like the following:

![Screenshot from 2020-07-25 14-22-56](https://user-images.githubusercontent.com/1286807/88449509-67288300-ce82-11ea-9c3b-b2176f6aac4e.png)

https://www.terraform.io/docs/providers/google/r/dns_managed_zone.html#visibility


Sample diff made by this PR:

```diff
diff --git a/website/docs/r/app_engine_domain_mapping.html.markdown b/website/docs/r/app_engine_domain_mapping.html.markdown
index 14b8bad2..4146a26a 100644
--- a/website/docs/r/app_engine_domain_mapping.html.markdown
+++ b/website/docs/r/app_engine_domain_mapping.html.markdown
@@ -64,18 +64,15 @@ The following arguments are supported:
 
 * `ssl_settings` -
   (Optional)
-  SSL configuration for this domain. If unconfigured, this domain will not serve with SSL.  Structure is documented below.
+  SSL configuration for this domain. If unconfigured, this domain will not serve with SSL.
+  Structure is documented below.
 
 * `override_strategy` -
   (Optional)
   Whether the domain creation should override any existing mappings for this domain.
   By default, overrides are rejected.
-
-  Default value: `STRICT`
-
-  Possible values are:
-  * `STRICT`
-  * `OVERRIDE`
+  Default value is `STRICT`.
+  Possible values are `STRICT` and `OVERRIDE`.
 
 * `project` - (Optional) The ID of the project in which the resource belongs.
     If it is not provided, the provider project is used.
```