### PR TITLE
Make defaultClientScopes publicly accessible

### DIFF
--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -194,7 +194,7 @@ type Config struct {
 var <%= product[:definitions].name -%>DefaultBasePath = "<%= product[:definitions].base_url -%>"
 <% end -%>
 
-var defaultClientScopes = []string{
+var DefaultClientScopes = []string{
 	"https://www.googleapis.com/auth/compute",
 	"https://www.googleapis.com/auth/cloud-platform",
 	"https://www.googleapis.com/auth/cloud-identity",
@@ -205,7 +205,7 @@ var defaultClientScopes = []string{
 
 func (c *Config) LoadAndValidate(ctx context.Context) error {
 	if len(c.Scopes) == 0 {
-		c.Scopes = defaultClientScopes
+		c.Scopes = DefaultClientScopes
 	}
 
 	tokenSource, err := c.getTokenSource(c.Scopes)


### PR DESCRIPTION
This patch makes the `defaultClientScopes` variable publicly accessible
to allow for code that depends on the provider to have the ability to
programmatically determine the default OAuth2 scopes used by the
provider, and to add to it if necessary.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
