### PR TITLE
Fix bug: diff being detected for source_repo_repository even when there are no changes

### DIFF
--- a/products/sourcerepo/terraform.yaml
+++ b/products/sourcerepo/terraform.yaml
@@ -49,9 +49,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           A Cloud Pub/Sub topic in this repo's project. Values are of the form
           `projects/<project>/topics/<topic>` or `<topic>` (where the topic will
           be inferred).
+        set_hash_func: 'resourceSourceRepoRepositoryPubSubConfigsHash'
       pubsubConfigs.serviceAccountEmail: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
+      constants: templates/terraform/constants/source_repo_repository.go.erb
       update_encoder: templates/terraform/update_encoder/source_repo_repository.erb
       post_create: templates/terraform/post_create/source_repo_repository_update.go.erb
 # This is for copying files over

--- a/templates/terraform/constants/source_repo_repository.go.erb
+++ b/templates/terraform/constants/source_repo_repository.go.erb
@@ -1,0 +1,30 @@
+<%- # the license inside this block applies to this file
+        # Copyright 2019 Google Inc.
+        # Licensed under the Apache License, Version 2.0 (the "License");
+        # you may not use this file except in compliance with the License.
+        # You may obtain a copy of the License at
+        #
+        #     http://www.apache.org/licenses/LICENSE-2.0
+        #
+        # Unless required by applicable law or agreed to in writing, software
+        # distributed under the License is distributed on an "AS IS" BASIS,
+        # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        # See the License for the specific language governing permissions and
+        # limitations under the License.
+-%>
+func resourceSourceRepoRepositoryPubSubConfigsHash(v interface{}) int {
+        if v == nil {
+                return 0
+        }
+
+        var buf bytes.Buffer
+        m := v.(map[string]interface{})
+
+        buf.WriteString(fmt.Sprintf("%s-", GetResourceNameFromSelfLink(m["topic"].(string))))
+        buf.WriteString(fmt.Sprintf("%s-", m["message_format"].(string)))
+        if v, ok := m["service_account_email"]; ok {
+                buf.WriteString(fmt.Sprintf("%s-", v.(string)))
+        }
+
+        return hashcode.String(buf.String())
+}


### PR DESCRIPTION
This patch fixes a bug in source_repo_repository where a diff was always being generated for the TypeSet field `pubsub_configs` since its Set hashing function was not accounting for the fact that `pubsub_configs[].topic` can contain either a topic's name or relative path.

To reproduce, apply the following Terraform configuration, then run `terraform plan` right after. Notice how `terraform plan` detects a diff even when nothing was actually changed.

```hcl
provider "google" {
  project = "my-project-test"
}

resource "google_pubsub_topic" "topic" {
  name = "my-topic-test"
}

resource "google_sourcerepo_repository" "repo" {
  name             = "my-repo-test"
  pubsub_configs {
    topic           = google_pubsub_topic.topic.name
    message_format  = "JSON"
  }
}
```

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
sourcerepo: fixed perma-diff in `google_sourcerepo_repository`
```
