### PR TITLE
Use proper prefix inside router_interface test

### DIFF
--- a/third_party/terraform/tests/resource_compute_router_interface_test.go
+++ b/third_party/terraform/tests/resource_compute_router_interface_test.go
@@ -256,7 +256,7 @@ resource "google_compute_network" "foobar" {
 }
 
 resource "google_compute_subnetwork" "foobar" {
-  name          = "router-interface-test-subnetwork-%s"
+  name          = "tf-test-router-interface-subnetwork-%s"
   network       = google_compute_network.foobar.self_link
   ip_cidr_range = "10.0.0.0/16"
   region        = "us-central1"
@@ -317,7 +317,7 @@ resource "google_compute_network" "foobar" {
 }
 
 resource "google_compute_subnetwork" "foobar" {
-  name          = "router-interface-test-subnetwork-%s"
+  name          = "tf-test-router-interface-subnetwork-%s"
   network       = google_compute_network.foobar.self_link
   ip_cidr_range = "10.0.0.0/16"
   region        = "us-central1"


### PR DESCRIPTION
This left a couple subnetworks floating around (which ends up leaving networks and ultimately routes)

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
