### PR TITLE
Fix colon in doc notes

### DIFF
--- a/products/cloudscheduler/api.yaml
+++ b/products/cloudscheduler/api.yaml
@@ -180,7 +180,7 @@ objects:
             name: topicName
             description: |
               The full resource name for the Cloud Pub/Sub topic to which
-              messages will be published when a job is delivered. ~>**NOTE**:
+              messages will be published when a job is delivered. ~>**NOTE:**
               The topic name must be in the same format as required by PubSub's
               PublishRequest.name, e.g. `projects/my-project/topics/my-topic`.
             required: true

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -652,7 +652,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           internal IP address will be automatically allocated from the IP range
           of the subnet or network configured for this forwarding rule.
 
-          An address must be specified by a literal IP address. ~> **NOTE**: While
+          An address must be specified by a literal IP address. ~> **NOTE:** While
           the API allows you to specify various resource paths for an address resource
           instead, Terraform requires this to specifically be an IP address to
           avoid needing to fetching the IP address from resource paths on refresh

--- a/products/deploymentmanager/terraform.yaml
+++ b/products/deploymentmanager/terraform.yaml
@@ -53,7 +53,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       preview: !ruby/object:Overrides::Terraform::PropertyOverride
         description: |
-          {{description}} ~>**NOTE**: Deployment Manager does not allow update
+          {{description}} ~>**NOTE:** Deployment Manager does not allow update
           of a deployment in preview (unless updating to preview=false). Thus,
           Terraform will force-recreate deployments if either preview is updated
           to true or if other fields are updated while preview is true.

--- a/products/kms/terraform.yaml
+++ b/products/kms/terraform.yaml
@@ -136,7 +136,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     description: |
       {{description}}
 
-      ~> **NOTE**: Using this resource will allow you to conceal secret data within your
+      ~> **NOTE:** Using this resource will allow you to conceal secret data within your
       resource definitions, but it does not take care of protecting that data in the
       logging output, plan output, or state output.  Please take care to secure your secret
       data outside of resource definitions.

--- a/third_party/terraform/website/docs/d/kms_secret.html.markdown
+++ b/third_party/terraform/website/docs/d/kms_secret.html.markdown
@@ -15,7 +15,7 @@ within your resource definitions.
 For more information see
 [the official documentation](https://cloud.google.com/kms/docs/encrypt-decrypt).
 
-~> **NOTE**: Using this data provider will allow you to conceal secret data within your
+~> **NOTE:** Using this data provider will allow you to conceal secret data within your
 resource definitions, but it does not take care of protecting that data in the
 logging output, plan output, or state output.  Please take care to secure your secret
 data outside of resource definitions.

--- a/third_party/terraform/website/docs/d/kms_secret_ciphertext.html.markdown
+++ b/third_party/terraform/website/docs/d/kms_secret_ciphertext.html.markdown
@@ -17,7 +17,7 @@ ciphertext within your resource definitions.
 For more information see
 [the official documentation](https://cloud.google.com/kms/docs/encrypt-decrypt).
 
-~> **NOTE**: Using this data source will allow you to conceal secret data within your
+~> **NOTE:** Using this data source will allow you to conceal secret data within your
 resource definitions, but it does not take care of protecting that data in the
 logging output, plan output, or state output.  Please take care to secure your secret
 data outside of resource definitions.

--- a/third_party/terraform/website/docs/guides/provider_reference.html.markdown
+++ b/third_party/terraform/website/docs/guides/provider_reference.html.markdown
@@ -115,7 +115,7 @@ Values are expected to include the version of the service, such as
 `https://www.googleapis.com/compute/v1/`.
 
 * `batching` - (Optional) This block controls batching GCP calls for groups of specific resource types. Structure is documented below.
-~>**NOTE**: Batching is not implemented for the majority or resources/request types and is bounded by two values. If you are running into issues with slow batches
+~>**NOTE:** Batching is not implemented for the majority or resources/request types and is bounded by two values. If you are running into issues with slow batches
 resources, you may need to adjust one or both of 1) the core [`-parallelism`](https://www.terraform.io/docs/commands/apply.html#parallelism-n) flag, which controls how many concurrent resources are being operated on and 2) `send_after`, the time interval after which a batch is sent.
 
 * `request_timeout` - (Optional) A duration string controlling the amount of time

--- a/third_party/terraform/website/docs/r/app_engine_application.html.markdown
+++ b/third_party/terraform/website/docs/r/app_engine_application.html.markdown
@@ -39,7 +39,7 @@ resource "google_app_engine_application" "app" {
 The following arguments are supported:
 
 * `project` - (Required) The project ID to create the application under.
-   ~>**NOTE**: GCP only accepts project ID, not project number. If you are using number,
+   ~>**NOTE:** GCP only accepts project ID, not project number. If you are using number,
    you may get a "Permission denied" error.
 
 * `location_id` - (Required) The [location](https://cloud.google.com/appengine/docs/locations)

--- a/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -113,7 +113,7 @@ The following arguments are supported:
 * `labels` - (Optional) A mapping of labels to assign to the resource.
 
 * `schema` - (Optional) A JSON schema for the table.
-    ~>**NOTE**: Because this field expects a JSON string, any changes to the
+    ~>**NOTE:** Because this field expects a JSON string, any changes to the
     string will create a diff, even if the JSON itself hasn't changed.
     If the API returns a different value for the same schema, e.g. it
     switched the order of values or replaced `STRUCT` field type with `RECORD`
@@ -166,7 +166,7 @@ The `external_data_configuration` block supports:
 * `schema` - (Optional) A JSON schema for the external table. Schema is required
     for CSV and JSON formats if autodetect is not on. Schema is disallowed
     for Google Cloud Bigtable, Cloud Datastore backups, Avro, ORC and Parquet formats.
-    ~>**NOTE**: Because this field expects a JSON string, any changes to the
+    ~>**NOTE:** Because this field expects a JSON string, any changes to the
     string will create a diff, even if the JSON itself hasn't changed.
     Furthermore drift for this field cannot not be detected because BigQuery
     only uses this schema to compute the effective schema for the table, therefore

--- a/third_party/terraform/website/docs/r/bigtable_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_table.html.markdown
@@ -13,7 +13,7 @@ Creates a Google Cloud Bigtable table inside an instance. For more information s
 [the official documentation](https://cloud.google.com/bigtable/) and
 [API](https://cloud.google.com/bigtable/docs/go/reference).
 
--> **Note**: It is strongly recommended to set `lifecycle { prevent_destroy = true }`
+-> **Note:** It is strongly recommended to set `lifecycle { prevent_destroy = true }`
 on tables in order to prevent accidental data loss. See
 [Terraform docs](https://www.terraform.io/docs/configuration/resources.html#prevent_destroy)
 for more information on lifecycle parameters.

--- a/third_party/terraform/website/docs/r/spanner_database_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/spanner_database_iam.html.markdown
@@ -126,6 +126,6 @@ IAM policy imports use the identifier of the resource in question, e.g.
 $ terraform import google_spanner_database_iam_policy.database project-name/instance-name/database-name
 ```
 
--> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
+-> **Custom Roles:** If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.
 

--- a/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -122,7 +122,7 @@ resource "google_sql_database_instance" "postgres" {
 ```
 
 ### Private IP Instance
-~> **NOTE**: For private IP instance setup, note that the `google_sql_database_instance` does not actually interpolate values from `google_service_networking_connection`. You must explicitly add a `depends_on`reference as shown below.
+~> **NOTE:** For private IP instance setup, note that the `google_sql_database_instance` does not actually interpolate values from `google_service_networking_connection`. You must explicitly add a `depends_on`reference as shown below.
 
 ```hcl
 resource "google_compute_network" "private_network" {


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

Fix various notes that end up putting the colon after the header like here: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_secret_ciphertext

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
