### PR TITLE
Discourage users to manage schema via terraform

### DIFF
--- a/products/spanner/api.yaml
+++ b/products/spanner/api.yaml
@@ -173,6 +173,9 @@ objects:
           database. Statements can create tables, indexes, etc. These statements
           execute atomically with the creation of the database: if there is an
           error in any statement, the database is not created.
+          Once a database is created, changes to this list cannot be used to
+          migrate the schema in the existing database. We recommend users to
+          rely on schema management tools instead of using this option.
         input: true
       - !ruby/object:Api::Type::Enum
         name: 'state'

--- a/products/spanner/terraform.yaml
+++ b/products/spanner/terraform.yaml
@@ -33,7 +33,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           database_name: "my-database"
       - !ruby/object:Provider::Terraform::Examples
         name: "legacy_spanner_database_ddl"
-        primary_resource_id: "database-ddl"
+        primary_resource_id: "database"
         skip_vcr: true
         vars:
           database_name: "my-database-dll"

--- a/products/spanner/terraform.yaml
+++ b/products/spanner/terraform.yaml
@@ -31,6 +31,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         skip_vcr: true
         vars:
           database_name: "my-database"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "legacy_spanner_database_ddl"
+        primary_resource_id: "database-ddl"
+        skip_vcr: true
+        vars:
+          database_name: "my-database-dll"
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation

--- a/templates/terraform/examples/legacy_spanner_database_ddl.erb
+++ b/templates/terraform/examples/legacy_spanner_database_ddl.erb
@@ -1,0 +1,13 @@
+resource "google_spanner_instance" "main" {
+  config       = "regional-europe-west1"
+  display_name = "main-instance"
+}
+
+resource "google_spanner_database" "database" {
+  instance = google_spanner_instance.main.name
+  name     = "<%= ctx[:vars]['database_name'] %>"
+  ddl = [
+    "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
+    "CREATE TABLE t2 (t2 INT64 NOT NULL,) PRIMARY KEY(t2)",
+  ]
+}

--- a/templates/terraform/examples/spanner_database_basic.tf.erb
+++ b/templates/terraform/examples/spanner_database_basic.tf.erb
@@ -6,8 +6,4 @@ resource "google_spanner_instance" "main" {
 resource "google_spanner_database" "database" {
   instance = google_spanner_instance.main.name
   name     = "<%= ctx[:vars]['database_name'] %>"
-  ddl = [
-    "CREATE TABLE t1 (t1 INT64 NOT NULL,) PRIMARY KEY(t1)",
-    "CREATE TABLE t2 (t2 INT64 NOT NULL,) PRIMARY KEY(t2)",
-  ]
 }


### PR DESCRIPTION
Changes to schema causes Terraform to recreate a database
instead of migrating the schema in an existing database. This
may cause user to accidentally delete a database unless if they
are not paying attention to the plan.

On the other hand, provisioning and managing Cloud Spanner
resources are not in the same pipeline of delivering schema migration.
We expect users to rely on migration schema tools for this
purpose. We are removing the DDL from the example not to highlight
this capability and adding some notes to how to manage schema
to the description of the DDL field.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
