### PR TITLE
add source_image and source_snapshot to google_compute_image

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -5617,6 +5617,54 @@ objects:
           The ID value of the image used to create this image. This value may be used
           to determine whether the image was taken from the current or a previous
           instance of a given image name.
+      - !ruby/object:Api::Type::ResourceRef
+        name: 'sourceSnapshot'
+        description: |
+          URL of the source snapshot used to create this image.
+
+          In order to create an image, you must provide the full or partial URL of one of the following:
+
+          The selfLink URL
+          This property
+          The sourceImage URL
+          The rawDisk.source URL
+          The sourceDisk URL
+        resource: 'Snapshot'
+        imports: 'selfLink'
+      - !ruby/object:Api::Type::NestedObject
+        name: 'sourceSnapshotEncryptionKey'
+        description: |
+          The customer-supplied encryption key of the source snapshot. Required if
+          the source snapshot is protected by a customer-supplied encryption key.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'rawKey'
+            description: |
+              Specifies a 256-bit customer-supplied encryption key, encoded in
+              RFC 4648 base64 to either encrypt or decrypt this resource.
+          - !ruby/object:Api::Type::String
+            name: 'sha256'
+            description: |
+              The RFC 4648 base64 encoded SHA-256 hash of the
+              customer-supplied encryption key that protects this resource.
+            output: true
+          - !ruby/object:Api::Type::String
+            name: 'kmsKeyServiceAccount'
+            description: |
+              The service account being used for the encryption request for the given KMS key.
+              If absent, the Compute Engine default service account is used.
+            output: true
+          - !ruby/object:Api::Type::String
+            # TODO(chrisst) Change to ResourceRef once KMS is in Magic Modules
+            name: 'kmsKeyName'
+            description: |
+              The name of the encryption key that is stored in Google Cloud KMS.
+      - !ruby/object:Api::Type::String
+        name: 'sourceSnapshotId'
+        description: |
+          The ID value of the snapshot used to create this image. This value may be used
+          to determine whether the snapshot was taken from the current or a previous
+          instance of a given snapshot name.
       - !ruby/object:Api::Type::Enum
         name: 'sourceType'
         description: |

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -5571,6 +5571,52 @@ objects:
           The ID value of the disk used to create this image. This value may
           be used to determine whether the image was taken from the current
           or a previous instance of a given disk name.
+      - !ruby/object:Api::Type::ResourceRef
+        name: 'sourceImage'
+        description: |
+          URL of the source image used to create this image. In order to create an image, you must provide the full or partial
+          URL of one of the following:
+
+          The selfLink URL
+          This property
+          The rawDisk.source URL
+          The sourceDisk URL
+        resource: 'Image'
+        imports: 'selfLink'
+      - !ruby/object:Api::Type::NestedObject
+        name: 'sourceImageEncryptionKey'
+        description: |
+          The customer-supplied encryption key of the source image. Required if
+          the source image is protected by a customer-supplied encryption key.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'rawKey'
+            description: |
+              Specifies a 256-bit customer-supplied encryption key, encoded in
+              RFC 4648 base64 to either encrypt or decrypt this resource.
+          - !ruby/object:Api::Type::String
+            name: 'sha256'
+            description: |
+              The RFC 4648 base64 encoded SHA-256 hash of the
+              customer-supplied encryption key that protects this resource.
+            output: true
+          - !ruby/object:Api::Type::String
+            name: 'kmsKeyServiceAccount'
+            description: |
+              The service account being used for the encryption request for the given KMS key.
+              If absent, the Compute Engine default service account is used.
+            output: true
+          - !ruby/object:Api::Type::String
+            # TODO(chrisst) Change to ResourceRef once KMS is in Magic Modules
+            name: 'kmsKeyName'
+            description: |
+              The name of the encryption key that is stored in Google Cloud KMS.
+      - !ruby/object:Api::Type::String
+        name: 'sourceImageId'
+        description: |
+          The ID value of the image used to create this image. This value may be used
+          to determine whether the image was taken from the current or a previous
+          instance of a given image name.
       - !ruby/object:Api::Type::Enum
         name: 'sourceType'
         description: |

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -5583,40 +5583,6 @@ objects:
           The sourceDisk URL
         resource: 'Image'
         imports: 'selfLink'
-      - !ruby/object:Api::Type::NestedObject
-        name: 'sourceImageEncryptionKey'
-        description: |
-          The customer-supplied encryption key of the source image. Required if
-          the source image is protected by a customer-supplied encryption key.
-        properties:
-          - !ruby/object:Api::Type::String
-            name: 'rawKey'
-            description: |
-              Specifies a 256-bit customer-supplied encryption key, encoded in
-              RFC 4648 base64 to either encrypt or decrypt this resource.
-          - !ruby/object:Api::Type::String
-            name: 'sha256'
-            description: |
-              The RFC 4648 base64 encoded SHA-256 hash of the
-              customer-supplied encryption key that protects this resource.
-            output: true
-          - !ruby/object:Api::Type::String
-            name: 'kmsKeyServiceAccount'
-            description: |
-              The service account being used for the encryption request for the given KMS key.
-              If absent, the Compute Engine default service account is used.
-            output: true
-          - !ruby/object:Api::Type::String
-            # TODO(chrisst) Change to ResourceRef once KMS is in Magic Modules
-            name: 'kmsKeyName'
-            description: |
-              The name of the encryption key that is stored in Google Cloud KMS.
-      - !ruby/object:Api::Type::String
-        name: 'sourceImageId'
-        description: |
-          The ID value of the image used to create this image. This value may be used
-          to determine whether the image was taken from the current or a previous
-          instance of a given image name.
       - !ruby/object:Api::Type::ResourceRef
         name: 'sourceSnapshot'
         description: |
@@ -5631,40 +5597,6 @@ objects:
           The sourceDisk URL
         resource: 'Snapshot'
         imports: 'selfLink'
-      - !ruby/object:Api::Type::NestedObject
-        name: 'sourceSnapshotEncryptionKey'
-        description: |
-          The customer-supplied encryption key of the source snapshot. Required if
-          the source snapshot is protected by a customer-supplied encryption key.
-        properties:
-          - !ruby/object:Api::Type::String
-            name: 'rawKey'
-            description: |
-              Specifies a 256-bit customer-supplied encryption key, encoded in
-              RFC 4648 base64 to either encrypt or decrypt this resource.
-          - !ruby/object:Api::Type::String
-            name: 'sha256'
-            description: |
-              The RFC 4648 base64 encoded SHA-256 hash of the
-              customer-supplied encryption key that protects this resource.
-            output: true
-          - !ruby/object:Api::Type::String
-            name: 'kmsKeyServiceAccount'
-            description: |
-              The service account being used for the encryption request for the given KMS key.
-              If absent, the Compute Engine default service account is used.
-            output: true
-          - !ruby/object:Api::Type::String
-            # TODO(chrisst) Change to ResourceRef once KMS is in Magic Modules
-            name: 'kmsKeyName'
-            description: |
-              The name of the encryption key that is stored in Google Cloud KMS.
-      - !ruby/object:Api::Type::String
-        name: 'sourceSnapshotId'
-        description: |
-          The ID value of the snapshot used to create this image. This value may be used
-          to determine whether the snapshot was taken from the current or a previous
-          instance of a given snapshot name.
       - !ruby/object:Api::Type::Enum
         name: 'sourceType'
         description: |

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -944,14 +944,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         exclude: true
       sourceDiskId: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
-      sourceImageEncryptionKey: !ruby/object:Overrides::Terraform::PropertyOverride
-        exclude: true
-      sourceImageId: !ruby/object:Overrides::Terraform::PropertyOverride
-        exclude: true
-      sourceSnapshotEncryptionKey: !ruby/object:Overrides::Terraform::PropertyOverride
-        exclude: true
-      sourceSnapshotId: !ruby/object:Overrides::Terraform::PropertyOverride
-        exclude: true
       sourceType: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
   Instance: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -948,6 +948,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         exclude: true
       sourceImageId: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
+      sourceSnapshotEncryptionKey: !ruby/object:Overrides::Terraform::PropertyOverride
+        exclude: true
+      sourceSnapshotId: !ruby/object:Overrides::Terraform::PropertyOverride
+        exclude: true
       sourceType: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
   Instance: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -944,6 +944,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         exclude: true
       sourceDiskId: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
+      sourceImageEncryptionKey: !ruby/object:Overrides::Terraform::PropertyOverride
+        exclude: true
+      sourceImageId: !ruby/object:Overrides::Terraform::PropertyOverride
+        exclude: true
       sourceType: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
   Instance: !ruby/object:Overrides::Terraform::ResourceOverride


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/2092

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `source_image` and `source_snapshot` to `google_compute_image`
```
