### PR TITLE
Set context early on in LoadAndValidate to prevent NPE

### DIFF
--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -208,6 +208,8 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 		c.Scopes = DefaultClientScopes
 	}
 
+	c.context = ctx
+
 	tokenSource, err := c.getTokenSource(c.Scopes)
 	if err != nil {
 		return err
@@ -243,7 +245,6 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 	userAgent := fmt.Sprintf("%s %s", tfUserAgent, providerVersion)
 
 	c.client = client
-	c.context = ctx
 	c.userAgent = userAgent
 
 	// This base path and some others below need the version and possibly more of the path


### PR DESCRIPTION
I do not know that this will fix the problem, but I believe it will. Cannot reproduce crash locally even though context is verified to be nil going in to `		creds, err := googleoauth.CredentialsFromJSON(c.context, []byte(contents), clientScopes...)`


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Fixed crash due to nil context when loading credentials
```
