### PR TITLE
Make project field in google_compute_network_endpoint_group ds optional

### DIFF
--- a/third_party/terraform/data_sources/data_source_compute_network_endpoint_group.go
+++ b/third_party/terraform/data_sources/data_source_compute_network_endpoint_group.go
@@ -14,6 +14,7 @@ func dataSourceGoogleComputeNetworkEndpointGroup() *schema.Resource {
 	// Set 'Optional' schema elements
 	addOptionalFieldsToSchema(dsSchema, "name")
 	addOptionalFieldsToSchema(dsSchema, "zone")
+	addOptionalFieldsToSchema(dsSchema, "project")
 	addOptionalFieldsToSchema(dsSchema, "self_link")
 
 	return &schema.Resource{


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6884

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed issue where the `project` field in `data.google_compute_network_endpoint_group` was returning an error when specified
```
