### PR TITLE
Add a random string to ad directory so tests can be run in parallel

### DIFF
--- a/third_party/terraform/tests/resource_active_directory_domain_update_test.go
+++ b/third_party/terraform/tests/resource_active_directory_domain_update_test.go
@@ -9,8 +9,9 @@ import (
 func TestAccActiveDirectoryDomain_update(t *testing.T) {
 	t.Parallel()
 
+	domain := fmt.Sprintf("mydomain%s.org1.com", randString(t, 5))
 	context := map[string]interface{}{
-		"domain":        "mydomain.org1.com",
+		"domain":        domain,
 		"resource_name": "ad-domain",
 	}
 

--- a/third_party/terraform/tests/resource_active_directory_domain_update_test.go
+++ b/third_party/terraform/tests/resource_active_directory_domain_update_test.go
@@ -1,6 +1,7 @@
 package google
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"


### PR DESCRIPTION
This will also fix VCR as it causes a dependency on the seed existing to get the random string, which will cause the test to fail until recorded successfully

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
