### PR TITLE
Add google_storage_bucket_object.media_link

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_storage_bucket_object.go
+++ b/third_party/terraform/data_sources/data_source_google_storage_bucket_object.go
@@ -49,6 +49,7 @@ func dataSourceGoogleStorageBucketObjectRead(d *schema.ResourceData, meta interf
 	d.Set("self_link", res["selfLink"])
 	d.Set("storage_class", res["storageClass"])
 	d.Set("md5hash", res["md5Hash"])
+	d.Set("media_link", res["mediaLink"])
 	d.Set("metadata", res["metadata"])
 
 	d.SetId(bucket + "-" + name)

--- a/third_party/terraform/resources/resource_storage_bucket_object.go
+++ b/third_party/terraform/resources/resource_storage_bucket_object.go
@@ -171,6 +171,12 @@ func resourceStorageBucketObject() *schema.Resource {
 				Computed:    true,
 				Description: `The name of the object. Use this field in interpolations with google_storage_object_acl to recreate google_storage_object_acl resources when your google_storage_bucket_object is recreated.`,
 			},
+
+			"media_link": {
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: `A url reference to download this object.`,
+			},
 		},
 	}
 }
@@ -269,6 +275,7 @@ func resourceStorageBucketObjectRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("self_link", res.SelfLink)
 	d.Set("output_name", res.Name)
 	d.Set("metadata", res.Metadata)
+	d.Set("media_link", res.MediaLink)
 
 	d.SetId(objectGetId(res))
 

--- a/third_party/terraform/website/docs/d/storage_bucket_object.html.markdown
+++ b/third_party/terraform/website/docs/d/storage_bucket_object.html.markdown
@@ -59,3 +59,5 @@ The following attributes are exported:
 * `storage_class` - (Computed) The [StorageClass](https://cloud.google.com/storage/docs/storage-classes) of the new bucket object.
     Supported values include: `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`, `COLDLINE`. If not provided, this defaults to the bucket's default
     storage class or to a [standard](https://cloud.google.com/storage/docs/storage-classes#standard) class.
+
+* `media_link` - (Computed) A url reference to download this object.

--- a/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
@@ -76,3 +76,5 @@ exported:
 
 * `output_name` - (Computed) The name of the object. Use this field in interpolations with `google_storage_object_acl` to recreate
 `google_storage_object_acl` resources when your `google_storage_bucket_object` is recreated.
+
+* `media_link` - (Computed) A url reference to download this object.


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
Upstreams https://github.com/terraform-providers/terraform-provider-google/pull/6897

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
storage: added output-only `media_link` to `google_storage_bucket_object`
```
