### PR TITLE
Use composer v1 for ga provider.

### DIFF
--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -297,6 +297,9 @@ func resourceComposerEnvironment() *schema.Resource {
 										Type:             schema.TypeString,
 										Computed:         true,
 										Optional:         true,
+<% if version == "ga" -%>
+										ForceNew:         true,
+<% end -%>
 										AtLeastOneOf:     composerSoftwareConfigKeys,
 										ValidateFunc:     validateRegexp(composerEnvironmentVersionRegexp),
 										DiffSuppressFunc: composerImageVersionDiffSuppress,

--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -11,7 +11,11 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+<% if version == "ga" -%>
+	"google.golang.org/api/composer/v1"
+<% else -%>
 	"google.golang.org/api/composer/v1beta1"
+<% end -%>
 )
 
 const (
@@ -617,6 +621,7 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 			}
 			d.SetPartial("config")
 		}
+<% unless version == "ga" -%>
 
 		// If web_server_network_access_control has more fields added it may require changes here.
 		// This is scoped specifically to allowed_ip_range due to https://github.com/hashicorp/terraform-plugin-sdk/issues/98
@@ -631,6 +636,7 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 			}
 			d.SetPartial("config")
 		}
+<% end -%>
 	}
 
 	if d.HasChange("labels") {

--- a/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -551,8 +551,9 @@ resource "google_composer_environment" "test" {
     }
 
     software_config {
+<% unless version == "ga" -%>
       image_version = data.google_composer_image_versions.all.image_versions[0].image_version_id
-
+<% end -%>
       airflow_config_overrides = {
         core-load_example = "True"
       }

--- a/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -554,6 +554,7 @@ resource "google_composer_environment" "test" {
 <% unless version == "ga" -%>
       image_version = data.google_composer_image_versions.all.image_versions[0].image_version_id
 <% end -%>
+
       airflow_config_overrides = {
         core-load_example = "True"
       }

--- a/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -12,7 +12,11 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+<% if version == 'ga' -%>
+	"google.golang.org/api/composer/v1"
+<% else -%>
 	"google.golang.org/api/composer/v1beta1"
+<% end -%>
 	"google.golang.org/api/storage/v1"
 )
 

--- a/third_party/terraform/utils/composer_operation.go.erb
+++ b/third_party/terraform/utils/composer_operation.go.erb
@@ -1,10 +1,15 @@
+<% autogen_exception -%>
 package google
 
 import (
 	"fmt"
 	"time"
 
+<% if version == 'ga' -%>
+	composer "google.golang.org/api/composer/v1"
+<% else -%>
 	composer "google.golang.org/api/composer/v1beta1"
+<% end -%>
 )
 
 type ComposerOperationWaiter struct {

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -34,7 +34,11 @@ import (
 	"google.golang.org/api/cloudkms/v1"
 	"google.golang.org/api/cloudresourcemanager/v1"
 	resourceManagerV2Beta1 "google.golang.org/api/cloudresourcemanager/v2beta1"
+<% if version == 'ga' -%>
+	"google.golang.org/api/composer/v1"
+<% else -%>
 	"google.golang.org/api/composer/v1beta1"
+<% end -%>
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/container/v1"


### PR DESCRIPTION
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
composer: Changed `google_cloud_composer_environment` API endpoint from `v1beta1` to `v1` for . If you wish to continue using the beta API, please use the google-beta provider.
```

I don't think this is documented, but GCP support tells me that cloud composer behavior is different when using the v1 vs the v1beta1 apis. Specifically, there's a private `enableDrsSetup` flag that's enabled with v1beta1 but not with v1. I would expect the beta provider to use the v1beta1 endpoint, but the ga provider to use the v1 endpoint. Let me know if this makes sense!