### PR TITLE
Update compute_security_policy docs to match src_ip_ranges constraints

### DIFF
--- a/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -90,7 +90,7 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 													MinItems:    1,
 													MaxItems:    10,
 													Elem:        &schema.Schema{Type: schema.TypeString},
-													Description: `Set of IP addresses or ranges (IPV4 or IPV6) in CIDR notation to match against inbound traffic. There is a limit of 5 IP ranges per rule. A value of '*' matches all IPs (can be used to override the default behavior).`,
+													Description: `Set of IP addresses or ranges (IPV4 or IPV6) in CIDR notation to match against inbound traffic. There is a limit of 10 IP ranges per rule. A value of '*' matches all IPs (can be used to override the default behavior).`,
 												},
 											},
 										},

--- a/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_security_policy.html.markdown
@@ -98,7 +98,7 @@ The `match` block supports:
 The `config` block supports:
 
 * `src_ip_ranges` - (Required) Set of IP addresses or ranges (IPV4 or IPV6) in CIDR notation
-    to match against inbound traffic. There is a limit of 5 IP ranges per rule. A value of '\*' matches all IPs
+    to match against inbound traffic. There is a limit of 10 IP ranges per rule. A value of '\*' matches all IPs
     (can be used to override the default behavior).
 
 The `expr` block supports:


### PR DESCRIPTION
The limit of 5 IP ranges per rule was increased to 10 in #3516. This commit updates the related documentation.

```release-note:none
This only updates the description and website documentation. The functionality was already implemented and added to the release notes. No further mention in the release notes is necessary.
```
