### PR TITLE
Fix description for ip_allocation_policy.cluster_secondary_range_name…

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -879,7 +879,7 @@ func resourceContainerCluster() *schema.Resource {
 							Computed:      true,
 							ForceNew:      true,
 							ConflictsWith: ipAllocationCidrBlockFields,
-							Description:   `The IP address range of the services IPs in this cluster. Set to blank to have a range chosen with the default size. Set to /netmask (e.g. /14) to have a range chosen with a specific netmask. Set to a CIDR notation (e.g. 10.96.0.0/14) from the RFC-1918 private networks (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to pick a specific range to use.`,
+							Description:   `The name of the existing secondary range in the cluster's subnetwork to use for pod IP addresses. Alternatively, cluster_ipv4_cidr_block can be used to automatically create a GKE-managed one.`,
 						},
 
 						"services_secondary_range_name": {


### PR DESCRIPTION
… in google_container_cluster

```release-note:none
Fixes the schema description for ip_allocation_policy.cluster_secondary_range_name on google_container_cluster
```
