### PR TITLE
more notebook instance fixes

### DIFF
--- a/products/notebooks/terraform.yaml
+++ b/products/notebooks/terraform.yaml
@@ -76,6 +76,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read: true
       dataDiskSizeGb: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
+      dataDiskType: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: 'emptyOrDefaultStringSuppress("DISK_TYPE_UNSPECIFIED")'
+      diskEncryption: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: 'emptyOrDefaultStringSuppress("DISK_ENCRYPTION_UNSPECIFIED")'
       instanceOwners: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
       machineType: !ruby/object:Overrides::Terraform::PropertyOverride


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
This was _probably_ an API-side change that we're reacting to, since the initial test failures don't line up with any obvious changes on our side.

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6915
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6798

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
notebook: fixed bug where not setting `data_disk_type` or `disk_encryption` would cause a diff on the next plan
```
