### PR TITLE
Add retry_policy to google_pubsub_subscription

### DIFF
--- a/products/pubsub/api.yaml
+++ b/products/pubsub/api.yaml
@@ -286,3 +286,35 @@ objects:
               This field will be honored on a best effort basis.
             
               If this parameter is 0, a default value of 5 is used.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'retryPolicy'
+        send_empty_value: true
+        description: |
+          A policy that specifies how Cloud Pub/Sub retries message delivery.
+
+          Retry delay will be exponential based on provided minimum and maximum backoffs.
+          https://en.wikipedia.org/wiki/Exponential_backoff.
+
+          RetryPolicy will be triggered on NACKs or acknowledgement deadline exceeded events
+          for a given message.
+
+          Retry Policy is implemented on a best effort basis. At times, the delay between
+          consecutive deliveries may not match the configuration. That is, delay can be more
+          or less than configured backoff.
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'maximumBackoff'
+            default_value: '600s'
+            description: |
+              Specifies the maximum delay between consecutive deliveries of a given message. 
+              Value should be between 0 and 600 seconds. Defaults to 600 seconds.
+              A duration in seconds with up to nine fractional digits, terminated by 's'.
+              Example - "3.5s".
+          - !ruby/object:Api::Type::String
+            name: 'minimumBackoff'
+            default_value: '10s'
+            description: |
+              Specifies the minimum delay between consecutive deliveries of a given message.
+              Value should be between 0 and 600 seconds. Defaults to 10 seconds.
+              A duration in seconds with up to nine fractional digits, terminated by 's'.
+              Example - "3.5s".

--- a/products/pubsub/terraform.yaml
+++ b/products/pubsub/terraform.yaml
@@ -124,6 +124,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       expirationPolicy.ttl: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'comparePubsubSubscriptionExpirationPolicy'
+      retryPolicy: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      retryPolicy.maximumBackoff: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+        diff_suppress_func: 'comparePubsubSubscriptionRetryPolicy'
+      retryPolicy.minimumBackoff: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+        diff_suppress_func: 'comparePubsubSubscriptionRetryPolicy'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/subscription.go.erb
       decoder: templates/terraform/decoders/pubsub_subscription.erb

--- a/templates/terraform/constants/subscription.go.erb
+++ b/templates/terraform/constants/subscription.go.erb
@@ -24,3 +24,15 @@ func comparePubsubSubscriptionExpirationPolicy(_, old, new string, _ *schema.Res
 	}
 	return trimmedNew == trimmedOld
 }
+
+func comparePubsubSubscriptionRetryPolicy(_, old, new string, _ *schema.ResourceData) bool {
+	trimmedNew := strings.TrimLeft(new, "0")
+	trimmedOld := strings.TrimLeft(old, "0")
+	if strings.Contains(trimmedNew, ".") {
+		trimmedNew = strings.TrimRight(strings.TrimSuffix(trimmedNew, "s"), "0") + "s"
+	}
+	if strings.Contains(trimmedOld, ".") {
+		trimmedOld = strings.TrimRight(strings.TrimSuffix(trimmedOld, "s"), "0") + "s"
+	}
+	return trimmedNew == trimmedOld
+}


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

This PR attempts to add support for retry_policy to google_pubsub_subscription resources.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
pubsub: Added `retry_policy` to `google_pubsub_subscription`
```
