### PR TITLE
Update google_billing_budget resource to add notifications

### DIFF
--- a/products/billingbudget/api.yaml
+++ b/products/billingbudget/api.yaml
@@ -179,6 +179,7 @@ objects:
                   at regular intervals to the topic.
               - !ruby/object:Api::Type::String
                 name: schemaVersion
+                default_value: "1.0"
                 description: |
                   The schema version of the notification. Only "1.0" is
                   accepted. It represents the JSON schema as defined in

--- a/products/billingbudget/api.yaml
+++ b/products/billingbudget/api.yaml
@@ -172,7 +172,6 @@ objects:
             properties:
               - !ruby/object:Api::Type::String
                 name: pubsubTopic
-                required: true
                 description: |
                   The name of the Cloud Pub/Sub topic where budget related
                   messages will be published, in the form
@@ -180,8 +179,15 @@ objects:
                   at regular intervals to the topic.
               - !ruby/object:Api::Type::String
                 name: schemaVersion
-                default_value: "1.0"
                 description: |
                   The schema version of the notification. Only "1.0" is
                   accepted. It represents the JSON schema as defined in
                   https://cloud.google.com/billing/docs/how-to/budgets#notification_format.
+              - !ruby/object:Api::Type::Array
+                name: monitoringNotificationChannels
+                description: |
+                  The full resource name of a monitoring notification
+                  channel in the form
+                  projects/{project_id}/notificationChannels/{channel_id}.
+                  A maximum of 5 channels are allowed.
+                item_type: Api::Type::String

--- a/products/billingbudget/api.yaml
+++ b/products/billingbudget/api.yaml
@@ -172,6 +172,9 @@ objects:
             properties:
               - !ruby/object:Api::Type::String
                 name: pubsubTopic
+                at_least_one_of:
+                  - budget.0.all_updates_rule.0.pubsub_topic
+                  - budget.0.all_updates_rule.0.monitoring_notification_channels
                 description: |
                   The name of the Cloud Pub/Sub topic where budget related
                   messages will be published, in the form
@@ -186,6 +189,9 @@ objects:
                   https://cloud.google.com/billing/docs/how-to/budgets#notification_format.
               - !ruby/object:Api::Type::Array
                 name: monitoringNotificationChannels
+                at_least_one_of:
+                  - budget.0.all_updates_rule.0.pubsub_topic
+                  - budget.0.all_updates_rule.0.monitoring_notification_channels
                 description: |
                   The full resource name of a monitoring notification
                   channel in the form

--- a/products/billingbudget/terraform.yaml
+++ b/products/billingbudget/terraform.yaml
@@ -34,6 +34,16 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_env_vars:
           billing_acct: :BILLING_ACCT
           project: :PROJECT_NAME
+      - !ruby/object:Provider::Terraform::Examples
+        name: 'billing_budget_notify'
+        min_version: beta
+        primary_resource_id: 'budget'
+        vars:
+          budget_name: 'Example Billing Budget'
+          channel_name: 'Example Notification Channel'
+        test_env_vars:
+          billing_acct: :BILLING_ACCT
+          project: :PROJECT_NAME
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/self_link_as_name.erb
       post_create: templates/terraform/post_create/set_computed_name.erb

--- a/templates/terraform/examples/billing_budget_notify.tf.erb
+++ b/templates/terraform/examples/billing_budget_notify.tf.erb
@@ -1,0 +1,45 @@
+data "google_billing_account" "account" {
+  provider        = google-beta
+  billing_account = "<%= ctx[:test_env_vars]['billing_acct'] -%>"
+}
+
+resource "google_billing_budget" "<%= ctx[:primary_resource_id] %>" {
+  provider        = google-beta
+  billing_account = data.google_billing_account.account.id
+  display_name    = "<%= ctx[:vars]['budget_name'] %>"
+
+  budget_filter {
+    projects = ["projects/<%= ctx[:test_env_vars]['project'] -%>"]
+  }
+
+  amount {
+    specified_amount {
+      currency_code = "USD"
+      units         = "100000"
+    }
+  }
+
+  threshold_rules {
+    threshold_percent = 1.0
+  }
+  threshold_rules {
+    threshold_percent = 1.0
+    spend_basis       = "FORECASTED_SPEND"
+  }
+  
+  all_updates_rule {
+    monitoring_notification_channels = [
+      google_monitoring_notification_channel.notification_channel.id,
+    ]
+  }
+}
+
+resource "google_monitoring_notification_channel" "notification_channel" {
+  provider     = google-beta
+  display_name = "<%= ctx[:vars]['channel_name'] %>"
+  type         = "email"
+  
+  labels = {
+    email_address = "address@example.com"
+  }
+}


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6868

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
billing_budget: Added support for `monitoring_notification_channels` to allow sending budget notifications to Cloud Monitoring email notification channels.
```