### PR TITLE
iamPolicyVersion needed to be configurable

### DIFF
--- a/api/resource/iam_policy.rb
+++ b/api/resource/iam_policy.rb
@@ -90,6 +90,9 @@ module Api
       # variables that are outside of the base_url qualifiers.
       attr_reader :import_format
 
+      # [Optional] Version number in the request payload.
+      # if set, it override the default iamPolicyVersion
+      attr_reader :iam_policy_version
       def validate
         super
 
@@ -112,6 +115,7 @@ module Api
           :example_config_body,
           type: String, default: 'templates/terraform/iam/iam_attributes.tf.erb'
         )
+        check :iam_policy_version, type: String
       end
     end
   end

--- a/api/resource/iam_policy.rb
+++ b/api/resource/iam_policy.rb
@@ -91,7 +91,7 @@ module Api
       attr_reader :import_format
 
       # [Optional] Version number in the request payload.
-      # if set, it override the default iamPolicyVersion
+      # if set, it overrides the default iamPolicyVersion
       attr_reader :iam_policy_version
       def validate
         super

--- a/templates/terraform/iam_policy.go.erb
+++ b/templates/terraform/iam_policy.go.erb
@@ -211,7 +211,7 @@ func (u *<%= resource_name -%>IamUpdater) SetResourceIamPolicy(policy *cloudreso
 	}
 
 <% if object.iam_policy.iam_policy_version -%>
-<%# This is an override of the existing version that might have been set in the resource_iam_member|policy|binding code -%>
+        // This is an override of the existing version that might have been set in the resource_iam_member|policy|binding code
         json["version"] = <%= object.iam_policy.iam_policy_version -%>
 <% end -%>
 

--- a/templates/terraform/iam_policy.go.erb
+++ b/templates/terraform/iam_policy.go.erb
@@ -178,14 +178,14 @@ func (u *<%= resource_name -%>IamUpdater) GetResourceIamPolicy() (*cloudresource
 <% end -%>
 	var obj map[string]interface{}
 <% if object.iam_policy.iam_conditions_request_type == :QUERY_PARAM -%>
-       url, err = addQueryParams(url, map[string]string{"optionsRequestedPolicyVersion": fmt.Sprintf("%d", <% if object.iam_policy.iam_policy_version -%> <%= object.iam_policy.iam_policy_version -%> <% else -%> iamPolicyVersion <% end -%>)})
+	url, err = addQueryParams(url, map[string]string{"optionsRequestedPolicyVersion": fmt.Sprintf("%d", <% if object.iam_policy.iam_policy_version -%> <%= object.iam_policy.iam_policy_version -%> <% else -%> iamPolicyVersion <% end -%>)})
 	if err != nil {
 		return nil, err
 	}
 <% elsif object.iam_policy.iam_conditions_request_type == :REQUEST_BODY -%>
 	obj = map[string]interface{}{
 		"options": map[string]interface{}{
-                       "requestedPolicyVersion": <% if object.iam_policy.iam_policy_version -%> <%= object.iam_policy.iam_policy_version -%> <% else -%> iamPolicyVersion <% end -%>,
+			"requestedPolicyVersion": <% if object.iam_policy.iam_policy_version -%> <%= object.iam_policy.iam_policy_version -%> <% else -%> iamPolicyVersion <% end -%>,
 		},
 	}
 <%  end -%>

--- a/templates/terraform/iam_policy.go.erb
+++ b/templates/terraform/iam_policy.go.erb
@@ -211,6 +211,7 @@ func (u *<%= resource_name -%>IamUpdater) SetResourceIamPolicy(policy *cloudreso
 	}
 
 <% if object.iam_policy.iam_policy_version -%>
+<%# This is an override of the existing version that might have been set in the resource_iam_member|policy|binding code -%>
         json["version"] = <%= object.iam_policy.iam_policy_version -%>
 <% end -%>
 

--- a/templates/terraform/iam_policy.go.erb
+++ b/templates/terraform/iam_policy.go.erb
@@ -178,14 +178,14 @@ func (u *<%= resource_name -%>IamUpdater) GetResourceIamPolicy() (*cloudresource
 <% end -%>
 	var obj map[string]interface{}
 <% if object.iam_policy.iam_conditions_request_type == :QUERY_PARAM -%>
-	url, err = addQueryParams(url, map[string]string{"optionsRequestedPolicyVersion": fmt.Sprintf("%d", iamPolicyVersion)})
+       url, err = addQueryParams(url, map[string]string{"optionsRequestedPolicyVersion": fmt.Sprintf("%d", <% if object.iam_policy.iam_policy_version -%> <%= object.iam_policy.iam_policy_version -%> <% else -%> iamPolicyVersion <% end -%>)})
 	if err != nil {
 		return nil, err
 	}
 <% elsif object.iam_policy.iam_conditions_request_type == :REQUEST_BODY -%>
 	obj = map[string]interface{}{
 		"options": map[string]interface{}{
-			"requestedPolicyVersion": iamPolicyVersion,
+                       "requestedPolicyVersion": <% if object.iam_policy.iam_policy_version -%> <%= object.iam_policy.iam_policy_version -%> <% else -%> iamPolicyVersion <% end -%>,
 		},
 	}
 <%  end -%>
@@ -209,6 +209,10 @@ func (u *<%= resource_name -%>IamUpdater) SetResourceIamPolicy(policy *cloudreso
 	if err != nil {
 		return err
 	}
+
+<% if object.iam_policy.iam_policy_version -%>
+        json["version"] = <%= object.iam_policy.iam_policy_version -%>
+<% end -%>
 
 <% if object.iam_policy.wrapped_policy_obj -%>
 	obj := make(map[string]interface{})


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6927
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Add iam_policy_version to iam_policy to make iamPolicyVersion configurable
```
