### PR TITLE
add support for point_in_time_recovery for sql instance

### DIFF
--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -42,6 +42,7 @@ var (
 		"settings.0.backup_configuration.0.enabled",
 		"settings.0.backup_configuration.0.start_time",
 		"settings.0.backup_configuration.0.location",
+		"settings.0.backup_configuration.0.point_in_time_recovery_enabled",
 	}
 
 	ipConfigurationKeys = []string{
@@ -184,6 +185,12 @@ settings.backup_configuration.binary_log_enabled are both set to true.`,
 										Optional:     true,
 										AtLeastOneOf: backupConfigurationKeys,
 										Description:  `Location of the backup configuration.`,
+									},
+									"point_in_time_recovery_enabled": {
+										Type:         schema.TypeBool,
+										Optional:     true,
+										AtLeastOneOf: backupConfigurationKeys,
+										Description:  `True if Point-in-time recovery is enabled.`,
 									},
 								},
 							},
@@ -861,11 +868,12 @@ func expandBackupConfiguration(configured []interface{}) *sqladmin.BackupConfigu
 
 	_backupConfiguration := configured[0].(map[string]interface{})
 	return &sqladmin.BackupConfiguration{
-		BinaryLogEnabled: _backupConfiguration["binary_log_enabled"].(bool),
-		Enabled:          _backupConfiguration["enabled"].(bool),
-		StartTime:        _backupConfiguration["start_time"].(string),
-		Location:         _backupConfiguration["location"].(string),
-		ForceSendFields:  []string{"BinaryLogEnabled", "Enabled"},
+		BinaryLogEnabled:           _backupConfiguration["binary_log_enabled"].(bool),
+		Enabled:                    _backupConfiguration["enabled"].(bool),
+		StartTime:                  _backupConfiguration["start_time"].(string),
+		Location:                   _backupConfiguration["location"].(string),
+		PointInTimeRecoveryEnabled: _backupConfiguration["point_in_time_recovery_enabled"].(bool),
+		ForceSendFields:            []string{"BinaryLogEnabled", "Enabled", "PointInTimeRecoveryEnabled"},
 	}
 }
 
@@ -1075,10 +1083,11 @@ func flattenSettings(settings *sqladmin.Settings) []map[string]interface{} {
 
 func flattenBackupConfiguration(backupConfiguration *sqladmin.BackupConfiguration) []map[string]interface{} {
 	data := map[string]interface{}{
-		"binary_log_enabled": backupConfiguration.BinaryLogEnabled,
-		"enabled":            backupConfiguration.Enabled,
-		"start_time":         backupConfiguration.StartTime,
-		"location":           backupConfiguration.Location,
+		"binary_log_enabled":             backupConfiguration.BinaryLogEnabled,
+		"enabled":                        backupConfiguration.Enabled,
+		"start_time":                     backupConfiguration.StartTime,
+		"location":                       backupConfiguration.Location,
+		"point_in_time_recovery_enabled": backupConfiguration.PointInTimeRecoveryEnabled,
 	}
 
 	return []map[string]interface{}{data}

--- a/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -656,6 +656,36 @@ func testAccCheckGoogleSqlDatabaseRootUserDoesNotExist(t *testing.T, instance st
 	}
 }
 
+func TestAccSqlDatabaseInstance_PointInTimeRecoveryEnabled(t *testing.T) {
+	t.Parallel()
+
+	masterID := randInt(t)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleSqlDatabaseInstance_PointInTimeRecoveryEnabled(masterID, true),
+			},
+			{
+				ResourceName:      "google_sql_database_instance.instance",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testGoogleSqlDatabaseInstance_PointInTimeRecoveryEnabled(masterID, false),
+			},
+			{
+				ResourceName:      "google_sql_database_instance.instance",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 var testGoogleSqlDatabaseInstance_basic2 = `
 resource "google_sql_database_instance" "instance" {
   region = "us-central1"
@@ -1024,3 +1054,21 @@ resource "google_sql_database_instance" "instance" {
   }
 }
 `
+
+func testGoogleSqlDatabaseInstance_PointInTimeRecoveryEnabled(masterID int, pointInTimeRecoveryEnabled bool) string {
+	return fmt.Sprintf(`
+resource "google_sql_database_instance" "instance" {
+  name             = "tf-test-%d"
+  region           = "us-central1"
+  database_version = "POSTGRES_9_6"
+  settings {
+    tier = "db-f1-micro"
+    backup_configuration {
+      enabled                        = true
+      start_time                     = "00:00"
+      point_in_time_recovery_enabled = %t
+    }
+  }
+}
+`, masterID, pointInTimeRecoveryEnabled)
+}

--- a/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -282,6 +282,7 @@ The optional `settings.backup_configuration` subblock supports:
 
 * `start_time` - (Optional) `HH:MM` format time indicating when backup
     configuration starts.
+* `point_in_time_recovery_enabled` - (Optional) True if Point-in-time recovery is enabled. Will restart database if enabled after instance creation. 
 
 The optional `settings.ip_configuration` subblock supports:
 


### PR DESCRIPTION
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
Upstreams https://github.com/terraform-providers/terraform-provider-google/pull/6715
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6774

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
sql: added support for point_in_time_recovery for `google_sql_database_instance`
```
