### PR TITLE
Convert inboundServices to an enum.

### DIFF
--- a/products/appengine/api.yaml
+++ b/products/appengine/api.yaml
@@ -461,8 +461,20 @@ objects:
       - !ruby/object:Api::Type::Array
         name: 'inboundServices'
         description: |
-          Before an application can receive email or XMPP messages, the application must be configured to enable the service.
-        item_type: Api::Type::String
+          A list of the types of messages that this application is able to receive.
+        item_type: !ruby/object:Api::Type::Enum
+          name: 'inboundService'
+          description: |
+            One type of message that this application is able to receive.
+          values:
+            - :INBOUND_SERVICE_MAIL
+            - :INBOUND_SERVICE_MAIL_BOUNCE
+            - :INBOUND_SERVICE_XMPP_ERROR
+            - :INBOUND_SERVICE_XMPP_MESSAGE
+            - :INBOUND_SERVICE_XMPP_SUBSCRIBE
+            - :INBOUND_SERVICE_XMPP_PRESENCE
+            - :INBOUND_SERVICE_CHANNEL_PRESENCE	
+            - :INBOUND_SERVICE_WARMUP
       - !ruby/object:Api::Type::String
         name: 'instanceClass'
         description: |
@@ -631,8 +643,20 @@ objects:
       - !ruby/object:Api::Type::Array
         name: 'inboundServices'
         description: |
-          Before an application can receive email or XMPP messages, the application must be configured to enable the service.
-        item_type: Api::Type::String
+          A list of the types of messages that this application is able to receive.
+        item_type: !ruby/object:Api::Type::Enum
+          name: 'inboundService'
+          description: |
+            One type of message that this application is able to receive.
+          values:
+            - :INBOUND_SERVICE_MAIL
+            - :INBOUND_SERVICE_MAIL_BOUNCE
+            - :INBOUND_SERVICE_XMPP_ERROR
+            - :INBOUND_SERVICE_XMPP_MESSAGE
+            - :INBOUND_SERVICE_XMPP_SUBSCRIBE
+            - :INBOUND_SERVICE_XMPP_PRESENCE
+            - :INBOUND_SERVICE_CHANNEL_PRESENCE	
+            - :INBOUND_SERVICE_WARMUP
       - !ruby/object:Api::Type::String
         name: 'instanceClass'
         description: |

--- a/templates/terraform/flatten_property_method.erb
+++ b/templates/terraform/flatten_property_method.erb
@@ -123,7 +123,7 @@ func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d 
   }
   <% if !property.set_hash_func.nil? -%>
   return schema.NewSet(<%= property.set_hash_func -%>, v.([]interface{}))
-  <% elsif property.item_type.is_a?(String) -%>
+  <% elsif property.item_type.is_a?(String) or property.item_type.is_a?(Api::Type::Enum) -%>
   return schema.NewSet(schema.HashString, v.([]interface{}))
   <% else raise 'Unknown hash function for property #{property.name}' -%>
   <% end -%>

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -115,6 +115,11 @@
       Elem: &schema.Schema{
         Type: <%= tf_types[property.item_type_class] -%>,
       },
+  <% elsif property.item_type.is_a?(Api::Type::Enum) -%>
+      Elem: &schema.Schema{
+        Type: <%= tf_types[property.item_type_class] -%>,
+        ValidateFunc: validation.StringInSlice([]string{"<%= property.item_type.values.join '","' -%>"}, false),
+      },
   <% else # array of basic types -%>
       Elem: &schema.Schema{
         Type: <%= tf_types[property.item_type.class] -%>,

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -126,7 +126,7 @@
   <% if property.is_set -%>
     <% if !property.set_hash_func.nil? -%>
     Set: <%= property.set_hash_func -%>,
-    <% elsif property.item_type.is_a?(String) -%>
+    <% elsif property.item_type.is_a?(String) or property.item_type.is_a?(Api::Type::Enum) -%>
     Set: schema.HashString,
     <% else -%>
     // Default schema.HashSchema is used.

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -117,7 +117,7 @@
       },
   <% elsif property.item_type.is_a?(Api::Type::Enum) -%>
       Elem: &schema.Schema{
-        Type: <%= tf_types[property.item_type_class] -%>,
+        Type: <%= tf_types[property.item_type.class] -%>,
         ValidateFunc: validation.StringInSlice([]string{"<%= property.item_type.values.join '","' -%>"}, false),
       },
   <% else # array of basic types -%>


### PR DESCRIPTION
This will make the documentation better and more readable.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
appengine: converted `google_app_engine_standard_app_version`'s `inbound_services` to an enum array, which enhances docs and provides some client-side validation.
```

Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6904.