### PR TITLE
Update ospatch's windows update classification field to be an array.

### DIFF
--- a/products/osconfig/api.yaml
+++ b/products/osconfig/api.yaml
@@ -376,7 +376,7 @@ objects:
             properties:
              - !ruby/object:Api::Type::Array
               name: 'classifications'
-              at_least_one_of:
+              exactly_one_of:
                 - patch_config.0.windowsUpdate.classifications
                 - patch_config.0.windowsUpdate.excludes
                 - patch_config.0.windowsUpdate.exclusive_patches
@@ -397,7 +397,7 @@ objects:
                   - :UPDATE
              - !ruby/object:Api::Type::Array
               name: 'excludes'
-              at_least_one_of:
+              exactly_one_of:
                 - patch_config.0.windowsUpdate.classifications
                 - patch_config.0.windowsUpdate.excludes
                 - patch_config.0.windowsUpdate.exclusive_patches
@@ -406,7 +406,7 @@ objects:
               item_type: Api::Type::String
              - !ruby/object:Api::Type::Array
               name: 'exclusivePatches'
-              at_least_one_of:
+              exactly_one_of:
                 - patch_config.0.windowsUpdate.classifications
                 - patch_config.0.windowsUpdate.excludes
                 - patch_config.0.windowsUpdate.exclusive_patches

--- a/products/osconfig/api.yaml
+++ b/products/osconfig/api.yaml
@@ -374,7 +374,7 @@ objects:
               - patch_config.0.pre_step
               - patch_config.0.post_step
             properties:
-             - !ruby/object:Api::Type::Enum
+             - !ruby/object:Api::Type::Array
               name: 'classifications'
               at_least_one_of:
                 - patch_config.0.windowsUpdate.classifications
@@ -382,16 +382,19 @@ objects:
                 - patch_config.0.windowsUpdate.exclusive_patches
               description: |
                 Only apply updates of these windows update classifications. If empty, all updates are applied.
-              values:
-                - :CRITICAL
-                - :SECURITY
-                - :DEFINITION
-                - :DRIVER
-                - :FEATURE_PACK
-                - :SERVICE_PACK
-                - :TOOL
-                - :UPDATE_ROLLUP
-                - :UPDATE
+              item_type: !ruby/object:Api::Type::Enum
+                name: 'classification'
+                description: 'What type of updates should we apply?'
+                values:
+                  - :CRITICAL
+                  - :SECURITY
+                  - :DEFINITION
+                  - :DRIVER
+                  - :FEATURE_PACK
+                  - :SERVICE_PACK
+                  - :TOOL
+                  - :UPDATE_ROLLUP
+                  - :UPDATE
              - !ruby/object:Api::Type::Array
               name: 'excludes'
               at_least_one_of:

--- a/templates/terraform/examples/os_config_patch_deployment_full.tf.erb
+++ b/templates/terraform/examples/os_config_patch_deployment_full.tf.erb
@@ -38,7 +38,6 @@ resource "google_os_config_patch_deployment" "<%= ctx[:primary_resource_id] %>" 
 
     windows_update {
       classifications = ["CRITICAL", "SECURITY", "UPDATE"]
-      exclusive_patches = ["KB4339284"]
     }
 
     pre_step {

--- a/templates/terraform/examples/os_config_patch_deployment_full.tf.erb
+++ b/templates/terraform/examples/os_config_patch_deployment_full.tf.erb
@@ -37,6 +37,7 @@ resource "google_os_config_patch_deployment" "<%= ctx[:primary_resource_id] %>" 
     }
 
     windows_update {
+      classifications = ["CRITICAL", "SECURITY", "UPDATE"]
       exclusive_patches = ["KB4339284"]
     }
 

--- a/templates/terraform/property_documentation.erb
+++ b/templates/terraform/property_documentation.erb
@@ -14,7 +14,12 @@
 <%   end -%>
 <% end -%>
 <%= indent(property.description.strip.gsub("\n\n", "\n"), 2) %>
-<% if property.is_a?(Api::Type::Enum) && !property.output && !property.skip_docs_values -%>
+<% if property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::Enum) && !property.output && !property.item_type.skip_docs_values -%>
+<% unless property.item_type.default_value.nil? || property.item_type.default_value == "" -%>
+  Default value is [`<%= property.item_type.default_value %>`].
+<% end -%>
+  Each value may be one of <%= property.item_type.values.select { |v| v != "" }.map { |v| "`#{v}`" }.to_sentence %>.
+<% elsif property.is_a?(Api::Type::Enum) && !property.output && !property.skip_docs_values -%>
 <% unless property.default_value.nil? || property.default_value == "" -%>
   Default value is `<%= property.default_value %>`.
 <% end -%>

--- a/templates/terraform/schema_property.erb
+++ b/templates/terraform/schema_property.erb
@@ -67,7 +67,14 @@
 	StateFunc: <%= property.state_func %>,
 <% end -%>
 <% enum_values_description = "" -%>
-<% if property.is_a?(Api::Type::Enum) && !property.output -%>
+<% if property.is_a?(Api::Type::Array) && property.item_type.is_a?(Api::Type::Enum) && !property.output && !property.item_type.skip_docs_values -%>
+<% unless property.item_type.default_value.nil? || property.item_type.default_value == "" -%>
+<% enum_values_description += " Default value: \"#{property.item_type.default_value}\"" -%>
+<% end -%>
+<% enum_values_description += " Possible values: [" -%>
+<% enum_values_description += property.item_type.values.select { |v| v != "" }.map { |v| "\"#{v}\"" }.join(', ') -%>
+<% enum_values_description += "]" -%>
+<% elsif property.is_a?(Api::Type::Enum) && !property.output -%>
 <% unless property.default_value.nil? || property.default_value == "" -%>
 <% enum_values_description += " Default value: \"#{property.default_value}\"" -%>
 <% end -%>


### PR DESCRIPTION
Also updates docs to display enum options in lists.
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6909.
Supports https://github.com/GoogleCloudPlatform/magic-modules/pull/3820, because it allows arrays of enums to display values in docs.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
osconfig: `google_os_config_patch_deployment`'s `windows_update.classifications` field now works correctly, accepting multiple values.
```
```release-note:note
all: Lists of enums now display the enum options in the documentation pages.
```