### PR TITLE
Fixed validation of service_level_indicator.0.windows_based_sli.0.metric_sum_in_range.0.range.0.max

### DIFF
--- a/products/monitoring/api.yaml
+++ b/products/monitoring/api.yaml
@@ -1990,4 +1990,3 @@ objects:
         This field allows time series to be associated with the intersection of this metric
         type and the monitored resource types in this list.
       item_type: Api::Type::String
-

--- a/products/monitoring/api.yaml
+++ b/products/monitoring/api.yaml
@@ -1562,8 +1562,8 @@ objects:
                       - !ruby/object:Api::Type::Integer
                         name: max
                         at_least_one_of:
-                          - service_level_indicator.0.windows_based_sli.0.metric_mean_in_range.0.range.0.min
-                          - service_level_indicator.0.windows_based_sli.0.metric_mean_in_range.0.range.0.max
+                          - service_level_indicator.0.windows_based_sli.0.metric_sum_in_range.0.range.0.min
+                          - service_level_indicator.0.windows_based_sli.0.metric_sum_in_range.0.range.0.max
                         description: |
                           max value for the range (inclusive). If not given,
                           will be set to "infinity", defining an open range


### PR DESCRIPTION
Fixed validation of service_level_indicator.0.windows_based_sli.0.metric_sum_in_range.0.range.0.max

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
monitoring: fixed validation rules for windows_based_sli.metric_sum_in_range.max field
```
