### PR TITLE
Add new monitoringNotificationChannels feature to billing budget API

### DIFF
--- a/products/billingbudget/api.yaml
+++ b/products/billingbudget/api.yaml
@@ -185,3 +185,15 @@ objects:
                   The schema version of the notification. Only "1.0" is
                   accepted. It represents the JSON schema as defined in
                   https://cloud.google.com/billing/docs/how-to/budgets#notification_format.
+              - !ruby/object:Api::Type::Array
+                name: monitoringNotificationChannels
+                description: |
+                  Targets to send notifications to when a threshold is
+                  exceeded. This is in addition to default recipients who have
+                  billing account roles. The value is the full REST resource
+                  name of a monitoring notification channel with the form
+                  projects/{project_id}/notificationChannels/{channel_id}.
+                  A maximum of 5 channels are allowed. See
+                  https://cloud.google.com/billing/docs/how-to/budgets-notification-recipients
+                  for more details.
+                item_type: Api::Type::String


### PR DESCRIPTION
Adding this feature since now it's fully supported in the official API: https://cloud.google.com/billing/docs/reference/budget/rest/v1beta1/billingAccounts.budgets#allupdatesrule

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6868

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
billing_budget: Added new monitoringNotificationChannels feature to billing budget resource
```
