### PR TITLE
migrating google and google-beta repos to hashicorp org

### DIFF
--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -6,11 +6,11 @@ function clone_repo() {
     SCRATCH_OWNER=modular-magician
     if [ "$REPO" == "terraform" ]; then
         if [ "$VERSION" == "ga" ]; then
-            UPSTREAM_OWNER=terraform-providers
+            UPSTREAM_OWNER=hashicorp
             GH_REPO=terraform-provider-google
             LOCAL_PATH=$GOPATH/src/github.com/terraform-providers/terraform-provider-google
         elif [ "$VERSION" == "beta" ]; then
-            UPSTREAM_OWNER=terraform-providers
+            UPSTREAM_OWNER=hashicorp
             GH_REPO=terraform-provider-google-beta
             LOCAL_PATH=$GOPATH/src/github.com/terraform-providers/terraform-provider-google-beta
         else

--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -8,11 +8,11 @@ function clone_repo() {
         if [ "$VERSION" == "ga" ]; then
             UPSTREAM_OWNER=hashicorp
             GH_REPO=terraform-provider-google
-            LOCAL_PATH=$GOPATH/src/github.com/terraform-providers/terraform-provider-google
+            LOCAL_PATH=$GOPATH/src/github.com/hashicorp/terraform-provider-google
         elif [ "$VERSION" == "beta" ]; then
             UPSTREAM_OWNER=hashicorp
             GH_REPO=terraform-provider-google-beta
-            LOCAL_PATH=$GOPATH/src/github.com/terraform-providers/terraform-provider-google-beta
+            LOCAL_PATH=$GOPATH/src/github.com/hashicorp/terraform-provider-google-beta
         else
             echo "Unrecognized version $VERSION"
             exit 1

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,6 +1,6 @@
 blank_issues_enabled: true
 contact_links:
   - name: Terraform-Specific Issue Tracking
-    url: https://github.com/terraform-providers/terraform-provider-google/issues/new/choose
+    url: https://github.com/hashicorp/terraform-provider-google/issues/new/choose
     about: |
       Please submit Terraform-specific issues or FRs here.

--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ you'll need to check out the repo(s) you're generating in your GOPATH. For
 example:
 
 ```
-git clone https://github.com/terraform-providers/terraform-provider-google.git $GOPATH/src/github.com/terraform-providers/terraform-provider-google
-git clone https://github.com/terraform-providers/terraform-provider-google-beta.git $GOPATH/src/github.com/terraform-providers/terraform-provider-google-beta
+git clone https://github.com/hashicorp/terraform-provider-google.git $GOPATH/src/github.com/hashicorp/terraform-provider-google
+git clone https://github.com/hashicorp/terraform-provider-google-beta.git $GOPATH/src/github.com/hashicorp/terraform-provider-google-beta
 ```
 
 Magic Modules won't work with old versions of the Terraform provider repos. If
@@ -124,14 +124,14 @@ common commands
 
 {{tool}}  | {{output_folder}}
 ----------|----------
-terraform | $GOPATH/src/github.com/terraform-providers/terraform-provider-google
+terraform | $GOPATH/src/github.com/hashicorp/terraform-provider-google
 ansible   | build/ansible
 inspec    | build/inspec
 
 For example, to generate Terraform:
 
 ```
-bundle exec compiler -a -v "ga" -e terraform -o "$GOPATH/src/github.com/terraform-providers/terraform-provider-google"
+bundle exec compiler -a -v "ga" -e terraform -o "$GOPATH/src/github.com/hashicorp/terraform-provider-google"
 ```
 
 It's worth noting that Magic Modules will only generate new files when ran
@@ -145,7 +145,7 @@ Terraform is the only tool to handle Beta features right now; you can generate
 and using the repository for the `google-beta` provider.
 
 ```
-bundle exec compiler -a -v "beta" -e terraform -o "$GOPATH/src/github.com/terraform-providers/terraform-provider-google-beta"
+bundle exec compiler -a -v "beta" -e terraform -o "$GOPATH/src/github.com/hashicorp/terraform-provider-google-beta"
 ```
 
 ### Making changes to resources
@@ -217,8 +217,8 @@ Tool             | Testing Guide
 -----------------|--------------
 ansible          | [instructions](https://docs.ansible.com/ansible/devel/dev_guide/testing.html)
 inspec           | [testing inspec-gcp](https://github.com/inspec/inspec-gcp/#test-inspec-gcp-resources)
-terraform        | [`google` provider testing guide](https://github.com/terraform-providers/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests)
-terraform (beta) | [`google-beta` provider testing guide](https://github.com/terraform-providers/terraform-provider-google-beta/blob/master/.github/CONTRIBUTING.md#tests)
+terraform        | [`google` provider testing guide](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests)
+terraform (beta) | [`google-beta` provider testing guide](https://github.com/hashicorp/terraform-provider-google-beta/blob/master/.github/CONTRIBUTING.md#tests)
 
 Don't worry about testing every tool, only the primary tool you're making
 changes against. The Magic Modules maintainers will ensure your changes work

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2673,7 +2673,7 @@ objects:
         base_url: 'projects/{{project}}/zones/{{zone}}/operations/{{op_id}}'
         wait_ms: 1000
         # Larger disks were timing out at creation. Bumping up to 5 minutes.
-        # https://github.com/terraform-providers/terraform-provider-google/issues/703
+        # https://github.com/hashicorp/terraform-provider-google/issues/703
         timeouts: !ruby/object:Api::Timeouts
           insert_minutes: 5
       result: !ruby/object:Api::OpAsync::Result
@@ -5610,7 +5610,7 @@ objects:
         base_url: 'projects/{{project}}/zones/{{zone}}/operations/{{op_id}}'
         wait_ms: 1000
         # Users were experiencing timeouts. Bumping up to 6 minutes.
-        # https://github.com/terraform-providers/terraform-provider-google/issues/852
+        # https://github.com/hashicorp/terraform-provider-google/issues/852
         timeouts: !ruby/object:Api::Timeouts
           insert_minutes: 6
           update_minutes: 6
@@ -13304,7 +13304,7 @@ objects:
         base_url: 'projects/{{project}}/regions/{{region}}/operations/{{op_id}}'
         wait_ms: 1000
         # Users were experiencing timeout. Bumping up to 6 minutes.
-        # https://github.com/terraform-providers/terraform-provider-google/issues/718
+        # https://github.com/hashicorp/terraform-provider-google/issues/718
         timeouts: !ruby/object:Api::Timeouts
           insert_minutes: 6
           update_minutes: 6

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -404,7 +404,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
   Disk: !ruby/object:Overrides::Terraform::ResourceOverride
     # Larger disks were timing out at creation. Bumping up to 5 minutes.
-    # https://github.com/terraform-providers/terraform-provider-google/issues/703
+    # https://github.com/hashicorp/terraform-provider-google/issues/703
     timeouts: !ruby/object:Api::Timeouts
       insert_minutes: 5
     properties:
@@ -948,7 +948,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         exclude: true
   Instance: !ruby/object:Overrides::Terraform::ResourceOverride
     # Users were experiencing timeouts. Bumping up to 6 minutes.
-    # https://github.com/terraform-providers/terraform-provider-google/issues/852
+    # https://github.com/hashicorp/terraform-provider-google/issues/852
     timeouts: !ruby/object:Api::Timeouts
       insert_minutes: 6
       update_minutes: 6
@@ -2270,7 +2270,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         exclude: true
   Subnetwork: !ruby/object:Overrides::Terraform::ResourceOverride
     # Users were experiencing timeout. Bumping up to 6 minutes.
-    # https://github.com/terraform-providers/terraform-provider-google/issues/718
+    # https://github.com/hashicorp/terraform-provider-google/issues/718
     timeouts: !ruby/object:Api::Timeouts
       insert_minutes: 6
       update_minutes: 6

--- a/products/pubsub/terraform.yaml
+++ b/products/pubsub/terraform.yaml
@@ -19,7 +19,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     # Because some users check whether the PubSub resource exists prior
     # to applying a new resource, we need to add this PollAsync to GET the
     # resource until it exists and the negative cached result goes away.
-    # Context: terraform-providers/terraform-provider-google#4993
+    # Context: hashicorp/terraform-provider-google#4993
     async: !ruby/object:Provider::Terraform::PollAsync
       check_response_func_existence: PollCheckForExistence
       actions: ['create']
@@ -69,7 +69,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     # Because some users check whether the PubSub resource exists prior
     # to applying a new resource, we need to add this PollAsync to GET the
     # resource until it exists and the negative cached result goes away.
-    # Context: terraform-providers/terraform-provider-google#4993
+    # Context: hashicorp/terraform-provider-google#4993
     async: !ruby/object:Provider::Terraform::PollAsync
       check_response_func_existence: PollCheckForExistence
       actions: ['create']

--- a/templates/terraform/examples/cloudbuild_trigger_github.tf.erb
+++ b/templates/terraform/examples/cloudbuild_trigger_github.tf.erb
@@ -1,6 +1,6 @@
 resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
   github {
-    owner = "terraform-providers"
+    owner = "hashicorp"
     name  = "terraform-provider-google-beta"
     push {
       branch = "feature-.*"

--- a/third_party/terraform/data_sources/data_source_google_storage_bucket_object.go
+++ b/third_party/terraform/data_sources/data_source_google_storage_bucket_object.go
@@ -28,7 +28,7 @@ func dataSourceGoogleStorageBucketObjectRead(d *schema.ResourceData, meta interf
 
 	// URL encode folder names, but to ensure backward compatibility don't url encode
 	// them if they were already encoded manually in config.
-	// see https://github.com/terraform-providers/terraform-provider-google/issues/3176
+	// see https://github.com/hashicorp/terraform-provider-google/issues/3176
 	if strings.Contains(name, "/") {
 		name = url.QueryEscape(name)
 	}

--- a/third_party/terraform/main.go.erb
+++ b/third_party/terraform/main.go.erb
@@ -3,7 +3,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/plugin"
-	"github.com/terraform-providers/terraform-provider-google<%= "-" + version unless version == 'ga'  -%>/google<%= "-" + version unless version == 'ga'  -%>"
+	"github.com/hashicorp/terraform-provider-google<%= "-" + version unless version == 'ga'  -%>/google<%= "-" + version unless version == 'ga'  -%>"
 )
 
 func main() {

--- a/third_party/terraform/resources/resource_app_engine_application.go
+++ b/third_party/terraform/resources/resource_app_engine_application.go
@@ -255,7 +255,7 @@ func resourceAppEngineApplicationRead(d *schema.ResourceData, meta interface{}) 
 	}
 	err = d.Set("url_dispatch_rule", dispatchRules)
 	if err != nil {
-		return fmt.Errorf("Error setting dispatch rules in state. This is a bug, please report it at https://github.com/terraform-providers/terraform-provider-google/issues. Error is:\n%s", err.Error())
+		return fmt.Errorf("Error setting dispatch rules in state. This is a bug, please report it at https://github.com/hashicorp/terraform-provider-google/issues. Error is:\n%s", err.Error())
 	}
 	featureSettings, err := flattenAppEngineApplicationFeatureSettings(app.FeatureSettings)
 	if err != nil {
@@ -263,7 +263,7 @@ func resourceAppEngineApplicationRead(d *schema.ResourceData, meta interface{}) 
 	}
 	err = d.Set("feature_settings", featureSettings)
 	if err != nil {
-		return fmt.Errorf("Error setting feature settings in state. This is a bug, please report it at https://github.com/terraform-providers/terraform-provider-google/issues. Error is:\n%s", err.Error())
+		return fmt.Errorf("Error setting feature settings in state. This is a bug, please report it at https://github.com/hashicorp/terraform-provider-google/issues. Error is:\n%s", err.Error())
 	}
 	iap, err := flattenAppEngineApplicationIap(d, app.Iap)
 	if err != nil {
@@ -271,7 +271,7 @@ func resourceAppEngineApplicationRead(d *schema.ResourceData, meta interface{}) 
 	}
 	err = d.Set("iap", iap)
 	if err != nil {
-		return fmt.Errorf("Error setting iap in state. This is a bug, please report it at https://github.com/terraform-providers/terraform-provider-google/issues. Error is:\n%s", err.Error())
+		return fmt.Errorf("Error setting iap in state. This is a bug, please report it at https://github.com/hashicorp/terraform-provider-google/issues. Error is:\n%s", err.Error())
 	}
 	return nil
 }

--- a/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -599,7 +599,7 @@ func resourceComputeInstanceTemplateSourceImageCustomizeDiff(diff *schema.Resour
 			}
 			// project must be retrieved once we know there is a diff to resolve, otherwise it will
 			// attempt to retrieve project during `plan` before all calculated fields are ready
-			// see https://github.com/terraform-providers/terraform-provider-google/issues/2878
+			// see https://github.com/hashicorp/terraform-provider-google/issues/2878
 			project, err := getProjectFromDiff(diff, config)
 			if err != nil {
 				return err

--- a/third_party/terraform/resources/resource_compute_security_policy.go.erb
+++ b/third_party/terraform/resources/resource_compute_security_policy.go.erb
@@ -115,7 +115,7 @@ func resourceComputeSecurityPolicy() *schema.Resource {
 													Required:    true,
 													Description: `Textual representation of an expression in Common Expression Language syntax. The application context of the containing message determines which well-known feature set of CEL is supported.`,
 												},
-												// These fields are not yet supported (Issue terraform-providers/terraform-provider-google#4497: mbang)
+												// These fields are not yet supported (Issue hashicorp/terraform-provider-google#4497: mbang)
 												// "title": {
 												// 	Type:     schema.TypeString,
 												// 	Optional: true,
@@ -414,7 +414,7 @@ func expandSecurityPolicyMatchExpr(expr []interface{}) *compute.Expr {
 	data := expr[0].(map[string]interface{})
 	return &compute.Expr{
 		Expression: data["expression"].(string),
-		// These fields are not yet supported  (Issue terraform-providers/terraform-provider-google#4497: mbang)
+		// These fields are not yet supported  (Issue hashicorp/terraform-provider-google#4497: mbang)
 		// Title:       data["title"].(string),
 		// Description: data["description"].(string),
 		// Location:    data["location"].(string),
@@ -470,7 +470,7 @@ func flattenMatchExpr(match *compute.SecurityPolicyRuleMatcher) []map[string]int
 
 	data := map[string]interface{}{
 		"expression": match.Expr.Expression,
-		// These fields are not yet supported (Issue terraform-providers/terraform-provider-google#4497: mbang)
+		// These fields are not yet supported (Issue hashicorp/terraform-provider-google#4497: mbang)
 		// "title":       match.Expr.Title,
 		// "description": match.Expr.Description,
 		// "location":    match.Expr.Location,

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1192,7 +1192,7 @@ func resourceContainerCluster() *schema.Resource {
 // previous syntax requires that schema.SchemaConfigModeAttr is set on the field it is advisable that
 // we have a work around for removing guest accelerators. Also Terraform 0.11 cannot use dynamic blocks
 // so this isn't a solution for module authors who want to dynamically omit guest accelerators
-// See https://github.com/terraform-providers/terraform-provider-google/issues/3786
+// See https://github.com/hashicorp/terraform-provider-google/issues/3786
 func resourceNodeConfigEmptyGuestAccelerator(diff *schema.ResourceDiff, meta interface{}) error {
 	old, new := diff.GetChange("node_config.0.guest_accelerator")
 	oList := old.([]interface{})
@@ -3580,7 +3580,7 @@ func containerClusterPrivateClusterConfigCustomDiff(d *schema.ResourceDiff, meta
 
 		// We can only apply this validation if we know the final value of the field, and we may
 		// not know the final value if users feed the value into their config in unintuitive ways.
-		// https://github.com/terraform-providers/terraform-provider-google/issues/4186
+		// https://github.com/hashicorp/terraform-provider-google/issues/4186
 		blockValueKnown := d.NewValueKnown("private_cluster_config.0.master_ipv4_cidr_block")
 
 		if blockValueKnown && (block == nil || block == "") {

--- a/third_party/terraform/resources/resource_google_organization_policy.go
+++ b/third_party/terraform/resources/resource_google_organization_policy.go
@@ -13,7 +13,7 @@ var schemaOrganizationPolicy = map[string]*schema.Schema{
 	// Although the API suggests that boolean_policy, list_policy, or restore_policy must be set,
 	// Organization policies can be "inherited from parent" in the UI, and this is the default
 	// state of the resource without any policy set.
-	// See https://github.com/terraform-providers/terraform-provider-google/issues/3607
+	// See https://github.com/hashicorp/terraform-provider-google/issues/3607
 	"constraint": {
 		Type:             schema.TypeString,
 		Required:         true,
@@ -257,7 +257,7 @@ func resourceGoogleOrganizationPolicyImportState(d *schema.ResourceData, meta in
 // state of the resource without any policy set. In order to revert to this state the current
 // resource cannot be updated it must instead be Deleted. This allows Terraform to assert that
 // no policy has been set even if previously one had.
-// See https://github.com/terraform-providers/terraform-provider-google/issues/3607
+// See https://github.com/hashicorp/terraform-provider-google/issues/3607
 func isOrganizationPolicyUnset(d *schema.ResourceData) bool {
 	listPolicy := d.Get("list_policy").([]interface{})
 	booleanPolicy := d.Get("boolean_policy").([]interface{})

--- a/third_party/terraform/resources/resource_logging_exclusion.go
+++ b/third_party/terraform/resources/resource_logging_exclusion.go
@@ -59,7 +59,7 @@ func resourceLoggingExclusionCreate(newUpdaterFunc newResourceLoggingExclusionUp
 		id, exclusion := expandResourceLoggingExclusion(d, updater.GetResourceType(), updater.GetResourceId())
 
 		// Logging exclusions don't seem to be able to be mutated in parallel, see
-		// https://github.com/terraform-providers/terraform-provider-google/issues/4796
+		// https://github.com/hashicorp/terraform-provider-google/issues/4796
 		mutexKV.Lock(id.parent())
 		defer mutexKV.Unlock(id.parent())
 
@@ -110,7 +110,7 @@ func resourceLoggingExclusionUpdate(newUpdaterFunc newResourceLoggingExclusionUp
 		exclusion, updateMask := expandResourceLoggingExclusionForUpdate(d)
 
 		// Logging exclusions don't seem to be able to be mutated in parallel, see
-		// https://github.com/terraform-providers/terraform-provider-google/issues/4796
+		// https://github.com/hashicorp/terraform-provider-google/issues/4796
 		mutexKV.Lock(id.parent())
 		defer mutexKV.Unlock(id.parent())
 
@@ -133,7 +133,7 @@ func resourceLoggingExclusionDelete(newUpdaterFunc newResourceLoggingExclusionUp
 
 		id, _ := expandResourceLoggingExclusion(d, updater.GetResourceType(), updater.GetResourceId())
 		// Logging exclusions don't seem to be able to be mutated in parallel, see
-		// https://github.com/terraform-providers/terraform-provider-google/issues/4796
+		// https://github.com/hashicorp/terraform-provider-google/issues/4796
 		mutexKV.Lock(id.parent())
 		defer mutexKV.Unlock(id.parent())
 

--- a/third_party/terraform/scripts/affectedtests/affectedtests.go
+++ b/third_party/terraform/scripts/affectedtests/affectedtests.go
@@ -119,7 +119,7 @@ func readProviderFiles(googleDir string) ([]string, error) {
 }
 
 func getDiffFromPR(pr uint, repo string) (string, error) {
-	resp, err := http.Get(fmt.Sprintf("https://github.com/terraform-providers/terraform-provider-%s/pull/%d.diff", repo, pr))
+	resp, err := http.Get(fmt.Sprintf("https://github.com/hashicorp/terraform-provider-%s/pull/%d.diff", repo, pr))
 	if err != nil {
 		return "", err
 	}

--- a/third_party/terraform/scripts/changelog-links.sh.erb
+++ b/third_party/terraform/scripts/changelog-links.sh.erb
@@ -26,7 +26,7 @@ else
 fi
 
 <% provider_name = version.nil? || version == 'ga' ? 'google' : 'google-' + version -%>
-PROVIDER_URL="https:\/\/github.com\/terraform-providers\/terraform-provider-<%= provider_name -%>\/issues"
+PROVIDER_URL="https:\/\/github.com\/hashicorp\/terraform-provider-<%= provider_name -%>\/issues"
 
 $SED "s/GH-([0-9]+)/\[#\1\]\($PROVIDER_URL\/\1\)/g" -e 's/\[\[#(.+)([0-9])\)]$/(\[#\1\2))/g' CHANGELOG.md
 

--- a/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_security_policy_test.go.erb
@@ -301,7 +301,7 @@ resource "google_compute_security_policy" "policy" {
 		priority = "2000"
 		match {
 			expr {
-				// These fields are not yet supported (Issue terraform-providers/terraform-provider-google#4497: mbang)
+				// These fields are not yet supported (Issue hashicorp/terraform-provider-google#4497: mbang)
 				// title = "Has User"
 				// description = "Determines whether the request has a user account"
 				expression = "evaluatePreconfiguredExpr('xss-canary')"

--- a/third_party/terraform/tests/resource_pubsub_subscription_test.go
+++ b/third_party/terraform/tests/resource_pubsub_subscription_test.go
@@ -118,7 +118,7 @@ func TestAccPubsubSubscription_push(t *testing.T) {
 	})
 }
 
-// Context: terraform-providers/terraform-provider-google#4993
+// Context: hashicorp/terraform-provider-google#4993
 // This test makes a call to GET an subscription before it is actually created.
 // The PubSub API negative-caches responses so this tests we are
 // correctly polling for existence post-creation.

--- a/third_party/terraform/utils/error_retry_predicates.go
+++ b/third_party/terraform/utils/error_retry_predicates.go
@@ -82,7 +82,7 @@ func isConnectionResetNetworkError(err error) (bool, string) {
 //
 //The only way right now to determine it is a retryable 409 due to
 // concurrent calls is to look at the contents of the error message.
-// See https://github.com/terraform-providers/terraform-provider-google/issues/3279
+// See https://github.com/hashicorp/terraform-provider-google/issues/3279
 func is409OperationInProgressError(err error) (bool, string) {
 	gerr, ok := err.(*googleapi.Error)
 	if !ok {
@@ -150,7 +150,7 @@ func iamMemberMissing(err error) (bool, string) {
 
 // Cloud PubSub returns a 400 error if a topic's parent project was recently created and an
 // organization policy has not propagated.
-// See https://github.com/terraform-providers/terraform-provider-google/issues/4349
+// See https://github.com/hashicorp/terraform-provider-google/issues/4349
 func pubsubTopicProjectNotReady(err error) (bool, string) {
 	if gerr, ok := err.(*googleapi.Error); ok {
 		if gerr.Code == 400 && strings.Contains(gerr.Body, "retry this operation") {

--- a/third_party/terraform/utils/iam.go.erb
+++ b/third_party/terraform/utils/iam.go.erb
@@ -118,7 +118,7 @@ func iamPolicyReadModifyWrite(updater ResourceIamUpdater, modify iamPolicyModify
 				}
 				log.Printf("[DEBUG]: Retrieved policy for %s: %+v\n", updater.DescribeResource(), p)
 				if new_p == nil {
-					// https://github.com/terraform-providers/terraform-provider-google/issues/2625
+					// https://github.com/hashicorp/terraform-provider-google/issues/2625
 					fetchBackoff = fetchBackoff * 2
 					continue
 				}

--- a/third_party/terraform/utils/provider_handwritten_endpoint.go.erb
+++ b/third_party/terraform/utils/provider_handwritten_endpoint.go.erb
@@ -4,7 +4,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/terraform-providers/terraform-provider-google-beta/google-beta"
+	"github.com/hashicorp/terraform-provider-google-beta/google-beta"
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/mutexkv"

--- a/third_party/terraform/utils/transport.go
+++ b/third_party/terraform/utils/transport.go
@@ -99,7 +99,7 @@ func sendRequestWithTimeout(config *Config, method, project, rawurl string, body
 	}
 
 	if res == nil {
-		return nil, fmt.Errorf("Unable to parse server response. This is most likely a terraform problem, please file a bug at https://github.com/terraform-providers/terraform-provider-google/issues.")
+		return nil, fmt.Errorf("Unable to parse server response. This is most likely a terraform problem, please file a bug at https://github.com/hashicorp/terraform-provider-google/issues.")
 	}
 
 	// The defer call must be made outside of the retryFunc otherwise it's closed too soon.

--- a/third_party/terraform/website/docs/guides/version_2_upgrade.html.markdown
+++ b/third_party/terraform/website/docs/guides/version_2_upgrade.html.markdown
@@ -21,7 +21,7 @@ for details if you're new to using `google-beta`.
 Most of the changes outlined in this guide have been previously marked as
 deprecated in the Terraform `plan`/`apply` output throughout previous provider
 releases, up to and including 1.20.0. These changes, such as deprecation notices,
-can always be found in the [CHANGELOG](https://github.com/terraform-providers/terraform-provider-google/blob/master/CHANGELOG.md).
+can always be found in the [CHANGELOG](https://github.com/hashicorp/terraform-provider-google/blob/master/CHANGELOG.md).
 
 ## Why version 2.0.0?
 
@@ -166,7 +166,7 @@ available. For more information see [the official documentation on GCP launch st
 
 Because the API for beta features can change before their GA launch, there may
 be breaking changes in the `google-beta` provider in minor release versions.
-These changes will be announced in the [`google-beta` CHANGELOG](https://github.com/terraform-providers/terraform-provider-google-beta/blob/master/CHANGELOG.md).
+These changes will be announced in the [`google-beta` CHANGELOG](https://github.com/hashicorp/terraform-provider-google-beta/blob/master/CHANGELOG.md).
 
 To have resources at different API versions, set up provider blocks for each version:
 
@@ -642,7 +642,7 @@ Then, import that suffix as the value of `random_id`:
 terraform import random_id.np example-np-,ELFZ1rbrAThoeQE
 ```
 
-For more details, see [terraform-provider-google#1054](https://github.com/terraform-providers/terraform-provider-google/issues/1054).
+For more details, see [terraform-provider-google#1054](https://github.com/hashicorp/terraform-provider-google/issues/1054).
 
 ## Resource: `google_endpoints_service`
 

--- a/third_party/terraform/website/docs/guides/version_3_upgrade.html.markdown
+++ b/third_party/terraform/website/docs/guides/version_3_upgrade.html.markdown
@@ -17,8 +17,8 @@ Most of the changes outlined in this guide have been previously marked as
 deprecated in the Terraform `plan`/`apply` output throughout previous provider
 releases, up to and including the final `2.X` series release. These changes,
 such as deprecation notices, can always be found in the CHANGELOG of the
-affected providers. [google](https://github.com/terraform-providers/terraform-provider-google/blob/master/CHANGELOG.md)
-[google-beta](https://github.com/terraform-providers/terraform-provider-google-beta/blob/master/CHANGELOG.md)
+affected providers. [google](https://github.com/hashicorp/terraform-provider-google/blob/master/CHANGELOG.md)
+[google-beta](https://github.com/hashicorp/terraform-provider-google-beta/blob/master/CHANGELOG.md)
 
 ## What is `3.0.0-beta.1`?
 

--- a/third_party/terraform/website/docs/index.html.markdown
+++ b/third_party/terraform/website/docs/index.html.markdown
@@ -43,8 +43,8 @@ If you have configuration questions, or general questions about using the provid
 ## Releases
 
 Interested in the provider's latest features, or want to make sure you're up to date?
-Check out the [`google` provider changelog](https://github.com/terraform-providers/terraform-provider-google/blob/master/CHANGELOG.md)
-and the [`google-beta` provider changelog](https://github.com/terraform-providers/terraform-provider-google-beta/blob/master/CHANGELOG.md))
+Check out the [`google` provider changelog](https://github.com/hashicorp/terraform-provider-google/blob/master/CHANGELOG.md)
+and the [`google-beta` provider changelog](https://github.com/hashicorp/terraform-provider-google-beta/blob/master/CHANGELOG.md))
 for release notes and additional information.
 
 Per [Terraform Provider Versioning](https://www.hashicorp.com/blog/hashicorp-terraform-provider-versioning),
@@ -75,7 +75,7 @@ lifecycle to give users plenty of time to safely update their configs.
 
 ## Features and Bug Requests
 
-The Google provider's bugs and feature requests can be found in the [GitHub repo issues](https://github.com/terraform-providers/terraform-provider-google/issues).
+The Google provider's bugs and feature requests can be found in the [GitHub repo issues](https://github.com/hashicorp/terraform-provider-google/issues).
 Please avoid "me too" or "+1" comments. Instead, use a thumbs up [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/)
 on enhancement requests. Provider maintainers will often prioritize work based on the
 number of thumbs on an issue.
@@ -86,9 +86,9 @@ experience for you using the Google provider.
 
 If you have a bug or feature request without an existing issue
 
-* and an existing resource or field is working in an unexpected way, [file a bug](https://github.com/terraform-providers/terraform-provider-google/issues/new?template=bug.md).
+* and an existing resource or field is working in an unexpected way, [file a bug](https://github.com/hashicorp/terraform-provider-google/issues/new?template=bug.md).
 
-* and you'd like the provider to support a new resource or field, [file an enhancement/feature request](https://github.com/terraform-providers/terraform-provider-google/issues/new?template=enhancement.md).
+* and you'd like the provider to support a new resource or field, [file an enhancement/feature request](https://github.com/hashicorp/terraform-provider-google/issues/new?template=enhancement.md).
 
 The provider maintainers will often use the assignee field on an issue to mark
 who is working on it.
@@ -104,7 +104,7 @@ the issue!
 ## Contributing
 
 If you'd like to help extend the Google provider, we gladly accept community
-contributions! Our full contribution guide is available at [CONTRIBUTING.md](https://github.com/terraform-providers/terraform-provider-google/blob/master/.github/CONTRIBUTING.md)
+contributions! Our full contribution guide is available at [CONTRIBUTING.md](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md)
 
 Pull requests can be made against either provider repo where a maintainer will
 apply them to both `google` and `google-beta`, or against [Magic Modules](https://github.com/GoogleCloudPlatform/magic-modules)

--- a/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -391,7 +391,7 @@ instance.
   * A `PRIVATE` address is an address for an instance which has been configured to use private networking see: [Private IP](https://cloud.google.com/sql/docs/mysql/private-ip).
 
 * `first_ip_address` - The first IPv4 address of any type assigned. This is to
-support accessing the [first address in the list in a terraform output](https://github.com/terraform-providers/terraform-provider-google/issues/912)
+support accessing the [first address in the list in a terraform output](https://github.com/hashicorp/terraform-provider-google/issues/912)
 when the resource is configured with a `count`.
 
 * `public_ip_address` - The first public (`PRIMARY`) IPv4 address assigned. This is

--- a/tools/bootstrap
+++ b/tools/bootstrap
@@ -24,13 +24,13 @@ fi
 if [[ -z "${GOPATH}" ]]; then
   echo "Skipping Terraform as GOPATH could not be determined"
 else
-    if [ ! -d "${GOPATH}/src/github.com/terraform-providers/terraform-provider-google" ]; then
-        git clone https://github.com/terraform-providers/terraform-provider-google.git \
-            $GOPATH/src/github.com/terraform-providers/terraform-provider-google
+    if [ ! -d "${GOPATH}/src/github.com/hashicorp/terraform-provider-google" ]; then
+        git clone https://github.com/hashicorp/terraform-provider-google.git \
+            $GOPATH/src/github.com/hashicorp/terraform-provider-google
     fi
-    if [ ! -d "${GOPATH}/src/github.com/terraform-providers/terraform-provider-google-beta" ]; then
-        git clone https://github.com/terraform-providers/terraform-provider-google-beta.git \
-            $GOPATH/src/github.com/terraform-providers/terraform-provider-google-beta
+    if [ ! -d "${GOPATH}/src/github.com/hashicorp/terraform-provider-google-beta" ]; then
+        git clone https://github.com/hashicorp/terraform-provider-google-beta.git \
+            $GOPATH/src/github.com/hashicorp/terraform-provider-google-beta
     fi
 fi
 


### PR DESCRIPTION
While migrating google and google-beta provider repos to hashicorp org in github, want to make sure our URLs are correct.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
