### PR TITLE
Fix GKE tests by checking for nil releasechannel before casting.

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -2940,7 +2940,7 @@ func expandDatabaseEncryption(configured interface{}) *containerBeta.DatabaseEnc
 }
 
 func expandReleaseChannel(configured interface{}) *containerBeta.ReleaseChannel {
-	if l == nil {
+	if configured == nil {
 		return nil
 	}
 	l := configured.([]interface{})

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -2940,6 +2940,9 @@ func expandDatabaseEncryption(configured interface{}) *containerBeta.DatabaseEnc
 }
 
 func expandReleaseChannel(configured interface{}) *containerBeta.ReleaseChannel {
+	if l == nil {
+		return nil
+	}
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
 		return nil


### PR DESCRIPTION
Should fix test failures in https://ci-oss.hashicorp.engineering/buildConfiguration/GoogleCloud_ProviderGoogleCloudMmUpstreamVcr/138115.


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```