### PR TITLE
Promote the schema block for release_channel to GA

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1065,7 +1065,6 @@ func resourceContainerCluster() *schema.Resource {
         },
       },
 
-<% unless version == 'ga' -%>
 			"release_channel": {
 				Type:        schema.TypeList,
 				Optional:    true,
@@ -1085,7 +1084,7 @@ func resourceContainerCluster() *schema.Resource {
 				},
 			},
 
-
+<% unless version == 'ga' -%>
 			"tpu_ipv4_cidr_block": {
 				Computed:    true,
 				Type:        schema.TypeString,


### PR DESCRIPTION
Fix-forward for https://github.com/GoogleCloudPlatform/magic-modules/pull/3834, supersedes https://github.com/GoogleCloudPlatform/magic-modules/pull/3836

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
