### PR TITLE
Fix buggy import of artifact repository.

### DIFF
--- a/products/artifactregistry/terraform.yaml
+++ b/products/artifactregistry/terraform.yaml
@@ -15,6 +15,7 @@
 overrides: !ruby/object:Overrides::ResourceOverrides
   Repository: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: projects/{{project}}/locations/{{location}}/repositories/{{repsitory_id}}
+    import_format: ["projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}", "{{repository_id}}"]
     autogen_async: true
     examples:
       - !ruby/object:Provider::Terraform::Examples


### PR DESCRIPTION
Fixes https://github.com/terraform-providers/terraform-provider-google/issues/6936.

The issue here is that in this resource, `name` is an output, `repository_id` is what we'd normally call `name`.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
artifactrepository: Fix import failure of `google_artifact_registry_repository`.
```