### PR TITLE
Promote release_channel_default_version field in data.google_container_engine_versions to GA

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_container_engine_versions.go.erb
+++ b/third_party/terraform/data_sources/data_source_google_container_engine_versions.go.erb
@@ -58,14 +58,11 @@ func dataSourceGoogleContainerEngineVersions() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-
-<% unless version == 'ga' -%>
 			"release_channel_default_version": {
 				Type:     schema.TypeMap,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-<% end %>
 		},
 	}
 }
@@ -118,13 +115,11 @@ func dataSourceGoogleContainerEngineVersionsRead(d *schema.ResourceData, meta in
 
 	d.Set("default_cluster_version", resp.DefaultClusterVersion)
 
-<% unless version == 'ga' -%>
   m := map[string]string{}
 	for _, v := range resp.Channels {
 		m[v.Channel] = v.DefaultVersion
 	}
 	d.Set("release_channel_default_version", m)
-<% end %>
 
 	d.SetId(time.Now().UTC().String())
 	return nil

--- a/third_party/terraform/website/docs/d/container_engine_versions.html.markdown
+++ b/third_party/terraform/website/docs/d/container_engine_versions.html.markdown
@@ -71,4 +71,4 @@ The following attributes are exported:
 * `latest_master_version` - The latest version available in the given zone for use with master instances.
 * `latest_node_version` - The latest version available in the given zone for use with node instances.
 * `default_cluster_version` - Version of Kubernetes the service deploys by default.
-* `release_channel_default_version` ([Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) - A map from a release channel name to the channel's default version.
+* `release_channel_default_version` - A map from a release channel name to the channel's default version.


### PR DESCRIPTION
One last failing test after https://github.com/GoogleCloudPlatform/magic-modules/pull/3837 uses this field.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added `release_channel_default_version` field to `data.google_container_engine_versions` (GA) 
```
