### PR TITLE
Update google_billing_budget resource to add last_period_amount

### DIFF
--- a/products/billingbudget/api.yaml
+++ b/products/billingbudget/api.yaml
@@ -113,11 +113,13 @@ objects:
             properties:
               - !ruby/object:Api::Type::NestedObject
                 name: specifiedAmount
+                exactly_one_of:
+                  - budget.0.amount.0.specified_amount
+                  - budget.0.amount.0.last_period_amount
                 description: |
                   A specified amount to use as the budget. currencyCode is
                   optional. If specified, it must match the currency of the
                   billing account. The currencyCode is provided on output.
-                required: true
                 properties:
                   - !ruby/object:Api::Type::String
                     name: currencyCode
@@ -138,6 +140,16 @@ objects:
                       negative. If units is negative, nanos must be negative or
                       zero. For example $-1.75 is represented as units=-1 and
                       nanos=-750,000,000.
+              - !ruby/object:Api::Type::Boolean
+                name: 'lastPeriodAmount'
+                exactly_one_of:
+                  - budget.0.amount.0.specified_amount
+                  - budget.0.amount.0.last_period_amount
+                description: |
+                  Configures a budget amount that is automatically set to 100% of
+                  last period's spend.
+                  Boolean. Set value to true to use. Do not set to false, instead
+                  use the `specified_amount` block.
           - !ruby/object:Api::Type::Array
             name: thresholdRules
             required: true

--- a/products/billingbudget/terraform.yaml
+++ b/products/billingbudget/terraform.yaml
@@ -26,6 +26,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_env_vars:
           billing_acct: :BILLING_ACCT
       - !ruby/object:Provider::Terraform::Examples
+        name: 'billing_budget_lastperiod'
+        min_version: beta
+        primary_resource_id: 'budget'
+        vars:
+          display_name: 'Example Billing Budget'
+        test_env_vars:
+          billing_acct: :BILLING_ACCT
+          project: :PROJECT_NAME
+      - !ruby/object:Provider::Terraform::Examples
         name: 'billing_budget_filter'
         min_version: beta
         primary_resource_id: 'budget'

--- a/products/billingbudget/terraform.yaml
+++ b/products/billingbudget/terraform.yaml
@@ -50,6 +50,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       budget: !ruby/object:Overrides::Terraform::PropertyOverride
         flatten_object: true
+      budget.amount.lastPeriodAmount: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/bool_to_object.go.erb'
+        custom_flatten: 'templates/terraform/custom_flatten/object_to_bool.go.erb'
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/templates/terraform/examples/billing_budget_lastperiod.tf.erb
+++ b/templates/terraform/examples/billing_budget_lastperiod.tf.erb
@@ -1,0 +1,25 @@
+data "google_billing_account" "account" {
+  provider = google-beta
+  billing_account = "<%= ctx[:test_env_vars]['billing_acct'] -%>"
+}
+
+resource "google_billing_budget" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+  billing_account = data.google_billing_account.account.id
+  display_name = "<%= ctx[:vars]['display_name'] %>"
+  
+  budget_filter {
+    projects = ["projects/<%= ctx[:test_env_vars]['project'] -%>"]
+  }
+
+  amount {
+    last_period_amount = true
+  }
+
+  threshold_rules {
+      threshold_percent =  10.0
+      # Typically threshold_percent would be set closer to 1.0 (100%).
+      # It has been purposely set high (10.0 / 1000%) in this example
+      # so it does not trigger alerts during automated testing.
+  }
+}

--- a/templates/terraform/examples/billing_budget_notify.tf.erb
+++ b/templates/terraform/examples/billing_budget_notify.tf.erb
@@ -13,8 +13,11 @@ resource "google_billing_budget" "<%= ctx[:primary_resource_id] %>" {
   }
 
   amount {
-    last_period_amount = true
-  }
+     specified_amount {
+       currency_code = "USD"
+       units         = "100000"
+     }
+   }
 
   threshold_rules {
     threshold_percent = 1.0

--- a/templates/terraform/examples/billing_budget_notify.tf.erb
+++ b/templates/terraform/examples/billing_budget_notify.tf.erb
@@ -13,10 +13,7 @@ resource "google_billing_budget" "<%= ctx[:primary_resource_id] %>" {
   }
 
   amount {
-    specified_amount {
-      currency_code = "USD"
-      units         = "100000"
-    }
+    last_period_amount = true
   }
 
   threshold_rules {

--- a/templates/terraform/examples/billing_budget_notify.tf.erb
+++ b/templates/terraform/examples/billing_budget_notify.tf.erb
@@ -13,11 +13,11 @@ resource "google_billing_budget" "<%= ctx[:primary_resource_id] %>" {
   }
 
   amount {
-     specified_amount {
-       currency_code = "USD"
-       units         = "100000"
-     }
-   }
+    specified_amount {
+      currency_code = "USD"
+      units         = "100000"
+    }
+  }
 
   threshold_rules {
     threshold_percent = 1.0


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/5245

This uses overrides for a boolean to transform it into an empty block, as the `LastPeriodAmount` field in the `billingAccounts.budgets` API doesn't currently have any configureable properties. [See details in API documentation.](https://cloud.google.com/billing/docs/reference/budget/rest/v1beta1/billingAccounts.budgets#lastperiodamount)

This workaround was mentioned by @danawillow in the above issue and is being used in [BigTable AppProfile](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/products/bigtable/api.yaml#L65). I can also see it's now being used in the [dns](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/products/dns/terraform.yaml#L129) and [secret manager](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/products/secretmanager/terraform.yaml#L25) resources.

In the Terraform example / test I've added somewhat of a disclaimer. I don't think this is typical, but felt this was needed to call out it's not a "good" example of how actually to set the `threshold_percent` value, and it could be confusing if not mentioned (people may assume 10.0 = 10% when it's actually 1000%).
My concern is if this is set to a more normal value (e.g. 1.0) it could trigger actual email alerts to Billing Admins when running tests.

---

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note: enhancement
billing_budget: added `last_period_amount` field to `google_billing_budget` to allow setting budget amount automatically to the last billing period's spend.
```