### PR TITLE
Add DatabaseConfig and WebServerConfig to Cloud Composer's EnvironmentConfig

### DIFF
--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -53,6 +53,10 @@ var (
 <% unless version == "ga" -%>
 		"config.0.web_server_network_access_control",
 <% end -%>
+<% unless version == "ga" -%>
+		"config.0.database_config",
+		"config.0.web_server_config",
+<% end -%>
 	}
 
 <% unless version == "ga" -%>
@@ -394,6 +398,44 @@ func resourceComposerEnvironment() *schema.Resource {
 							},
 						},
 <% end -%>
+<% unless version == "ga" -%>
+						"database_config": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: composerConfigKeys,
+							MaxItems:     1,
+							Description:  `The configuration of Cloud SQL instance that is used by the Apache Airflow software.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"machine_type": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										Description: `Optional. Cloud SQL machine type used by Airflow database. It has to be one of: db-n1-standard-2, db-n1-standard-4, db-n1-standard-8 or db-n1-standard-16. If not specified, db-n1-standard-2 will be used.`,
+									},
+								},
+							},
+						},
+						"web_server_config": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: composerConfigKeys,
+							MaxItems:     1,
+							Description:  `The configuration settings for the Airflow web server App Engine instance.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"machine_type": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ForceNew:     true,
+										Description: `Optional. Machine type on which Airflow web server is running. It has to be one of: composer-n1-webserver-2, composer-n1-webserver-4 or composer-n1-webserver-8. If not specified, composer-n1-webserver-2 will be used. Value custom is returned only in response, if Airflow web server parameters were manually changed to a non-standard values.`,
+									},
+								},
+							},
+						},
+<% end -%>
 						"airflow_uri": {
 							Type:        schema.TypeString,
 							Computed:    true,
@@ -631,6 +673,32 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 			}
 			d.SetPartial("config")
 		}
+
+<% unless version == "ga" -%>
+		if d.HasChange("config.0.database_config") {
+			patchObj := &composer.Environment{Config: &composer.EnvironmentConfig{}}
+			if config != nil {
+				patchObj.Config.DatabaseConfig = config.DatabaseConfig
+			}
+			err = resourceComposerEnvironmentPatchField("config.databaseConfig", patchObj, d, tfConfig)
+			if err != nil {
+				return err
+			}
+			d.SetPartial("config")
+		}
+
+		if d.HasChange("config.0.web_server_config") {
+			patchObj := &composer.Environment{Config: &composer.EnvironmentConfig{}}
+			if config != nil {
+				patchObj.Config.WebServerConfig = config.WebServerConfig
+			}
+			err = resourceComposerEnvironmentPatchField("config.webServerConfig", patchObj, d, tfConfig)
+			if err != nil {
+				return err
+			}
+			d.SetPartial("config")
+		}
+<% end -%>
 	}
 
 	if d.HasChange("labels") {
@@ -750,6 +818,10 @@ func flattenComposerEnvironmentConfig(envCfg *composer.EnvironmentConfig) interf
 <% unless version == "ga" -%>
 	transformed["web_server_network_access_control"] = flattenComposerEnvironmentConfigWebServerNetworkAccessControl(envCfg.WebServerNetworkAccessControl)
 <% end -%>
+<% unless version == "ga" -%>
+	transformed["database_config"] = flattenComposerEnvironmentConfigDatabaseConfig(envCfg.DatabaseConfig)
+	transformed["web_server_config"] = flattenComposerEnvironmentConfigWebServerConfig(envCfg.WebServerConfig)
+<% end -%>
 
 	return []interface{}{transformed}
 }
@@ -775,8 +847,32 @@ func flattenComposerEnvironmentConfigWebServerNetworkAccessControl(accessControl
 
 	return []interface{}{webServerNetworkAccessControl}
 }
-
 <% end -%>
+
+<% unless version == "ga" -%>
+func flattenComposerEnvironmentConfigDatabaseConfig(databaseCfg *composer.DatabaseConfig) interface{} {
+	if databaseCfg == nil {
+		return nil
+	}
+
+	transformed := make(map[string]interface{})
+	transformed["machine_type"] = databaseCfg.MachineType
+
+	return []interface{}{transformed}
+}
+
+func flattenComposerEnvironmentConfigWebServerConfig(webServerCfg *composer.WebServerConfig) interface{} {
+	if webServerCfg == nil {
+		return nil
+	}
+
+	transformed := make(map[string]interface{})
+	transformed["machine_type"] = webServerCfg.MachineType
+
+	return []interface{}{transformed}
+}
+<% end -%>
+
 func flattenComposerEnvironmentConfigPrivateEnvironmentConfig(envCfg *composer.PrivateEnvironmentConfig) interface{} {
 	if envCfg == nil {
 		return nil
@@ -891,6 +987,21 @@ func expandComposerEnvironmentConfig(v interface{}, d *schema.ResourceData, conf
 	transformed.WebServerNetworkAccessControl = transformedWebServerNetworkAccessControl
 
 <% end -%>
+
+<% unless version == "ga" -%>
+	transformedDatabaseConfig, err := expandComposerEnvironmentConfigDatabaseConfig(original["database_config"], d, config)
+	if err != nil {
+		return nil, err
+	}
+	transformed.DatabaseConfig = transformedDatabaseConfig
+
+	transformedWebServerConfig, err := expandComposerEnvironmentConfigWebServerConfig(original["web_server_config"], d, config)
+	if err != nil {
+		return nil, err
+	}
+	transformed.WebServerConfig = transformedWebServerConfig
+
+<% end -%>
 	return transformed, nil
 }
 
@@ -932,6 +1043,38 @@ func expandComposerEnvironmentConfigWebServerNetworkAccessControl(v interface{},
 }
 
 <% end -%>
+
+<% unless version == "ga" -%>
+func expandComposerEnvironmentConfigDatabaseConfig(v interface{}, d *schema.ResourceData, config *Config) (*composer.DatabaseConfig, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+
+	transformed := &composer.DatabaseConfig{}
+	transformed.MachineType = original["machine_type"].(string)
+
+	return transformed, nil
+}
+
+func expandComposerEnvironmentConfigWebServerConfig(v interface{}, d *schema.ResourceData, config *Config) (*composer.WebServerConfig, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+
+	transformed := &composer.WebServerConfig{}
+	transformed.MachineType = original["machine_type"].(string)
+
+	return transformed, nil
+}
+
+<% end -%>
+
 func expandComposerEnvironmentConfigPrivateEnvironmentConfig(v interface{}, d *schema.ResourceData, config *Config) (*composer.PrivateEnvironmentConfig, error) {
 	l := v.([]interface{})
 	if len(l) == 0 {

--- a/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -223,6 +223,78 @@ func TestAccComposerEnvironment_privateWithWebServerControl(t *testing.T) {
 }
 
 <% end -%>
+
+<% unless version == "ga" -%>
+func TestAccComposerEnvironment_withDatabaseConfig(t *testing.T) {
+	t.Parallel()
+	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
+	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
+	subnetwork := network + "-1"
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccComposerEnvironmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComposerEnvironment_databaseCfg(envName, network, subnetwork),
+			},
+			{
+				Config: testAccComposerEnvironment_databaseCfgUpdated(envName, network, subnetwork),
+			},
+			{
+				ResourceName:      "google_composer_environment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// This is a terrible clean-up step in order to get destroy to succeed,
+			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
+			// TODO(emilyye): Remove this check if firewall rules bug gets fixed by Composer.
+			{
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+				Config:             testAccComposerEnvironment_databaseCfgUpdated(envName, network, subnetwork),
+				Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
+			},
+		},
+	})
+}
+
+func TestAccComposerEnvironment_withWebServerConfig(t *testing.T) {
+	t.Parallel()
+	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
+	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
+	subnetwork := network + "-1"
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccComposerEnvironmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComposerEnvironment_webServerCfg(envName, network, subnetwork),
+			},
+			{
+				Config: testAccComposerEnvironment_webServerCfgUpdated(envName, network, subnetwork),
+			},
+			{
+				ResourceName:      "google_composer_environment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// This is a terrible clean-up step in order to get destroy to succeed,
+			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
+			// TODO(emilyye): Remove this check if firewall rules bug gets fixed by Composer.
+			{
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+				Config:             testAccComposerEnvironment_webServerCfgUpdated(envName, network, subnetwork),
+				Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
+			},
+		},
+	})
+}
+<% end -%>
 // Checks behavior of node config, including dependencies on Compute resources.
 func TestAccComposerEnvironment_withNodeConfig(t *testing.T) {
 	t.Parallel()
@@ -260,7 +332,7 @@ func TestAccComposerEnvironment_withNodeConfig(t *testing.T) {
 
 func TestAccComposerEnvironment_withSoftwareConfig(t *testing.T) {
 	t.Parallel()
- 	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
+	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
 	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
 	subnetwork := network + "-1"
 
@@ -357,29 +429,29 @@ func testAccComposerEnvironmentDestroyProducer(t *testing.T) func(s *terraform.S
 func testAccComposerEnvironment_basic(name, network, subnetwork string) string {
 	return fmt.Sprintf(`
 resource "google_composer_environment" "test" {
-  name   = "%s"
-  region = "us-central1"
-  config {
-    node_config {
-      network    = google_compute_network.test.self_link
-      subnetwork = google_compute_subnetwork.test.self_link
-      zone       = "us-central1-a"
-    }
-  }
+	name   = "%s"
+	region = "us-central1"
+	config {
+		node_config {
+			network    = google_compute_network.test.self_link
+			subnetwork = google_compute_subnetwork.test.self_link
+			zone       = "us-central1-a"
+		}
+	}
 }
 
 // use a separate network to avoid conflicts with other tests running in parallel
 // that use the default network/subnet
 resource "google_compute_network" "test" {
-  name                    = "%s"
-  auto_create_subnetworks = false
+	name                    = "%s"
+	auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "test" {
-  name          = "%s"
-  ip_cidr_range = "10.2.0.0/16"
-  region        = "us-central1"
-  network       = google_compute_network.test.self_link
+	name          = "%s"
+	ip_cidr_range = "10.2.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.test.self_link
 }
 `, name, network, subnetwork)
 }
@@ -387,38 +459,38 @@ resource "google_compute_subnetwork" "test" {
 func testAccComposerEnvironment_private(name, network, subnetwork string) string {
 	return fmt.Sprintf(`
 resource "google_composer_environment" "test" {
-  name   = "%s"
-  region = "us-central1"
+	name   = "%s"
+	region = "us-central1"
 
-  config {
-    node_config {
-      network    = google_compute_network.test.self_link
-      subnetwork = google_compute_subnetwork.test.self_link
-      zone       = "us-central1-a"
-      ip_allocation_policy {
-        use_ip_aliases          = true
-        cluster_ipv4_cidr_block = "10.0.0.0/16"
-      }
-    }
-    private_environment_config {
-      enable_private_endpoint = true
-    }
-  }
+	config {
+		node_config {
+			network    = google_compute_network.test.self_link
+			subnetwork = google_compute_subnetwork.test.self_link
+			zone       = "us-central1-a"
+			ip_allocation_policy {
+				use_ip_aliases          = true
+				cluster_ipv4_cidr_block = "10.0.0.0/16"
+			}
+		}
+		private_environment_config {
+			enable_private_endpoint = true
+		}
+	}
 }
 
 // use a separate network to avoid conflicts with other tests running in parallel
 // that use the default network/subnet
 resource "google_compute_network" "test" {
-  name                    = "%s"
-  auto_create_subnetworks = false
+	name                    = "%s"
+	auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "test" {
-  name                     = "%s"
-  ip_cidr_range            = "10.2.0.0/16"
-  region                   = "us-central1"
-  network                  = google_compute_network.test.self_link
-  private_ip_google_access = true
+	name                     = "%s"
+	ip_cidr_range            = "10.2.0.0/16"
+	region                   = "us-central1"
+	network                  = google_compute_network.test.self_link
+	private_ip_google_access = true
 }
 `, name, network, subnetwork)
 }
@@ -427,51 +499,51 @@ resource "google_compute_subnetwork" "test" {
 func testAccComposerEnvironment_privateWithWebServerControl(name, network, subnetwork string) string {
 	return fmt.Sprintf(`
 resource "google_composer_environment" "test" {
-  name   = "%s"
-  region = "us-central1"
+	name   = "%s"
+	region = "us-central1"
 
-  config {
-    node_config {
-      network    = google_compute_network.test.self_link
-      subnetwork = google_compute_subnetwork.test.self_link
-      zone       = "us-central1-a"
-      ip_allocation_policy {
-        use_ip_aliases          = true
-        cluster_ipv4_cidr_block = "10.56.0.0/14"
-        services_ipv4_cidr_block = "10.122.0.0/20"
-      }
-    }
-    private_environment_config {
-      enable_private_endpoint = false
-      web_server_ipv4_cidr_block = "172.30.240.0/24"
-      cloud_sql_ipv4_cidr_block = "10.32.0.0/12"
-      master_ipv4_cidr_block =  "172.17.50.0/28"
-    }
-    web_server_network_access_control {
-      allowed_ip_range {
-        value = "192.168.0.1"
-        description = "my range1"
-      }
-      allowed_ip_range {
-        value = "0.0.0.0/0"
-      }
-  	}
-  }
+	config {
+		node_config {
+			network    = google_compute_network.test.self_link
+			subnetwork = google_compute_subnetwork.test.self_link
+			zone       = "us-central1-a"
+			ip_allocation_policy {
+				use_ip_aliases          = true
+				cluster_ipv4_cidr_block = "10.56.0.0/14"
+				services_ipv4_cidr_block = "10.122.0.0/20"
+			}
+		}
+		private_environment_config {
+			enable_private_endpoint = false
+			web_server_ipv4_cidr_block = "172.30.240.0/24"
+			cloud_sql_ipv4_cidr_block = "10.32.0.0/12"
+			master_ipv4_cidr_block =  "172.17.50.0/28"
+		}
+		web_server_network_access_control {
+			allowed_ip_range {
+				value = "192.168.0.1"
+				description = "my range1"
+			}
+			allowed_ip_range {
+				value = "0.0.0.0/0"
+			}
+		}
+	}
 }
 
 // use a separate network to avoid conflicts with other tests running in parallel
 // that use the default network/subnet
 resource "google_compute_network" "test" {
-  name                    = "%s"
-  auto_create_subnetworks = false
+	name                    = "%s"
+	auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "test" {
-  name                     = "%s"
-  ip_cidr_range            = "10.2.0.0/16"
-  region                   = "us-central1"
-  network                  = google_compute_network.test.self_link
-  private_ip_google_access = true
+	name                     = "%s"
+	ip_cidr_range            = "10.2.0.0/16"
+	region                   = "us-central1"
+	network                  = google_compute_network.test.self_link
+	private_ip_google_access = true
 }
 `, name, network, subnetwork)
 }
@@ -479,51 +551,186 @@ resource "google_compute_subnetwork" "test" {
 func testAccComposerEnvironment_privateWithWebServerControlUpdated(name, network, subnetwork string) string {
 	return fmt.Sprintf(`
 resource "google_composer_environment" "test" {
-  name   = "%s"
-  region = "us-central1"
+	name   = "%s"
+	region = "us-central1"
 
-  config {
-    node_config {
-      network    = google_compute_network.test.self_link
-      subnetwork = google_compute_subnetwork.test.self_link
-      zone       = "us-central1-a"
-      ip_allocation_policy {
-        use_ip_aliases          = true
-        cluster_ipv4_cidr_block = "10.56.0.0/14"
-        services_ipv4_cidr_block = "10.122.0.0/20"
-      }
-    }
-    private_environment_config {
-      enable_private_endpoint = false
-      web_server_ipv4_cidr_block = "172.30.240.0/24"
-      cloud_sql_ipv4_cidr_block = "10.32.0.0/12"
-      master_ipv4_cidr_block =  "172.17.50.0/28"
-    }
-    web_server_network_access_control {
-      allowed_ip_range {
-        value = "192.168.0.1"
-        description = "my range1"
-      }
-      allowed_ip_range {
-        value = "0.0.0.0/0"
-      }
-  	}
-  }
+	config {
+		node_config {
+			network    = google_compute_network.test.self_link
+			subnetwork = google_compute_subnetwork.test.self_link
+			zone       = "us-central1-a"
+			ip_allocation_policy {
+				use_ip_aliases          = true
+				cluster_ipv4_cidr_block = "10.56.0.0/14"
+				services_ipv4_cidr_block = "10.122.0.0/20"
+			}
+		}
+		private_environment_config {
+			enable_private_endpoint = false
+			web_server_ipv4_cidr_block = "172.30.240.0/24"
+			cloud_sql_ipv4_cidr_block = "10.32.0.0/12"
+			master_ipv4_cidr_block =  "172.17.50.0/28"
+		}
+		web_server_network_access_control {
+			allowed_ip_range {
+				value = "192.168.0.1"
+				description = "my range1"
+			}
+			allowed_ip_range {
+				value = "0.0.0.0/0"
+			}
+		}
+	}
 }
 
 // use a separate network to avoid conflicts with other tests running in parallel
 // that use the default network/subnet
 resource "google_compute_network" "test" {
-  name                    = "%s"
-  auto_create_subnetworks = false
+	name                    = "%s"
+	auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "test" {
-  name                     = "%s"
-  ip_cidr_range            = "10.2.0.0/16"
-  region                   = "us-central1"
-  network                  = google_compute_network.test.self_link
-  private_ip_google_access = true
+	name                     = "%s"
+	ip_cidr_range            = "10.2.0.0/16"
+	region                   = "us-central1"
+	network                  = google_compute_network.test.self_link
+	private_ip_google_access = true
+}
+`, name, network, subnetwork)
+}
+
+<% end -%>
+
+<% unless version == "ga" -%>
+func testAccComposerEnvironment_databaseCfg(name, network, subnetwork string) string {
+	return fmt.Sprintf(`
+resource "google_composer_environment" "test" {
+	name   = "%s"
+	region = "us-central1"
+	config {
+		node_config {
+			network    = google_compute_network.test.self_link
+			subnetwork = google_compute_subnetwork.test.self_link
+			zone       = "us-central1-a"
+		}
+		database_config {
+			machine_type  = "db-n1-standard-4"
+		}
+	}
+}
+
+// use a separate network to avoid conflicts with other tests running in parallel
+// that use the default network/subnet
+resource "google_compute_network" "test" {
+	name                    = "%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+	name          = "%s"
+	ip_cidr_range = "10.2.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.test.self_link
+}
+`, name, network, subnetwork)
+}
+
+func testAccComposerEnvironment_databaseCfgUpdated(name, network, subnetwork string) string {
+	return fmt.Sprintf(`
+resource "google_composer_environment" "test" {
+	name   = "%s"
+	region = "us-central1"
+	config {
+		node_config {
+			network    = google_compute_network.test.self_link
+			subnetwork = google_compute_subnetwork.test.self_link
+			zone       = "us-central1-a"
+		}
+		database_config {
+			machine_type  = "db-n1-standard-8"
+		}
+	}
+}
+
+// use a separate network to avoid conflicts with other tests running in parallel
+// that use the default network/subnet
+resource "google_compute_network" "test" {
+	name                    = "%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+	name          = "%s"
+	ip_cidr_range = "10.2.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.test.self_link
+}
+`, name, network, subnetwork)
+}
+
+func testAccComposerEnvironment_webServerCfg(name, network, subnetwork string) string {
+	return fmt.Sprintf(`
+resource "google_composer_environment" "test" {
+	name   = "%s"
+	region = "us-central1"
+	config {
+		node_config {
+			network    = google_compute_network.test.self_link
+			subnetwork = google_compute_subnetwork.test.self_link
+			zone       = "us-central1-a"
+		}
+		web_server_config {
+			machine_type  = "composer-n1-webserver-4"
+		}
+	}
+}
+
+// use a separate network to avoid conflicts with other tests running in parallel
+// that use the default network/subnet
+resource "google_compute_network" "test" {
+	name                    = "%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+	name          = "%s"
+	ip_cidr_range = "10.2.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.test.self_link
+}
+`, name, network, subnetwork)
+}
+
+func testAccComposerEnvironment_webServerCfgUpdated(name, network, subnetwork string) string {
+	return fmt.Sprintf(`
+resource "google_composer_environment" "test" {
+	name   = "%s"
+	region = "us-central1"
+	config {
+		node_config {
+			network    = google_compute_network.test.self_link
+			subnetwork = google_compute_subnetwork.test.self_link
+			zone       = "us-central1-a"
+		}
+		web_server_config {
+			machine_type  = "composer-n1-webserver-8"
+		}
+	}
+}
+
+// use a separate network to avoid conflicts with other tests running in parallel
+// that use the default network/subnet
+resource "google_compute_network" "test" {
+	name                    = "%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+	name          = "%s"
+	ip_cidr_range = "10.2.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.test.self_link
 }
 `, name, network, subnetwork)
 }
@@ -535,52 +742,61 @@ data "google_composer_image_versions" "all" {
 }
 
 resource "google_composer_environment" "test" {
-  name   = "%s"
-  region = "us-central1"
+	name   = "%s"
+	region = "us-central1"
 
-  config {
-    node_count = 4
-    node_config {
-      network    = google_compute_network.test.self_link
-      subnetwork = google_compute_subnetwork.test.self_link
-      zone       = "us-central1-a"
-    }
+	config {
+		node_count = 4
+		node_config {
+			network    = google_compute_network.test.self_link
+			subnetwork = google_compute_subnetwork.test.self_link
+			zone       = "us-central1-a"
+		}
 
-    software_config {
-      image_version = data.google_composer_image_versions.all.image_versions[0].image_version_id
+		software_config {
+			image_version = data.google_composer_image_versions.all.image_versions[0].image_version_id
 
-      airflow_config_overrides = {
-        core-load_example = "True"
-      }
+			airflow_config_overrides = {
+				core-load_example = "True"
+			}
 
-      pypi_packages = {
-        numpy = ""
-      }
+			pypi_packages = {
+				numpy = ""
+			}
 
-      env_variables = {
-        FOO = "bar"
-      }
-    }
-  }
+			env_variables = {
+				FOO = "bar"
+			}
+		}
+<% unless version == "ga" -%>
+		web_server_config {
+			machine_type = "composer-n1-webserver-4"
+		}
 
-  labels = {
-    foo          = "bar"
-    anotherlabel = "boo"
-  }
+		database_config {
+			machine_type = "db-n1-standard-4"
+		}
+<% end -%>
+	}
+
+	labels = {
+		foo          = "bar"
+		anotherlabel = "boo"
+	}
 }
 
 // use a separate network to avoid conflicts with other tests running in parallel
 // that use the default network/subnet
 resource "google_compute_network" "test" {
-  name                    = "%s"
-  auto_create_subnetworks = false
+	name                    = "%s"
+	auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "test" {
-  name          = "%s"
-  ip_cidr_range = "10.2.0.0/16"
-  region        = "us-central1"
-  network       = google_compute_network.test.self_link
+	name          = "%s"
+	ip_cidr_range = "10.2.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.test.self_link
 }
 `, name, network, subnetwork)
 }
@@ -588,41 +804,41 @@ resource "google_compute_subnetwork" "test" {
 func testAccComposerEnvironment_nodeCfg(environment, network, subnetwork, serviceAccount string) string {
 	return fmt.Sprintf(`
 resource "google_composer_environment" "test" {
-  name   = "%s"
-  region = "us-central1"
-  config {
-    node_config {
-      network    = google_compute_network.test.self_link
-      subnetwork = google_compute_subnetwork.test.self_link
-      zone       = "us-central1-a"
+	name   = "%s"
+	region = "us-central1"
+	config {
+		node_config {
+			network    = google_compute_network.test.self_link
+			subnetwork = google_compute_subnetwork.test.self_link
+			zone       = "us-central1-a"
 
-      service_account = google_service_account.test.name
-    }
-  }
+			service_account = google_service_account.test.name
+		}
+	}
 
-  depends_on = [google_project_iam_member.composer-worker]
+	depends_on = [google_project_iam_member.composer-worker]
 }
 
 resource "google_compute_network" "test" {
-  name                    = "%s"
-  auto_create_subnetworks = false
+	name                    = "%s"
+	auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "test" {
-  name          = "%s"
-  ip_cidr_range = "10.2.0.0/16"
-  region        = "us-central1"
-  network       = google_compute_network.test.self_link
+	name          = "%s"
+	ip_cidr_range = "10.2.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.test.self_link
 }
 
 resource "google_service_account" "test" {
-  account_id   = "%s"
-  display_name = "Test Service Account for Composer Environment"
+	account_id   = "%s"
+	display_name = "Test Service Account for Composer Environment"
 }
 
 resource "google_project_iam_member" "composer-worker" {
-  role   = "roles/composer.worker"
-  member = "serviceAccount:${google_service_account.test.email}"
+	role   = "roles/composer.worker"
+	member = "serviceAccount:${google_service_account.test.email}"
 }
 `, environment, network, subnetwork, serviceAccount)
 }
@@ -633,33 +849,33 @@ data "google_composer_image_versions" "all" {
 }
 
 resource "google_composer_environment" "test" {
-  name   = "%s"
-  region = "us-central1"
-  config {
-    node_config {
-      network    = google_compute_network.test.self_link
-      subnetwork = google_compute_subnetwork.test.self_link
-      zone       = "us-central1-a"
-    }
-    software_config {
-      image_version  = data.google_composer_image_versions.all.image_versions[0].image_version_id
-      python_version = "3"
-    }
-  }
+	name   = "%s"
+	region = "us-central1"
+	config {
+		node_config {
+			network    = google_compute_network.test.self_link
+			subnetwork = google_compute_subnetwork.test.self_link
+			zone       = "us-central1-a"
+		}
+		software_config {
+			image_version  = data.google_composer_image_versions.all.image_versions[0].image_version_id
+			python_version = "3"
+		}
+	}
 }
 
 // use a separate network to avoid conflicts with other tests running in parallel
 // that use the default network/subnet
 resource "google_compute_network" "test" {
-  name                    = "%s"
-  auto_create_subnetworks = false
+	name                    = "%s"
+	auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "test" {
-  name          = "%s"
-  ip_cidr_range = "10.2.0.0/16"
-  region        = "us-central1"
-  network       = google_compute_network.test.self_link
+	name          = "%s"
+	ip_cidr_range = "10.2.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.test.self_link
 }
 `, name, network, subnetwork)
 }
@@ -667,34 +883,34 @@ resource "google_compute_subnetwork" "test" {
 func testAccComposerEnvironment_updateOnlyFields(name, network, subnetwork string) string {
 	return fmt.Sprintf(`
 resource "google_composer_environment" "test" {
-  name   = "%s"
-  region = "us-central1"
-  config {
-    node_config {
-      network    = google_compute_network.test.self_link
-      subnetwork = google_compute_subnetwork.test.self_link
-      zone       = "us-central1-a"
-    }
-    software_config {
-      pypi_packages = {
-        scipy = "==1.1.0"
-      }
-    }
-  }
+	name   = "%s"
+	region = "us-central1"
+	config {
+		node_config {
+			network    = google_compute_network.test.self_link
+			subnetwork = google_compute_subnetwork.test.self_link
+			zone       = "us-central1-a"
+		}
+		software_config {
+			pypi_packages = {
+				scipy = "==1.1.0"
+			}
+		}
+	}
 }
 
 // use a separate network to avoid conflicts with other tests running in parallel
 // that use the default network/subnet
 resource "google_compute_network" "test" {
-  name                    = "%s"
-  auto_create_subnetworks = false
+	name                    = "%s"
+	auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "test" {
-  name          = "%s"
-  ip_cidr_range = "10.2.0.0/16"
-  region        = "us-central1"
-  network       = google_compute_network.test.self_link
+	name          = "%s"
+	ip_cidr_range = "10.2.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.test.self_link
 }
 `, name, network, subnetwork)
 }

--- a/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -173,6 +173,13 @@ The `config` block supports:
   (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
   The network-level access control policy for the Airflow web server. If unspecified, no network-level access restrictions will be applied.
 
+* `database_config` -
+  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  The configuration settings for Cloud SQL instance used internally by Apache Airflow software.
+
+* `web_server_config` -
+  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  The configuration settings for the Airflow web server App Engine instance.
 
 The `node_config` block supports:
 
@@ -368,6 +375,22 @@ The `ip_allocation_policy` block supports:
   Set to a CIDR notation (e.g. 10.96.0.0/14) from the RFC-1918 private networks
   (e.g. 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) to pick a specific range to use.
   Specify either `services_secondary_range_name` or `services_ipv4_cidr_block` but not both.
+
+The `database_config` block supports:
+
+* `machine_type` -
+  (Required)
+  Cloud SQL machine type used by Airflow database. It has to be one of: db-n1-standard-2,
+  db-n1-standard-4, db-n1-standard-8 or db-n1-standard-16.
+
+The `web_server_config` block supports:
+
+* `machine_type` -
+  (Required)
+  Machine type on which Airflow web server is running. It has to be one of: composer-n1-webserver-2,
+  composer-n1-webserver-4 or composer-n1-webserver-8.
+  Value custom is returned only in response, if Airflow web server parameters were
+  manually changed to a non-standard values.
 
 
 


### PR DESCRIPTION
Adds new sections to Cloud Composer's EnvironmentConfig used for environment creation and updating

See: https://cloud.google.com/composer/docs/reference/rest/v1beta1/projects.locations.environments#EnvironmentConfig

fixes {https://github.com/hashicorp/terraform-provider-google/issues/6916}

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
composer: added `database_config` and `web_server_config` to `google_composer_environment` resource (TPGB only)
```
