### PR TITLE
Send empty privateVisibilityConfig network array

### DIFF
--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -182,6 +182,7 @@ objects:
         description: |
           For privately visible zones, the set of Virtual Private Cloud
           resources that the zone is visible from.
+        send_empty_value: true
         properties:
           - !ruby/object:Api::Type::Array
             name: 'networks'

--- a/products/dns/terraform.yaml
+++ b/products/dns/terraform.yaml
@@ -66,6 +66,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         exclude: true
       nameServerSet: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
+      privateVisibilityConfig: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/dns_managed_zone_private_visibility_config.go.erb'
       privateVisibilityConfig.networks: !ruby/object:Overrides::Terraform::PropertyOverride
         is_set: true
         set_hash_func: |-
@@ -89,7 +91,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           and apply an incorrect update to the resource. If you encounter this issue, remove all `networks`
           blocks in an update and then apply another update adding all of them back simultaneously.
       privateVisibilityConfig.networks.networkUrl: !ruby/object:Overrides::Terraform::PropertyOverride
-        custom_expand: 'templates/terraform/custom_expand/network_full_url.erb'
         diff_suppress_func: 'compareSelfLinkOrResourceName'
         description: |
           The id or fully qualified URL of the VPC network to bind to.

--- a/templates/terraform/custom_expand/dns_managed_zone_private_visibility_config.go.erb
+++ b/templates/terraform/custom_expand/dns_managed_zone_private_visibility_config.go.erb
@@ -1,0 +1,73 @@
+<%- # the license inside this block applies to this file
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		// The API won't remove the the field unless an empty network array is sent.
+		transformed := make(map[string]interface{})
+		emptyNetwork := make([]interface{}, 0)
+		transformed["networks"] = emptyNetwork
+		return transformed, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
+
+	transformedNetworks, err := expandDNSManagedZonePrivateVisibilityConfigNetworks(original["networks"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedNetworks); val.IsValid() && !isEmptyValue(val) {
+		transformed["networks"] = transformedNetworks
+	}
+
+	return transformed, nil
+}
+
+func expand<%= prefix -%><%= titlelize_property(property) -%>Networks(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	v = v.(*schema.Set).List()
+	l := v.([]interface{})
+	req := make([]interface{}, 0, len(l))
+	for _, raw := range l {
+		if raw == nil {
+			continue
+		}
+		original := raw.(map[string]interface{})
+		transformed := make(map[string]interface{})
+
+		transformedNetworkUrl, err := expandDNSManagedZonePrivateVisibilityConfigNetworksNetworkUrl(original["network_url"], d, config)
+		if err != nil {
+			return nil, err
+		} else if val := reflect.ValueOf(transformedNetworkUrl); val.IsValid() && !isEmptyValue(val) {
+			transformed["networkUrl"] = transformedNetworkUrl
+		}
+
+		req = append(req, transformed)
+	}
+	return req, nil
+}
+
+func expand<%= prefix -%><%= titlelize_property(property) -%>NetworksNetworkUrl(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	if v == nil || v.(string) == "" {
+		return "", nil
+	} else if strings.HasPrefix(v.(string), "https://") {
+		return v, nil
+	}
+	url, err := replaceVars(d, config, "{{ComputeBasePath}}"+v.(string))
+	if err != nil {
+		return "", err
+	}
+	return ConvertSelfLinkToV1(url), nil
+}
+


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fixes https://github.com/hashicorp/terraform-provider-google/issues/6973

The api only removes the `privateVisibilityConfig` block when sending an empty `networks` array like so:
```
  "privateVisibilityConfig": {
    "networks": []
  }
```

Added a custom expander to do this. Using a custom expander on the parent field removed the expanders for the subfields, so I included the subfield expanders in the template. This makes the custom expander looks excessive, but generates small downstream diffs.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
dns: fixed an issue where `google_dns_managed_zone` would not remove `private_visibility_config` on updates
```
