### PR TITLE
Add archive class to gcs

### DIFF
--- a/products/storage/api.yaml
+++ b/products/storage/api.yaml
@@ -300,8 +300,8 @@ objects:
                       description: |
                         Objects having any of the storage classes specified by
                         this condition will be matched. Values include
-                        MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, STANDARD,
-                        and DURABLE_REDUCED_AVAILABILITY.
+                        MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE,
+                        STANDARD, and DURABLE_REDUCED_AVAILABILITY.
                       item_type: Api::Type::String
                     - !ruby/object:Api::Type::Integer
                       name: 'numNewerVersions'
@@ -359,16 +359,17 @@ objects:
           The bucket's default storage class, used whenever no storageClass is
           specified for a newly-created object. This defines how objects in the
           bucket are stored and determines the SLA and the cost of storage.
-          Values include MULTI_REGIONAL, REGIONAL, STANDARD, NEARLINE, COLDLINE,
-          and DURABLE_REDUCED_AVAILABILITY. If this value is not specified when
-          the bucket is created, it will default to STANDARD. For more
-          information, see storage classes.
+          Values include MULTI_REGIONAL, REGIONAL, STANDARD, NEARLINE,
+          COLDLINE, ARCHIVE, and DURABLE_REDUCED_AVAILABILITY. If this value is
+          not specified when the bucket is created, it will default to 
+          STANDARD. For more information, see storage classes.
         values:
           - :MULTI_REGIONAL
           - :REGIONAL
           - :STANDARD
           - :NEARLINE
           - :COLDLINE
+          - :ARCHIVE
           - :DURABLE_REDUCED_AVAILABILITY
       - !ruby/object:Api::Type::Time
         name: 'timeCreated'

--- a/templates/terraform/examples/storage_bucket_storage_class.tf.erb
+++ b/templates/terraform/examples/storage_bucket_storage_class.tf.erb
@@ -1,0 +1,4 @@
+resource "google_storage_bucket" "<%= ctx[:primary_resource_id] %>" {
+  name          = "<%= ctx[:vars]['name'] %>"
+  storage_class = "ARCHIVE"
+}

--- a/third_party/terraform/resources/resource_storage_bucket.go
+++ b/third_party/terraform/resources/resource_storage_bucket.go
@@ -114,7 +114,7 @@ func resourceStorageBucket() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Default:     "STANDARD",
-				Description: `The Storage Class of the new bucket. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE.`,
+				Description: `The Storage Class of the new bucket. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE.`,
 			},
 
 			"lifecycle_rule": {
@@ -139,7 +139,7 @@ func resourceStorageBucket() *schema.Resource {
 									"storage_class": {
 										Type:        schema.TypeString,
 										Optional:    true,
-										Description: `The target Storage Class of objects affected by this Lifecycle Rule. Supported values include: MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE.`,
+										Description: `The target Storage Class of objects affected by this Lifecycle Rule. Supported values include: MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE.`,
 									},
 								},
 							},
@@ -181,7 +181,7 @@ func resourceStorageBucket() *schema.Resource {
 										Optional:    true,
 										MinItems:    1,
 										Elem:        &schema.Schema{Type: schema.TypeString},
-										Description: `Storage Class of objects to satisfy this condition. Supported values include: MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, STANDARD, DURABLE_REDUCED_AVAILABILITY.`,
+										Description: `Storage Class of objects to satisfy this condition. Supported values include: MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE, STANDARD, DURABLE_REDUCED_AVAILABILITY.`,
 									},
 									"num_newer_versions": {
 										Type:        schema.TypeInt,

--- a/third_party/terraform/resources/resource_storage_bucket_object.go
+++ b/third_party/terraform/resources/resource_storage_bucket_object.go
@@ -148,7 +148,7 @@ func resourceStorageBucketObject() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 				Computed:    true,
-				Description: `The StorageClass of the new bucket object. Supported values include: MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE. If not provided, this defaults to the bucket's default storage class or to a standard class.`,
+				Description: `The StorageClass of the new bucket object. Supported values include: MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE. If not provided, this defaults to the bucket's default storage class or to a standard class.`,
 			},
 
 			"metadata": {

--- a/third_party/terraform/tests/resource_storage_bucket_test.go
+++ b/third_party/terraform/tests/resource_storage_bucket_test.go
@@ -1269,6 +1269,15 @@ resource "google_storage_bucket" "bucket" {
       num_newer_versions = 10
     }
   }
+  lifecycle_rule {
+    action {
+      type          = "SetStorageClass"
+      storage_class = "ARCHIVE"
+    }
+    condition {
+      with_state = "ARCHIVED"
+    }
+  }
 }
 `, bucketName)
 }

--- a/third_party/terraform/website/docs/d/storage_bucket_object.html.markdown
+++ b/third_party/terraform/website/docs/d/storage_bucket_object.html.markdown
@@ -57,7 +57,7 @@ The following attributes are exported:
 * `self_link` - (Computed) A url reference to this object.
 
 * `storage_class` - (Computed) The [StorageClass](https://cloud.google.com/storage/docs/storage-classes) of the new bucket object.
-    Supported values include: `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`, `COLDLINE`. If not provided, this defaults to the bucket's default
+    Supported values include: `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`, `COLDLINE`, `ARCHIVE`. If not provided, this defaults to the bucket's default
     storage class or to a [standard](https://cloud.google.com/storage/docs/storage-classes#standard) class.
 
 * `media_link` - (Computed) A url reference to download this object.

--- a/third_party/terraform/website/docs/r/storage_bucket.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_bucket.html.markdown
@@ -81,7 +81,7 @@ The following arguments are supported:
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
 
-* `storage_class` - (Optional, Default: 'STANDARD') The [Storage Class](https://cloud.google.com/storage/docs/storage-classes) of the new bucket. Supported values include: `STANDARD`, `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`, `COLDLINE`.
+* `storage_class` - (Optional, Default: 'STANDARD') The [Storage Class](https://cloud.google.com/storage/docs/storage-classes) of the new bucket. Supported values include: `STANDARD`, `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`, `COLDLINE`, `ARCHIVE`.
 
 * `lifecycle_rule` - (Optional) The bucket's [Lifecycle Rules](https://cloud.google.com/storage/docs/lifecycle#configuration) configuration. Multiple blocks of this type are permitted. Structure is documented below.
 
@@ -113,7 +113,7 @@ The `action` block supports:
 
 * `type` - The type of the action of this Lifecycle Rule. Supported values include: `Delete` and `SetStorageClass`.
 
-* `storage_class` - (Required if action type is `SetStorageClass`) The target [Storage Class](https://cloud.google.com/storage/docs/storage-classes) of objects affected by this Lifecycle Rule. Supported values include: `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`, `COLDLINE`.
+* `storage_class` - (Required if action type is `SetStorageClass`) The target [Storage Class](https://cloud.google.com/storage/docs/storage-classes) of objects affected by this Lifecycle Rule. Supported values include: `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`, `COLDLINE`, `ARCHIVE`.
 
 The `condition` block supports the following elements, and requires at least one to be defined. If you specify multiple conditions in a rule, an object has to match all of the conditions for the action to be taken:
 
@@ -123,7 +123,7 @@ The `condition` block supports the following elements, and requires at least one
 
 * `with_state` - (Optional) Match to live and/or archived objects. Unversioned buckets have only live objects. Supported values include: `"LIVE"`, `"ARCHIVED"`, `"ANY"`.
 
-* `matches_storage_class` - (Optional) [Storage Class](https://cloud.google.com/storage/docs/storage-classes) of objects to satisfy this condition. Supported values include: `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`, `COLDLINE`, `STANDARD`, `DURABLE_REDUCED_AVAILABILITY`.
+* `matches_storage_class` - (Optional) [Storage Class](https://cloud.google.com/storage/docs/storage-classes) of objects to satisfy this condition. Supported values include: `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`, `COLDLINE`, `ARCHIVE`, `STANDARD`, `DURABLE_REDUCED_AVAILABILITY`.
 
 * `num_newer_versions` - (Optional) Relevant only for versioned objects. The number of newer versions of an object to satisfy this condition.
 

--- a/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
+++ b/third_party/terraform/website/docs/r/storage_bucket_object.html.markdown
@@ -60,7 +60,7 @@ One of the following is required:
 * `content_type` - (Optional) [Content-Type](https://tools.ietf.org/html/rfc7231#section-3.1.1.5) of the object data. Defaults to "application/octet-stream" or "text/plain; charset=utf-8".
 
 * `storage_class` - (Optional) The [StorageClass](https://cloud.google.com/storage/docs/storage-classes) of the new bucket object.
-    Supported values include: `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`, `COLDLINE`. If not provided, this defaults to the bucket's default
+    Supported values include: `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`, `COLDLINE`, `ARCHIVE`. If not provided, this defaults to the bucket's default
     storage class or to a [standard](https://cloud.google.com/storage/docs/storage-classes#standard) class.
 
 ## Attributes Reference


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Small changes that add "ARCHIVE" class to GCS documentation `google_storage_bucket` and `google_storage_bucket_object`.
I also added a lifecycle rule in one of the tests to use that new class.
Then I updated the `api.yaml` to handle the archive class.

Note : Acceptance tests did not run because the changes are quite small. I decided to not run the full tests suite.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
storage: added `ARCHIVE` as an accepted class for `google_storage_bucket` and `google_storage_bucket_object`
```
