### PR TITLE
fix cloud identity groups sweeper

### DIFF
--- a/products/cloudidentity/terraform.yaml
+++ b/products/cloudidentity/terraform.yaml
@@ -15,6 +15,8 @@
 overrides: !ruby/object:Overrides::ResourceOverrides
   Group: !ruby/object:Overrides::Terraform::ResourceOverride
     import_format: ["{{name}}"]
+    # Cloud Identity Group requires a customized sweeper
+    skip_sweeper: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "cloud_identity_groups_basic"
@@ -40,6 +42,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       custom_import: templates/terraform/custom_import/set_id_name_with_slashes.go.erb
   GroupMembership: !ruby/object:Overrides::Terraform::ResourceOverride
     import_format: ["{{name}}"]
+    # These will be sweeped with the parent groups
+    skip_sweeper: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "cloud_identity_group_membership"

--- a/third_party/terraform/resources/resource_cloud_identity_group_sweeper_test.go.erb
+++ b/third_party/terraform/resources/resource_cloud_identity_group_sweeper_test.go.erb
@@ -1,0 +1,122 @@
+<% autogen_exception -%>
+package google
+
+<% unless version == 'ga' -%>
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/url"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func init() {
+	resource.AddTestSweepers("CloudIdentityGroup", &resource.Sweeper{
+		Name: "CloudIdentityGroup",
+		F:    testSweepCloudIdentityGroup,
+	})
+}
+
+// At the time of writing, the CI only passes us-central1 as the region
+func testSweepCloudIdentityGroup(region string) error {
+	resourceName := "CloudIdentityGroup"
+	log.Printf("[INFO][SWEEPER_LOG] Starting sweeper for %s", resourceName)
+
+	log.Printf("[INFO][SWEEPER_LOG] BEFORE SHARED CONFIG")
+	config, err := sharedConfigForRegion(region)
+	log.Printf("[INFO][SWEEPER_LOG] AFTER SHARED CONFIG: %s", err)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error getting shared config for region: %s", err)
+		return err
+	}
+
+	log.Printf("[INFO][SWEEPER_LOG] CALLING LOAD AND VALIDATE: %s", err)
+	err = config.LoadAndValidate(context.Background())
+	log.Printf("[INFO][SWEEPER_LOG] RETURNED FROM LOAD AND VALIDATE: %s", err)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error loading: %s", err)
+		return err
+	}
+
+	log.Printf("[INFO][SWEEPER_LOG] BEFORE TESTING")
+	t := &testing.T{}
+	log.Printf("[INFO][SWEEPER_LOG] AFTER TESTING")
+	custId := getTestCustIdFromEnv(t)
+	log.Printf("[INFO][SWEEPER_LOG] AFTER BILLING ACCOUNT ID")
+
+	// Setup variables to replace in list template
+	d := &ResourceDataMock{
+		FieldsInSchema: map[string]interface{}{
+			"project":  config.Project,
+			"region":   region,
+			"location": region,
+			"zone":     "-",
+			"parent":   url.PathEscape(fmt.Sprintf("customers/%s", custId)),
+		},
+	}
+
+	listTemplate := "https://cloudidentity.googleapis.com/v1beta1/groups?parent={{parent}}"
+	listUrl, err := replaceVars(d, config, listTemplate)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] error preparing sweeper list url: %s", err)
+		return nil
+	}
+
+	log.Printf("[INFO][SWEEPER_LOG] list url: %s", listUrl)
+	res, err := sendRequest(config, "GET", config.Project, listUrl, nil)
+	if err != nil {
+		log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)
+		return nil
+	}
+
+	resourceList, ok := res["groups"]
+	if !ok {
+		log.Printf("[INFO][SWEEPER_LOG] Nothing found in response.")
+		return nil
+	}
+
+	rl := resourceList.([]interface{})
+
+	log.Printf("[INFO][SWEEPER_LOG] Found %d items in %s list response.", len(rl), resourceName)
+	// Keep count of items that aren't sweepable for logging.
+	nonPrefixCount := 0
+	for _, ri := range rl {
+		obj := ri.(map[string]interface{})
+		if obj["displayName"] == nil {
+			log.Printf("[INFO][SWEEPER_LOG] %s resource name was nil", resourceName)
+			return nil
+		}
+
+		name := obj["name"].(string)
+		// Skip resources that shouldn't be sweeped
+		if !isSweepableTestResource(obj["displayName"].(string)) {
+			nonPrefixCount++
+			continue
+		}
+
+		deleteTemplate := "https://cloudidentity.googleapis.com/v1beta1/{{name}}"
+		deleteUrl, err := replaceVars(d, config, deleteTemplate)
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] error preparing delete url: %s", err)
+			return nil
+		}
+		deleteUrl = deleteUrl + name
+
+		// Don't wait on operations as we may have a lot to delete
+		_, err = sendRequest(config, "DELETE", config.Project, deleteUrl, nil)
+		if err != nil {
+			log.Printf("[INFO][SWEEPER_LOG] Error deleting for url %s : %s", deleteUrl, err)
+		} else {
+			log.Printf("[INFO][SWEEPER_LOG] Sent delete request for %s resource: %s", resourceName, name)
+		}
+	}
+
+	if nonPrefixCount > 0 {
+		log.Printf("[INFO][SWEEPER_LOG] %d items were non-sweepable and skipped.", nonPrefixCount)
+	}
+
+	return nil
+}
+<% end -%>

--- a/third_party/terraform/resources/resource_cloud_identity_group_sweeper_test.go.erb
+++ b/third_party/terraform/resources/resource_cloud_identity_group_sweeper_test.go.erb
@@ -24,27 +24,20 @@ func testSweepCloudIdentityGroup(region string) error {
 	resourceName := "CloudIdentityGroup"
 	log.Printf("[INFO][SWEEPER_LOG] Starting sweeper for %s", resourceName)
 
-	log.Printf("[INFO][SWEEPER_LOG] BEFORE SHARED CONFIG")
 	config, err := sharedConfigForRegion(region)
-	log.Printf("[INFO][SWEEPER_LOG] AFTER SHARED CONFIG: %s", err)
 	if err != nil {
 		log.Printf("[INFO][SWEEPER_LOG] error getting shared config for region: %s", err)
 		return err
 	}
 
-	log.Printf("[INFO][SWEEPER_LOG] CALLING LOAD AND VALIDATE: %s", err)
 	err = config.LoadAndValidate(context.Background())
-	log.Printf("[INFO][SWEEPER_LOG] RETURNED FROM LOAD AND VALIDATE: %s", err)
 	if err != nil {
 		log.Printf("[INFO][SWEEPER_LOG] error loading: %s", err)
 		return err
 	}
 
-	log.Printf("[INFO][SWEEPER_LOG] BEFORE TESTING")
 	t := &testing.T{}
-	log.Printf("[INFO][SWEEPER_LOG] AFTER TESTING")
 	custId := getTestCustIdFromEnv(t)
-	log.Printf("[INFO][SWEEPER_LOG] AFTER BILLING ACCOUNT ID")
 
 	// Setup variables to replace in list template
 	d := &ResourceDataMock{
@@ -64,7 +57,6 @@ func testSweepCloudIdentityGroup(region string) error {
 		return nil
 	}
 
-	log.Printf("[INFO][SWEEPER_LOG] list url: %s", listUrl)
 	res, err := sendRequest(config, "GET", config.Project, listUrl, nil)
 	if err != nil {
 		log.Printf("[INFO][SWEEPER_LOG] Error in response from request %s: %s", listUrl, err)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Found that the cloud identity groups sweeper doesn't work properly, so customized it, and removed the sweeper for memberships, since they should be deleted with their parent groups.

The `displayname` of the group is what we need to check is sweepable ("tf-test-") but we need to delete by `name`, also we need to send `parent` in the url parameters when listing the groups.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
