### PR TITLE
Fix grpc healthcheck behaviour.

### DIFF
--- a/templates/terraform/encoders/health_check_type.erb
+++ b/templates/terraform/encoders/health_check_type.erb
@@ -84,4 +84,19 @@ if _, ok := d.GetOk("ssl_health_check"); ok {
 	return obj, nil
 }
 
+if _, ok := d.GetOk("grpc_health_check"); ok {
+	hc := d.Get("grpc_health_check").([]interface{})[0]
+	ps := hc.(map[string]interface{})["port_specification"]
+	pn := hc.(map[string]interface{})["port_name"]
+
+	if ps == "USE_FIXED_PORT" || (ps == "" && pn == "") {
+		m := obj["grpcHealthCheck"].(map[string]interface{})
+		if m["port"] == nil {
+			return nil, fmt.Errorf("error in HealthCheck %s: `port` must be set for GRPC health checks`.", d.Get("name").(string))
+		}
+	}
+	obj["type"] = "GRPC"
+	return obj, nil
+}
+
 return nil, fmt.Errorf("error in HealthCheck %s: No health check block specified.", d.Get("name").(string))

--- a/third_party/terraform/tests/resource_compute_health_check_test.go
+++ b/third_party/terraform/tests/resource_compute_health_check_test.go
@@ -149,7 +149,7 @@ func TestAccComputeHealthCheck_tcpAndSsl_shouldFail(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccComputeHealthCheck_tcpAndSsl_shouldFail(hckName),
-				ExpectError: regexp.MustCompile("only one of `http2_health_check,http_health_check,https_health_check,ssl_health_check,tcp_health_check` can be specified"),
+				ExpectError: regexp.MustCompile("only one of `grpc_health_check,http2_health_check,http_health_check,https_health_check,ssl_health_check,tcp_health_check` can be specified"),
 			},
 		},
 	})

--- a/third_party/terraform/tests/resource_compute_region_health_check_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_health_check_test.go.erb
@@ -156,7 +156,7 @@ func TestAccComputeRegionHealthCheck_tcpAndSsl_shouldFail(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccComputeRegionHealthCheck_tcpAndSsl_shouldFail(hckName),
-				ExpectError: regexp.MustCompile("only one of `http2_health_check,http_health_check,https_health_check,ssl_health_check,tcp_health_check` can be specified"),
+				ExpectError: regexp.MustCompile("only one of `grpc_health_check,http2_health_check,http_health_check,https_health_check,ssl_health_check,tcp_health_check` can be specified"),
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Make up for the fact that past!Riley did not run the tests for https://github.com/GoogleCloudPlatform/magic-modules/pull/3825

Followup for https://github.com/hashicorp/terraform-provider-google/issues/6826

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
bug fix for an unreleased field
```
