### PR TITLE
Add support for regional NEG stripping of maxUtilization based on url

### DIFF
--- a/templates/terraform/encoders/backend_service.go.erb
+++ b/templates/terraform/encoders/backend_service.go.erb
@@ -43,14 +43,15 @@ for _, backendRaw := range backends {
 	if !ok {
 		continue
 	}
-	serverlessNegMatchers := [2]*regexp.Regexp{regexp.MustCompile("projects/(?P<project>[^/]+)/regions/(?P<region>[^/]+)/networkEndpointGroups/(?P<name>[^/]+)"), regexp.MustCompile("projects/(?P<project>[^/]+)/global/networkEndpointGroups/(?P<name>[^/]+)")}
-	for _, regex := range serverlessNegMatchers {
-		if regex.MatchString(backendGroup.(string)) {
-			// Remove `max_utilization` from any backend that belongs to a serverless NEG. This field
-			// has a default value and causes API validation errors
-			backend["maxUtilization"] = nil
-			break
-		}
+
+	match, err := regexp.MatchString("(?:global|regions/[^/]+)/networkEndpointGroups", backendGroup.(string))
+	if err != nil {
+		return nil, err
+	}
+	if match {
+		// Remove `max_utilization` from any backend that belongs to a serverless NEG. This field
+		// has a default value and causes API validation errors
+		backend["maxUtilization"] = nil
 	}
 }
 

--- a/templates/terraform/encoders/backend_service.go.erb
+++ b/templates/terraform/encoders/backend_service.go.erb
@@ -43,14 +43,14 @@ for _, backendRaw := range backends {
 	if !ok {
 		continue
 	}
-	match, err := regexp.MatchString("projects/(?P<project>[^/]+)/regions/(?P<region>[^/]+)/networkEndpointGroups/(?P<name>[^/]+)", backendGroup.(string))
-	if err != nil {
-		return nil, err
-	}
-	if match || strings.Contains(backendGroup.(string), "global/networkEndpointGroups") {
-		// Remove `max_utilization` from any backend that belongs to a serverless NEG. This field
-		// has a default value and causes API validation errors
-		backend["maxUtilization"] = nil
+	serverlessNegMatchers := [2]*regexp.Regexp{regexp.MustCompile("projects/(?P<project>[^/]+)/regions/(?P<region>[^/]+)/networkEndpointGroups/(?P<name>[^/]+)"), regexp.MustCompile("projects/(?P<project>[^/]+)/global/networkEndpointGroups/(?P<name>[^/]+)")}
+	for _, regex := range serverlessNegMatchers {
+		if regex.MatchString(backendGroup.(string)) {
+			// Remove `max_utilization` from any backend that belongs to a serverless NEG. This field
+			// has a default value and causes API validation errors
+			backend["maxUtilization"] = nil
+			break
+		}
 	}
 }
 

--- a/templates/terraform/encoders/backend_service.go.erb
+++ b/templates/terraform/encoders/backend_service.go.erb
@@ -43,8 +43,12 @@ for _, backendRaw := range backends {
 	if !ok {
 		continue
 	}
-	if strings.Contains(backendGroup.(string), "global/networkEndpointGroups") {
-		// Remove `max_utilization` from any backend that belongs to a global NEG. This field
+	match, err := regexp.MatchString("projects/(?P<project>[^/]+)/regions/(?P<region>[^/]+)/networkEndpointGroups/(?P<name>[^/]+)", backendGroup.(string))
+	if err != nil {
+		return nil, err
+	}
+	if match || strings.Contains(backendGroup.(string), "global/networkEndpointGroups") {
+		// Remove `max_utilization` from any backend that belongs to a serverless NEG. This field
 		// has a default value and causes API validation errors
 		backend["maxUtilization"] = nil
 	}

--- a/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
@@ -1537,7 +1537,7 @@ resource "google_compute_http_health_check" "zero" {
 func testAccComputeBackendService_regionNegBackend(suffix string) string {
 	return fmt.Sprintf(`
 resource "google_compute_backend_service" "backend" {
-  name                            = "backend%s"
+  name                            = "tf-test-backend%s"
   enable_cdn                      = true
   connection_draining_timeout_sec = 10
  
@@ -1547,7 +1547,7 @@ resource "google_compute_backend_service" "backend" {
 }
 
 resource "google_compute_region_network_endpoint_group" "cloudrun_neg" {
-  name                  = "cloudrun-neg%s"
+  name                  = "tf-test-neg%s"
   network_endpoint_type = "SERVERLESS"
   region                = "us-central1"
   cloud_run {
@@ -1556,7 +1556,7 @@ resource "google_compute_region_network_endpoint_group" "cloudrun_neg" {
 }
 
 resource "google_cloud_run_service" "cloudrun_neg" {
-  name     = "cloudrun-neg%s"
+  name     = "tf-test-cr%s"
   location = "us-central1"
 
   template {

--- a/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
@@ -653,6 +653,30 @@ func TestAccComputeBackendService_trafficDirectorUpdateFull(t *testing.T) {
 }
 <% end -%>
 
+<% unless version == 'ga' -%>
+func TestAccComputeBackendService_regionNegBackend(t *testing.T) {
+	t.Parallel()
+
+	suffix := randString(t, 10)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeBackendService_regionNegBackend(suffix),
+			},
+			{
+				ResourceName:      "google_compute_backend_service.backend",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+<% end -%>
+
 func testAccComputeBackendService_trafficDirectorBasic(serviceName, checkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
@@ -1508,3 +1532,47 @@ resource "google_compute_http_health_check" "zero" {
 }
 `, serviceName, sampleRate, checkName)
 }
+
+<% unless version == 'ga' -%>
+func testAccComputeBackendService_regionNegBackend(suffix string) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "backend" {
+  name                            = "backend%s"
+  enable_cdn                      = true
+  connection_draining_timeout_sec = 10
+ 
+  backend {
+    group = google_compute_region_network_endpoint_group.cloudrun_neg.id
+  }
+}
+
+resource "google_compute_region_network_endpoint_group" "cloudrun_neg" {
+  name                  = "cloudrun-neg%s"
+  network_endpoint_type = "SERVERLESS"
+  region                = "us-central1"
+  cloud_run {
+    service = google_cloud_run_service.cloudrun_neg.name
+  }
+}
+
+resource "google_cloud_run_service" "cloudrun_neg" {
+  name     = "cloudrun-neg%s"
+  location = "us-central1"
+
+  template {
+    spec {
+      containers {
+        image = "gcr.io/cloudrun/hello"
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+}
+
+`, suffix, suffix, suffix)
+}
+<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/7051


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added support to `google_compute_backend_service` for setting a serverless regional network endpoint group as `backend.group`
```
