### PR TITLE
Use `lineage` instead of `api_name` for property conflicts

### DIFF
--- a/api/type.rb
+++ b/api/type.rb
@@ -77,7 +77,8 @@ module Api
       attr_reader :min_version
       attr_reader :exact_version
 
-      # A list of properties that conflict with this property.
+      # A list of properties that conflict with this property. Uses the "lineage"
+      # field to identify the property eg: parent.meta.label.foo
       attr_reader :conflicts
 
       # A list of properties that at least one of must be set.
@@ -203,8 +204,7 @@ module Api
 
       return if @conflicts.empty?
 
-      names = @__resource.all_user_properties.map(&:api_name) +
-              @__resource.all_user_properties.map(&:name)
+      names = @__resource.all_user_properties.map(&:lineage)
       @conflicts.each do |p|
         raise "#{p} does not exist" unless names.include?(p)
       end
@@ -214,8 +214,8 @@ module Api
     def conflicting
       return [] unless @__resource
 
-      (@__resource.all_user_properties.select { |p| @conflicts.include?(p.api_name) } +
-       @__resource.all_user_properties.select { |p| p.conflicts.include?(@api_name) }).uniq
+      (@__resource.all_user_properties.select { |p| @conflicts.include?(p.lineage) } +
+      @__resource.all_user_properties.select { |p| p.conflicts.include?(lineage) }).uniq
     end
 
     # Checks that all properties that needs at least one of their fields actually exist.

--- a/products/appengine/api.yaml
+++ b/products/appengine/api.yaml
@@ -487,8 +487,8 @@ objects:
         description: |
           Automatic scaling is based on request rate, response latencies, and other application metrics.
         conflicts:
-          - basicScaling
-          - manualScaling
+          - basic_scaling
+          - manual_scaling
         properties:
           - !ruby/object:Api::Type::Integer
             name: 'maxConcurrentRequests'
@@ -540,8 +540,8 @@ objects:
         description: |
           Basic scaling creates instances when your application receives requests. Each instance will be shut down when the application becomes idle. Basic scaling is ideal for work that is intermittent or driven by user activity.
         conflicts:
-          - automaticScaling
-          - manualScaling
+          - automatic_scaling
+          - manual_scaling
         properties:
           - !ruby/object:Api::Type::String
             name: 'idleTimeout'
@@ -559,8 +559,8 @@ objects:
         description: |
           A service with manual scaling runs continuously, allowing you to perform complex initialization and rely on the state of its memory over time.
         conflicts:
-          - automaticScaling
-          - basicScaling
+          - automatic_scaling
+          - basic_scaling
         properties:
           - !ruby/object:Api::Type::Integer
             name: 'instances'

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -3066,8 +3066,8 @@ objects:
           must be expressed in CIDR format. Only IPv4 is supported.
         item_type: Api::Type::String
         conflicts:
-          - sourceRanges
-          - sourceTags
+          - source_ranges
+          - source_tags
       - !ruby/object:Api::Type::Enum
         name: 'direction'
         description: |
@@ -3179,8 +3179,8 @@ objects:
         item_type: Api::Type::String
         max_size: 10
         conflicts:
-          - sourceTags
-          - targetTags
+          - source_tags
+          - target_tags
       - !ruby/object:Api::Type::Array
         name: 'sourceTags'
         description: |
@@ -3206,8 +3206,8 @@ objects:
         item_type: Api::Type::String
         max_size: 10
         conflicts:
-          - sourceTags
-          - targetTags
+          - source_tags
+          - target_tags
       - !ruby/object:Api::Type::Array
         name: 'targetTags'
         description: |
@@ -8060,7 +8060,7 @@ objects:
           Node type to use for nodes group that are created from this template.
           Only one of nodeTypeFlexibility and nodeType can be specified.
         conflicts:
-          - nodeTypeFlexibility
+          - node_type_flexibility
       - !ruby/object:Api::Type::NestedObject
         name: 'nodeTypeFlexibility'
         description: |
@@ -8069,7 +8069,7 @@ objects:
           these properties. Only one of nodeTypeFlexibility and nodeType can
           be specified.
         conflicts:
-          - nodeType
+          - node_type
         properties:
           - !ruby/object:Api::Type::String
             name: cpus
@@ -11779,7 +11779,7 @@ objects:
       - !ruby/object:Api::Type::NestedObject
         name: 'snapshotSchedulePolicy'
         conflicts:
-          - 'groupPlacementPolicy'
+          - 'group_placement_policy'
         description: |
           Policy for creating snapshots of persistent disks.
         properties:
@@ -11923,7 +11923,7 @@ objects:
       - !ruby/object:Api::Type::NestedObject
         name: 'groupPlacementPolicy'
         conflicts:
-          - 'snapshotSchedulePolicy'
+          - 'snapshot_schedule_policy'
         description: |
           Policy for creating snapshots of persistent disks.
         properties:
@@ -16204,7 +16204,7 @@ objects:
               name: 'defaultRouteAction'
               # TODO: (mbang) conflicts also won't work for array path matchers yet, uncomment here once supported.
               # conflicts:
-              #   - defaultUrlRedirect
+              #   - path_matcher.path_matcher.default_url_redirect
               description: |
                 defaultRouteAction takes effect when none of the pathRules or routeRules match. The load balancer performs
                 advanced routing actions like URL rewrites, header transformations, etc. prior to forwarding the request
@@ -16547,7 +16547,7 @@ objects:
           - default_url_redirect
           - default_route_action.0.weighted_backend_services
         conflicts:
-          - defaultRouteAction
+          - default_route_action
         description: |
           When none of the specified hostRules match, the request is redirected to a URL specified
           by defaultUrlRedirect. If defaultUrlRedirect is specified, defaultService or
@@ -16614,7 +16614,7 @@ objects:
       - !ruby/object:Api::Type::NestedObject
         name: 'defaultRouteAction'
         conflicts:
-          - defaultUrlRedirect
+          - default_url_redirect
         description: |
           defaultRouteAction takes effect when none of the hostRules match. The load balancer performs advanced routing actions
           like URL rewrites, header transformations, etc. prior to forwarding the request to the selected backend.

--- a/products/mlengine/api.yaml
+++ b/products/mlengine/api.yaml
@@ -211,7 +211,7 @@ objects:
           response to increases and decreases in traffic. Care should be taken
           to ramp up traffic according to the model's ability to scale or you
           will start seeing increases in latency and 429 response codes.
-        conflicts: ['manualScaling']
+        conflicts: ['manual_scaling']
         properties:
           - !ruby/object:Api::Type::Integer
             name: 'minNodes'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/6967

Within `google_compute_url_map`, both `default_url_redirect` and `path_matcher.default_url_redirect` exist, as well as `default_route_action` and `path_matcher.default_route_action`. `default_url_redirect` is set to conflict with `default_route_action`, but the `path_matcher` subfields are not intended to conflict with anything.

The logic to generate `ConflictsWith` used `api_name` which does not differentiate between the two versions of each field, causing the `path_matcher` subfields to conflict with the top-level fields. Using `lineage` instead of `api_name` will remove these unintended conflicts.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed an issue where `google_compute_url_map` `path_matcher.default_route_action` would conflict with `default_url_redirect`
```
