### PR TITLE
Removed instances where input and output are both defined

### DIFF
--- a/products/bigqueryconnection/api.yaml
+++ b/products/bigqueryconnection/api.yaml
@@ -44,7 +44,7 @@ objects:
         description: |-
           The resource name of the connection in the form of: 
           "projects/{project_id}/locations/{location_id}/connections/{connectionId}"
-        input: true
+        output: true
       - !ruby/object:Api::Type::String
         name: connection_id
         description: |

--- a/products/bigqueryconnection/api.yaml
+++ b/products/bigqueryconnection/api.yaml
@@ -45,7 +45,6 @@ objects:
           The resource name of the connection in the form of: 
           "projects/{project_id}/locations/{location_id}/connections/{connectionId}"
         input: true
-        output: true
       - !ruby/object:Api::Type::String
         name: connection_id
         description: |

--- a/products/redis/api.yaml
+++ b/products/redis/api.yaml
@@ -102,7 +102,6 @@ objects:
           instances, this can be either [locationId] or [alternativeLocationId]
           and can change after a failover event.
         output: true
-        input: true
       - !ruby/object:Api::Type::String
         name: displayName
         description: |


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Removing instances where input and output are both true on a single Resource.

note: For ```BigqueryConnection.name``` I'm unsure as to whether input should be specified or not. Looked at the [api documentation](https://cloud.google.com/bigquery/docs/reference/bigqueryconnection/rest/v1beta1/projects.locations.connections#Connection). I'm following the pattern from querydatatransfer here. Please advise it is incorrect.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
Removing situations where input and output are both specified... has no affect downstream
```
