### PR TITLE
Drop recommendation to use -provider= on import

### DIFF
--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -185,12 +185,9 @@ This resource provides the following
 
 ```
 <% import_id_formats_from_resource(object).map{ |id| id.gsub('%', '') }.each do |id_format| -%>
-$ terraform import <% if object.min_version.name == 'beta' %>-provider=google-beta <% end -%><%= terraform_name -%>.default <%= id_format %>
+$ terraform import <%= terraform_name -%>.default <%= id_format %>
 <% end -%>
 ```
-
--> If you're importing a resource with beta features, make sure to include `-provider=google-beta`
-as an argument so that Terraform uses the correct provider to import your resource.
 
 <% end -%>
 <% if object.base_url.include?("{{project}}") || object.supports_indirect_user_project_override -%>

--- a/templates/terraform/resource_iam.html.markdown.erb
+++ b/templates/terraform/resource_iam.html.markdown.erb
@@ -262,7 +262,7 @@ Any variables not passed in the import command will be taken from the provider c
 
 IAM member imports use space-delimited identifiers: the resource in question, the role, and the member identity, e.g.
 ```
-$ terraform import <% if object.min_version.name == 'beta' %>-provider=google-beta <% end -%><%= resource_ns_iam -%>_member.editor "<%= all_formats.first.gsub('{{name}}', "{{#{object.name.underscore}}}") -%> <%= object.iam_policy.allowed_iam_role -%> user:jane@example.com"
+$ terraform import <%= resource_ns_iam -%>_member.editor "<%= all_formats.first.gsub('{{name}}', "{{#{object.name.underscore}}}") -%> <%= object.iam_policy.allowed_iam_role -%> user:jane@example.com"
 ```
 
 IAM binding imports use space-delimited identifiers: the resource in question and the role, e.g.
@@ -272,11 +272,8 @@ $ terraform import <%= resource_ns_iam -%>_binding.editor "<%= all_formats.first
 
 IAM policy imports use the identifier of the resource in question, e.g.
 ```
-$ terraform import <% if object.min_version.name == 'beta' %>-provider=google-beta <% end -%><%= resource_ns_iam -%>_policy.editor <%= all_formats.first.gsub('{{name}}', "{{#{object.name.underscore}}}") %>
+$ terraform import <%= resource_ns_iam -%>_policy.editor <%= all_formats.first.gsub('{{name}}', "{{#{object.name.underscore}}}") %>
 ```
-
--> If you're importing a resource with beta features, make sure to include `-provider=google-beta`
-as an argument so that Terraform uses the correct provider to import your resource.
 
 -> **Custom Roles**: If you're importing a IAM resource with a custom role, make sure to use the
  full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/roles/my-custom-role`.

--- a/third_party/terraform/website/docs/guides/provider_versions.html.markdown
+++ b/third_party/terraform/website/docs/guides/provider_versions.html.markdown
@@ -112,7 +112,7 @@ with the `-provider` flag, similarly to if you were using a provider alias.
 
 
 ```bash
-terraform import -provider=google-beta google_compute_instance.beta-instance my-instance
+terraform import google_compute_instance.beta-instance my-instance
 ```
 
 ## Converting resources between versions

--- a/third_party/terraform/website/docs/r/google_kms_crypto_key_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/google_kms_crypto_key_iam.html.markdown
@@ -196,6 +196,3 @@ IAM policy imports use the identifier of the resource in question.  This policy 
 ```
 $ terraform import google_kms_crypto_key_iam_policy.crypto_key your-project-id/location-name/key-ring-name/key-name
 ```
-
--> If you're importing a resource with beta features, make sure to include `-provider=google-beta`
-as an argument so that Terraform uses the correct provider to import your resource.

--- a/third_party/terraform/website/docs/r/google_kms_key_ring_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/google_kms_key_ring_iam.html.markdown
@@ -199,6 +199,3 @@ IAM policy imports use the identifier of the resource in question.  This policy 
 ```
 $ terraform import google_kms_key_ring_iam_policy.key_ring_iam your-project-id/location-name/key-ring-name
 ```
-
--> If you're importing a resource with beta features, make sure to include `-provider=google-beta`
-as an argument so that Terraform uses the correct provider to import your resource.

--- a/third_party/terraform/website/docs/r/google_service_account_iam.html.markdown
+++ b/third_party/terraform/website/docs/r/google_service_account_iam.html.markdown
@@ -194,7 +194,7 @@ full name of the custom role, e.g. `[projects/my-project|organizations/my-org]/r
 
 With conditions:
 ```
-$ terraform import -provider=google-beta google_service_account_iam_binding.admin-account-iam "projects/{your-project-id}/serviceAccounts/{your-service-account-email} iam.serviceAccountUser expires_after_2019_12_31"
+$ terraform import google_service_account_iam_binding.admin-account-iam "projects/{your-project-id}/serviceAccounts/{your-service-account-email} iam.serviceAccountUser expires_after_2019_12_31"
 
-$ terraform import -provider=google-beta google_service_account_iam_member.admin-account-iam "projects/{your-project-id}/serviceAccounts/{your-service-account-email} iam.serviceAccountUser user:foo@example.com expires_after_2019_12_31"
+$ terraform import google_service_account_iam_member.admin-account-iam "projects/{your-project-id}/serviceAccounts/{your-service-account-email} iam.serviceAccountUser user:foo@example.com expires_after_2019_12_31"
 ```

--- a/third_party/terraform/website/docs/r/monitoring_dashboard.html.markdown
+++ b/third_party/terraform/website/docs/r/monitoring_dashboard.html.markdown
@@ -148,9 +148,6 @@ $ terraform import google_monitoring_dashboard.default project/{{project}}/dashb
 $ terraform import google_monitoring_dashboard.default {{dashboard_id}}
 ```
 
--> If you're importing a resource with beta features, make sure to include `-provider=google-beta`
-as an argument so that Terraform uses the correct provider to import your resource.
-
 ## User Project Overrides
 
 This resource supports [User Project Overrides](https://www.terraform.io/docs/providers/google/guides/provider_reference.html#user_project_override).


### PR DESCRIPTION
This was deprecated in 0.12 and is removed in 0.13.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
Drop recommendation to use -provider= on import in documentation
```
