### PR TITLE
fix active directory domain sweeper

### DIFF
--- a/products/activedirectory/api.yaml
+++ b/products/activedirectory/api.yaml
@@ -24,7 +24,8 @@ objects:
   - !ruby/object:Api::Resource
     name: 'Domain'
     kind: 'activedirectory#domain'
-    base_url : projects/{{project}}/locations/global/domains?domainName={{domain_name}}
+    base_url: projects/{{project}}/locations/global/domains
+    create_url: projects/{{project}}/locations/global/domains?domainName={{domain_name}}
     update_verb: :PATCH
     update_mask: true
     self_link: '{{name}}'

--- a/products/activedirectory/terraform.yaml
+++ b/products/activedirectory/terraform.yaml
@@ -32,7 +32,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "ad-domain"
         vars:
           name: "myorg"
-          domain_name: name
+          # the part of the domain before the first "." must be <15 chars, and
+          # the random suffix is 10 chars. In order to make sure these get swept,
+          # 'tfgen' is the only option here.
+          domain_name: tfgen
   DomainTrust: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: "projects/{{project}}/locations/global/domains/{{domain}}/{{target_domain_name}}"
     import_format: ["projects/{{project}}/locations/global/domains/{{domain}}/{{target_domain_name}}"]

--- a/third_party/terraform/tests/resource_active_directory_domain_update_test.go
+++ b/third_party/terraform/tests/resource_active_directory_domain_update_test.go
@@ -10,7 +10,7 @@ import (
 func TestAccActiveDirectoryDomain_update(t *testing.T) {
 	t.Parallel()
 
-	domain := fmt.Sprintf("mydomain%s.org1.com", randString(t, 5))
+	domain := fmt.Sprintf("tf-test%s.org1.com", randString(t, 5))
 	context := map[string]interface{}{
 		"domain":        domain,
 		"resource_name": "ad-domain",


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

For https://github.com/hashicorp/terraform-provider-google/issues/7084. Updates the list endpoint and resource prefixes.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
