### PR TITLE
Correct data type for Notebook Instance Owners field, add some enums

### DIFF
--- a/products/notebooks/api.yaml
+++ b/products/notebooks/api.yaml
@@ -187,7 +187,7 @@ objects:
         description: |
             The proxy endpoint that is used to access the Jupyter notebook.
         output: true
-      - !ruby/object:Api::Type::String
+      - !ruby/object:Api::Type::Array
         name: 'instanceOwners'
         description: |
             The owner of this instance after creation. 
@@ -195,6 +195,7 @@ objects:
             Currently supports one owner only. 
             If not specified, all of the service account users of 
             your VM instance's service account can use the instance.
+        item_type: Api::Type::String
       - !ruby/object:Api::Type::String
         name: 'serviceAccount'
         description: |
@@ -247,6 +248,7 @@ objects:
           - STOPPING
           - STOPPED
           - DELETED
+          - INITIALIZING
         description: |
             The state of this instance.
         output: true

--- a/products/notebooks/api.yaml
+++ b/products/notebooks/api.yaml
@@ -190,12 +190,11 @@ objects:
       - !ruby/object:Api::Type::Array
         name: 'instanceOwners'
         description: |
-            The owner of this instance after creation. 
+            The list of owners of this instance after creation. 
             Format: alias@example.com.
             Currently supports one owner only. 
             If not specified, all of the service account users of 
             your VM instance's service account can use the instance.
-        required: false
         item_type: Api::Type::String
       - !ruby/object:Api::Type::String
         name: 'serviceAccount'
@@ -239,17 +238,8 @@ objects:
             required: true
             description: |
               Count of cores of this accelerator.
-      - !ruby/object:Api::Type::Enum
+      - !ruby/object:Api::Type::String
         name: 'state'
-        values:
-          - STATE_UNSPECIFIED
-          - STARTING
-          - PROVISIONING
-          - ACTIVE
-          - STOPPING
-          - STOPPED
-          - DELETED
-          - INITIALIZING
         description: |
             The state of this instance.
         output: true
@@ -270,6 +260,7 @@ objects:
           - DISK_TYPE_UNSPECIFIED
           - PD_STANDARD
           - PD_SSD
+          - PD_BALANCED
         description: |
             Possible disk types for notebook instances.
       - !ruby/object:Api::Type::Integer
@@ -284,6 +275,7 @@ objects:
           - DISK_TYPE_UNSPECIFIED
           - PD_STANDARD
           - PD_SSD
+          - PD_BALANCED
         description: |
             Possible disk types for notebook instances.
       - !ruby/object:Api::Type::Integer

--- a/products/notebooks/api.yaml
+++ b/products/notebooks/api.yaml
@@ -195,6 +195,7 @@ objects:
             Currently supports one owner only. 
             If not specified, all of the service account users of 
             your VM instance's service account can use the instance.
+        required: false
         item_type: Api::Type::String
       - !ruby/object:Api::Type::String
         name: 'serviceAccount'


### PR DESCRIPTION
Add Initialization state
Getting: Error: 
```
Error reading Instance: instance_owners: '' expected type 'string', got unconvertible type '[]interface {}'
```
Currently Instance owners is type Array with string items
https://cloud.google.com/ai-platform/notebooks/docs/reference/rest/v1beta1/projects.locations.instances#Instance


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
notebooks: fixed broken `google_notebooks_instance.instance_owners` field by making it a list instead of a string
```
```release-note:enhancement
notebooks: added `PD_BALANCED` as a possible disk type for `google_notebooks_instance`
```
