### PR TITLE
GKE Hub Membership resource.

### DIFF
--- a/products/gkehub/api.yaml
+++ b/products/gkehub/api.yaml
@@ -1,0 +1,118 @@
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: GKEHub
+display_name: GKEHub
+versions:
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://gkehub.googleapis.com/v1beta1/
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: GKEHub API
+    url: https://console.cloud.google.com/apis/library/gkehub.googleapis.com
+objects:
+  - !ruby/object:Api::Resource
+    min_version: beta
+    name: 'Membership'
+    base_url: "projects/{{project}}/locations/global/memberships"
+    create_url: "projects/{{project}}/locations/global/memberships?membershipId={{membership_id}}"
+    update_url: "projects/{{project}}/locations/global/memberships/{{membership_id}}"
+    self_link: "{{name}}"
+    update_verb: :PATCH
+    update_mask: true
+    description: |
+      Membership contains information about a member cluster.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+          'https://cloud.google.com/gkehub/docs/'
+      api: 'https://cloud.google.com/gkehub/docs/reference/rest/v1beta1/projects.locations.memberships'
+    async: !ruby/object:Api::OpAsync
+      operation: !ruby/object:Api::OpAsync::Operation
+        kind: 'gkehub#operation'
+        path: 'name'
+        base_url: '{{op_id}}'
+        wait_ms: 1000
+      result: !ruby/object:Api::OpAsync::Result
+        path: 'response'
+        resource_inside_response: true
+      status: !ruby/object:Api::OpAsync::Status
+        path: 'done'
+        complete: 'true'
+        allowed:
+          - 'true'
+          - 'false'
+      error: !ruby/object:Api::OpAsync::Error
+        path: 'error/errors'
+        message: 'message'
+
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'membershipId'
+        description: |
+          The client-provided identifier of the membership.
+        required: true
+        input: true
+        url_param_only: true
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        output: true
+        description: |
+          The unique identifier of the membership.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          The name of this entity type to be displayed on the console.
+        required: true
+        input: true
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'labels'
+        description: |
+          Labels to apply to this membership.
+      - !ruby/object:Api::Type::String
+        name: 'externalId'
+        description: |
+          An externally-generated and managed ID for this Membership.
+          This ID may still be modified after creation but it is not recommended to do so.
+          The ID must match the regex: `[a-zA-Z0-9][a-zA-Z0-9_\-\.]*` If this Membership
+          represents a Kubernetes cluster, this value should be set to the UUID of the
+          kube-system namespace object.
+        required: true
+      - !ruby/object:Api::Type::String
+        name: 'uniqueId'
+        description: |
+          Output only. Google-generated UUID for this resource.
+        output: true
+      - !ruby/object:Api::Type::NestedObject
+        name: 'endpoint'
+        input: true
+        description: |
+          If this Membership is a Kubernetes API server hosted on GKE, this is a self link to its GCP resource.
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: 'gkeCluster'
+            input: true
+            description: |
+              If this Membership is a Kubernetes API server hosted on GKE, this is a self link to its GCP resource.
+            properties:
+              - !ruby/object:Api::Type::String
+                name: 'resourceLink'
+                description: |
+                  Self-link of the GCP resource for the GKE cluster.
+                  For example: `//container.googleapis.com/v1/projects/my-project/zones/us-west1-a/clusters/my-cluster`.
+                  It can be at the most 1000 characters in length.
+                input: true

--- a/products/gkehub/api.yaml
+++ b/products/gkehub/api.yaml
@@ -113,6 +113,7 @@ objects:
                 name: 'resourceLink'
                 description: |
                   Self-link of the GCP resource for the GKE cluster.
-                  For example: `//container.googleapis.com/v1/projects/my-project/zones/us-west1-a/clusters/my-cluster`.
-                  It can be at the most 1000 characters in length.
+                  For example: `//container.googleapis.com/projects/my-project/zones/us-west1-a/clusters/my-cluster`.
+                  It can be at the most 1000 characters in length.  If the cluster is provisioned with Terraform,
+                  this is `"//container.googleapis.com/${google_container_cluster.my-cluster.id}"`.
                 input: true

--- a/products/gkehub/terraform.yaml
+++ b/products/gkehub/terraform.yaml
@@ -1,0 +1,35 @@
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Terraform::Config
+overrides: !ruby/object:Overrides::ResourceOverrides
+  Membership: !ruby/object:Overrides::Terraform::ResourceOverride
+    autogen_async: true
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        min_version: beta
+        name: "gkehub_membership_basic"
+        primary_resource_id: "basic_membership"
+        vars:
+          name: "basic"
+          cluster_name: "basiccluster"
+    # Skip sweeper gen since this is a child resource.
+    skip_sweeper: true
+    id_format: "{{name}}"
+    import_format: ["{{name}}"]
+# This is for copying files over
+files: !ruby/object:Provider::Config::Files
+  # These files have templating (ERB) code that will be run.
+  # This is usually to add licensing info, autogeneration notices, etc.
+  compile:
+<%= lines(indent(compile('provider/terraform/product~compile.yaml'), 4)) -%>

--- a/templates/terraform/examples/gkehub_membership_basic.tf.erb
+++ b/templates/terraform/examples/gkehub_membership_basic.tf.erb
@@ -1,0 +1,18 @@
+resource "google_container_cluster" "primary" {
+  name               = "<%= ctx[:vars]['cluster_name'] %>"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  provider = google-beta
+}
+
+resource "google_gke_hub_membership" "membership" {
+  membership_id = "<%= ctx[:vars]['name'] %>"
+  external_id = "aaaaaaaaa"
+  endpoint {
+    gke_cluster {
+      resource_link = "//container.googleapis.com/${google_container_cluster.primary.id}"
+    }
+  }
+  description = "test resource."
+  provider = google-beta
+}


### PR DESCRIPTION
GKE Hub Membership resource.



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_gke_hub_membership`
```

Fixes https://github.com/hashicorp/terraform-provider-google/issues/5880.