### PR TITLE
Allow IGM to resume operation after interruption

### DIFF
--- a/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
+++ b/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
@@ -485,7 +485,10 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 		d.Set("operation", "")
 		err = computeOperationWaitTime(config, op, project, "Creating InstanceGroupManager", d.Timeout(schema.TimeoutCreate))
 		if err != nil {
-			return err
+			// remove from state to allow refresh to finish
+			log.Printf("[DEBUG] Resumed operation returned an error, removing from state: %s",err)
+			d.SetId("")
+			return nil
 		}
 	}
 

--- a/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
+++ b/third_party/terraform/resources/resource_compute_instance_group_manager.go.erb
@@ -302,6 +302,10 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 				},
 			},
 <% end -%>
+			"operation": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -381,6 +385,18 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 	// Wait for the operation to complete
 	err = computeOperationWaitTime(config, op, project, "Creating InstanceGroupManager", d.Timeout(schema.TimeoutCreate))
 	if err != nil {
+		// Check if the create operation failed because Terraform was prematurely terminated. If it was we can persist the
+		// operation id to state so that a subsequent refresh of this resource will wait until the operation has terminated
+		// before attempting to Read the state of the manager. This allows a graceful resumption of a Create that was killed
+		// by the upstream Terraform process exiting early such as a sigterm.
+		select {
+		case <-config.context.Done():
+			log.Printf("[DEBUG] Persisting %s so this operation can be resumed \n", op.Name)
+			d.Set("operation", op.Name)
+			return nil
+		default:
+			// leaving default case to ensure this is non blocking
+		}
 		return err
 	}
 
@@ -456,6 +472,21 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	project, err := getProject(d, config)
 	if err != nil {
 		return err
+	}
+
+	operation := d.Get("operation").(string)
+	if operation != "" {
+		log.Printf("[DEBUG] in progress operation detected at %v, attempting to resume", operation)
+		zone, _ := getZone(d, config)
+		op := &computeBeta.Operation{
+			Name: operation,
+			Zone: zone,
+		}
+		d.Set("operation", "")
+		err = computeOperationWaitTime(config, op, project, "Creating InstanceGroupManager", d.Timeout(schema.TimeoutCreate))
+		if err != nil {
+			return err
+		}
 	}
 
 	manager, err := getManager(d, meta)

--- a/third_party/terraform/utils/compute_operation.go.erb
+++ b/third_party/terraform/utils/compute_operation.go.erb
@@ -3,7 +3,10 @@ package google
 
 import (
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
+	"log"
 	"time"
 
 	"google.golang.org/api/compute/v1"
@@ -18,6 +21,7 @@ type ComputeOperationWaiter struct {
 	Service *computeBeta.Service
 	Op      *computeBeta.Operation
 <% end -%>
+	Context context.Context
 	Project string
 <% unless version == 'ga' -%>
 	Parent  string
@@ -67,6 +71,13 @@ func (w *ComputeOperationWaiter) QueryOp() (interface{}, error) {
 	if w == nil || w.Op == nil {
 		return nil, fmt.Errorf("Cannot query operation, it's unset or nil.")
 	}
+	select {
+	case <-w.Context.Done():
+		log.Println("[WARN] request has been cancelled early")
+		return w.Op, errors.New("unable to finish polling, context has been cancelled")
+	default:
+		// default must be here to keep the previous case from blocking
+	}
 	if w.Op.Zone != "" {
 		zone := GetResourceNameFromSelfLink(w.Op.Zone)
 		return w.Service.ZoneOperations.Get(w.Project, zone, w.Op.Name).Do()
@@ -114,6 +125,7 @@ func computeOperationWaitTime(config *Config, res interface{}, project, activity
 <% else -%>
 		Service: config.clientComputeBeta,
 <% end -%>
+		Context: config.context,
 		Op:      op,
 		Project: project,
 	}

--- a/third_party/terraform/utils/compute_operation.go.erb
+++ b/third_party/terraform/utils/compute_operation.go.erb
@@ -71,12 +71,14 @@ func (w *ComputeOperationWaiter) QueryOp() (interface{}, error) {
 	if w == nil || w.Op == nil {
 		return nil, fmt.Errorf("Cannot query operation, it's unset or nil.")
 	}
-	select {
-	case <-w.Context.Done():
-		log.Println("[WARN] request has been cancelled early")
-		return w.Op, errors.New("unable to finish polling, context has been cancelled")
-	default:
-		// default must be here to keep the previous case from blocking
+	if w.Context != nil {
+		select {
+		case <-w.Context.Done():
+			log.Println("[WARN] request has been cancelled early")
+			return w.Op, errors.New("unable to finish polling, context has been cancelled")
+		default:
+			// default must be here to keep the previous case from blocking
+		}
 	}
 	if w.Op.Zone != "" {
 		zone := GetResourceNameFromSelfLink(w.Op.Zone)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/6683

Applied the GKE feature here https://github.com/GoogleCloudPlatform/magic-modules/pull/2857/files to IGM.



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
`compute`: Added graceful termination to `google_compute_instance_group_manager` create calls so that partially created instance group managers will resume the original operation if the Terraform process is killed mid create.
```
