### PR TITLE
add sensitive_params to bigquery_data_transfer_config

### DIFF
--- a/products/bigquerydatatransfer/api.yaml
+++ b/products/bigquerydatatransfer/api.yaml
@@ -120,3 +120,16 @@ objects:
         required: true
         description: |
           These parameters are specific to each data source.
+      - !ruby/object:Api::Type::NestedObject
+        name: sensitiveParams
+        # This is a helper object for Terraform only
+        exclude: true
+        url_param_only: true
+        description: |
+          Terraform only field
+        properties:
+          - !ruby/object:Api::Type::String
+            name: secretAccessKey
+            required: true
+            description: |
+              The Secret Access Key of the AWS account transfering data from.

--- a/products/bigquerydatatransfer/api.yaml
+++ b/products/bigquerydatatransfer/api.yaml
@@ -132,4 +132,4 @@ objects:
             name: secretAccessKey
             required: true
             description: |
-              The Secret Access Key of the AWS account transfering data from.
+              The Secret Access Key of the AWS account transferring data from.

--- a/products/bigquerydatatransfer/terraform.yaml
+++ b/products/bigquerydatatransfer/terraform.yaml
@@ -24,7 +24,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       location: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
       params: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: resourceBigQueryDataTransferDiffSuppress
         custom_flatten: templates/terraform/custom_flatten/json_to_string_map.go.erb
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      constants: templates/terraform/constants/bigquery_data_transfer.go.erb
     examples:
       - !ruby/object:Provider::Terraform::Examples
         skip_test: true

--- a/products/bigquerydatatransfer/terraform.yaml
+++ b/products/bigquerydatatransfer/terraform.yaml
@@ -42,6 +42,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       constants: templates/terraform/constants/bigquery_data_transfer.go.erb
       decoder: templates/terraform/decoders/bigquery_data_transfer.go.erb
       encoder: templates/terraform/encoders/bigquery_data_transfer.go.erb
+      custom_import: templates/terraform/custom_import/self_link_as_name.erb
+      post_create: templates/terraform/post_create/set_computed_name.erb
     examples:
       - !ruby/object:Provider::Terraform::Examples
         skip_test: true

--- a/products/bigquerydatatransfer/terraform.yaml
+++ b/products/bigquerydatatransfer/terraform.yaml
@@ -38,6 +38,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       sensitiveParams.secretAccessKey: !ruby/object:Overrides::Terraform::PropertyOverride
         sensitive: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
+      resource_definition: templates/terraform/resource_definition/bigquery_data_transfer.go.erb
       constants: templates/terraform/constants/bigquery_data_transfer.go.erb
       decoder: templates/terraform/decoders/bigquery_data_transfer.go.erb
       encoder: templates/terraform/encoders/bigquery_data_transfer.go.erb

--- a/products/bigquerydatatransfer/terraform.yaml
+++ b/products/bigquerydatatransfer/terraform.yaml
@@ -24,10 +24,23 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       location: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
       params: !ruby/object:Overrides::Terraform::PropertyOverride
-        diff_suppress_func: resourceBigQueryDataTransferDiffSuppress
         custom_flatten: templates/terraform/custom_flatten/json_to_string_map.go.erb
+      sensitiveParams: !ruby/object:Overrides::Terraform::PropertyOverride
+        exclude: false
+        description: |
+          Different parameters are configured primarily using the the `params` field on this
+          resource. This block contains the parameters which contain secrets or passwords so that they can be marked
+          sensitive and hidden from plan output. The name of the field, eg: secret_access_key, will be the key
+          in the `params` map in the api request.
+
+          Credentials may not be specified in both locations and will cause an error. Changing from one location
+          to a different credential configuration in the config will require an apply to update state.
+      sensitiveParams.secretAccessKey: !ruby/object:Overrides::Terraform::PropertyOverride
+        sensitive: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/bigquery_data_transfer.go.erb
+      decoder: templates/terraform/decoders/bigquery_data_transfer.go.erb
+      encoder: templates/terraform/encoders/bigquery_data_transfer.go.erb
     examples:
       - !ruby/object:Provider::Terraform::Examples
         skip_test: true

--- a/templates/terraform/constants/bigquery_data_transfer.go.erb
+++ b/templates/terraform/constants/bigquery_data_transfer.go.erb
@@ -1,6 +1,12 @@
-func resourceBigQueryDataTransferDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	if k == "params.secret_access_key" {
-		return true
+var sensitiveParams = []string{"secret_access_key"}
+
+func sensitiveParamCustomizeDiff(diff *schema.ResourceDiff, v interface{}) error {
+	for _, sp := range sensitiveParams {
+		mapLabel := diff.Get("params." + sp).(string)
+		authLabel := diff.Get("sensitive_params.0." + sp).(string)
+		if mapLabel != "" && authLabel != "" {
+			return fmt.Errorf("Sensitive param [%s] cannot be set in both `params` and the `sensitive_params` block.", sp)
+		}
 	}
-	return false
+	return nil
 }

--- a/templates/terraform/constants/bigquery_data_transfer.go.erb
+++ b/templates/terraform/constants/bigquery_data_transfer.go.erb
@@ -1,0 +1,6 @@
+func resourceBigQueryDataTransferDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	if k == "params.secret_access_key" {
+		return true
+	}
+	return false
+}

--- a/templates/terraform/decoders/bigquery_data_transfer.go.erb
+++ b/templates/terraform/decoders/bigquery_data_transfer.go.erb
@@ -1,0 +1,28 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+if paramMap, ok := res["params"]; ok {
+	params := paramMap.(map[string]interface{})
+	for _, sp := range sensitiveParams {
+		if _, apiOk := params[sp]; apiOk {
+			if _, exists := d.GetOkExists("sensitive_params.0." + sp); exists {
+				delete(params, sp)
+			} else {
+				params[sp] = d.Get("params." + sp)
+			}
+		}
+	}
+}
+
+return res, nil

--- a/templates/terraform/encoders/bigquery_data_transfer.go.erb
+++ b/templates/terraform/encoders/bigquery_data_transfer.go.erb
@@ -1,0 +1,31 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+paramMap, ok := obj["params"]
+if !ok {
+	paramMap = make(map[string]string)
+}
+
+var params map[string]string
+params = paramMap.(map[string]string)
+
+for _, sp := range sensitiveParams {
+	if auth, _ := d.GetOkExists("sensitive_params.0." + sp); auth != "" {
+		params[sp] = auth.(string)
+	}
+}
+
+obj["params"] = params
+
+return obj, nil

--- a/templates/terraform/resource_definition/bigquery_data_transfer.go.erb
+++ b/templates/terraform/resource_definition/bigquery_data_transfer.go.erb
@@ -1,0 +1,15 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+CustomizeDiff: sensitiveParamCustomizeDiff,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/7125

I tested this locally, but not sure I can add a test in since it would require AWS credentials.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquerydatatransfer: fixed `params.secret_access_key` perma-diff for AWS S3 data transfer config types by adding a `sensitive_params` block with the `secret_access_key` attribute.
```
