### PR TITLE
Allow updates to composer webserver and database.

### DIFF
--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -411,7 +411,6 @@ func resourceComposerEnvironment() *schema.Resource {
 									"machine_type": {
 										Type:         schema.TypeString,
 										Required:     true,
-										ForceNew:     true,
 										Description: `Optional. Cloud SQL machine type used by Airflow database. It has to be one of: db-n1-standard-2, db-n1-standard-4, db-n1-standard-8 or db-n1-standard-16. If not specified, db-n1-standard-2 will be used.`,
 									},
 								},
@@ -429,7 +428,6 @@ func resourceComposerEnvironment() *schema.Resource {
 									"machine_type": {
 										Type:         schema.TypeString,
 										Required:     true,
-										ForceNew:     true,
 										Description: `Optional. Machine type on which Airflow web server is running. It has to be one of: composer-n1-webserver-2, composer-n1-webserver-4 or composer-n1-webserver-8. If not specified, composer-n1-webserver-2 will be used. Value custom is returned only in response, if Airflow web server parameters were manually changed to a non-standard values.`,
 									},
 								},

--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -673,24 +673,24 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 		}
 
 <% unless version == "ga" -%>
-		if d.HasChange("config.0.database_config") {
+		if d.HasChange("config.0.database_config.0.machine_type") {
 			patchObj := &composer.Environment{Config: &composer.EnvironmentConfig{}}
 			if config != nil {
 				patchObj.Config.DatabaseConfig = config.DatabaseConfig
 			}
-			err = resourceComposerEnvironmentPatchField("config.databaseConfig", patchObj, d, tfConfig)
+			err = resourceComposerEnvironmentPatchField("config.databaseConfig.machineType", patchObj, d, tfConfig)
 			if err != nil {
 				return err
 			}
 			d.SetPartial("config")
 		}
 
-		if d.HasChange("config.0.web_server_config") {
+		if d.HasChange("config.0.web_server_config.0.machine_type") {
 			patchObj := &composer.Environment{Config: &composer.EnvironmentConfig{}}
 			if config != nil {
 				patchObj.Config.WebServerConfig = config.WebServerConfig
 			}
-			err = resourceComposerEnvironmentPatchField("config.webServerConfig", patchObj, d, tfConfig)
+			err = resourceComposerEnvironmentPatchField("config.webServerConfig.machineType", patchObj, d, tfConfig)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The composer api allows in-place updates to webserver and database machine types, and the provider implements those updates. But because both properties are marked `ForceNew`, the update code is unreachable. This patch drops the `ForceNew` flags for these properties.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
composer: allow in-place updates to webserver and database machine type
```
