### PR TITLE
Revert `eraseWindowsVssSignature` field and test

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -2911,13 +2911,6 @@ objects:
         description: |
           URL of the disk type resource describing which disk type to use to
           create the disk. Provide this when creating the disk.
-      - !ruby/object:Api::Type::Boolean
-        name: 'eraseWindowsVssSignature'
-        min_version: beta
-        default_value: false
-        description: |
-          Specifies whether the disk restored from a source snapshot
-          should erase Windows specific VSS signature.
       - !ruby/object:Api::Type::String
         name: 'sourceImage'
         description: |

--- a/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -457,32 +457,6 @@ func TestAccComputeDisk_resourcePolicies(t *testing.T) {
 }
 <% end -%>
 
-<% unless version == 'ga' -%>
-func TestAccComputeDisk_VSSWindows(t *testing.T) {
-	t.Parallel()
-
-	diskName := fmt.Sprintf("tf-test-%s", randString(t, 10))
-	firstDiskName := fmt.Sprintf("tf-test-%s", randString(t, 10))
-	snapshotName := fmt.Sprintf("tf-test-%s", randString(t, 10))
-	projectName := getTestProjectFromEnv()
-
-	vcrTest(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComputeDisk_WindowsVSS(firstDiskName, projectName, snapshotName, diskName),
-			},
-			{
-				ResourceName:      "google_compute_disk.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-<% end -%>
-
 func testAccCheckComputeDiskExists(t *testing.T, n, p string, disk *compute.Disk) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -799,40 +773,5 @@ resource "google_compute_disk" "foobar" {
   resource_policies = [google_compute_resource_policy.foo.self_link]
 }
 `, policyName, diskName)
-}
-<% end -%>
-
-
-<% unless version == 'ga' -%>
-func testAccComputeDisk_WindowsVSS(firstDiskName, projectName, snapshotName, diskName string) string {
-	return fmt.Sprintf(`
-resource "google_compute_disk" "sourcedisk" {
-  name    = "d1-%s"
-  image   = "windows-server-2019-dc-v20200813"
-  size    = 50
-  type    = "pd-ssd"
-  zone    = "us-central1-a"
-  project = "%s"
-}
-
-resource "google_compute_snapshot" "snapdisk" {
-  name        = "%s"
-  source_disk = google_compute_disk.sourcedisk.name
-  zone        = "us-central1-a"
-  project     = "%s"
-}
-
-resource "google_compute_disk" "foobar" {
-  name                        = "%s"
-  snapshot                    = google_compute_snapshot.snapdisk.self_link
-  size                        = 50
-  type                        = "pd-ssd"
-  zone                        = "us-central1-a"
-  erase_windows_vss_signature = true
-  timeouts {
-    create = "10m"
-  }
-}
-`, firstDiskName, projectName, snapshotName, projectName, diskName)
 }
 <% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The test doesn't work as-is, and it shouldn't have been merged yet. Field works as intended, but reverting for now until we have a working test and better documentation on how to use it.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
