### PR TITLE
Allow updating single_cluster_routing in google_bigtable_app_profile

### DIFF
--- a/products/bigtable/api.yaml
+++ b/products/bigtable/api.yaml
@@ -79,7 +79,6 @@ objects:
           - multi_cluster_routing_use_any
         description: |
           Use a single-cluster routing policy.
-        input: true
         properties:
             - !ruby/object:Api::Type::String
               name: 'clusterId'

--- a/third_party/terraform/tests/resource_bigtable_app_profile_test.go
+++ b/third_party/terraform/tests/resource_bigtable_app_profile_test.go
@@ -59,10 +59,14 @@ resource "google_bigtable_app_profile" "ap" {
   instance       = google_bigtable_instance.instance.id
   app_profile_id = "test"
 
-  multi_cluster_routing_use_any = true
+  single_cluster_routing {
+    cluster_id                 = %q
+    allow_transactional_writes = true
+  }
+
   ignore_warnings               = true
 }
-`, instanceName, instanceName)
+`, instanceName, instanceName, instanceName)
 }
 
 func testAccBigtableAppProfile_update(instanceName string) string {
@@ -84,8 +88,12 @@ resource "google_bigtable_app_profile" "ap" {
   app_profile_id = "test"
   description    = "add a description"
 
-  multi_cluster_routing_use_any = true
+  single_cluster_routing {
+    cluster_id                 = %q
+    allow_transactional_writes = false
+  }
+
   ignore_warnings               = true
 }
-`, instanceName, instanceName)
+`, instanceName, instanceName, instanceName)
 }

--- a/third_party/terraform/tests/resource_bigtable_app_profile_test.go
+++ b/third_party/terraform/tests/resource_bigtable_app_profile_test.go
@@ -20,7 +20,7 @@ func TestAccBigtableAppProfile_update(t *testing.T) {
 		CheckDestroy: testAccCheckBigtableAppProfileDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccBigtableAppProfile_multiClusterRouting(instanceName),
+				Config: testAccBigtableAppProfile_update1(instanceName),
 			},
 			{
 				ResourceName:            "google_bigtable_app_profile.ap",
@@ -29,7 +29,7 @@ func TestAccBigtableAppProfile_update(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"ignore_warnings"},
 			},
 			{
-				Config: testAccBigtableAppProfile_update(instanceName),
+				Config: testAccBigtableAppProfile_update2(instanceName),
 			},
 			{
 				ResourceName:            "google_bigtable_app_profile.ap",
@@ -41,7 +41,7 @@ func TestAccBigtableAppProfile_update(t *testing.T) {
 	})
 }
 
-func testAccBigtableAppProfile_multiClusterRouting(instanceName string) string {
+func testAccBigtableAppProfile_update1(instanceName string) string {
 	return fmt.Sprintf(`
 resource "google_bigtable_instance" "instance" {
   name = "%s"
@@ -69,7 +69,7 @@ resource "google_bigtable_app_profile" "ap" {
 `, instanceName, instanceName, instanceName)
 }
 
-func testAccBigtableAppProfile_update(instanceName string) string {
+func testAccBigtableAppProfile_update2(instanceName string) string {
 	return fmt.Sprintf(`
 resource "google_bigtable_instance" "instance" {
   name = "%s"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes b/168053560 (updating certain bt app profile fields failed)

Terraform believed the subfields of `single_cluster_routing` were updatable and they should have been, but in practice Magic Modules didn't generate the write update handlers.

I don't believe updating to/from `single_cluster_routing` and `multi_cluster_routing` is possible, so this schema is a little misleading. However I believe it's an acceptable tradeoff:

- Since this and mcr are ExactlyOneOf, mcr's ForceNew will still trigger if the user changes which field is set
- MM doesn't support updating fields that are updatable while their parent field isn't
- MM doesn't support update masks for non-top-level fields (but specifying the top level field will update all of it's children)


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigtable: fixed the update behaviour of the `single_cluster_routing` sub-fields in `google_bigtable_app_profile`
```
