### PR TITLE
Use Cloud Composer v1 API for google provider

### DIFF
--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -11,7 +11,13 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+<% if version == "ga" -%>
+	composer "google.golang.org/api/composer/v1"
+	"google.golang.org/api/composer/v1"
+<% else -%>
+	composer "google.golang.org/api/composer/v1beta1"
 	"google.golang.org/api/composer/v1beta1"
+<% end -%>
 )
 
 const (
@@ -665,6 +671,7 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 			}
 		}
 
+<% unless version == "ga" -%>
 		// If web_server_network_access_control has more fields added it may require changes here.
 		// This is scoped specifically to allowed_ip_range due to https://github.com/hashicorp/terraform-plugin-sdk/issues/98
 		if d.HasChange("config.0.web_server_network_access_control.0.allowed_ip_range") {
@@ -677,6 +684,7 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 				return err
 			}
 		}
+<% end -%>
 
 <% unless version == "ga" -%>
 		if d.HasChange("config.0.database_config.0.machine_type") {

--- a/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -12,7 +12,11 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+<% if version == "ga" -%>
+	"google.golang.org/api/composer/v1"
+<% else -%>
 	"google.golang.org/api/composer/v1beta1"
+<% end -%>
 	"google.golang.org/api/storage/v1"
 )
 

--- a/third_party/terraform/utils/composer_operation.go.erb
+++ b/third_party/terraform/utils/composer_operation.go.erb
@@ -1,10 +1,15 @@
+<% autogen_exception -%>
 package google
 
 import (
 	"fmt"
 	"time"
 
+<% if version == "ga" -%>
+	composer "google.golang.org/api/composer/v1"
+<% else -%>
 	composer "google.golang.org/api/composer/v1beta1"
+<% end -%>
 )
 
 type ComposerOperationWaiter struct {

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -35,8 +35,13 @@ import (
 	"google.golang.org/api/cloudkms/v1"
 	"google.golang.org/api/cloudresourcemanager/v1"
 	resourceManagerV2Beta1 "google.golang.org/api/cloudresourcemanager/v2beta1"
+<% if version == "beta" -%>
 	composer "google.golang.org/api/composer/v1beta1"
 	"google.golang.org/api/composer/v1beta1"
+<% else -%>
+	composer "google.golang.org/api/composer/v1"
+	"google.golang.org/api/composer/v1"
+<% end -%>
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/container/v1"

--- a/third_party/terraform/utils/provider_handwritten_endpoint.go.erb
+++ b/third_party/terraform/utils/provider_handwritten_endpoint.go.erb
@@ -28,7 +28,11 @@ var CloudBillingCustomEndpointEntry = &schema.Schema{
 	}, CloudBillingDefaultBasePath),
 }
 
+<% if version == "beta" -%>
 var ComposerDefaultBasePath = "https://composer.googleapis.com/v1beta1/"
+<% else -%>
+var ComposerDefaultBasePath = "https://composer.googleapis.com/v1/"
+<% end -%>
 var ComposerCustomEndpointEntryKey = "composer_custom_endpoint"
 var ComposerCustomEndpointEntry = &schema.Schema{
 	Type:         schema.TypeString,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


fixes https://github.com/hashicorp/terraform-provider-google/issues/7250

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
call v1 API instead of v1beta1 API. Helps with synchronization issue occurring when environment is created with v1beta1 API.
```
