### PR TITLE
Allow google.project.id for passing project to resource_project_service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ tools/ansible-pr/templates/*
 
 # Used by OiCS tutorial
 build/*
+
+# vscode workspace settings
+.vscode

--- a/third_party/terraform/resources/resource_google_project_service.go
+++ b/third_party/terraform/resources/resource_google_project_service.go
@@ -103,13 +103,6 @@ func resourceGoogleProjectService() *schema.Resource {
 	}
 }
 
-// Since we allow the project to now come from config in the form of
-// /projects/${myproject} we need to correct for this when reading the value.
-func adjustProjectReference(project string) string {
-	parts := strings.Split(project, "/")
-	return parts[len(parts)-1]
-}
-
 func resourceGoogleProjectServiceImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.Split(d.Id(), "/")
 	if len(parts) != 2 {
@@ -127,7 +120,7 @@ func resourceGoogleProjectServiceCreate(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
-	project = adjustProjectReference(project)
+	project = GetResourceNameFromSelfLink(project)
 
 	srv := d.Get("service").(string)
 	id := project + "/" + srv
@@ -161,7 +154,7 @@ func resourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return err
 	}
-	project = adjustProjectReference(project)
+	project = GetResourceNameFromSelfLink(project)
 
 	// Verify project for services still exists
 	projectGetCall := config.clientResourceManager.Projects.Get(project)
@@ -213,7 +206,7 @@ func resourceGoogleProjectServiceDelete(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
-	project = adjustProjectReference(project)
+	project = GetResourceNameFromSelfLink(project)
 
 	service := d.Get("service").(string)
 	disableDependencies := d.Get("disable_dependent_services").(bool)

--- a/third_party/terraform/tests/resource_google_project_service_test.go
+++ b/third_party/terraform/tests/resource_google_project_service_test.go
@@ -39,7 +39,7 @@ func TestAccProjectService_basic(t *testing.T) {
 				ResourceName:            "google_project_service.test2",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"disable_on_destroy"},
+				ImportStateVerifyIgnore: []string{"disable_on_destroy", "project"},
 			},
 			// Use a separate TestStep rather than a CheckDestroy because we need the project to still exist.
 			{
@@ -189,7 +189,7 @@ func testAccProjectService_basic(services []string, pid, name, org string) strin
 	return fmt.Sprintf(`
 provider "google" {
   user_project_override = true
-}	
+}
 resource "google_project" "acceptance" {
   project_id = "%s"
   name       = "%s"
@@ -202,7 +202,7 @@ resource "google_project_service" "test" {
 }
 
 resource "google_project_service" "test2" {
-  project = google_project.acceptance.project_id
+  project = google_project.acceptance.id
   service = "%s"
 }
 `, pid, name, org, services[0], services[1])


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Added ability to pass google.project.id to google.project_service.project

Fixes [7203](https://github.com/hashicorp/terraform-provider-google/issues/7203)

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
project_service: Added ability to pass google.project.id to project property
```
