### PR TITLE
allow updating dataproc cluster autoscaling_policy

### DIFF
--- a/third_party/terraform/resources/resource_dataproc_cluster.go.erb
+++ b/third_party/terraform/resources/resource_dataproc_cluster.go.erb
@@ -530,17 +530,19 @@ by Dataproc`,
 							},
 						},
 						"autoscaling_config": {
-							Type:         schema.TypeList,
-							Optional:     true,
-							AtLeastOneOf: clusterConfigKeys,
-							MaxItems:     1,
-							Description:  `The autoscaling policy config associated with the cluster.`,
+							Type:             schema.TypeList,
+							Optional:         true,
+							AtLeastOneOf:     clusterConfigKeys,
+							MaxItems:         1,
+							Description:      `The autoscaling policy config associated with the cluster.`,
+							DiffSuppressFunc: emptyOrUnsetBlockDiffSuppress,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"policy_uri": {
-										Type:        schema.TypeString,
-										Required:    true,
-										Description: `The autoscaling policy used by the cluster.`,
+										Type:             schema.TypeString,
+										Required:         true,
+										Description:      `The autoscaling policy used by the cluster.`,
+										DiffSuppressFunc: locationDiffSuppress,
 									},
 								},
 							},
@@ -1204,6 +1206,15 @@ func resourceDataprocClusterUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 
 		updMask = append(updMask, "config.secondary_worker_config.num_instances")
+	}
+
+	if d.HasChange("cluster_config.0.autoscaling_config") {
+		desiredPolicy := d.Get("cluster_config.0.autoscaling_config.0.policy_uri").(string)
+		cluster.Config.AutoscalingConfig = &dataproc.AutoscalingConfig{
+			PolicyUri: desiredPolicy,
+		}
+
+		updMask = append(updMask, "config.autoscaling_config.policy_uri")
 	}
 
 <% unless version == 'ga' -%>

--- a/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -722,6 +722,26 @@ func TestAccDataprocCluster_withKerberos(t *testing.T) {
 	})
 }
 
+func TestAccDataprocCluster_withAutoscalingPolicy(t *testing.T) {
+	t.Parallel()
+
+	rnd := randString(t, 10)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDataprocClusterDestroy(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataprocCluster_withAutoscalingPolicy(rnd),
+			},
+			{
+				Config: testAccDataprocCluster_removeAutoscalingPolicy(rnd),
+			},
+		},
+	})
+}
+
 func testAccCheckDataprocClusterDestroy(t *testing.T) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
@@ -1539,4 +1559,68 @@ resource "google_dataproc_cluster" "kerb" {
   }
 }
 `, rnd, rnd, rnd, kmsKey)
+}
+
+func testAccDataprocCluster_withAutoscalingPolicy(rnd string) string {
+	return fmt.Sprintf(`
+resource "google_dataproc_cluster" "basic" {
+  name     = "tf-test-dataproc-policy-%s"
+  region   = "us-central1"
+
+  cluster_config {
+    autoscaling_config {
+      policy_uri = google_dataproc_autoscaling_policy.asp.id
+    }
+  }
+}
+  
+resource "google_dataproc_autoscaling_policy" "asp" {
+  policy_id = "tf-test-dataproc-policy-%s"
+  location  = "us-central1"
+
+  worker_config {
+    max_instances = 3
+  }
+
+  basic_algorithm {
+    yarn_config {
+      graceful_decommission_timeout = "30s"
+      scale_up_factor   = 0.5
+      scale_down_factor = 0.5
+    }
+  }
+}
+`, rnd, rnd)
+}
+
+func testAccDataprocCluster_removeAutoscalingPolicy(rnd string) string {
+	return fmt.Sprintf(`
+resource "google_dataproc_cluster" "basic" {
+  name     = "tf-test-dataproc-policy-%s"
+  region   = "us-central1"
+
+  cluster_config {
+    autoscaling_config {
+      policy_uri = ""
+    }
+  }
+}
+  
+resource "google_dataproc_autoscaling_policy" "asp" {
+  policy_id = "tf-test-dataproc-policy-%s"
+  location  = "us-central1"
+
+  worker_config {
+    max_instances = 3
+  }
+
+  basic_algorithm {
+    yarn_config {
+      graceful_decommission_timeout = "30s"
+      scale_up_factor   = 0.5
+      scale_down_factor = 0.5
+    }
+  }
+}
+`, rnd, rnd)
 }

--- a/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -727,6 +727,7 @@ func TestAccDataprocCluster_withAutoscalingPolicy(t *testing.T) {
 
 	rnd := randString(t, 10)
 
+	var cluster dataproc.Cluster
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -734,9 +735,17 @@ func TestAccDataprocCluster_withAutoscalingPolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataprocCluster_withAutoscalingPolicy(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
+					testAccCheckDataprocClusterAutoscaling(t, &cluster, true),
+				),
 			},
 			{
 				Config: testAccDataprocCluster_removeAutoscalingPolicy(rnd),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
+					testAccCheckDataprocClusterAutoscaling(t, &cluster, false),
+				),
 			},
 		},
 	})
@@ -788,6 +797,18 @@ func testAccCheckDataprocClusterHasServiceScopes(t *testing.T, cluster *dataproc
 			return fmt.Errorf("Cluster does not contain expected set of service account scopes : %v : instead %v",
 				scopes, cluster.Config.GceClusterConfig.ServiceAccountScopes)
 		}
+		return nil
+	}
+}
+
+func testAccCheckDataprocClusterAutoscaling(t *testing.T, cluster *dataproc.Cluster, expectAutoscaling bool) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		if cluster.Config.AutoscalingConfig == nil && expectAutoscaling {
+			return fmt.Errorf("Cluster does not contain AutoscalingConfig, expected it would")
+		} else if cluster.Config.AutoscalingConfig != nil && !expectAutoscaling {
+			return fmt.Errorf("Cluster contains AutoscalingConfig, expected it not to")
+		}
+
 		return nil
 	}
 }

--- a/third_party/terraform/utils/common_diff_suppress.go.erb
+++ b/third_party/terraform/utils/common_diff_suppress.go.erb
@@ -78,6 +78,42 @@ func rfc3339TimeDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	return false
 }
 
+// Suppress diffs for blocks where one version is completely unset and the other is set
+// to an empty block. This might occur in situations where removing a block completely
+// is impossible (if it's computed or part of an AtLeastOneOf), so instead the user sets
+// its values to empty.
+func emptyOrUnsetBlockDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	o, n := d.GetChange(strings.TrimSuffix(k, ".#"))
+	var l []interface{}
+	if old == "0" && new == "1" {
+		l = n.([]interface{})
+	} else if new == "0" && old == "1" {
+		l = o.([]interface{})
+	} else {
+		// we don't have one set and one unset, so don't suppress the diff
+		return false
+	}
+
+	contents := l[0].(map[string]interface{})
+	for _, v := range contents {
+		if !isEmptyValue(reflect.ValueOf(v)) {
+			return false
+		}
+	}
+	return true
+}
+
+// Suppress diffs for values that are equivalent except for their use of the words "location"
+// compared to "region" or "zone"
+func locationDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	return locationDiffSuppressHelper(old, new) || locationDiffSuppressHelper(new, old)
+}
+
+func locationDiffSuppressHelper(a, b string) bool {
+	return strings.Replace(a, "/locations/", "/regions/", 1) == b ||
+		strings.Replace(a, "/locations/", "/zones/", 1) == b
+}
+
 <% unless version == 'ga' -%>
 // For managed SSL certs, if new is an absolute FQDN (trailing '.') but old isn't, treat them as equals.
 func absoluteDomainSuppress(k, old, new string, _ *schema.ResourceData) bool {

--- a/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -176,6 +176,8 @@ The `cluster_config` block supports:
 * `security_config` (Optional) Security related configuration. Structure defined below.
 
 * `autoscaling_config` (Optional)  The autoscaling policy config associated with the cluster.
+   Note that once set, if `autoscaling_config` is the only field set in `cluster_config`, it can
+   only be removed by setting `policy_uri = ""`, rather than removing the whole block.
    Structure defined below.
 
 * `initialization_action` (Optional) Commands to execute on each node after config is completed.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/7096



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
dataproc: fixed issues where updating `google_dataproc_cluster.cluster_config.autoscaling_policy` would do nothing, and where there was no way to remove a policy.
```
