### PR TITLE
Upstream Support configuring Internal load balancer for Cloud Run for Anthos

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -286,8 +286,9 @@ func resourceContainerCluster() *schema.Resource {
 										Required: true,
 									},
 									"load_balancer_type": {
-										Type:     schema.TypeString,
-										Optional: true,
+										Type:         schema.TypeString,
+										ValidateFunc: validation.StringInSlice([]string{"internal"}, true),
+										Optional:     true,
 									},
 								},
 							},
@@ -2688,12 +2689,9 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 			Disabled:        addon["disabled"].(bool),
 			ForceSendFields: []string{"Disabled"},
 		}
-		if !ac.CloudRunConfig.Disabled {
-			if v, ok := addon["load_balancer_type"]; ok {
-				ac.CloudRunConfig.LoadBalancerType = v.(string)
-			} else {
-				ac.CloudRunConfig.LoadBalancerType = "LOAD_BALANCER_TYPE_EXTERNAL"
-			}
+		if addon["load_balancer_type"] != "" {
+			// Currently we only allow setting load_balancer_type to INTERNAL
+			ac.CloudRunConfig.LoadBalancerType = "LOAD_BALANCER_TYPE_INTERNAL"
 		}
 	}
 
@@ -3205,12 +3203,13 @@ func flattenClusterAddonsConfig(c *containerBeta.AddonsConfig) []map[string]inte
 	}
 
 	if c.CloudRunConfig != nil {
-		result["cloudrun_config"] = []map[string]interface{}{
-			{
-				"disabled":           c.CloudRunConfig.Disabled,
-				"load_balancer_type": c.CloudRunConfig.LoadBalancerType,
-			},
+		cloudRunConfig := map[string]interface{}{
+			"disabled": c.CloudRunConfig.Disabled,
 		}
+		if c.CloudRunConfig.LoadBalancerType == "LOAD_BALANCER_TYPE_INTERNAL" {
+			cloudRunConfig["load_balancer_type"] = "internal"
+		}
+		result["cloudrun_config"] = []map[string]interface{}{cloudRunConfig}
 	}
 
 <% unless version == 'ga' -%>

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -2688,10 +2688,12 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 			Disabled:        addon["disabled"].(bool),
 			ForceSendFields: []string{"Disabled"},
 		}
-		if v, ok := addon["load_balancer_type"]; ok {
-			ac.CloudRunConfig.LoadBalancerType = v.(string)
-		} else {
-			ac.CloudRunConfig.LoadBalancerType = "LOAD_BALANCER_TYPE_EXTERNAL"
+		if !ac.CloudRunConfig.Disabled {
+			if v, ok := addon["load_balancer_type"]; ok {
+				ac.CloudRunConfig.LoadBalancerType = v.(string)
+			} else {
+				ac.CloudRunConfig.LoadBalancerType = "LOAD_BALANCER_TYPE_EXTERNAL"
+			}
 		}
 	}
 

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -287,7 +287,7 @@ func resourceContainerCluster() *schema.Resource {
 									},
 									"load_balancer_type": {
 										Type:         schema.TypeString,
-										ValidateFunc: validation.StringInSlice([]string{"INTERNAL"}, false),
+										ValidateFunc: validation.StringInSlice([]string{"LOAD_BALANCER_TYPE_INTERNAL"}, false),
 										Optional:     true,
 									},
 								},
@@ -2690,7 +2690,7 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 			ForceSendFields: []string{"Disabled"},
 		}
 		if addon["load_balancer_type"] != "" {
-			ac.CloudRunConfig.LoadBalancerType = "LOAD_BALANCER_TYPE_INTERNAL"
+			ac.CloudRunConfig.LoadBalancerType = addon["load_balancer_type"].(string)
 		}
 	}
 
@@ -3206,8 +3206,8 @@ func flattenClusterAddonsConfig(c *containerBeta.AddonsConfig) []map[string]inte
 			"disabled": c.CloudRunConfig.Disabled,
 		}
 		if c.CloudRunConfig.LoadBalancerType == "LOAD_BALANCER_TYPE_INTERNAL" {
-			// Currently we only allow setting load_balancer_type to INTERNAL
-			cloudRunConfig["load_balancer_type"] = "INTERNAL"
+			// Currently we only allow setting load_balancer_type to LOAD_BALANCER_TYPE_INTERNAL
+			cloudRunConfig["load_balancer_type"] = "LOAD_BALANCER_TYPE_INTERNAL"
 		}
 		result["cloudrun_config"] = []map[string]interface{}{cloudRunConfig}
 	}

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -285,6 +285,10 @@ func resourceContainerCluster() *schema.Resource {
 										Type:     schema.TypeBool,
 										Required: true,
 									},
+									"load_balancer_type": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
 								},
 							},
 						},
@@ -2684,6 +2688,11 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 			Disabled:        addon["disabled"].(bool),
 			ForceSendFields: []string{"Disabled"},
 		}
+		if v, ok := addon["load_balancer_type"]; ok {
+			ac.CloudRunConfig.LoadBalancerType = v.(string)
+		} else {
+			ac.CloudRunConfig.LoadBalancerType = "LOAD_BALANCER_TYPE_EXTERNAL"
+		}
 	}
 
 <% unless version == 'ga' -%>
@@ -3196,7 +3205,8 @@ func flattenClusterAddonsConfig(c *containerBeta.AddonsConfig) []map[string]inte
 	if c.CloudRunConfig != nil {
 		result["cloudrun_config"] = []map[string]interface{}{
 			{
-				"disabled": c.CloudRunConfig.Disabled,
+				"disabled":           c.CloudRunConfig.Disabled,
+				"load_balancer_type": c.CloudRunConfig.LoadBalancerType,
 			},
 		}
 	}

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -287,7 +287,7 @@ func resourceContainerCluster() *schema.Resource {
 									},
 									"load_balancer_type": {
 										Type:         schema.TypeString,
-										ValidateFunc: validation.StringInSlice([]string{"internal"}, true),
+										ValidateFunc: validation.StringInSlice([]string{"INTERNAL"}, false),
 										Optional:     true,
 									},
 								},
@@ -2690,7 +2690,6 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 			ForceSendFields: []string{"Disabled"},
 		}
 		if addon["load_balancer_type"] != "" {
-			// Currently we only allow setting load_balancer_type to INTERNAL
 			ac.CloudRunConfig.LoadBalancerType = "LOAD_BALANCER_TYPE_INTERNAL"
 		}
 	}
@@ -3207,7 +3206,8 @@ func flattenClusterAddonsConfig(c *containerBeta.AddonsConfig) []map[string]inte
 			"disabled": c.CloudRunConfig.Disabled,
 		}
 		if c.CloudRunConfig.LoadBalancerType == "LOAD_BALANCER_TYPE_INTERNAL" {
-			cloudRunConfig["load_balancer_type"] = "internal"
+			// Currently we only allow setting load_balancer_type to INTERNAL
+			cloudRunConfig["load_balancer_type"] = "INTERNAL"
 		}
 		result["cloudrun_config"] = []map[string]interface{}{cloudRunConfig}
 	}

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2245,7 +2245,7 @@ resource "google_container_cluster" "primary" {
     }
     cloudrun_config {
 	  disabled = false
-	  load_balancer_type = "INTERNAL"
+	  load_balancer_type = "LOAD_BALANCER_TYPE_INTERNAL"
     }
   }
 }

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2245,7 +2245,7 @@ resource "google_container_cluster" "primary" {
     }
     cloudrun_config {
 	  disabled = false
-	  load_balancer_type = "internal"
+	  load_balancer_type = "INTERNAL"
     }
   }
 }

--- a/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -160,6 +160,15 @@ func TestAccContainerCluster_withAddons(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"min_master_version"},
 			},
+			{
+				Config: testAccContainerCluster_withInternalLoadBalancer(pid, clusterName),
+			},
+			{
+				ResourceName:            "google_container_cluster.primary",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
+			},
 		},
 	})
 }
@@ -2202,6 +2211,42 @@ resource "google_container_cluster" "primary" {
 	  enabled = true
 	}
 <% end -%>
+  }
+}
+`, projectID, clusterName)
+}
+
+func testAccContainerCluster_withInternalLoadBalancer(projectID string, clusterName string) string {
+	return fmt.Sprintf(`
+data "google_project" "project" {
+  project_id = "%s"
+}
+
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+
+  min_master_version = "latest"
+
+  workload_identity_config {
+    identity_namespace = "${data.google_project.project.project_id}.svc.id.goog"
+  }
+
+  addons_config {
+    http_load_balancing {
+      disabled = false
+    }
+    horizontal_pod_autoscaling {
+      disabled = false
+    }
+    network_policy_config {
+      disabled = false
+    }
+    cloudrun_config {
+	  disabled = false
+	  load_balancer_type = "internal"
+    }
   }
 }
 `, projectID, clusterName)

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -393,7 +393,10 @@ The `database_encryption` block supports:
 
 The `cloudrun_config` block supports:
 
-* `disabled` - (Ooptional)
+* `disabled` - (Optional) The status of the CloudRun addon. It is disabled by default. Set `disabled=false` to enable.
+
+* `load_balancer_type` - (Optional) The load balancer type of CloudRun ingress service. It is external load balancer by default.
+    Set `load_balancer_type=LOAD_BALANCER_TYPE_INTERNAL` to configure it as internal load balancer.
 
 The `istio_config` block supports:
 

--- a/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -350,9 +350,7 @@ The `addons_config` block supports:
     It can only be disabled if the nodes already do not have network policies enabled.
     Defaults to disabled; set `disabled = false` to enable.
 
-* `cloudrun_config` - (Optional).
-    The status of the CloudRun addon. It is disabled by default.
-    Set `disabled = false` to enable.
+* `cloudrun_config` - (Optional). Structure is documented below.
 
 * `istio_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)).
     Structure is documented below.
@@ -392,6 +390,10 @@ The `database_encryption` block supports:
 * `state` - (Required) `ENCRYPTED` or `DECRYPTED`
 
 * `key_name` - (Required) the key to use to encrypt/decrypt secrets.  See the [DatabaseEncryption definition](https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#Cluster.DatabaseEncryption) for more information.
+
+The `cloudrun_config` block supports:
+
+* `disabled` - (Ooptional)
 
 The `istio_config` block supports:
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Upstreams https://github.com/hashicorp/terraform-provider-google/pull/7268
Fixes https://github.com/hashicorp/terraform-provider-google/issues/7275


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added support for `load_balancer_type` to `google_container_cluster` Cloud Run config addon.
```
