### PR TITLE
update cloudiot_device_registry configs to be lists rather than maps

### DIFF
--- a/templates/terraform/constants/cloudiot.go.erb
+++ b/templates/terraform/constants/cloudiot.go.erb
@@ -1,55 +1,70 @@
 func expandCloudIotDeviceRegistryHTTPConfig(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
-    original := v.(map[string]interface{})
-    transformed := make(map[string]interface{})
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
 
-    transformedHTTPEnabledState, err := expandCloudIotDeviceRegistryHTTPEnabledState(original["http_enabled_state"], d, config)
-    if err != nil {
-        return nil, err
-    } else if val := reflect.ValueOf(transformedHTTPEnabledState); val.IsValid() && !isEmptyValue(val) {
-        transformed["httpEnabledState"] = transformedHTTPEnabledState
-    }
+	transformedHTTPEnabledState, err := expandCloudIotDeviceRegistryHTTPEnabledState(original["http_enabled_state"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedHTTPEnabledState); val.IsValid() && !isEmptyValue(val) {
+		transformed["httpEnabledState"] = transformedHTTPEnabledState
+	}
 
-    return transformed, nil
+	return transformed, nil
 }
 
 func expandCloudIotDeviceRegistryHTTPEnabledState(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
-    return v, nil
+	return v, nil
 }
 
 func expandCloudIotDeviceRegistryMqttConfig(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
-    original := v.(map[string]interface{})
-    transformed := make(map[string]interface{})
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
 
-    transformedMqttEnabledState, err := expandCloudIotDeviceRegistryMqttEnabledState(original["mqtt_enabled_state"], d, config)
-    if err != nil {
-        return nil, err
-    } else if val := reflect.ValueOf(transformedMqttEnabledState); val.IsValid() && !isEmptyValue(val) {
-        transformed["mqttEnabledState"] = transformedMqttEnabledState
-    }
+	transformedMqttEnabledState, err := expandCloudIotDeviceRegistryMqttEnabledState(original["mqtt_enabled_state"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedMqttEnabledState); val.IsValid() && !isEmptyValue(val) {
+		transformed["mqttEnabledState"] = transformedMqttEnabledState
+	}
 
-    return transformed, nil
+	return transformed, nil
 }
 
 func expandCloudIotDeviceRegistryMqttEnabledState(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
-    return v, nil
+	return v, nil
 }
 
 func expandCloudIotDeviceRegistryStateNotificationConfig(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
-    original := v.(map[string]interface{})
-    transformed := make(map[string]interface{})
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
 
-    transformedPubsubTopicName, err := expandCloudIotDeviceRegistryStateNotificationConfigPubsubTopicName(original["pubsub_topic_name"], d, config)
-    if err != nil {
-        return nil, err
-    } else if val := reflect.ValueOf(transformedPubsubTopicName); val.IsValid() && !isEmptyValue(val) {
-        transformed["pubsubTopicName"] = transformedPubsubTopicName
-    }
+	transformedPubsubTopicName, err := expandCloudIotDeviceRegistryStateNotificationConfigPubsubTopicName(original["pubsub_topic_name"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedPubsubTopicName); val.IsValid() && !isEmptyValue(val) {
+		transformed["pubsubTopicName"] = transformedPubsubTopicName
+	}
 
-    return transformed, nil
+	return transformed, nil
 }
 
 func expandCloudIotDeviceRegistryStateNotificationConfigPubsubTopicName(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
-    return v, nil
+	return v, nil
 }
 
 func expandCloudIotDeviceRegistryCredentials(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
@@ -77,32 +92,37 @@ func expandCloudIotDeviceRegistryCredentials(v interface{}, d TerraformResourceD
 }
 
 func expandCloudIotDeviceRegistryCredentialsPublicKeyCertificate(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
-    original := v.(map[string]interface{})
-    transformed := make(map[string]interface{})
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := make(map[string]interface{})
 
-    transformedFormat, err := expandCloudIotDeviceRegistryPublicKeyCertificateFormat(original["format"], d, config)
-    if err != nil {
-        return nil, err
-    } else if val := reflect.ValueOf(transformedFormat); val.IsValid() && !isEmptyValue(val) {
-        transformed["format"] = transformedFormat
-    }
+	transformedFormat, err := expandCloudIotDeviceRegistryPublicKeyCertificateFormat(original["format"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedFormat); val.IsValid() && !isEmptyValue(val) {
+		transformed["format"] = transformedFormat
+	}
 
-    transformedCertificate, err := expandCloudIotDeviceRegistryPublicKeyCertificateCertificate(original["certificate"], d, config)
-    if err != nil {
-        return nil, err
-    } else if val := reflect.ValueOf(transformedCertificate); val.IsValid() && !isEmptyValue(val) {
-        transformed["certificate"] = transformedCertificate
-    }
+	transformedCertificate, err := expandCloudIotDeviceRegistryPublicKeyCertificateCertificate(original["certificate"], d, config)
+	if err != nil {
+		return nil, err
+	} else if val := reflect.ValueOf(transformedCertificate); val.IsValid() && !isEmptyValue(val) {
+		transformed["certificate"] = transformedCertificate
+	}
 
-    return transformed, nil
+	return transformed, nil
 }
 
 func expandCloudIotDeviceRegistryPublicKeyCertificateFormat(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
-    return v, nil
+	return v, nil
 }
 
 func expandCloudIotDeviceRegistryPublicKeyCertificateCertificate(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
-    return v, nil
+	return v, nil
 }
 
 func flattenCloudIotDeviceRegistryCredentials(v interface{}, d *schema.ResourceData, config *Config) interface{} {
@@ -114,8 +134,8 @@ func flattenCloudIotDeviceRegistryCredentials(v interface{}, d *schema.ResourceD
 	l := v.([]interface{})
 	transformed := make([]interface{}, 0, len(l))
 	for _, raw := range l {
-        original := raw.(map[string]interface{})
-        log.Printf("[DEBUG] Original credential: %+v", original)
+		original := raw.(map[string]interface{})
+		log.Printf("[DEBUG] Original credential: %+v", original)
 		if len(original) < 1 {
 			log.Printf("[DEBUG] Excluding empty credential that the API returned. %q", d.Id())
 			continue
@@ -148,94 +168,94 @@ func flattenCloudIotDeviceRegistryCredentialsPublicKeyCertificate(v interface{},
 
 	log.Printf("[DEBUG] Transformed public key certificate: %+v", transformed)
 
-	return transformed
+	return []interface{}{transformed}
 }
 
 func flattenCloudIotDeviceRegistryPublicKeyCertificateFormat(v interface{}, d *schema.ResourceData, config *Config) interface{} {
-    return v
+	return v
 }
 
 func flattenCloudIotDeviceRegistryPublicKeyCertificateCertificate(v interface{}, d *schema.ResourceData, config *Config) interface{} {
-    return v
+	return v
 }
 
 func flattenCloudIotDeviceRegistryHTTPConfig(v interface{}, d *schema.ResourceData, config *Config) interface{} {
-    if v == nil {
-        return v
-    }
+	if v == nil {
+		return v
+	}
 
-    original := v.(map[string]interface{})
-    transformed := make(map[string]interface{})
+	original := v.(map[string]interface{})
+	transformed := make(map[string]interface{})
 
-    transformedHTTPEnabledState := flattenCloudIotDeviceRegistryHTTPConfigHTTPEnabledState(original["httpEnabledState"], d, config)
-    transformed["http_enabled_state"] = transformedHTTPEnabledState
+	transformedHTTPEnabledState := flattenCloudIotDeviceRegistryHTTPConfigHTTPEnabledState(original["httpEnabledState"], d, config)
+	transformed["http_enabled_state"] = transformedHTTPEnabledState
 
-    return transformed
+	return []interface{}{transformed}
 }
 
 func flattenCloudIotDeviceRegistryHTTPConfigHTTPEnabledState(v interface{}, d *schema.ResourceData, config *Config) interface{} {
-    return v
+	return v
 }
 
 func flattenCloudIotDeviceRegistryMqttConfig(v interface{}, d *schema.ResourceData, config *Config) interface{} {
-    if v == nil {
-        return v
-    }
+	if v == nil {
+		return v
+	}
 
-    original := v.(map[string]interface{})
-    transformed := make(map[string]interface{})
+	original := v.(map[string]interface{})
+	transformed := make(map[string]interface{})
 
-    transformedMqttEnabledState := flattenCloudIotDeviceRegistryMqttConfigMqttEnabledState(original["mqttEnabledState"], d, config)
-    transformed["mqtt_enabled_state"] = transformedMqttEnabledState
+	transformedMqttEnabledState := flattenCloudIotDeviceRegistryMqttConfigMqttEnabledState(original["mqttEnabledState"], d, config)
+	transformed["mqtt_enabled_state"] = transformedMqttEnabledState
 
-    return transformed
+	return []interface{}{transformed}
 }
 
 func flattenCloudIotDeviceRegistryMqttConfigMqttEnabledState(v interface{}, d *schema.ResourceData, config *Config) interface{} {
-    return v
+	return v
 }
 
 func flattenCloudIotDeviceRegistryStateNotificationConfig(v interface{}, d *schema.ResourceData, config *Config) interface{} {
-    log.Printf("[DEBUG] Flattening state notification config: %+v", v)
-    if v == nil {
-        return v
-    }
+	log.Printf("[DEBUG] Flattening state notification config: %+v", v)
+	if v == nil {
+		return v
+	}
 
-    original := v.(map[string]interface{})
-    transformed := make(map[string]interface{})
+	original := v.(map[string]interface{})
+	transformed := make(map[string]interface{})
 
-    transformedPubsubTopicName := flattenCloudIotDeviceRegistryStateNotificationConfigPubsubTopicName(original["pubsubTopicName"], d, config)
-    if val := reflect.ValueOf(transformedPubsubTopicName); val.IsValid() && !isEmptyValue(val) {
-        log.Printf("[DEBUG] pubsub topic name is not null: %v", d.Get("pubsub_topic_name"))
-        transformed["pubsub_topic_name"] = transformedPubsubTopicName
-    }
+	transformedPubsubTopicName := flattenCloudIotDeviceRegistryStateNotificationConfigPubsubTopicName(original["pubsubTopicName"], d, config)
+	if val := reflect.ValueOf(transformedPubsubTopicName); val.IsValid() && !isEmptyValue(val) {
+		log.Printf("[DEBUG] pubsub topic name is not null: %v", d.Get("pubsub_topic_name"))
+		transformed["pubsub_topic_name"] = transformedPubsubTopicName
+	}
 
 
-    return transformed
+	return []interface{}{transformed}
 }
 
 func flattenCloudIotDeviceRegistryStateNotificationConfigPubsubTopicName(v interface{}, d *schema.ResourceData, config *Config) interface{} {
-    return v
+	return v
 }
 
 func validateCloudIotDeviceRegistryID(v interface{}, k string) (warnings []string, errors []error) {
-    value := v.(string)
-    if strings.HasPrefix(value, "goog") {
-        errors = append(errors, fmt.Errorf(
-            "%q (%q) can not start with \"goog\"", k, value))
-    }
-    if !regexp.MustCompile(CloudIoTIdRegex).MatchString(value) {
-        errors = append(errors, fmt.Errorf(
-            "%q (%q) doesn't match regexp %q", k, value, CloudIoTIdRegex))
-    }
-    return
+	value := v.(string)
+	if strings.HasPrefix(value, "goog") {
+		errors = append(errors, fmt.Errorf(
+			"%q (%q) can not start with \"goog\"", k, value))
+	}
+	if !regexp.MustCompile(CloudIoTIdRegex).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q (%q) doesn't match regexp %q", k, value, CloudIoTIdRegex))
+	}
+	return
 }
 
 func validateCloudIotDeviceRegistrySubfolderMatch(v interface{}, k string) (warnings []string, errors []error) {
-    value := v.(string)
-    if strings.HasPrefix(value, "/") {
-        errors = append(errors, fmt.Errorf(
-            "%q (%q) can not start with '/'", k, value))
-    }
-    return
+	value := v.(string)
+	if strings.HasPrefix(value, "/") {
+		errors = append(errors, fmt.Errorf(
+			"%q (%q) can not start with '/'", k, value))
+	}
+	return
 }

--- a/templates/terraform/examples/cloudiot_device_registry_full.tf.erb
+++ b/templates/terraform/examples/cloudiot_device_registry_full.tf.erb
@@ -23,22 +23,22 @@ resource "google_cloudiot_registry" "<%= ctx[:primary_resource_id] %>" {
     subfolder_matches = ""
   }
 
-  state_notification_config = {
+  state_notification_config {
     pubsub_topic_name = google_pubsub_topic.default-devicestatus.id
   }
 
-  mqtt_config = {
+  mqtt_config {
     mqtt_enabled_state = "MQTT_ENABLED"
   }
 
-  http_config = {
+  http_config {
     http_enabled_state = "HTTP_ENABLED"
   }
 
   log_level = "INFO"
 
   credentials {
-    public_key_certificate = {
+    public_key_certificate {
       format      = "X509_CERTIFICATE_PEM"
       certificate = file("test-fixtures/rsa_cert.pem")
     }

--- a/templates/terraform/extra_schema_entry/cloudiot_device_registry.go.erb
+++ b/templates/terraform/extra_schema_entry/cloudiot_device_registry.go.erb
@@ -1,7 +1,8 @@
 "state_notification_config": {
-    Type:     schema.TypeMap,
+    Type:     schema.TypeList,
     Description: `A PubSub topic to publish device state updates.`,
-    Optional: true,
+    Optional:    true,
+    ConfigMode:  schema.SchemaConfigModeAttr,
     Elem: &schema.Resource{
         Schema: map[string]*schema.Schema{
             "pubsub_topic_name": {
@@ -14,10 +15,11 @@
     },
 },
 "mqtt_config": {
-    Type:     schema.TypeMap,
+    Type:     schema.TypeList,
     Description: `Activate or deactivate MQTT.`,
-    Computed: true,
-    Optional: true,
+    Computed:    true,
+    Optional:    true,
+    ConfigMode:  schema.SchemaConfigModeAttr,
     Elem: &schema.Resource{
         Schema: map[string]*schema.Schema{
         "mqtt_enabled_state": {
@@ -31,10 +33,11 @@
     },
 },
 "http_config": {
-    Type:     schema.TypeMap,
+    Type:     schema.TypeList,
     Description: `Activate or deactivate HTTP.`,
-    Computed: true,
-    Optional: true,
+    Computed:    true,
+    Optional:    true,
+    ConfigMode:  schema.SchemaConfigModeAttr,
     Elem: &schema.Resource{
         Schema: map[string]*schema.Schema{
             "http_enabled_state": {
@@ -55,9 +58,10 @@
     Elem: &schema.Resource{
         Schema: map[string]*schema.Schema{
             "public_key_certificate": {
-                Type:     schema.TypeMap,
+                Type:     schema.TypeList,
                 Description: `A public key certificate format and data.`,
-                Required: true,
+                Required:    true,
+                ConfigMode:  schema.SchemaConfigModeAttr,
                 Elem: &schema.Resource{
                     Schema: map[string]*schema.Schema{
                         "format": {

--- a/templates/terraform/extra_schema_entry/cloudiot_device_registry.go.erb
+++ b/templates/terraform/extra_schema_entry/cloudiot_device_registry.go.erb
@@ -2,6 +2,7 @@
     Type:     schema.TypeList,
     Description: `A PubSub topic to publish device state updates.`,
     Optional:    true,
+    Computed:    true,
     ConfigMode:  schema.SchemaConfigModeAttr,
     Elem: &schema.Resource{
         Schema: map[string]*schema.Schema{

--- a/third_party/terraform/tests/resource_cloudiot_device_registry_update_test.go
+++ b/third_party/terraform/tests/resource_cloudiot_device_registry_update_test.go
@@ -86,20 +86,20 @@ resource "google_cloudiot_registry" "%s" {
     subfolder_matches = ""
   }
 
-  state_notification_config = {
+  state_notification_config {
     pubsub_topic_name = google_pubsub_topic.default-devicestatus.id
   }
 
-  mqtt_config = {
+  mqtt_config {
     mqtt_enabled_state = "MQTT_DISABLED"
   }
 
-  http_config = {
+  http_config {
     http_enabled_state = "HTTP_DISABLED"
   }
 
   credentials {
-    public_key_certificate = {
+    public_key_certificate {
       format      = "X509_CERTIFICATE_PEM"
       certificate = file("test-fixtures/rsa_cert.pem")
     }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR is split from sdkv2 upgrade from this comment thread: https://github.com/GoogleCloudPlatform/magic-modules/pull/3971/files#r488804044

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
