### PR TITLE
Add network peerings for inspec

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -7340,6 +7340,45 @@ objects:
           values:
             - :REGIONAL
             - :GLOBAL
+      - !ruby/object:Api::Type::Array
+        name: 'peerings'
+        # This is only used in InSpec, handled via fine-grained in Terraform
+        exclude: true
+        output: true
+        description: |
+          Peerings for a network
+        item_type: !ruby/object:Api::Type::NestedObject
+          name: subnetworks
+          description: The subnetworks that should be mirrored.
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'name'
+              description: |
+                Name of the peering.
+            - !ruby/object:Api::Type::String
+              name: 'state'
+              description: |
+                State of the peering.
+            - !ruby/object:Api::Type::String
+              name: 'stateDetails'
+              description: |
+                Details about the current state of the peering.
+            - !ruby/object:Api::Type::String
+              name: 'network'
+              description: |
+                URL of the peer network
+            - !ruby/object:Api::Type::Boolean
+              name: 'exportCustomRoutes'
+              description: |
+                Whether to export the custom routes to the peer network.
+            - !ruby/object:Api::Type::Boolean
+              name: 'importCustomRoutes'
+              description: |
+                Whether to import the custom routes to the peer network.
+            - !ruby/object:Api::Type::Integer
+              name: 'peerMtu'
+              description: |
+                Maximum Transmission Unit in bytes.
   - !ruby/object:Api::Resource
     name: 'NetworkEndpoint'
     kind: 'compute#networkEndpoint'

--- a/products/compute/inspec.yaml
+++ b/products/compute/inspec.yaml
@@ -106,6 +106,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         override_name: "network_id"
       name: !ruby/object:Overrides::Inspec::PropertyOverride
         override_name: "network_name"
+      peerings: !ruby/object:Overrides::Inspec::PropertyOverride
+        exclude: false
   NetworkEndpoint: !ruby/object:Overrides::Inspec::ResourceOverride
     exclude: true
   GlobalNetworkEndpoint: !ruby/object:Overrides::Inspec::ResourceOverride


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds network peerings to InSpec network resource. Fine-grained in TF so exclude



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
