### PR TITLE
Add Region field to dataflow_flex_template_job

### DIFF
--- a/third_party/terraform/resources/resource_dataflow_flex_template_job.go.erb
+++ b/third_party/terraform/resources/resource_dataflow_flex_template_job.go.erb
@@ -41,6 +41,13 @@ func resourceDataflowFlexTemplateJob() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"region": {
+				Type:        shema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `The region in which the created job should run.`,
+			),
+
 			"on_delete": {
 				Type:         schema.TypeString,
 				ValidateFunc: validation.StringInSlice([]string{"cancel", "drain"}, false),

--- a/third_party/terraform/resources/resource_dataflow_flex_template_job.go.erb
+++ b/third_party/terraform/resources/resource_dataflow_flex_template_job.go.erb
@@ -47,7 +47,7 @@ func resourceDataflowFlexTemplateJob() *schema.Resource {
 				ForceNew:    true,
 				Computed:    true,
 				Description: `The region in which the created job should run.`,
-			),
+			},
 
 			"on_delete": {
 				Type:         schema.TypeString,

--- a/third_party/terraform/resources/resource_dataflow_flex_template_job.go.erb
+++ b/third_party/terraform/resources/resource_dataflow_flex_template_job.go.erb
@@ -42,9 +42,10 @@ func resourceDataflowFlexTemplateJob() *schema.Resource {
 			},
 
 			"region": {
-				Type:        shema.TypeString,
+				Type:        schema.TypeString,
 				Optional:    true,
 				ForceNew:    true,
+				Computed:    true,
 				Description: `The region in which the created job should run.`,
 			),
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Dataflow flex template jobs use region, but no region field is present on the Terraform resource.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
**Magic modules setup fails for me on debug inspector.**
```make: *** No rule to make target `/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/include/ruby-2.6.0/universal-darwin19/ruby/config.h', needed by `debug_inspector.o'.  Stop.```
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
**Terraform provider not generated**
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


```release-note:enhancement
dataflow: Add `region` field to `google_dataflow_flex_template_job` resource
```
