### PR TITLE
Compute_instance bugfix - only update network interface if there are changes

### DIFF
--- a/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -1470,8 +1470,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			if opErr != nil {
 				return opErr
 			}
-		} else {
-
+		} else if updateDuringStop {
 			networkInterface.Fingerprint = instNetworkInterface.Fingerprint
 			updateCall := config.clientComputeBeta.Instances.UpdateNetworkInterface(project, zone, instance.Name, networkName, networkInterface).Do
 			updatesToNIWhileStopped = append(updatesToNIWhileStopped, updateCall)

--- a/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -1492,6 +1492,7 @@ func TestAccComputeInstance_updateRunning_desiredStatusRunning_allowStoppingForU
 	})
 }
 
+const errorAllowStoppingMsg = "Changing the machine_type, min_cpu_platform, service_account, enable_display, shielded_instance_config, or network_interface.\\[#d\\].\\(network/subnetwork/subnetwork_project\\) on a started instance requires stopping it. To acknowledge this, please set allow_stopping_for_update = true in your config. You can also stop it by setting desired_status = \"TERMINATED\", but the instance will not be restarted after the update."
 func TestAccComputeInstance_updateRunning_desiredStatusNotSet_notAllowStoppingForUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -1512,12 +1513,8 @@ func TestAccComputeInstance_updateRunning_desiredStatusNotSet_notAllowStoppingFo
 				),
 			},
 			{
-				Config: testAccComputeInstance_machineType_desiredStatus_allowStoppingForUpdate(instanceName, "n1-standard-2", "", false),
-				ExpectError: regexp.MustCompile("Changing the machine_type, min_cpu_platform, service_account, " +
-					"enable_display, or shielded_instance_config on a started instance requires stopping it. To acknowledge this, please set " +
-					"allow_stopping_for_update = true in your config. " +
-					"You can also stop it by setting desired_status = \"TERMINATED\", but the instance will not " +
-					"be restarted after the update."),
+				Config:      testAccComputeInstance_machineType_desiredStatus_allowStoppingForUpdate(instanceName, "n1-standard-2", "", false),
+				ExpectError: regexp.MustCompile(errorAllowStoppingMsg),
 			},
 		},
 	})
@@ -1543,12 +1540,8 @@ func TestAccComputeInstance_updateRunning_desiredStatusRunning_notAllowStoppingF
 				),
 			},
 			{
-				Config: testAccComputeInstance_machineType_desiredStatus_allowStoppingForUpdate(instanceName, "n1-standard-2", "RUNNING", false),
-				ExpectError: regexp.MustCompile("Changing the machine_type, min_cpu_platform, service_account, " +
-					"enable_display, or shielded_instance_config on a started instance requires stopping it. To acknowledge this, please set " +
-					"allow_stopping_for_update = true in your config. " +
-					"You can also stop it by setting desired_status = \"TERMINATED\", but the instance will not " +
-					"be restarted after the update."),
+				Config:      testAccComputeInstance_machineType_desiredStatus_allowStoppingForUpdate(instanceName, "n1-standard-2", "RUNNING", false),
+				ExpectError: regexp.MustCompile(errorAllowStoppingMsg),
 			},
 		},
 	})

--- a/third_party/terraform/utils/compute_instance_helpers.go.erb
+++ b/third_party/terraform/utils/compute_instance_helpers.go.erb
@@ -210,15 +210,16 @@ func flattenNetworkInterfaces(d *schema.ResourceData, config *Config, networkInt
 func expandAccessConfigs(configs []interface{}) []*computeBeta.AccessConfig {
 	acs := make([]*computeBeta.AccessConfig, len(configs))
 	for i, raw := range configs {
-		data := raw.(map[string]interface{})
-		acs[i] = &computeBeta.AccessConfig{
-			Type:        "ONE_TO_ONE_NAT",
-			NatIP:       data["nat_ip"].(string),
-			NetworkTier: data["network_tier"].(string),
-		}
-		if ptr, ok := data["public_ptr_domain_name"]; ok && ptr != "" {
-			acs[i].SetPublicPtr = true
-			acs[i].PublicPtrDomainName = ptr.(string)
+		acs[i] = &computeBeta.AccessConfig{}
+		acs[i].Type = "ONE_TO_ONE_NAT"
+		if raw != nil {
+			data := raw.(map[string]interface{})
+			acs[i].NatIP = data["nat_ip"].(string)
+			acs[i].NetworkTier = data["network_tier"].(string)
+			if ptr, ok := data["public_ptr_domain_name"]; ok && ptr != "" {
+				acs[i].SetPublicPtr = true
+				acs[i].PublicPtrDomainName = ptr.(string)
+			}
 		}
 	}
 	return acs


### PR DESCRIPTION
Bug fix for testcase failures in vcr.

We only want to compose a patch call for update during stop if there is an applicable update.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
