### PR TITLE
move validateHttpHeaders definition into cloud scheduler

### DIFF
--- a/products/cloudscheduler/terraform.yaml
+++ b/products/cloudscheduler/terraform.yaml
@@ -16,7 +16,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   Job: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: 'projects/{{project}}/locations/{{region}}/jobs/{{name}}'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
-      constants: templates/terraform/constants/scheduler_auth.erb
+      constants: templates/terraform/constants/scheduler.erb
       resource_definition: templates/terraform/resource_definition/scheduler_auth.erb
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/templates/terraform/constants/scheduler.erb
+++ b/templates/terraform/constants/scheduler.erb
@@ -48,3 +48,22 @@ func authHeaderDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 
     return false
 }
+
+func validateHttpHeaders() schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (s []string, es []error) {
+		headers := i.(map[string]interface{})
+		if _, ok := headers["Content-Length"]; ok {
+			es = append(es, fmt.Errorf("Cannot set the Content-Length header on %s", k))
+			return
+		}
+		r := regexp.MustCompile(`(X-Google-|X-AppEngine-).*`)
+		for key, _ := range headers {
+			if r.MatchString(key) {
+				es = append(es, fmt.Errorf("Cannot set the %s header on %s", key, k))
+				return
+			}
+		}
+
+		return
+	}
+}

--- a/templates/terraform/constants/tpu_node.erb
+++ b/templates/terraform/constants/tpu_node.erb
@@ -44,21 +44,3 @@ func tpuNodeCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, meta int
 	}
 	return nil
 }
-func validateHttpHeaders() schema.SchemaValidateFunc {
-	return func(i interface{}, k string) (s []string, es []error) {
-		headers := i.(map[string]interface{})
-		if _, ok := headers["Content-Length"]; ok {
-			es = append(es, fmt.Errorf("Cannot set the Content-Length header on %s", k))
-			return
-		}
-		r := regexp.MustCompile(`(X-Google-|X-AppEngine-).*`)
-		for key, _ := range headers {
-			if r.MatchString(key) {
-				es = append(es, fmt.Errorf("Cannot set the %s header on %s", key, k))
-				return
-			}
-		}
-
-		return
-	}
-}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This function is only used in the cloud scheduler resource, so no reason to have it defined with the tpu node resource.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
