### PR TITLE
refactor clientCompute from config and replace with new compute client

### DIFF
--- a/templates/terraform/constants/vpn_tunnel.erb
+++ b/templates/terraform/constants/vpn_tunnel.erb
@@ -84,10 +84,10 @@ var invalidPeerAddrs = []struct {
 	},
 }
 
-func getVpnTunnelLink(config *Config, project string, region string, tunnel string) (string, error) {
+func getVpnTunnelLink(config *Config, project, region, tunnel, userAgent string) (string, error) {
 	if !strings.Contains(tunnel, "/") {
 		// Tunnel value provided is just the name, lookup the tunnel SelfLink
-		tunnelData, err := config.clientCompute.VpnTunnels.Get(
+		tunnelData, err := config.NewComputeClient(userAgent).VpnTunnels.Get(
 			project, region, tunnel).Do()
 		if err != nil {
 			return "", fmt.Errorf("Error reading tunnel: %s", err)

--- a/templates/terraform/custom_expand/route_instance.erb
+++ b/templates/terraform/custom_expand/route_instance.erb
@@ -6,7 +6,13 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d T
 		if err != nil {
 				return nil, err
 		}
-		nextInstance, err := config.clientCompute.Instances.Get(val.Project, val.Zone, val.Name).Do()
+
+		userAgent, err := generateUserAgentString(d.(*schema.ResourceData), config.userAgent)
+		if err != nil {
+			return nil, err
+		}
+
+		nextInstance, err := config.NewComputeClient(userAgent).Instances.Get(val.Project, val.Zone, val.Name).Do()
 		if err != nil {
 				return nil, err
 		}

--- a/templates/terraform/encoders/disk.erb
+++ b/templates/terraform/encoders/disk.erb
@@ -4,6 +4,12 @@ project, err := getProject(d, config)
 if err != nil {
  	return nil, err
 }
+
+userAgent, err := generateUserAgentString(d, config.userAgent)
+if err != nil {
+	return nil, err
+}
+
 <% if object.name == 'Disk' -%>
 if v, ok := d.GetOk("type"); ok {
 	log.Printf("[DEBUG] Loading disk type: %s", v.(string))
@@ -36,7 +42,7 @@ end
 
 if v, ok := d.GetOk("image"); ok {
 	log.Printf("[DEBUG] Resolving image name: %s", v.(string))
-	imageUrl, err := resolveImage(config, project, v.(string))
+	imageUrl, err := resolveImage(config, project, v.(string), userAgent)
 	if err != nil {
 		return nil, fmt.Errorf(
 			"Error resolving image name '%s': %s",

--- a/templates/terraform/post_create/compute_backend_service_security_policy.go.erb
+++ b/templates/terraform/post_create/compute_backend_service_security_policy.go.erb
@@ -4,7 +4,7 @@ if o, n := d.GetChange("security_policy"); o.(string) != n.(string) {
   if err != nil {
     return errwrap.Wrapf("Error parsing Backend Service security policy: {{err}}", err)
   }
-  op, err := config.clientCompute.BackendServices.SetSecurityPolicy(
+  op, err := config.NewComputeClient(userAgent).BackendServices.SetSecurityPolicy(
     project, obj["name"].(string), &compute.SecurityPolicyReference{
       SecurityPolicy: pol.RelativeLink(),
     }).Do()

--- a/templates/terraform/post_create/compute_network_delete_default_route.erb
+++ b/templates/terraform/post_create/compute_network_delete_default_route.erb
@@ -1,13 +1,13 @@
 if d.Get("delete_default_routes_on_create").(bool) {
 	token := ""
 	for paginate := true; paginate; {
-		network, err := config.clientCompute.Networks.Get(project, d.Get("name").(string)).Do()
+		network, err := config.NewComputeClient(userAgent).Networks.Get(project, d.Get("name").(string)).Do()
 		if err != nil {
 			return fmt.Errorf("Error finding network in proj: %s", err)
 		}
 		filter := fmt.Sprintf("(network=\"%s\") AND (destRange=\"0.0.0.0/0\")", network.SelfLink)
 		log.Printf("[DEBUG] Getting routes for network %q with filter '%q'", d.Get("name").(string), filter)
-		resp, err := config.clientCompute.Routes.List(project).Filter(filter).Do()
+		resp, err := config.NewComputeClient(userAgent).Routes.List(project).Filter(filter).Do()
 		if err != nil {
 			return fmt.Errorf("Error listing routes in proj: %s", err)
 		}
@@ -15,7 +15,7 @@ if d.Get("delete_default_routes_on_create").(bool) {
 		log.Printf("[DEBUG] Found %d routes rules in %q network", len(resp.Items), d.Get("name").(string))
 
 		for _, route := range resp.Items {
-			op, err := config.clientCompute.Routes.Delete(project, route.Name).Do()
+			op, err := config.NewComputeClient(userAgent).Routes.Delete(project, route.Name).Do()
 			if err != nil {
 				return fmt.Errorf("Error deleting route: %s", err)
 			}

--- a/templates/terraform/pre_delete/detach_disk.erb
+++ b/templates/terraform/pre_delete/detach_disk.erb
@@ -15,7 +15,7 @@ if v, ok := readRes["users"].([]interface{}); ok {
 			return err
 		}
 
-		i, err := config.clientCompute.Instances.Get(instanceProject, instanceZone, instanceName).Do()
+		i, err := config.NewComputeClient(userAgent).Instances.Get(instanceProject, instanceZone, instanceName).Do()
 		if err != nil {
 			if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 				log.Printf("[WARN] instance %q not found, not bothering to detach disks", instance)
@@ -36,7 +36,7 @@ if v, ok := readRes["users"].([]interface{}); ok {
 	}
 
 	for _, call := range detachCalls {
-		op, err := config.clientCompute.Instances.DetachDisk(call.project, call.zone, call.instance, call.deviceName).Do()
+		op, err := config.NewComputeClient(userAgent).Instances.DetachDisk(call.project, call.zone, call.instance, call.deviceName).Do()
 		if err != nil {
 			return fmt.Errorf("Error detaching disk %s from instance %s/%s/%s: %s", call.deviceName, call.project,
 				call.zone, call.instance, err.Error())

--- a/third_party/terraform/data_sources/data_source_google_compute_address.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_address.go
@@ -59,7 +59,6 @@ func dataSourceGoogleComputeAddressRead(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
@@ -71,7 +70,7 @@ func dataSourceGoogleComputeAddressRead(d *schema.ResourceData, meta interface{}
 	}
 	name := d.Get("name").(string)
 
-	address, err := config.clientCompute.Addresses.Get(project, region, name).Do()
+	address, err := config.NewComputeClient(userAgent).Addresses.Get(project, region, name).Do()
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("Address Not Found : %s", name))
 	}

--- a/third_party/terraform/data_sources/data_source_google_compute_default_service_account.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_default_service_account.go
@@ -40,14 +40,13 @@ func dataSourceGoogleComputeDefaultServiceAccountRead(d *schema.ResourceData, me
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
 		return err
 	}
 
-	projectCompResource, err := config.clientCompute.Projects.Get(project).Do()
+	projectCompResource, err := config.NewComputeClient(userAgent).Projects.Get(project).Do()
 	if err != nil {
 		return handleNotFoundError(err, d, "GCE default service account")
 	}

--- a/third_party/terraform/data_sources/data_source_google_compute_forwarding_rule.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_forwarding_rule.go
@@ -93,7 +93,6 @@ func dataSourceGoogleComputeForwardingRuleRead(d *schema.ResourceData, meta inte
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	region, err := getRegion(d, config)
 	if err != nil {
@@ -107,7 +106,7 @@ func dataSourceGoogleComputeForwardingRuleRead(d *schema.ResourceData, meta inte
 
 	name := d.Get("name").(string)
 
-	frule, err := config.clientCompute.ForwardingRules.Get(
+	frule, err := config.NewComputeClient(userAgent).ForwardingRules.Get(
 		project, region, name).Do()
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("Forwarding Rule Not Found : %s", name))

--- a/third_party/terraform/data_sources/data_source_google_compute_global_address.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_global_address.go
@@ -46,14 +46,13 @@ func dataSourceGoogleComputeGlobalAddressRead(d *schema.ResourceData, meta inter
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
 		return err
 	}
 	name := d.Get("name").(string)
-	address, err := config.clientCompute.GlobalAddresses.Get(project, name).Do()
+	address, err := config.NewComputeClient(userAgent).GlobalAddresses.Get(project, name).Do()
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("Global Address Not Found : %s", name))
 	}

--- a/third_party/terraform/data_sources/data_source_google_compute_image.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_image.go
@@ -110,7 +110,6 @@ func dataSourceGoogleComputeImageRead(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
@@ -120,11 +119,11 @@ func dataSourceGoogleComputeImageRead(d *schema.ResourceData, meta interface{}) 
 	var image *compute.Image
 	if v, ok := d.GetOk("name"); ok {
 		log.Printf("[DEBUG] Fetching image %s", v.(string))
-		image, err = config.clientCompute.Images.Get(project, v.(string)).Do()
+		image, err = config.NewComputeClient(userAgent).Images.Get(project, v.(string)).Do()
 		log.Printf("[DEBUG] Fetched image %s", v.(string))
 	} else if v, ok := d.GetOk("family"); ok {
 		log.Printf("[DEBUG] Fetching latest non-deprecated image from family %s", v.(string))
-		image, err = config.clientCompute.Images.GetFromFamily(project, v.(string)).Do()
+		image, err = config.NewComputeClient(userAgent).Images.GetFromFamily(project, v.(string)).Do()
 		log.Printf("[DEBUG] Fetched latest non-deprecated image from family %s", v.(string))
 	} else {
 		return fmt.Errorf("one of name or family must be set")

--- a/third_party/terraform/data_sources/data_source_google_compute_instance_serial_port.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_instance_serial_port.go
@@ -41,7 +41,6 @@ func computeInstanceSerialPortRead(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
@@ -59,7 +58,7 @@ func computeInstanceSerialPortRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	port := int64(d.Get("port").(int))
-	output, err := config.clientCompute.Instances.GetSerialPortOutput(project, zone, d.Get("instance").(string)).Port(port).Do()
+	output, err := config.NewComputeClient(userAgent).Instances.GetSerialPortOutput(project, zone, d.Get("instance").(string)).Port(port).Do()
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/data_sources/data_source_google_compute_network.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_network.go
@@ -51,14 +51,13 @@ func dataSourceGoogleComputeNetworkRead(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
 		return err
 	}
 	name := d.Get("name").(string)
-	network, err := config.clientCompute.Networks.Get(project, name).Do()
+	network, err := config.NewComputeClient(userAgent).Networks.Get(project, name).Do()
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("Network Not Found : %s", name))
 	}

--- a/third_party/terraform/data_sources/data_source_google_compute_node_types.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_node_types.go
@@ -38,7 +38,6 @@ func dataSourceGoogleComputeNodeTypesRead(d *schema.ResourceData, meta interface
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
@@ -50,7 +49,7 @@ func dataSourceGoogleComputeNodeTypesRead(d *schema.ResourceData, meta interface
 		return fmt.Errorf("Please specify zone to get appropriate node types for zone. Unable to get zone: %s", err)
 	}
 
-	resp, err := config.clientCompute.NodeTypes.List(project, zone).Do()
+	resp, err := config.NewComputeClient(userAgent).NodeTypes.List(project, zone).Do()
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/data_sources/data_source_google_compute_region_instance_group.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_region_instance_group.go
@@ -91,20 +91,19 @@ func dataSourceComputeRegionInstanceGroupRead(d *schema.ResourceData, meta inter
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, region, name, err := GetRegionalResourcePropertiesFromSelfLinkOrSchema(d, config)
 	if err != nil {
 		return err
 	}
 
-	instanceGroup, err := config.clientCompute.RegionInstanceGroups.Get(
+	instanceGroup, err := config.NewComputeClient(userAgent).RegionInstanceGroups.Get(
 		project, region, name).Do()
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("Region Instance Group %q", name))
 	}
 
-	members, err := config.clientCompute.RegionInstanceGroups.ListInstances(
+	members, err := config.NewComputeClient(userAgent).RegionInstanceGroups.ListInstances(
 		project, region, name, &compute.RegionInstanceGroupsListInstancesRequest{
 			InstanceState: "ALL",
 		}).Do()

--- a/third_party/terraform/data_sources/data_source_google_compute_regions.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_regions.go
@@ -39,7 +39,6 @@ func dataSourceGoogleComputeRegionsRead(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
@@ -50,7 +49,7 @@ func dataSourceGoogleComputeRegionsRead(d *schema.ResourceData, meta interface{}
 		filter = fmt.Sprintf(" (status eq %s)", s)
 	}
 
-	call := config.clientCompute.Regions.List(project).Filter(filter)
+	call := config.NewComputeClient(userAgent).Regions.List(project).Filter(filter)
 
 	resp, err := call.Do()
 	if err != nil {

--- a/third_party/terraform/data_sources/data_source_google_compute_resource_policy.go.erb
+++ b/third_party/terraform/data_sources/data_source_google_compute_resource_policy.go.erb
@@ -47,7 +47,6 @@ func dataSourceGoogleComputeResourcePolicyRead(d *schema.ResourceData, meta inte
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
@@ -58,7 +57,7 @@ func dataSourceGoogleComputeResourcePolicyRead(d *schema.ResourceData, meta inte
 		return err
 	}
 	name := d.Get("name").(string)
-	resourcePolicy, err := config.clientCompute.ResourcePolicies.Get(project, region, name).Do()
+	resourcePolicy, err := config.NewComputeClient(userAgent).ResourcePolicies.Get(project, region, name).Do()
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("ResourcePolicy Not Found : %s", name))
 	}

--- a/third_party/terraform/data_sources/data_source_google_compute_subnetwork.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_subnetwork.go
@@ -78,14 +78,13 @@ func dataSourceGoogleComputeSubnetworkRead(d *schema.ResourceData, meta interfac
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, region, name, err := GetRegionalResourcePropertiesFromSelfLinkOrSchema(d, config)
 	if err != nil {
 		return err
 	}
 
-	subnetwork, err := config.clientCompute.Subnetworks.Get(project, region, name).Do()
+	subnetwork, err := config.NewComputeClient(userAgent).Subnetworks.Get(project, region, name).Do()
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("Subnetwork Not Found : %s", name))
 	}

--- a/third_party/terraform/data_sources/data_source_google_compute_vpn_gateway.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_vpn_gateway.go
@@ -53,7 +53,6 @@ func dataSourceGoogleComputeVpnGatewayRead(d *schema.ResourceData, meta interfac
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	region, err := getRegion(d, config)
 	if err != nil {
@@ -67,7 +66,7 @@ func dataSourceGoogleComputeVpnGatewayRead(d *schema.ResourceData, meta interfac
 
 	name := d.Get("name").(string)
 
-	vpnGatewaysService := compute.NewTargetVpnGatewaysService(config.clientCompute)
+	vpnGatewaysService := compute.NewTargetVpnGatewaysService(config.NewComputeClient(userAgent))
 
 	gateway, err := vpnGatewaysService.Get(project, region, name).Do()
 	if err != nil {

--- a/third_party/terraform/data_sources/data_source_google_compute_zones.go
+++ b/third_party/terraform/data_sources/data_source_google_compute_zones.go
@@ -44,7 +44,6 @@ func dataSourceGoogleComputeZonesRead(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	region := config.Region
 	if r, ok := d.GetOk("region"); ok {
@@ -62,7 +61,7 @@ func dataSourceGoogleComputeZonesRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	zones := []string{}
-	err = config.clientCompute.Zones.List(project).Filter(filter).Pages(config.context, func(zl *compute.ZoneList) error {
+	err = config.NewComputeClient(userAgent).Zones.List(project).Filter(filter).Pages(config.context, func(zl *compute.ZoneList) error {
 		for _, zone := range zl.Items {
 			// We have no way to guarantee a specific base path for the region, but the built-in API-level filtering
 			// only lets us query on exact matches, so we do our own filtering here.

--- a/third_party/terraform/resources/resource_compute_attached_disk.go
+++ b/third_party/terraform/resources/resource_compute_attached_disk.go
@@ -80,7 +80,6 @@ func resourceAttachedDiskCreate(d *schema.ResourceData, meta interface{}) error 
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	zv, err := parseZonalFieldValue("instances", d.Get("instance").(string), "project", "zone", d, config, false)
 	if err != nil {
@@ -106,7 +105,7 @@ func resourceAttachedDiskCreate(d *schema.ResourceData, meta interface{}) error 
 		DeviceName: d.Get("device_name").(string),
 	}
 
-	op, err := config.clientCompute.Instances.AttachDisk(zv.Project, zv.Zone, zv.Name, &attachedDisk).Do()
+	op, err := config.NewComputeClient(userAgent).Instances.AttachDisk(zv.Project, zv.Zone, zv.Name, &attachedDisk).Do()
 	if err != nil {
 		return err
 	}
@@ -129,7 +128,6 @@ func resourceAttachedDiskRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	zv, err := parseZonalFieldValue("instances", d.Get("instance").(string), "project", "zone", d, config, false)
 	if err != nil {
@@ -144,7 +142,7 @@ func resourceAttachedDiskRead(d *schema.ResourceData, meta interface{}) error {
 
 	diskName := GetResourceNameFromSelfLink(d.Get("disk").(string))
 
-	instance, err := config.clientCompute.Instances.Get(zv.Project, zv.Zone, zv.Name).Do()
+	instance, err := config.NewComputeClient(userAgent).Instances.Get(zv.Project, zv.Zone, zv.Name).Do()
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("AttachedDisk %q", d.Id()))
 	}
@@ -190,7 +188,6 @@ func resourceAttachedDiskDelete(d *schema.ResourceData, meta interface{}) error 
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	zv, err := parseZonalFieldValue("instances", d.Get("instance").(string), "project", "zone", d, config, false)
 	if err != nil {
@@ -199,7 +196,7 @@ func resourceAttachedDiskDelete(d *schema.ResourceData, meta interface{}) error 
 
 	diskName := GetResourceNameFromSelfLink(d.Get("disk").(string))
 
-	instance, err := config.clientCompute.Instances.Get(zv.Project, zv.Zone, zv.Name).Do()
+	instance, err := config.NewComputeClient(userAgent).Instances.Get(zv.Project, zv.Zone, zv.Name).Do()
 	if err != nil {
 		return err
 	}
@@ -211,7 +208,7 @@ func resourceAttachedDiskDelete(d *schema.ResourceData, meta interface{}) error 
 		return nil
 	}
 
-	op, err := config.clientCompute.Instances.DetachDisk(zv.Project, zv.Zone, zv.Name, ad.DeviceName).Do()
+	op, err := config.NewComputeClient(userAgent).Instances.DetachDisk(zv.Project, zv.Zone, zv.Name, ad.DeviceName).Do()
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -743,7 +743,12 @@ func getDisk(diskUri string, d *schema.ResourceData, config *Config) (*compute.D
 		return nil, err
 	}
 
-	disk, err := config.clientCompute.Disks.Get(source.Project, source.Zone, source.Name).Do()
+	userAgent, err := generateUserAgentString(d, config.userAgent)
+	if err != nil {
+		return nil, err
+	}
+
+	disk, err := config.NewComputeClient(userAgent).Disks.Get(source.Project, source.Zone, source.Name).Do()
 	if err != nil {
 		return nil, err
 	}
@@ -914,7 +919,7 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 	log.Printf("[DEBUG] Loading zone: %s", z)
-	zone, err := config.clientCompute.Zones.Get(
+	zone, err := config.NewComputeClient(userAgent).Zones.Get(
 		project, z).Do()
 	if err != nil {
 		return fmt.Errorf("Error loading zone '%s': %s", z, err)
@@ -1217,8 +1222,6 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
-	config.clientComputeBeta.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
@@ -1263,7 +1266,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 				metadataV1.Fingerprint = instance.Metadata.Fingerprint
 
-				op, err := config.clientCompute.Instances.SetMetadata(project, zone, instance.Name, metadataV1).Do()
+				op, err := config.NewComputeClient(userAgent).Instances.SetMetadata(project, zone, instance.Name, metadataV1).Do()
 				if err != nil {
 					return fmt.Errorf("Error updating metadata: %s", err)
 				}
@@ -1288,7 +1291,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		if err := Convert(tags, tagsV1); err != nil {
 			return err
 		}
-		op, err := config.clientCompute.Instances.SetTags(
+		op, err := config.NewComputeClient(userAgent).Instances.SetTags(
 			project, zone, d.Get("name").(string), tagsV1).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating tags: %s", err)
@@ -1305,7 +1308,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		labelFingerprint := d.Get("label_fingerprint").(string)
 		req := compute.InstancesSetLabelsRequest{Labels: labels, LabelFingerprint: labelFingerprint}
 
-		op, err := config.clientCompute.Instances.SetLabels(project, zone, instance.Name, &req).Do()
+		op, err := config.NewComputeClient(userAgent).Instances.SetLabels(project, zone, instance.Name, &req).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating labels: %s", err)
 		}
@@ -1375,7 +1378,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				if err != nil {
 					return fmt.Errorf("Cannot determine self_link for subnetwork %q: %s", subnetwork, err)
 				}
-				resp, err := config.clientCompute.Subnetworks.Get(sf.Project, sf.Region, sf.Name).Do()
+				resp, err := config.NewComputeClient(userAgent).Subnetworks.Get(sf.Project, sf.Region, sf.Name).Do()
 				if err != nil {
 					return errwrap.Wrapf("Error getting subnetwork value: {{err}}", err)
 				}
@@ -1397,7 +1400,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 			// Delete any accessConfig that currently exists in instNetworkInterface
 			for _, ac := range instNetworkInterface.AccessConfigs {
-				op, err := config.clientCompute.Instances.DeleteAccessConfig(
+				op, err := config.NewComputeClient(userAgent).Instances.DeleteAccessConfig(
 					project, zone, instance.Name, ac.Name, networkName).Do()
 				if err != nil {
 					return fmt.Errorf("Error deleting old access_config: %s", err)
@@ -1550,7 +1553,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		// Detach the old disks.
 		for hash, deviceName := range oDisks {
 			if _, ok := nDisks[hash]; !ok {
-				op, err := config.clientCompute.Instances.DetachDisk(project, zone, instance.Name, deviceName).Do()
+				op, err := config.NewComputeClient(userAgent).Instances.DetachDisk(project, zone, instance.Name, deviceName).Do()
 				if err != nil {
 					return errwrap.Wrapf("Error detaching disk: %s", err)
 				}
@@ -1565,7 +1568,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 
 		// Attach the new disks
 		for _, disk := range attach {
-			op, err := config.clientCompute.Instances.AttachDisk(project, zone, instance.Name, disk).Do()
+			op, err := config.NewComputeClient(userAgent).Instances.AttachDisk(project, zone, instance.Name, disk).Do()
 			if err != nil {
 				return errwrap.Wrapf("Error attaching disk : {{err}}", err)
 			}
@@ -1597,7 +1600,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 	if d.HasChange("deletion_protection") {
 		nDeletionProtection := d.Get("deletion_protection").(bool)
 
-		op, err := config.clientCompute.Instances.SetDeletionProtection(project, zone, d.Get("name").(string)).DeletionProtection(nDeletionProtection).Do()
+		op, err := config.NewComputeClient(userAgent).Instances.SetDeletionProtection(project, zone, d.Get("name").(string)).DeletionProtection(nDeletionProtection).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating deletion protection flag: %s", err)
 		}
@@ -1622,7 +1625,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 					return errwrap.Wrapf("Error starting instance: {{err}}", err)
 				}
 			} else if desiredStatus == "TERMINATED" {
-				op, err = config.clientCompute.Instances.Stop(project, zone, instance.Name).Do()
+				op, err = config.NewComputeClient(userAgent).Instances.Stop(project, zone, instance.Name).Do()
 				if err != nil {
 					return err
 				}
@@ -1649,7 +1652,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		}
 
 		if statusBeforeUpdate != "TERMINATED" {
-			op, err := config.clientCompute.Instances.Stop(project, zone, instance.Name).Do()
+			op, err := config.NewComputeClient(userAgent).Instances.Stop(project, zone, instance.Name).Do()
 			if err != nil {
 				return errwrap.Wrapf("Error stopping instance: {{err}}", err)
 			}
@@ -1668,7 +1671,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			req := &compute.InstancesSetMachineTypeRequest{
 				MachineType: mt.RelativeLink(),
 			}
-			op, err := config.clientCompute.Instances.SetMachineType(project, zone, instance.Name, req).Do()
+			op, err := config.NewComputeClient(userAgent).Instances.SetMachineType(project, zone, instance.Name, req).Do()
 			if err != nil {
 				return err
 			}
@@ -1689,7 +1692,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 			req := &compute.InstancesSetMinCpuPlatformRequest{
 				MinCpuPlatform: minCpuPlatform.(string),
 			}
-			op, err := config.clientCompute.Instances.SetMinCpuPlatform(project, zone, instance.Name, req).Do()
+			op, err := config.NewComputeClient(userAgent).Instances.SetMinCpuPlatform(project, zone, instance.Name, req).Do()
 			if err != nil {
 				return err
 			}
@@ -1707,7 +1710,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				req.Email = saMap["email"].(string)
 				req.Scopes = canonicalizeServiceScopes(convertStringSet(saMap["scopes"].(*schema.Set)))
 			}
-			op, err := config.clientCompute.Instances.SetServiceAccount(project, zone, instance.Name, req).Do()
+			op, err := config.NewComputeClient(userAgent).Instances.SetServiceAccount(project, zone, instance.Name, req).Do()
 			if err != nil {
 				return err
 			}
@@ -1722,7 +1725,7 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 				EnableDisplay:   d.Get("enable_display").(bool),
 				ForceSendFields: []string{"EnableDisplay"},
 			}
-			op, err := config.clientCompute.Instances.UpdateDisplayDevice(project, zone, instance.Name, req).Do()
+			op, err := config.NewComputeClient(userAgent).Instances.UpdateDisplayDevice(project, zone, instance.Name, req).Do()
 			if err != nil {
 				return fmt.Errorf("Error updating display device: %s", err)
 			}
@@ -1790,6 +1793,11 @@ func startInstanceOperation(d *schema.ResourceData, config *Config) (*compute.Op
 		return nil, err
 	}
 
+	userAgent, err := generateUserAgentString(d, config.userAgent)
+	if err != nil {
+		return nil, err
+	}
+
 	// Use beta api directly in order to read network_interface.fingerprint without having to put it in the schema.
 	// Change back to getInstance(config, d) once updating alias ips is GA.
 	instance, err := config.clientComputeBeta.Instances.Get(project, zone, d.Get("name").(string)).Do()
@@ -1816,9 +1824,9 @@ func startInstanceOperation(d *schema.ResourceData, config *Config) (*compute.Op
 
 	if len(encrypted) > 0 {
 		request := compute.InstancesStartWithEncryptionKeyRequest{Disks: encrypted}
-		op, err = config.clientCompute.Instances.StartWithEncryptionKey(project, zone, instance.Name, &request).Do()
+		op, err = config.NewComputeClient(userAgent).Instances.StartWithEncryptionKey(project, zone, instance.Name, &request).Do()
 	} else {
-		op, err = config.clientCompute.Instances.Start(project, zone, instance.Name).Do()
+		op, err = config.NewComputeClient(userAgent).Instances.Start(project, zone, instance.Name).Do()
 	}
 
 	return op, err
@@ -1972,7 +1980,6 @@ func resourceComputeInstanceDelete(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
@@ -1988,7 +1995,7 @@ func resourceComputeInstanceDelete(d *schema.ResourceData, meta interface{}) err
 	if d.Get("deletion_protection").(bool) {
 		return fmt.Errorf("Cannot delete instance %s: instance Deletion Protection is enabled. Set deletion_protection to false for this resource and run \"terraform apply\" before attempting to delete it.", d.Get("name").(string))
 	} else {
-		op, err := config.clientCompute.Instances.Delete(project, zone, d.Get("name").(string)).Do()
+		op, err := config.NewComputeClient(userAgent).Instances.Delete(project, zone, d.Get("name").(string)).Do()
 		if err != nil {
 			return fmt.Errorf("Error deleting instance: %s", err)
 		}
@@ -2025,6 +2032,11 @@ func resourceComputeInstanceImportState(d *schema.ResourceData, meta interface{}
 }
 
 func expandBootDisk(d *schema.ResourceData, config *Config, project string) (*computeBeta.AttachedDisk, error) {
+	userAgent, err := generateUserAgentString(d, config.userAgent)
+	if err != nil {
+		return nil, err
+	}
+
 	disk := &computeBeta.AttachedDisk{
 		AutoDelete: d.Get("boot_disk.0.auto_delete").(bool),
 		Boot:       true,
@@ -2076,7 +2088,7 @@ func expandBootDisk(d *schema.ResourceData, config *Config, project string) (*co
 
 		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.image"); ok {
 			imageName := v.(string)
-			imageUrl, err := resolveImage(config, project, imageName)
+			imageUrl, err := resolveImage(config, project, imageName, userAgent)
 			if err != nil {
 				return nil, fmt.Errorf("Error resolving image name '%s': %s", imageName, err)
 			}

--- a/third_party/terraform/resources/resource_compute_instance_from_template.go
+++ b/third_party/terraform/resources/resource_compute_instance_from_template.go
@@ -107,7 +107,7 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 		return err
 	}
 	log.Printf("[DEBUG] Loading zone: %s", z)
-	zone, err := config.clientCompute.Zones.Get(project, z).Do()
+	zone, err := config.NewComputeClient(userAgent).Zones.Get(project, z).Do()
 	if err != nil {
 		return fmt.Errorf("Error loading zone '%s': %s", z, err)
 	}

--- a/third_party/terraform/resources/resource_compute_instance_group.go
+++ b/third_party/terraform/resources/resource_compute_instance_group.go
@@ -140,7 +140,6 @@ func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
@@ -172,7 +171,7 @@ func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	log.Printf("[DEBUG] InstanceGroup insert request: %#v", instanceGroup)
-	op, err := config.clientCompute.InstanceGroups.Insert(
+	op, err := config.NewComputeClient(userAgent).InstanceGroups.Insert(
 		project, zone, instanceGroup).Do()
 	if err != nil {
 		return fmt.Errorf("Error creating InstanceGroup: %s", err)
@@ -209,7 +208,7 @@ func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}
 		}
 
 		log.Printf("[DEBUG] InstanceGroup add instances request: %#v", addInstanceReq)
-		op, err := config.clientCompute.InstanceGroups.AddInstances(
+		op, err := config.NewComputeClient(userAgent).InstanceGroups.AddInstances(
 			project, zone, name, addInstanceReq).Do()
 		if err != nil {
 			return fmt.Errorf("Error adding instances to InstanceGroup: %s", err)
@@ -231,7 +230,6 @@ func resourceComputeInstanceGroupRead(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
@@ -245,7 +243,7 @@ func resourceComputeInstanceGroupRead(d *schema.ResourceData, meta interface{}) 
 	name := d.Get("name").(string)
 
 	// retrieve instance group
-	instanceGroup, err := config.clientCompute.InstanceGroups.Get(
+	instanceGroup, err := config.NewComputeClient(userAgent).InstanceGroups.Get(
 		project, zone, name).Do()
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("Instance Group %q", name))
@@ -253,7 +251,7 @@ func resourceComputeInstanceGroupRead(d *schema.ResourceData, meta interface{}) 
 
 	// retrieve instance group members
 	var memberUrls []string
-	members, err := config.clientCompute.InstanceGroups.ListInstances(
+	members, err := config.NewComputeClient(userAgent).InstanceGroups.ListInstances(
 		project, zone, name, &compute.InstanceGroupsListInstancesRequest{
 			InstanceState: "ALL",
 		}).Do()
@@ -309,7 +307,6 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
@@ -346,7 +343,7 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 			}
 
 			log.Printf("[DEBUG] InstanceGroup remove instances request: %#v", removeReq)
-			removeOp, err := config.clientCompute.InstanceGroups.RemoveInstances(
+			removeOp, err := config.NewComputeClient(userAgent).InstanceGroups.RemoveInstances(
 				project, zone, name, removeReq).Do()
 			if err != nil {
 				if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
@@ -370,7 +367,7 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 			}
 
 			log.Printf("[DEBUG] InstanceGroup adding instances request: %#v", addReq)
-			addOp, err := config.clientCompute.InstanceGroups.AddInstances(
+			addOp, err := config.NewComputeClient(userAgent).InstanceGroups.AddInstances(
 				project, zone, name, addReq).Do()
 			if err != nil {
 				return fmt.Errorf("Error adding instances from InstanceGroup: %s", err)
@@ -392,7 +389,7 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 		}
 
 		log.Printf("[DEBUG] InstanceGroup updating named ports request: %#v", namedPortsReq)
-		op, err := config.clientCompute.InstanceGroups.SetNamedPorts(
+		op, err := config.NewComputeClient(userAgent).InstanceGroups.SetNamedPorts(
 			project, zone, name, namedPortsReq).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating named ports for InstanceGroup: %s", err)
@@ -415,7 +412,6 @@ func resourceComputeInstanceGroupDelete(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
@@ -427,7 +423,7 @@ func resourceComputeInstanceGroupDelete(d *schema.ResourceData, meta interface{}
 		return err
 	}
 	name := d.Get("name").(string)
-	op, err := config.clientCompute.InstanceGroups.Delete(project, zone, name).Do()
+	op, err := config.NewComputeClient(userAgent).InstanceGroups.Delete(project, zone, name).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting InstanceGroup: %s", err)
 	}

--- a/third_party/terraform/resources/resource_compute_instance_migrate.go
+++ b/third_party/terraform/resources/resource_compute_instance_migrate.go
@@ -329,7 +329,7 @@ func getInstanceFromInstanceState(config *Config, is *terraform.InstanceState) (
 		}
 	}
 
-	instance, err := config.clientCompute.Instances.Get(
+	instance, err := config.NewComputeClient(config.userAgent).Instances.Get(
 		project, zone, is.ID).Do()
 	if err != nil {
 		return nil, fmt.Errorf("error reading instance: %s", err)
@@ -360,7 +360,7 @@ func getAllDisksFromInstanceState(config *Config, is *terraform.InstanceState) (
 	diskList := []*compute.Disk{}
 	token := ""
 	for {
-		disks, err := config.clientCompute.Disks.List(project, zone).PageToken(token).Do()
+		disks, err := config.NewComputeClient(config.userAgent).Disks.List(project, zone).PageToken(token).Do()
 		if err != nil {
 			return nil, fmt.Errorf("error reading disks: %s", err)
 		}
@@ -448,7 +448,7 @@ func getDiskFromEncryptionKey(instance *compute.Instance, encryptionKey string) 
 }
 
 func getDiskFromAutoDeleteAndImage(config *Config, instance *compute.Instance, allDisks map[string]*compute.Disk, autoDelete bool, image, project, zone string) (*compute.AttachedDisk, error) {
-	img, err := resolveImage(config, project, image)
+	img, err := resolveImage(config, project, image, config.userAgent)
 	if err != nil {
 		return nil, err
 	}

--- a/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -626,7 +626,7 @@ func resourceComputeInstanceTemplateSourceImageCustomizeDiff(_ context.Context, 
 			if err != nil {
 				return err
 			}
-			oldResolved, err := resolveImage(config, project, old.(string))
+			oldResolved, err := resolveImage(config, project, old.(string), config.userAgent)
 			if err != nil {
 				return err
 			}
@@ -634,7 +634,7 @@ func resourceComputeInstanceTemplateSourceImageCustomizeDiff(_ context.Context, 
 			if err != nil {
 				return err
 			}
-			newResolved, err := resolveImage(config, project, new.(string))
+			newResolved, err := resolveImage(config, project, new.(string), config.userAgent)
 			if err != nil {
 				return err
 			}
@@ -702,6 +702,11 @@ func buildDisks(d *schema.ResourceData, config *Config) ([]*computeBeta.Attached
 		return nil, err
 	}
 
+	userAgent, err := generateUserAgentString(d, config.userAgent)
+	if err != nil {
+		return nil, err
+	}
+
 	disksCount := d.Get("disk.#").(int)
 
 	disks := make([]*computeBeta.AttachedDisk, 0, disksCount)
@@ -755,7 +760,7 @@ func buildDisks(d *schema.ResourceData, config *Config) ([]*computeBeta.Attached
 
 			if v, ok := d.GetOk(prefix + ".source_image"); ok {
 				imageName := v.(string)
-				imageUrl, err := resolveImage(config, project, imageName)
+				imageUrl, err := resolveImage(config, project, imageName, userAgent)
 				if err != nil {
 					return nil, fmt.Errorf(
 						"Error resolving image name '%s': %s",
@@ -823,7 +828,6 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 	if err != nil {
 		return err
 	}
-	config.clientComputeBeta.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
@@ -1270,7 +1274,6 @@ func resourceComputeInstanceTemplateDelete(d *schema.ResourceData, meta interfac
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
@@ -1278,7 +1281,7 @@ func resourceComputeInstanceTemplateDelete(d *schema.ResourceData, meta interfac
 	}
 
 	splits := strings.Split(d.Id(), "/")
-	op, err := config.clientCompute.InstanceTemplates.Delete(
+	op, err := config.NewComputeClient(userAgent).InstanceTemplates.Delete(
 		project, splits[len(splits)-1]).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting instance template: %s", err)

--- a/third_party/terraform/resources/resource_compute_project_default_network_tier.go
+++ b/third_party/terraform/resources/resource_compute_project_default_network_tier.go
@@ -52,7 +52,6 @@ func resourceComputeProjectDefaultNetworkTierCreateOrUpdate(d *schema.ResourceDa
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	projectID, err := getProject(d, config)
 	if err != nil {
@@ -62,7 +61,7 @@ func resourceComputeProjectDefaultNetworkTierCreateOrUpdate(d *schema.ResourceDa
 	request := &compute.ProjectsSetDefaultNetworkTierRequest{
 		NetworkTier: d.Get("network_tier").(string),
 	}
-	op, err := config.clientCompute.Projects.SetDefaultNetworkTier(projectID, request).Do()
+	op, err := config.NewComputeClient(userAgent).Projects.SetDefaultNetworkTier(projectID, request).Do()
 	if err != nil {
 		return fmt.Errorf("SetDefaultNetworkTier failed: %s", err)
 	}
@@ -84,11 +83,10 @@ func resourceComputeProjectDefaultNetworkTierRead(d *schema.ResourceData, meta i
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	projectId := d.Id()
 
-	project, err := config.clientCompute.Projects.Get(projectId).Do()
+	project, err := config.NewComputeClient(userAgent).Projects.Get(projectId).Do()
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("Project data for project %q", projectId))
 	}

--- a/third_party/terraform/resources/resource_compute_project_metadata.go
+++ b/third_party/terraform/resources/resource_compute_project_metadata.go
@@ -51,7 +51,6 @@ func resourceComputeProjectMetadataCreateOrUpdate(d *schema.ResourceData, meta i
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	projectID, err := getProject(d, config)
 	if err != nil {
@@ -78,7 +77,6 @@ func resourceComputeProjectMetadataRead(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	// At import time, we have no state to draw from. We'll wrongly pull the
 	// provider default project if we use a normal getProject, so we need to
@@ -91,7 +89,7 @@ func resourceComputeProjectMetadataRead(d *schema.ResourceData, meta interface{}
 	// but would create metadata for the provider project on a destroy/create.
 	projectId := d.Id()
 
-	project, err := config.clientCompute.Projects.Get(projectId).Do()
+	project, err := config.NewComputeClient(userAgent).Projects.Get(projectId).Do()
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("Project metadata for project %q", projectId))
 	}
@@ -114,7 +112,6 @@ func resourceComputeProjectMetadataDelete(d *schema.ResourceData, meta interface
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	projectID, err := getProject(d, config)
 	if err != nil {
@@ -133,13 +130,13 @@ func resourceComputeProjectMetadataDelete(d *schema.ResourceData, meta interface
 func resourceComputeProjectMetadataSet(projectID, userAgent string, config *Config, md *compute.Metadata, timeout time.Duration) error {
 	createMD := func() error {
 		log.Printf("[DEBUG] Loading project service: %s", projectID)
-		project, err := config.clientCompute.Projects.Get(projectID).Do()
+		project, err := config.NewComputeClient(userAgent).Projects.Get(projectID).Do()
 		if err != nil {
 			return fmt.Errorf("Error loading project '%s': %s", projectID, err)
 		}
 
 		md.Fingerprint = project.CommonInstanceMetadata.Fingerprint
-		op, err := config.clientCompute.Projects.SetCommonInstanceMetadata(projectID, md).Do()
+		op, err := config.NewComputeClient(userAgent).Projects.SetCommonInstanceMetadata(projectID, md).Do()
 		if err != nil {
 			return fmt.Errorf("SetCommonInstanceMetadata failed: %s", err)
 		}

--- a/third_party/terraform/resources/resource_compute_project_metadata_item.go
+++ b/third_party/terraform/resources/resource_compute_project_metadata_item.go
@@ -61,7 +61,6 @@ func resourceComputeProjectMetadataItemCreate(d *schema.ResourceData, meta inter
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	projectID, err := getProject(d, config)
 	if err != nil {
@@ -87,7 +86,6 @@ func resourceComputeProjectMetadataItemRead(d *schema.ResourceData, meta interfa
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	projectID, err := getProject(d, config)
 	if err != nil {
@@ -95,7 +93,7 @@ func resourceComputeProjectMetadataItemRead(d *schema.ResourceData, meta interfa
 	}
 
 	log.Printf("[DEBUG] Loading project metadata: %s", projectID)
-	project, err := config.clientCompute.Projects.Get(projectID).Do()
+	project, err := config.NewComputeClient(userAgent).Projects.Get(projectID).Do()
 	if err != nil {
 		return fmt.Errorf("Error loading project '%s': %s", projectID, err)
 	}
@@ -127,7 +125,6 @@ func resourceComputeProjectMetadataItemUpdate(d *schema.ResourceData, meta inter
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	projectID, err := getProject(d, config)
 	if err != nil {
@@ -153,7 +150,6 @@ func resourceComputeProjectMetadataItemDelete(d *schema.ResourceData, meta inter
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	projectID, err := getProject(d, config)
 	if err != nil {
@@ -174,7 +170,7 @@ func resourceComputeProjectMetadataItemDelete(d *schema.ResourceData, meta inter
 func updateComputeCommonInstanceMetadata(config *Config, projectID, key, userAgent string, afterVal *string, timeout time.Duration, failIfPresent metadataPresentBehavior) error {
 	updateMD := func() error {
 		log.Printf("[DEBUG] Loading project metadata: %s", projectID)
-		project, err := config.clientCompute.Projects.Get(projectID).Do()
+		project, err := config.NewComputeClient(userAgent).Projects.Get(projectID).Do()
 		if err != nil {
 			return fmt.Errorf("Error loading project '%s': %s", projectID, err)
 		}
@@ -205,7 +201,7 @@ func updateComputeCommonInstanceMetadata(config *Config, projectID, key, userAge
 		}
 
 		// Attempt to write the new value now
-		op, err := config.clientCompute.Projects.SetCommonInstanceMetadata(
+		op, err := config.NewComputeClient(userAgent).Projects.SetCommonInstanceMetadata(
 			projectID,
 			&compute.Metadata{
 				Fingerprint: project.CommonInstanceMetadata.Fingerprint,

--- a/third_party/terraform/resources/resource_compute_router_interface.go
+++ b/third_party/terraform/resources/resource_compute_router_interface.go
@@ -89,7 +89,6 @@ func resourceComputeRouterInterfaceCreate(d *schema.ResourceData, meta interface
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	region, err := getRegion(d, config)
 	if err != nil {
@@ -108,7 +107,7 @@ func resourceComputeRouterInterfaceCreate(d *schema.ResourceData, meta interface
 	mutexKV.Lock(routerLock)
 	defer mutexKV.Unlock(routerLock)
 
-	routersService := config.clientCompute.Routers
+	routersService := config.NewComputeClient(userAgent).Routers
 	router, err := routersService.Get(project, region, routerName).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
@@ -136,7 +135,7 @@ func resourceComputeRouterInterfaceCreate(d *schema.ResourceData, meta interface
 	}
 
 	if vpnVal, ok := d.GetOk("vpn_tunnel"); ok {
-		vpnTunnel, err := getVpnTunnelLink(config, project, region, vpnVal.(string))
+		vpnTunnel, err := getVpnTunnelLink(config, project, region, vpnVal.(string), userAgent)
 		if err != nil {
 			return err
 		}
@@ -144,7 +143,7 @@ func resourceComputeRouterInterfaceCreate(d *schema.ResourceData, meta interface
 	}
 
 	if icVal, ok := d.GetOk("interconnect_attachment"); ok {
-		interconnectAttachment, err := getInterconnectAttachmentLink(config, project, region, icVal.(string))
+		interconnectAttachment, err := getInterconnectAttachmentLink(config, project, region, icVal.(string), userAgent)
 		if err != nil {
 			return err
 		}
@@ -178,7 +177,6 @@ func resourceComputeRouterInterfaceRead(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	region, err := getRegion(d, config)
 	if err != nil {
@@ -193,7 +191,7 @@ func resourceComputeRouterInterfaceRead(d *schema.ResourceData, meta interface{}
 	routerName := d.Get("router").(string)
 	ifaceName := d.Get("name").(string)
 
-	routersService := config.clientCompute.Routers
+	routersService := config.NewComputeClient(userAgent).Routers
 	router, err := routersService.Get(project, region, routerName).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
@@ -240,7 +238,6 @@ func resourceComputeRouterInterfaceDelete(d *schema.ResourceData, meta interface
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	region, err := getRegion(d, config)
 	if err != nil {
@@ -259,7 +256,7 @@ func resourceComputeRouterInterfaceDelete(d *schema.ResourceData, meta interface
 	mutexKV.Lock(routerLock)
 	defer mutexKV.Unlock(routerLock)
 
-	routersService := config.clientCompute.Routers
+	routersService := config.NewComputeClient(userAgent).Routers
 	router, err := routersService.Get(project, region, routerName).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {

--- a/third_party/terraform/resources/resource_compute_shared_vpc_service_project.go
+++ b/third_party/terraform/resources/resource_compute_shared_vpc_service_project.go
@@ -81,7 +81,6 @@ func resourceComputeSharedVpcServiceProjectRead(d *schema.ResourceData, meta int
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	split := strings.Split(d.Id(), "/")
 	if len(split) != 2 {
@@ -90,7 +89,7 @@ func resourceComputeSharedVpcServiceProjectRead(d *schema.ResourceData, meta int
 	hostProject := split[0]
 	serviceProject := split[1]
 
-	associatedHostProject, err := config.clientCompute.Projects.GetXpnHost(serviceProject).Do()
+	associatedHostProject, err := config.NewComputeClient(userAgent).Projects.GetXpnHost(serviceProject).Do()
 	if err != nil {
 		log.Printf("[WARN] Removing shared VPC service. The service project is not associated with any host")
 

--- a/third_party/terraform/resources/resource_compute_target_pool.go
+++ b/third_party/terraform/resources/resource_compute_target_pool.go
@@ -184,7 +184,6 @@ func resourceComputeTargetPoolCreate(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	region, err := getRegion(d, config)
 	if err != nil {
@@ -219,7 +218,7 @@ func resourceComputeTargetPoolCreate(d *schema.ResourceData, meta interface{}) e
 		tpool.FailoverRatio = d.Get("failover_ratio").(float64)
 	}
 	log.Printf("[DEBUG] TargetPool insert request: %#v", tpool)
-	op, err := config.clientCompute.TargetPools.Insert(
+	op, err := config.NewComputeClient(userAgent).TargetPools.Insert(
 		project, region, tpool).Do()
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 && strings.Contains(gerr.Message, "httpHealthChecks") {
@@ -248,7 +247,6 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	region, err := getRegion(d, config)
 	if err != nil {
@@ -283,7 +281,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 		for i, v := range remove {
 			removeReq.HealthChecks[i] = &compute.HealthCheckReference{HealthCheck: v}
 		}
-		op, err := config.clientCompute.TargetPools.RemoveHealthCheck(
+		op, err := config.NewComputeClient(userAgent).TargetPools.RemoveHealthCheck(
 			project, region, name, removeReq).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating health_check: %s", err)
@@ -299,7 +297,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 		for i, v := range add {
 			addReq.HealthChecks[i] = &compute.HealthCheckReference{HealthCheck: v}
 		}
-		op, err = config.clientCompute.TargetPools.AddHealthCheck(
+		op, err = config.NewComputeClient(userAgent).TargetPools.AddHealthCheck(
 			project, region, name, addReq).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating health_check: %s", err)
@@ -332,7 +330,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 		for i, v := range addUrls {
 			addReq.Instances[i] = &compute.InstanceReference{Instance: v}
 		}
-		op, err := config.clientCompute.TargetPools.AddInstance(
+		op, err := config.NewComputeClient(userAgent).TargetPools.AddInstance(
 			project, region, name, addReq).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating instances: %s", err)
@@ -348,7 +346,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 		for i, v := range removeUrls {
 			removeReq.Instances[i] = &compute.InstanceReference{Instance: v}
 		}
-		op, err = config.clientCompute.TargetPools.RemoveInstance(
+		op, err = config.NewComputeClient(userAgent).TargetPools.RemoveInstance(
 			project, region, name, removeReq).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating instances: %s", err)
@@ -364,7 +362,7 @@ func resourceComputeTargetPoolUpdate(d *schema.ResourceData, meta interface{}) e
 		tref := &compute.TargetReference{
 			Target: bpool_name,
 		}
-		op, err := config.clientCompute.TargetPools.SetBackup(
+		op, err := config.NewComputeClient(userAgent).TargetPools.SetBackup(
 			project, region, name, tref).Do()
 		if err != nil {
 			return fmt.Errorf("Error updating backup_pool: %s", err)
@@ -397,7 +395,6 @@ func resourceComputeTargetPoolRead(d *schema.ResourceData, meta interface{}) err
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	region, err := getRegion(d, config)
 	if err != nil {
@@ -409,7 +406,7 @@ func resourceComputeTargetPoolRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 
-	tpool, err := config.clientCompute.TargetPools.Get(
+	tpool, err := config.NewComputeClient(userAgent).TargetPools.Get(
 		project, region, d.Get("name").(string)).Do()
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("Target Pool %q", d.Get("name").(string)))
@@ -460,7 +457,6 @@ func resourceComputeTargetPoolDelete(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	region, err := getRegion(d, config)
 	if err != nil {
@@ -473,7 +469,7 @@ func resourceComputeTargetPoolDelete(d *schema.ResourceData, meta interface{}) e
 	}
 
 	// Delete the TargetPool
-	op, err := config.clientCompute.TargetPools.Delete(
+	op, err := config.NewComputeClient(userAgent).TargetPools.Delete(
 		project, region, d.Get("name").(string)).Do()
 	if err != nil {
 		return fmt.Errorf("Error deleting TargetPool: %s", err)

--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1677,7 +1677,7 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	igUrls, err := getInstanceGroupUrlsFromManagerUrls(config, cluster.InstanceGroupUrls)
+	igUrls, err := getInstanceGroupUrlsFromManagerUrls(config, userAgent, cluster.InstanceGroupUrls)
 	if err != nil {
 		return err
 	}
@@ -2683,7 +2683,7 @@ func containerClusterAwaitRestingState(config *Config, project, location, cluste
 // container engine's API returns the instance group manager's URL instead of the instance
 // group's URL in its responses, while the field is named as if it should have been the group
 // and not the manager. This shim should be supported for backwards compatibility reasons.
-func getInstanceGroupUrlsFromManagerUrls(config *Config, igmUrls []string) ([]string, error) {
+func getInstanceGroupUrlsFromManagerUrls(config *Config, userAgent string, igmUrls []string) ([]string, error) {
 	instanceGroupURLs := make([]string, 0, len(igmUrls))
 	for _, u := range igmUrls {
 		if !instanceGroupManagerURL.MatchString(u) {
@@ -2691,7 +2691,7 @@ func getInstanceGroupUrlsFromManagerUrls(config *Config, igmUrls []string) ([]st
 			continue
 		}
 		matches := instanceGroupManagerURL.FindStringSubmatch(u)
-		instanceGroupManager, err := config.clientCompute.InstanceGroupManagers.Get(matches[1], matches[2], matches[3]).Do()
+		instanceGroupManager, err := config.NewComputeClient(userAgent).InstanceGroupManagers.Get(matches[1], matches[2], matches[3]).Do()
 		if isGoogleApiErrorWithCode(err, 404) {
 			// The IGM URL is stale; don't include it
 			continue

--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -470,7 +470,7 @@ func forceDeleteComputeNetwork(d *schema.ResourceData, config *Config, projectId
 
 	// Read the network from the API so we can get the correct self link format. We can't construct it from the
 	// base path because it might not line up exactly (compute.googleapis.com vs www.googleapis.com)
-	net, err := config.clientCompute.Networks.Get(projectId, networkName).Do()
+	net, err := config.NewComputeClient(userAgent).Networks.Get(projectId, networkName).Do()
 	if err != nil {
 		return err
 	}
@@ -478,7 +478,7 @@ func forceDeleteComputeNetwork(d *schema.ResourceData, config *Config, projectId
 	token := ""
 	for paginate := true; paginate; {
 		filter := fmt.Sprintf("network eq %s", net.SelfLink)
-		resp, err := config.clientCompute.Firewalls.List(projectId).Filter(filter).Do()
+		resp, err := config.NewComputeClient(userAgent).Firewalls.List(projectId).Filter(filter).Do()
 		if err != nil {
 			return errwrap.Wrapf("Error listing firewall rules in proj: {{err}}", err)
 		}
@@ -486,7 +486,7 @@ func forceDeleteComputeNetwork(d *schema.ResourceData, config *Config, projectId
 		log.Printf("[DEBUG] Found %d firewall rules in %q network", len(resp.Items), networkName)
 
 		for _, firewall := range resp.Items {
-			op, err := config.clientCompute.Firewalls.Delete(projectId, firewall.Name).Do()
+			op, err := config.NewComputeClient(userAgent).Firewalls.Delete(projectId, firewall.Name).Do()
 			if err != nil {
 				return errwrap.Wrapf("Error deleting firewall: {{err}}", err)
 			}
@@ -546,7 +546,7 @@ func updateProjectBillingAccount(d *schema.ResourceData, config *Config) error {
 }
 
 func deleteComputeNetwork(project, network, userAgent string, config *Config) error {
-	op, err := config.clientCompute.Networks.Delete(
+	op, err := config.NewComputeClient(userAgent).Networks.Delete(
 		project, network).Do()
 	if err != nil {
 		return errwrap.Wrapf("Error deleting network: {{err}}", err)

--- a/third_party/terraform/resources/resource_storage_bucket.go
+++ b/third_party/terraform/resources/resource_storage_bucket.go
@@ -634,7 +634,7 @@ func resourceStorageBucketRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	if d.Get("project") == "" {
-		proj, err := config.clientCompute.Projects.Get(strconv.FormatUint(res.ProjectNumber, 10)).Do()
+		proj, err := config.NewComputeClient(userAgent).Projects.Get(strconv.FormatUint(res.ProjectNumber, 10)).Do()
 		if err != nil {
 			return err
 		}

--- a/third_party/terraform/resources/resource_usage_export_bucket.go
+++ b/third_party/terraform/resources/resource_usage_export_bucket.go
@@ -53,14 +53,13 @@ func resourceProjectUsageBucketRead(d *schema.ResourceData, meta interface{}) er
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
 		return err
 	}
 
-	p, err := config.clientCompute.Projects.Get(project).Do()
+	p, err := config.NewComputeClient(userAgent).Projects.Get(project).Do()
 	if err != nil {
 		return handleNotFoundError(err, d, fmt.Sprintf("Project data for project %s", project))
 	}
@@ -89,14 +88,13 @@ func resourceProjectUsageBucketCreate(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
 		return err
 	}
 
-	op, err := config.clientCompute.Projects.SetUsageExportBucket(project, &compute.UsageExportLocation{
+	op, err := config.NewComputeClient(userAgent).Projects.SetUsageExportBucket(project, &compute.UsageExportLocation{
 		ReportNamePrefix: d.Get("prefix").(string),
 		BucketName:       d.Get("bucket_name").(string),
 	}).Do()
@@ -123,14 +121,13 @@ func resourceProjectUsageBucketDelete(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return err
 	}
-	config.clientCompute.UserAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {
 		return err
 	}
 
-	op, err := config.clientCompute.Projects.SetUsageExportBucket(project, nil).Do()
+	op, err := config.NewComputeClient(userAgent).Projects.SetUsageExportBucket(project, nil).Do()
 	if err != nil {
 		return err
 	}

--- a/third_party/terraform/tests/data_source_google_compute_address_test.go
+++ b/third_party/terraform/tests/data_source_google_compute_address_test.go
@@ -153,7 +153,7 @@ func testAccCheckDataSourceComputeAddressDestroy(t *testing.T, name string) reso
 				return err
 			}
 
-			_, err = config.clientCompute.Addresses.Get(
+			_, err = config.NewComputeClient(config.userAgent).Addresses.Get(
 				config.Project, addressId.Region, addressId.Name).Do()
 			if err == nil {
 				return fmt.Errorf("Address still exists")

--- a/third_party/terraform/tests/data_source_google_compute_resource_policy_test.go.erb
+++ b/third_party/terraform/tests/data_source_google_compute_resource_policy_test.go.erb
@@ -88,7 +88,7 @@ func testAccCheckDataSourceComputeResourcePolicyDestroy(t *testing.T, name strin
 
 			policyAttrs := rs.Primary.Attributes
 
-			_, err := config.clientCompute.ResourcePolicies.Get(
+			_, err := config.NewComputeClient(config.userAgent).ResourcePolicies.Get(
 				config.Project, policyAttrs["region"], policyAttrs["name"]).Do()
 			if err == nil {
 				return fmt.Errorf("Resource Policy still exists")

--- a/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -1060,12 +1060,12 @@ func testAccCheckClearComposerEnvironmentFirewalls(t *testing.T, networkName str
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
 		config.Project = getTestProjectFromEnv()
-		network, err := config.clientCompute.Networks.Get(getTestProjectFromEnv(), networkName).Do()
+		network, err := config.NewComputeClient(config.userAgent).Networks.Get(getTestProjectFromEnv(), networkName).Do()
 		if err != nil {
 			return err
 		}
 
-		foundFirewalls, err := config.clientCompute.Firewalls.List(config.Project).Do()
+		foundFirewalls, err := config.NewComputeClient(config.userAgent).Firewalls.List(config.Project).Do()
 		if err != nil {
 			return fmt.Errorf("Unable to list firewalls for network %q: %s", network.Name, err)
 		}
@@ -1076,7 +1076,7 @@ func testAccCheckClearComposerEnvironmentFirewalls(t *testing.T, networkName str
 				continue
 			}
 			log.Printf("[DEBUG] Deleting firewall %q for test-resource network %q", firewall.Name, network.Name)
-			op, err := config.clientCompute.Firewalls.Delete(config.Project, firewall.Name).Do()
+			op, err := config.NewComputeClient(config.userAgent).Firewalls.Delete(config.Project, firewall.Name).Do()
 			if err != nil {
 				allErrors = multierror.Append(allErrors,
 					fmt.Errorf("Unable to delete firewalls for network %q: %s", network.Name, err))

--- a/third_party/terraform/tests/resource_compute_attached_disk_test.go
+++ b/third_party/terraform/tests/resource_compute_attached_disk_test.go
@@ -128,7 +128,7 @@ func testCheckAttachedDiskIsNowDetached(t *testing.T, instanceName, diskName str
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
 
-		instance, err := config.clientCompute.Instances.Get(getTestProjectFromEnv(), "us-central1-a", instanceName).Do()
+		instance, err := config.NewComputeClient(config.userAgent).Instances.Get(getTestProjectFromEnv(), "us-central1-a", instanceName).Do()
 		if err != nil {
 			return err
 		}
@@ -146,7 +146,7 @@ func testCheckAttachedDiskContainsManyDisks(t *testing.T, instanceName string, c
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
 
-		instance, err := config.clientCompute.Instances.Get(getTestProjectFromEnv(), "us-central1-a", instanceName).Do()
+		instance, err := config.NewComputeClient(config.userAgent).Instances.Get(getTestProjectFromEnv(), "us-central1-a", instanceName).Do()
 		if err != nil {
 			return err
 		}

--- a/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -189,7 +189,7 @@ func TestAccComputeDisk_imageDiffSuppressPublicVendorsFamilyNames(t *testing.T) 
 	for _, publicImageProject := range imageMap {
 		token := ""
 		for paginate := true; paginate; {
-			resp, err := config.clientCompute.Images.List(publicImageProject).Filter("deprecated.replacement ne .*images.*").PageToken(token).Do()
+			resp, err := config.NewComputeClient(config.userAgent).Images.List(publicImageProject).Filter("deprecated.replacement ne .*images.*").PageToken(token).Do()
 			if err != nil {
 				t.Fatalf("Can't list public images for project %q", publicImageProject)
 			}
@@ -470,7 +470,7 @@ func testAccCheckComputeDiskExists(t *testing.T, n, p string, disk *compute.Disk
 
 		config := googleProviderConfig(t)
 
-		found, err := config.clientCompute.Disks.Get(
+		found, err := config.NewComputeClient(config.userAgent).Disks.Get(
 			p, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"]).Do()
 		if err != nil {
 			return err

--- a/third_party/terraform/tests/resource_compute_http_health_check_test.go
+++ b/third_party/terraform/tests/resource_compute_http_health_check_test.go
@@ -60,7 +60,7 @@ func testAccCheckComputeHttpHealthCheckExists(t *testing.T, n string, healthChec
 
 		config := googleProviderConfig(t)
 
-		found, err := config.clientCompute.HttpHealthChecks.Get(
+		found, err := config.NewComputeClient(config.userAgent).HttpHealthChecks.Get(
 			config.Project, rs.Primary.Attributes["name"]).Do()
 		if err != nil {
 			return err

--- a/third_party/terraform/tests/resource_compute_image_test.go
+++ b/third_party/terraform/tests/resource_compute_image_test.go
@@ -169,7 +169,7 @@ func testAccCheckComputeImageExists(t *testing.T, n string, image *compute.Image
 
 		config := googleProviderConfig(t)
 
-		found, err := config.clientCompute.Images.Get(
+		found, err := config.NewComputeClient(config.userAgent).Images.Get(
 			config.Project, rs.Primary.Attributes["name"]).Do()
 		if err != nil {
 			return err
@@ -237,7 +237,7 @@ func testAccCheckComputeImageResolution(t *testing.T, n string) resource.TestChe
 		family := rs.Primary.Attributes["family"]
 		link := rs.Primary.Attributes["self_link"]
 
-		latestDebian, err := config.clientCompute.Images.GetFromFamily("debian-cloud", "debian-9").Do()
+		latestDebian, err := config.NewComputeClient(config.userAgent).Images.GetFromFamily("debian-cloud", "debian-9").Do()
 		if err != nil {
 			return fmt.Errorf("Error retrieving latest debian: %s", err)
 		}
@@ -260,7 +260,7 @@ func testAccCheckComputeImageResolution(t *testing.T, n string) resource.TestChe
 		}
 
 		for input, expectation := range images {
-			result, err := resolveImage(config, project, input)
+			result, err := resolveImage(config, project, input, config.userAgent)
 			if err != nil {
 				return fmt.Errorf("Error resolving input %s to image: %+v\n", input, err)
 			}

--- a/third_party/terraform/tests/resource_compute_instance_from_template_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_from_template_test.go
@@ -224,7 +224,7 @@ func testAccCheckComputeInstanceFromTemplateDestroyProducer(t *testing.T) func(s
 				continue
 			}
 
-			_, err := config.clientCompute.Instances.Get(
+			_, err := config.NewComputeClient(config.userAgent).Instances.Get(
 				config.Project, rs.Primary.Attributes["zone"], rs.Primary.ID).Do()
 			if err == nil {
 				return fmt.Errorf("Instance still exists")

--- a/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_instance_group_manager_test.go.erb
@@ -34,7 +34,7 @@ func testSweepComputeInstanceGroupManager(region string) error {
 		return err
 	}
 
-	found, err := config.clientCompute.InstanceGroupManagers.AggregatedList(config.Project).Do()
+	found, err := config.NewComputeClient(config.userAgent).InstanceGroupManagers.AggregatedList(config.Project).Do()
 	if err != nil {
 		log.Printf("[INFO][SWEEPER_LOG] Error in response from request: %s", err)
 		return nil
@@ -50,7 +50,7 @@ func testSweepComputeInstanceGroupManager(region string) error {
 			}
 
 			// Don't wait on operations as we may have a lot to delete
-			_, err := config.clientCompute.InstanceGroupManagers.Delete(config.Project, GetResourceNameFromSelfLink(zone), igm.Name).Do()
+			_, err := config.NewComputeClient(config.userAgent).InstanceGroupManagers.Delete(config.Project, GetResourceNameFromSelfLink(zone), igm.Name).Do()
 			if err != nil {
 				log.Printf("[INFO][SWEEPER_LOG] Error deleting %s resource %s : %s", resourceName, igm.Name, err)
 			} else {
@@ -374,7 +374,7 @@ func testAccCheckInstanceGroupManagerDestroyProducer(t *testing.T) func(s *terra
 			if rs.Type != "google_compute_instance_group_manager" {
 				continue
 			}
-			_, err := config.clientCompute.InstanceGroupManagers.Get(
+			_, err := config.NewComputeClient(config.userAgent).InstanceGroupManagers.Get(
 				config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"]).Do()
 			if err == nil {
 				return fmt.Errorf("InstanceGroupManager still exists")

--- a/third_party/terraform/tests/resource_compute_instance_group_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_group_test.go
@@ -179,7 +179,7 @@ func testAccComputeInstanceGroup_destroyProducer(t *testing.T) func(s *terraform
 			if rs.Type != "google_compute_instance_group" {
 				continue
 			}
-			_, err := config.clientCompute.InstanceGroups.Get(
+			_, err := config.NewComputeClient(config.userAgent).InstanceGroups.Get(
 				config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"]).Do()
 			if err == nil {
 				return fmt.Errorf("InstanceGroup still exists")
@@ -203,7 +203,7 @@ func testAccComputeInstanceGroup_exists(t *testing.T, n string, instanceGroup *c
 
 		config := googleProviderConfig(t)
 
-		found, err := config.clientCompute.InstanceGroups.Get(
+		found, err := config.NewComputeClient(config.userAgent).InstanceGroups.Get(
 			config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"]).Do()
 		if err != nil {
 			return err
@@ -228,7 +228,7 @@ func testAccComputeInstanceGroup_updated(t *testing.T, n string, size int64, ins
 
 		config := googleProviderConfig(t)
 
-		instanceGroup, err := config.clientCompute.InstanceGroups.Get(
+		instanceGroup, err := config.NewComputeClient(config.userAgent).InstanceGroups.Get(
 			config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"]).Do()
 		if err != nil {
 			return err
@@ -257,7 +257,7 @@ func testAccComputeInstanceGroup_named_ports(t *testing.T, n string, np map[stri
 
 		config := googleProviderConfig(t)
 
-		instanceGroup, err := config.clientCompute.InstanceGroups.Get(
+		instanceGroup, err := config.NewComputeClient(config.userAgent).InstanceGroups.Get(
 			config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"]).Do()
 		if err != nil {
 			return err
@@ -291,7 +291,7 @@ func testAccComputeInstanceGroup_hasCorrectNetwork(t *testing.T, nInstanceGroup 
 		if rsInstanceGroup.Primary.ID == "" {
 			return fmt.Errorf("No ID is set")
 		}
-		instanceGroup, err := config.clientCompute.InstanceGroups.Get(
+		instanceGroup, err := config.NewComputeClient(config.userAgent).InstanceGroups.Get(
 			config.Project, rsInstanceGroup.Primary.Attributes["zone"], rsInstanceGroup.Primary.Attributes["name"]).Do()
 		if err != nil {
 			return err
@@ -304,7 +304,7 @@ func testAccComputeInstanceGroup_hasCorrectNetwork(t *testing.T, nInstanceGroup 
 		if rsNetwork.Primary.ID == "" {
 			return fmt.Errorf("No ID is set")
 		}
-		network, err := config.clientCompute.Networks.Get(
+		network, err := config.NewComputeClient(config.userAgent).Networks.Get(
 			config.Project, rsNetwork.Primary.Attributes["name"]).Do()
 		if err != nil {
 			return err

--- a/third_party/terraform/tests/resource_compute_instance_migrate_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_migrate_test.go
@@ -103,7 +103,7 @@ func TestAccComputeInstanceMigrateState(t *testing.T) {
 			},
 		},
 	}
-	op, err := config.clientCompute.Instances.Insert(config.Project, config.Zone, instance).Do()
+	op, err := config.NewComputeClient(config.userAgent).Instances.Insert(config.Project, config.Zone, instance).Do()
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
@@ -175,7 +175,7 @@ func TestAccComputeInstanceMigrateState_bootDisk(t *testing.T) {
 			},
 		},
 	}
-	op, err := config.clientCompute.Instances.Insert(config.Project, zone, instance).Do()
+	op, err := config.NewComputeClient(config.userAgent).Instances.Insert(config.Project, zone, instance).Do()
 
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
@@ -243,7 +243,7 @@ func TestAccComputeInstanceMigrateState_v4FixBootDisk(t *testing.T) {
 			},
 		},
 	}
-	op, err := config.clientCompute.Instances.Insert(config.Project, zone, instance).Do()
+	op, err := config.NewComputeClient(config.userAgent).Instances.Insert(config.Project, zone, instance).Do()
 
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
@@ -297,7 +297,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromSource(t *testing.T) {
 		SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 		Zone:        zone,
 	}
-	op, err := config.clientCompute.Disks.Insert(config.Project, zone, disk).Do()
+	op, err := config.NewComputeClient(config.userAgent).Disks.Insert(config.Project, zone, disk).Do()
 	if err != nil {
 		t.Fatalf("Error creating disk: %s", err)
 	}
@@ -329,7 +329,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromSource(t *testing.T) {
 			},
 		},
 	}
-	op, err = config.clientCompute.Instances.Insert(config.Project, zone, instance).Do()
+	op, err = config.NewComputeClient(config.userAgent).Instances.Insert(config.Project, zone, instance).Do()
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
@@ -378,7 +378,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromSource(t *testing.T
 		SourceImage: "projects/debian-cloud/global/images/family/debian-9",
 		Zone:        zone,
 	}
-	op, err := config.clientCompute.Disks.Insert(config.Project, zone, disk).Do()
+	op, err := config.NewComputeClient(config.userAgent).Disks.Insert(config.Project, zone, disk).Do()
 	if err != nil {
 		t.Fatalf("Error creating disk: %s", err)
 	}
@@ -410,7 +410,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromSource(t *testing.T
 			},
 		},
 	}
-	op, err = config.clientCompute.Instances.Insert(config.Project, zone, instance).Do()
+	op, err = config.NewComputeClient(config.userAgent).Instances.Insert(config.Project, zone, instance).Do()
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
@@ -479,7 +479,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromEncryptionKey(t *testing
 			},
 		},
 	}
-	op, err := config.clientCompute.Instances.Insert(config.Project, zone, instance).Do()
+	op, err := config.NewComputeClient(config.userAgent).Instances.Insert(config.Project, zone, instance).Do()
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
@@ -548,7 +548,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromEncryptionKey(t *te
 			},
 		},
 	}
-	op, err := config.clientCompute.Instances.Insert(config.Project, zone, instance).Do()
+	op, err := config.NewComputeClient(config.userAgent).Instances.Insert(config.Project, zone, instance).Do()
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
@@ -619,7 +619,7 @@ func TestAccComputeInstanceMigrateState_attachedDiskFromAutoDeleteAndImage(t *te
 			},
 		},
 	}
-	op, err := config.clientCompute.Instances.Insert(config.Project, zone, instance).Do()
+	op, err := config.NewComputeClient(config.userAgent).Instances.Insert(config.Project, zone, instance).Do()
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
@@ -692,7 +692,7 @@ func TestAccComputeInstanceMigrateState_v4FixAttachedDiskFromAutoDeleteAndImage(
 			},
 		},
 	}
-	op, err := config.clientCompute.Instances.Insert(config.Project, zone, instance).Do()
+	op, err := config.NewComputeClient(config.userAgent).Instances.Insert(config.Project, zone, instance).Do()
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
@@ -760,7 +760,7 @@ func TestAccComputeInstanceMigrateState_scratchDisk(t *testing.T) {
 			},
 		},
 	}
-	op, err := config.clientCompute.Instances.Insert(config.Project, zone, instance).Do()
+	op, err := config.NewComputeClient(config.userAgent).Instances.Insert(config.Project, zone, instance).Do()
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
@@ -825,7 +825,7 @@ func TestAccComputeInstanceMigrateState_v4FixScratchDisk(t *testing.T) {
 			},
 		},
 	}
-	op, err := config.clientCompute.Instances.Insert(config.Project, zone, instance).Do()
+	op, err := config.NewComputeClient(config.userAgent).Instances.Insert(config.Project, zone, instance).Do()
 	if err != nil {
 		t.Fatalf("Error creating instance: %s", err)
 	}
@@ -901,7 +901,7 @@ func runInstanceMigrateTest(t *testing.T, id, testName string, version int, attr
 }
 
 func cleanUpInstance(config *Config, instanceName, zone string) {
-	op, err := config.clientCompute.Instances.Delete(config.Project, zone, instanceName).Do()
+	op, err := config.NewComputeClient(config.userAgent).Instances.Delete(config.Project, zone, instanceName).Do()
 	if err != nil {
 		log.Printf("[WARNING] Error deleting instance %q, dangling resources may exist: %s", instanceName, err)
 		return
@@ -915,7 +915,7 @@ func cleanUpInstance(config *Config, instanceName, zone string) {
 }
 
 func cleanUpDisk(config *Config, diskName, zone string) {
-	op, err := config.clientCompute.Disks.Delete(config.Project, zone, diskName).Do()
+	op, err := config.NewComputeClient(config.userAgent).Disks.Delete(config.Project, zone, diskName).Do()
 	if err != nil {
 		log.Printf("[WARNING] Error deleting disk %q, dangling resources may exist: %s", diskName, err)
 		return

--- a/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
@@ -912,7 +912,7 @@ func testAccCheckComputeInstanceTemplateDestroyProducer(t *testing.T) func(s *te
 			}
 
 			splits := strings.Split(rs.Primary.ID, "/")
-			_, err := config.clientCompute.InstanceTemplates.Get(
+			_, err := config.NewComputeClient(config.userAgent).InstanceTemplates.Get(
 				config.Project, splits[len(splits)-1]).Do()
 			if err == nil {
 				return fmt.Errorf("Instance template still exists")
@@ -953,7 +953,7 @@ func testAccCheckComputeInstanceTemplateExistsInProject(t *testing.T, n, p strin
 
 		splits := strings.Split(rs.Primary.ID, "/")
 		templateName := splits[len(splits)-1]
-		found, err := config.clientCompute.InstanceTemplates.Get(
+		found, err := config.NewComputeClient(config.userAgent).InstanceTemplates.Get(
 			p, templateName).Do()
 		if err != nil {
 			return err

--- a/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -44,7 +44,7 @@ func testSweepComputeInstance(region string) error {
 		return err
 	}
 
-	found, err := config.clientCompute.Instances.AggregatedList(config.Project).Do()
+	found, err := config.NewComputeClient(config.userAgent).Instances.AggregatedList(config.Project).Do()
 	if err != nil {
 		log.Printf("[INFO][SWEEPER_LOG] Error in response from request: %s", err)
 		return nil
@@ -60,7 +60,7 @@ func testSweepComputeInstance(region string) error {
 			}
 
 			// Don't wait on operations as we may have a lot to delete
-			_, err := config.clientCompute.Instances.Delete(config.Project, GetResourceNameFromSelfLink(zone), instance.Name).Do()
+			_, err := config.NewComputeClient(config.userAgent).Instances.Delete(config.Project, GetResourceNameFromSelfLink(zone), instance.Name).Do()
 			if err != nil {
 				log.Printf("[INFO][SWEEPER_LOG] Error deleting %s resource %s : %s", resourceName, instance.Name, err)
 			} else {
@@ -1904,7 +1904,7 @@ func testAccCheckComputeInstanceUpdateMachineType(t *testing.T, n string) resour
 
 		config := googleProviderConfig(t)
 
-		op, err := config.clientCompute.Instances.Stop(config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"]).Do()
+		op, err := config.NewComputeClient(config.userAgent).Instances.Stop(config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"]).Do()
 		if err != nil {
 			return fmt.Errorf("Could not stop instance: %s", err)
 		}
@@ -1917,7 +1917,7 @@ func testAccCheckComputeInstanceUpdateMachineType(t *testing.T, n string) resour
 			MachineType: "zones/us-central1-a/machineTypes/f1-micro",
 		}
 
-		op, err = config.clientCompute.Instances.SetMachineType(
+		op, err = config.NewComputeClient(config.userAgent).Instances.SetMachineType(
 			config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"], &machineType).Do()
 		if err != nil {
 			return fmt.Errorf("Could not change machine type: %s", err)
@@ -1939,7 +1939,7 @@ func testAccCheckComputeInstanceDestroyProducer(t *testing.T) func(s *terraform.
 				continue
 			}
 
-			_, err := config.clientCompute.Instances.Get(
+			_, err := config.NewComputeClient(config.userAgent).Instances.Get(
 				config.Project, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"]).Do()
 			if err == nil {
 				return fmt.Errorf("Instance still exists")
@@ -1978,7 +1978,7 @@ func testAccCheckComputeInstanceExistsInProject(t *testing.T, n, p string, insta
 
 		config := googleProviderConfig(t)
 
-		found, err := config.clientCompute.Instances.Get(
+		found, err := config.NewComputeClient(config.userAgent).Instances.Get(
 			p, rs.Primary.Attributes["zone"], rs.Primary.Attributes["name"]).Do()
 		if err != nil {
 			return err
@@ -2145,7 +2145,7 @@ func testAccCheckComputeInstanceBootDiskType(t *testing.T, instanceName string, 
 		config := googleProviderConfig(t)
 
 		// boot disk is named the same as the Instance
-		disk, err := config.clientCompute.Disks.Get(config.Project, "us-central1-a", instanceName).Do()
+		disk, err := config.NewComputeClient(config.userAgent).Disks.Get(config.Project, "us-central1-a", instanceName).Do()
 		if err != nil {
 			return err
 		}

--- a/third_party/terraform/tests/resource_compute_network_peering_test.go
+++ b/third_party/terraform/tests/resource_compute_network_peering_test.go
@@ -68,7 +68,7 @@ func testAccComputeNetworkPeeringDestroyProducer(t *testing.T) func(s *terraform
 				continue
 			}
 
-			_, err := config.clientCompute.Networks.Get(
+			_, err := config.NewComputeClient(config.userAgent).Networks.Get(
 				config.Project, rs.Primary.ID).Do()
 			if err == nil {
 				return fmt.Errorf("Network peering still exists")

--- a/third_party/terraform/tests/resource_compute_network_test.go
+++ b/third_party/terraform/tests/resource_compute_network_test.go
@@ -160,7 +160,7 @@ func testAccCheckComputeNetworkExists(t *testing.T, n string, network *compute.N
 
 		config := googleProviderConfig(t)
 
-		found, err := config.clientCompute.Networks.Get(
+		found, err := config.NewComputeClient(config.userAgent).Networks.Get(
 			config.Project, rs.Primary.Attributes["name"]).Do()
 		if err != nil {
 			return err
@@ -189,7 +189,7 @@ func testAccCheckComputeNetworkDefaultRoutesDeleted(t *testing.T, n string, netw
 
 		config := googleProviderConfig(t)
 
-		routes, err := config.clientCompute.Routes.List(config.Project).Filter(fmt.Sprintf("(network=\"%s\") AND (destRange=\"0.0.0.0/0\")", network.SelfLink)).Do()
+		routes, err := config.NewComputeClient(config.userAgent).Routes.List(config.Project).Filter(fmt.Sprintf("(network=\"%s\") AND (destRange=\"0.0.0.0/0\")", network.SelfLink)).Do()
 		if err != nil {
 			return err
 		}
@@ -206,7 +206,7 @@ func testAccCheckComputeNetworkIsAutoSubnet(t *testing.T, n string, network *com
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
 
-		found, err := config.clientCompute.Networks.Get(
+		found, err := config.NewComputeClient(config.userAgent).Networks.Get(
 			config.Project, network.Name).Do()
 		if err != nil {
 			return err
@@ -228,7 +228,7 @@ func testAccCheckComputeNetworkIsCustomSubnet(t *testing.T, n string, network *c
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
 
-		found, err := config.clientCompute.Networks.Get(
+		found, err := config.NewComputeClient(config.userAgent).Networks.Get(
 			config.Project, network.Name).Do()
 		if err != nil {
 			return err
@@ -259,7 +259,7 @@ func testAccCheckComputeNetworkHasRoutingMode(t *testing.T, n string, network *c
 			return fmt.Errorf("Routing mode not found on resource")
 		}
 
-		found, err := config.clientCompute.Networks.Get(
+		found, err := config.NewComputeClient(config.userAgent).Networks.Get(
 			config.Project, network.Name).Do()
 		if err != nil {
 			return err

--- a/third_party/terraform/tests/resource_compute_project_metadata_item_test.go
+++ b/third_party/terraform/tests/resource_compute_project_metadata_item_test.go
@@ -152,7 +152,7 @@ func testAccCheckProjectMetadataItemDestroyProducer(t *testing.T) func(s *terraf
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
 
-		project, err := config.clientCompute.Projects.Get(config.Project).Do()
+		project, err := config.NewComputeClient(config.userAgent).Projects.Get(config.Project).Do()
 		if err != nil {
 			return err
 		}

--- a/third_party/terraform/tests/resource_compute_project_metadata_test.go
+++ b/third_party/terraform/tests/resource_compute_project_metadata_test.go
@@ -110,7 +110,7 @@ func testAccCheckComputeProjectMetadataDestroyProducer(t *testing.T) func(s *ter
 				continue
 			}
 
-			project, err := config.clientCompute.Projects.Get(rs.Primary.ID).Do()
+			project, err := config.NewComputeClient(config.userAgent).Projects.Get(rs.Primary.ID).Do()
 			if err == nil && len(project.CommonInstanceMetadata.Items) > 0 {
 				return fmt.Errorf("Error, metadata items still exist in %s", rs.Primary.ID)
 			}

--- a/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go.erb
@@ -36,7 +36,7 @@ func testSweepComputeRegionInstanceGroupManager(region string) error {
 		return err
 	}
 
-	found, err := config.clientCompute.RegionInstanceGroupManagers.List(config.Project, region).Do()
+	found, err := config.NewComputeClient(config.userAgent).RegionInstanceGroupManagers.List(config.Project, region).Do()
 	if err != nil {
 		log.Printf("[INFO][SWEEPER_LOG] Error in response from request: %s", err)
 		return nil
@@ -51,7 +51,7 @@ func testSweepComputeRegionInstanceGroupManager(region string) error {
 		}
 
 		// Don't wait on operations as we may have a lot to delete
-		_, err := config.clientCompute.RegionInstanceGroupManagers.Delete(config.Project, region, rigm.Name).Do()
+		_, err := config.NewComputeClient(config.userAgent).RegionInstanceGroupManagers.Delete(config.Project, region, rigm.Name).Do()
 		if err != nil {
 			log.Printf("[INFO][SWEEPER_LOG] Error deleting %s resource %s : %s", resourceName, rigm.Name, err)
 		} else {
@@ -383,7 +383,7 @@ func testAccCheckRegionInstanceGroupManagerDestroyProducer(t *testing.T) func(s 
 			if rs.Type != "google_compute_region_instance_group_manager" {
 				continue
 			}
-			_, err := config.clientCompute.RegionInstanceGroupManagers.Get(
+			_, err := config.NewComputeClient(config.userAgent).RegionInstanceGroupManagers.Get(
 				rs.Primary.Attributes["project"], rs.Primary.Attributes["region"], rs.Primary.Attributes["name"]).Do()
 			if err == nil {
 				return fmt.Errorf("RegionInstanceGroupManager still exists")

--- a/third_party/terraform/tests/resource_compute_router_bgp_peer_test.go
+++ b/third_party/terraform/tests/resource_compute_router_bgp_peer_test.go
@@ -63,7 +63,7 @@ func testAccCheckComputeRouterPeerDestroyProducer(t *testing.T) func(s *terrafor
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
 
-		routersService := config.clientCompute.Routers
+		routersService := config.NewComputeClient(config.userAgent).Routers
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "google_compute_router" {
@@ -98,7 +98,7 @@ func testAccCheckComputeRouterPeerDelete(t *testing.T, n string) resource.TestCh
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
 
-		routersService := config.clientCompute.Routers
+		routersService := config.NewComputeClient(config.userAgent).Routers
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "google_compute_router_peer" {
@@ -163,7 +163,7 @@ func testAccCheckComputeRouterPeerExists(t *testing.T, n string) resource.TestCh
 		name := rs.Primary.Attributes["name"]
 		routerName := rs.Primary.Attributes["router"]
 
-		routersService := config.clientCompute.Routers
+		routersService := config.NewComputeClient(config.userAgent).Routers
 		router, err := routersService.Get(project, region, routerName).Do()
 
 		if err != nil {

--- a/third_party/terraform/tests/resource_compute_router_interface_test.go
+++ b/third_party/terraform/tests/resource_compute_router_interface_test.go
@@ -63,7 +63,7 @@ func testAccCheckComputeRouterInterfaceDestroyProducer(t *testing.T) func(s *ter
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
 
-		routersService := config.clientCompute.Routers
+		routersService := config.NewComputeClient(config.userAgent).Routers
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "google_compute_router" {
@@ -98,7 +98,7 @@ func testAccCheckComputeRouterInterfaceDelete(t *testing.T, n string) resource.T
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
 
-		routersService := config.clientCompute.Routers
+		routersService := config.NewComputeClient(config.userAgent).Routers
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "google_compute_router_interface" {
@@ -163,7 +163,7 @@ func testAccCheckComputeRouterInterfaceExists(t *testing.T, n string) resource.T
 		name := rs.Primary.Attributes["name"]
 		routerName := rs.Primary.Attributes["router"]
 
-		routersService := config.clientCompute.Routers
+		routersService := config.NewComputeClient(config.userAgent).Routers
 		router, err := routersService.Get(project, region, routerName).Do()
 
 		if err != nil {

--- a/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_router_nat_test.go.erb
@@ -177,7 +177,7 @@ func testAccCheckComputeRouterNatDestroyProducer(t *testing.T) func(s *terraform
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
 
-		routersService := config.clientCompute.Routers
+		routersService := config.NewComputeClient(config.userAgent).Routers
 
 		for _, rs := range s.RootModule().Resources {
 			if rs.Type != "google_compute_router" {

--- a/third_party/terraform/tests/resource_compute_shared_vpc_test.go
+++ b/third_party/terraform/tests/resource_compute_shared_vpc_test.go
@@ -56,7 +56,7 @@ func testAccCheckComputeSharedVpcHostProject(t *testing.T, hostProject string, e
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
 
-		found, err := config.clientCompute.Projects.Get(hostProject).Do()
+		found, err := config.NewComputeClient(config.userAgent).Projects.Get(hostProject).Do()
 		if err != nil {
 			return fmt.Errorf("Error reading project %s: %s", hostProject, err)
 		}
@@ -76,7 +76,7 @@ func testAccCheckComputeSharedVpcHostProject(t *testing.T, hostProject string, e
 func testAccCheckComputeSharedVpcServiceProject(t *testing.T, hostProject, serviceProject string, enabled bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
-		serviceHostProject, err := config.clientCompute.Projects.GetXpnHost(serviceProject).Do()
+		serviceHostProject, err := config.NewComputeClient(config.userAgent).Projects.GetXpnHost(serviceProject).Do()
 		if err != nil {
 			if enabled {
 				return fmt.Errorf("Expected service project to be enabled.")

--- a/third_party/terraform/tests/resource_compute_ssl_certificate_test.go
+++ b/third_party/terraform/tests/resource_compute_ssl_certificate_test.go
@@ -50,7 +50,7 @@ func testAccCheckComputeSslCertificateExists(t *testing.T, n string) resource.Te
 		// We don't specify a name, but it is saved during create
 		name := rs.Primary.Attributes["name"]
 
-		found, err := config.clientCompute.SslCertificates.Get(
+		found, err := config.NewComputeClient(config.userAgent).SslCertificates.Get(
 			config.Project, name).Do()
 		if err != nil {
 			return err

--- a/third_party/terraform/tests/resource_compute_ssl_policy_test.go
+++ b/third_party/terraform/tests/resource_compute_ssl_policy_test.go
@@ -170,7 +170,7 @@ func testAccCheckComputeSslPolicyExists(t *testing.T, n string, sslPolicy *compu
 
 		name := rs.Primary.Attributes["name"]
 
-		found, err := config.clientCompute.SslPolicies.Get(
+		found, err := config.NewComputeClient(config.userAgent).SslPolicies.Get(
 			project, name).Do()
 		if err != nil {
 			return fmt.Errorf("Error Reading SSL Policy %s: %s", name, err)

--- a/third_party/terraform/tests/resource_compute_subnetwork_test.go
+++ b/third_party/terraform/tests/resource_compute_subnetwork_test.go
@@ -345,7 +345,7 @@ func testAccCheckComputeSubnetworkExists(t *testing.T, n string, subnetwork *com
 		region := rs.Primary.Attributes["region"]
 		subnet_name := rs.Primary.Attributes["name"]
 
-		found, err := config.clientCompute.Subnetworks.Get(
+		found, err := config.NewComputeClient(config.userAgent).Subnetworks.Get(
 			config.Project, region, subnet_name).Do()
 		if err != nil {
 			return err

--- a/third_party/terraform/tests/resource_compute_target_http_proxy_test.go
+++ b/third_party/terraform/tests/resource_compute_target_http_proxy_test.go
@@ -55,7 +55,7 @@ func testAccCheckComputeTargetHttpProxyExists(t *testing.T, n string) resource.T
 		config := googleProviderConfig(t)
 		name := rs.Primary.Attributes["name"]
 
-		found, err := config.clientCompute.TargetHttpProxies.Get(
+		found, err := config.NewComputeClient(config.userAgent).TargetHttpProxies.Get(
 			config.Project, name).Do()
 		if err != nil {
 			return err

--- a/third_party/terraform/tests/resource_compute_target_https_proxy_test.go
+++ b/third_party/terraform/tests/resource_compute_target_https_proxy_test.go
@@ -62,7 +62,7 @@ func testAccCheckComputeTargetHttpsProxyExists(t *testing.T, n string, proxy *co
 		config := googleProviderConfig(t)
 		name := rs.Primary.Attributes["name"]
 
-		found, err := config.clientCompute.TargetHttpsProxies.Get(
+		found, err := config.NewComputeClient(config.userAgent).TargetHttpsProxies.Get(
 			config.Project, name).Do()
 		if err != nil {
 			return err

--- a/third_party/terraform/tests/resource_compute_target_pool_test.go
+++ b/third_party/terraform/tests/resource_compute_target_pool_test.go
@@ -88,7 +88,7 @@ func testAccCheckComputeTargetPoolDestroyProducer(t *testing.T) func(s *terrafor
 				continue
 			}
 
-			_, err := config.clientCompute.TargetPools.Get(
+			_, err := config.NewComputeClient(config.userAgent).TargetPools.Get(
 				config.Project, config.Region, rs.Primary.Attributes["name"]).Do()
 			if err == nil {
 				return fmt.Errorf("TargetPool still exists")
@@ -112,7 +112,7 @@ func testAccCheckComputeTargetPoolExists(t *testing.T, n string) resource.TestCh
 
 		config := googleProviderConfig(t)
 
-		found, err := config.clientCompute.TargetPools.Get(
+		found, err := config.NewComputeClient(config.userAgent).TargetPools.Get(
 			config.Project, config.Region, rs.Primary.Attributes["name"]).Do()
 		if err != nil {
 			return err

--- a/third_party/terraform/tests/resource_compute_target_ssl_proxy_test.go
+++ b/third_party/terraform/tests/resource_compute_target_ssl_proxy_test.go
@@ -54,7 +54,7 @@ func testAccCheckComputeTargetSslProxy(t *testing.T, n, proxyHeader, sslCert str
 		config := googleProviderConfig(t)
 		name := rs.Primary.Attributes["name"]
 
-		found, err := config.clientCompute.TargetSslProxies.Get(
+		found, err := config.NewComputeClient(config.userAgent).TargetSslProxies.Get(
 			config.Project, name).Do()
 		if err != nil {
 			return err

--- a/third_party/terraform/tests/resource_compute_target_tcp_proxy_test.go
+++ b/third_party/terraform/tests/resource_compute_target_tcp_proxy_test.go
@@ -52,7 +52,7 @@ func testAccCheckComputeTargetTcpProxyExists(t *testing.T, n string) resource.Te
 		config := googleProviderConfig(t)
 		name := rs.Primary.Attributes["name"]
 
-		found, err := config.clientCompute.TargetTcpProxies.Get(
+		found, err := config.NewComputeClient(config.userAgent).TargetTcpProxies.Get(
 			config.Project, name).Do()
 		if err != nil {
 			return err

--- a/third_party/terraform/tests/resource_compute_url_map_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_url_map_test.go.erb
@@ -162,7 +162,7 @@ func testAccCheckComputeUrlMapExists(t *testing.T, n string) resource.TestCheckF
 		config := googleProviderConfig(t)
 		name := rs.Primary.Attributes["name"]
 
-		found, err := config.clientCompute.UrlMaps.Get(
+		found, err := config.NewComputeClient(config.userAgent).UrlMaps.Get(
 			config.Project, name).Do()
 		if err != nil {
 			return err

--- a/third_party/terraform/tests/resource_dataflow_job_test.go
+++ b/third_party/terraform/tests/resource_dataflow_job_test.go
@@ -449,7 +449,7 @@ func testAccDataflowJobGetGeneratedInstanceTemplate(t *testing.T, s *terraform.S
 	var instanceTemplate *compute.InstanceTemplate
 
 	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
-		instanceTemplates, rerr := config.clientCompute.InstanceTemplates.
+		instanceTemplates, rerr := config.NewComputeClient(config.userAgent).InstanceTemplates.
 			List(config.Project).
 			Filter(filter).
 			MaxResults(2).

--- a/third_party/terraform/utils/bootstrap_utils_test.go
+++ b/third_party/terraform/utils/bootstrap_utils_test.go
@@ -229,7 +229,7 @@ func BootstrapSharedTestNetwork(t *testing.T, testId string) string {
 	}
 
 	log.Printf("[DEBUG] Getting shared test network %q", networkName)
-	_, err := config.clientCompute.Networks.Get(project, networkName).Do()
+	_, err := config.NewComputeClient(config.userAgent).Networks.Get(project, networkName).Do()
 	if err != nil && isGoogleApiErrorWithCode(err, 404) {
 		log.Printf("[DEBUG] Network %q not found, bootstrapping", networkName)
 		url := fmt.Sprintf("%sprojects/%s/global/networks", config.ComputeBasePath, project)
@@ -250,7 +250,7 @@ func BootstrapSharedTestNetwork(t *testing.T, testId string) string {
 		}
 	}
 
-	network, err := config.clientCompute.Networks.Get(project, networkName).Do()
+	network, err := config.NewComputeClient(config.userAgent).Networks.Get(project, networkName).Do()
 	if err != nil {
 		t.Errorf("Error getting shared test network %q: %s", networkName, err)
 	}

--- a/third_party/terraform/utils/compute_operation.go.erb
+++ b/third_party/terraform/utils/compute_operation.go.erb
@@ -123,7 +123,7 @@ func computeOperationWaitTime(config *Config, res interface{}, project, activity
 
 	w := &ComputeOperationWaiter{
 <% if version == 'ga' -%>
-		Service: config.clientCompute,
+		Service: config.NewComputeClient(userAgent),
 <% else -%>
 		Service: config.clientComputeBeta,
 <% end -%>

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -105,8 +105,6 @@ type Config struct {
 	ComposerBasePath string
 	clientComposer   *composer.Service
 
-	clientCompute   *compute.Service
-
 	ComputeBetaBasePath string
 	clientComputeBeta   *computeBeta.Service
 
@@ -247,14 +245,6 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 	// while most only want the host URL, some older ones also want the version and some
 	// of those "projects" as well. You can find out if this is required by looking at
 	// the basePath value in the client library file.
-	computeClientBasePath := c.ComputeBasePath + "projects/"
-	log.Printf("[INFO] Instantiating GCE client for path %s", computeClientBasePath)
-	c.clientCompute, err = compute.NewService(ctx, option.WithHTTPClient(client))
-	if err != nil {
-		return err
-	}
-	c.clientCompute.UserAgent = c.userAgent
-	c.clientCompute.BasePath = computeClientBasePath
 
 	computeBetaClientBasePath := c.ComputeBetaBasePath + "projects/"
 	log.Printf("[INFO] Instantiating GCE Beta client for path %s", computeBetaClientBasePath)

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -643,6 +643,22 @@ func (c *Config) getTokenSource(clientScopes []string) (oauth2.TokenSource, erro
 	return creds.TokenSource, nil
 }
 
+
+// methods to create new services from config
+func (c *Config) NewComputeClient(userAgent string) *compute.Service {
+	computeClientBasePath := c.ComputeBasePath + "projects/"
+	log.Printf("[INFO] Instantiating GCE client for path %s", computeClientBasePath)
+	clientCompute, err := compute.NewService(c.context, option.WithHTTPClient(c.client))
+	if err != nil {
+		log.Printf("[WARN] Error creating client compute: %s", err)
+		return nil
+	}
+	clientCompute.UserAgent = userAgent
+	clientCompute.BasePath = computeClientBasePath
+
+	return clientCompute
+}
+
 // staticTokenSource is used to be able to identify static token sources without reflection.
 type staticTokenSource struct {
 	oauth2.TokenSource

--- a/third_party/terraform/utils/config_test.go
+++ b/third_party/terraform/utils/config_test.go
@@ -84,7 +84,7 @@ func TestAccConfigLoadValidate_credentials(t *testing.T) {
 		t.Fatalf("error: %v", err)
 	}
 
-	_, err = config.clientCompute.Zones.Get(proj, "us-central1-a").Do()
+	_, err = config.NewComputeClient(config.userAgent).Zones.Get(proj, "us-central1-a").Do()
 	if err != nil {
 		t.Fatalf("expected call with loaded config client to work, got error: %s", err)
 	}
@@ -122,7 +122,7 @@ func TestAccConfigLoadValidate_accessToken(t *testing.T) {
 		t.Fatalf("error: %v", err)
 	}
 
-	_, err = config.clientCompute.Zones.Get(proj, "us-central1-a").Do()
+	_, err = config.NewComputeClient(config.userAgent).Zones.Get(proj, "us-central1-a").Do()
 	if err != nil {
 		t.Fatalf("expected API call with loaded config to work, got error: %s", err)
 	}

--- a/third_party/terraform/utils/utils.go.erb
+++ b/third_party/terraform/utils/utils.go.erb
@@ -376,9 +376,9 @@ func paginatedListRequest(project, baseUrl, userAgent string, config *Config, fl
 	return ls, nil
 }
 
-func getInterconnectAttachmentLink(config *Config, project, region, ic string) (string, error) {
+func getInterconnectAttachmentLink(config *Config, project, region, ic, userAgent string) (string, error) {
 	if !strings.Contains(ic, "/") {
-		icData, err := config.clientCompute.InterconnectAttachments.Get(
+		icData, err := config.NewComputeClient(userAgent).InterconnectAttachments.Get(
 			project, region, ic).Do()
 		if err != nil {
 			return "", fmt.Errorf("Error reading interconnect attachment: %s", err)

--- a/third_party/validator/compute_instance.go
+++ b/third_party/validator/compute_instance.go
@@ -234,6 +234,11 @@ func expandInstanceGuestAccelerators(d TerraformResourceData, config *Config) ([
 }
 
 func expandBootDisk(d TerraformResourceData, config *Config, project string) (*computeBeta.AttachedDisk, error) {
+	userAgent, err := generateUserAgentString(d, config.userAgent)
+	if err != nil {
+		return nil, err
+	}
+
 	disk := &computeBeta.AttachedDisk{
 		AutoDelete: d.Get("boot_disk.0.auto_delete").(bool),
 		Boot:       true,
@@ -285,7 +290,7 @@ func expandBootDisk(d TerraformResourceData, config *Config, project string) (*c
 
 		if v, ok := d.GetOk("boot_disk.0.initialize_params.0.image"); ok {
 			imageName := v.(string)
-			imageUrl, err := resolveImage(config, project, imageName)
+			imageUrl, err := resolveImage(config, project, imageName, userAgent)
 			if err != nil {
 				return nil, fmt.Errorf("Error resolving image name '%s': %s", imageName, err)
 			}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Remove `clientCompute` from `config` and replace with `config.NewComputeClient` which creates a new compute service for each API call.

Addresses https://github.com/hashicorp/terraform-provider-google/issues/7373

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
