### PR TITLE
Upstream resource_logging_project_sink exclusions

### DIFF
--- a/third_party/terraform/resources/resource_logging_sink.go
+++ b/third_party/terraform/resources/resource_logging_sink.go
@@ -2,7 +2,6 @@ package google
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -34,7 +33,6 @@ func resourceLoggingSinkSchema() map[string]*schema.Schema {
 		"exclusions": {
 			Type:        schema.TypeList,
 			Optional:    true,
-			Computed:    true,
 			Description: `Log entries that match any of the exclusion filters will not be exported. If a log entry is matched by both filter and one of exclusion_filters it will not be exported.`,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
@@ -193,12 +191,11 @@ func expandLoggingSinkExclusions(v interface{}) []*logging.LogExclusion {
 	results := make([]*logging.LogExclusion, 0, len(exclusions))
 	for _, e := range exclusions {
 		exclusion := e.(map[string]interface{})
-		disabled, _ := exclusion["disabled"].(bool)
 		results = append(results, &logging.LogExclusion{
 			Name:        exclusion["name"].(string),
 			Description: exclusion["description"].(string),
 			Filter:      exclusion["filter"].(string),
-			Disabled:    disabled,
+			Disabled:    exclusion["disabled"].(bool),
 		})
 	}
 	return results
@@ -214,7 +211,7 @@ func flattenLoggingSinkExclusion(exclusions []*logging.LogExclusion) []map[strin
 			"name":        e.Name,
 			"description": e.Description,
 			"filter":      e.Filter,
-			"disabled":    strconv.FormatBool(e.Disabled),
+			"disabled":    e.Disabled,
 		}
 		flattenedExclusions = append(flattenedExclusions, flattenedExclusion)
 

--- a/third_party/terraform/resources/resource_logging_sink.go
+++ b/third_party/terraform/resources/resource_logging_sink.go
@@ -54,9 +54,9 @@ func resourceLoggingSinkSchema() map[string]*schema.Schema {
 						Description: `An advanced logs filter that matches the log entries to be excluded. By using the sample function, you can exclude less than 100% of the matching log entries`,
 					},
 					"disabled": {
-						Type:        schema.TypeString,
+						Type:        schema.TypeBool,
 						Optional:    true,
-						Default:     "false",
+						Default:     false,
 						Description: `If set to True, then this exclusion is disabled and it does not exclude any log entries`,
 					},
 				},
@@ -193,7 +193,7 @@ func expandLoggingSinkExclusions(v interface{}) []*logging.LogExclusion {
 	results := make([]*logging.LogExclusion, 0, len(exclusions))
 	for _, e := range exclusions {
 		exclusion := e.(map[string]interface{})
-		disabled, _ := strconv.ParseBool(exclusion["disabled"].(string))
+		disabled, _ := exclusion["disabled"].(bool)
 		results = append(results, &logging.LogExclusion{
 			Name:        exclusion["name"].(string),
 			Description: exclusion["description"].(string),

--- a/third_party/terraform/tests/resource_logging_project_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_project_sink_test.go
@@ -117,6 +117,29 @@ func TestAccLoggingProjectSink_heredoc(t *testing.T) {
 	})
 }
 
+func TestAccLoggingProjectSink_loggingbucket(t *testing.T) {
+	t.Parallel()
+
+	sinkName := "tf-test-sink-" + randString(t, 10)
+	logBucketID := "tf-test-logbucket-" + randString(t, 10)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLoggingProjectSinkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingProjectSink_loggingbucket(sinkName, getTestProjectFromEnv(), logBucketID),
+			},
+			{
+				ResourceName:      "google_logging_project_sink.loggingbucket",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckLoggingProjectSinkDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
@@ -247,4 +270,33 @@ resource "google_bigquery_dataset" "logging_sink" {
   description = "Log sink (generated during acc test of terraform-provider-google(-beta))."
 }
 `, sinkName, getTestProjectFromEnv(), getTestProjectFromEnv(), bqDatasetID)
+}
+
+func testAccLoggingProjectSink_loggingbucket(name, project, logBucketID string) string {
+	return fmt.Sprintf(`
+resource "google_logging_project_sink" "loggingbucket" {
+  name        = "%s"
+  project     = "%s"
+  destination = "logging.googleapis.com/projects/%s/locations/global/buckets/${google_logging_project_bucket_config.logbucket.id}"
+  exclusions {
+		name = "ex1"
+		description = "test"
+		filter = "resource.type = k8s_container"
+	}
+
+	exclusions {
+		name = "ex2"
+		description = "test-2"
+		filter = "resource.type = k8s_container"
+	}
+
+  unique_writer_identity = false
+}
+
+resource "google_logging_project_bucket_config" "logbucket" {
+    location  = "global"
+    retention_days = 30
+    bucket_id = "%s"
+}
+`, name, project, project, logBucketID)
 }

--- a/third_party/terraform/tests/resource_logging_project_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_project_sink_test.go
@@ -121,7 +121,6 @@ func TestAccLoggingProjectSink_loggingbucket(t *testing.T) {
 	t.Parallel()
 
 	sinkName := "tf-test-sink-" + randString(t, 10)
-	logBucketID := "tf-test-logbucket-" + randString(t, 10)
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -129,7 +128,7 @@ func TestAccLoggingProjectSink_loggingbucket(t *testing.T) {
 		CheckDestroy: testAccCheckLoggingProjectSinkDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccLoggingProjectSink_loggingbucket(sinkName, getTestProjectFromEnv(), logBucketID),
+				Config: testAccLoggingProjectSink_loggingbucket(sinkName, getTestProjectFromEnv()),
 			},
 			{
 				ResourceName:      "google_logging_project_sink.loggingbucket",
@@ -272,12 +271,12 @@ resource "google_bigquery_dataset" "logging_sink" {
 `, sinkName, getTestProjectFromEnv(), getTestProjectFromEnv(), bqDatasetID)
 }
 
-func testAccLoggingProjectSink_loggingbucket(name, project, logBucketID string) string {
+func testAccLoggingProjectSink_loggingbucket(name, project string) string {
 	return fmt.Sprintf(`
 resource "google_logging_project_sink" "loggingbucket" {
   name        = "%s"
   project     = "%s"
-  destination = "logging.googleapis.com/projects/%s/locations/global/buckets/${google_logging_project_bucket_config.logbucket.id}"
+  destination = "logging.googleapis.com/projects/%s/locations/global/buckets/_Default"
   exclusions {
 		name = "ex1"
 		description = "test"
@@ -290,13 +289,8 @@ resource "google_logging_project_sink" "loggingbucket" {
 		filter = "resource.type = k8s_container"
 	}
 
-  unique_writer_identity = false
+  unique_writer_identity = true
 }
 
-resource "google_logging_project_bucket_config" "logbucket" {
-    location  = "global"
-    retention_days = 30
-    bucket_id = "%s"
-}
-`, name, project, project, logBucketID)
+`, name, project, project)
 }

--- a/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -86,6 +86,30 @@ resource "google_project_iam_binding" "log-writer" {
 }
 ```
 
+The following example uses `exclusions` to filter logs that will not be exported. In this example logs are exported to a [log bucket](https://cloud.google.com/logging/docs/buckets) and there are 2 exclusions configured
+
+```hcl
+resource "google_logging_project_sink" "log-bucket" {
+  name        = "my-logging-sink"
+  destination = "logging.googleapis.com/projects/my-project/locations/global/buckets/_Default"
+
+  exclusions {
+		name = "nsexcllusion1"
+		description = "Exclude logs from namespace-1 in k8s"
+		filter = "resource.type = k8s_container resource.labels.namespace_name=\"namespace-1\" "
+	}
+
+	exclusions {
+		name = "nsexcllusion2"
+		description = "Exclude logs from namespace-2 in k8s"
+		filter = "resource.type = k8s_container resource.labels.namespace_name=\"namespace-2\" "
+	}
+
+  unique_writer_identity = true
+```
+
+
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -115,12 +139,22 @@ The following arguments are supported:
 
 * `bigquery_options` - (Optional) Options that affect sinks exporting data to BigQuery. Structure documented below.
 
+* `exclusions` - (Optional) Log entries that match any of the exclusion filters will not be exported. If a log entry is matched by both filter and one of exclusion_filters it will not be exported.  Can be repeated multiple times for multiple exclusions. Structure is documented below.
+
 The `bigquery_options` block supports:
 
 * `use_partitioned_tables` - (Required) Whether to use [BigQuery's partition tables](https://cloud.google.com/bigquery/docs/partitioned-tables).
     By default, Logging creates dated tables based on the log entries' timestamps, e.g. syslog_20170523. With partitioned
     tables the date suffix is no longer present and [special query syntax](https://cloud.google.com/bigquery/docs/querying-partitioned-tables)
     has to be used instead. In both cases, tables are sharded based on UTC timezone.
+
+The `exclusions` block support:
+
+* `name` - (Required) A client-assigned identifier, such as `load-balancer-exclusion`. Identifiers are limited to 100 characters and can include only letters, digits, underscores, hyphens, and periods. First character has to be alphanumeric.
+* `description` - (Optional) A description of this exclusion.
+* `filter` - (Required) An advanced logs filter that matches the log entries to be excluded. By using the sample function, you can exclude less than 100% of the matching log entries. See [Advanced Log Filters](https://cloud.google.com/logging/docs/view/advanced_filters) for information on how to
+    write a filter.
+* `disabled` - (Optional) If set to True, then this exclusion is disabled and it does not exclude any log entries.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Upstreams: https://github.com/hashicorp/terraform-provider-google/pull/7335

Added as defined in https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.sinks#LogExclusion
Log entries that match any of the exclusion filters will not be exported.
If a log entry is matched by both filter and one of exclusion_filters it will not be exported.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
logging: Added support for exclusions options for `google_logging_project_sink `
```
