### PR TITLE
Add google_cloud_run_service datasource

### DIFF
--- a/third_party/terraform/data_sources/data_source_cloud_run_service.go
+++ b/third_party/terraform/data_sources/data_source_cloud_run_service.go
@@ -1,0 +1,30 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceGoogleCloudRunService() *schema.Resource {
+
+	dsSchema := datasourceSchemaFromResourceSchema(resourceCloudRunService().Schema)
+	addRequiredFieldsToSchema(dsSchema, "name", "location")
+	addOptionalFieldsToSchema(dsSchema, "project")
+
+	return &schema.Resource{
+		Read:   dataSourceGoogleCloudRunServiceRead,
+		Schema: dsSchema,
+	}
+}
+
+func dataSourceGoogleCloudRunServiceRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	id, err := replaceVars(d, config, "locations/{{location}}/namespaces/{{project}}/services/{{name}}")
+	if err != nil {
+		return fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+	return resourceCloudRunServiceRead(d, meta)
+}

--- a/third_party/terraform/tests/data_source_cloud_run_service_test.go
+++ b/third_party/terraform/tests/data_source_cloud_run_service_test.go
@@ -1,0 +1,106 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceGoogleCloudRunService_basic(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudRunServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleCloudRunService_basic(context),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceStateMatchesResourceState("data.google_cloud_run_service.foo", "google_cloud_run_service.foo"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceGoogleCloudRunService_optionalProject(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudRunServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleCloudRunService_optionalProject(context),
+				Check: resource.ComposeTestCheckFunc(
+					checkDataSourceStateMatchesResourceState("data.google_cloud_run_service.foo", "google_cloud_run_service.foo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleCloudRunService_basic(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_cloud_run_service" "foo" {
+  name     = "tf-test-cloudrun-srv%{random_suffix}"
+  location = "us-central1"
+
+  template {
+    spec {
+      containers {
+        image = "gcr.io/cloudrun/hello"
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+}
+
+data "google_cloud_run_service" "foo" {
+  name     = google_cloud_run_service.foo.name
+  location = google_cloud_run_service.foo.location
+  project  = google_cloud_run_service.foo.project
+}
+`, context)
+}
+
+func testAccDataSourceGoogleCloudRunService_optionalProject(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_cloud_run_service" "foo" {
+  name     = "tf-test-cloudrun-srv%{random_suffix}"
+  location = "us-central1"
+
+  template {
+    spec {
+      containers {
+        image = "gcr.io/cloudrun/hello"
+      }
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+}
+
+data "google_cloud_run_service" "foo" {
+  name     = google_cloud_run_service.foo.name
+  location = google_cloud_run_service.foo.location
+}
+`, context)
+}

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -170,6 +170,7 @@ func Provider() *schema.Provider {
 			"google_cloud_identity_groups":                     dataSourceGoogleCloudIdentityGroups(),
 			"google_cloud_identity_group_memberships":          dataSourceGoogleCloudIdentityGroupMemberships(),
 			<% end -%>
+			"google_cloud_run_service":                         dataSourceGoogleCloudRunService(),
 			"google_composer_image_versions":                   dataSourceGoogleComposerImageVersions(),
 			"google_compute_address":                           dataSourceGoogleComputeAddress(),
 			"google_compute_backend_service":                   dataSourceGoogleComputeBackendService(),

--- a/third_party/terraform/website/docs/d/cloud_run_service.html.markdown
+++ b/third_party/terraform/website/docs/d/cloud_run_service.html.markdown
@@ -1,0 +1,40 @@
+---
+subcategory: "Cloud Run"
+layout: "google"
+page_title: "Google: google_cloud_run_service"
+sidebar_current: "docs-google-datasource-cloud-run-service"
+description: |-
+  Get information about a Google Cloud Run Service.
+---
+
+# google\_cloud\_run\_service
+
+Get information about a Google Cloud Run. For more information see
+the [official documentation](https://cloud.google.com/run/docs/)
+and [API](https://cloud.google.com/run/docs/apis).
+
+## Example Usage
+
+```hcl
+data "google_cloud_run_service" "run-service" {
+  name = "my-service"
+  location = "us-central1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the Cloud Run Service.
+
+* `location` - (Required) The location of the cloud run instance. eg us-central1
+
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+## Attributes Reference
+
+See [google_cloud_run_service](https://www.terraform.io/docs/providers/google/r/cloud_run_service.html#argument-reference) resource for details of the available attributes.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Upstreams https://github.com/hashicorp/terraform-provider-google/pull/7388

Fixes https://github.com/hashicorp/terraform-provider-google/issues/7363

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudrun: Add support for a `google_cloud_run_service` datasource
```
