### PR TITLE
feat: Add forwarding_path to google_dns_policy

### DIFF
--- a/products/dns/api.yaml
+++ b/products/dns/api.yaml
@@ -312,6 +312,15 @@ objects:
                   name: 'ipv4Address'
                   required: true
                   description: 'IPv4 address to forward to.'
+                - !ruby/object:Api::Type::Enum
+                  name: 'forwardingPath'
+                  description: |
+                    Forwarding path for this TargetNameServer. If unset or `default` Cloud DNS will make forwarding
+                    decision based on address ranges, i.e. RFC1918 addresses go to the VPC, Non-RFC1918 addresses go
+                    to the Internet. When set to `private`, Cloud DNS will always send queries through VPC for this target
+                  values:
+                  - :default
+                  - :private
       - !ruby/object:Api::Type::String
         name: 'description'
         description: |

--- a/templates/terraform/examples/dns_policy_basic.tf.erb
+++ b/templates/terraform/examples/dns_policy_basic.tf.erb
@@ -6,7 +6,8 @@ resource "google_dns_policy" "<%= ctx[:primary_resource_id] %>" {
 
   alternative_name_server_config {
     target_name_servers {
-      ipv4_address = "172.16.1.10"
+      ipv4_address    = "172.16.1.10"
+      forwarding_path = "private"
     }
     target_name_servers {
       ipv4_address = "172.16.1.20"

--- a/third_party/terraform/tests/resource_dns_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_dns_policy_test.go.erb
@@ -19,7 +19,7 @@ func TestAccDNSPolicy_update(t *testing.T) {
 		CheckDestroy: testAccCheckDNSPolicyDestroyProducer(t),
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDnsPolicy_privateUpdate(policySuffix, "true", "172.16.1.10", "network-1"),
+				Config: testAccDnsPolicy_privateUpdate(policySuffix, "true", "172.16.1.10", "172.16.1.30", "network-1"),
 			},
 			resource.TestStep{
 				ResourceName:      "google_dns_policy.example-policy",
@@ -27,7 +27,7 @@ func TestAccDNSPolicy_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			resource.TestStep{
-				Config: testAccDnsPolicy_privateUpdate(policySuffix, "false", "172.16.1.20", "network-2"),
+				Config: testAccDnsPolicy_privateUpdate(policySuffix, "false", "172.16.1.20", "172.16.1.40", "network-2"),
 			},
 			resource.TestStep{
 				ResourceName:      "google_dns_policy.example-policy",
@@ -38,7 +38,7 @@ func TestAccDNSPolicy_update(t *testing.T) {
 	})
 }
 
-func testAccDnsPolicy_privateUpdate(suffix, forwarding, nameserver, network string) string {
+func testAccDnsPolicy_privateUpdate(suffix, forwarding, first_nameserver, second_nameserver, network string) string {
 	return fmt.Sprintf(`
 resource "google_dns_policy" "example-policy" {
   name                      = "example-policy-%s"
@@ -47,6 +47,10 @@ resource "google_dns_policy" "example-policy" {
   alternative_name_server_config {
     target_name_servers {
       ipv4_address = "%s"
+    }
+	target_name_servers {
+	  ipv4_address    = "%s"
+	  forwarding_path = "private"
     }
   }
 
@@ -64,5 +68,5 @@ resource "google_compute_network" "network-2" {
   name                    = "network-2-%s"
   auto_create_subnetworks = false
 }
-`, suffix, forwarding, nameserver, network, suffix, suffix)
+`, suffix, forwarding, first_nameserver, second_nameserver, network, suffix, suffix)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
fixes https://github.com/hashicorp/terraform-provider-google/issues/7413

P.S: This is my first PR to MM so if there are any conventions I should be following please lmk.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dns: added `forwarding_path` field to `google_dns_policy` resource
```
