### PR TITLE
Stateful MIG -> GA

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -8579,7 +8579,6 @@ objects:
   - !ruby/object:Api::Resource
     name: 'PerInstanceConfig'
     base_url:  'projects/{{project}}/zones/{{zone}}/instanceGroupManagers/{{instance_group_manager}}'
-    min_version: beta
     description: |
       A config defined for a single managed instance that belongs to an instance group manager. It preserves the instance name
       across instance group manager operations and can define stateful disks or metadata that are unique to the instance.
@@ -8699,7 +8698,6 @@ objects:
   - !ruby/object:Api::Resource
     name: 'RegionPerInstanceConfig'
     base_url:  'projects/{{project}}/regions/{{region}}/instanceGroupManagers/{{region_instance_group_manager}}'
-    min_version: beta
     description: |
       A config defined for a single managed instance that belongs to an instance group manager. It preserves the instance name
       across instance group manager operations and can define stateful disks or metadata that are unique to the instance.

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -8598,7 +8598,7 @@ objects:
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Official Documentation': 'https://cloud.google.com/compute/docs/instance-groups/stateful-migs#per-instance_configs'
-      api: 'https://cloud.google.com/compute/docs/reference/rest/beta/instanceGroupManagers'
+      api: 'https://cloud.google.com/compute/docs/reference/rest/v1/instanceGroupManagers'
     async: !ruby/object:Api::OpAsync
       operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
@@ -8718,7 +8718,7 @@ objects:
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Official Documentation': 'https://cloud.google.com/compute/docs/instance-groups/stateful-migs#per-instance_configs'
-      api: 'https://cloud.google.com/compute/docs/reference/rest/beta/instanceGroupManagers'
+      api: 'https://cloud.google.com/compute/docs/reference/rest/v1/instanceGroupManagers'
     async: !ruby/object:Api::OpAsync
       operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'

--- a/third_party/terraform/resources/resource_compute_instance_group_manager.go
+++ b/third_party/terraform/resources/resource_compute_instance_group_manager.go
@@ -1,5 +1,3 @@
-// <% autogen_exception -%>
-
 package google
 
 import (
@@ -264,7 +262,6 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 				Default:     false,
 				Description: `Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out.`,
 			},
-<% unless version == 'ga' -%>
 			"stateful_disk": {
 				Type:        schema.TypeSet,
 				Optional:    true,
@@ -287,7 +284,6 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 					},
 				},
 			},
-<% end -%>
 			"operation": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -350,9 +346,7 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 		AutoHealingPolicies: expandAutoHealingPolicies(d.Get("auto_healing_policies").([]interface{})),
 		Versions:            expandVersions(d.Get("version").([]interface{})),
 		UpdatePolicy:        expandUpdatePolicy(d.Get("update_policy").([]interface{})),
-<% unless version == 'ga' -%>
-		StatefulPolicy: expandStatefulPolicy(d.Get("stateful_disk").(*schema.Set).List()),
-<% end -%>
+		StatefulPolicy:      expandStatefulPolicy(d.Get("stateful_disk").(*schema.Set).List()),
 		// Force send TargetSize to allow a value of 0.
 		ForceSendFields: []string{"TargetSize"},
 	}
@@ -470,7 +464,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	if err != nil {
 		return err
 	}
-	
+
 	project, err := getProject(d, config)
 	if err != nil {
 		return err
@@ -490,7 +484,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 		err = computeOperationWaitTime(config, op, project, "Creating InstanceGroupManager", userAgent, d.Timeout(schema.TimeoutCreate))
 		if err != nil {
 			// remove from state to allow refresh to finish
-			log.Printf("[DEBUG] Resumed operation returned an error, removing from state: %s",err)
+			log.Printf("[DEBUG] Resumed operation returned an error, removing from state: %s", err)
 			d.SetId("")
 			return nil
 		}
@@ -530,11 +524,9 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	if err = d.Set("named_port", flattenNamedPortsBeta(manager.NamedPorts)); err != nil {
 		return fmt.Errorf("Error setting named_port in state: %s", err.Error())
 	}
-<% unless version == 'ga' -%>
 	if err = d.Set("stateful_disk", flattenStatefulPolicy(manager.StatefulPolicy)); err != nil {
 		return fmt.Errorf("Error setting stateful_disk in state: %s", err.Error())
 	}
-<% end -%>
 	if err := d.Set("fingerprint", manager.Fingerprint); err != nil {
 		return fmt.Errorf("Error setting fingerprint: %s", err)
 	}
@@ -615,13 +607,11 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 		change = true
 	}
 
-<% unless version == 'ga' -%>
 	if d.HasChange("stateful_disk") {
 		updatedManager.StatefulPolicy = expandStatefulPolicy(d.Get("stateful_disk").(*schema.Set).List())
 		change = true
 	}
 
-<% end -%>
 	if change {
 		op, err := config.NewComputeBetaClient(userAgent).InstanceGroupManagers.Patch(project, zone, d.Get("name").(string), updatedManager).Do()
 		if err != nil {
@@ -756,7 +746,6 @@ func expandAutoHealingPolicies(configured []interface{}) []*computeBeta.Instance
 	return autoHealingPolicies
 }
 
-<% unless version == 'ga' -%>
 func expandStatefulPolicy(configured []interface{}) *computeBeta.StatefulPolicy {
 	disks := make(map[string]computeBeta.StatefulPolicyPreservedStateDiskDevice)
 	for _, raw := range configured {
@@ -772,7 +761,6 @@ func expandStatefulPolicy(configured []interface{}) *computeBeta.StatefulPolicy 
 	return nil
 }
 
-<% end -%>
 func expandVersions(configured []interface{}) []*computeBeta.InstanceGroupManagerVersion {
 	versions := make([]*computeBeta.InstanceGroupManagerVersion, 0, len(configured))
 	for _, raw := range configured {
@@ -863,7 +851,6 @@ func flattenAutoHealingPolicies(autoHealingPolicies []*computeBeta.InstanceGroup
 	return autoHealingPoliciesSchema
 }
 
-<% unless version == 'ga' -%>
 func flattenStatefulPolicy(statefulPolicy *computeBeta.StatefulPolicy) []map[string]interface{} {
 	if statefulPolicy == nil || statefulPolicy.PreservedState == nil || statefulPolicy.PreservedState.Disks == nil {
 		return make([]map[string]interface{}, 0, 0)
@@ -880,7 +867,6 @@ func flattenStatefulPolicy(statefulPolicy *computeBeta.StatefulPolicy) []map[str
 	return result
 }
 
-<% end -%>
 func flattenUpdatePolicy(updatePolicy *computeBeta.InstanceGroupManagerUpdatePolicy) []map[string]interface{} {
 	results := []map[string]interface{}{}
 	if updatePolicy != nil {

--- a/third_party/terraform/resources/resource_compute_region_instance_group_manager.go
+++ b/third_party/terraform/resources/resource_compute_region_instance_group_manager.go
@@ -1,5 +1,3 @@
-// <% autogen_exception -%>
-
 package google
 
 import (
@@ -284,7 +282,6 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 					},
 				},
 			},
-<% unless version == 'ga' -%>
 
 			"stateful_disk": {
 				Type:        schema.TypeSet,
@@ -308,7 +305,6 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 					},
 				},
 			},
-<% end -%>
 		},
 	}
 }
@@ -341,9 +337,7 @@ func resourceComputeRegionInstanceGroupManagerCreate(d *schema.ResourceData, met
 		Versions:            expandVersions(d.Get("version").([]interface{})),
 		UpdatePolicy:        expandRegionUpdatePolicy(d.Get("update_policy").([]interface{})),
 		DistributionPolicy:  expandDistributionPolicy(d.Get("distribution_policy_zones").(*schema.Set)),
-<% unless version == 'ga' -%>
-		StatefulPolicy: expandStatefulPolicy(d.Get("stateful_disk").(*schema.Set).List()),
-<% end -%>
+		StatefulPolicy:      expandStatefulPolicy(d.Get("stateful_disk").(*schema.Set).List()),
 		// Force send TargetSize to allow size of 0.
 		ForceSendFields: []string{"TargetSize"},
 	}
@@ -476,12 +470,10 @@ func resourceComputeRegionInstanceGroupManagerRead(d *schema.ResourceData, meta 
 	if err := d.Set("update_policy", flattenRegionUpdatePolicy(manager.UpdatePolicy)); err != nil {
 		return fmt.Errorf("Error setting update_policy in state: %s", err.Error())
 	}
-<% unless version == 'ga' -%>
 	if err = d.Set("stateful_disk", flattenStatefulPolicy(manager.StatefulPolicy)); err != nil {
 		return fmt.Errorf("Error setting stateful_disk in state: %s", err.Error())
 	}
 
-<% end -%>
 	if d.Get("wait_for_instances").(bool) {
 		conf := resource.StateChangeConf{
 			Pending: []string{"creating", "error"},
@@ -542,13 +534,11 @@ func resourceComputeRegionInstanceGroupManagerUpdate(d *schema.ResourceData, met
 		change = true
 	}
 
-<% unless version == 'ga' -%>
 	if d.HasChange("stateful_disk") {
 		updatedManager.StatefulPolicy = expandStatefulPolicy(d.Get("stateful_disk").(*schema.Set).List())
 		change = true
 	}
 
-<% end -%>
 	if change {
 		op, err := config.NewComputeBetaClient(userAgent).RegionInstanceGroupManagers.Patch(project, region, d.Get("name").(string), updatedManager).Do()
 		if err != nil {

--- a/third_party/terraform/tests/resource_compute_instance_group_manager_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_group_manager_test.go
@@ -1,8 +1,9 @@
-<% autogen_exception -%>
 package google
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -331,7 +332,6 @@ func TestAccInstanceGroupManager_autoHealingPolicies(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccInstanceGroupManager_stateful(t *testing.T) {
 	t.Parallel()
 
@@ -365,7 +365,6 @@ func TestAccInstanceGroupManager_stateful(t *testing.T) {
 	})
 }
 
-<% end -%>
 func testAccCheckInstanceGroupManagerDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
@@ -1218,7 +1217,6 @@ resource "google_compute_instance_group_manager" "igm-basic" {
 `, primaryTemplate, canaryTemplate, igm)
 }
 
-<% unless version == 'ga' -%>
 func testAccInstanceGroupManager_stateful(template, target, igm, hck string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -1367,4 +1365,3 @@ resource "google_compute_http_health_check" "zero" {
 }
 `, template, target, igm, hck)
 }
-<% end -%>

--- a/third_party/terraform/tests/resource_compute_per_instance_config_test.go
+++ b/third_party/terraform/tests/resource_compute_per_instance_config_test.go
@@ -1,7 +1,5 @@
-<% autogen_exception -%>
 package google
 
-<% unless version == 'ga' -%>
 import (
 	"fmt"
 	"testing"
@@ -10,23 +8,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccComputeRegionPerInstanceConfig_statefulBasic(t *testing.T) {
+func TestAccComputePerInstanceConfig_statefulBasic(t *testing.T) {
 	// Multiple fine-grained resources
 	skipIfVcr(t)
 	t.Parallel()
 
 	suffix := randString(t, 10)
-	rigmName := fmt.Sprintf("tf-test-rigm-%s", suffix)
+	igmName := fmt.Sprintf("tf-test-igm-%s", suffix)
 	context := map[string]interface{}{
-		"rigm_name": rigmName,
+		"igm_name": igmName,
 		"random_suffix": suffix,
 		"config_name" : fmt.Sprintf("instance-%s", randString(t, 10)),
 		"config_name2" : fmt.Sprintf("instance-%s", randString(t, 10)),
 		"config_name3" : fmt.Sprintf("instance-%s", randString(t, 10)),
 		"config_name4" : fmt.Sprintf("instance-%s", randString(t, 10)),
 	}
-	rigmId := fmt.Sprintf("projects/%s/regions/%s/instanceGroupManagers/%s",
-		getTestProjectFromEnv(), "us-central1", rigmName)
+	igmId := fmt.Sprintf("projects/%s/zones/%s/instanceGroupManagers/%s",
+		getTestProjectFromEnv(), "us-central1-c", igmName)
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -34,68 +32,68 @@ func TestAccComputeRegionPerInstanceConfig_statefulBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Create one endpoint
-				Config: testAccComputeRegionPerInstanceConfig_statefulBasic(context),
+				Config: testAccComputePerInstanceConfig_statefulBasic(context),
 			},
 			{
-				ResourceName:      "google_compute_region_per_instance_config.default",
+				ResourceName:      "google_compute_per_instance_config.default",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
 				// Force-recreate old config
-				Config: testAccComputeRegionPerInstanceConfig_statefulModified(context),
+				Config: testAccComputePerInstanceConfig_statefulModified(context),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputeRegionPerInstanceConfigDestroyed(t, rigmId, context["config_name"].(string)),
+					testAccCheckComputePerInstanceConfigDestroyed(t, igmId, context["config_name"].(string)),
 				),
 			},
 			{
-				ResourceName:      "google_compute_region_per_instance_config.default",
+				ResourceName:      "google_compute_per_instance_config.default",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
 				// Add two new endpoints
-				Config: testAccComputeRegionPerInstanceConfig_statefulAdditional(context),
+				Config: testAccComputePerInstanceConfig_statefulAdditional(context),
 			},
 			{
-				ResourceName:      "google_compute_region_per_instance_config.default",
+				ResourceName:      "google_compute_per_instance_config.default",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
-				ResourceName:            "google_compute_region_per_instance_config.with_disks",
+				ResourceName:            "google_compute_per_instance_config.with_disks",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"most_disruptive_allowed_action", "minimal_action", "remove_instance_state_on_destroy"},
 			},
 			{
-				ResourceName:      "google_compute_region_per_instance_config.add2",
+				ResourceName:      "google_compute_per_instance_config.add2",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
 				// delete all configs
-				Config: testAccComputeRegionPerInstanceConfig_rigm(context),
+				Config: testAccComputePerInstanceConfig_igm(context),
 				Check: resource.ComposeTestCheckFunc(
 					// Config with remove_instance_state_on_destroy = false won't be destroyed (config4)
-					testAccCheckComputeRegionPerInstanceConfigDestroyed(t, rigmId, context["config_name2"].(string)),
-					testAccCheckComputeRegionPerInstanceConfigDestroyed(t, rigmId, context["config_name3"].(string)),
+					testAccCheckComputePerInstanceConfigDestroyed(t, igmId, context["config_name2"].(string)),
+					testAccCheckComputePerInstanceConfigDestroyed(t, igmId, context["config_name3"].(string)),
 				),
 			},
 		},
 	})
 }
 
-func TestAccComputeRegionPerInstanceConfig_update(t *testing.T) {
+func TestAccComputePerInstanceConfig_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
 		"random_suffix": randString(t, 10),
-		"rigm_name": fmt.Sprintf("tf-test-rigm-%s", randString(t, 10)),
+		"igm_name": fmt.Sprintf("tf-test-igm-%s", randString(t, 10)),
 		"config_name" : fmt.Sprintf("instance-%s", randString(t, 10)),
 	}
 
@@ -105,20 +103,20 @@ func TestAccComputeRegionPerInstanceConfig_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Create one config
-				Config: testAccComputeRegionPerInstanceConfig_statefulBasic(context),
+				Config: testAccComputePerInstanceConfig_statefulBasic(context),
 			},
 			{
-				ResourceName:      "google_compute_region_per_instance_config.default",
+				ResourceName:      "google_compute_per_instance_config.default",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
 				// Update an existing config
-				Config: testAccComputeRegionPerInstanceConfig_update(context),
+				Config: testAccComputePerInstanceConfig_update(context),
 			},
 			{
-				ResourceName:      "google_compute_region_per_instance_config.default",
+				ResourceName:      "google_compute_per_instance_config.default",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
@@ -127,11 +125,11 @@ func TestAccComputeRegionPerInstanceConfig_update(t *testing.T) {
 	})
 }
 
-func testAccComputeRegionPerInstanceConfig_statefulBasic(context map[string]interface{}) string {
+func testAccComputePerInstanceConfig_statefulBasic(context map[string]interface{}) string {
 	return Nprintf(`
-resource "google_compute_region_per_instance_config" "default" {
-	region = google_compute_region_instance_group_manager.rigm.region
-	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
+resource "google_compute_per_instance_config" "default" {
+	zone = google_compute_instance_group_manager.igm.zone
+	instance_group_manager = google_compute_instance_group_manager.igm.name
 	name = "%{config_name}"
 	remove_instance_state_on_destroy = true
 	preserved_state {
@@ -140,31 +138,31 @@ resource "google_compute_region_per_instance_config" "default" {
 		}
 	}
 }
-`, context) + testAccComputeRegionPerInstanceConfig_rigm(context)
+`, context) + testAccComputePerInstanceConfig_igm(context)
 }
 
-func testAccComputeRegionPerInstanceConfig_update(context map[string]interface{}) string {
+func testAccComputePerInstanceConfig_update(context map[string]interface{}) string {
 	return Nprintf(`
-resource "google_compute_region_per_instance_config" "default" {
-	region = google_compute_region_instance_group_manager.rigm.region
-	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
+resource "google_compute_per_instance_config" "default" {
+	zone = google_compute_instance_group_manager.igm.zone
+	instance_group_manager = google_compute_instance_group_manager.igm.name
 	name = "%{config_name}"
 	remove_instance_state_on_destroy = true
 	preserved_state {
 		metadata = {
-			asdf = "foo"
-			updated = "12345"
+			asdf = "asdf"
+			update = "12345"
 		}
 	}
 }
-`, context) + testAccComputeRegionPerInstanceConfig_rigm(context)
+`, context) + testAccComputePerInstanceConfig_igm(context)
 }
 
-func testAccComputeRegionPerInstanceConfig_statefulModified(context map[string]interface{}) string {
+func testAccComputePerInstanceConfig_statefulModified(context map[string]interface{}) string {
 	return Nprintf(`
-resource "google_compute_region_per_instance_config" "default" {
-	region = google_compute_region_instance_group_manager.rigm.region
-	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
+resource "google_compute_per_instance_config" "default" {
+	zone = google_compute_instance_group_manager.igm.zone
+	instance_group_manager = google_compute_instance_group_manager.igm.name
 	name = "%{config_name2}"
 	remove_instance_state_on_destroy = true
 	preserved_state {
@@ -173,14 +171,14 @@ resource "google_compute_region_per_instance_config" "default" {
 		}
 	}
 }
-`, context) + testAccComputeRegionPerInstanceConfig_rigm(context)
+`, context) + testAccComputePerInstanceConfig_igm(context)
 }
 
-func testAccComputeRegionPerInstanceConfig_statefulAdditional(context map[string]interface{}) string {
+func testAccComputePerInstanceConfig_statefulAdditional(context map[string]interface{}) string {
 	return Nprintf(`
-resource "google_compute_region_per_instance_config" "default" {
-	region = google_compute_region_instance_group_manager.rigm.region
-	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
+resource "google_compute_per_instance_config" "default" {
+	zone = google_compute_instance_group_manager.igm.zone
+	instance_group_manager = google_compute_instance_group_manager.igm.name
 	name = "%{config_name2}"
 	remove_instance_state_on_destroy = true
 	preserved_state {
@@ -190,9 +188,9 @@ resource "google_compute_region_per_instance_config" "default" {
 	}
 }
 
-resource "google_compute_region_per_instance_config" "with_disks" {
-	region = google_compute_region_instance_group_manager.rigm.region
-	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
+resource "google_compute_per_instance_config" "with_disks" {
+	zone = google_compute_instance_group_manager.igm.zone
+	instance_group_manager = google_compute_instance_group_manager.igm.name
 	name = "%{config_name3}"
 	most_disruptive_allowed_action = "REFRESH"
 	minimal_action = "REFRESH"
@@ -219,9 +217,9 @@ resource "google_compute_region_per_instance_config" "with_disks" {
 	}
 }
 
-resource "google_compute_region_per_instance_config" "add2" {
-	region = google_compute_region_instance_group_manager.rigm.region
-	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
+resource "google_compute_per_instance_config" "add2" {
+	zone = google_compute_instance_group_manager.igm.zone
+	instance_group_manager = google_compute_instance_group_manager.igm.name
 	name = "%{config_name4}"
 	preserved_state {
 		metadata = {
@@ -233,7 +231,7 @@ resource "google_compute_region_per_instance_config" "add2" {
 resource "google_compute_disk" "disk" {
   name  = "test-disk-%{random_suffix}"
   type  = "pd-ssd"
-  zone  = "us-central1-c"
+  zone  = google_compute_instance_group_manager.igm.zone
   image = "debian-8-jessie-v20170523"
   physical_block_size_bytes = 4096
 }
@@ -241,7 +239,7 @@ resource "google_compute_disk" "disk" {
 resource "google_compute_disk" "disk1" {
   name  = "test-disk2-%{random_suffix}"
   type  = "pd-ssd"
-  zone  = "us-central1-c"
+  zone  = google_compute_instance_group_manager.igm.zone
   image = "debian-cloud/debian-9"
   physical_block_size_bytes = 4096
 }
@@ -249,22 +247,22 @@ resource "google_compute_disk" "disk1" {
 resource "google_compute_disk" "disk2" {
   name  = "test-disk3-%{random_suffix}"
   type  = "pd-ssd"
-  zone  = "us-central1-c"
+  zone  = google_compute_instance_group_manager.igm.zone
   image = "https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/centos-7-v20190729"
   physical_block_size_bytes = 4096
 }
-`, context) + testAccComputeRegionPerInstanceConfig_rigm(context)
+`, context) + testAccComputePerInstanceConfig_igm(context)
 }
 
-func testAccComputeRegionPerInstanceConfig_rigm(context map[string]interface{}) string {
+func testAccComputePerInstanceConfig_igm(context map[string]interface{}) string {
 	return Nprintf(`
 data "google_compute_image" "my_image" {
   family  = "debian-9"
   project = "debian-cloud"
 }
 
-resource "google_compute_instance_template" "rigm-basic" {
-  name           = "rigm-temp-%{random_suffix}"
+resource "google_compute_instance_template" "igm-basic" {
+  name           = "igm-temp-%{random_suffix}"
   machine_type   = "n1-standard-1"
   can_ip_forward = false
   tags           = ["foo", "bar"]
@@ -285,34 +283,25 @@ resource "google_compute_instance_template" "rigm-basic" {
   }
 }
 
-resource "google_compute_region_instance_group_manager" "rigm" {
+resource "google_compute_instance_group_manager" "igm" {
   description = "Terraform test instance group manager"
-  name        = "%{rigm_name}"
+  name        = "%{igm_name}"
 
   version {
     name              = "prod"
-    instance_template = google_compute_instance_template.rigm-basic.self_link
+    instance_template = google_compute_instance_template.igm-basic.self_link
   }
 
-  base_instance_name = "rigm-no-tp"
-  region             = "us-central1"
-
-  update_policy {
-    instance_redistribution_type = "NONE"
-    type                         = "OPPORTUNISTIC"
-    minimal_action               = "REPLACE"
-    max_surge_fixed              = 0
-    max_unavailable_fixed        = 6
-    min_ready_sec                = 20
-  }
+  base_instance_name = "igm-no-tp"
+  zone               = "us-central1-c"
 }
 `, context)
 }
 
 // Checks that the per instance config with the given name was destroyed
-func testAccCheckComputeRegionPerInstanceConfigDestroyed(t *testing.T, rigmId, configName string) resource.TestCheckFunc {
+func testAccCheckComputePerInstanceConfigDestroyed(t *testing.T, igmId, configName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		foundNames, err := testAccComputePerInstanceConfigListNames(t, rigmId)
+		foundNames, err := testAccComputePerInstanceConfigListNames(t, igmId)
 		if err != nil {
 			return fmt.Errorf("unable to confirm config with name %s was destroyed: %v", configName, err)
 		}
@@ -323,4 +312,25 @@ func testAccCheckComputeRegionPerInstanceConfigDestroyed(t *testing.T, rigmId, c
 		return nil
 	}
 }
-<% end -%>
+
+func testAccComputePerInstanceConfigListNames(t *testing.T, igmId string) (map[string]struct{}, error) {
+	config := googleProviderConfig(t)
+
+	url := fmt.Sprintf("%s%s/listPerInstanceConfigs", config.ComputeBasePath, igmId)
+	res, err := sendRequest(config, "POST", "", url, config.userAgent, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	v, ok := res["items"]
+	if !ok || v == nil {
+		return nil, nil
+	}
+	items := v.([]interface{})
+	instanceConfigs := make(map[string]struct{})
+	for _, item := range items {
+		perInstanceConfig := item.(map[string]interface{})
+		instanceConfigs[fmt.Sprintf("%v", perInstanceConfig["name"])] = struct{}{}
+	}
+	return instanceConfigs, nil
+}

--- a/third_party/terraform/tests/resource_compute_per_instance_config_test.go
+++ b/third_party/terraform/tests/resource_compute_per_instance_config_test.go
@@ -16,12 +16,12 @@ func TestAccComputePerInstanceConfig_statefulBasic(t *testing.T) {
 	suffix := randString(t, 10)
 	igmName := fmt.Sprintf("tf-test-igm-%s", suffix)
 	context := map[string]interface{}{
-		"igm_name": igmName,
+		"igm_name":      igmName,
 		"random_suffix": suffix,
-		"config_name" : fmt.Sprintf("instance-%s", randString(t, 10)),
-		"config_name2" : fmt.Sprintf("instance-%s", randString(t, 10)),
-		"config_name3" : fmt.Sprintf("instance-%s", randString(t, 10)),
-		"config_name4" : fmt.Sprintf("instance-%s", randString(t, 10)),
+		"config_name":   fmt.Sprintf("instance-%s", randString(t, 10)),
+		"config_name2":  fmt.Sprintf("instance-%s", randString(t, 10)),
+		"config_name3":  fmt.Sprintf("instance-%s", randString(t, 10)),
+		"config_name4":  fmt.Sprintf("instance-%s", randString(t, 10)),
 	}
 	igmId := fmt.Sprintf("projects/%s/zones/%s/instanceGroupManagers/%s",
 		getTestProjectFromEnv(), "us-central1-c", igmName)
@@ -35,9 +35,9 @@ func TestAccComputePerInstanceConfig_statefulBasic(t *testing.T) {
 				Config: testAccComputePerInstanceConfig_statefulBasic(context),
 			},
 			{
-				ResourceName:      "google_compute_per_instance_config.default",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_per_instance_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
@@ -48,9 +48,9 @@ func TestAccComputePerInstanceConfig_statefulBasic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "google_compute_per_instance_config.default",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_per_instance_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
@@ -58,9 +58,9 @@ func TestAccComputePerInstanceConfig_statefulBasic(t *testing.T) {
 				Config: testAccComputePerInstanceConfig_statefulAdditional(context),
 			},
 			{
-				ResourceName:      "google_compute_per_instance_config.default",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_per_instance_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
@@ -70,9 +70,9 @@ func TestAccComputePerInstanceConfig_statefulBasic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"most_disruptive_allowed_action", "minimal_action", "remove_instance_state_on_destroy"},
 			},
 			{
-				ResourceName:      "google_compute_per_instance_config.add2",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_per_instance_config.add2",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
@@ -93,8 +93,8 @@ func TestAccComputePerInstanceConfig_update(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": randString(t, 10),
-		"igm_name": fmt.Sprintf("tf-test-igm-%s", randString(t, 10)),
-		"config_name" : fmt.Sprintf("instance-%s", randString(t, 10)),
+		"igm_name":      fmt.Sprintf("tf-test-igm-%s", randString(t, 10)),
+		"config_name":   fmt.Sprintf("instance-%s", randString(t, 10)),
 	}
 
 	vcrTest(t, resource.TestCase{
@@ -106,9 +106,9 @@ func TestAccComputePerInstanceConfig_update(t *testing.T) {
 				Config: testAccComputePerInstanceConfig_statefulBasic(context),
 			},
 			{
-				ResourceName:      "google_compute_per_instance_config.default",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_per_instance_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
@@ -116,9 +116,9 @@ func TestAccComputePerInstanceConfig_update(t *testing.T) {
 				Config: testAccComputePerInstanceConfig_update(context),
 			},
 			{
-				ResourceName:      "google_compute_per_instance_config.default",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_per_instance_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 		},

--- a/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go
+++ b/third_party/terraform/tests/resource_compute_region_instance_group_manager_test.go
@@ -1,9 +1,9 @@
-<% autogen_exception -%>
-
 package google
 
 import (
+	"context"
 	"fmt"
+	"log"
 	"strings"
 	"testing"
 
@@ -343,7 +343,6 @@ func TestAccRegionInstanceGroupManager_distributionPolicy(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccRegionInstanceGroupManager_stateful(t *testing.T) {
 	t.Parallel()
 
@@ -375,7 +374,6 @@ func TestAccRegionInstanceGroupManager_stateful(t *testing.T) {
 	})
 }
 
-<% end -%>
 func testAccCheckRegionInstanceGroupManagerDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
@@ -1233,7 +1231,6 @@ resource "google_compute_region_instance_group_manager" "igm-rolling-update-poli
 `, igm)
 }
 
-<% unless version == 'ga' -%>
 func testAccRegionInstanceGroupManager_stateful(template, igm string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
@@ -1350,4 +1347,3 @@ resource "google_compute_region_instance_group_manager" "igm-basic" {
 }
 `, template, igm)
 }
-<% end -%>

--- a/third_party/terraform/tests/resource_compute_region_per_instance_config_test.go
+++ b/third_party/terraform/tests/resource_compute_region_per_instance_config_test.go
@@ -1,7 +1,5 @@
-<% autogen_exception -%>
 package google
 
-<% unless version == 'ga' -%>
 import (
 	"fmt"
 	"testing"
@@ -10,23 +8,23 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccComputePerInstanceConfig_statefulBasic(t *testing.T) {
+func TestAccComputeRegionPerInstanceConfig_statefulBasic(t *testing.T) {
 	// Multiple fine-grained resources
 	skipIfVcr(t)
 	t.Parallel()
 
 	suffix := randString(t, 10)
-	igmName := fmt.Sprintf("tf-test-igm-%s", suffix)
+	rigmName := fmt.Sprintf("tf-test-rigm-%s", suffix)
 	context := map[string]interface{}{
-		"igm_name": igmName,
+		"rigm_name": rigmName,
 		"random_suffix": suffix,
 		"config_name" : fmt.Sprintf("instance-%s", randString(t, 10)),
 		"config_name2" : fmt.Sprintf("instance-%s", randString(t, 10)),
 		"config_name3" : fmt.Sprintf("instance-%s", randString(t, 10)),
 		"config_name4" : fmt.Sprintf("instance-%s", randString(t, 10)),
 	}
-	igmId := fmt.Sprintf("projects/%s/zones/%s/instanceGroupManagers/%s",
-		getTestProjectFromEnv(), "us-central1-c", igmName)
+	rigmId := fmt.Sprintf("projects/%s/regions/%s/instanceGroupManagers/%s",
+		getTestProjectFromEnv(), "us-central1", rigmName)
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -34,68 +32,68 @@ func TestAccComputePerInstanceConfig_statefulBasic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Create one endpoint
-				Config: testAccComputePerInstanceConfig_statefulBasic(context),
+				Config: testAccComputeRegionPerInstanceConfig_statefulBasic(context),
 			},
 			{
-				ResourceName:      "google_compute_per_instance_config.default",
+				ResourceName:      "google_compute_region_per_instance_config.default",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
 				// Force-recreate old config
-				Config: testAccComputePerInstanceConfig_statefulModified(context),
+				Config: testAccComputeRegionPerInstanceConfig_statefulModified(context),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckComputePerInstanceConfigDestroyed(t, igmId, context["config_name"].(string)),
+					testAccCheckComputeRegionPerInstanceConfigDestroyed(t, rigmId, context["config_name"].(string)),
 				),
 			},
 			{
-				ResourceName:      "google_compute_per_instance_config.default",
+				ResourceName:      "google_compute_region_per_instance_config.default",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
 				// Add two new endpoints
-				Config: testAccComputePerInstanceConfig_statefulAdditional(context),
+				Config: testAccComputeRegionPerInstanceConfig_statefulAdditional(context),
 			},
 			{
-				ResourceName:      "google_compute_per_instance_config.default",
+				ResourceName:      "google_compute_region_per_instance_config.default",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
-				ResourceName:            "google_compute_per_instance_config.with_disks",
+				ResourceName:            "google_compute_region_per_instance_config.with_disks",
 				ImportState:             true,
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"most_disruptive_allowed_action", "minimal_action", "remove_instance_state_on_destroy"},
 			},
 			{
-				ResourceName:      "google_compute_per_instance_config.add2",
+				ResourceName:      "google_compute_region_per_instance_config.add2",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
 				// delete all configs
-				Config: testAccComputePerInstanceConfig_igm(context),
+				Config: testAccComputeRegionPerInstanceConfig_rigm(context),
 				Check: resource.ComposeTestCheckFunc(
 					// Config with remove_instance_state_on_destroy = false won't be destroyed (config4)
-					testAccCheckComputePerInstanceConfigDestroyed(t, igmId, context["config_name2"].(string)),
-					testAccCheckComputePerInstanceConfigDestroyed(t, igmId, context["config_name3"].(string)),
+					testAccCheckComputeRegionPerInstanceConfigDestroyed(t, rigmId, context["config_name2"].(string)),
+					testAccCheckComputeRegionPerInstanceConfigDestroyed(t, rigmId, context["config_name3"].(string)),
 				),
 			},
 		},
 	})
 }
 
-func TestAccComputePerInstanceConfig_update(t *testing.T) {
+func TestAccComputeRegionPerInstanceConfig_update(t *testing.T) {
 	t.Parallel()
 
 	context := map[string]interface{}{
 		"random_suffix": randString(t, 10),
-		"igm_name": fmt.Sprintf("tf-test-igm-%s", randString(t, 10)),
+		"rigm_name": fmt.Sprintf("tf-test-rigm-%s", randString(t, 10)),
 		"config_name" : fmt.Sprintf("instance-%s", randString(t, 10)),
 	}
 
@@ -105,20 +103,20 @@ func TestAccComputePerInstanceConfig_update(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// Create one config
-				Config: testAccComputePerInstanceConfig_statefulBasic(context),
+				Config: testAccComputeRegionPerInstanceConfig_statefulBasic(context),
 			},
 			{
-				ResourceName:      "google_compute_per_instance_config.default",
+				ResourceName:      "google_compute_region_per_instance_config.default",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
 				// Update an existing config
-				Config: testAccComputePerInstanceConfig_update(context),
+				Config: testAccComputeRegionPerInstanceConfig_update(context),
 			},
 			{
-				ResourceName:      "google_compute_per_instance_config.default",
+				ResourceName:      "google_compute_region_per_instance_config.default",
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
@@ -127,11 +125,11 @@ func TestAccComputePerInstanceConfig_update(t *testing.T) {
 	})
 }
 
-func testAccComputePerInstanceConfig_statefulBasic(context map[string]interface{}) string {
+func testAccComputeRegionPerInstanceConfig_statefulBasic(context map[string]interface{}) string {
 	return Nprintf(`
-resource "google_compute_per_instance_config" "default" {
-	zone = google_compute_instance_group_manager.igm.zone
-	instance_group_manager = google_compute_instance_group_manager.igm.name
+resource "google_compute_region_per_instance_config" "default" {
+	region = google_compute_region_instance_group_manager.rigm.region
+	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
 	name = "%{config_name}"
 	remove_instance_state_on_destroy = true
 	preserved_state {
@@ -140,31 +138,31 @@ resource "google_compute_per_instance_config" "default" {
 		}
 	}
 }
-`, context) + testAccComputePerInstanceConfig_igm(context)
+`, context) + testAccComputeRegionPerInstanceConfig_rigm(context)
 }
 
-func testAccComputePerInstanceConfig_update(context map[string]interface{}) string {
+func testAccComputeRegionPerInstanceConfig_update(context map[string]interface{}) string {
 	return Nprintf(`
-resource "google_compute_per_instance_config" "default" {
-	zone = google_compute_instance_group_manager.igm.zone
-	instance_group_manager = google_compute_instance_group_manager.igm.name
+resource "google_compute_region_per_instance_config" "default" {
+	region = google_compute_region_instance_group_manager.rigm.region
+	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
 	name = "%{config_name}"
 	remove_instance_state_on_destroy = true
 	preserved_state {
 		metadata = {
-			asdf = "asdf"
-			update = "12345"
+			asdf = "foo"
+			updated = "12345"
 		}
 	}
 }
-`, context) + testAccComputePerInstanceConfig_igm(context)
+`, context) + testAccComputeRegionPerInstanceConfig_rigm(context)
 }
 
-func testAccComputePerInstanceConfig_statefulModified(context map[string]interface{}) string {
+func testAccComputeRegionPerInstanceConfig_statefulModified(context map[string]interface{}) string {
 	return Nprintf(`
-resource "google_compute_per_instance_config" "default" {
-	zone = google_compute_instance_group_manager.igm.zone
-	instance_group_manager = google_compute_instance_group_manager.igm.name
+resource "google_compute_region_per_instance_config" "default" {
+	region = google_compute_region_instance_group_manager.rigm.region
+	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
 	name = "%{config_name2}"
 	remove_instance_state_on_destroy = true
 	preserved_state {
@@ -173,14 +171,14 @@ resource "google_compute_per_instance_config" "default" {
 		}
 	}
 }
-`, context) + testAccComputePerInstanceConfig_igm(context)
+`, context) + testAccComputeRegionPerInstanceConfig_rigm(context)
 }
 
-func testAccComputePerInstanceConfig_statefulAdditional(context map[string]interface{}) string {
+func testAccComputeRegionPerInstanceConfig_statefulAdditional(context map[string]interface{}) string {
 	return Nprintf(`
-resource "google_compute_per_instance_config" "default" {
-	zone = google_compute_instance_group_manager.igm.zone
-	instance_group_manager = google_compute_instance_group_manager.igm.name
+resource "google_compute_region_per_instance_config" "default" {
+	region = google_compute_region_instance_group_manager.rigm.region
+	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
 	name = "%{config_name2}"
 	remove_instance_state_on_destroy = true
 	preserved_state {
@@ -190,9 +188,9 @@ resource "google_compute_per_instance_config" "default" {
 	}
 }
 
-resource "google_compute_per_instance_config" "with_disks" {
-	zone = google_compute_instance_group_manager.igm.zone
-	instance_group_manager = google_compute_instance_group_manager.igm.name
+resource "google_compute_region_per_instance_config" "with_disks" {
+	region = google_compute_region_instance_group_manager.rigm.region
+	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
 	name = "%{config_name3}"
 	most_disruptive_allowed_action = "REFRESH"
 	minimal_action = "REFRESH"
@@ -219,9 +217,9 @@ resource "google_compute_per_instance_config" "with_disks" {
 	}
 }
 
-resource "google_compute_per_instance_config" "add2" {
-	zone = google_compute_instance_group_manager.igm.zone
-	instance_group_manager = google_compute_instance_group_manager.igm.name
+resource "google_compute_region_per_instance_config" "add2" {
+	region = google_compute_region_instance_group_manager.rigm.region
+	region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
 	name = "%{config_name4}"
 	preserved_state {
 		metadata = {
@@ -233,7 +231,7 @@ resource "google_compute_per_instance_config" "add2" {
 resource "google_compute_disk" "disk" {
   name  = "test-disk-%{random_suffix}"
   type  = "pd-ssd"
-  zone  = google_compute_instance_group_manager.igm.zone
+  zone  = "us-central1-c"
   image = "debian-8-jessie-v20170523"
   physical_block_size_bytes = 4096
 }
@@ -241,7 +239,7 @@ resource "google_compute_disk" "disk" {
 resource "google_compute_disk" "disk1" {
   name  = "test-disk2-%{random_suffix}"
   type  = "pd-ssd"
-  zone  = google_compute_instance_group_manager.igm.zone
+  zone  = "us-central1-c"
   image = "debian-cloud/debian-9"
   physical_block_size_bytes = 4096
 }
@@ -249,22 +247,22 @@ resource "google_compute_disk" "disk1" {
 resource "google_compute_disk" "disk2" {
   name  = "test-disk3-%{random_suffix}"
   type  = "pd-ssd"
-  zone  = google_compute_instance_group_manager.igm.zone
+  zone  = "us-central1-c"
   image = "https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/centos-7-v20190729"
   physical_block_size_bytes = 4096
 }
-`, context) + testAccComputePerInstanceConfig_igm(context)
+`, context) + testAccComputeRegionPerInstanceConfig_rigm(context)
 }
 
-func testAccComputePerInstanceConfig_igm(context map[string]interface{}) string {
+func testAccComputeRegionPerInstanceConfig_rigm(context map[string]interface{}) string {
 	return Nprintf(`
 data "google_compute_image" "my_image" {
   family  = "debian-9"
   project = "debian-cloud"
 }
 
-resource "google_compute_instance_template" "igm-basic" {
-  name           = "igm-temp-%{random_suffix}"
+resource "google_compute_instance_template" "rigm-basic" {
+  name           = "rigm-temp-%{random_suffix}"
   machine_type   = "n1-standard-1"
   can_ip_forward = false
   tags           = ["foo", "bar"]
@@ -285,25 +283,34 @@ resource "google_compute_instance_template" "igm-basic" {
   }
 }
 
-resource "google_compute_instance_group_manager" "igm" {
+resource "google_compute_region_instance_group_manager" "rigm" {
   description = "Terraform test instance group manager"
-  name        = "%{igm_name}"
+  name        = "%{rigm_name}"
 
   version {
     name              = "prod"
-    instance_template = google_compute_instance_template.igm-basic.self_link
+    instance_template = google_compute_instance_template.rigm-basic.self_link
   }
 
-  base_instance_name = "igm-no-tp"
-  zone               = "us-central1-c"
+  base_instance_name = "rigm-no-tp"
+  region             = "us-central1"
+
+  update_policy {
+    instance_redistribution_type = "NONE"
+    type                         = "OPPORTUNISTIC"
+    minimal_action               = "REPLACE"
+    max_surge_fixed              = 0
+    max_unavailable_fixed        = 6
+    min_ready_sec                = 20
+  }
 }
 `, context)
 }
 
 // Checks that the per instance config with the given name was destroyed
-func testAccCheckComputePerInstanceConfigDestroyed(t *testing.T, igmId, configName string) resource.TestCheckFunc {
+func testAccCheckComputeRegionPerInstanceConfigDestroyed(t *testing.T, rigmId, configName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		foundNames, err := testAccComputePerInstanceConfigListNames(t, igmId)
+		foundNames, err := testAccComputePerInstanceConfigListNames(t, rigmId)
 		if err != nil {
 			return fmt.Errorf("unable to confirm config with name %s was destroyed: %v", configName, err)
 		}
@@ -314,26 +321,3 @@ func testAccCheckComputePerInstanceConfigDestroyed(t *testing.T, igmId, configNa
 		return nil
 	}
 }
-
-func testAccComputePerInstanceConfigListNames(t *testing.T, igmId string) (map[string]struct{}, error) {
-	config := googleProviderConfig(t)
-
-	url := fmt.Sprintf("%s%s/listPerInstanceConfigs", config.ComputeBasePath, igmId)
-	res, err := sendRequest(config, "POST", "", url, config.userAgent, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	v, ok := res["items"]
-	if !ok || v == nil {
-		return nil, nil
-	}
-	items := v.([]interface{})
-	instanceConfigs := make(map[string]struct{})
-	for _, item := range items {
-		perInstanceConfig := item.(map[string]interface{})
-		instanceConfigs[fmt.Sprintf("%v", perInstanceConfig["name"])] = struct{}{}
-	}
-	return instanceConfigs, nil
-}
-<% end -%>

--- a/third_party/terraform/tests/resource_compute_region_per_instance_config_test.go
+++ b/third_party/terraform/tests/resource_compute_region_per_instance_config_test.go
@@ -16,12 +16,12 @@ func TestAccComputeRegionPerInstanceConfig_statefulBasic(t *testing.T) {
 	suffix := randString(t, 10)
 	rigmName := fmt.Sprintf("tf-test-rigm-%s", suffix)
 	context := map[string]interface{}{
-		"rigm_name": rigmName,
+		"rigm_name":     rigmName,
 		"random_suffix": suffix,
-		"config_name" : fmt.Sprintf("instance-%s", randString(t, 10)),
-		"config_name2" : fmt.Sprintf("instance-%s", randString(t, 10)),
-		"config_name3" : fmt.Sprintf("instance-%s", randString(t, 10)),
-		"config_name4" : fmt.Sprintf("instance-%s", randString(t, 10)),
+		"config_name":   fmt.Sprintf("instance-%s", randString(t, 10)),
+		"config_name2":  fmt.Sprintf("instance-%s", randString(t, 10)),
+		"config_name3":  fmt.Sprintf("instance-%s", randString(t, 10)),
+		"config_name4":  fmt.Sprintf("instance-%s", randString(t, 10)),
 	}
 	rigmId := fmt.Sprintf("projects/%s/regions/%s/instanceGroupManagers/%s",
 		getTestProjectFromEnv(), "us-central1", rigmName)
@@ -35,9 +35,9 @@ func TestAccComputeRegionPerInstanceConfig_statefulBasic(t *testing.T) {
 				Config: testAccComputeRegionPerInstanceConfig_statefulBasic(context),
 			},
 			{
-				ResourceName:      "google_compute_region_per_instance_config.default",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_region_per_instance_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
@@ -48,9 +48,9 @@ func TestAccComputeRegionPerInstanceConfig_statefulBasic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      "google_compute_region_per_instance_config.default",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_region_per_instance_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
@@ -58,9 +58,9 @@ func TestAccComputeRegionPerInstanceConfig_statefulBasic(t *testing.T) {
 				Config: testAccComputeRegionPerInstanceConfig_statefulAdditional(context),
 			},
 			{
-				ResourceName:      "google_compute_region_per_instance_config.default",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_region_per_instance_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
@@ -70,9 +70,9 @@ func TestAccComputeRegionPerInstanceConfig_statefulBasic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"most_disruptive_allowed_action", "minimal_action", "remove_instance_state_on_destroy"},
 			},
 			{
-				ResourceName:      "google_compute_region_per_instance_config.add2",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_region_per_instance_config.add2",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
@@ -93,8 +93,8 @@ func TestAccComputeRegionPerInstanceConfig_update(t *testing.T) {
 
 	context := map[string]interface{}{
 		"random_suffix": randString(t, 10),
-		"rigm_name": fmt.Sprintf("tf-test-rigm-%s", randString(t, 10)),
-		"config_name" : fmt.Sprintf("instance-%s", randString(t, 10)),
+		"rigm_name":     fmt.Sprintf("tf-test-rigm-%s", randString(t, 10)),
+		"config_name":   fmt.Sprintf("instance-%s", randString(t, 10)),
 	}
 
 	vcrTest(t, resource.TestCase{
@@ -106,9 +106,9 @@ func TestAccComputeRegionPerInstanceConfig_update(t *testing.T) {
 				Config: testAccComputeRegionPerInstanceConfig_statefulBasic(context),
 			},
 			{
-				ResourceName:      "google_compute_region_per_instance_config.default",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_region_per_instance_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 			{
@@ -116,9 +116,9 @@ func TestAccComputeRegionPerInstanceConfig_update(t *testing.T) {
 				Config: testAccComputeRegionPerInstanceConfig_update(context),
 			},
 			{
-				ResourceName:      "google_compute_region_per_instance_config.default",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_compute_region_per_instance_config.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"remove_instance_state_on_destroy"},
 			},
 		},

--- a/third_party/terraform/utils/stateful_mig_polling.go
+++ b/third_party/terraform/utils/stateful_mig_polling.go
@@ -1,13 +1,10 @@
-
-<% autogen_exception -%>
 package google
 
-<% unless version == 'ga' -%>
 import (
 	"fmt"
-	"log"
+	"strings"
 
-	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 // PerInstanceConfig needs both regular operation polling AND custom polling for deletion which is why this is not generated
@@ -150,4 +147,3 @@ func PollCheckInstanceConfigDeleted(resp map[string]interface{}, respErr error) 
 	}
 	return ErrorPollResult(fmt.Errorf("Expected PerInstanceConfig to be deleting but status is: %s", status))
 }
-<% end -%>

--- a/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -134,7 +134,7 @@ The following arguments are supported:
 * `auto_healing_policies` - (Optional) The autohealing policies for this managed instance
 group. You can specify only one value. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/creating-groups-of-managed-instances#monitoring_groups).
 
-* `stateful_disk` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Disks created on the instances that will be preserved on instance delete, update, etc. Structure is documented below. For more information see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs).
+* `stateful_disk` - (Optional)) Disks created on the instances that will be preserved on instance delete, update, etc. Structure is documented below. For more information see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs).
 
 * `update_policy` - (Optional) The update policy for this managed instance group. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/updating-managed-instance-groups) and [API](https://cloud.google.com/compute/docs/reference/rest/beta/instanceGroupManagers/patch)
 

--- a/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -136,7 +136,7 @@ group. You can specify only one value. Structure is documented below. For more i
 
 * `stateful_disk` - (Optional)) Disks created on the instances that will be preserved on instance delete, update, etc. Structure is documented below. For more information see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs).
 
-* `update_policy` - (Optional) The update policy for this managed instance group. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/updating-managed-instance-groups) and [API](https://cloud.google.com/compute/docs/reference/rest/beta/instanceGroupManagers/patch)
+* `update_policy` - (Optional) The update policy for this managed instance group. Structure is documented below. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/updating-managed-instance-groups) and [API](https://cloud.google.com/compute/docs/reference/rest/v1/instanceGroupManagers/patch)
 
 - - -
 

--- a/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -138,7 +138,7 @@ group. You can specify only one value. Structure is documented below. For more i
 * `distribution_policy_zones` - (Optional) The distribution policy for this managed instance
 group. You can specify one or more values. For more information, see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/distributing-instances-with-regional-instance-groups#selectingzones).
 
-* `stateful_disk` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Disks created on the instances that will be preserved on instance delete, update, etc. Structure is documented below. For more information see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs). Proactive cross zone instance redistribution must be disabled before you can update stateful disks on existing instance group managers. This can be controlled via the `update_policy`.
+* `stateful_disk` - (Optional) Disks created on the instances that will be preserved on instance delete, update, etc. Structure is documented below. For more information see the [official documentation](https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs). Proactive cross zone instance redistribution must be disabled before you can update stateful disks on existing instance group managers. This can be controlled via the `update_policy`.
 
 - - -
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/7323.

Stateful MIG is controlled with PerInstanceConfig and RegionPerInstanceConfig. This PR makes those both available in GA as well as related utilities and tests.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Marked `stateful_disk` as GA in `google_compute_ instance_group_manager` 
```
```release-note:enhancement
compute: Marked `stateful_disk` as GA in `google_compute_ region_instance_group_manager` 
```
```release-note:enhancement
compute: Marked `google_compute_ per_instance_config` as GA
```
```release-note:enhancement
compute: Marked `google_compute_ region_per_instance_config` as GA
```
