### PR TITLE
Make RegionBackendService health checks optional

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -1115,7 +1115,8 @@ objects:
            for health checking this BackendService. Currently at most one health
            check can be specified.
 
-           A health check must be specified unless the backend service uses an internet NEG as a backend.
+           A health check must be specified unless the backend service uses an internet
+           or serverless NEG as a backend.
 
            For internal load balancing, a URL to a HealthCheck resource must be specified instead.
       - !ruby/object:Api::Type::Integer
@@ -1960,13 +1961,15 @@ objects:
       - !ruby/object:Api::Type::Array
         name: 'healthChecks'
         item_type: Api::Type::String
-        required: true
         min_size: 1
         max_size: 1
         description: |
            The set of URLs to HealthCheck resources for health checking
            this RegionBackendService. Currently at most one health
-           check can be specified, and a health check is required.
+           check can be specified. 
+
+           A health check must be specified unless the backend service uses an internet
+           or serverless NEG as a backend.
       - !ruby/object:Api::Type::Integer
         name: 'id'
         description: 'The unique identifier for the resource.'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Part of https://github.com/hashicorp/terraform-provider-google/issues/7311

Health checks for backend services are not required when using a serverless NEG. Trying to specify a health check results in the API error:
```
Error: Error creating RegionBackendService: googleapi: Error 400: Invalid value for field 'resource.healthChecks': ''. 
A backend service cannot have a healthcheck with Serverless network endpoint group backends., invalid
```



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: Fixed an issue where `google_compute_region_backend_service` required `healthChecks` for a serverless network endpoint group.
```
