### PR TITLE
Override artifact registry self_link and self_link iam override

### DIFF
--- a/api/resource/iam_policy.rb
+++ b/api/resource/iam_policy.rb
@@ -90,6 +90,10 @@ module Api
       # variables that are outside of the base_url qualifiers.
       attr_reader :import_format
 
+      # Allows us to override the self_link of the resource. This is required for Artifact Registry
+      # to prevent breaking changes
+      attr_reader :self_link
+
       # [Optional] Version number in the request payload.
       # if set, it overrides the default iamPolicyVersion
       attr_reader :iam_policy_version
@@ -110,6 +114,7 @@ module Api
         check :test_project_name, type: String
         check :iam_conditions_request_type, type: Symbol, allowed: %i[REQUEST_BODY QUERY_PARAM]
         check :base_url, type: String
+        check :self_link, type: String
         check :import_format, type: Array, item_type: String
         check(
           :example_config_body,

--- a/products/artifactregistry/api.yaml
+++ b/products/artifactregistry/api.yaml
@@ -46,6 +46,7 @@ objects:
     name: 'Repository'
     base_url: projects/{{project}}/locations/{{location}}/repositories
     create_url: projects/{{project}}/locations/{{location}}/repositories?repository_id={{repository_id}}
+    self_link: projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}
     min_version: beta
     description: A repository for storing artifacts
     references: !ruby/object:Api::Resource::ReferenceLinks
@@ -56,8 +57,11 @@ objects:
     iam_policy: !ruby/object:Api::Resource::IamPolicy
       exclude: false
       method_name_separator: ':'
+      # TODO (camthornton): Change to repository_id in 4.0
       parent_resource_attribute: 'repository'
       import_format: ["projects/{{project}}/locations/{{location}}/repositories/{{repository}}", "{{repository}}"]
+      base_url: projects/{{project}}/locations/{{location}}/repositories/{{name}}
+      self_link: projects/{{project}}/locations/{{location}}/repositories/{{name}}
     properties:
     - !ruby/object:Api::Type::String
       name: name

--- a/products/artifactregistry/terraform.yaml
+++ b/products/artifactregistry/terraform.yaml
@@ -14,7 +14,7 @@
 --- !ruby/object:Provider::Terraform::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
   Repository: !ruby/object:Overrides::Terraform::ResourceOverride
-    id_format: projects/{{project}}/locations/{{location}}/repositories/{{repsitory_id}}
+    id_format: projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}
     import_format: ["projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}", "{{repository_id}}"]
     autogen_async: true
     examples:

--- a/templates/terraform/examples/base_configs/iam_test_file.go.erb
+++ b/templates/terraform/examples/base_configs/iam_test_file.go.erb
@@ -17,7 +17,7 @@ import (
          .first -%>
 <% resource_name = product_ns + object.name -%>
 <%
-individual_url = object.self_link_url
+individual_url = object.iam_policy.self_link || object.self_link_url
 -%>
 <%
   tf_product = (@config.legacy_name || product_ns).underscore

--- a/templates/terraform/iam/iam_attributes.tf.erb
+++ b/templates/terraform/iam/iam_attributes.tf.erb
@@ -1,10 +1,11 @@
 <% example = object.examples
          .reject { |e| @api.version_obj_or_closest(version) < @api.version_obj_or_closest(e.min_version) }
          .first -%>
-<% parent_resource_last_param_name = extract_identifiers(object.self_link_url).last -%>
+<% self_link_url = object.iam_policy.self_link || object.self_link_url -%>
+<% parent_resource_last_param_name = extract_identifiers(self_link_url).last -%>
 <% parent_resource_type_type = object.iam_policy.parent_resource_type || resource_ns -%>
-<% extract_identifiers(object.self_link_url).each_with_index do |p, i| -%>
-<% if i == extract_identifiers(object.self_link_url).size - 1 -%>
+<% extract_identifiers(self_link_url).each_with_index do |p, i| -%>
+<% if i == extract_identifiers(self_link_url).size - 1 -%>
 <% attribute_val = object.iam_policy.parent_resource_attribute || parent_resource_last_param_name.underscore -%>
 <% else -%>
 <% attribute_val = p.underscore -%>

--- a/templates/terraform/resource_iam.html.markdown.erb
+++ b/templates/terraform/resource_iam.html.markdown.erb
@@ -76,7 +76,7 @@ See [Provider Versions](https://terraform.io/docs/providers/google/guides/provid
 <% end -%>
 
 <% markdown_escaped_name = resource_ns_iam.gsub("_", "\\_") %>
-<% params = extract_identifiers(object.self_link_url) -%>
+<% params = extract_identifiers(object.iam_policy.self_link || object.self_link_url) -%>
 <%
 url_properties = object.all_user_properties.select do
   |param| params.include?(param.name)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/7324
The self_link and id formatting for `google_artifact_registry_repository` were incorrect.

Updating these affected the IAM policy by changing the field `repository` to be `repository_id` (which is more correct, but would be a breaking change). IAM changes in this PR are to prevent changes in the IAM policy from generating.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
artifactregistry: fixed an issue where `google_artifact_registry_repository` would import an empty state
```
