### PR TITLE
fix permadiff with new access approval cloud product mappings

### DIFF
--- a/products/accessapproval/api.yaml
+++ b/products/accessapproval/api.yaml
@@ -74,16 +74,29 @@ objects:
               required: true
               description: |
                 The product for which Access Approval will be enrolled. Allowed values are listed (case-sensitive):
-                  all
-                  appengine.googleapis.com
-                  bigquery.googleapis.com
-                  bigtable.googleapis.com
-                  cloudkms.googleapis.com
-                  compute.googleapis.com
-                  dataflow.googleapis.com
-                  iam.googleapis.com
-                  pubsub.googleapis.com
-                  storage.googleapis.com
+                  * all
+                  * App Engine
+                  * BigQuery
+                  * Cloud Bigtable
+                  * Cloud Key Management Service
+                  * Compute Engine
+                  * Cloud Dataflow
+                  * Cloud Identity and Access Management
+                  * Cloud Pub/Sub
+                  * Cloud Storage
+                  * Persistent Disk
+
+                Note: These values are supported as input, but considered a legacy format:
+                  * all
+                  * appengine.googleapis.com
+                  * bigquery.googleapis.com
+                  * bigtable.googleapis.com
+                  * cloudkms.googleapis.com
+                  * compute.googleapis.com
+                  * dataflow.googleapis.com
+                  * iam.googleapis.com
+                  * pubsub.googleapis.com
+                  * storage.googleapis.com
             - !ruby/object:Api::Type::Enum
               name: enrollmentLevel
               description: |

--- a/products/accessapproval/terraform.yaml
+++ b/products/accessapproval/terraform.yaml
@@ -28,12 +28,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_delete: templates/terraform/custom_delete/clear_folder_access_approval_settings.go.erb
       pre_create: templates/terraform/update_mask.erb
+      constants: templates/terraform/constants/access_approval.go.erb
     properties:
       notificationEmails: !ruby/object:Overrides::Terraform::PropertyOverride
         is_set: true
         default_from_api: true
       enrolledServices: !ruby/object:Overrides::Terraform::PropertyOverride
         is_set: true
+      enrolledServices.cloudProduct: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: accessApprovalCloudProductDiffSuppress
   ProjectSettings: !ruby/object:Overrides::Terraform::ResourceOverride
     legacy_name: "google_project_access_approval_settings"
     import_format: ["projects/{{project}}/accessApprovalSettings"]
@@ -54,6 +57,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       enrolledServices: !ruby/object:Overrides::Terraform::PropertyOverride
         is_set: true
+      enrolledServices.cloudProduct: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: accessApprovalCloudProductDiffSuppress
   OrganizationSettings: !ruby/object:Overrides::Terraform::ResourceOverride
     legacy_name: "google_organization_access_approval_settings"
     import_format: ["organizations/{{organization_id}}/accessApprovalSettings"]
@@ -73,6 +78,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       enrolledServices: !ruby/object:Overrides::Terraform::PropertyOverride
         is_set: true
+      enrolledServices.cloudProduct: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: accessApprovalCloudProductDiffSuppress
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/products/accessapproval/terraform.yaml
+++ b/products/accessapproval/terraform.yaml
@@ -35,8 +35,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       enrolledServices: !ruby/object:Overrides::Terraform::PropertyOverride
         is_set: true
-      enrolledServices.cloudProduct: !ruby/object:Overrides::Terraform::PropertyOverride
-        diff_suppress_func: accessApprovalCloudProductDiffSuppress
+        set_hash_func: accessApprovalEnrolledServicesHash
   ProjectSettings: !ruby/object:Overrides::Terraform::ResourceOverride
     legacy_name: "google_project_access_approval_settings"
     import_format: ["projects/{{project}}/accessApprovalSettings"]
@@ -57,8 +56,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       enrolledServices: !ruby/object:Overrides::Terraform::PropertyOverride
         is_set: true
-      enrolledServices.cloudProduct: !ruby/object:Overrides::Terraform::PropertyOverride
-        diff_suppress_func: accessApprovalCloudProductDiffSuppress
+        set_hash_func: accessApprovalEnrolledServicesHash
   OrganizationSettings: !ruby/object:Overrides::Terraform::ResourceOverride
     legacy_name: "google_organization_access_approval_settings"
     import_format: ["organizations/{{organization_id}}/accessApprovalSettings"]
@@ -78,8 +76,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       enrolledServices: !ruby/object:Overrides::Terraform::PropertyOverride
         is_set: true
-      enrolledServices.cloudProduct: !ruby/object:Overrides::Terraform::PropertyOverride
-        diff_suppress_func: accessApprovalCloudProductDiffSuppress
+        set_hash_func: accessApprovalEnrolledServicesHash
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/templates/terraform/constants/access_approval.go.erb
+++ b/templates/terraform/constants/access_approval.go.erb
@@ -14,14 +14,14 @@
 -%>
 var accessApprovalCloudProductMapping = map[string]string{
 	"appengine.googleapis.com": "App Engine",
-    "bigquery.googleapis.com": "BigQuery",
-    "bigtable.googleapis.com": "Cloud Bigtable",
-    "cloudkms.googleapis.com": "Cloud Key Management Service",
-    "compute.googleapis.com": "Compute Engine",
-    "dataflow.googleapis.com": "Cloud Dataflow",
-    "iam.googleapis.com": "Cloud Identity and Access Management",
-    "pubsub.googleapis.com": "Cloud Pub/Sub",
-    "storage.googleapis.com": "Cloud Storage",
+	"bigquery.googleapis.com": "BigQuery",
+	"bigtable.googleapis.com": "Cloud Bigtable",
+	"cloudkms.googleapis.com": "Cloud Key Management Service",
+	"compute.googleapis.com": "Compute Engine",
+	"dataflow.googleapis.com": "Cloud Dataflow",
+	"iam.googleapis.com": "Cloud Identity and Access Management",
+	"pubsub.googleapis.com": "Cloud Pub/Sub",
+	"storage.googleapis.com": "Cloud Storage",
 }
 func accessApprovalEnrolledServicesHash(v interface{}) int {
 	var buf bytes.Buffer

--- a/templates/terraform/constants/access_approval.go.erb
+++ b/templates/terraform/constants/access_approval.go.erb
@@ -23,16 +23,14 @@ var accessApprovalCloudProductMapping = map[string]string{
     "pubsub.googleapis.com": "Cloud Pub/Sub",
     "storage.googleapis.com": "Cloud Storage",
 }
-func accessApprovalCloudProductDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	if n, ok := accessApprovalCloudProductMapping[old]; ok {
-        if n == new {
-            return true
-        }
-    }
-    if o, ok := accessApprovalCloudProductMapping[new]; ok {
-        if o == old {
-            return true
-        }
-    }
-    return false
+func accessApprovalEnrolledServicesHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	cp := m["cloud_product"].(string)
+	if n, ok := accessApprovalCloudProductMapping[cp]; ok {
+		cp = n
+	}
+	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(cp))) // ToLower just in case
+	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["enrollment_level"].(string))))
+	return hashcode(buf.String())
 }

--- a/templates/terraform/constants/access_approval.go.erb
+++ b/templates/terraform/constants/access_approval.go.erb
@@ -1,0 +1,38 @@
+<%- # the license inside this block applies to this file
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+var accessApprovalCloudProductMapping = map[string]string{
+	"appengine.googleapis.com": "App Engine",
+    "bigquery.googleapis.com": "BigQuery",
+    "bigtable.googleapis.com": "Cloud Bigtable",
+    "cloudkms.googleapis.com": "Cloud Key Management Service",
+    "compute.googleapis.com": "Compute Engine",
+    "dataflow.googleapis.com": "Cloud Dataflow",
+    "iam.googleapis.com": "Cloud Identity and Access Management",
+    "pubsub.googleapis.com": "Cloud Pub/Sub",
+    "storage.googleapis.com": "Cloud Storage",
+}
+func accessApprovalCloudProductDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	if n, ok := accessApprovalCloudProductMapping[old]; ok {
+        if n == new {
+            return true
+        }
+    }
+    if o, ok := accessApprovalCloudProductMapping[new]; ok {
+        if o == old {
+            return true
+        }
+    }
+    return false
+}

--- a/third_party/terraform/tests/resource_access_approval_organization_settings_test.go
+++ b/third_party/terraform/tests/resource_access_approval_organization_settings_test.go
@@ -51,7 +51,7 @@ resource "google_organization_access_approval_settings" "organization_access_app
   notification_emails = ["testuser@example.com"]
 
   enrolled_services {
-    cloud_product = "appengine.googleapis.com"
+    cloud_product = "App Engine"
   }
 
   enrolled_services {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/7432


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
accessapproval: fixed issue where, due to a recent API change, `google_*_access_approval.enrolled_services.cloud_product` entries specified as a URL would result in a permadiff
```
