### PR TITLE
docs(bigquery): remove list of location

### DIFF
--- a/products/bigquery/api.yaml
+++ b/products/bigquery/api.yaml
@@ -209,14 +209,6 @@ objects:
           contains at least two geographic places.
 
 
-          Possible regional values include: `asia-east1`, `asia-northeast1`,
-          `asia-southeast1`, `australia-southeast1`, `europe-north1`,
-          `europe-west2` and `us-east4`.
-
-
-          Possible multi-regional values: `EU` and `US`.
-
-
           The default value is multi-regional location `US`.
           Changing this forces a new resource to be created.
         default_value: US


### PR DESCRIPTION
This list of locations used in the documentation is outdated. It's fairly complicated to be sync with the official docs especially for this kind of value. The suggestion is to remove the list but rely on the link to the official docs. The description of the field remains valid but the list is hosted on the official docs.

> https://www.terraform.io/docs/providers/google/r/bigquery_dataset.html#location

If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
