### PR TITLE
Project precheck

### DIFF
--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -213,6 +213,8 @@ func resourceGoogleProjectCheckPreRequisites(config *Config, d *schema.ResourceD
 	if !d.Get("auto_create_network").(bool) {
 		_, err := config.NewServiceUsageClient(userAgent).Services.Get("projects/00000000000/services/serviceusage.googleapis.com").Do()
 		switch {
+		// We are querying a dummy project since the call is already coming from the quota project.
+		// If the API is enabled we get a not found message or accessNotConfigured if API is not enabled.
 		case err.Error() == "googleapi: Error 403: Project '00000000000' not found or permission denied., forbidden":
 			return nil
 		case strings.Contains(err.Error(), "accessNotConfigured"):

--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -210,6 +210,15 @@ func resourceGoogleProjectCheckPreRequisites(config *Config, d *schema.ResourceD
 	if !stringInSlice(resp.Permissions, perm) {
 		return fmt.Errorf("missing permission on %q: %v", ba, perm)
 	}
+	if !d.Get("auto_create_network").(bool) {
+		_, err := config.NewServiceUsageClient(userAgent).Services.Get("projects/00000000000/services/serviceusage.googleapis.com").Do()
+		switch {
+		case err.Error() == "googleapi: Error 403: Project '00000000000' not found or permission denied., forbidden":
+			return nil
+		case strings.Contains(err.Error(), "accessNotConfigured"):
+			return fmt.Errorf("API serviceusage not enabled.\nFound error: %v", err)
+		}
+	}
 	return nil
 }
 

--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -210,14 +210,12 @@ func resourceGoogleProjectCheckPreRequisites(config *Config, d *schema.ResourceD
 	if !stringInSlice(resp.Permissions, perm) {
 		return fmt.Errorf("missing permission on %q: %v", ba, perm)
 	}
-	errExpected := "googleapi: Error 403: Project '00000000000' not found or permission denied., forbidden"
-	errAPINotEnabled := "accessNotConfigured"
 	if !d.Get("auto_create_network").(bool) {
 		_, err := config.NewServiceUsageClient(userAgent).Services.Get("projects/00000000000/services/serviceusage.googleapis.com").Do()
 		switch {
-		case err.Error() == errExpected:
+		case err.Error() == "googleapi: Error 403: Project '00000000000' not found or permission denied., forbidden":
 			return nil
-		case strings.Contains(err.Error(), errAPINotEnabled):
+		case strings.Contains(err.Error(), "accessNotConfigured"):
 			return fmt.Errorf("API serviceusage not enabled.\nFound error: %v", err)
 		}
 	}

--- a/third_party/terraform/resources/resource_google_project.go
+++ b/third_party/terraform/resources/resource_google_project.go
@@ -210,12 +210,14 @@ func resourceGoogleProjectCheckPreRequisites(config *Config, d *schema.ResourceD
 	if !stringInSlice(resp.Permissions, perm) {
 		return fmt.Errorf("missing permission on %q: %v", ba, perm)
 	}
+	errExpected := "googleapi: Error 403: Project '00000000000' not found or permission denied., forbidden"
+	errAPINotEnabled := "accessNotConfigured"
 	if !d.Get("auto_create_network").(bool) {
 		_, err := config.NewServiceUsageClient(userAgent).Services.Get("projects/00000000000/services/serviceusage.googleapis.com").Do()
 		switch {
-		case err.Error() == "googleapi: Error 403: Project '00000000000' not found or permission denied., forbidden":
+		case err.Error() == errExpected:
 			return nil
-		case strings.Contains(err.Error(), "accessNotConfigured"):
+		case strings.Contains(err.Error(), errAPINotEnabled):
 			return fmt.Errorf("API serviceusage not enabled.\nFound error: %v", err)
 		}
 	}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Upstreams https://github.com/hashicorp/terraform-provider-google/pull/7447


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
resourcemanager: added a precheck that the serviceusage API is enabled to `google_project` when `auto_create_network` is false, as configuring the GCE API is required in that circumstance
```
