### PR TITLE
 Added stackdriver_logging_config to cloud_tasks_queue resource

### DIFF
--- a/products/cloudtasks/api.yaml
+++ b/products/cloudtasks/api.yaml
@@ -177,6 +177,7 @@ objects:
         properties:
           - !ruby/object:Api::Type::Double
             name: 'samplingRatio'
+            required: true
             description: |
               Specifies the fraction of operations to write to Stackdriver Logging.
               This field may contain any value between 0.0 and 1.0, inclusive. 0.0 is the

--- a/products/cloudtasks/api.yaml
+++ b/products/cloudtasks/api.yaml
@@ -170,6 +170,18 @@ objects:
             name: 'purgeTime'
             output: true
             description: The last time this queue was purged.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'stackdriverLoggingConfig'
+        description: |
+          Configuration options for writing logs to Stackdriver Logging.
+        properties:
+          - !ruby/object:Api::Type::Double
+            name: 'samplingRatio'
+            description: |
+              Specifies the fraction of operations to write to Stackdriver Logging.
+              This field may contain any value between 0.0 and 1.0, inclusive. 0.0 is the
+              default and means that no operations are logged.
+
 
 
 

--- a/products/cloudtasks/terraform.yaml
+++ b/products/cloudtasks/terraform.yaml
@@ -48,7 +48,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         exclude: true
       status: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
-    examples: 
+    examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "queue_basic"
         primary_resource_id: "default"

--- a/products/cloudtasks/terraform.yaml
+++ b/products/cloudtasks/terraform.yaml
@@ -54,7 +54,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "default"
         vars:
           name: "cloud-tasks-queue-test"
-
+      - !ruby/object:Provider::Terraform::Examples
+        name: "cloud_tasks_queue_advanced"
+        primary_resource_id: "advanced_configuration"
+        ignore_read_extra:
+          - "app_engine_routing_override.0.service"
+          - "app_engine_routing_override.0.version"
+          - "app_engine_routing_override.0.instance"
+        vars:
+          name: "instance-name"
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.

--- a/templates/terraform/examples/cloud_tasks_queue_advanced.tf.erb
+++ b/templates/terraform/examples/cloud_tasks_queue_advanced.tf.erb
@@ -19,9 +19,9 @@ resource "google_cloud_tasks_queue" "<%= ctx[:primary_resource_id] %>" {
     max_backoff = "3s"
     min_backoff = "2s"
     max_doublings = 1
-	}
+  }
 
-	stackdriver_logging_config {
-		sampling_ratio = 0.9
-	}
+  stackdriver_logging_config {
+    sampling_ratio = 0.9
+  }
 }

--- a/templates/terraform/examples/cloud_tasks_queue_advanced.tf.erb
+++ b/templates/terraform/examples/cloud_tasks_queue_advanced.tf.erb
@@ -1,0 +1,27 @@
+resource "google_cloud_tasks_queue" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]["name"] %>"
+  location = "us-central1"
+
+  app_engine_routing_override {
+    service = "worker"
+    version = "1.0"
+    instance = "test"
+  }
+
+  rate_limits {
+    max_concurrent_dispatches = 3
+    max_dispatches_per_second = 2
+  }
+
+  retry_config {
+    max_attempts = 5
+    max_retry_duration = "4s"
+    max_backoff = "3s"
+    min_backoff = "2s"
+    max_doublings = 1
+	}
+
+	stackdriver_logging_config {
+		sampling_ratio = 0.9
+	}
+}

--- a/third_party/terraform/tests/resource_cloud_tasks_queue_test.go.erb
+++ b/third_party/terraform/tests/resource_cloud_tasks_queue_test.go.erb
@@ -79,7 +79,7 @@ resource "google_cloud_tasks_queue" "default" {
   retry_config {
     max_attempts = 5
   }
-  
+
 }
 `, name)
 }
@@ -107,7 +107,11 @@ resource "google_cloud_tasks_queue" "default" {
     max_backoff = "3s"
     min_backoff = "2s"
     max_doublings = 1
-  }
+	}
+
+	stackdriver_logging_config {
+		sampling_ratio = 0.9
+	}
 }
 `, name)
 }
@@ -135,7 +139,11 @@ resource "google_cloud_tasks_queue" "default" {
     max_backoff = "4s"
     min_backoff = "3s"
     max_doublings = 2
-  }
+	}
+
+	stackdriver_logging_config {
+		sampling_ratio = 0.1
+	}
 }
 `, name)
 }


### PR DESCRIPTION
 Added `stackdriver_logging_config` field to `cloud_tasks_queue` resource

Closes [5544](https://github.com/hashicorp/terraform-provider-google/issues/5544)

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloud_tasks: added stackdriver_logging_config` field to `cloud_tasks_queue` resource
```
