### PR TITLE
Added field graceful_decomissioning_timeout to resource dataproc_cluster

### DIFF
--- a/products/dataproc/api.yaml
+++ b/products/dataproc/api.yaml
@@ -210,6 +210,7 @@ objects:
     name: 'Cluster'
     base_url: "projects/{{project}}/regions/{{region}}/clusters"
     self_link: "projects/{{project}}/regions/{{region}}/clusters/{{clusterName}}"
+    update_url: "projects/{{project}}/regions/{{region}}/clusters/{{clusterName}}?gracefulDecommissionTimeout={{graceful_decommission_timeout}}"
     description: |
       Describes an autoscaling policy for Dataproc cluster autoscaler.
     parameters:
@@ -219,6 +220,21 @@ objects:
         input: true
         description: |
           The region in which the cluster and associated nodes will be created in.
+      - !ruby/object:Api::Type::String
+        name: 'gracefulDecommissionTimeout'
+        url_param_only: true
+        input: true
+        description: |
+          This parameter is used when updating the number of worker nodes directly through a terraform apply.
+          For more [context](https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters/patch#query-parameters)
+
+          Timeout for graceful YARN decomissioning. Graceful decommissioning allows
+          removing nodes from the cluster without interrupting jobs in progress.
+          Timeout specifies how long to wait for jobs in progress to finish before forcefully removing nodes (and potentially interrupting jobs).
+          Default timeout is 0 (for forceful decommission), and the maximum allowed timeout is 1 day. (see JSON representation of
+          [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json)).
+
+          Only supported on Dataproc image versions 1.2 and higher.
     properties:
       - !ruby/object:Api::Type::String
         name: 'clusterName'
@@ -476,7 +492,7 @@ objects:
                   The version of software inside the cluster. It must be one of the supported Cloud Dataproc
                   Versions, such as "1.2" (including a subminor version, such as "1.2.29"), or the "preview"
                   version.
-              - !ruby/object:Api::Type::KeyValuePairs              
+              - !ruby/object:Api::Type::KeyValuePairs
                 name: 'properties'
                 description: |
                   The properties to set on daemon config files.

--- a/products/dataproc/api.yaml
+++ b/products/dataproc/api.yaml
@@ -210,7 +210,6 @@ objects:
     name: 'Cluster'
     base_url: "projects/{{project}}/regions/{{region}}/clusters"
     self_link: "projects/{{project}}/regions/{{region}}/clusters/{{clusterName}}"
-    update_url: "projects/{{project}}/regions/{{region}}/clusters/{{clusterName}}?gracefulDecommissionTimeout={{graceful_decommission_timeout}}"
     description: |
       Describes an autoscaling policy for Dataproc cluster autoscaler.
     parameters:
@@ -220,19 +219,6 @@ objects:
         input: true
         description: |
           The region in which the cluster and associated nodes will be created in.
-      - !ruby/object:Api::Type::String
-        name: 'gracefulDecommissionTimeout'
-        url_param_only: true
-        input: true
-        description: |
-          This parameter is used when updating the number of worker nodes directly through a terraform apply.
-          For more [context](https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters/patch#query-parameters)
-          Timeout for graceful YARN decomissioning. Graceful decommissioning allows
-          removing nodes from the cluster without interrupting jobs in progress.
-          Timeout specifies how long to wait for jobs in progress to finish before forcefully removing nodes (and potentially interrupting jobs).
-          Default timeout is 0 (for forceful decommission), and the maximum allowed timeout is 1 day. (see JSON representation of
-          [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json)).
-          Only supported on Dataproc image versions 1.2 and higher.
     properties:
       - !ruby/object:Api::Type::String
         name: 'clusterName'
@@ -490,7 +476,7 @@ objects:
                   The version of software inside the cluster. It must be one of the supported Cloud Dataproc
                   Versions, such as "1.2" (including a subminor version, such as "1.2.29"), or the "preview"
                   version.
-              - !ruby/object:Api::Type::KeyValuePairs
+              - !ruby/object:Api::Type::KeyValuePairs              
                 name: 'properties'
                 description: |
                   The properties to set on daemon config files.

--- a/products/dataproc/api.yaml
+++ b/products/dataproc/api.yaml
@@ -227,13 +227,11 @@ objects:
         description: |
           This parameter is used when updating the number of worker nodes directly through a terraform apply.
           For more [context](https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters/patch#query-parameters)
-
           Timeout for graceful YARN decomissioning. Graceful decommissioning allows
           removing nodes from the cluster without interrupting jobs in progress.
           Timeout specifies how long to wait for jobs in progress to finish before forcefully removing nodes (and potentially interrupting jobs).
           Default timeout is 0 (for forceful decommission), and the maximum allowed timeout is 1 day. (see JSON representation of
           [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json)).
-
           Only supported on Dataproc image versions 1.2 and higher.
     properties:
       - !ruby/object:Api::Type::String

--- a/third_party/terraform/resources/resource_dataproc_cluster.go.erb
+++ b/third_party/terraform/resources/resource_dataproc_cluster.go.erb
@@ -118,6 +118,14 @@ func resourceDataprocCluster() *schema.Resource {
 				Description: `The region in which the cluster and associated nodes will be created in. Defaults to global.`,
 			},
 
+			"graceful_decommission_timeout": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "0s",
+				Description: `The timeout duration which allows graceful decomissioning when you change the number of worker nodes directly through a terraform apply`,
+			},
+
+
 			"labels": {
 				Type:     schema.TypeMap,
 				Optional: true,
@@ -1250,9 +1258,13 @@ func resourceDataprocClusterUpdate(d *schema.ResourceData, meta interface{}) err
 <% end -%>
 
 	if len(updMask) > 0 {
+		gracefulDecommissionTimeout := d.Get("graceful_decommission_timeout").(string)
+
 		patch := config.NewDataprocBetaClient(userAgent).Projects.Regions.Clusters.Patch(
 			project, region, clusterName, cluster)
-		op, err := patch.UpdateMask(strings.Join(updMask, ",")).Do()
+		patch.GracefulDecommissionTimeout(gracefulDecommissionTimeout)
+		patch.UpdateMask(strings.Join(updMask, ","))
+		op, err := patch.Do()
 		if err != nil {
 			return err
 		}

--- a/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -1221,7 +1221,8 @@ func testAccDataprocCluster_updatable(rnd string, w, p int) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "updatable" {
   name   = "tf-test-dproc-%s"
-  region = "us-central1"
+	region = "us-central1"
+	graceful_decommission_timeout = "0.2s"
 
   cluster_config {
     master_config {
@@ -1594,7 +1595,7 @@ resource "google_dataproc_cluster" "basic" {
     }
   }
 }
-  
+
 resource "google_dataproc_autoscaling_policy" "asp" {
   policy_id = "tf-test-dataproc-policy-%s"
   location  = "us-central1"
@@ -1626,7 +1627,7 @@ resource "google_dataproc_cluster" "basic" {
     }
   }
 }
-  
+
 resource "google_dataproc_autoscaling_policy" "asp" {
   policy_id = "tf-test-dataproc-policy-%s"
   location  = "us-central1"

--- a/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -1221,8 +1221,8 @@ func testAccDataprocCluster_updatable(rnd string, w, p int) string {
 	return fmt.Sprintf(`
 resource "google_dataproc_cluster" "updatable" {
   name   = "tf-test-dproc-%s"
-	region = "us-central1"
-	graceful_decommission_timeout = "0.2s"
+  region = "us-central1"
+  graceful_decommission_timeout = "0.2s"
 
   cluster_config {
     master_config {

--- a/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -32,6 +32,7 @@ resource "google_dataproc_cluster" "simplecluster" {
 resource "google_dataproc_cluster" "mycluster" {
   name     = "mycluster"
   region   = "us-central1"
+  graceful_decommission_timeout = "120s"
   labels = {
     foo = "bar"
   }
@@ -131,6 +132,14 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
 * `cluster_config` - (Optional) Allows you to configure various aspects of the cluster.
    Structure defined below.
 
+* `graceful_decommission_timout` - (Optional) Allows graceful decomissioning when you change the number of worker nodes directly through a terraform apply.
+      Does not affect auto scaling decomissioning from an autoscaling policy.
+      Graceful decommissioning allows removing nodes from the cluster without interrupting jobs in progress.
+      Timeout specifies how long to wait for jobs in progress to finish before forcefully removing nodes (and potentially interrupting jobs).
+      Default timeout is 0 (for forceful decommission), and the maximum allowed timeout is 1 day. (see JSON representation of
+      [Duration](https://developers.google.com/protocol-buffers/docs/proto3#json)).
+      Only supported on Dataproc image versions 1.2 and higher.
+      For more context see the [docs](https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters/patch#query-parameters)
 - - -
 
 The `cluster_config` block supports:
@@ -240,10 +249,10 @@ The `cluster_config.gce_cluster_config` block supports:
 * `tags` - (Optional) The list of instance tags applied to instances in the cluster.
    Tags are used to identify valid sources or targets for network firewalls.
 
-* `internal_ip_only` - (Optional) By default, clusters are not restricted to internal IP addresses, 
-   and will have ephemeral external IP addresses assigned to each instance. If set to true, all 
-   instances in the cluster will only have internal IP addresses. Note: Private Google Access 
-   (also known as `privateIpGoogleAccess`) must be enabled on the subnetwork that the cluster 
+* `internal_ip_only` - (Optional) By default, clusters are not restricted to internal IP addresses,
+   and will have ephemeral external IP addresses assigned to each instance. If set to true, all
+   instances in the cluster will only have internal IP addresses. Note: Private Google Access
+   (also known as `privateIpGoogleAccess`) must be enabled on the subnetwork that the cluster
    will be launched in.
 
 * `metadata` - (Optional) A map of the Compute Engine metadata entries to add to all instances
@@ -436,7 +445,7 @@ cluster_config {
    a cluster. For a list of valid properties please see
   [Cluster properties](https://cloud.google.com/dataproc/docs/concepts/cluster-properties)
 
-* `optional_components` - (Optional) The set of optional components to activate on the cluster. 
+* `optional_components` - (Optional) The set of optional components to activate on the cluster.
     Accepted values are:
     * ANACONDA
     * DRUID


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Added field `graceful_decomissioning_timeout` to resource `dataproc_cluster`
Closes [3999](https://github.com/hashicorp/terraform-provider-google/issues/3999)

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dataproc: Added `graceful_decomissioning_timeout` field to `dataproc_cluster` resource
```
