### PR TITLE
Terraform 7459 redis AUTH support in beta

### DIFF
--- a/products/redis/api.yaml
+++ b/products/redis/api.yaml
@@ -71,6 +71,14 @@ objects:
           If provided, it must be a different zone from the one provided in
           [locationId].
         input: true
+      - !ruby/object:Api::Type::Boolean
+        name: authEnabled
+        description: |
+          Optional. Indicates whether OSS Redis AUTH is enabled for the
+          instance. If set to "true" AUTH is enabled on the instance.
+          Default value is "false" meaning AUTH is disabled.
+        default_value: false
+        min_version: beta
       - !ruby/object:Api::Type::String
         name: authorizedNetwork
         description: |

--- a/third_party/terraform/tests/resource_redis_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_redis_instance_test.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package google
 
 import (
@@ -69,6 +70,37 @@ func TestAccRedisInstance_regionFromLocation(t *testing.T) {
 	})
 }
 
+
+<% unless version == 'ga' -%>
+func TestAccRedisInstance_redisInstanceAuthEnabled(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {},
+		},
+		CheckDestroy: testAccCheckRedisInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRedisInstance_redisInstanceAuthEnabled(context),
+			},
+			{
+				ResourceName:            "google_redis_instance.cache",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region"},
+			},
+		},
+	})
+}
+<% end -%>
+
 func testAccRedisInstance_update(name string) string {
 	return fmt.Sprintf(`
 resource "google_redis_instance" "test" {
@@ -119,3 +151,16 @@ resource "google_redis_instance" "test" {
 }
 `, name, zone)
 }
+
+
+<% unless version == 'ga' -%>
+func testAccRedisInstance_redisInstanceAuthEnabled(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_redis_instance" "cache" {
+  name           = "tf-test-memory-cache%{random_suffix}"
+  memory_size_gb = 1
+  auth_enabled = true
+}
+`, context)
+}
+<% end -%>

--- a/third_party/terraform/tests/resource_redis_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_redis_instance_test.go.erb
@@ -96,6 +96,15 @@ func TestAccRedisInstance_redisInstanceAuthEnabled(t *testing.T) {
 				ImportStateVerify:       true,
 				ImportStateVerifyIgnore: []string{"region"},
 			},
+			{
+				Config: testAccRedisInstance_redisInstanceAuthDisabled(context),
+			},
+			{
+				ResourceName:            "google_redis_instance.cache",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region"},
+			},
 		},
 	})
 }
@@ -160,6 +169,16 @@ resource "google_redis_instance" "cache" {
   name           = "tf-test-memory-cache%{random_suffix}"
   memory_size_gb = 1
   auth_enabled = true
+}
+`, context)
+}
+
+func testAccRedisInstance_redisInstanceAuthDisabled(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_redis_instance" "cache" {
+  name           = "tf-test-memory-cache%{random_suffix}"
+  memory_size_gb = 1
+  auth_enabled = false
 }
 `, context)
 }

--- a/third_party/terraform/website/docs/d/redis_instance.html.markdown
+++ b/third_party/terraform/website/docs/d/redis_instance.html.markdown
@@ -9,7 +9,7 @@ description: |-
 
 # google\_redis\_instance
 
-Get info about a Google Cloud Redis instance from its name.
+Get info about a Google Cloud Redis instance.
 
 ## Example Usage
 

--- a/third_party/terraform/website/docs/d/redis_instance.html.markdown
+++ b/third_party/terraform/website/docs/d/redis_instance.html.markdown
@@ -9,15 +9,25 @@ description: |-
 
 # google\_redis\_instance
 
-Get information about a Google Cloud Redis instance. For more information see
-the [official documentation](https://cloud.google.com/memorystore/docs/redis)
-and [API](https://cloud.google.com/memorystore/docs/redis/apis).
+Get info about a Google Cloud Redis instance from its name.
 
 ## Example Usage
 
-```hcl
-data "google_redis_instance" "default" {
+```tf
+data "google_redis_instance" "my_instance" {
   name = "my-redis-instance"
+}
+
+output "instance_memory_size_gb" {
+  value = data.google_redis_instance.my_instance.memory_size_gb
+}
+
+output "instance_connect_mode" {
+  value = data.google_redis_instance.my_instance.connect_mode
+}
+
+output "instance_authorized_network" {
+  value = data.google_redis_instance.my_instance.authorized_network
 }
 ```
 
@@ -37,78 +47,4 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-In addition to the arguments listed above, the following computed attributes are exported:
-
-* `memory_size_gb` -
-  Redis memory size in GiB.
-
-* `alternative_location_id` -
-  Only applicable to STANDARD_HA tier which protects the instance
-  against zonal failures by provisioning it across two zones.
-  If provided, it must be a different zone from the one provided in
-  [locationId].
-
-* `authorized_network` -
-  The full name of the Google Compute Engine network to which the
-  instance is connected. If left unspecified, the default network
-  will be used.
-
-* `connect_mode` -
-  The connection mode of the Redis instance.
-
-* `display_name` -
-  An arbitrary and optional user-provided name for the instance.
-
-* `labels` -
-  Resource labels to represent user provided metadata.
-
-* `redis_configs` -
-  Redis configuration parameters, according to http://redis.io/topics/config.
-  Please check Memorystore documentation for the list of supported parameters:
-  https://cloud.google.com/memorystore/docs/redis/reference/rest/v1/projects.locations.instances#Instance.FIELDS.redis_configs
-
-* `location_id` -
-  The zone where the instance will be provisioned. If not provided,
-  the service will choose a zone for the instance. For STANDARD_HA tier,
-  instances will be created across two zones for protection against
-  zonal failures. If [alternativeLocationId] is also provided, it must
-  be different from [locationId].
-
-* `redis_version` -
-  The version of Redis software. If not provided, latest supported
-  version will be used. Currently, the supported values are:
-  - REDIS_4_0 for Redis 4.0 compatibility
-  - REDIS_3_2 for Redis 3.2 compatibility
-
-* `reserved_ip_range` -
-  The CIDR range of internal addresses that are reserved for this
-  instance. If not provided, the service will choose an unused /29
-  block, for example, 10.0.0.0/29 or 192.168.0.0/29. Ranges must be
-  unique and non-overlapping with existing subnets in an authorized
-  network.
-
-* `tier` -
-  The service tier of the instance. Must be one of these values:
-  - BASIC: standalone instance
-  - STANDARD_HA: highly available primary/replica instances
-
-  Default value: `BASIC`
-  Possible values are:
-  * `BASIC`
-  * `STANDARD_HA`
-
-* `host` - Hostname or IP address of the exposed Redis endpoint used by clients
-  to connect to the service.
-
-* `port` - The port number of the exposed Redis endpoint.
-
-* `create_time` -
-  The time the instance was created in RFC3339 UTC "Zulu" format,
-  accurate to nanoseconds.
-
-* `current_location_id` -
-  The current zone where the Redis endpoint is placed.
-  For Basic Tier instances, this will always be the same as the
-  [locationId] provided by the user at creation time. For Standard Tier
-  instances, this can be either [locationId] or [alternativeLocationId]
-  and can change after a failover event.
+See [google_redis_instance](https://www.terraform.io/docs/providers/google/r/redis_instance.html) resource for details of the available attributes.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/7459.

Adds support for redis AUTH in beta.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
redis: Added `auth_enabled` field to `google_redis_instance` (google-beta provider only)
```
