### PR TITLE
send empty value for [region]healthcheck description

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -4146,6 +4146,7 @@ objects:
         description: |
           An optional description of this resource. Provide this property when
           you create the resource.
+        send_empty_value: true
       - !ruby/object:Api::Type::Integer
         name: 'healthyThreshold'
         description: |
@@ -11070,6 +11071,7 @@ objects:
         description: |
           An optional description of this resource. Provide this property when
           you create the resource.
+        send_empty_value: true
       - !ruby/object:Api::Type::Integer
         name: 'healthyThreshold'
         description: |

--- a/third_party/terraform/tests/resource_compute_health_check_test.go
+++ b/third_party/terraform/tests/resource_compute_health_check_test.go
@@ -175,7 +175,6 @@ func testAccComputeHealthCheck_tcp_update(hckName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_health_check" "foobar" {
   check_interval_sec  = 3
-  description         = "Resource updated for Terraform acceptance testing"
   healthy_threshold   = 10
   name                = "health-test-%s"
   timeout_sec         = 2

--- a/third_party/terraform/tests/resource_compute_region_health_check_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_health_check_test.go.erb
@@ -183,7 +183,6 @@ func testAccComputeRegionHealthCheck_tcp_update(hckName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_health_check" "foobar" {
   check_interval_sec  = 3
-  description         = "Resource updated for Terraform acceptance testing"
   healthy_threshold   = 10
   name                = "health-test-%s"
   timeout_sec         = 2


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/7440


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed ability to clear `description` field on `google_compute_health_check` and `google_compute_region_health_check`
```
