### PR TITLE
add deletion_protection=false to tests with sql_database_instance

### DIFF
--- a/products/cloudrun/terraform.yaml
+++ b/products/cloudrun/terraform.yaml
@@ -82,6 +82,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           cloud_run_service_name: "cloudrun-srv"
           cloud_run_sql_name: "cloudrun-sql"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
+        oics_vars_overrides:
+          deletion_protection: "false"
         test_env_vars:
           project: :PROJECT_NAME
         ignore_read_extra:

--- a/products/sql/terraform.yaml
+++ b/products/sql/terraform.yaml
@@ -31,6 +31,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           database_name: "my-database"
           database_instance_name: "my-database-instance"
+          deletion_protection: "true"
+        test_vars_overrides:
+          deletion_protection: "false"
+        oics_vars_overrides:
+          deletion_protection: "false"
     timeouts: !ruby/object:Api::Timeouts
       insert_minutes: 15
       update_minutes: 10

--- a/templates/terraform/examples/cloud_run_service_sql.tf.erb
+++ b/templates/terraform/examples/cloud_run_service_sql.tf.erb
@@ -26,4 +26,6 @@ resource "google_sql_database_instance" "instance" {
   settings {
     tier = "db-f1-micro"
   }
+
+  deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
 }

--- a/templates/terraform/examples/sql_database_basic.tf.erb
+++ b/templates/terraform/examples/sql_database_basic.tf.erb
@@ -9,4 +9,6 @@ resource "google_sql_database_instance" "instance" {
   settings {
     tier = "db-f1-micro"
   }
+
+  deletion_protection  = "<%= ctx[:vars]['deletion_protection'] %>"
 }

--- a/third_party/terraform/tests/data_source_google_sql_ca_certs_test.go
+++ b/third_party/terraform/tests/data_source_google_sql_ca_certs_test.go
@@ -78,6 +78,8 @@ resource "google_sql_database_instance" "foo" {
     tier                   = "db-f1-micro"
     crash_safe_replication = false
   }
+
+  deletion_protection = false
 }
 
 data "google_sql_ca_certs" "ca_certs" {

--- a/third_party/terraform/tests/data_source_sql_database_instance_test.go
+++ b/third_party/terraform/tests/data_source_sql_database_instance_test.go
@@ -20,7 +20,13 @@ func TestAccDataSourceSqlDatabaseInstance_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceSqlDatabaseInstance_basic(context),
 				Check: resource.ComposeTestCheckFunc(
-					checkDataSourceStateMatchesResourceState("data.google_sql_database_instance.qa", "google_sql_database_instance.master"),
+					checkDataSourceStateMatchesResourceStateWithIgnores(
+						"data.google_sql_database_instance.qa",
+						"google_sql_database_instance.master",
+						map[string]struct{}{
+							"deletion_protection": {},
+						},
+					),
 				),
 			},
 		},

--- a/third_party/terraform/tests/data_source_sql_database_instance_test.go
+++ b/third_party/terraform/tests/data_source_sql_database_instance_test.go
@@ -39,6 +39,8 @@ resource "google_sql_database_instance" "master" {
     # type. See argument reference below.
     tier = "db-f1-micro"
   }
+
+  deletion_protection = false
 }
 
 data "google_sql_database_instance" "qa" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fix sql database tests

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
