### PR TITLE
add retry to disable project services, update serviceUsageServiceBeingActivated

### DIFF
--- a/third_party/terraform/resources/resource_google_project_service.go
+++ b/third_party/terraform/resources/resource_google_project_service.go
@@ -276,7 +276,7 @@ func disableServiceUsageProjectService(service, project string, d *schema.Resour
 			return waitErr
 		}
 		return nil
-	}, d.Timeout(schema.TimeoutDelete))
+	}, d.Timeout(schema.TimeoutDelete), serviceUsageServiceBeingActivated)
 	if err != nil {
 		return fmt.Errorf("Error disabling service %q for project %q: %v", service, project, err)
 	}

--- a/third_party/terraform/utils/error_retry_predicates.go
+++ b/third_party/terraform/utils/error_retry_predicates.go
@@ -197,10 +197,10 @@ func isSqlOperationInProgressError(err error) (bool, string) {
 func serviceUsageServiceBeingActivated(err error) (bool, string) {
 	if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 400 {
 		if strings.Contains(gerr.Body, "Another activation or deactivation is in progress") {
-			return false, ""
+			return true, "Waiting for same service activation/deactivation to finish"
 		}
 
-		return true, "Waiting for same service activation/deactivation to finish"
+		return false, ""
 	}
 	return false, ""
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/7493

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
serviceusage: fixed bug where concurrent activations/deactivations of project services would fail, now they retry
```
