### PR TITLE
Fix a typo in "detatch" word, add a "do".

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -8696,7 +8696,7 @@ objects:
                   description: |
                     A value that prescribes what should happen to the stateful disk when the VM instance is deleted.
                     The available options are `NEVER` and `ON_PERMANENT_INSTANCE_DELETION`.
-                    `NEVER` detatch the disk when the VM is deleted, but not delete the disk.
+                    `NEVER` - detach the disk when the VM is deleted, but do not delete the disk.
                     `ON_PERMANENT_INSTANCE_DELETION` will delete the stateful disk when the VM is permanently
                     deleted from the instance group.
                   values:
@@ -8816,7 +8816,7 @@ objects:
                   description: |
                     A value that prescribes what should happen to the stateful disk when the VM instance is deleted.
                     The available options are `NEVER` and `ON_PERMANENT_INSTANCE_DELETION`.
-                    `NEVER` detatch the disk when the VM is deleted, but not delete the disk.
+                    `NEVER` - detach the disk when the VM is deleted, but do not delete the disk.
                     `ON_PERMANENT_INSTANCE_DELETION` will delete the stateful disk when the VM is permanently
                     deleted from the instance group.
                   values:

--- a/third_party/terraform/resources/resource_compute_instance_group_manager.go
+++ b/third_party/terraform/resources/resource_compute_instance_group_manager.go
@@ -279,7 +279,7 @@ func resourceComputeInstanceGroupManager() *schema.Resource {
 							Default:      "NEVER",
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice([]string{"NEVER", "ON_PERMANENT_INSTANCE_DELETION"}, true),
-							Description:  `A value that prescribes what should happen to the stateful disk when the VM instance is deleted. The available options are NEVER and ON_PERMANENT_INSTANCE_DELETION. NEVER detatch the disk when the VM is deleted, but not delete the disk. ON_PERMANENT_INSTANCE_DELETION will delete the stateful disk when the VM is permanently deleted from the instance group. The default is NEVER.`,
+							Description:  `A value that prescribes what should happen to the stateful disk when the VM instance is deleted. The available options are NEVER and ON_PERMANENT_INSTANCE_DELETION. NEVER - detach the disk when the VM is deleted, but do not delete the disk. ON_PERMANENT_INSTANCE_DELETION will delete the stateful disk when the VM is permanently deleted from the instance group. The default is NEVER.`,
 						},
 					},
 				},

--- a/third_party/terraform/resources/resource_compute_region_instance_group_manager.go
+++ b/third_party/terraform/resources/resource_compute_region_instance_group_manager.go
@@ -299,7 +299,7 @@ func resourceComputeRegionInstanceGroupManager() *schema.Resource {
 							Type:         schema.TypeString,
 							Default:      "NEVER",
 							Optional:     true,
-							Description:  `A value that prescribes what should happen to the stateful disk when the VM instance is deleted. The available options are NEVER and ON_PERMANENT_INSTANCE_DELETION. NEVER detatch the disk when the VM is deleted, but not delete the disk. ON_PERMANENT_INSTANCE_DELETION will delete the stateful disk when the VM is permanently deleted from the instance group. The default is NEVER.`,
+							Description:  `A value that prescribes what should happen to the stateful disk when the VM instance is deleted. The available options are NEVER and ON_PERMANENT_INSTANCE_DELETION. NEVER - detach the disk when the VM is deleted, but do not delete the disk. ON_PERMANENT_INSTANCE_DELETION will delete the stateful disk when the VM is permanently deleted from the instance group. The default is NEVER.`,
 							ValidateFunc: validation.StringInSlice([]string{"NEVER", "ON_PERMANENT_INSTANCE_DELETION"}, true),
 						},
 					},

--- a/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_instance_group_manager.html.markdown
@@ -227,7 +227,7 @@ The `stateful_disk` block supports: (Include a `stateful_disk` block for each st
 
 * `device_name` - (Required), The device name of the disk to be attached.
 
-* `delete_rule` - (Optional), A value that prescribes what should happen to the stateful disk when the VM instance is deleted. The available options are `NEVER` and `ON_PERMANENT_INSTANCE_DELETION`. `NEVER` detatch the disk when the VM is deleted, but not delete the disk. `ON_PERMANENT_INSTANCE_DELETION` will delete the stateful disk when the VM is permanently deleted from the instance group. The default is `NEVER`.
+* `delete_rule` - (Optional), A value that prescribes what should happen to the stateful disk when the VM instance is deleted. The available options are `NEVER` and `ON_PERMANENT_INSTANCE_DELETION`. `NEVER` - detach the disk when the VM is deleted, but do not delete the disk. `ON_PERMANENT_INSTANCE_DELETION` will delete the stateful disk when the VM is permanently deleted from the instance group. The default is `NEVER`.
 
 
 ## Attributes Reference

--- a/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
+++ b/third_party/terraform/website/docs/r/compute_region_instance_group_manager.html.markdown
@@ -231,7 +231,7 @@ The `stateful_disk` block supports: (Include a `stateful_disk` block for each st
 
 * `device_name` - (Required), The device name of the disk to be attached.
 
-* `delete_rule` - (Optional), A value that prescribes what should happen to the stateful disk when the VM instance is deleted. The available options are `NEVER` and `ON_PERMANENT_INSTANCE_DELETION`. `NEVER` detatch the disk when the VM is deleted, but not delete the disk. `ON_PERMANENT_INSTANCE_DELETION` will delete the stateful disk when the VM is permanently deleted from the instance group. The default is `NEVER`.
+* `delete_rule` - (Optional), A value that prescribes what should happen to the stateful disk when the VM instance is deleted. The available options are `NEVER` and `ON_PERMANENT_INSTANCE_DELETION`. `NEVER` - detach the disk when the VM is deleted, but do not delete the disk. `ON_PERMANENT_INSTANCE_DELETION` will delete the stateful disk when the VM is permanently deleted from the instance group. The default is `NEVER`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Just fixes a typo and a grammar


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
