### PR TITLE
add config and deployment script for triage app

### DIFF
--- a/.ci/containers/terraform-triage-party/config.yaml
+++ b/.ci/containers/terraform-triage-party/config.yaml
@@ -1,3 +1,15 @@
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 settings:
   name: terraform
   min_similarity: 0.65

--- a/.ci/containers/terraform-triage-party/config.yaml
+++ b/.ci/containers/terraform-triage-party/config.yaml
@@ -1,0 +1,138 @@
+settings:
+  name: terraform
+  min_similarity: 0.65
+  repos:
+    - https://github.com/terraform-providers/terraform-provider-google
+  
+collections:
+  - id: untriaged
+    name: Untriaged
+    rules:
+      - untriaged
+      - missing-milestone
+      - missing-size
+  - id: priority
+    name: Priority
+    rules:
+      - p1
+      - 30-reacts
+      - p2
+      - 10-reacts
+  - id: blocked
+    name: Blocked
+    rules:
+      - upstream
+      - upstream-terraform
+      - waiting-response
+  - id: bugs
+    name: Bugs
+    rules:
+      - bug-unassigned
+      - bug-assigned
+  
+rules:
+  # Untriaged
+  untriaged:
+    name: "Untriaged"
+    type: issue
+    filters:
+      - label: "!bug"
+      - label: "!upstream"
+      - label: "!upstream-terraform"
+      - label: "!waiting-response"
+      - label: "!question"
+      - label: "!size/.*"
+      - milestone: "^$"
+  missing-milestone:
+    name: "Missing Milestone"
+    type: issue
+    filters:
+      - label: "!bug"
+      - label: "!upstream"
+      - label: "!upstream-terraform"
+      - label: "!question"
+      - label: "size/.*"
+      - milestone: "^$"
+  missing-size:
+    name: "Missing Size"
+    type: issue
+    filters:
+      - label: "!bug"
+      - label: "!upstream"
+      - label: "!upstream-terraform"
+      - label: "!question"
+      - label: "!size/.*"
+      - milestone: "!^$"
+  
+  # Priority
+  p1:
+    name: "P1s"
+    type: issue
+    filters:
+      - label: "!bug"
+      - label: "!upstream"
+      - label: "!upstream-terraform"
+      - label: "priority/1"
+  30-reacts:
+    name: "30+ reactions"
+    type: issue
+    filters:
+      - label: "!bug"
+      - label: "!upstream"
+      - label: "!upstream-terraform"
+      - reactions: ">=30"
+  p2:
+    name: "P2s"
+    type: issue
+    filters:
+      - label: "!bug"
+      - label: "!upstream"
+      - label: "!upstream-terraform"
+      - label: "priority/2"
+      - reactions: "<30"
+  10-reacts:
+    name: "10+ reactions"
+    type: issue
+    filters:
+      - label: "!bug"
+      - label: "!upstream"
+      - label: "!upstream-terraform"
+      - reactions: ">=10"
+      - reactions: "<30"
+
+  # Blocked
+  upstream:
+    name: "Blocked on GCP"
+    type: issue
+    filters:
+      - label: "upstream"
+  upstream-terraform:
+    name: "Blocked on Terraform"
+    type: issue
+    filters:
+      - label: "upstream-terraform"
+  waiting-response:
+    name: "Waiting for user response"
+    type: issue
+    filters:
+      - label: "waiting-response"
+
+  # Bugs
+  bug-assigned:
+    name: "Assigned Bugs"
+    type: issue
+    filters:
+      - label: "bug"
+      - label: "!upstream"
+      - label: "!upstream-terraform"
+      - label: "!waiting-response"
+      - tag: "assigned"
+  bug-unassigned:
+    name: "Unassigned Bugs"
+    type: issue
+    filters:
+      - label: "bug"
+      - label: "!upstream"
+      - label: "!upstream-terraform"
+      - label: "!waiting-response"
+      - tag: "!assigned"

--- a/.ci/containers/terraform-triage-party/deploy.sh
+++ b/.ci/containers/terraform-triage-party/deploy.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+# Need to set GITHUB_TOKEN environment variable. Use one from the magician.
+if [ -z "$GITHUB_TOKEN" ]; then
+    echo "Did not provide GITHUB_TOKEN environment variable."
+    exit 1
+fi
+
+set -x
+
+export PROJECT=terraform-triage
+export IMAGE=gcr.io/terraform-triage/triage-party
+export SERVICE_NAME=terraform-gcp-triage
+export CONFIG_FILE=config.yaml
+export TP_VERSION="v1.3.0"
+
+git clone --branch $TP_VERSION --depth 1 https://github.com/google/triage-party
+cp $CONFIG_FILE triage-party/config/config.yaml
+
+docker build triage-party/ -t "${IMAGE}"
+
+rm -rf triage-party/
+
+docker push "${IMAGE}" || exit 2
+
+# TODO: add persistance to make it run faster: env vars PERSIST_BACKEND, PERSIST_PATH
+gcloud beta run deploy "${SERVICE_NAME}" \
+    --project "${PROJECT}" \
+    --image "${IMAGE}" \
+    --set-env-vars="GITHUB_TOKEN=${GITHUB_TOKEN}" \
+    --allow-unauthenticated \
+    --region us-central1 \
+    --memory 384Mi \
+    --platform managed


### PR DESCRIPTION
I thought about creating a cloud builder for it but decided that would be overengineering given that we're realistically updating this once a year or so. Given that it's just a script and a file (and I've opted not to hard code the access token in), it could probably easily go in TPG. Let me know if you care.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
