### PR TITLE
add docs for create_before_destroy on network endpoint groups

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -7494,6 +7494,10 @@ objects:
       backend with internal load balancers. Because NEG backends allow you to
       specify IP addresses and ports, you can distribute traffic in a granular
       fashion among applications or containers running within VM instances.
+
+      Recreating a network endpoint group that's in use by another resource will give a
+      `resourceInUseByAnotherResource` error. Use `lifecycle.create_before_destroy`
+      to avoid this type of error.
     async: !ruby/object:Api::OpAsync
       operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
@@ -7660,6 +7664,10 @@ objects:
     description: |
       A global network endpoint group contains endpoints that reside outside of Google Cloud.
       Currently a global network endpoint group can only support a single endpoint.
+
+      Recreating a global network endpoint group that's in use by another resource will give a
+      `resourceInUseByAnotherResource` error. Use `lifecycle.create_before_destroy`
+      to avoid this type of error.
     async: !ruby/object:Api::OpAsync
       operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'
@@ -7726,6 +7734,10 @@ objects:
       api: 'https://cloud.google.com/compute/docs/reference/rest/beta/regionNetworkEndpointGroups'
     description: |
       A regional NEG that can support Serverless Products.
+
+      Recreating a region network endpoint group that's in use by another resource will give a
+      `resourceInUseByAnotherResource` error. Use `lifecycle.create_before_destroy`
+      to avoid this type of error.
     async: !ruby/object:Api::OpAsync
       operation: !ruby/object:Api::OpAsync::Operation
         kind: 'compute#operation'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Adds documentation suggesting the user add `lifecycle.create_before_destroy` to network endpoint groups in cases where they are used by other resources.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/7503

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
