### PR TITLE
Stop editing the global config object with new useragent entries

### DIFF
--- a/products/appengine/terraform.yaml
+++ b/products/appengine/terraform.yaml
@@ -195,8 +195,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     id_format: "apps/{{project}}/services/{{service}}"
     import_format: ["apps/{{project}}/services/{{service}}"]
     mutex: "apps/{{project}}"
+    skip_delete: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
-      custom_delete: templates/terraform/custom_delete/skip_delete.go.erb
       test_check_destroy: templates/terraform/custom_check_destroy/skip_delete_during_test.go.erb
     properties:
       split: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1242,6 +1242,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     import_format: ["projects/{{project}}/global/networks/{{network}}/networkPeerings/{{peering}}"]
     # format from google_compute_network_peering
     mutex: 'projects/{{project}}/global/networks/{{network}}/peerings'
+    skip_delete: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "network_peering_routes_config_basic"
@@ -1266,7 +1267,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       exportCustomRoutes: !ruby/object:Overrides::Terraform::PropertyOverride
         send_empty_value: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
-      custom_delete: 'templates/terraform/custom_delete/skip_delete.go.erb'
       encoder: 'templates/terraform/encoders/network_peering_routes_config.go.erb'
   NodeGroup: !ruby/object:Overrides::Terraform::ResourceOverride
     docs: !ruby/object:Provider::Terraform::Docs

--- a/products/iap/terraform.yaml
+++ b/products/iap/terraform.yaml
@@ -168,6 +168,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       but *will not delete it from Google Cloud.*
     id_format: '{{name}}'
     import_format: ['{{name}}']
+    skip_delete: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "iap_brand"
@@ -179,7 +180,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           org_domain: :ORG_DOMAIN
         skip_test: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
-      custom_delete: templates/terraform/custom_delete/skip_delete.go.erb
       custom_import: templates/terraform/custom_import/iap_brand.go.erb
       post_create: templates/terraform/post_create/set_computed_name.erb
   Client: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/products/kms/terraform.yaml
+++ b/products/kms/terraform.yaml
@@ -22,6 +22,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       *will not delete the resource on the server.*
     id_format: "projects/{{project}}/locations/{{location}}/keyRings/{{name}}"
     import_format: ["projects/{{project}}/locations/{{location}}/keyRings/{{name}}"]
+    skip_delete: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "kms_key_ring_basic"
@@ -42,7 +43,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       location: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
-      custom_delete: templates/terraform/custom_delete/skip_delete.go.erb
       decoder: templates/terraform/decoders/long_name_to_self_link.go.erb
       encoder: templates/terraform/encoders/send_nil_body.go.erb
       extra_schema_entry: templates/terraform/extra_schema_entry/kms_self_link.erb
@@ -144,6 +144,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     supports_indirect_user_project_override: true
     exclude_import: true
     exclude_validator: true
+    skip_delete: true
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "kms_secret_ciphertext_basic"
@@ -167,7 +168,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       ciphertext: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
-      custom_delete: templates/terraform/custom_delete/skip_delete.go.erb
       post_create: templates/terraform/post_create/kms_secret_ciphertext.go.erb
       decoder: templates/terraform/decoders/noop.go.erb
 # This is for copying files over

--- a/products/securitycenter/terraform.yaml
+++ b/products/securitycenter/terraform.yaml
@@ -15,6 +15,7 @@
 legacy_name: scc
 overrides: !ruby/object:Overrides::ResourceOverrides
   Source: !ruby/object:Overrides::Terraform::ResourceOverride
+    skip_delete: true
     examples:
      - !ruby/object:Provider::Terraform::Examples
       name: "scc_source_basic"
@@ -33,7 +34,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         validation: !ruby/object:Provider::Terraform::Validation
           regex: '[\p{L}\p{N}]({\p{L}\p{N}_- ]{0,30}[\p{L}\p{N}])?'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
-      custom_delete: templates/terraform/custom_delete/skip_delete.go.erb
       custom_import: templates/terraform/custom_import/scc_source_self_link_as_name_set_organization.go.erb
       post_create: templates/terraform/post_create/set_computed_name.erb
 # This is for copying files over

--- a/templates/terraform/custom_delete/skip_delete.go.erb
+++ b/templates/terraform/custom_delete/skip_delete.go.erb
@@ -1,6 +1,0 @@
-log.Printf("[WARNING] <%= object.__product.name + " " + object.name %> resources" +
-" cannot be deleted from GCP. The resource %s will be removed from Terraform" +
-" state, but will still be present on the server.", d.Id())
-d.SetId("")
-
-return nil

--- a/templates/terraform/resource.erb
+++ b/templates/terraform/resource.erb
@@ -562,7 +562,6 @@ func resource<%= resource_name -%>Update(d *schema.ResourceData, meta interface{
     if err != nil {
     	return err
     }
-    config.userAgent = userAgent
 
     billingProject := ""
 
@@ -821,7 +820,6 @@ func resource<%= resource_name -%>Delete(d *schema.ResourceData, meta interface{
     if err != nil {
     	return err
     }
-    config.userAgent = userAgent
 
 <% if object.custom_code.custom_delete -%>
 <%= lines(compile(pwd + '/' + object.custom_code.custom_delete)) -%>

--- a/third_party/terraform/resources/resource_google_project_service.go
+++ b/third_party/terraform/resources/resource_google_project_service.go
@@ -123,7 +123,6 @@ func resourceGoogleProjectServiceCreate(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
-	config.userAgent = userAgent
 
 	project, err := getProject(d, config)
 	if err != nil {

--- a/third_party/terraform/resources/resource_google_project_service.go
+++ b/third_party/terraform/resources/resource_google_project_service.go
@@ -119,10 +119,6 @@ func resourceGoogleProjectServiceImport(d *schema.ResourceData, m interface{}) (
 
 func resourceGoogleProjectServiceCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
-	userAgent, err := generateUserAgentString(d, config.userAgent)
-	if err != nil {
-		return err
-	}
 
 	project, err := getProject(d, config)
 	if err != nil {

--- a/third_party/terraform/resources/resource_iam_audit_config.go
+++ b/third_party/terraform/resources/resource_iam_audit_config.go
@@ -140,7 +140,6 @@ func resourceIamAuditConfigCreateUpdate(newUpdaterFunc newResourceIamUpdaterFunc
 		if err != nil {
 			return err
 		}
-		config.userAgent = userAgent
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {
@@ -174,7 +173,7 @@ func resourceIamAuditConfigDelete(newUpdaterFunc newResourceIamUpdaterFunc, enab
 		if err != nil {
 			return err
 		}
-		config.userAgent = userAgent
+
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {
 			return err

--- a/third_party/terraform/resources/resource_iam_audit_config.go
+++ b/third_party/terraform/resources/resource_iam_audit_config.go
@@ -136,10 +136,6 @@ func iamAuditConfigImport(resourceIdParser resourceIdParserFunc) schema.StateFun
 func resourceIamAuditConfigCreateUpdate(newUpdaterFunc newResourceIamUpdaterFunc, enableBatching bool) func(*schema.ResourceData, interface{}) error {
 	return func(d *schema.ResourceData, meta interface{}) error {
 		config := meta.(*Config)
-		userAgent, err := generateUserAgentString(d, config.userAgent)
-		if err != nil {
-			return err
-		}
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {
@@ -169,10 +165,6 @@ func resourceIamAuditConfigCreateUpdate(newUpdaterFunc newResourceIamUpdaterFunc
 func resourceIamAuditConfigDelete(newUpdaterFunc newResourceIamUpdaterFunc, enableBatching bool) schema.DeleteFunc {
 	return func(d *schema.ResourceData, meta interface{}) error {
 		config := meta.(*Config)
-		userAgent, err := generateUserAgentString(d, config.userAgent)
-		if err != nil {
-			return err
-		}
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {

--- a/third_party/terraform/resources/resource_iam_binding.go.erb
+++ b/third_party/terraform/resources/resource_iam_binding.go.erb
@@ -121,7 +121,7 @@ func resourceIamBindingRead(newUpdaterFunc newResourceIamUpdaterFunc) schema.Rea
 		if err != nil {
 			return err
 		}
-		config.userAgent = userAgent
+
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {
 			return err
@@ -259,7 +259,7 @@ func resourceIamBindingDelete(newUpdaterFunc newResourceIamUpdaterFunc, enableBa
 		if err != nil {
 			return err
 		}
-		config.userAgent = userAgent
+
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {
 			return err

--- a/third_party/terraform/resources/resource_iam_binding.go.erb
+++ b/third_party/terraform/resources/resource_iam_binding.go.erb
@@ -117,10 +117,6 @@ func resourceIamBindingCreateUpdate(newUpdaterFunc newResourceIamUpdaterFunc, en
 func resourceIamBindingRead(newUpdaterFunc newResourceIamUpdaterFunc) schema.ReadFunc {
 	return func(d *schema.ResourceData, meta interface{}) error {
 		config := meta.(*Config)
-		userAgent, err := generateUserAgentString(d, config.userAgent)
-		if err != nil {
-			return err
-		}
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {
@@ -255,10 +251,6 @@ func iamBindingImport(newUpdaterFunc newResourceIamUpdaterFunc, resourceIdParser
 func resourceIamBindingDelete(newUpdaterFunc newResourceIamUpdaterFunc, enableBatching bool) schema.DeleteFunc {
 	return func(d *schema.ResourceData, meta interface{}) error {
 		config := meta.(*Config)
-		userAgent, err := generateUserAgentString(d, config.userAgent)
-		if err != nil {
-			return err
-		}
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {

--- a/third_party/terraform/resources/resource_iam_member.go.erb
+++ b/third_party/terraform/resources/resource_iam_member.go.erb
@@ -168,10 +168,6 @@ func getResourceIamMember(d *schema.ResourceData) *cloudresourcemanager.Binding 
 func resourceIamMemberCreate(newUpdaterFunc newResourceIamUpdaterFunc, enableBatching bool) schema.CreateFunc {
 	return func(d *schema.ResourceData, meta interface{}) error {
 		config := meta.(*Config)
-		userAgent, err := generateUserAgentString(d, config.userAgent)
-		if err != nil {
-			return err
-		}
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {
@@ -205,10 +201,6 @@ func resourceIamMemberCreate(newUpdaterFunc newResourceIamUpdaterFunc, enableBat
 func resourceIamMemberRead(newUpdaterFunc newResourceIamUpdaterFunc) schema.ReadFunc {
 	return func(d *schema.ResourceData, meta interface{}) error {
 		config := meta.(*Config)
-		userAgent, err := generateUserAgentString(d, config.userAgent)
-		if err != nil {
-			return err
-		}
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {
@@ -271,10 +263,6 @@ func resourceIamMemberRead(newUpdaterFunc newResourceIamUpdaterFunc) schema.Read
 func resourceIamMemberDelete(newUpdaterFunc newResourceIamUpdaterFunc, enableBatching bool) schema.DeleteFunc {
 	return func(d *schema.ResourceData, meta interface{}) error {
 		config := meta.(*Config)
-		userAgent, err := generateUserAgentString(d, config.userAgent)
-		if err != nil {
-			return err
-		}
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {

--- a/third_party/terraform/resources/resource_iam_member.go.erb
+++ b/third_party/terraform/resources/resource_iam_member.go.erb
@@ -172,7 +172,6 @@ func resourceIamMemberCreate(newUpdaterFunc newResourceIamUpdaterFunc, enableBat
 		if err != nil {
 			return err
 		}
-		config.userAgent = userAgent
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {
@@ -210,7 +209,6 @@ func resourceIamMemberRead(newUpdaterFunc newResourceIamUpdaterFunc) schema.Read
 		if err != nil {
 			return err
 		}
-		config.userAgent = userAgent
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {
@@ -277,7 +275,6 @@ func resourceIamMemberDelete(newUpdaterFunc newResourceIamUpdaterFunc, enableBat
 		if err != nil {
 			return err
 		}
-		config.userAgent = userAgent
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {

--- a/third_party/terraform/resources/resource_iam_policy.go.erb
+++ b/third_party/terraform/resources/resource_iam_policy.go.erb
@@ -59,7 +59,6 @@ func ResourceIamPolicyCreate(newUpdaterFunc newResourceIamUpdaterFunc) schema.Cr
 		if err != nil {
 			return err
 		}
-		config.userAgent = userAgent
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {
@@ -82,7 +81,6 @@ func ResourceIamPolicyRead(newUpdaterFunc newResourceIamUpdaterFunc) schema.Read
 		if err != nil {
 			return err
 		}
-		config.userAgent = userAgent
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {
@@ -112,7 +110,6 @@ func ResourceIamPolicyUpdate(newUpdaterFunc newResourceIamUpdaterFunc) schema.Up
 		if err != nil {
 			return err
 		}
-		config.userAgent = userAgent
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {
@@ -136,7 +133,6 @@ func ResourceIamPolicyDelete(newUpdaterFunc newResourceIamUpdaterFunc) schema.De
 		if err != nil {
 			return err
 		}
-		config.userAgent = userAgent
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {

--- a/third_party/terraform/resources/resource_iam_policy.go.erb
+++ b/third_party/terraform/resources/resource_iam_policy.go.erb
@@ -55,10 +55,6 @@ func ResourceIamPolicy(parentSpecificSchema map[string]*schema.Schema, newUpdate
 func ResourceIamPolicyCreate(newUpdaterFunc newResourceIamUpdaterFunc) schema.CreateFunc {
 	return func(d *schema.ResourceData, meta interface{}) error {
 		config := meta.(*Config)
-		userAgent, err := generateUserAgentString(d, config.userAgent)
-		if err != nil {
-			return err
-		}
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {
@@ -77,10 +73,6 @@ func ResourceIamPolicyCreate(newUpdaterFunc newResourceIamUpdaterFunc) schema.Cr
 func ResourceIamPolicyRead(newUpdaterFunc newResourceIamUpdaterFunc) schema.ReadFunc {
 	return func(d *schema.ResourceData, meta interface{}) error {
 		config := meta.(*Config)
-		userAgent, err := generateUserAgentString(d, config.userAgent)
-		if err != nil {
-			return err
-		}
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {
@@ -106,10 +98,6 @@ func ResourceIamPolicyRead(newUpdaterFunc newResourceIamUpdaterFunc) schema.Read
 func ResourceIamPolicyUpdate(newUpdaterFunc newResourceIamUpdaterFunc) schema.UpdateFunc {
 	return func(d *schema.ResourceData, meta interface{}) error {
 		config := meta.(*Config)
-		userAgent, err := generateUserAgentString(d, config.userAgent)
-		if err != nil {
-			return err
-		}
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {
@@ -129,10 +117,6 @@ func ResourceIamPolicyUpdate(newUpdaterFunc newResourceIamUpdaterFunc) schema.Up
 func ResourceIamPolicyDelete(newUpdaterFunc newResourceIamUpdaterFunc) schema.DeleteFunc {
 	return func(d *schema.ResourceData, meta interface{}) error {
 		config := meta.(*Config)
-		userAgent, err := generateUserAgentString(d, config.userAgent)
-		if err != nil {
-			return err
-		}
 
 		updater, err := newUpdaterFunc(d, config)
 		if err != nil {

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -507,7 +507,6 @@ func TestAccProviderMeta_setModuleName(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccProviderMeta_setModuleName(moduleName, randString(t, 10)),
-				Check:  testAccCheckConfigAgentModified(t, moduleName),
 			},
 			{
 				ResourceName:      "google_compute_address.default",
@@ -516,16 +515,6 @@ func TestAccProviderMeta_setModuleName(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccCheckConfigAgentModified(t *testing.T, moduleName string) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		config := googleProviderConfig(t)
-		if !strings.Contains(config.userAgent, moduleName) {
-			return fmt.Errorf("expected userAgent to contain provider_meta set module_name")
-		}
-		return nil
-	}
 }
 
 func TestAccProviderUserProjectOverride(t *testing.T) {

--- a/third_party/terraform/utils/utils.go.erb
+++ b/third_party/terraform/utils/utils.go.erb
@@ -462,7 +462,7 @@ func generateUserAgentString(d *schema.ResourceData, currentUserAgent string) (s
 		return currentUserAgent, err
 	}
 
-	if m != nil && m != "" {
+	if m != nil && m.ModuleName != "" {
 		return strings.Join([]string{currentUserAgent, m.ModuleName}, " "), nil
 	}
 

--- a/third_party/terraform/utils/utils.go.erb
+++ b/third_party/terraform/utils/utils.go.erb
@@ -462,5 +462,9 @@ func generateUserAgentString(d *schema.ResourceData, currentUserAgent string) (s
 		return currentUserAgent, err
 	}
 
-	return strings.Join([]string{currentUserAgent, m.ModuleName}, " "), nil
+	if m != nil && m != "" {
+		return strings.Join([]string{currentUserAgent, m.ModuleName}, " "), nil
+	}
+
+	return currentUserAgent, nil
 }

--- a/third_party/terraform/utils/utils.go.erb
+++ b/third_party/terraform/utils/utils.go.erb
@@ -462,7 +462,7 @@ func generateUserAgentString(d *schema.ResourceData, currentUserAgent string) (s
 		return currentUserAgent, err
 	}
 
-	if m != nil && m.ModuleName != "" {
+	if m.ModuleName != "" {
 		return strings.Join([]string{currentUserAgent, m.ModuleName}, " "), nil
 	}
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

It looks like some occurrences of this were left in after https://github.com/GoogleCloudPlatform/magic-modules/pull/4016. This means we'd keep appending onto the end of it while a single provider instance was alive, possibly causing issues in large applies.

Also don't append to the user agent if the `m.ModuleName` value is nil or empty- we would have added a space every time `generateUserAgentString` was called.

Notably, this breaks module attribution for batched requests. I'm pretty comfortable with that- it just affects service management and IAM, and we can fix them in a followup.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
provider: fixed an issue where the request headers would grow proportionally to the number of resources in a given `terraform apply`
```
