### PR TITLE
VPC network custom MTU support

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -7394,6 +7394,12 @@ objects:
               name: 'peerMtu'
               description: |
                 Maximum Transmission Unit in bytes.
+      - !ruby/object:Api::Type::Integer
+        name: 'mtu'
+        description: |
+          Maximum Transmission Unit in bytes. The minimum value for this field is 1460
+          and the maximum value is 1500 bytes.
+        input: true
   - !ruby/object:Api::Resource
     name: 'NetworkEndpoint'
     kind: 'compute#networkEndpoint'

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -1075,6 +1075,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "vpc_network"
         vars:
           network_name: "vpc-network"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "network_custom_mtu"
+        primary_resource_id: "vpc_network"
+        vars:
+          network_name: "vpc-network"
     virtual_fields:
       - !ruby/object:Api::Type::Boolean
         name: 'delete_default_routes_on_create'
@@ -1108,6 +1113,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         # while required inside routingConfig, routingMode is an optional convenience
         # field.
         required: false
+        default_from_api: true
+      mtu: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       post_create: templates/terraform/post_create/compute_network_delete_default_route.erb

--- a/templates/terraform/examples/network_custom_mtu.tf.erb
+++ b/templates/terraform/examples/network_custom_mtu.tf.erb
@@ -1,0 +1,4 @@
+resource "google_compute_network" "<%= ctx[:primary_resource_id] %>" {
+  name = "<%= ctx[:vars]['network_name'] %>"
+  mtu  = 1500
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `mtu` field to `google_compute_network` resource
```

fixes hashicorp/terraform-provider-google#7563