### PR TITLE
added project service to validator

### DIFF
--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -103,7 +103,7 @@ module Provider
                        ['google/container.go',
                         'third_party/validator/container.go'],
                        ['google/project_service.go',
-                        'third_party/validator/project_service.go']
+                        'third_party/validator/project_service.go'],
                        ['google/image.go',
                         'third_party/terraform/utils/image.go'],
                        ['google/disk_type.go',

--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -102,6 +102,8 @@ module Provider
                         'third_party/validator/folder_iam.go'],
                        ['google/container.go',
                         'third_party/validator/container.go'],
+                       ['google/project_service.go',
+                        'third_party/validator/project_service.go']
                        ['google/image.go',
                         'third_party/terraform/utils/image.go'],
                        ['google/disk_type.go',
@@ -141,9 +143,7 @@ module Provider
                        ['google/retry_transport.go',
                         'third_party/terraform/utils/retry_transport.go'],
                        ['google/error_retry_predicates.go',
-                        'third_party/terraform/utils/error_retry_predicates.go'],
-                       ['google/project_service.go',
-                        'third_party/validator/project_service.go']
+                        'third_party/terraform/utils/error_retry_predicates.go']
                      ])
     end
 

--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -141,7 +141,9 @@ module Provider
                        ['google/retry_transport.go',
                         'third_party/terraform/utils/retry_transport.go'],
                        ['google/error_retry_predicates.go',
-                        'third_party/terraform/utils/error_retry_predicates.go']
+                        'third_party/terraform/utils/error_retry_predicates.go'],
+                       ['google/project_service.go',
+                        'third_party/validator/project_service.go']
                      ])
     end
 

--- a/third_party/validator/project_service.go
+++ b/third_party/validator/project_service.go
@@ -21,9 +21,8 @@ func GetServiceUsageCaiObject(d TerraformResourceData, config *Config) (Asset, e
 				Data:                 obj,
 			},
 		}, nil
-	} else {
-		return Asset{}, err
 	}
+	return Asset{}, err
 }
 
 func GetServiceUsageApiObject(d TerraformResourceData, config *Config) (map[string]interface{}, error) {
@@ -31,9 +30,9 @@ func GetServiceUsageApiObject(d TerraformResourceData, config *Config) (map[stri
 	parentProjectProp, err := expandServiceUsageParentProject(d.Get("project"), d, config)
 	if err != nil {
 		return nil, err
-	} else if v, ok := d.GetOkExists("project"); !isEmptyValue(reflect.ValueOf(parentProjectProp)) && (ok || !reflect.DeepEqual(v, parentProjectProp)) {
-		obj["parent"] = parentProjectProp
 	}
+	obj["parent"] = parentProjectProp
+
 	serviceNameProp, err := expandServiceUsageServiceName(d.Get("service"), d, config)
 	if err != nil {
 		return nil, err

--- a/third_party/validator/project_service.go
+++ b/third_party/validator/project_service.go
@@ -1,0 +1,61 @@
+package google
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func GetServiceUsageCaiObject(d TerraformResourceData, config *Config) (Asset, error) {
+	name, err := assetName(d, config, "//serviceusage.googleapis.com/projects/{{project}}/services/{{service}}")
+	if err != nil {
+		return Asset{}, err
+	}
+	if obj, err := GetServiceUsageApiObject(d, config); err == nil {
+		return Asset{
+			Name: name,
+			Type: "serviceusage.googleapis.com/Service",
+			Resource: &AssetResource{
+				Version:              "v1",
+				DiscoveryDocumentURI: "https://www.googleapis.com/discovery/v1/apis/serviceusage/v1/rest",
+				DiscoveryName:        "Service",
+				Data:                 obj,
+			},
+		}, nil
+	} else {
+		return Asset{}, err
+	}
+}
+
+func GetServiceUsageApiObject(d TerraformResourceData, config *Config) (map[string]interface{}, error) {
+	obj := make(map[string]interface{})
+	parentProjectProp, err := expandServiceUsageParentProject(d.Get("project"), d, config)
+	if err != nil {
+		return nil, err
+	} else if v, ok := d.GetOkExists("project"); !isEmptyValue(reflect.ValueOf(parentProjectProp)) && (ok || !reflect.DeepEqual(v, parentProjectProp)) {
+		obj["parent"] = parentProjectProp
+	}
+	serviceNameProp, err := expandServiceUsageServiceName(d.Get("service"), d, config)
+	if err != nil {
+		return nil, err
+	} else if v, ok := d.GetOkExists("service"); !isEmptyValue(reflect.ValueOf(serviceNameProp)) && (ok || !reflect.DeepEqual(v, serviceNameProp)) {
+		obj["name"] = serviceNameProp
+	}
+
+	obj["state"] = "ENABLED"
+
+	return obj, nil
+}
+
+func expandServiceUsageParentProject(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	if v == nil || v.(string) == "" {
+		// It does not try to construct anything from empty.
+		return "", nil
+	}
+	// Ideally we should use project_number, but since that is generated server-side,
+	// we substitute project_id.
+	return fmt.Sprintf("projects/%s", v.(string)), nil
+}
+
+func expandServiceUsageServiceName(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	return v, nil
+}

--- a/third_party/validator/project_service_test.go
+++ b/third_party/validator/project_service_test.go
@@ -1,0 +1,93 @@
+package google
+
+import (
+	"testing"
+)
+
+func TestParseServiceForExistingProject(t *testing.T) {
+	cases := []struct {
+		name                  string
+		data                  TerraformResourceData
+		expectedType          string
+		expectedAssetName     string
+		expectedParentProject string
+		expectedService       string
+		expectedState         string
+	}{
+		{
+			name: "resource has service and project",
+			data: &mockTerraformResourceData{
+				m: map[string]interface{}{
+					"project": "test-project",
+					"service": "iamcredentials.googleapis.com",
+				},
+			},
+			expectedType:          "serviceusage.googleapis.com/Service",
+			expectedAssetName:     "//serviceusage.googleapis.com/projects/test-project/services/iamcredentials.googleapis.com",
+			expectedParentProject: "projects/test-project",
+			expectedServiceName:   "iamcredentials.googleapis.com",
+			expectedState:         "ENABLED",
+		},
+		{
+			name: "resource has service but missing project",
+			data: &mockTerraformResourceData{
+				m: map[string]interface{}{
+					"service": "iamcredentials.googleapis.com",
+				},
+			},
+			expectedType:          "serviceusage.googleapis.com/Service",
+			expectedAssetName:     "//serviceusage.googleapis.com/projects/default_project/services/iamcredentials.googleapis.com",
+			expectedParentProject: "",
+			expectedServiceName:   "iamcredentials.googleapis.com",
+			expectedState:         "ENABLED",
+		},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &Config{}
+			config.Project = "default_project"
+			asset, err := GetServiceUsageCaiObject(tt.data, config)
+			if err != nil {
+				t.Errorf("%s failed to convert project_service resource:%q", tt.name, err)
+			}
+			if asset.Type != tt.expectedType {
+				t.Errorf("Case: %s. Error converting asset type. Expected: %q got: %q", tt.name, tt.expectedType, asset.Type)
+			}
+			if asset.Name != tt.expectedAssetName {
+				t.Errorf("Case: %s. Error converting asset name. Expected: %q got: %q", tt.name, tt.expectedAssetName, asset.Name)
+			}
+			if asset.Resource.Data["parent"] != tt.expectedParentProject {
+				t.Errorf("Case: %s. Error converting asset parent project. Expected: %q got: %q", tt.name, tt.expectedParentProject, asset.Resource.Data["parent"])
+			}
+			if asset.Resource.Data["name"] != tt.expectedServiceName {
+				t.Errorf("Case: %s. Error converting asset service name. Expected: %q got: %q", tt.name, tt.expectedServiceName, asset.Resource.Data["name"])
+			}
+			if asset.Resource.Data["state"] != tt.expectedState {
+				t.Errorf("Case: %s. Error converting asset state. Expected: %q got: %q", tt.name, tt.expectedService, asset.Resource.Data["state"])
+			}
+		})
+	}
+}
+
+type mockTerraformResourceData struct {
+	m map[string]interface{}
+	TerraformResourceData
+}
+
+func (d *mockTerraformResourceData) GetOkExists(k string) (interface{}, bool) {
+	v, ok := d.m[k]
+	return v, ok
+}
+
+func (d *mockTerraformResourceData) GetOk(k string) (interface{}, bool) {
+	v, ok := d.m[k]
+	return v, ok
+}
+
+func (d *mockTerraformResourceData) Get(k string) interface{} {
+	v, ok := d.m[k]
+	if !ok {
+		return nil
+	}
+	return v
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Added conversion of project_service to serviceusage  in validator.

[Terrafor-validator](https://github.com/GoogleCloudPlatform/terraform-validator) uses downstream repo [terraform-google-conversion](https://github.com/GoogleCloudPlatform/terraform-google-conversion) to [map](https://github.com/GoogleCloudPlatform/terraform-validator/blob/master/converters/google/mappers.go) the resources that can be converted.

Required step  to fix https://github.com/GoogleCloudPlatform/terraform-validator/issues/153 

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Added conversion from project_service to CAI service usage for validator
```
