### PR TITLE
Added newline after virtual fields in documentation generation 

### DIFF
--- a/templates/terraform/resource.html.markdown.erb
+++ b/templates/terraform/resource.html.markdown.erb
@@ -139,10 +139,11 @@ The following arguments are supported:
 <%- unless object.virtual_fields.empty? -%>
 <%-   object.virtual_fields.each do |field| -%>
 * `<%= field.name -%>` - (Optional) <%= field.description -%>
+
 <%    end -%>
 <% end -%>
 <%- unless object.docs.optional_properties.nil? -%>
-<%= "\n" + object.docs.optional_properties -%>
+<%= object.docs.optional_properties -%>
 <% end -%>
 <% properties.reject(&:required).reject(&:output).each do |prop| -%>
 <%= lines(build_nested_property_documentation(prop, pwd)) -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Noticed in this [pr](https://github.com/hashicorp/terraform-provider-google/pull/7550) a community member opened 


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
