### PR TITLE
update network peering custom routes

### DIFF
--- a/third_party/terraform/tests/resource_compute_network_peering_test.go
+++ b/third_party/terraform/tests/resource_compute_network_peering_test.go
@@ -59,6 +59,41 @@ func TestAccComputeNetworkPeering_subnetRoutes(t *testing.T) {
 	})
 }
 
+func TestAccComputeNetworkPeering_customRoutesUpdate(t *testing.T) {
+	t.Parallel()
+
+	primaryNetworkName := fmt.Sprintf("network-test-1-%d", randInt(t))
+	peeringName := fmt.Sprintf("peering-test-%d", randInt(t))
+	importId := fmt.Sprintf("%s/%s/%s", getTestProjectFromEnv(), primaryNetworkName, peeringName)
+	suffix := randString(t, 10)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccComputeNetworkPeeringDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeNetworkPeeringDefaultCustomRoutes(primaryNetworkName, peeringName, suffix),
+			},
+			{
+				ResourceName:      "google_compute_network_peering.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     importId,
+			},
+			{
+				Config: testAccComputeNetworkPeering_basic(primaryNetworkName, peeringName, suffix),
+			},
+			{
+				ResourceName:      "google_compute_network_peering.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     importId,
+			},
+		},
+	})
+}
+
 func testAccComputeNetworkPeeringDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
@@ -127,4 +162,30 @@ resource "google_compute_network_peering" "bar" {
   export_subnet_routes_with_public_ip = false
 }
 `, primaryNetworkName, suffix, peeringName)
+}
+
+func testAccComputeNetworkPeeringDefaultCustomRoutes(primaryNetworkName, peeringName, suffix string) string {
+	s := `
+resource "google_compute_network" "network1" {
+  name                    = "%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_network_peering" "foo" {
+  name         = "%s"
+  network      = google_compute_network.network1.self_link
+  peer_network = google_compute_network.network2.self_link
+}
+
+resource "google_compute_network" "network2" {
+  name                    = "network-test-2-%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_network_peering" "bar" {
+  network      = google_compute_network.network2.self_link
+  peer_network = google_compute_network.network1.self_link
+  name         = "peering-test-2-%s"
+}`
+	return fmt.Sprintf(s, primaryNetworkName, peeringName, suffix, suffix)
 }


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/5971
Upstreams/Updates: https://github.com/hashicorp/terraform-provider-google/pull/6020

Updated the original PR to be consistent with general changes made to the providers since the PR was pushed. Added a few other fixes to both the update logic and tests.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added support for non-destructive updates to `export_custom_routes` and `import_custom_routes` for `google_compute_network_peering`
```
