### PR TITLE
Don't run sql precheck if projects.get call fails

### DIFF
--- a/third_party/terraform/resources/resource_service_networking_connection.go
+++ b/third_party/terraform/resources/resource_service_networking_connection.go
@@ -320,10 +320,12 @@ func retrieveServiceNetworkingNetworkName(d *schema.ResourceData, config *Config
 	if pid == "" {
 		return "", fmt.Errorf("Could not determine project")
 	}
-
+	log.Printf("[DEBUG] Retrieving project number by doing a GET with the project id, as required by service networking")
 	project, err := config.NewResourceManagerClient(userAgent).Projects.Get(pid).Do()
 	if err != nil {
-		return "", fmt.Errorf("Failed to retrieve project, pid: %s, err: %s", pid, err)
+		// note: returning a wrapped error is part of this method's contract!
+		// https://blog.golang.org/go1.13-errors
+		return "", fmt.Errorf("Failed to retrieve project, pid: %s, err: %w", pid, err)
 	}
 
 	networkName := networkFieldValue.Name

--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -664,22 +664,30 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 		return fmt.Errorf("Error setting name: %s", err)
 	}
 
-	// Before we create the instance, check if at least 1 service connection exists for private SQL Instances.
+	// SQL Instances that fail to create are expensive- see https://github.com/hashicorp/terraform-provider-google/issues/7154
+	// We can fail fast to stop instance names from getting reserved.
 	network := d.Get("settings.0.ip_configuration.0.private_network").(string)
 	if network != "" {
-		// Borrow some of the functions from resource_service_networking_connection.go
+		log.Printf("[DEBUG] checking network %q for at least one service networking connection", network)
+		// This call requires projects.get permissions, which may not have been granted to the Terraform actor,
+		// particularly in shared VPC setups. Most will! But it's not strictly required.
 		serviceNetworkingNetworkName, err := retrieveServiceNetworkingNetworkName(d, config, network, userAgent)
 		if err != nil {
-			return err
-		}
-		response, err := config.NewServiceNetworkingClient(userAgent).Services.Connections.List("services/servicenetworking.googleapis.com").
-			Network(serviceNetworkingNetworkName).Do()
-		if err != nil {
-			// It is possible that the identity creating the SQL Instance might not have permissions to call servicenetworking.services.connections.list
-			log.Printf("[WARNING] Failed to list Service Networking of the project. Skipping Service Networking check.")
+			var gerr *googleapi.Error
+			if errors.As(err, &gerr) {
+				log.Printf("[DEBUG] retrieved googleapi error while creating sn name for %q. skipping precheck. code %v and message: %s", network, gerr.Code, gerr.Body)
+			} else {
+				return err
+			}
 		} else {
-			if len(response.Connections) < 1 {
-				return fmt.Errorf("Error, failed to create instance because the network doesn't have at least 1 private services connection. Please see https://cloud.google.com/sql/docs/mysql/private-ip#network_requirements for how to create this connection.")
+			response, err := config.NewServiceNetworkingClient(userAgent).Services.Connections.List("services/servicenetworking.googleapis.com").Network(serviceNetworkingNetworkName).Do()
+			if err != nil {
+				// It is possible that the actor creating the SQL Instance might not have permissions to call servicenetworking.services.connections.list
+				log.Printf("[WARNING] Failed to list Service Networking of the project. Skipping Service Networking check.")
+			} else {
+				if len(response.Connections) < 1 {
+					return fmt.Errorf("Error, failed to create instance because the network doesn't have at least 1 private services connection. Please see https://cloud.google.com/sql/docs/mysql/private-ip#network_requirements for how to create this connection.")
+				}
 			}
 		}
 	}

--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -675,7 +675,7 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 		if err != nil {
 			var gerr *googleapi.Error
 			if errors.As(err, &gerr) {
-				log.Printf("[DEBUG] retrieved googleapi error while creating sn name for %q. skipping precheck. code %v and message: %s", network, gerr.Code, gerr.Body)
+				log.Printf("[DEBUG] retrieved googleapi error while creating sn name for %q. precheck skipped. code %v and message: %s", network, gerr.Code, gerr.Body)
 			} else {
 				return err
 			}
@@ -683,7 +683,7 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 			response, err := config.NewServiceNetworkingClient(userAgent).Services.Connections.List("services/servicenetworking.googleapis.com").Network(serviceNetworkingNetworkName).Do()
 			if err != nil {
 				// It is possible that the actor creating the SQL Instance might not have permissions to call servicenetworking.services.connections.list
-				log.Printf("[WARNING] Failed to list Service Networking of the project. Skipping Service Networking check.")
+				log.Printf("[WARNING] Failed to list Service Networking of the project. Skipped Service Networking precheck.")
 			} else {
 				if len(response.Connections) < 1 {
 					return fmt.Errorf("Error, failed to create instance because the network doesn't have at least 1 private services connection. Please see https://cloud.google.com/sql/docs/mysql/private-ip#network_requirements for how to create this connection.")

--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -668,27 +668,9 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 	// We can fail fast to stop instance names from getting reserved.
 	network := d.Get("settings.0.ip_configuration.0.private_network").(string)
 	if network != "" {
-		log.Printf("[DEBUG] checking network %q for at least one service networking connection", network)
-		// This call requires projects.get permissions, which may not have been granted to the Terraform actor,
-		// particularly in shared VPC setups. Most will! But it's not strictly required.
-		serviceNetworkingNetworkName, err := retrieveServiceNetworkingNetworkName(d, config, network, userAgent)
+		err = sqlDatabaseInstanceServiceNetworkPrecheck(d, config, userAgent, network)
 		if err != nil {
-			var gerr *googleapi.Error
-			if errors.As(err, &gerr) {
-				log.Printf("[DEBUG] retrieved googleapi error while creating sn name for %q. precheck skipped. code %v and message: %s", network, gerr.Code, gerr.Body)
-			} else {
-				return err
-			}
-		} else {
-			response, err := config.NewServiceNetworkingClient(userAgent).Services.Connections.List("services/servicenetworking.googleapis.com").Network(serviceNetworkingNetworkName).Do()
-			if err != nil {
-				// It is possible that the actor creating the SQL Instance might not have permissions to call servicenetworking.services.connections.list
-				log.Printf("[WARNING] Failed to list Service Networking of the project. Skipped Service Networking precheck.")
-			} else {
-				if len(response.Connections) < 1 {
-					return fmt.Errorf("Error, failed to create instance because the network doesn't have at least 1 private services connection. Please see https://cloud.google.com/sql/docs/mysql/private-ip#network_requirements for how to create this connection.")
-				}
-			}
+			return err
 		}
 	}
 
@@ -1331,4 +1313,33 @@ func instanceMutexKey(project, instance_name string) string {
 func sqlDatabaseIsMaster(d *schema.ResourceData) bool {
 	_, ok := d.GetOk("master_instance_name")
 	return !ok
+}
+
+func sqlDatabaseInstanceServiceNetworkPrecheck(d *schema.ResourceData, config *Config, userAgent, network string) error {
+		log.Printf("[DEBUG] checking network %q for at least one service networking connection", network)
+		// This call requires projects.get permissions, which may not have been granted to the Terraform actor,
+		// particularly in shared VPC setups. Most will! But it's not strictly required.
+		serviceNetworkingNetworkName, err := retrieveServiceNetworkingNetworkName(d, config, network, userAgent)
+		if err != nil {
+			var gerr *googleapi.Error
+			if errors.As(err, &gerr) {
+				log.Printf("[DEBUG] retrieved googleapi error while creating sn name for %q. precheck skipped. code %v and message: %s", network, gerr.Code, gerr.Body)
+				return nil
+			}
+
+			return err
+		}
+
+		response, err := config.NewServiceNetworkingClient(userAgent).Services.Connections.List("services/servicenetworking.googleapis.com").Network(serviceNetworkingNetworkName).Do()
+		if err != nil {
+			// It is possible that the actor creating the SQL Instance might not have permissions to call servicenetworking.services.connections.list
+			log.Printf("[WARNING] Failed to list Service Networking of the project. Skipped Service Networking precheck.")
+			return nil
+		}
+
+		if len(response.Connections) < 1 {
+			return fmt.Errorf("Error, failed to create instance because the network doesn't have at least 1 private services connection. Please see https://cloud.google.com/sql/docs/mysql/private-ip#network_requirements for how to create this connection.")
+		}
+
+		return nil
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/7595

Reproduced locally, and this fixes the error the user experienced. This requires a whole bunch of host project / service project IAM setup that doesn't make it worth setting up an integration test for imo.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
sql: fixed a case in `google_sql_database_instance` where we inadvertently required the `projects.get` permission for a service networking precheck introduced in `v3.44.0`
```
