### PR TITLE
rename test resources so they get swept

### DIFF
--- a/third_party/terraform/tests/resource_compute_instance_from_template_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_from_template_test.go
@@ -14,8 +14,8 @@ func TestAccComputeInstanceFromTemplate_basic(t *testing.T) {
 	t.Parallel()
 
 	var instance compute.Instance
-	instanceName := fmt.Sprintf("terraform-test-%s", randString(t, 10))
-	templateName := fmt.Sprintf("terraform-test-%s", randString(t, 10))
+	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	templateName := fmt.Sprintf("tf-test-%s", randString(t, 10))
 	resourceName := "google_compute_instance_from_template.foobar"
 
 	vcrTest(t, resource.TestCase{
@@ -42,10 +42,10 @@ func TestAccComputeInstanceFromTemplate_overrideBootDisk(t *testing.T) {
 	t.Parallel()
 
 	var instance compute.Instance
-	instanceName := fmt.Sprintf("terraform-test-%s", randString(t, 10))
-	templateName := fmt.Sprintf("terraform-test-%s", randString(t, 10))
-	templateDisk := fmt.Sprintf("terraform-test-%s", randString(t, 10))
-	overrideDisk := fmt.Sprintf("terraform-test-%s", randString(t, 10))
+	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	templateName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	templateDisk := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	overrideDisk := fmt.Sprintf("tf-test-%s", randString(t, 10))
 	resourceName := "google_compute_instance_from_template.inst"
 
 	vcrTest(t, resource.TestCase{
@@ -71,10 +71,10 @@ func TestAccComputeInstanceFromTemplate_overrideAttachedDisk(t *testing.T) {
 	t.Parallel()
 
 	var instance compute.Instance
-	instanceName := fmt.Sprintf("terraform-test-%s", randString(t, 10))
-	templateName := fmt.Sprintf("terraform-test-%s", randString(t, 10))
-	templateDisk := fmt.Sprintf("terraform-test-%s", randString(t, 10))
-	overrideDisk := fmt.Sprintf("terraform-test-%s", randString(t, 10))
+	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	templateName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	templateDisk := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	overrideDisk := fmt.Sprintf("tf-test-%s", randString(t, 10))
 	resourceName := "google_compute_instance_from_template.inst"
 
 	vcrTest(t, resource.TestCase{
@@ -100,10 +100,10 @@ func TestAccComputeInstanceFromTemplate_overrideScratchDisk(t *testing.T) {
 	t.Parallel()
 
 	var instance compute.Instance
-	instanceName := fmt.Sprintf("terraform-test-%s", randString(t, 10))
-	templateName := fmt.Sprintf("terraform-test-%s", randString(t, 10))
-	templateDisk := fmt.Sprintf("terraform-test-%s", randString(t, 10))
-	overrideDisk := fmt.Sprintf("terraform-test-%s", randString(t, 10))
+	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	templateName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	templateDisk := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	overrideDisk := fmt.Sprintf("tf-test-%s", randString(t, 10))
 	resourceName := "google_compute_instance_from_template.inst"
 
 	vcrTest(t, resource.TestCase{
@@ -153,8 +153,8 @@ func TestAccComputeInstanceFromTemplate_012_removableFields(t *testing.T) {
 	t.Parallel()
 
 	var instance compute.Instance
-	instanceName := fmt.Sprintf("terraform-test-%s", randString(t, 10))
-	templateName := fmt.Sprintf("terraform-test-%s", randString(t, 10))
+	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	templateName := fmt.Sprintf("tf-test-%s", randString(t, 10))
 	resourceName := "google_compute_instance_from_template.inst"
 
 	// First config is a basic instance from template, second tests the empty list syntax
@@ -194,8 +194,8 @@ func TestAccComputeInstanceFromTemplate_012_removableFields(t *testing.T) {
 
 func TestAccComputeInstanceFromTemplate_overrideMetadataDotStartupScript(t *testing.T) {
 	var instance compute.Instance
-	instanceName := fmt.Sprintf("terraform-test-%s", randString(t, 10))
-	templateName := fmt.Sprintf("terraform-test-%s", randString(t, 10))
+	instanceName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	templateName := fmt.Sprintf("tf-test-%s", randString(t, 10))
 	resourceName := "google_compute_instance_from_template.inst"
 
 	vcrTest(t, resource.TestCase{


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
