### PR TITLE
Add support for custom info types to inspect template.

### DIFF
--- a/products/dlp/api.yaml
+++ b/products/dlp/api.yaml
@@ -628,6 +628,98 @@ objects:
                                       description: |
                                         Name of the information type. Either a name of your choosing when creating a CustomInfoType, or one of the names listed
                                         at https://cloud.google.com/dlp/docs/infotypes-reference when specifying a built-in type.
+          - !ruby/object:Api::Type::Array
+            name: 'customInfoTypes'
+            description: |
+              Custom info types to be used. See https://cloud.google.com/dlp/docs/creating-custom-infotypes to learn more.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'infoType'
+                  required: true
+                  description: |
+                    CustomInfoType can either be a new infoType, or an extension of built-in infoType, when the name matches one of existing
+                    infoTypes and that infoType is specified in `info_types` field. Specifying the latter adds findings to the
+                    one detected by the system. If built-in info type is not specified in `info_types` list then the name is
+                    treated as a custom info type.
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: 'name'
+                      required: true
+                      description: |
+                        Name of the information type. Either a name of your choosing when creating a CustomInfoType, or one of the names
+                        listed at https://cloud.google.com/dlp/docs/infotypes-reference when specifying a built-in type.
+                - !ruby/object:Api::Type::Enum
+                  name: 'likelihood'
+                  description: |
+                    Likelihood to return for this CustomInfoType. This base value can be altered by a detection rule if the finding meets the criteria
+                    specified by the rule.
+                  values:
+                    - :VERY_UNLIKELY
+                    - :UNLIKELY
+                    - :POSSIBLE
+                    - :LIKELY
+                    - :VERY_LIKELY
+                  default_value: :VERY_LIKELY
+                - !ruby/object:Api::Type::Enum
+                  name: 'exclusionType'
+                  description: |
+                    If set to EXCLUSION_TYPE_EXCLUDE this infoType will not cause a finding to be returned. It still can be used for rules matching.
+                  values:
+                    - :EXCLUSION_TYPE_EXCLUDE
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'regex'
+                  description: Regular expression which defines the rule.
+                  input: true
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: 'pattern'
+                      required: true
+                      description: |
+                        Pattern defining the regular expression.
+                        Its syntax (https://github.com/google/re2/wiki/Syntax) can be found under the google/re2 repository on GitHub.
+                    - !ruby/object:Api::Type::Array
+                      name: 'groupIndexes'
+                      description: |
+                        The index of the submatch to extract as findings. When not specified, the entire match is returned. No more than 3 may be included.
+                      item_type: Api::Type::Integer
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'dictionary'
+                  description: Dictionary which defines the rule.
+                  input: true
+                  properties:
+                    - !ruby/object:Api::Type::NestedObject
+                      name: 'wordList'
+                      description: List of words or phrases to search for.
+                      properties:
+                        - !ruby/object:Api::Type::Array
+                          name: 'words'
+                          required: true
+                          description: |
+                            Words or phrases defining the dictionary. The dictionary must contain at least one
+                            phrase and every phrase must contain at least 2 characters that are letters or digits.
+                          item_type: Api::Type::String
+                    - !ruby/object:Api::Type::NestedObject
+                      name: 'cloudStoragePath'
+                      description: Newline-delimited file of words in Cloud Storage. Only a single file is accepted.
+                      properties:
+                        - !ruby/object:Api::Type::String
+                          name: 'path'
+                          required: true
+                          description: |
+                            A url representing a file or path (no wildcards) in Cloud Storage. Example: `gs://[BUCKET_NAME]/dictionary.txt`
+                - !ruby/object:Api::Type::NestedObject
+                  name: 'storedType'
+                  description: A reference to a StoredInfoType to use with scanning.
+                  input: true
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: 'name'
+                      required: true
+                      description: |
+                        Resource name of the requested StoredInfoType, for example `organizations/433245324/storedInfoTypes/432452342`
+                        or `projects/project-id/storedInfoTypes/432452342`.
+
   - !ruby/object:Api::Resource
     name: 'StoredInfoType'
     create_url:  "{{parent}}/storedInfoTypes"

--- a/products/dlp/terraform.yaml
+++ b/products/dlp/terraform.yaml
@@ -56,6 +56,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           template: "temp"
         test_env_vars:
           project: :PROJECT_NAME
+      - !ruby/object:Provider::Terraform::Examples
+        name: "dlp_inspect_template_custom_type"
+        primary_resource_id: "custom"
+        vars:
+          template: "temp"
+        test_env_vars:
+          project: :PROJECT_NAME
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       encoder: templates/terraform/encoders/wrap_object.go.erb
       custom_import: templates/terraform/custom_import/dlp_import.go.erb

--- a/templates/terraform/examples/dlp_inspect_template_custom_type.tf.erb
+++ b/templates/terraform/examples/dlp_inspect_template_custom_type.tf.erb
@@ -1,0 +1,43 @@
+resource "google_data_loss_prevention_inspect_template" "<%= ctx[:primary_resource_id] %>" {
+	parent = "projects/<%= ctx[:test_env_vars]['project'] %>"
+	description = "My description"
+	display_name = "display_name"
+
+	inspect_config {
+		custom_info_types {
+			info_type {
+				name = "MY_CUSTOM_TYPE"
+			}
+
+			likelihood = "UNLIKELY"
+
+			regex {
+				pattern = "test*"
+			}
+		}
+
+		info_types {
+			name = "EMAIL_ADDRESS"
+		}
+
+		min_likelihood = "UNLIKELY"
+		rule_set {
+			info_types {
+				name = "EMAIL_ADDRESS"
+			}
+			rules {
+				exclusion_rule {
+					regex {
+						pattern = ".+@example.com"
+					}
+					matching_type = "MATCHING_TYPE_FULL_MATCH"
+				}
+			}
+		}
+
+		limits {
+			max_findings_per_item    = 10
+			max_findings_per_request = 50
+		}
+	}
+}

--- a/templates/terraform/examples/dlp_inspect_template_custom_type.tf.erb
+++ b/templates/terraform/examples/dlp_inspect_template_custom_type.tf.erb
@@ -35,6 +35,25 @@ resource "google_data_loss_prevention_inspect_template" "<%= ctx[:primary_resour
 			}
 		}
 
+		rule_set {
+			info_types {
+				name = "MY_CUSTOM_TYPE"
+			}
+			rules {
+				hotword_rule {
+					hotword_regex {
+						pattern = "example*"
+					}
+					proximity {
+						window_before = 50
+					}
+					likelihood_adjustment {
+						fixed_likelihood = "VERY_LIKELY"
+					}
+				}
+			}
+		}
+
 		limits {
 			max_findings_per_item    = 10
 			max_findings_per_request = 50


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/7625

Couple of fields not supported, as they are marked as deprecated or structure undocumented



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dlp: added `custom_info_types` to `google_dlp_inspect_template`
```
