### PR TITLE
Updated disruption budget to use API-correct percent key instead of p…

### DIFF
--- a/products/osconfig/api.yaml
+++ b/products/osconfig/api.yaml
@@ -874,7 +874,7 @@ objects:
                   - rollout.0.disruption_budget.0.fixed
                   - rollout.0.disruption_budget.0.percentage
               - !ruby/object:Api::Type::Integer
-                name: percentage
+                name: percent
                 description: |
                   Specifies the relative value defined as a percentage, which will be multiplied by a reference value.
                 exactly_one_of:

--- a/products/osconfig/api.yaml
+++ b/products/osconfig/api.yaml
@@ -874,7 +874,8 @@ objects:
                   - rollout.0.disruption_budget.0.fixed
                   - rollout.0.disruption_budget.0.percentage
               - !ruby/object:Api::Type::Integer
-                name: percent
+                name: percentage
+                api_name: percent
                 description: |
                   Specifies the relative value defined as a percentage, which will be multiplied by a reference value.
                 exactly_one_of:

--- a/products/osconfig/terraform.yaml
+++ b/products/osconfig/terraform.yaml
@@ -58,7 +58,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           function: 'validation.IntBetween(-1,31)'
       recurringSchedule.frequency: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
-      rollout.disruptionBudget.percent: !ruby/object:Overrides::Terraform::PropertyOverride
+      rollout.disruptionBudget.percentage: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validation.IntBetween(0,100)'
       rollout.disruptionBudget.fixed: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/products/osconfig/terraform.yaml
+++ b/products/osconfig/terraform.yaml
@@ -58,7 +58,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           function: 'validation.IntBetween(-1,31)'
       recurringSchedule.frequency: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
-      rollout.disruptionBudget.percentage: !ruby/object:Overrides::Terraform::PropertyOverride
+      rollout.disruptionBudget.percent: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validation.IntBetween(0,100)'
       rollout.disruptionBudget.fixed: !ruby/object:Overrides::Terraform::PropertyOverride


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This resolves issue: https://github.com/hashicorp/terraform-provider-google/issues/7612

Where API calls to the OS config patch api is incorrect in the provider


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Bug:** fixing google_os_config_patch_management resource

```release-note:bug
osconfig: fixed an issue where the `rollout.disruption_budget.percentage` field in `google_os_config_patch_deployment` did not correspond to a field in the API
```
