### PR TITLE
Moving CI to Github workflows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,37 @@
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: test
+on:
+  # Trigger the workflow on push or pull request, but only for the main branch
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-ruby@v1
+      with:
+        ruby-version: '2.6' # Version range or exact version of a Ruby version to use, using semvers version range syntax.
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3'
+    # install black, required for tests
+    - run: python -m pip install --user black
+    - run: gem install bundler
+    - run: bundle install
+    - run: bundle exec rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby # ruby version defined in .ruby-version will be used
-
-script:
-- bundle exec rake test
-
-git:
-  submodules: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,5 +74,4 @@ DEPENDENCIES
   rubocop (>= 0.77.0)
 
 BUNDLED WITH
-   1.17.2
-
+   2.1.4


### PR DESCRIPTION
Travis is moving to travis-ci.com, which requires access to all
repositories via the "repo" scope.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
