### PR TITLE
feat(bigquery-data-transfer): add email preferences

### DIFF
--- a/products/bigquerydatatransfer/api.yaml
+++ b/products/bigquerydatatransfer/api.yaml
@@ -146,10 +146,9 @@ objects:
         properties:
           - !ruby/object:Api::Type::Boolean
             name: 'enableFailureEmail'
+            required: true
             description: |
               If true, email notifications will be sent on transfer run failures.
-            at_least_one_of:
-              - email_preferences.0.enable_failure_email
       - !ruby/object:Api::Type::String
           name: 'notificationPubsubTopic'
           description: |

--- a/products/bigquerydatatransfer/api.yaml
+++ b/products/bigquerydatatransfer/api.yaml
@@ -138,6 +138,18 @@ objects:
               - schedule_options.0.disable_auto_scheduling
               - schedule_options.0.start_time
               - schedule_options.0.end_time
+      - !ruby/object:Api::Type::NestedObject
+        name: 'emailPreferences'
+        description: |
+          Email notifications will be sent according to these preferences to the
+          email address of the user who owns this transfer config.
+        properties:
+          - !ruby/object:Api::Type::Boolean
+            name: 'enableFailureEmail'
+            description: |
+              If true, email notifications will be sent on transfer run failures.
+            at_least_one_of:
+              - email_preferences.0.enable_failure_email
       - !ruby/object:Api::Type::String
           name: 'notificationPubsubTopic'
           description: |

--- a/third_party/terraform/tests/resource_bigquery_data_transfer_config_test.go
+++ b/third_party/terraform/tests/resource_bigquery_data_transfer_config_test.go
@@ -191,6 +191,9 @@ resource "google_bigquery_data_transfer_config" "query_config" {
   }
   destination_dataset_id = google_bigquery_dataset.my_dataset.dataset_id
   notification_pubsub_topic = google_pubsub_topic.my_topic.id
+  email_preferences = {
+    enable_failure_email = true
+  }
   params = {
     destination_table_name_template = "my_table"
     write_disposition               = "WRITE_APPEND"


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/5320

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: added `email_preferences ` field to `google_bigquery_data_transfer_config` resource
```
