### PR TITLE
Add MQL based alerts

### DIFF
--- a/products/monitoring/api.yaml
+++ b/products/monitoring/api.yaml
@@ -295,6 +295,59 @@ objects:
                policy.
              output: true
            - !ruby/object:Api::Type::NestedObject
+             name: conditionMonitoringQueryLanguage
+             description: |
+               A Monitoring Query Language query that outputs a boolean stream
+             properties:
+              - !ruby/object:Api::Type::String
+                name: query
+                description: |
+                  Monitoring Query Language query that outputs a boolean stream.
+                required: true
+              - !ruby/object:Api::Type::String
+                name: duration
+                required: true
+                description: |
+                  The amount of time that a time series must
+                  violate the threshold to be considered
+                  failing. Currently, only values that are a
+                  multiple of a minute--e.g., 0, 60, 120, or
+                  300 seconds--are supported. If an invalid
+                  value is given, an error will be returned.
+                  When choosing a duration, it is useful to
+                  keep in mind the frequency of the underlying
+                  time series data (which may also be affected
+                  by any alignments specified in the
+                  aggregations field); a good duration is long
+                  enough so that a single outlier does not
+                  generate spurious alerts, but short enough
+                  that unhealthy states are detected and
+                  alerted on quickly.
+              - !ruby/object:Api::Type::NestedObject
+                name: trigger
+                description: |
+                  The number/percent of time series for which
+                  the comparison must hold in order for the
+                  condition to trigger. If unspecified, then
+                  the condition will trigger if the comparison
+                  is true for any of the time series that have
+                  been identified by filter and aggregations,
+                  or by the ratio, if denominator_filter and
+                  denominator_aggregations are specified.
+                properties:
+                 - !ruby/object:Api::Type::Double
+                   name: percent
+                   description: |
+                     The percentage of time series that
+                     must fail the predicate for the
+                     condition to be triggered.
+                 - !ruby/object:Api::Type::Integer
+                   name: count
+                   description: |
+                     The absolute number of time series
+                     that must fail the predicate for the
+                     condition to be triggered.
+           - !ruby/object:Api::Type::NestedObject
              name: conditionThreshold
              description: |
                A condition that compares a time series against a


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR adds MQL based alerting for the monitoring alert resource.

Fixes hashicorp/terraform-provider-google#7464

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
monitoring: Added Monitoring Query Language based alerting for `google_monitoring_alert_policy`
```
