### PR TITLE
Moving rake tests to cloud build

### DIFF
--- a/.ci/gcb-downstream-builder.yml
+++ b/.ci/gcb-downstream-builder.yml
@@ -10,4 +10,7 @@ steps:
             '--cache-from', 'gcr.io/$PROJECT_ID/downstream-builder:latest',
             './.ci/containers/downstream-builder'
         ]
+# the downstream-builder takes around 15 minutes to build
+timeout: "8000s"
+# note: this container is also used for the run-rake-tests build
 images: ['gcr.io/$PROJECT_ID/downstream-builder:latest']

--- a/.ci/gcb-run-rake-tests.yml
+++ b/.ci/gcb-run-rake-tests.yml
@@ -1,0 +1,9 @@
+---
+steps:
+- name: 'gcr.io/$PROJECT_ID/downstream-builder'
+  id: run-rake-tests
+  entrypoint: bundle
+  args:
+      - exec
+      - rake
+      - test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby # ruby version defined in .ruby-version will be used
-
-script:
-- bundle exec rake test
-
-git:
-  submodules: false


### PR DESCRIPTION
travis-ci is shutting down .org in the next few months.
As travis-ci.com asks for global repo scope, and
all of our existing validation uses cloud build, migrating
the remaining travis workflow (rake tests) to cloud build.

During testing found that the downstream builder would not
finish due to timeouts. Thus adjusted the timeout.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```

Once this is merged, there will be a one-time manual step to add this to trigger to cloud build. 
