### PR TITLE
Add support for google_project_default_service_accounts resource

### DIFF
--- a/third_party/terraform/resources/resource_google_project_default_service_accounts.go
+++ b/third_party/terraform/resources/resource_google_project_default_service_accounts.go
@@ -1,0 +1,202 @@
+package google
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
+	"google.golang.org/api/iam/v1"
+)
+
+// resourceGoogleProjectDefaultServiceAccounts returns a *schema.Resource that allows a customer
+// to manage all the default serviceAccounts.
+// It does mean that terraform tried to perform the action in the SA at some point but does not ensure that
+// all defaults serviceAccounts where managed. Eg.: API was activated after project creation.
+func resourceGoogleProjectDefaultServiceAccounts() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGoogleProjectDefaultServiceAccountsCreate,
+		Read:   schema.Noop,
+		Update: schema.Noop,
+		Delete: resourceGoogleProjectDefaultServiceAccountsDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Read:   schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateProjectID(),
+				Description:  `The project ID where service accounts are created.`,
+			},
+			"action": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"DEPRIVILEGE", "DELETE", "DISABLE"}, false),
+				Description: `The action to be performed in the default service accounts. Valid values are: DEPRIVILEGE, DELETE, DISABLE.
+				Note that DEPRIVILEGE action will ignore the REVERT configuration in the restore_policy.`,
+			},
+			"restore_policy": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "REVERT",
+				ValidateFunc: validation.StringInSlice([]string{"NONE", "REVERT"}, false),
+				Description: `The action to be performed in the default service accounts on the resource destroy.
+				Valid values are NONE and REVERT. If set to REVERT it will attempt to restore all default SAs but in the DEPRIVILEGE action.`,
+			},
+			"service_accounts": {
+				Type:        schema.TypeMap,
+				Computed:    true,
+				Description: `The Service Accounts changed by this resource. It is used for revert the action on the destroy.`,
+			},
+		},
+	}
+}
+
+func resourceGoogleProjectDefaultServiceAccountsDoAction(d *schema.ResourceData, meta interface{}, action, uniqueID, email, project string) error {
+	config := meta.(*Config)
+	userAgent, err := generateUserAgentString(d, config.userAgent)
+	if err != nil {
+		return err
+	}
+
+	serviceAccountSelfLink := fmt.Sprintf("projects/%s/serviceAccounts/%s", project, uniqueID)
+	switch action {
+	case "DELETE":
+		_, err := config.NewIamClient(userAgent).Projects.ServiceAccounts.Delete(serviceAccountSelfLink).Do()
+		if err != nil {
+			return fmt.Errorf("cannot delete service account %s: %v", serviceAccountSelfLink, err)
+		}
+	case "UNDELETE":
+		_, err := config.NewIamClient(userAgent).Projects.ServiceAccounts.Undelete(serviceAccountSelfLink, &iam.UndeleteServiceAccountRequest{}).Do()
+		if err != nil {
+			return fmt.Errorf("cannot undelete service account %s: %v", serviceAccountSelfLink, err)
+		}
+	case "DISABLE":
+		_, err := config.NewIamClient(userAgent).Projects.ServiceAccounts.Disable(serviceAccountSelfLink, &iam.DisableServiceAccountRequest{}).Do()
+		if err != nil {
+			return fmt.Errorf("cannot disable service account %s: %v", serviceAccountSelfLink, err)
+		}
+	case "ENABLE":
+		_, err := config.NewIamClient(userAgent).Projects.ServiceAccounts.Enable(serviceAccountSelfLink, &iam.EnableServiceAccountRequest{}).Do()
+		if err != nil {
+			return fmt.Errorf("cannot enable service account %s: %v", serviceAccountSelfLink, err)
+		}
+	case "DEPRIVILEGE":
+		iamPolicy, err := config.NewResourceManagerClient(userAgent).Projects.GetIamPolicy(project, &cloudresourcemanager.GetIamPolicyRequest{}).Do()
+		if err != nil {
+			return fmt.Errorf("cannot get IAM policy on project %s: %v", project, err)
+		}
+
+		// Creates a new slice with all members but the service account
+		for _, bind := range iamPolicy.Bindings {
+			newMembers := []string{}
+			for _, member := range bind.Members {
+				if member != fmt.Sprintf("serviceAccount:%s", email) {
+					newMembers = append(newMembers, member)
+				}
+			}
+			bind.Members = newMembers
+		}
+		_, err = config.NewResourceManagerClient(userAgent).Projects.SetIamPolicy(project, &cloudresourcemanager.SetIamPolicyRequest{}).Do()
+		if err != nil {
+			return fmt.Errorf("cannot update IAM policy on project %s: %v", project, err)
+		}
+	default:
+		return fmt.Errorf("action %s is not a valid action", action)
+	}
+
+	return nil
+}
+
+func resourceGoogleProjectDefaultServiceAccountsCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	userAgent, err := generateUserAgentString(d, config.userAgent)
+	if err != nil {
+		return err
+	}
+	pid := d.Get("project").(string)
+	action := d.Get("action").(string)
+
+	serviceAccounts, err := resourceGoogleProjectDefaultServiceAccountsList(config, d, userAgent)
+	if err != nil {
+		return fmt.Errorf("error listing service accounts on project %s: %v", pid, err)
+	}
+	changedServiceAccounts := make(map[string]interface{})
+	for _, sa := range serviceAccounts {
+		// As per documentation https://cloud.google.com/iam/docs/service-accounts#default
+		// we have just two default SAs and the e-mail may change. So, it is been filtered
+		// by the Display Name
+		if isDefaultServiceAccount(sa.DisplayName) {
+			err := resourceGoogleProjectDefaultServiceAccountsDoAction(d, meta, action, sa.UniqueId, sa.Email, pid)
+			if err != nil {
+				return fmt.Errorf("error doing action %s on Service Account %s: %v", action, sa.Email, err)
+			}
+			changedServiceAccounts[sa.UniqueId] = sa.Email
+		}
+	}
+	if err := d.Set("service_accounts", changedServiceAccounts); err != nil {
+		return fmt.Errorf("error setting service_accounts: %s", err)
+	}
+	d.SetId(prefixedProject(pid))
+
+	return nil
+}
+
+func resourceGoogleProjectDefaultServiceAccountsList(config *Config, d *schema.ResourceData, userAgent string) ([]*iam.ServiceAccount, error) {
+	pid := d.Get("project").(string)
+	response, err := config.NewIamClient(userAgent).Projects.ServiceAccounts.List(prefixedProject(pid)).Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list service accounts on project %q: %v", pid, err)
+	}
+	return response.Accounts, nil
+}
+
+func resourceGoogleProjectDefaultServiceAccountsDelete(d *schema.ResourceData, meta interface{}) error {
+	if d.Get("restore_policy").(string) == "NONE" {
+		d.SetId("")
+		return nil
+	}
+
+	pid := d.Get("project").(string)
+	for saUniqueID, saEmail := range d.Get("service_accounts").(map[string]interface{}) {
+		origAction := d.Get("action").(string)
+		newAction := ""
+		// We agreed to not revert the DEPRIVILEGE because Morgante said it is not required.
+		// It may be an enhancement. https://github.com/hashicorp/terraform-provider-google/issues/4135#issuecomment-709480278
+		if origAction == "DISABLE" {
+			newAction = "ENABLE"
+		} else if origAction == "DELETE" {
+			newAction = "UNDELETE"
+		}
+		if newAction != "" {
+			err := resourceGoogleProjectDefaultServiceAccountsDoAction(d, meta, newAction, saUniqueID, saEmail.(string), pid)
+			if err != nil {
+				return fmt.Errorf("error doing action %s on Service Account %s: %v", newAction, saUniqueID, err)
+			}
+		}
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func isDefaultServiceAccount(displayName string) bool {
+	gceDefaultSA := "compute engine default service account"
+	appEngineDefaultSA := "app engine default service account"
+	saDisplayName := strings.ToLower(displayName)
+	if saDisplayName == gceDefaultSA || saDisplayName == appEngineDefaultSA {
+		return true
+	}
+
+	return false
+}

--- a/third_party/terraform/tests/resource_google_project_default_service_accounts_test.go
+++ b/third_party/terraform/tests/resource_google_project_default_service_accounts_test.go
@@ -1,0 +1,247 @@
+package google
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
+)
+
+func TestAccResourceGoogleProjectDefaultServiceAccountsBasic(t *testing.T) {
+	t.Parallel()
+
+	resourceName := "google_project_default_service_accounts.acceptance"
+	org := getTestOrgFromEnv(t)
+	project := fmt.Sprintf("tf-project-%d", randInt(t))
+	billingAccount := getTestBillingAccountFromEnv(t)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGoogleProjectDefaultServiceAccountsBasic(org, project, billingAccount),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "id", "projects/"+project),
+					resource.TestCheckResourceAttrSet(resourceName, "project"),
+					resource.TestCheckResourceAttrSet(resourceName, "action"),
+					resource.TestCheckResourceAttrSet(resourceName, "restore_policy"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGoogleProjectDefaultServiceAccountsBasic(org, project, billingAccount string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+	project_id = "%s"
+	name       = "%s"
+	org_id  = "%s"
+	billing_account = "%s"
+}
+
+resource "google_project_default_service_accounts" "acceptance" {
+	project = google_project.acceptance.project_id
+	action = "DISABLE"
+}
+`, project, project, org, billingAccount)
+}
+
+func TestAccResourceGoogleProjectDefaultServiceAccountsDisable(t *testing.T) {
+	t.Parallel()
+
+	org := getTestOrgFromEnv(t)
+	project := fmt.Sprintf("tf-project-%d", randInt(t))
+	billingAccount := getTestBillingAccountFromEnv(t)
+	action := "DISABLE"
+	restorePolicy := "REVERT"
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGoogleProjectDefaultServiceAccountsRevert(t, project, action),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGoogleProjectDefaultServiceAccountsAdvanced(org, project, billingAccount, action, restorePolicy),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_project_default_service_accounts.acceptance", "id", "projects/"+project),
+					resource.TestCheckResourceAttrSet("google_project_default_service_accounts.acceptance", "project"),
+					resource.TestCheckResourceAttr("google_project_default_service_accounts.acceptance", "action", action),
+					resource.TestCheckResourceAttrSet("google_project_default_service_accounts.acceptance", "project"),
+					sleepInSecondsForTest(5),
+					testAccCheckGoogleProjectDefaultServiceAccountsChanges(t, project, action),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceGoogleProjectDefaultServiceAccountsDelete(t *testing.T) {
+	t.Parallel()
+
+	org := getTestOrgFromEnv(t)
+	project := fmt.Sprintf("tf-project-%d", randInt(t))
+	billingAccount := getTestBillingAccountFromEnv(t)
+	action := "DELETE"
+	restorePolicy := "REVERT"
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGoogleProjectDefaultServiceAccountsRevert(t, project, action),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGoogleProjectDefaultServiceAccountsAdvanced(org, project, billingAccount, action, restorePolicy),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_project_default_service_accounts.acceptance", "id", "projects/"+project),
+					resource.TestCheckResourceAttrSet("google_project_default_service_accounts.acceptance", "project"),
+					resource.TestCheckResourceAttr("google_project_default_service_accounts.acceptance", "action", action),
+					resource.TestCheckResourceAttrSet("google_project_default_service_accounts.acceptance", "project"),
+					sleepInSecondsForTest(10),
+					testAccCheckGoogleProjectDefaultServiceAccountsChanges(t, project, action),
+				),
+			},
+		},
+	})
+}
+
+func TestAccResourceGoogleProjectDefaultServiceAccountsDeprivilege(t *testing.T) {
+	t.Parallel()
+
+	org := getTestOrgFromEnv(t)
+	project := fmt.Sprintf("tf-project-%d", randInt(t))
+	billingAccount := getTestBillingAccountFromEnv(t)
+	action := "DEPRIVILEGE"
+	restorePolicy := "REVERT"
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGoogleProjectDefaultServiceAccountsRevert(t, project, action),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGoogleProjectDefaultServiceAccountsAdvanced(org, project, billingAccount, action, restorePolicy),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_project_default_service_accounts.acceptance", "id", "projects/"+project),
+					resource.TestCheckResourceAttrSet("google_project_default_service_accounts.acceptance", "project"),
+					resource.TestCheckResourceAttr("google_project_default_service_accounts.acceptance", "action", action),
+					resource.TestCheckResourceAttrSet("google_project_default_service_accounts.acceptance", "project"),
+					sleepInSecondsForTest(5),
+					testAccCheckGoogleProjectDefaultServiceAccountsChanges(t, project, action),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGoogleProjectDefaultServiceAccountsAdvanced(org, project, billingAccount, action, restorePolicy string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+	project_id = "%s"
+	name       = "%s"
+	org_id  = "%s"
+	billing_account = "%s"
+}
+
+resource "google_project_service" "acceptance" {
+	project = google_project.acceptance.project_id
+	service = "compute.googleapis.com"
+
+	disable_dependent_services = true
+}
+
+resource "google_project_default_service_accounts" "acceptance" {
+	depends_on = [google_project_service.acceptance]
+	project = google_project.acceptance.project_id
+	action = "%s"
+	restore_policy = "%s"
+}
+`, project, project, org, billingAccount, action, restorePolicy)
+}
+
+func testAccCheckGoogleProjectDefaultServiceAccountsChanges(t *testing.T, project, action string) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		config := googleProviderConfig(t)
+		response, err := config.NewIamClient(config.userAgent).Projects.ServiceAccounts.List(prefixedProject(project)).Do()
+		if err != nil {
+			return fmt.Errorf("failed to list service accounts on project %q: %v", project, err)
+		}
+		for _, sa := range response.Accounts {
+			if testAccIsDefaultServiceAccount(sa.DisplayName) {
+				switch action {
+				case "DISABLE":
+					if !sa.Disabled {
+						return fmt.Errorf("compute engine default service account is not disabled, disable field is %t", sa.Disabled)
+					}
+				case "DELETE":
+					return fmt.Errorf("compute engine default service account is not deleted")
+				case "DEPRIVILEGE":
+					iamPolicy, err := config.NewResourceManagerClient(config.userAgent).Projects.GetIamPolicy(project, &cloudresourcemanager.GetIamPolicyRequest{}).Do()
+					if err != nil {
+						return fmt.Errorf("cannot get IAM policy on project %s: %v", project, err)
+					}
+					for _, bind := range iamPolicy.Bindings {
+						for _, member := range bind.Members {
+							if member == fmt.Sprintf("serviceAccount:%s", sa.Email) {
+								return fmt.Errorf("compute engine default service account is not deprivileged")
+							}
+						}
+					}
+					return nil
+				}
+			}
+		}
+		return nil
+	}
+}
+
+// Test if actions were reverted properly
+func testAccCheckGoogleProjectDefaultServiceAccountsRevert(t *testing.T, project, action string) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		config := googleProviderConfig(t)
+		response, err := config.NewIamClient(config.userAgent).Projects.ServiceAccounts.List(prefixedProject(project)).Do()
+		if err != nil {
+			return fmt.Errorf("failed to list service accounts on project %q: %v", project, err)
+		}
+		for _, sa := range response.Accounts {
+			if testAccIsDefaultServiceAccount(sa.DisplayName) {
+				// We agreed to not revert the DEPRIVILEGE action because will be hard to track the roles over the time
+				if action == "DISABLE" {
+					if sa.Disabled {
+						return fmt.Errorf("compute engine default service account is not enabled, disable field is %t", sa.Disabled)
+					}
+				} else if action == "DELETE" {
+					// A deleted service account was found meaning the undelete action triggered
+					// on destroy worked
+					return nil
+				}
+			}
+		}
+		// if action is DELETE, the service account should be found in the previous loop
+		// due to undelete action
+		if action == "DELETE" {
+			return fmt.Errorf("service account changes were not reverted after destroy")
+		}
+
+		return nil
+	}
+}
+
+// testAccIsDefaultServiceAccount is a helper function to facilitate TDD when there is a need
+// to update how we determine whether it's a default SA or not.
+// If you follow TDD, it is going to be different from isDefaultServiceAccount func while coding
+// but they must be identical before commit/push
+func testAccIsDefaultServiceAccount(displayName string) bool {
+	gceDefaultSA := "compute engine default service account"
+	appEngineDefaultSA := "app engine default service account"
+	saDisplayName := strings.ToLower(displayName)
+	if saDisplayName == gceDefaultSA || saDisplayName == appEngineDefaultSA {
+		return true
+	}
+
+	return false
+}

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -433,6 +433,7 @@ end     # products.each do
 				"google_organization_iam_audit_config":         ResourceIamAuditConfig(IamOrganizationSchema, NewOrganizationIamUpdater, OrgIdParseFunc),
 				"google_organization_policy":                   resourceGoogleOrganizationPolicy(),
 				"google_project":                               resourceGoogleProject(),
+				"google_project_default_service_accounts":      resourceGoogleProjectDefaultServiceAccounts(),
 				"google_project_iam_policy":                    ResourceIamPolicy(IamPolicyProjectSchema, NewProjectIamPolicyUpdater, ProjectIdParseFunc),
 				"google_project_iam_binding":                   ResourceIamBindingWithBatching(IamProjectSchema, NewProjectIamUpdater, ProjectIdParseFunc, IamBatchingEnabled),
 				"google_project_iam_member":                    ResourceIamMemberWithBatching(IamProjectSchema, NewProjectIamUpdater, ProjectIdParseFunc, IamBatchingEnabled),

--- a/third_party/terraform/utils/provider_test.go.erb
+++ b/third_party/terraform/utils/provider_test.go.erb
@@ -947,3 +947,10 @@ func skipIfVcr(t *testing.T) {
 		t.Skipf("VCR enabled, skipping test: %s", t.Name())
 	}
 }
+
+func sleepInSecondsForTest(t int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		time.Sleep(time.Duration(t) * time.Second)
+		return nil
+	}
+}

--- a/third_party/terraform/website/docs/r/google_project_default_service_accounts.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_default_service_accounts.html.markdown
@@ -1,0 +1,68 @@
+---
+subcategory: "Cloud Platform"
+layout: "google"
+page_title: "Google: google_project_default_service_accounts"
+sidebar_current: "docs-google-project-default-service-accounts-x"
+description: |-
+  Allows management of Google Cloud Platform project default service accounts.
+---
+
+# google_project_default_service_accounts
+
+Allows management of Google Cloud Platform project default service accounts.
+
+When certain service APIs are enabled, Google Cloud Platform automatically creates service accounts to help get started, but
+this is not recommended for production environments as per [Google's documentation](https://cloud.google.com/iam/docs/service-accounts#default).
+See the [Organization documentation](https://cloud.google.com/resource-manager/docs/quickstarts) for more details.
+~> This resource works on a best-effort basis, as no API formally describes the default service accounts. If the default service accounts change their name or additional service accounts are added, this resource will need to be updated.
+
+## Example Usage
+
+```hcl
+resource "google_project_default_service_accounts" "my_project" {
+  project = "my-project-id"
+  action = "DELETE"
+}
+```
+
+To enable the default service accounts on the resource destroy:
+
+```hcl
+resource "google_project_default_service_accounts" "my_project" {
+  project = "my-project-id"
+  action = "DISABLE"
+  restore_policy = "REVERT"
+}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+- `project` - (Required) The project ID where service accounts are created.
+
+- `action` - (Required) The action to be performed in the default service accounts. Valid values are: `DEPRIVILEGE`, `DELETE`, `DISABLE`. Note that `DEPRIVILEGE` action will ignore the REVERT configuration in the restore_policy
+
+- `restore_policy` - (Optional) The action to be performed in the default service accounts on the resource destroy. Valid values are `NONE` and `REVERT`. If set to `REVERT` it will attempt to restore all default SAs but in the `DEPRIVILEGE` action.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+- `id` - an identifier for the resource with format `projects/{{project}}`
+- `service_accounts` - The Service Accounts changed by this resource. It is used for `REVERT` the `action` on the destroy.
+
+## Timeouts
+
+This resource provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - Default is 10 minutes.
+- `update` - Default is 10 minutes.
+- `delete` - Default is 10 minutes.
+
+## Import
+
+This resource does not support import


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Upstreams https://github.com/hashicorp/terraform-provider-google/pull/7541, Fixes https://github.com/hashicorp/terraform-provider-google/issues/4135


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_project_default_service_accounts`
```
