### PR TITLE
re-adding travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: ruby # ruby version defined in .ruby-version will be used	
+
+script:	
+- bundle exec rake test	
+
+git:	
+  submodules: false


### PR DESCRIPTION
Cloud builds for run-rake-test are timing out:

https://console.cloud.google.com/cloud-build/builds/d35ae5d7-f69c-4e05-abe9-6c186c351361?project=673497134629

Requested support from the cloud build team, but re-adding travis in the
meantime.


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
