### PR TITLE
add compute_instance_helpers.go.erb to the list of compiled files

### DIFF
--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -61,6 +61,8 @@ module Provider
                            'third_party/terraform/utils/config.go.erb'],
                           ['google/utils.go',
                            'third_party/terraform/utils/utils.go.erb'],
+                          ['google/compute_instance_helpers.go',
+                           'third_party/terraform/utils/compute_instance_helpers.go.erb'],
                           ['google/provider_handwritten_endpoint.go',
                            'third_party/terraform/utils/provider_handwritten_endpoint.go.erb']
                         ],
@@ -124,8 +126,6 @@ module Provider
                         'third_party/terraform/utils/common_operation.go'],
                        ['google/compute_shared_operation.go',
                         'third_party/terraform/utils/compute_shared_operation.go'],
-                       ['google/compute_instance_helpers.go',
-                        'third_party/terraform/utils/compute_instance_helpers.go.erb'],
                        ['google/convert.go',
                         'third_party/terraform/utils/convert.go'],
                        ['google/metadata.go',


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Add the file `compute_instance_helpers.go.erb` to the list of files that need to be compiled before been copied to downstream `terraform-google-conversion` repo.

Related to https://github.com/GoogleCloudPlatform/terraform-google-conversion/issues/572

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Compile erb template before copy of compute_instance_helpers.go file
```
