### PR TITLE
Add ignore_warnings to `google_bigtable_app_profile` create call

### DIFF
--- a/products/firestore/api.yaml
+++ b/products/firestore/api.yaml
@@ -108,3 +108,32 @@ objects:
                 be specified.
               values:
                 - :CONTAINS
+  - !ruby/object:Api::Resource
+    name: 'Document'
+    base_url: projects/{{project}}/databases/{{database}}/documents/{{collection}}/indexes
+    self_link: '{{name}}'
+    input: true
+    description: |
+      Cloud Firestore indexes enable simple and complex queries against documents in a database.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation': 'https://cloud.google.com/firestore/docs/query-data/indexing'
+      api: 'https://cloud.google.com/firestore/docs/reference/rest/v1/projects.databases.collectionGroups.indexes'
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: database
+        default_value: '(default)'
+        description: |
+          The Firestore database id. Defaults to `"(default)"`.
+      - !ruby/object:Api::Type::String
+        name: collection
+        required: true
+        description: |
+          The collection ID, relative to parent, to list.
+    properties:
+      - !ruby/object:Api::Type::String
+        name: name
+        output: true
+        description: |
+          The resource name of the document, for example:
+          projects/{{project}}/databases/{{database}}//documents/{document_path}

--- a/templates/terraform/constants/cloud_run_service.go.erb
+++ b/templates/terraform/constants/cloud_run_service.go.erb
@@ -6,11 +6,11 @@ func revisionNameCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, v i
 	return nil
 }
 
-const cloudRunGoogleProvidedAnnotation = "serving.knative.dev"
+var cloudRunGoogleProvidedAnnotations = regexp.MustCompile("serving\\.knative\\.dev/(?:(?:creator)|(?:lastModifier))$")
 
 func cloudrunAnnotationDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 	// Suppress diffs for the annotations provided by Google
-	if strings.Contains(k, cloudRunGoogleProvidedAnnotation) && new == "" {
+	if cloudRunGoogleProvidedAnnotations.MatchString(k) && new == "" {
 		return true
 	}
 

--- a/third_party/terraform/tests/resource_cloud_run_service_test.go
+++ b/third_party/terraform/tests/resource_cloud_run_service_test.go
@@ -46,7 +46,10 @@ resource "google_cloud_run_service" "default" {
   location = "us-central1"
 
   metadata {
-    namespace = "%s"
+  namespace = "%s"
+  annotations = {
+      generated-by = "magic-modules"
+    }
   }
 
   template {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Closes [7754](https://github.com/hashicorp/terraform-provider-google/issues/7754)


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigtable: added ignore_warnings flag to create call for `google_bigtable_app_profile`
```
