### PR TITLE
Add custom response headers for backend service

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -1123,6 +1123,12 @@ objects:
         description: |
           Headers that the HTTP/S load balancer should add to proxied
           requests.
+      - !ruby/object:Api::Type::Array
+        name: 'customResponseHeaders'
+        item_type: Api::Type::String
+        description: |
+          Headers that the HTTP/S load balancer should add to proxied
+          responses.
       - !ruby/object:Api::Type::Fingerprint
         name: 'fingerprint'
         output: true

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -230,6 +230,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: connection_draining_timeout_sec
       customRequestHeaders: !ruby/object:Overrides::Terraform::PropertyOverride
         is_set: true
+      customResponseHeaders: !ruby/object:Overrides::Terraform::PropertyOverride
+        is_set: true
       backends.group: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'compareSelfLinkRelativePaths'
         custom_flatten: templates/terraform/custom_flatten/guard_self_link.go.erb

--- a/templates/terraform/examples/backend_service_network_endpoint.tf.erb
+++ b/templates/terraform/examples/backend_service_network_endpoint.tf.erb
@@ -17,6 +17,7 @@ resource "google_compute_backend_service" "<%= ctx[:primary_resource_id] %>" {
   connection_draining_timeout_sec = 10
  
   custom_request_headers          = ["host: ${google_compute_global_network_endpoint.proxy.fqdn}"]
+  custom_response_headers         = ["X-Cache-Hit: {cdn_cache_status}"]
 
   backend {
     group = google_compute_global_network_endpoint_group.external_proxy.id

--- a/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
@@ -1499,6 +1499,7 @@ resource "google_compute_backend_service" "foobar" {
   health_checks = [google_compute_http_health_check.zero.self_link]
 
   custom_request_headers = ["Client-Region: {client_region}", "Client-Rtt: {client_rtt_msec}"]
+  custom_response_headers = ["X-Cache-Hit: {cdn_cache_status}", "X-Cache-Id: {cdn_cache_id}"]
 }
 
 resource "google_compute_http_health_check" "zero" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Part of hashicorp/terraform-provider-google#7299

First PR to magic-modules. Please forgive rookie mistakes.

I am unable to run the acceptance tests also.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement 
compute: added `custom_response_headers` field to `google_compute_backend_service` resource
```