### PR TITLE
Add support for abandoning sql user

### DIFF
--- a/third_party/terraform/resources/resource_sql_user.go
+++ b/third_party/terraform/resources/resource_sql_user.go
@@ -71,8 +71,8 @@ func resourceSqlUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Description: `The deletion policy for the user. Setting ABANDON allows the resource
-				to be abandoned rather than deleted. This is useful for situations where Postgres users that cannot be deleted due
-				existing SQL permissions. Possible values are: "ABANDON".`,
+				to be abandoned rather than deleted. This is useful for Postgres, where users cannot be deleted from the API if they
+				have been granted SQL roles. Possible values are: "ABANDON".`,
 				ValidateFunc: validation.StringInSlice([]string{"ABANDON"}, false),
 			},
 		},

--- a/third_party/terraform/resources/resource_sql_user.go
+++ b/third_party/terraform/resources/resource_sql_user.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
@@ -64,6 +65,15 @@ func resourceSqlUser() *schema.Resource {
 				Computed:    true,
 				ForceNew:    true,
 				Description: `The ID of the project in which the resource belongs. If it is not provided, the provider project is used.`,
+			},
+
+			"deletion_policy": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: `The deletion policy for the user. Setting ABANDON allows the resource
+				to be abandoned rather than deleted. This is useful for situations where Postgres users that cannot be deleted due
+				existing SQL permissions. Possible values are: "ABANDON".`,
+				ValidateFunc: validation.StringInSlice([]string{"ABANDON"}, false),
 			},
 		},
 	}
@@ -236,6 +246,13 @@ func resourceSqlUserUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceSqlUserDelete(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
+
+	if deletionPolicy := d.Get("deletion_policy"); deletionPolicy == "ABANDON" {
+		// Allows for user to be abandoned without deletion to avoid deletion failing
+		// for Postgres users in some circumstances due to existing SQL roles
+		return nil
+	}
+
 	userAgent, err := generateUserAgentString(d, config.userAgent)
 	if err != nil {
 		return err

--- a/third_party/terraform/resources/resource_sql_user.go
+++ b/third_party/terraform/resources/resource_sql_user.go
@@ -73,7 +73,7 @@ func resourceSqlUser() *schema.Resource {
 				Description: `The deletion policy for the user. Setting ABANDON allows the resource
 				to be abandoned rather than deleted. This is useful for Postgres, where users cannot be deleted from the API if they
 				have been granted SQL roles. Possible values are: "ABANDON".`,
-				ValidateFunc: validation.StringInSlice([]string{"ABANDON"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"ABANDON", ""}, false),
 			},
 		},
 	}

--- a/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -54,10 +54,10 @@ The following arguments are supported:
     instances this is a Required field.
 
 * `deletion_policy` - (Optional) The deletion policy for the user.
-    Setting ABANDON allows the resource to be abandoned rather than deleted. This is useful
+    Setting `ABANDON` allows the resource to be abandoned rather than deleted. This is useful
     for Postgres, where users cannot be deleted from the API if they have been granted SQL roles.
     
-    Possible values are: "ABANDON".
+    Possible values are: `ABANDON`.
 
 - - -
 

--- a/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -53,6 +53,12 @@ The following arguments are supported:
 * `password` - (Optional) The password for the user. Can be updated. For Postgres
     instances this is a Required field.
 
+* `deletion_policy` - (Optional) The deletion policy for the user.
+    Setting ABANDON allows the resource to be abandoned rather than deleted. This is useful
+    for situations where Postgres users that cannot be deleted due existing SQL permissions.
+    
+    Possible values are: "ABANDON".
+
 - - -
 
 * `host` - (Optional) The host the user can connect from. This is only supported

--- a/third_party/terraform/website/docs/r/sql_user.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_user.html.markdown
@@ -55,7 +55,7 @@ The following arguments are supported:
 
 * `deletion_policy` - (Optional) The deletion policy for the user.
     Setting ABANDON allows the resource to be abandoned rather than deleted. This is useful
-    for situations where Postgres users that cannot be deleted due existing SQL permissions.
+    for Postgres, where users cannot be deleted from the API if they have been granted SQL roles.
     
     Possible values are: "ABANDON".
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/7677



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
sql: added `deletion_policy` field to `google_sql_user` to enable abandoning users rather than deleting them
```
