### PR TITLE
Add description and disabled to logging sinks

### DIFF
--- a/third_party/terraform/resources/resource_logging_sink.go
+++ b/third_party/terraform/resources/resource_logging_sink.go
@@ -30,6 +30,18 @@ func resourceLoggingSinkSchema() map[string]*schema.Schema {
 			Description:      `The filter to apply when exporting logs. Only log entries that match the filter are exported.`,
 		},
 
+		"description": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: `A description of this sink. The maximum length of the description is 8000 characters.`,
+		},
+
+		"disabled": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: `If set to True, then this sink is disabled and it does not export any log entries.`,
+		},
+
 		"exclusions": {
 			Type:        schema.TypeList,
 			Optional:    true,
@@ -97,6 +109,8 @@ func expandResourceLoggingSink(d *schema.ResourceData, resourceType, resourceId 
 		Name:            d.Get("name").(string),
 		Destination:     d.Get("destination").(string),
 		Filter:          d.Get("filter").(string),
+		Description:     d.Get("description").(string),
+		Disabled:        d.Get("disabled").(bool),
 		Exclusions:      expandLoggingSinkExclusions(d.Get("exclusions")),
 		BigqueryOptions: expandLoggingSinkBigqueryOptions(d.Get("bigquery_options")),
 	}
@@ -112,6 +126,12 @@ func flattenResourceLoggingSink(d *schema.ResourceData, sink *logging.LogSink) e
 	}
 	if err := d.Set("filter", sink.Filter); err != nil {
 		return fmt.Errorf("Error setting filter: %s", err)
+	}
+	if err := d.Set("description", sink.Description); err != nil {
+		return fmt.Errorf("Error setting description: %s", err)
+	}
+	if err := d.Set("disabled", sink.Disabled); err != nil {
+		return fmt.Errorf("Error setting disabled: %s", err)
 	}
 	if err := d.Set("writer_identity", sink.WriterIdentity); err != nil {
 		return fmt.Errorf("Error setting writer_identity: %s", err)
@@ -141,6 +161,12 @@ func expandResourceLoggingSinkForUpdate(d *schema.ResourceData) (sink *logging.L
 	}
 	if d.HasChange("filter") {
 		updateFields = append(updateFields, "filter")
+	}
+	if d.HasChange("description") {
+		updateFields = append(updateFields, "description")
+	}
+	if d.HasChange("disabled") {
+		updateFields = append(updateFields, "disabled")
 	}
 	if d.HasChange("exclusions") {
 		sink.Exclusions = expandLoggingSinkExclusions(d.Get("exclusions"))

--- a/third_party/terraform/tests/resource_logging_billing_account_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_billing_account_sink_test.go
@@ -83,6 +83,64 @@ func TestAccLoggingBillingAccountSink_update(t *testing.T) {
 	}
 }
 
+func TestAccLoggingBillingAccountSink_described(t *testing.T) {
+	t.Parallel()
+
+	sinkName := "tf-test-sink-" + randString(t, 10)
+	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
+	billingAccount := getTestBillingAccountFromEnv(t)
+
+	var sink logging.LogSink
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLoggingBillingAccountSinkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingBillingAccountSink_described(sinkName, bucketName, billingAccount),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoggingBillingAccountSinkExists(t, "google_logging_billing_account_sink.described", &sink),
+					testAccCheckLoggingBillingAccountSink(&sink, "google_logging_billing_account_sink.described"),
+				),
+			}, {
+				ResourceName:      "google_logging_billing_account_sink.described",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLoggingBillingAccountSink_disabled(t *testing.T) {
+	t.Parallel()
+
+	sinkName := "tf-test-sink-" + randString(t, 10)
+	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
+	billingAccount := getTestBillingAccountFromEnv(t)
+
+	var sink logging.LogSink
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLoggingBillingAccountSinkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingBillingAccountSink_disabled(sinkName, bucketName, billingAccount),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoggingBillingAccountSinkExists(t, "google_logging_billing_account_sink.disabled", &sink),
+					testAccCheckLoggingBillingAccountSink(&sink, "google_logging_billing_account_sink.disabled"),
+				),
+			}, {
+				ResourceName:      "google_logging_billing_account_sink.disabled",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccLoggingBillingAccountSink_updateBigquerySink(t *testing.T) {
 	t.Parallel()
 
@@ -209,6 +267,36 @@ func testAccCheckLoggingBillingAccountSink(sink *logging.LogSink, n string) reso
 func testAccLoggingBillingAccountSink_basic(name, bucketName, billingAccount string) string {
 	return fmt.Sprintf(`
 resource "google_logging_billing_account_sink" "basic" {
+  name            = "%s"
+  billing_account = "%s"
+  destination     = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  filter          = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+}
+
+resource "google_storage_bucket" "log-bucket" {
+  name = "%s"
+}
+`, name, billingAccount, getTestProjectFromEnv(), bucketName)
+}
+
+func testAccLoggingBillingAccountSink_described(name, bucketName, billingAccount string) string {
+	return fmt.Sprintf(`
+resource "google_logging_billing_account_sink" "described" {
+  name            = "%s"
+  billing_account = "%s"
+  destination     = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  filter          = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+}
+
+resource "google_storage_bucket" "log-bucket" {
+  name = "%s"
+}
+`, name, billingAccount, getTestProjectFromEnv(), bucketName)
+}
+
+func testAccLoggingBillingAccountSink_disabled(name, bucketName, billingAccount string) string {
+	return fmt.Sprintf(`
+resource "google_logging_billing_account_sink" "disabled" {
   name            = "%s"
   billing_account = "%s"
   destination     = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"

--- a/third_party/terraform/tests/resource_logging_billing_account_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_billing_account_sink_test.go
@@ -99,10 +99,6 @@ func TestAccLoggingBillingAccountSink_described(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLoggingBillingAccountSink_described(sinkName, bucketName, billingAccount),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLoggingBillingAccountSinkExists(t, "google_logging_billing_account_sink.described", &sink),
-					testAccCheckLoggingBillingAccountSink(&sink, "google_logging_billing_account_sink.described"),
-				),
 			}, {
 				ResourceName:      "google_logging_billing_account_sink.described",
 				ImportState:       true,
@@ -128,10 +124,6 @@ func TestAccLoggingBillingAccountSink_disabled(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLoggingBillingAccountSink_disabled(sinkName, bucketName, billingAccount),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLoggingBillingAccountSinkExists(t, "google_logging_billing_account_sink.disabled", &sink),
-					testAccCheckLoggingBillingAccountSink(&sink, "google_logging_billing_account_sink.disabled"),
-				),
 			}, {
 				ResourceName:      "google_logging_billing_account_sink.disabled",
 				ImportState:       true,
@@ -283,6 +275,7 @@ func testAccLoggingBillingAccountSink_described(name, bucketName, billingAccount
 	return fmt.Sprintf(`
 resource "google_logging_billing_account_sink" "described" {
   name            = "%s"
+  description     = "this is a description"
   billing_account = "%s"
   destination     = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
   filter          = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
@@ -315,6 +308,7 @@ resource "google_logging_billing_account_sink" "update" {
   name            = "%s"
   billing_account = "%s"
   destination     = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  disabled         = true
   filter          = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
 }
 
@@ -332,7 +326,7 @@ resource "google_logging_billing_account_sink" "heredoc" {
   destination     = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
   filter          = <<EOS
 
-	logName="projects/%s/logs/compute.googleapis.com%%2Factivity_log"
+  logName="projects/%s/logs/compute.googleapis.com%%2Factivity_log"
 AND severity>=ERROR
 
 

--- a/third_party/terraform/tests/resource_logging_billing_account_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_billing_account_sink_test.go
@@ -90,8 +90,6 @@ func TestAccLoggingBillingAccountSink_described(t *testing.T) {
 	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
 	billingAccount := getTestBillingAccountFromEnv(t)
 
-	var sink logging.LogSink
-
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -114,8 +112,6 @@ func TestAccLoggingBillingAccountSink_disabled(t *testing.T) {
 	sinkName := "tf-test-sink-" + randString(t, 10)
 	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
 	billingAccount := getTestBillingAccountFromEnv(t)
-
-	var sink logging.LogSink
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/third_party/terraform/tests/resource_logging_folder_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_folder_sink_test.go
@@ -49,8 +49,6 @@ func TestAccLoggingFolderSink_described(t *testing.T) {
 	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
 	folderName := "tf-test-folder-" + randString(t, 10)
 
-	var sink logging.LogSink
-
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -74,8 +72,6 @@ func TestAccLoggingFolderSink_disabled(t *testing.T) {
 	sinkName := "tf-test-sink-" + randString(t, 10)
 	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
 	folderName := "tf-test-folder-" + randString(t, 10)
-
-	var sink logging.LogSink
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/third_party/terraform/tests/resource_logging_folder_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_folder_sink_test.go
@@ -58,10 +58,6 @@ func TestAccLoggingFolderSink_described(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLoggingFolderSink_described(sinkName, bucketName, folderName, "organizations/"+org),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLoggingFolderSinkExists(t, "google_logging_folder_sink.described", &sink),
-					testAccCheckLoggingFolderSink(&sink, "google_logging_folder_sink.described"),
-				),
 			}, {
 				ResourceName:      "google_logging_folder_sink.described",
 				ImportState:       true,
@@ -88,10 +84,6 @@ func TestAccLoggingFolderSink_disabled(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLoggingFolderSink_disabled(sinkName, bucketName, folderName, "organizations/"+org),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLoggingFolderSinkExists(t, "google_logging_folder_sink.disabled", &sink),
-					testAccCheckLoggingFolderSink(&sink, "google_logging_folder_sink.disabled"),
-				),
 			}, {
 				ResourceName:      "google_logging_folder_sink.disabled",
 				ImportState:       true,
@@ -415,19 +407,19 @@ resource "google_folder" "my-folder" {
 func testAccLoggingFolderSink_removeOptionals(sinkName, bucketName, folderName, folderParent string) string {
 	return fmt.Sprintf(`
 resource "google_logging_folder_sink" "basic" {
-	name             = "%s"
-	folder           = "${element(split("/", google_folder.my-folder.name), 1)}"
-	destination      = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
-	filter           = ""
-	include_children = true
+  name             = "%s"
+  folder           = "${element(split("/", google_folder.my-folder.name), 1)}"
+  destination      = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  filter           = ""
+  include_children = true
 }
 
 resource "google_storage_bucket" "log-bucket" {
-	name = "%s"
+  name = "%s"
 }
 
 resource "google_folder" "my-folder" {
-	display_name = "%s"
+  display_name = "%s"
     parent       = "%s"
 }`, sinkName, bucketName, folderName, folderParent)
 }
@@ -461,7 +453,7 @@ resource "google_logging_folder_sink" "heredoc" {
   destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
   filter      = <<EOS
 
-	logName="projects/%s/logs/compute.googleapis.com%%2Factivity_log"
+  logName="projects/%s/logs/compute.googleapis.com%%2Factivity_log"
 AND severity>=ERROR
 
 

--- a/third_party/terraform/tests/resource_logging_organization_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_organization_sink_test.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"testing"
 
+	"strconv"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"google.golang.org/api/logging/v2"
-	"strconv"
 )
 
 func TestAccLoggingOrganizationSink_basic(t *testing.T) {
@@ -82,6 +83,64 @@ func TestAccLoggingOrganizationSink_update(t *testing.T) {
 		t.Errorf("Expected WriterIdentity to be the same, but it differs: before = %#v, after = %#v",
 			sinkBefore.WriterIdentity, sinkAfter.WriterIdentity)
 	}
+}
+
+func TestAccLoggingOrganizationSink_described(t *testing.T) {
+	t.Parallel()
+
+	org := getTestOrgFromEnv(t)
+	sinkName := "tf-test-sink-" + randString(t, 10)
+	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
+
+	var sink logging.LogSink
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLoggingOrganizationSinkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingOrganizationSink_described(sinkName, bucketName, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoggingOrganizationSinkExists(t, "google_logging_organization_sink.described", &sink),
+					testAccCheckLoggingOrganizationSink(&sink, "google_logging_organization_sink.described"),
+				),
+			}, {
+				ResourceName:      "google_logging_organization_sink.described",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLoggingOrganizationSink_disabled(t *testing.T) {
+	t.Parallel()
+
+	org := getTestOrgFromEnv(t)
+	sinkName := "tf-test-sink-" + randString(t, 10)
+	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
+
+	var sink logging.LogSink
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLoggingOrganizationSinkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingOrganizationSink_disabled(sinkName, bucketName, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLoggingOrganizationSinkExists(t, "google_logging_organization_sink.disabled", &sink),
+					testAccCheckLoggingOrganizationSink(&sink, "google_logging_organization_sink.disabled"),
+				),
+			}, {
+				ResourceName:      "google_logging_organization_sink.disabled",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
 }
 
 func TestAccLoggingOrganizationSink_updateBigquerySink(t *testing.T) {
@@ -242,6 +301,42 @@ resource "google_logging_organization_sink" "update" {
   destination      = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
   filter           = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
   include_children = false
+}
+
+resource "google_storage_bucket" "log-bucket" {
+  name = "%s"
+}
+`, sinkName, orgId, getTestProjectFromEnv(), bucketName)
+}
+
+func testAccLoggingOrganizationSink_described(sinkName, bucketName, orgId string) string {
+	return fmt.Sprintf(`
+resource "google_logging_organization_sink" "described" {
+  name        = "%s"
+  project     = "%s"
+  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+  description = "this is a description for an organization level logging sink"
+
+  unique_writer_identity = false
+}
+
+resource "google_storage_bucket" "log-bucket" {
+  name = "%s"
+}
+`, sinkName, orgId, getTestProjectFromEnv(), bucketName)
+}
+
+func testAccLoggingOrganizationSink_disabled(sinkName, bucketName, orgId string) string {
+	return fmt.Sprintf(`
+resource "google_logging_organization_sink" "disabled" {
+  name        = "%s"
+  project     = "%s"
+  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+  disabled    = true
+
+  unique_writer_identity = false
 }
 
 resource "google_storage_bucket" "log-bucket" {

--- a/third_party/terraform/tests/resource_logging_organization_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_organization_sink_test.go
@@ -92,8 +92,6 @@ func TestAccLoggingOrganizationSink_described(t *testing.T) {
 	sinkName := "tf-test-sink-" + randString(t, 10)
 	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
 
-	var sink logging.LogSink
-
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -116,8 +114,6 @@ func TestAccLoggingOrganizationSink_disabled(t *testing.T) {
 	org := getTestOrgFromEnv(t)
 	sinkName := "tf-test-sink-" + randString(t, 10)
 	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
-
-	var sink logging.LogSink
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/third_party/terraform/tests/resource_logging_organization_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_organization_sink_test.go
@@ -101,10 +101,6 @@ func TestAccLoggingOrganizationSink_described(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLoggingOrganizationSink_described(sinkName, bucketName, org),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLoggingOrganizationSinkExists(t, "google_logging_organization_sink.described", &sink),
-					testAccCheckLoggingOrganizationSink(&sink, "google_logging_organization_sink.described"),
-				),
 			}, {
 				ResourceName:      "google_logging_organization_sink.described",
 				ImportState:       true,
@@ -130,10 +126,6 @@ func TestAccLoggingOrganizationSink_disabled(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLoggingOrganizationSink_disabled(sinkName, bucketName, org),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckLoggingOrganizationSinkExists(t, "google_logging_organization_sink.disabled", &sink),
-					testAccCheckLoggingOrganizationSink(&sink, "google_logging_organization_sink.disabled"),
-				),
 			}, {
 				ResourceName:      "google_logging_organization_sink.disabled",
 				ImportState:       true,
@@ -353,7 +345,7 @@ resource "google_logging_organization_sink" "heredoc" {
   destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
   filter      = <<EOS
 
-	logName="projects/%s/logs/compute.googleapis.com%%2Factivity_log"
+  logName="projects/%s/logs/compute.googleapis.com%%2Factivity_log"
 AND severity>=ERROR
 
 

--- a/third_party/terraform/tests/resource_logging_project_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_project_sink_test.go
@@ -31,6 +31,52 @@ func TestAccLoggingProjectSink_basic(t *testing.T) {
 	})
 }
 
+func TestAccLoggingProjectSink_described(t *testing.T) {
+	t.Parallel()
+
+	sinkName := "tf-test-sink-" + randString(t, 10)
+	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLoggingProjectSinkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingProjectSink_described(sinkName, getTestProjectFromEnv(), bucketName),
+			},
+			{
+				ResourceName:      "google_logging_project_sink.described",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLoggingProjectSink_disabled(t *testing.T) {
+	t.Parallel()
+
+	sinkName := "tf-test-sink-" + randString(t, 10)
+	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLoggingProjectSinkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingProjectSink_disabled(sinkName, getTestProjectFromEnv(), bucketName),
+			},
+			{
+				ResourceName:      "google_logging_project_sink.disabled",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccLoggingProjectSink_updatePreservesUniqueWriter(t *testing.T) {
 	t.Parallel()
 
@@ -167,6 +213,42 @@ resource "google_logging_project_sink" "basic" {
   project     = "%s"
   destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
   filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+
+  unique_writer_identity = false
+}
+
+resource "google_storage_bucket" "log-bucket" {
+  name = "%s"
+}
+`, name, project, project, bucketName)
+}
+
+func testAccLoggingProjectSink_described(name, project, bucketName string) string {
+	return fmt.Sprintf(`
+resource "google_logging_project_sink" "described" {
+  name        = "%s"
+  project     = "%s"
+  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+  description = "this is a description for a project level logging sink"
+
+  unique_writer_identity = false
+}
+
+resource "google_storage_bucket" "log-bucket" {
+  name = "%s"
+}
+`, name, project, project, bucketName)
+}
+
+func testAccLoggingProjectSink_disabled(name, project, bucketName string) string {
+	return fmt.Sprintf(`
+resource "google_logging_project_sink" "disabled" {
+  name        = "%s"
+  project     = "%s"
+  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+  disabled    = true
 
   unique_writer_identity = false
 }

--- a/third_party/terraform/tests/resource_logging_project_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_project_sink_test.go
@@ -300,7 +300,7 @@ resource "google_logging_project_sink" "heredoc" {
 
   filter = <<EOS
 
-	logName="projects/%s/logs/compute.googleapis.com%%2Factivity_log"
+  logName="projects/%s/logs/compute.googleapis.com%%2Factivity_log"
 AND severity>=ERROR
 
 
@@ -360,16 +360,16 @@ resource "google_logging_project_sink" "loggingbucket" {
   project     = "%s"
   destination = "logging.googleapis.com/projects/%s/locations/global/buckets/_Default"
   exclusions {
-		name = "ex1"
-		description = "test"
-		filter = "resource.type = k8s_container"
-	}
+    name = "ex1"
+    description = "test"
+    filter = "resource.type = k8s_container"
+  }
 
-	exclusions {
-		name = "ex2"
-		description = "test-2"
-		filter = "resource.type = k8s_container"
-	}
+  exclusions {
+    name = "ex2"
+    description = "test-2"
+    filter = "resource.type = k8s_container"
+  }
 
   unique_writer_identity = true
 }

--- a/third_party/terraform/website/docs/r/logging_billing_account_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_billing_account_sink.html.markdown
@@ -23,6 +23,7 @@ typical IAM roles granted on a project.
 ```hcl
 resource "google_logging_billing_account_sink" "my-sink" {
   name            = "my-sink"
+  description = "some explaination on what this is"
   billing_account = "ABCDEF-012345-GHIJKL"
 
   # Can export to pubsub, cloud storage, or bigquery
@@ -63,6 +64,10 @@ The following arguments are supported:
 * `filter` - (Optional) The filter to apply when exporting logs. Only log entries that match the filter are exported.
     See [Advanced Log Filters](https://cloud.google.com/logging/docs/view/advanced_filters) for information on how to
     write a filter.
+
+* `description` - (Optional) A description of this sink. The maximum length of the description is 8000 characters.
+
+* `disabled` - (Optional) If set to True, then this sink is disabled and it does not export any log entries.
 
 * `bigquery_options` - (Optional) Options that affect sinks exporting data to BigQuery. Structure documented below.
 

--- a/third_party/terraform/website/docs/r/logging_folder_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_folder_sink.html.markdown
@@ -21,6 +21,7 @@ granted to the credentials used with terraform.
 ```hcl
 resource "google_logging_folder_sink" "my-sink" {
   name   = "my-sink"
+  description = "some explaination on what this is"
   folder = google_folder.my-folder.name
 
   # Can export to pubsub, cloud storage, or bigquery
@@ -70,6 +71,10 @@ The following arguments are supported:
 * `filter` - (Optional) The filter to apply when exporting logs. Only log entries that match the filter are exported.
     See [Advanced Log Filters](https://cloud.google.com/logging/docs/view/advanced_filters) for information on how to
     write a filter.
+
+* `description` - (Optional) A description of this sink. The maximum length of the description is 8000 characters.
+
+* `disabled` - (Optional) If set to True, then this sink is disabled and it does not export any log entries.
 
 * `include_children` - (Optional) Whether or not to include children folders in the sink export. If true, logs
     associated with child projects are also exported; otherwise only logs relating to the provided folder are included.

--- a/third_party/terraform/website/docs/r/logging_organization_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_organization_sink.html.markdown
@@ -21,6 +21,7 @@ granted to the credentials used with terraform.
 ```hcl
 resource "google_logging_organization_sink" "my-sink" {
   name   = "my-sink"
+  description = "some explaination on what this is"
   org_id = "123456789"
 
   # Can export to pubsub, cloud storage, or bigquery
@@ -62,6 +63,10 @@ The following arguments are supported:
 * `filter` - (Optional) The filter to apply when exporting logs. Only log entries that match the filter are exported.
     See [Advanced Log Filters](https://cloud.google.com/logging/docs/view/advanced_filters) for information on how to
     write a filter.
+
+* `description` - (Optional) A description of this sink. The maximum length of the description is 8000 characters.
+
+* `disabled` - (Optional) If set to True, then this sink is disabled and it does not export any log entries.
 
 * `include_children` - (Optional) Whether or not to include children organizations in the sink export. If true, logs
     associated with child projects are also exported; otherwise only logs relating to the provided organization are included.

--- a/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -70,6 +70,7 @@ resource "google_storage_bucket" "log-bucket" {
 # Our sink; this logs all activity related to our "my-logged-instance" instance
 resource "google_logging_project_sink" "instance-sink" {
   name        = "my-instance-sink"
+  description = "some explaination on what this is"
   destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
   filter      = "resource.type = gce_instance AND resource.labels.instance_id = \"${google_compute_instance.my-logged-instance.instance_id}\""
 
@@ -129,6 +130,10 @@ The following arguments are supported:
 * `filter` - (Optional) The filter to apply when exporting logs. Only log entries that match the filter are exported.
     See [Advanced Log Filters](https://cloud.google.com/logging/docs/view/advanced_filters) for information on how to
     write a filter.
+
+* `description` - (Optional) A description of this sink. The maximum length of the description is 8000 characters.
+
+* `disabled` - (Optional) If set to True, then this sink is disabled and it does not export any log entries.
 
 * `project` - (Optional) The ID of the project to create the sink in. If omitted, the project associated with the provider is
     used.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Upstreaming [7795](https://github.com/hashicorp/terraform-provider-google/pull/7795/files)


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
logging: added `description` field to `google_logging_folder_sink` resource
logging: added `description` field to `google_logging_project_sink` resource
logging: added `description` field to `google_logging_organization_sink` resource
logging: added `description` field to `google_logging_billing_account_sink` resource
logging: added `disabled` field to `google_logging_folder_sink` resource
logging: added `disabled` field to `google_logging_project_sink` resource
logging: added `disabled` field to `google_logging_organization_sink` resource
logging: added `disabled` field to `google_logging_billing_account_sink` resource
```
