### PR TITLE
Fix validator imports

### DIFF
--- a/templates/terraform/constants/monitoring_slo.go.erb
+++ b/templates/terraform/constants/monitoring_slo.go.erb
@@ -5,3 +5,20 @@ func validateMonitoringSloGoal(v interface{}, k string) (warnings []string, erro
 	}
 	return
 }
+<% if compiler == "terraformobjectlibrary-codegen" -%>
+
+func expandMonitoringSloRollingPeriodDays(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
+	i, ok := v.(int)
+	if !ok {
+		return nil, fmt.Errorf("unexpected value is not int: %v", v)
+	}
+	if i == 0 {
+		return "", nil
+	}
+	// Day = 86400s
+	return fmt.Sprintf("%ds", i*86400), nil
+}
+<% end -%>

--- a/templates/terraform/constants/secret_version.go.erb
+++ b/templates/terraform/constants/secret_version.go.erb
@@ -1,3 +1,4 @@
+<% unless compiler == "terraformobjectlibrary-codegen" -%>
 func resourceSecretManagerSecretVersionUpdate(d *schema.ResourceData, meta interface{}) error {
     config := meta.(*Config)
 
@@ -8,3 +9,4 @@ func resourceSecretManagerSecretVersionUpdate(d *schema.ResourceData, meta inter
 
     return resourceSecretManagerSecretVersionRead(d, meta)
 }
+<% end -%>

--- a/templates/terraform/encoders/disk.erb
+++ b/templates/terraform/encoders/disk.erb
@@ -5,7 +5,11 @@ if err != nil {
  	return nil, err
 }
 
+<% unless compiler == "terraformobjectlibrary-codegen" -%>
 userAgent, err := generateUserAgentString(d, config.userAgent)
+<% else %>
+userAgent, err := generateUserAgentString(d.(*schema.ResourceData), config.userAgent)
+<% end -%>
 if err != nil {
 	return nil, err
 }

--- a/templates/terraform/objectlib/base.go.erb
+++ b/templates/terraform/objectlib/base.go.erb
@@ -2,6 +2,22 @@
 
 package google
 
+import (
+<%- # We list all the v2 imports here and unstable imports, because we run 'goimports' to guess the correct
+    # set of imports, which will never guess the major version correctly. -%>
+  "github.com/apparentlymart/go-cidr/cidr"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+  "github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
+  "google.golang.org/api/bigtableadmin/v2"
+)
+
 <%
     resource_name = product_ns + object.name
     properties = object.all_user_properties

--- a/third_party/terraform/utils/config.go.erb
+++ b/third_party/terraform/utils/config.go.erb
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/api/cloudkms/v1"
 	"google.golang.org/api/cloudresourcemanager/v1"
 	resourceManagerV2Beta1 "google.golang.org/api/cloudresourcemanager/v2beta1"
+	composer "google.golang.org/api/composer/v1beta1"
 	"google.golang.org/api/composer/v1beta1"
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR fixes current build issue in downstream repository terraform-google-conversion.

- Added sdk v2 imports in to the validator base template to help goimports to find the correct version to import (replicates what was done in https://github.com/GoogleCloudPlatform/magic-modules/pull/3989 for the provider resource base template)
- Added two imports in to the validator base template that goimports was not able to correctly choose
- Added composer import in handwritten resource
- Added conditional tags in the ERB fragments to select the correct code to be used in the provider or in the validator

**After this PR is merged another PR in the terraform-google-conversion repository is necessary to the update  go.mod, go sum and vendor folder.**


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
Added sdk v2 imports, some unstable imports and conditional erb compile tags
```
