### PR TITLE
Add google_composer_environment data source

### DIFF
--- a/third_party/terraform/data_sources/data_source_google_composer_environment.go
+++ b/third_party/terraform/data_sources/data_source_google_composer_environment.go
@@ -1,0 +1,31 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceGoogleComposerEnvironment() *schema.Resource {
+	return &schema.Resource{
+		Read:   dataSourceGoogleComposerEnvironmentRead,
+		Schema: resourceComposerEnvironment().Schema,
+	}
+}
+
+func dataSourceGoogleComposerEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+	envName := d.Get("name").(string)
+
+	d.SetId(fmt.Sprintf("projects/%s/locations/%s/environments/%s", project, region, envName))
+
+	return resourceComposerEnvironmentRead(d, meta)
+}

--- a/third_party/terraform/tests/data_source_google_composer_environment_test.go
+++ b/third_party/terraform/tests/data_source_google_composer_environment_test.go
@@ -1,0 +1,77 @@
+package google
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+var testAccCheckGoogleComposerEnvironmentConfig = `
+data "google_composer_environment" "composer_env" {
+	name = "data_google_composer_environment_test"
+}
+`
+
+func TestAccDataSourceComposerEnvironment_basic(t *testing.T) {
+	t.Parallel()
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGoogleComposerEnvironmentConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleComposerEnvironmentMeta("data.google_composer_environment.composer_env"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGoogleComposerEnvironmentMeta(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("can't find environment data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("environment data source ID not set.")
+		}
+
+		configCountStr, ok := rs.Primary.Attributes["config.#"]
+		if !ok {
+			return errors.New("can't find 'config' attribute")
+		}
+
+		configCount, err := strconv.Atoi(configCountStr)
+		if err != nil {
+			return errors.New("failed to read number of valid config entries")
+		}
+		if configCount < 1 {
+			return fmt.Errorf("expected at least 1 valid config entry, received %d, this is most likely a bug",
+				configCount)
+		}
+
+		for i := 0; i < configCount; i++ {
+			idx := "config." + strconv.Itoa(i)
+
+			if v, ok := rs.Primary.Attributes[idx+".airflow_uri"]; !ok || v == "" {
+				return fmt.Errorf("config %v is missing airflow_uri", i)
+			}
+			if v, ok := rs.Primary.Attributes[idx+".dag_gcs_prefix"]; !ok || v == "" {
+				return fmt.Errorf("config %v is missing dag_gcs_prefix", i)
+			}
+			if v, ok := rs.Primary.Attributes[idx+".gke_cluster"]; !ok || v == "" {
+				return fmt.Errorf("config %v is missing gke_cluster", i)
+			}
+		}
+
+		return nil
+	}
+}

--- a/third_party/terraform/tests/data_source_google_composer_environment_test.go
+++ b/third_party/terraform/tests/data_source_google_composer_environment_test.go
@@ -12,7 +12,7 @@ import (
 
 var testAccCheckGoogleComposerEnvironmentConfig = `
 data "google_composer_environment" "composer_env" {
-	name = "data_google_composer_environment_test"
+	name = "data-google-composer-environment-test"
 }
 `
 

--- a/third_party/terraform/tests/data_source_google_composer_environment_test.go
+++ b/third_party/terraform/tests/data_source_google_composer_environment_test.go
@@ -12,7 +12,7 @@ import (
 
 var testAccCheckGoogleComposerEnvironmentConfig = `
 data "google_composer_environment" "composer_env" {
-	name = "data-google-composer-environment-test"
+	name = "data-test"
 }
 `
 

--- a/third_party/terraform/utils/provider.go.erb
+++ b/third_party/terraform/utils/provider.go.erb
@@ -183,6 +183,7 @@ func Provider() *schema.Provider {
 			"google_cloud_identity_groups":                     dataSourceGoogleCloudIdentityGroups(),
 			"google_cloud_identity_group_memberships":          dataSourceGoogleCloudIdentityGroupMemberships(),
 			"google_cloud_run_service":                         dataSourceGoogleCloudRunService(),
+			"google_composer_environment":                      dataSourceGoogleComposerEnvironment(),
 			"google_composer_image_versions":                   dataSourceGoogleComposerImageVersions(),
 			"google_compute_address":                           dataSourceGoogleComputeAddress(),
 			"google_compute_backend_service":                   dataSourceGoogleComputeBackendService(),

--- a/third_party/terraform/website/docs/d/composer_environment.html.markdown
+++ b/third_party/terraform/website/docs/d/composer_environment.html.markdown
@@ -1,0 +1,54 @@
+---
+subcategory: "Cloud Composer"
+layout: "google"
+page_title: "Google: google_composer_environment"
+sidebar_current: "docs-google-datasource-composer-environment"
+description: |-
+  Provides Cloud Composer environment configuration data.
+---
+
+# google\_composer\_environment
+
+Provides access to Cloud Composer environment configuration in a region for a given project.
+
+## Example Usage
+
+```hcl
+data "google_composer_environment" "composer_env" {
+    name = "data_google_composer_environment_test"
+}
+
+output "debug" {
+    value = data.google_composer_environment.composer_env.config
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the environment.
+
+* `project` - (Optional) The ID of the project in which the resource belongs.
+    If it is not provided, the provider project is used.
+
+* `region` - (Optional) The location or Compute Engine region of the environment.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - An identifier for the resource in format `projects/{{project}}/locations/{{region}}/environments/{{name}}`
+
+* `config` - Configuration parameters for the environment.
+    Full structure is provided by [composer environment resource documentation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/composer_environment#config).
+
+    * `config.0.gke_cluster` -
+    The Kubernetes Engine cluster used to run the environment.
+
+    * `config.0.dag_gcs_prefix` -
+    The Cloud Storage prefix of the DAGs for the environment.
+
+    * `config.0.airflow_uri` -
+    The URI of the Apache Airflow Web UI hosted within the
+    environment.

--- a/third_party/terraform/website/docs/d/composer_environment.html.markdown
+++ b/third_party/terraform/website/docs/d/composer_environment.html.markdown
@@ -14,8 +14,14 @@ Provides access to Cloud Composer environment configuration in a region for a gi
 ## Example Usage
 
 ```hcl
+resource "google_composer_environment" "composer_env" {
+    name = "composer-environment"
+}
+
 data "google_composer_environment" "composer_env" {
-    name = "data_google_composer_environment_test"
+    name = google_composer_environment.test.name
+
+    depends_on = [google_composer_environment.composer_env]
 }
 
 output "debug" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Resolved hashicorp/terraform-provider-google#7826

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-datasource
composer: added datasource for `google_composer_environment`
```