### PR TITLE
Fix apigateway config tests for vcr

### DIFF
--- a/products/apigateway/terraform.yaml
+++ b/products/apigateway/terraform.yaml
@@ -67,6 +67,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "api_cfg"
         vars:
           name: "api-cfg"
+          config: "cfg"
       - !ruby/object:Provider::Terraform::Examples
         skip_docs: true
         min_version: beta
@@ -102,6 +103,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "api_gw"
         vars:
           name: "api-gw"
+          config: "config"
       - !ruby/object:Provider::Terraform::Examples
         skip_docs: true
         min_version: beta

--- a/templates/terraform/examples/apigateway_api_config_basic.tf.erb
+++ b/templates/terraform/examples/apigateway_api_config_basic.tf.erb
@@ -6,7 +6,7 @@ resource "google_api_gateway_api" "<%= ctx[:primary_resource_id] %>" {
 resource "google_api_gateway_api_config" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
   api = google_api_gateway_api.<%= ctx[:primary_resource_id] %>.api_id
-  api_config_id_prefix = "api-cfg-"
+  api_config_id = "<%= ctx[:vars]["config"] %>"
 
   openapi_documents {
     document {

--- a/templates/terraform/examples/apigateway_gateway_basic.tf.erb
+++ b/templates/terraform/examples/apigateway_gateway_basic.tf.erb
@@ -6,7 +6,7 @@ resource "google_api_gateway_api" "<%= ctx[:primary_resource_id] %>" {
 resource "google_api_gateway_api_config" "<%= ctx[:primary_resource_id] %>" {
   provider = google-beta
   api = google_api_gateway_api.<%= ctx[:primary_resource_id] %>.api_id
-  api_config_id_prefix = "tf-test-"
+  api_config_id = "<%= ctx[:vars]["config"] %>"
 
   openapi_documents {
     document {

--- a/third_party/terraform/tests/resource_api_gateway_api_config_test.go.erb
+++ b/third_party/terraform/tests/resource_api_gateway_api_config_test.go.erb
@@ -36,6 +36,30 @@ func TestAccApiGatewayApiConfig_apigatewayApiConfigBasicExampleUpdated(t *testin
 	})
 }
 
+func TestAccApiGatewayApiConfig_generatedPrefix(t *testing.T) {
+	// Random generated id within resource
+	skipIfVcr(t)
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProvidersOiCS,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {},
+		},
+		CheckDestroy: testAccCheckApiGatewayApiConfigDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccApiGatewayApiConfig_generatedPrefix(context),
+			},
+		},
+	})
+}
+
 func testAccApiGatewayApiConfig_apigatewayApiConfigBasicExampleUpdated(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_api_gateway_api" "api_cfg" {
@@ -47,6 +71,32 @@ resource "google_api_gateway_api_config" "api_cfg" {
   provider = google-beta
   api = google_api_gateway_api.api_cfg.api_id
   api_config_id = "tf-test-api-cfg%{random_suffix}"
+  display_name = "MM Dev API Config"
+  labels = {
+    environment = "dev"
+  }
+
+  openapi_documents {
+    document {
+      path = "spec.yaml"
+      contents = filebase64("test-fixtures/apigateway/openapi.yaml")
+    }
+  }
+}
+`, context)
+}
+
+func testAccApiGatewayApiConfig_generatedPrefix(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_api_gateway_api" "api_cfg" {
+  provider = google-beta
+  api_id = "tf-test-api-cfg%{random_suffix}"
+}
+
+resource "google_api_gateway_api_config" "api_cfg" {
+  provider = google-beta
+  api = google_api_gateway_api.api_cfg.api_id
+  api_config_id_prefix = "tf-test-"
   display_name = "MM Dev API Config"
   labels = {
     environment = "dev"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

These broke because of unique ids generated within the resource. Only test changes


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
