### PR TITLE
Improve composer sweeper logging, fallthrough to deletion case

### DIFF
--- a/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -952,39 +952,45 @@ func testSweepComposerEnvironments(config *Config) error {
 	}
 
 	if len(found.Environments) == 0 {
-		log.Printf("No environment need to be cleaned up")
+		log.Printf("composer: no environments need to be cleaned up")
 		return nil
 	}
+
+	log.Printf("composer: %d environments need to be cleaned up", len(found.Environments))
 
 	var allErrors error
 	for _, e := range found.Environments {
 		createdAt, err := time.Parse(time.RFC3339Nano, e.CreateTime)
 		if err != nil {
-			return fmt.Errorf("[ERROR] Environment %q has invalid create time %q", e.Name, e.CreateTime)
+			return fmt.Errorf("composer: environment %q has invalid create time %q", e.Name, e.CreateTime)
 		}
 		// Skip environments that were created in same day
 		// This sweeper should really only clean out very old environments.
 		if time.Since(createdAt) < time.Hour*24 {
+			log.Printf("composer: skipped environment %q, it was created today", e.Name)
 			continue
 		}
 
 		switch e.State {
 		case "CREATING":
+			fallthrough
 		case "UPDATING":
-			log.Printf("Skipping pending Environment %q with state %q", e.Name, e.State)
+			log.Printf("composer: skipping pending Environment %q with state %q", e.Name, e.State)
 		case "DELETING":
-			log.Printf("Skipping pending Environment %q that is currently deleting", e.Name)
+			log.Printf("composer: skipping pending Environment %q that is currently deleting", e.Name)
 		case "RUNNING":
+			fallthrough
 		case "ERROR":
+			fallthrough
 		default:
 			op, deleteErr := config.NewComposerClient(config.userAgent).Projects.Locations.Environments.Delete(e.Name).Do()
 			if deleteErr != nil {
-				allErrors = multierror.Append(allErrors, fmt.Errorf("Unable to delete environment %q: %s", e.Name, deleteErr))
+				allErrors = multierror.Append(allErrors, fmt.Errorf("composer: unable to delete environment %q: %s", e.Name, deleteErr))
 				continue
 			}
 			waitErr := composerOperationWaitTime(config, op, config.Project, "Sweeping old test environments", config.userAgent, 10*time.Minute)
 			if waitErr != nil {
-				allErrors = multierror.Append(allErrors, fmt.Errorf("Unable to delete environment %q: %s", e.Name, waitErr))
+				allErrors = multierror.Append(allErrors, fmt.Errorf("composer: unable to delete environment %q: %s", e.Name, waitErr))
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

I noticed an excessive number of composer environments billing us, which caused me to look into the sweeper logs for the cause. I think we were just dropping most environments completely- this should cause us to hit the deletion code correctly, and improve the logging so that if it doesn't it's easier to inspect what's up (mostly by having the sweeper say how many envs it expects to process).

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
