### PR TITLE
Fix typo breaking compilation of downstream conversion

### DIFF
--- a/third_party/validator/project_organization_policy.go
+++ b/third_party/validator/project_organization_policy.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"google3/third_party/golang/hashicorp/terraform_plugin_sdk/helper/schema/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func GetProjectOrgPolicyCaiObject(d TerraformResourceData, config *Config) (Asset, error) {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR fixes a small typo that is breaking compilation of downstream terraform-google-conversion





<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
Fixed typo breaking compilation of conversion code
```
