### PR TITLE
Fix typo in composer docs.

### DIFF
--- a/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -223,7 +223,7 @@ func resourceComposerEnvironment() *schema.Resource {
 													Type:        schema.TypeBool,
 													Required:    true,
 													ForceNew:    true,
-													Description: `Whether or not to enable Alias IPs in the GKE cluster. If true, a VPC-native cluster is created. Defaults to true if the ip_allocation_block is present in config.`,
+													Description: `Whether or not to enable Alias IPs in the GKE cluster. If true, a VPC-native cluster is created. Defaults to true if the ip_allocation_policy block is present in config.`,
 												},
 												"cluster_secondary_range_name": {
 													Type:          schema.TypeString,

--- a/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -344,7 +344,7 @@ The `ip_allocation_policy` block supports:
 * `use_ip_aliases` -
   (Required)
   Whether or not to enable Alias IPs in the GKE cluster. If true, a VPC-native cluster is created.
-  Defaults to true if the `ip_allocation_block` is present in config.
+  Defaults to true if the `ip_allocation_policy` block is present in config.
 
 * `cluster_secondary_range_name` -
   (Optional)


### PR DESCRIPTION
Fix some minor typos in the cloud composer docs.

If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
Fix typos in composer docs.
```
