### PR TITLE
Replaced google3 path with github path

### DIFF
--- a/third_party/validator/project_organization_policy.go
+++ b/third_party/validator/project_organization_policy.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"google3/third_party/golang/hashicorp/terraform_plugin_sdk/helper/schema/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func GetProjectOrgPolicyCaiObject(d TerraformResourceData, config *Config) (Asset, error) {


### PR DESCRIPTION
Fixed issue of invalid path for terraform-plugin-sdk/v2/helper/schema. This was creating issues in updating vendor folder in terraform validator
@rileykarson @melinath Please take a look