### PR TITLE
Upstream new restore policy

### DIFF
--- a/third_party/terraform/resources/resource_google_project_default_service_accounts.go
+++ b/third_party/terraform/resources/resource_google_project_default_service_accounts.go
@@ -80,12 +80,12 @@ func resourceGoogleProjectDefaultServiceAccountsDoAction(d *schema.ResourceData,
 		_, err := config.NewIamClient(userAgent).Projects.ServiceAccounts.Undelete(serviceAccountSelfLink, &iam.UndeleteServiceAccountRequest{}).Do()
 		errExpected := restorePolicy == "REVERT_AND_IGNORE_FAILURE"
 		errReceived := err != nil
-		if errExpected && errReceived {
+		if errReceived {
+			if !errExpected {
+				return fmt.Errorf("cannot undelete service account %s: %v", serviceAccountSelfLink, err)
+			}
 			log.Printf("cannot undelete service account %s: %v", serviceAccountSelfLink, err)
 			log.Printf("restore policy is %s... ignoring error", restorePolicy)
-		}
-		if !errExpected && errReceived {
-			return fmt.Errorf("cannot undelete service account %s: %v", serviceAccountSelfLink, err)
 		}
 	case "DISABLE":
 		_, err := config.NewIamClient(userAgent).Projects.ServiceAccounts.Disable(serviceAccountSelfLink, &iam.DisableServiceAccountRequest{}).Do()
@@ -96,12 +96,12 @@ func resourceGoogleProjectDefaultServiceAccountsDoAction(d *schema.ResourceData,
 		_, err := config.NewIamClient(userAgent).Projects.ServiceAccounts.Enable(serviceAccountSelfLink, &iam.EnableServiceAccountRequest{}).Do()
 		errReceived := err != nil
 		errExpected := restorePolicy == "REVERT_AND_IGNORE_FAILURE"
-		if errExpected && errReceived {
+		if errReceived {
+			if !errExpected {
+				return fmt.Errorf("cannot enable service account %s: %v", serviceAccountSelfLink, err)
+			}
 			log.Printf("cannot enable service account %s: %v", serviceAccountSelfLink, err)
 			log.Printf("restore policy is %s... ignoring error", restorePolicy)
-		}
-		if !errExpected && errReceived {
-			return fmt.Errorf("cannot enable service account %s: %v", serviceAccountSelfLink, err)
 		}
 	case "DEPRIVILEGE":
 		iamPolicy, err := config.NewResourceManagerClient(userAgent).Projects.GetIamPolicy(project, &cloudresourcemanager.GetIamPolicyRequest{}).Do()

--- a/third_party/terraform/tests/resource_google_project_default_service_accounts_test.go
+++ b/third_party/terraform/tests/resource_google_project_default_service_accounts_test.go
@@ -109,6 +109,34 @@ func TestAccResourceGoogleProjectDefaultServiceAccountsDelete(t *testing.T) {
 	})
 }
 
+func TestAccResourceGoogleProjectDefaultServiceAccountsDeleteRevertIgnoreFailure(t *testing.T) {
+	t.Parallel()
+
+	org := getTestOrgFromEnv(t)
+	project := fmt.Sprintf("tf-project-%d", randInt(t))
+	billingAccount := getTestBillingAccountFromEnv(t)
+	action := "DELETE"
+	restorePolicy := "REVERT_AND_IGNORE_FAILURE"
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGoogleProjectDefaultServiceAccountsAdvanced(org, project, billingAccount, action, restorePolicy),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_project_default_service_accounts.acceptance", "id", "projects/"+project),
+					resource.TestCheckResourceAttrSet("google_project_default_service_accounts.acceptance", "project"),
+					resource.TestCheckResourceAttr("google_project_default_service_accounts.acceptance", "action", action),
+					resource.TestCheckResourceAttrSet("google_project_default_service_accounts.acceptance", "project"),
+					sleepInSecondsForTest(10),
+					testAccCheckGoogleProjectDefaultServiceAccountsChanges(t, project, action),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceGoogleProjectDefaultServiceAccountsDeprivilege(t *testing.T) {
 	t.Parallel()
 

--- a/third_party/terraform/website/docs/r/google_project_default_service_accounts.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_default_service_accounts.html.markdown
@@ -44,7 +44,10 @@ The following arguments are supported:
 
 - `action` - (Required) The action to be performed in the default service accounts. Valid values are: `DEPRIVILEGE`, `DELETE`, `DISABLE`. Note that `DEPRIVILEGE` action will ignore the REVERT configuration in the restore_policy
 
-- `restore_policy` - (Optional) The action to be performed in the default service accounts on the resource destroy. Valid values are `NONE` and `REVERT`. If set to `REVERT` it will attempt to restore all default SAs but in the `DEPRIVILEGE` action.
+- `restore_policy` - (Optional) The action to be performed in the default service accounts on the resource destroy.
+  Valid values are NONE, REVERT and REVERT_AND_IGNORE_FAILURE. It is applied for any action but in the DEPRIVILEGE.
+  If set to REVERT it attempt to restore all default SAs but the DEPRIVILEGE action.
+  If set to REVERT_AND_IGNORE_FAILURE it is the same behavior as REVERT but ignores errors returned by the API.
 
 ## Attributes Reference
 

--- a/third_party/terraform/website/docs/r/google_project_default_service_accounts.html.markdown
+++ b/third_party/terraform/website/docs/r/google_project_default_service_accounts.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 
 - `restore_policy` - (Optional) The action to be performed in the default service accounts on the resource destroy.
   Valid values are NONE, REVERT and REVERT_AND_IGNORE_FAILURE. It is applied for any action but in the DEPRIVILEGE.
-  If set to REVERT it attempt to restore all default SAs but the DEPRIVILEGE action.
+  If set to REVERT it attempts to restore all default SAs but the DEPRIVILEGE action.
   If set to REVERT_AND_IGNORE_FAILURE it is the same behavior as REVERT but ignores errors returned by the API.
 
 ## Attributes Reference


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Upstreams https://github.com/hashicorp/terraform-provider-google/pull/7768



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
project: added new restore_policy `REVERT_AND_IGNORE_FAILURE` to `google_project_default_service_accounts`
```
