### PR TITLE
Allow url map to handle backend service fields that can also be backend buckets.

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -2728,7 +2728,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       defaultService: !ruby/object:Overrides::Terraform::PropertyOverride
         # ResourceRef only supports 1 type and UrlMap has references to a BackendBucket or BackendService.
         # Just read the self_link string instead of extracting the name and making a self_link out of it.
-        custom_expand: 'templates/terraform/custom_expand/resourceref_as_string.go.erb'
+        custom_expand: 'templates/terraform/custom_expand/reference_to_backend.erb'
         description: The backend service or backend bucket to use when none of the given rules match.
       hostRules: !ruby/object:Overrides::Terraform::PropertyOverride
         name: "host_rule"
@@ -2740,21 +2740,37 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       pathMatchers.defaultService: !ruby/object:Overrides::Terraform::PropertyOverride
         # ResourceRef only supports 1 type and UrlMap has references to a BackendBucket or BackendService.
         # Just read the self_link string instead of extracting the name and making a self_link out of it.
-        custom_expand: 'templates/terraform/custom_expand/resourceref_as_string.go.erb'
+        custom_expand: 'templates/terraform/custom_expand/reference_to_backend.erb'
         description: The backend service or backend bucket to use when none of the given paths match.
       pathMatchers.pathRules: !ruby/object:Overrides::Terraform::PropertyOverride
         name: "path_rule"
       pathMatchers.pathRules.paths: !ruby/object:Overrides::Terraform::PropertyOverride
         is_set: true
+      pathMatchers.defaultRouteAction.weightedBackendServices.backendService: !ruby/object:Overrides::Terraform::PropertyOverride
+        # ResourceRef only supports 1 type and UrlMap has references to a BackendBucket or BackendService.
+        # Just read the self_link string instead of extracting the name and making a self_link out of it.
+        custom_expand: 'templates/terraform/custom_expand/reference_to_backend.erb'
+      pathMatchers.defaultRouteAction.requestMirrorPolicy.backendService: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/reference_to_backend.erb'
+      defaultRouteAction.weightedBackendServices.backendService: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/reference_to_backend.erb'
+      defaultRouteAction.requestMirrorPolicy.backendService: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/reference_to_backend.erb'
+      pathMatchers.routeRules.service: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/reference_to_backend.erb'
       pathMatchers.pathRules.service: !ruby/object:Overrides::Terraform::PropertyOverride
-        # ResourceRef only supports 1 type and UrlMap has references to a BackendBucket or BackendService.
-        # Just read the self_link string instead of extracting the name and making a self_link out of it.
-        custom_expand: 'templates/terraform/custom_expand/resourceref_as_string.go.erb'
+        custom_expand: 'templates/terraform/custom_expand/reference_to_backend.erb'
         description: The backend service or backend bucket to use if any of the given paths match.
+      pathMatchers.routeRules.routeAction.weightedBackendServices.backendService: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/reference_to_backend.erb'
+      pathMatchers.pathRules.routeAction.weightedBackendServices.backendService: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/reference_to_backend.erb'
+      pathMatchers.routeRules.routeAction.requestMirrorPolicy.backendService: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/reference_to_backend.erb'
+      pathMatchers.pathRules.routeAction.requestMirrorPolicy.backendService: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/reference_to_backend.erb'
       tests.service: !ruby/object:Overrides::Terraform::PropertyOverride
-        # ResourceRef only supports 1 type and UrlMap has references to a BackendBucket or BackendService.
-        # Just read the self_link string instead of extracting the name and making a self_link out of it.
-        custom_expand: 'templates/terraform/custom_expand/resourceref_as_string.go.erb'
+        custom_expand: 'templates/terraform/custom_expand/reference_to_backend.erb'
         description: The backend service or backend bucket link that should be matched by this test.
       tests: !ruby/object:Overrides::Terraform::PropertyOverride
         name: "test"

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -2672,7 +2672,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           url_map_name: "urlmap"
           login_backend_service_name: "login"
-          home_backend_service_name: "home"
           http_health_check_name: "health-check"
           backend_bucket_name: "static-asset-backend-bucket"
           storage_bucket_name: "static-asset-bucket"

--- a/templates/terraform/custom_expand/reference_to_backend.erb
+++ b/templates/terraform/custom_expand/reference_to_backend.erb
@@ -12,6 +12,19 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
+<%# This provides the best long-form self link possible given the input.
+  # If the input is a full URL including scheme, we return it unmodified
+  #      https://compute.googleapis.com/v1/projects/foo/regions/bar/backendBuckets/baz -> (the same)
+  # If the input is a partial self-link, we return it with the compute base path in front.
+  #      projects/foo/regions/bar/backendServices/baz -> https://compute.googleapis.com/v1/projects/foo/regions/bar/backendServices/baz
+  # If the input is an even-more-partial link (not including projects), we return it with the compute base path
+  # and the specified project in front
+  #      regions/bar/backendServices/baz -> https://compute.googleapis.com/v1/projects/provider-project/regions/bar/backendServices/baz
+  # If the input is just project/region/name, region/name, or just name, we treat it like a backendService.
+  #      baz -> https://compute.googleapis.com/v1/projects/provider-project/regions/provider-region/backendServices/baz
+  #      bar/baz -> https://compute.googleapis.com/v1/projects/provider-project/regions/bar/backendServices/baz
+  #      foo/bar/baz -> https://compute.googleapis.com/v1/projects/foo/regions/bar/backendServices/baz
+-%>
 func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
   // This method returns a full self link from whatever the input is.
   if v == nil || v.(string) == "" {

--- a/templates/terraform/custom_expand/reference_to_backend.erb
+++ b/templates/terraform/custom_expand/reference_to_backend.erb
@@ -1,0 +1,45 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2017 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+  // This method returns a full self link from whatever the input is.
+  if v == nil || v.(string) == "" {
+    // It does not try to construct anything from empty.
+    return "", nil
+  } else if strings.HasPrefix(v.(string), "https://") {
+    // Anything that starts with a URL scheme is assumed to be a self link worth using.
+    return v, nil
+  } else if strings.HasPrefix(v.(string), "projects/") {
+    // If the self link references a project, we'll just stuck the compute prefix on it
+    url, err := replaceVars(d, config, "{{ComputeBasePath}}" + v.(string))
+    if err != nil {
+      return "", err
+    }
+    return url, nil
+  } else if strings.HasPrefix(v.(string), "regions/") || strings.HasPrefix(v.(string), "zones/") {
+    // For regional or zonal resources which include their region or zone, just put the project in front.
+    url, err := replaceVars(d, config, "{{ComputeBasePath}}projects/{{project}}/")
+    if err != nil {
+      return nil, err
+    }
+    return url + v.(string), nil
+  }
+  // Anything else is assumed to be a reference to a global backend service.
+  f, err := parseGlobalFieldValue("backendServices", v.(string), "project", d, config, true)
+  if err != nil {
+    return "", err
+  }
+
+  return f.RelativeLink(), nil
+}

--- a/templates/terraform/examples/url_map_basic.tf.erb
+++ b/templates/terraform/examples/url_map_basic.tf.erb
@@ -2,7 +2,7 @@ resource "google_compute_url_map" "<%= ctx[:primary_resource_id] %>" {
   name        = "<%= ctx[:vars]['url_map_name'] %>"
   description = "a description"
 
-  default_service = google_compute_backend_service.home.id
+  default_service = google_compute_backend_bucket.static.id
 
   host_rule {
     hosts        = ["mysite.com"]
@@ -16,11 +16,11 @@ resource "google_compute_url_map" "<%= ctx[:primary_resource_id] %>" {
 
   path_matcher {
     name            = "mysite"
-    default_service = google_compute_backend_service.home.id
+    default_service = google_compute_backend_bucket.static.id
 
     path_rule {
       paths   = ["/home"]
-      service = google_compute_backend_service.home.id
+      service = google_compute_backend_bucket.static.id
     }
 
     path_rule {
@@ -36,11 +36,11 @@ resource "google_compute_url_map" "<%= ctx[:primary_resource_id] %>" {
 
   path_matcher {
     name            = "otherpaths"
-    default_service = google_compute_backend_service.home.id
+    default_service = google_compute_backend_bucket.static.id
   }
 
   test {
-    service = google_compute_backend_service.home.id
+    service = google_compute_backend_bucket.static.id
     host    = "hi.com"
     path    = "/home"
   }
@@ -48,15 +48,6 @@ resource "google_compute_url_map" "<%= ctx[:primary_resource_id] %>" {
 
 resource "google_compute_backend_service" "login" {
   name        = "<%= ctx[:vars]['login_backend_service_name'] %>"
-  port_name   = "http"
-  protocol    = "HTTP"
-  timeout_sec = 10
-
-  health_checks = [google_compute_http_health_check.default.id]
-}
-
-resource "google_compute_backend_service" "home" {
-  name        = "<%= ctx[:vars]['home_backend_service_name'] %>"
   port_name   = "http"
   protocol    = "HTTP"
   timeout_sec = 10


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/7886.



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: `google_compute_url_map`'s fields referring to backend services can now also refer to backend buckets.
```