### PR TITLE
Add CDN to regional backend service, add flexible cache control to backend service.

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -602,12 +602,16 @@ objects:
                 description: |
                   The TTL (in seconds) for which to cache responses with the corresponding status code. The maximum allowed value is 1800s
                   (30 minutes), noting that infrequently accessed objects may be evicted from the cache before the defined TTL.
-        - !ruby/object:Api::Type::String
+        - !ruby/object:Api::Type::Enum
           name: 'cacheMode'
           min_version: beta
           description: |
             Specifies the cache setting for all responses from this backend.
             The possible values are: USE_ORIGIN_HEADERS, FORCE_CACHE_ALL and CACHE_ALL_STATIC
+          values:
+            - :USE_ORIGIN_HEADERS
+            - :FORCE_CACHE_ALL
+            - :CACHE_ALL_STATIC
         - !ruby/object:Api::Type::Integer
           name: 'serveWhileStale'
           min_version: beta
@@ -1200,12 +1204,16 @@ objects:
                   description: |
                     The TTL (in seconds) for which to cache responses with the corresponding status code. The maximum allowed value is 1800s
                     (30 minutes), noting that infrequently accessed objects may be evicted from the cache before the defined TTL.
-          - !ruby/object:Api::Type::String
+          - !ruby/object:Api::Type::Enum
             name: 'cacheMode'
             min_version: beta
             description: |
               Specifies the cache setting for all responses from this backend.
               The possible values are: USE_ORIGIN_HEADERS, FORCE_CACHE_ALL and CACHE_ALL_STATIC
+            values:
+              - :USE_ORIGIN_HEADERS
+              - :FORCE_CACHE_ALL
+              - :CACHE_ALL_STATIC
           - !ruby/object:Api::Type::Integer
             name: 'serveWhileStale'
             min_version: beta
@@ -2175,12 +2183,16 @@ objects:
                   description: |
                     The TTL (in seconds) for which to cache responses with the corresponding status code. The maximum allowed value is 1800s
                     (30 minutes), noting that infrequently accessed objects may be evicted from the cache before the defined TTL.
-          - !ruby/object:Api::Type::String
+          - !ruby/object:Api::Type::Enum
             name: 'cacheMode'
             min_version: beta
             description: |
               Specifies the cache setting for all responses from this backend.
               The possible values are: USE_ORIGIN_HEADERS, FORCE_CACHE_ALL and CACHE_ALL_STATIC
+            values:
+              - :USE_ORIGIN_HEADERS
+              - :FORCE_CACHE_ALL
+              - :CACHE_ALL_STATIC
           - !ruby/object:Api::Type::Integer
             name: 'serveWhileStale'
             min_version: beta

--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -613,6 +613,7 @@ objects:
           min_version: beta
           description: |
             Serve existing content from the cache (if available) when revalidating content with the origin, or when an error is encountered when refreshing the cache. 
+
       - !ruby/object:Api::Type::Array
         name: 'customResponseHeaders'
         min_version: beta
@@ -1158,6 +1159,58 @@ objects:
               "Cache-Control: public, max-age=[TTL]" header, regardless of any
               existing Cache-Control header. The actual headers served in
               responses will not be altered.
+          - !ruby/object:Api::Type::Integer
+            name: 'defaultTtl'
+            min_version: beta
+            description: |
+              Specifies the default TTL for cached content served by this origin for responses 
+              that do not have an existing valid TTL (max-age or s-max-age).
+          - !ruby/object:Api::Type::Integer
+            name: 'maxTtl'
+            min_version: beta
+            description: |
+              Specifies the maximum allowed TTL for cached content served by this origin.
+          - !ruby/object:Api::Type::Integer
+            name: 'clientTtl'
+            min_version: beta
+            description: |
+              Specifies the maximum allowed TTL for cached content served by this origin.
+          - !ruby/object:Api::Type::Boolean
+            name: 'negativeCaching'
+            min_version: beta
+            description: |
+              Negative caching allows per-status code TTLs to be set, in order to apply fine-grained caching for common errors or redirects.
+          - !ruby/object:Api::Type::Array
+            name: 'negativeCachingPolicy'
+            min_version: beta
+            description: |
+              Sets a cache TTL for the specified HTTP status code. negativeCaching must be enabled to configure negativeCachingPolicy.
+              Omitting the policy and leaving negativeCaching enabled will use Cloud CDN's default cache TTLs.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::Integer
+                  name: 'code'
+                  min_version: beta
+                  description: |
+                    The HTTP status code to define a TTL against. Only HTTP status codes 300, 301, 308, 404, 405, 410, 421, 451 and 501
+                    can be specified as values, and you cannot specify a status code more than once.
+                - !ruby/object:Api::Type::Integer
+                  name: 'ttl'
+                  min_version: beta
+                  description: |
+                    The TTL (in seconds) for which to cache responses with the corresponding status code. The maximum allowed value is 1800s
+                    (30 minutes), noting that infrequently accessed objects may be evicted from the cache before the defined TTL.
+          - !ruby/object:Api::Type::String
+            name: 'cacheMode'
+            min_version: beta
+            description: |
+              Specifies the cache setting for all responses from this backend.
+              The possible values are: USE_ORIGIN_HEADERS, FORCE_CACHE_ALL and CACHE_ALL_STATIC
+          - !ruby/object:Api::Type::Integer
+            name: 'serveWhileStale'
+            min_version: beta
+            description: |
+              Serve existing content from the cache (if available) when revalidating content with the origin, or when an error is encountered when refreshing the cache. 
       - !ruby/object:Api::Type::NestedObject
         name: 'connectionDraining'
         description: |
@@ -1981,6 +2034,160 @@ objects:
               virtual node.
               Defaults to 1024.
       - !ruby/object:Api::Type::NestedObject
+        name: 'cdnPolicy'
+        description: 'Cloud CDN configuration for this BackendService.'
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: 'cacheKeyPolicy'
+            description: 'The CacheKeyPolicy for this CdnPolicy.'
+            at_least_one_of:
+              - cdn_policy.0.cache_key_policy
+              - cdn_policy.0.signed_url_cache_max_age_sec
+            properties:
+              - !ruby/object:Api::Type::Boolean
+                name: 'includeHost'
+                send_empty_value: true
+                at_least_one_of:
+                  - cdn_policy.0.cache_key_policy.0.include_host
+                  - cdn_policy.0.cache_key_policy.0.include_protocol
+                  - cdn_policy.0.cache_key_policy.0.include_query_string
+                  - cdn_policy.0.cache_key_policy.0.query_string_blacklist
+                  - cdn_policy.0.cache_key_policy.0.query_string_whitelist
+                description: |
+                  If true requests to different hosts will be cached separately.
+              - !ruby/object:Api::Type::Boolean
+                name: 'includeProtocol'
+                send_empty_value: true
+                at_least_one_of:
+                  - cdn_policy.0.cache_key_policy.0.include_host
+                  - cdn_policy.0.cache_key_policy.0.include_protocol
+                  - cdn_policy.0.cache_key_policy.0.include_query_string
+                  - cdn_policy.0.cache_key_policy.0.query_string_blacklist
+                  - cdn_policy.0.cache_key_policy.0.query_string_whitelist
+                description: |
+                  If true, http and https requests will be cached separately.
+              - !ruby/object:Api::Type::Boolean
+                name: 'includeQueryString'
+                send_empty_value: true
+                at_least_one_of:
+                  - cdn_policy.0.cache_key_policy.0.include_host
+                  - cdn_policy.0.cache_key_policy.0.include_protocol
+                  - cdn_policy.0.cache_key_policy.0.include_query_string
+                  - cdn_policy.0.cache_key_policy.0.query_string_blacklist
+                  - cdn_policy.0.cache_key_policy.0.query_string_whitelist
+                description: |
+                  If true, include query string parameters in the cache key
+                  according to query_string_whitelist and
+                  query_string_blacklist. If neither is set, the entire query
+                  string will be included.
+
+                  If false, the query string will be excluded from the cache
+                  key entirely.
+              - !ruby/object:Api::Type::Array
+                name: 'queryStringBlacklist'
+                send_empty_value: true
+                at_least_one_of:
+                  - cdn_policy.0.cache_key_policy.0.include_host
+                  - cdn_policy.0.cache_key_policy.0.include_protocol
+                  - cdn_policy.0.cache_key_policy.0.include_query_string
+                  - cdn_policy.0.cache_key_policy.0.query_string_blacklist
+                  - cdn_policy.0.cache_key_policy.0.query_string_whitelist
+                description: |
+                  Names of query string parameters to exclude in cache keys.
+
+                  All other parameters will be included. Either specify
+                  query_string_whitelist or query_string_blacklist, not both.
+                  '&' and '=' will be percent encoded and not treated as
+                  delimiters.
+                item_type: Api::Type::String
+              - !ruby/object:Api::Type::Array
+                send_empty_value: true
+                name: 'queryStringWhitelist'
+                at_least_one_of:
+                  - cdn_policy.0.cache_key_policy.0.include_host
+                  - cdn_policy.0.cache_key_policy.0.include_protocol
+                  - cdn_policy.0.cache_key_policy.0.include_query_string
+                  - cdn_policy.0.cache_key_policy.0.query_string_blacklist
+                  - cdn_policy.0.cache_key_policy.0.query_string_whitelist
+                description: |
+                  Names of query string parameters to include in cache keys.
+
+                  All other parameters will be excluded. Either specify
+                  query_string_whitelist or query_string_blacklist, not both.
+                  '&' and '=' will be percent encoded and not treated as
+                  delimiters.
+                item_type: Api::Type::String
+          - !ruby/object:Api::Type::Integer
+            name: 'signedUrlCacheMaxAgeSec'
+            default_value: 3600
+            at_least_one_of:
+              - cdn_policy.0.cache_key_policy
+              - cdn_policy.0.signed_url_cache_max_age_sec
+            description: |
+              Maximum number of seconds the response to a signed URL request
+              will be considered fresh, defaults to 1hr (3600s). After this
+              time period, the response will be revalidated before
+              being served.
+
+              When serving responses to signed URL requests, Cloud CDN will
+              internally behave as though all responses from this backend had a
+              "Cache-Control: public, max-age=[TTL]" header, regardless of any
+              existing Cache-Control header. The actual headers served in
+              responses will not be altered.
+          - !ruby/object:Api::Type::Integer
+            name: 'defaultTtl'
+            min_version: beta
+            description: |
+              Specifies the default TTL for cached content served by this origin for responses 
+              that do not have an existing valid TTL (max-age or s-max-age).
+          - !ruby/object:Api::Type::Integer
+            name: 'maxTtl'
+            min_version: beta
+            description: |
+              Specifies the maximum allowed TTL for cached content served by this origin.
+          - !ruby/object:Api::Type::Integer
+            name: 'clientTtl'
+            min_version: beta
+            description: |
+              Specifies the maximum allowed TTL for cached content served by this origin.
+          - !ruby/object:Api::Type::Boolean
+            name: 'negativeCaching'
+            min_version: beta
+            description: |
+              Negative caching allows per-status code TTLs to be set, in order to apply fine-grained caching for common errors or redirects.
+          - !ruby/object:Api::Type::Array
+            name: 'negativeCachingPolicy'
+            min_version: beta
+            description: |
+              Sets a cache TTL for the specified HTTP status code. negativeCaching must be enabled to configure negativeCachingPolicy.
+              Omitting the policy and leaving negativeCaching enabled will use Cloud CDN's default cache TTLs.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::Integer
+                  name: 'code'
+                  min_version: beta
+                  description: |
+                    The HTTP status code to define a TTL against. Only HTTP status codes 300, 301, 308, 404, 405, 410, 421, 451 and 501
+                    can be specified as values, and you cannot specify a status code more than once.
+                - !ruby/object:Api::Type::Integer
+                  name: 'ttl'
+                  min_version: beta
+                  description: |
+                    The TTL (in seconds) for which to cache responses with the corresponding status code. The maximum allowed value is 1800s
+                    (30 minutes), noting that infrequently accessed objects may be evicted from the cache before the defined TTL.
+          - !ruby/object:Api::Type::String
+            name: 'cacheMode'
+            min_version: beta
+            description: |
+              Specifies the cache setting for all responses from this backend.
+              The possible values are: USE_ORIGIN_HEADERS, FORCE_CACHE_ALL and CACHE_ALL_STATIC
+          - !ruby/object:Api::Type::Integer
+            name: 'serveWhileStale'
+            min_version: beta
+            description: |
+              Serve existing content from the cache (if available) when revalidating content with the origin, or when an error is encountered when refreshing the cache. 
+
+      - !ruby/object:Api::Type::NestedObject
         name: 'connectionDraining'
         description: |
           Settings for connection draining
@@ -2047,6 +2254,10 @@ objects:
               backend in the "force" mode, where traffic will be spread to the healthy
               VMs with the best effort, or to all VMs when no VM is healthy.
               This field is only used with l4 load balancing.
+      - !ruby/object:Api::Type::Boolean
+        name: 'enableCDN'
+        description: |
+          If true, enable Cloud CDN for this RegionBackendService.
       - !ruby/object:Api::Type::Fingerprint
         name: 'fingerprint'
         output: true

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -197,6 +197,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           backend_service_name: "backend-service"
           http_health_check_name: "health-check"
       - !ruby/object:Provider::Terraform::Examples
+        name: "backend_service_cache"
+        primary_resource_id: "default"
+        vars:
+          backend_service_name: "backend-service"
+          http_health_check_name: "health-check"
+      - !ruby/object:Provider::Terraform::Examples
         name: "backend_service_traffic_director_round_robin"
         min_version: beta
         primary_resource_id: "default"
@@ -236,6 +242,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         is_set: true
       cdnPolicy.cacheKeyPolicy.queryStringBlacklist: !ruby/object:Overrides::Terraform::PropertyOverride
         is_set: true
+      cdnPolicy.cacheMode: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      cdnPolicy.negativeCaching: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       connectionDraining: !ruby/object:Overrides::Terraform::PropertyOverride
         flatten_object: true
       connectionDraining.drainingTimeoutSec: !ruby/object:Overrides::Terraform::PropertyOverride
@@ -286,6 +296,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           region_backend_service_name: "region-service"
           health_check_name: "rbs-health-check"
       - !ruby/object:Provider::Terraform::Examples
+        name: "region_backend_service_cache"
+        primary_resource_id: "default"
+        vars:
+          region_backend_service_name: "region-service"
+          health_check_name: "rbs-health-check"
+      - !ruby/object:Provider::Terraform::Examples
         name: "region_backend_service_ilb_round_robin"
         primary_resource_id: "default"
         vars:
@@ -318,6 +334,16 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       decoder: templates/terraform/decoders/region_backend_service.go.erb
       resource_definition: 'templates/terraform/resource_definition/region_backend_service.go.erb'
     properties:
+      cdnPolicy: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      cdnPolicy.cacheKeyPolicy.queryStringWhitelist: !ruby/object:Overrides::Terraform::PropertyOverride
+        is_set: true
+      cdnPolicy.cacheKeyPolicy.queryStringBlacklist: !ruby/object:Overrides::Terraform::PropertyOverride
+        is_set: true
+      cdnPolicy.cacheMode: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      cdnPolicy.negativeCaching: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       region: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
         required: false

--- a/templates/terraform/examples/backend_service_cache.tf.erb
+++ b/templates/terraform/examples/backend_service_cache.tf.erb
@@ -1,0 +1,20 @@
+resource "google_compute_backend_service" "<%= ctx[:primary_resource_id] %>" {
+  name          = "<%= ctx[:vars]['backend_service_name'] %>"
+  health_checks = [google_compute_http_health_check.default.id]
+  enable_cdn  = true
+  cdn_policy {
+    cache_mode = "CACHE_ALL_STATIC"
+    default_ttl = 3600
+    client_ttl  = 7200
+    max_ttl     = 10800
+    negative_caching = true
+    signed_url_cache_max_age_sec = 7200
+  }
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "<%= ctx[:vars]['http_health_check_name'] %>"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}

--- a/templates/terraform/examples/region_backend_service_cache.tf.erb
+++ b/templates/terraform/examples/region_backend_service_cache.tf.erb
@@ -1,0 +1,28 @@
+resource "google_compute_region_backend_service" "<%= ctx[:primary_resource_id] %>" {
+  name                            = "<%= ctx[:vars]['region_backend_service_name'] %>"
+  region                          = "us-central1"
+  health_checks                   = [google_compute_region_health_check.default.id]
+  enable_cdn  = true
+  cdn_policy {
+    cache_mode = "CACHE_ALL_STATIC"
+    default_ttl = 3600
+    client_ttl  = 7200
+    max_ttl     = 10800
+    negative_caching = true
+    signed_url_cache_max_age_sec = 7200
+  }
+
+  load_balancing_scheme = "EXTERNAL"
+  protocol              = "HTTP"
+
+}
+
+resource "google_compute_region_health_check" "default" {
+  provider           = google-beta
+  name               = "<%= ctx[:vars]['health_check_name'] %>"
+  region             = "us-central1"
+
+  http_health_check {
+    port = 80
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/7792

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added Flexible Cache Control features to `google_compute_backend_service`.
```
```release-note:enhancement
compute: added CDN features to `google_compute_region_backend_service`.
```