### PR TITLE
some APIs treat 412s as the conflict code.

### DIFF
--- a/third_party/terraform/utils/utils.go.erb
+++ b/third_party/terraform/utils/utils.go.erb
@@ -145,11 +145,11 @@ func isFailedPreconditionError(err error) bool {
 }
 
 func isConflictError(err error) bool {
-	if e, ok := err.(*googleapi.Error); ok && e.Code == 409 {
+	if e, ok := err.(*googleapi.Error); ok && (e.Code == 409 || e.Code == 412) {
 		return true
 	} else if !ok && errwrap.ContainsType(err, &googleapi.Error{}) {
 		e := errwrap.GetType(err, &googleapi.Error{}).(*googleapi.Error)
-		if e.Code == 409 {
+		if e.Code == 409 || e.Code == 412 {
 			return true
 		}
 	}

--- a/third_party/terraform/utils/utils_test.go
+++ b/third_party/terraform/utils/utils_test.go
@@ -575,3 +575,25 @@ func TestRetryTimeDuration_URLTimeoutsShouldRetry(t *testing.T) {
 		t.Errorf("expected the retryFunc to be called %v time(s), instead was called %v time(s)", expectedRunCount, runCount)
 	}
 }
+
+func TestConflictError(t *testing.T) {
+	confErr := &googleapi.Error{
+		Code: 409,
+	}
+	if !isConflictError(confErr) {
+		t.Error("did not find that a 409 was a conflict error.")
+	}
+	if !isConflictError(errwrap.Wrapf("wrap", confErr)) {
+		t.Error("did not find that a wrapped 409 was a conflict error.")
+	}
+	confErr = &googleapi.Error{
+		Code: 412,
+	}
+	if !isConflictError(confErr) {
+		t.Error("did not find that a 412 was a conflict error.")
+	}
+	if !isConflictError(errwrap.Wrapf("wrap", confErr)) {
+		t.Error("did not find that a wrapped 412 was a conflict error.")
+	}
+	// skipping negative tests as other cases may be added later.
+}


### PR DESCRIPTION
it stands for 'invalid etag' in that context.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/7853

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
iam: fixed iam conflict handling so that optimistic-locking retries will succeed more often.
```