### PR TITLE
Added step to generate-diffs to run tgc tester

### DIFF
--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -179,6 +179,13 @@ steps:
       args:
           - $_PR_NUMBER
 
+    - name: 'gcr.io/graphite-docker-images/terraform-google-conversion-tester'
+      id: tgc-test
+      secretEnv: ["GITHUB_TOKEN"]
+      waitFor: ["diff"]
+      args:
+          - $_PR_NUMBER
+
     - name: 'gcr.io/graphite-docker-images/terraform-tester'
       id: tpgb-test
       secretEnv: ["GITHUB_TOKEN"]


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Added step to generate-diffs which runs the tgc-tester to make sure we don't break tgc.

I have not been able to test this locally due to not having a service account. Hypothetically, you should be able to test that it works as expected by commenting out all unrelated steps (i.e. everything after `merged` that doesn't reference tf-conversion / tgc) and secrets (TEAMCITY_TOKEN is unused at that point) and running the following from the root of the repo in an environment with cloud-build-local installed:

```
cd .ci
cloud-build-local --config=./gcb-generate-diffs.yml --dryrun=false --no-source --substitutions=_PR_NUMBER=4278,_HEAD_REPO_URL="https://github.com/melinath/magic-modules",_HEAD_BRANCH="tpg-7781-test-change",_BASE_BRANCH="master"
```


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
