### PR TITLE
Upstream Bigtable seconds

### DIFF
--- a/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -58,13 +58,13 @@ func resourceBigtableGCPolicy() *schema.Resource {
 				Optional:     true,
 				ForceNew:     true,
 				Description:  `GC policy that applies to all cells older than the given age.`,
-				ExactlyOneOf: []string{"max_age.0.days", "max_age.0.seconds"},
+				ExactlyOneOf: []string{"max_age.0.days", "max_age.0.duration"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"days": {
 							Type:        schema.TypeInt,
 							Optional:    true,
-							Deprecated:  "Deprecated in favor of seconds",
+							Deprecated:  "Deprecated in favor of duration",
 							Description: `Number of days before applying GC policy.`,
 						},
 						"duration": {
@@ -271,10 +271,12 @@ func generateBigtableGCPolicy(d *schema.ResourceData) (bigtable.GCPolicy, error)
 }
 
 func getMaxAgeDuration(values map[string]interface{}) (time.Duration, error) {
-	d := values["seconds"].(string)
-	if d == "" {
-		d = values["days"].(string)
+	d := values["duration"].(string)
+	if d != "" {
+		return time.ParseDuration(d)
 	}
 
-	return time.ParseDuration(d)
+	days := values["days"].(int)
+
+	return time.Hour * 24 * time.Duration(days), nil
 }

--- a/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -54,24 +54,25 @@ func resourceBigtableGCPolicy() *schema.Resource {
 			},
 
 			"max_age": {
-				Type:         schema.TypeList,
-				Optional:     true,
-				ForceNew:     true,
-				Description:  `GC policy that applies to all cells older than the given age.`,
-				ExactlyOneOf: []string{"max_age.0.days", "max_age.0.duration"},
+				Type:        schema.TypeList,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `GC policy that applies to all cells older than the given age.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"days": {
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Deprecated:  "Deprecated in favor of duration",
-							Description: `Number of days before applying GC policy.`,
+							Type:         schema.TypeInt,
+							Optional:     true,
+							Deprecated:   "Deprecated in favor of duration",
+							Description:  `Number of days before applying GC policy.`,
+							ExactlyOneOf: []string{"max_age.0.days", "max_age.0.duration"},
 						},
 						"duration": {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Description:  `Duration before applying GC policy`,
 							ValidateFunc: validateDuration(),
+							ExactlyOneOf: []string{"max_age.0.days", "max_age.0.duration"},
 						},
 					},
 				},

--- a/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -62,7 +62,7 @@ func resourceBigtableGCPolicy() *schema.Resource {
 					Schema: map[string]*schema.Schema{
 						"days": {
 							Type:        schema.TypeInt,
-							Required:    false,
+							Optional:    true,
 							Deprecated:  "Deprecated in favor of seconds",
 							Description: `Number of days before applying GC policy.`,
 						},

--- a/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -54,10 +54,10 @@ func resourceBigtableGCPolicy() *schema.Resource {
 			},
 
 			"max_age": {
-				Type:        schema.TypeList,
-				Optional:    true,
-				ForceNew:    true,
-				Description: `GC policy that applies to all cells older than the given age.`,
+				Type:         schema.TypeList,
+				Optional:     true,
+				ForceNew:     true,
+				Description:  `GC policy that applies to all cells older than the given age.`,
 				ExactlyOneOf: []string{"max_age.0.days", "max_age.0.seconds"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -68,9 +68,9 @@ func resourceBigtableGCPolicy() *schema.Resource {
 							Description: `Number of days before applying GC policy.`,
 						},
 						"duration": {
-							Type:        schema.TypeString,
-							Optional:    true,
-							Description: `Duration before applying GC policy`,
+							Type:         schema.TypeString,
+							Optional:     true,
+							Description:  `Duration before applying GC policy`,
 							ValidateFunc: validateDuration(),
 						},
 					},
@@ -85,9 +85,9 @@ func resourceBigtableGCPolicy() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"number": {
-							Type:        schema.TypeInt,
-							Required:    true,
-							Description: `Number of version before applying the GC policy.`,
+							Type:         schema.TypeInt,
+							Required:     true,
+							Description:  `Number of version before applying the GC policy.`,
 							ValidateFunc: validation.IntAtLeast(1),
 						},
 					},

--- a/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -58,6 +58,7 @@ func resourceBigtableGCPolicy() *schema.Resource {
 				Optional:    true,
 				ForceNew:    true,
 				Description: `GC policy that applies to all cells older than the given age.`,
+				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"days": {
@@ -89,7 +90,6 @@ func resourceBigtableGCPolicy() *schema.Resource {
 							Type:         schema.TypeInt,
 							Required:     true,
 							Description:  `Number of version before applying the GC policy.`,
-							ValidateFunc: validation.IntAtLeast(1),
 						},
 					},
 				},

--- a/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -87,9 +87,9 @@ func resourceBigtableGCPolicy() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"number": {
-							Type:         schema.TypeInt,
-							Required:     true,
-							Description:  `Number of version before applying the GC policy.`,
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: `Number of version before applying the GC policy.`,
 						},
 					},
 				},

--- a/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -158,7 +158,7 @@ resource "google_bigtable_gc_policy" "policy" {
   column_family = "%s"
 
   max_age {
-    seconds = 3600 * 24 * 3
+    duration = "72h"
   }
 }
 `, instanceName, instanceName, tableName, family, family)
@@ -195,7 +195,7 @@ resource "google_bigtable_gc_policy" "policy" {
   mode = "UNION"
 
   max_age {
-    seconds = 3600 * 24 * 3
+    duration = "72h"
   }
 
   max_version {

--- a/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
+++ b/third_party/terraform/tests/resource_bigtable_gc_policy_test.go
@@ -158,7 +158,7 @@ resource "google_bigtable_gc_policy" "policy" {
   column_family = "%s"
 
   max_age {
-    days = 3
+    seconds = 3600 * 24 * 3
   }
 }
 `, instanceName, instanceName, tableName, family, family)
@@ -195,7 +195,7 @@ resource "google_bigtable_gc_policy" "policy" {
   mode = "UNION"
 
   max_age {
-    days = 3
+    seconds = 3600 * 24 * 3
   }
 
   max_version {

--- a/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
@@ -42,7 +42,7 @@ resource "google_bigtable_gc_policy" "policy" {
   column_family = "name"
 
   max_age {
-    seconds = 3600 * 24 * 7 # 7 days
+    duration = "168h" # 7 days
   }
 }
 ```
@@ -58,7 +58,7 @@ resource "google_bigtable_gc_policy" "policy" {
   mode = "UNION"
 
   max_age {
-    seconds = 3600 * 24 * 7 # 7 days
+    duration = "168h" # 7 days
   }
 
   max_version {

--- a/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
@@ -42,7 +42,7 @@ resource "google_bigtable_gc_policy" "policy" {
   column_family = "name"
 
   max_age {
-    days = 7
+    seconds = 3600 * 24 * 7 # 7 days
   }
 }
 ```
@@ -58,7 +58,7 @@ resource "google_bigtable_gc_policy" "policy" {
   mode = "UNION"
 
   max_age {
-    days = 7
+    seconds = 3600 * 24 * 7 # 7 days
   }
 
   max_version {
@@ -89,7 +89,9 @@ The following arguments are supported:
 
 `max_age` supports the following arguments:
 
-* `days` - (Required) Number of days before applying GC policy.
+* `days` - (Deprecated) Number of days before applying GC policy.
+
+* `seconds` - (Required) Number of seconds before applying GC policy.
 
 -----
 

--- a/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
@@ -91,7 +91,7 @@ The following arguments are supported:
 
 * `days` - (Deprecated) Number of days before applying GC policy.
 
-* `seconds` - (Required) Number of seconds before applying GC policy.
+* `duration` - (Required) Duration before applying GC policy (ex. "8h"). This is required when `days` isn't set
 
 -----
 

--- a/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
+++ b/third_party/terraform/website/docs/r/bigtable_gc_policy.html.markdown
@@ -42,7 +42,7 @@ resource "google_bigtable_gc_policy" "policy" {
   column_family = "name"
 
   max_age {
-    duration = "168h" # 7 days
+    duration = "168h"
   }
 }
 ```
@@ -89,9 +89,9 @@ The following arguments are supported:
 
 `max_age` supports the following arguments:
 
-* `days` - (Deprecated) Number of days before applying GC policy.
+* `days` - (Optional, Deprecated in favor of duration) Number of days before applying GC policy.
 
-* `duration` - (Required) Duration before applying GC policy (ex. "8h"). This is required when `days` isn't set
+* `duration` - (Optional) Duration before applying GC policy (ex. "8h"). This is required when `days` isn't set
 
 -----
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Upstreams: https://github.com/hashicorp/terraform-provider-google/pull/7879



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigtable: added support for specifying `duration` for `bigtable_gc_policy` to allow durations shorter than a day
```
