### PR TITLE
Move `customResponseHeaders` to beta only

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -1182,6 +1182,7 @@ objects:
           requests.
       - !ruby/object:Api::Type::Array
         name: 'customResponseHeaders'
+        min_version: beta
         item_type: Api::Type::String
         description: |
           Headers that the HTTP/S load balancer should add to proxied

--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -212,6 +212,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           health_check_name: "health-check"
       - !ruby/object:Provider::Terraform::Examples
         name: "backend_service_network_endpoint"
+        min_version: beta
         primary_resource_id: "default"
         vars:
           backend_service_name: "backend-service"

--- a/templates/terraform/examples/backend_service_network_endpoint.tf.erb
+++ b/templates/terraform/examples/backend_service_network_endpoint.tf.erb
@@ -1,16 +1,19 @@
 resource "google_compute_global_network_endpoint_group" "external_proxy" {
+  provider=google-beta
   name                  = "<%= ctx[:vars]['neg_name'] %>"
   network_endpoint_type = "INTERNET_FQDN_PORT"
   default_port          = "443"
 }
 
 resource "google_compute_global_network_endpoint" "proxy" {
+  provider=google-beta
   global_network_endpoint_group = google_compute_global_network_endpoint_group.external_proxy.id
   fqdn                          = "test.example.com"
   port                          = google_compute_global_network_endpoint_group.external_proxy.default_port
 }
 
 resource "google_compute_backend_service" "<%= ctx[:primary_resource_id] %>" {
+  provider=google-beta
   name                            = "<%= ctx[:vars]['backend_service_name'] %>"
   enable_cdn                      = true
   timeout_sec                     = 10

--- a/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
@@ -539,6 +539,7 @@ func TestAccComputeBackendService_withMaxConnectionsPerEndpoint(t *testing.T) {
 	})
 }
 
+<% unless version == 'ga' -%>
 func TestAccComputeBackendService_withCustomHeaders(t *testing.T) {
 	t.Parallel()
 
@@ -569,6 +570,7 @@ func TestAccComputeBackendService_withCustomHeaders(t *testing.T) {
 		},
 	})
 }
+<% end -%>
 
 func TestAccComputeBackendService_internalLoadBalancing(t *testing.T) {
 	t.Parallel()
@@ -1492,6 +1494,7 @@ resource "google_compute_health_check" "default" {
 `, service, maxRate, instance, neg, network, network, check)
 }
 
+<% unless version == 'ga' -%>
 func testAccComputeBackendService_withCustomHeaders(serviceName, checkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
@@ -1510,6 +1513,7 @@ resource "google_compute_http_health_check" "zero" {
 }
 `, serviceName, checkName)
 }
+<% end -%>
 
 <%# This test is for import functionality. It can be removed and added to examples when this goes GA %>
 func testAccComputeBackendService_internalLoadBalancing(fr, proxy, backend, hc, urlmap string) string {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes https://github.com/hashicorp/terraform-provider-google/issues/7299

`customResponseHeaders` only appears in the beta Compute API, and should be removed from the GA provider.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: removed `custom_response_headers` from GA `google_compute_backend_service` since it only works in the Beta version
```
