### PR TITLE
Fix path_matcher in region url maps

### DIFF
--- a/products/compute/api.yaml
+++ b/products/compute/api.yaml
@@ -10159,7 +10159,6 @@ objects:
               exactly_one_of:
                 - path_matchers.0.default_service
                 - path_matchers.0.default_url_redirect
-              required: true
               resource: 'RegionBackendService'
               imports: 'selfLink'
               description: |

--- a/third_party/terraform/tests/resource_compute_region_url_map_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_url_map_test.go.erb
@@ -181,6 +181,28 @@ func TestAccComputeRegionUrlMap_defaultUrlRedirect(t *testing.T) {
 	})
 }
 
+func TestAccComputeRegionUrlMap_defaultUrlRedirectWithinPathMatcher(t *testing.T) {
+	t.Parallel()
+
+	randomSuffix := randString(t, 10)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeUrlMapDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: TestAccComputeRegionUrlMap_defaultUrlRedirectWithinPathMatcherConfig(randomSuffix),
+			},
+			{
+				ResourceName:      "google_compute_region_url_map.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccComputeRegionUrlMap_basic1(randomSuffix string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_backend_service" "foobar" {
@@ -851,6 +873,30 @@ resource "google_compute_region_url_map" "foobar" {
   default_url_redirect {
     https_redirect = true
     strip_query    = false
+  }
+}
+`, randomSuffix)
+}
+
+func TestAccComputeRegionUrlMap_defaultUrlRedirectWithinPathMatcherConfig(randomSuffix string) string {
+	return fmt.Sprintf(`
+resource "google_compute_region_url_map" "foobar" {
+  name            = "urlmap-test-%s"
+  default_url_redirect {
+    https_redirect = true
+    strip_query    = false
+  }
+  host_rule {
+    hosts        = ["mysite.com"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name             = "allpaths"
+    default_url_redirect {
+      https_redirect = true
+      strip_query    = false
+    }
   }
 }
 `, randomSuffix)

--- a/third_party/terraform/tests/resource_compute_region_url_map_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_region_url_map_test.go.erb
@@ -192,7 +192,7 @@ func TestAccComputeRegionUrlMap_defaultUrlRedirectWithinPathMatcher(t *testing.T
 		CheckDestroy: testAccCheckComputeUrlMapDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: TestAccComputeRegionUrlMap_defaultUrlRedirectWithinPathMatcherConfig(randomSuffix),
+				Config: testAccComputeRegionUrlMap_defaultUrlRedirectWithinPathMatcherConfig(randomSuffix),
 			},
 			{
 				ResourceName:      "google_compute_region_url_map.foobar",
@@ -878,7 +878,7 @@ resource "google_compute_region_url_map" "foobar" {
 `, randomSuffix)
 }
 
-func TestAccComputeRegionUrlMap_defaultUrlRedirectWithinPathMatcherConfig(randomSuffix string) string {
+func testAccComputeRegionUrlMap_defaultUrlRedirectWithinPathMatcherConfig(randomSuffix string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_url_map" "foobar" {
   name            = "urlmap-test-%s"


### PR DESCRIPTION
The default_service in path_matcher is actually not required as it should be default_service **or** default_url_redirect.
(related to https://github.com/hashicorp/terraform-provider-google/issues/7951)

Further info in https://cloud.google.com/compute/docs/reference/rest/v1/regionUrlMaps , extract below:
> pathMatchers[].defaultService 
> Only one of defaultService, defaultUrlRedirect or defaultRouteAction.weightedBackendService must be set.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:bug
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
google_compute_region_url_map: removed requirement for default_service, as it should be a choice of default_service or default_url_redirect
```
