### PR TITLE
Add customized diff for unique_writer_identity on resource google_logging_project_sink

### DIFF
--- a/third_party/terraform/resources/resource_logging_project_sink.go
+++ b/third_party/terraform/resources/resource_logging_project_sink.go
@@ -79,7 +79,7 @@ func resourceLoggingProjectSinkCustomizeDiffFunc(diff TerraformResourceDiff) err
 	if bigqueryOptions > 0 {
 		uwi := diff.Get("unique_writer_identity")
 		if !uwi.(bool) {
-			return errors.New("unique_writer_identity must be true when bigquery_options is suppplied")
+			return errors.New("unique_writer_identity must be true when bigquery_options is supplied")
 		}
 	}
 	return nil

--- a/third_party/terraform/resources/resource_logging_project_sink.go
+++ b/third_party/terraform/resources/resource_logging_project_sink.go
@@ -1,6 +1,8 @@
 package google
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -10,11 +12,12 @@ const nonUniqueWriterAccount = "serviceAccount:cloud-logs@system.gserviceaccount
 
 func resourceLoggingProjectSink() *schema.Resource {
 	schm := &schema.Resource{
-		Create: resourceLoggingProjectSinkCreate,
-		Read:   resourceLoggingProjectSinkRead,
-		Delete: resourceLoggingProjectSinkDelete,
-		Update: resourceLoggingProjectSinkUpdate,
-		Schema: resourceLoggingSinkSchema(),
+		Create:        resourceLoggingProjectSinkCreate,
+		Read:          resourceLoggingProjectSinkRead,
+		Delete:        resourceLoggingProjectSinkDelete,
+		Update:        resourceLoggingProjectSinkUpdate,
+		Schema:        resourceLoggingSinkSchema(),
+		CustomizeDiff: resourceLoggingProjectSinkCustomizeDiff,
 		Importer: &schema.ResourceImporter{
 			State: resourceLoggingSinkImportState("project"),
 		},
@@ -59,6 +62,27 @@ func resourceLoggingProjectSinkCreate(d *schema.ResourceData, meta interface{}) 
 	d.SetId(id.canonicalId())
 
 	return resourceLoggingProjectSinkRead(d, meta)
+}
+
+// if bigquery_options is set unique_writer_identity must be true
+func resourceLoggingProjectSinkCustomizeDiff(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	// separate func to allow unit testing
+	return resourceLoggingProjectSinkCustomizeDiffFunc(d)
+}
+
+func resourceLoggingProjectSinkCustomizeDiffFunc(diff TerraformResourceDiff) error {
+	if !diff.HasChange("bigquery_options.#") {
+		return nil
+	}
+
+	bigqueryOptions := diff.Get("bigquery_options.#").(int)
+	if bigqueryOptions > 0 {
+		uwi := diff.Get("unique_writer_identity")
+		if !uwi.(bool) {
+			return errors.New("unique_writer_identity must be true when bigquery_options is suppplied")
+		}
+	}
+	return nil
 }
 
 func resourceLoggingProjectSinkRead(d *schema.ResourceData, meta interface{}) error {

--- a/third_party/terraform/tests/resource_logging_project_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_project_sink_test.go
@@ -185,7 +185,7 @@ func TestAccLoggingProjectSink_loggingbucket(t *testing.T) {
 	})
 }
 
-func TestAccLoggingProjectSink_bigqueryOptionCustomizedDiff(t *testing.T) {
+func TestLoggingProjectSink_bigqueryOptionCustomizedDiff(t *testing.T) {
 	t.Parallel()
 
 	type LoggingProjectSink struct {

--- a/third_party/terraform/tests/resource_logging_project_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_project_sink_test.go
@@ -185,6 +185,62 @@ func TestAccLoggingProjectSink_loggingbucket(t *testing.T) {
 	})
 }
 
+func TestAccLoggingProjectSink_bigqueryOptionCustomizedDiff(t *testing.T) {
+	t.Parallel()
+
+	type LoggingProjectSink struct {
+		BigqueryOptions      int
+		UniqueWriterIdentity bool
+	}
+	cases := map[string]struct {
+		ExpectedError bool
+		After         LoggingProjectSink
+	}{
+		"no biquery options with false unique writer identity": {
+			ExpectedError: false,
+			After: LoggingProjectSink{
+				BigqueryOptions:      0,
+				UniqueWriterIdentity: false,
+			},
+		},
+		"no biquery options with true unique writer identity": {
+			ExpectedError: false,
+			After: LoggingProjectSink{
+				BigqueryOptions:      0,
+				UniqueWriterIdentity: true,
+			},
+		},
+		"biquery options with false unique writer identity": {
+			ExpectedError: true,
+			After: LoggingProjectSink{
+				BigqueryOptions:      1,
+				UniqueWriterIdentity: false,
+			},
+		},
+		"biquery options with true unique writer identity": {
+			ExpectedError: false,
+			After: LoggingProjectSink{
+				BigqueryOptions:      1,
+				UniqueWriterIdentity: true,
+			},
+		},
+	}
+
+	for tn, tc := range cases {
+		d := &ResourceDiffMock{
+			After: map[string]interface{}{
+				"bigquery_options.#":     tc.After.BigqueryOptions,
+				"unique_writer_identity": tc.After.UniqueWriterIdentity,
+			},
+		}
+		err := resourceLoggingProjectSinkCustomizeDiffFunc(d)
+		hasError := err != nil
+		if tc.ExpectedError != hasError {
+			t.Errorf("%v: expected has error %v, but was %v", tn, tc.ExpectedError, hasError)
+		}
+	}
+}
+
 func testAccCheckLoggingProjectSinkDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)

--- a/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
+++ b/third_party/terraform/website/docs/r/logging_project_sink.html.markdown
@@ -140,8 +140,8 @@ The following arguments are supported:
 
 * `unique_writer_identity` - (Optional) Whether or not to create a unique identity associated with this sink. If `false`
     (the default), then the `writer_identity` used is `serviceAccount:cloud-logs@system.gserviceaccount.com`. If `true`,
-    then a unique service account is created and used for this sink. If you wish to publish logs across projects, you
-    must set `unique_writer_identity` to true.
+    then a unique service account is created and used for this sink. If you wish to publish logs across projects or utilize
+    `bigquery_options`, you must set `unique_writer_identity` to true.
 
 * `bigquery_options` - (Optional) Options that affect sinks exporting data to BigQuery. Structure documented below.
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

For` logging_project_sink` we are adding a customized diff for `unique_writer_identity`. If `big_query_options` is populated this field must be true.

Closes [6122](https://github.com/hashicorp/terraform-provider-google/issues/6122)


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
logging: added plan time validation for `unique_writer_identity` on `google_logging_project_sink`
```
