### PR TITLE
Marked terraform provider imports as v3

### DIFF
--- a/third_party/terraform/main.go.erb
+++ b/third_party/terraform/main.go.erb
@@ -3,7 +3,7 @@ package main
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-	"github.com/hashicorp/terraform-provider-google<%= "-" + version unless version == 'ga'  -%>/google<%= "-" + version unless version == 'ga'  -%>"
+	"github.com/hashicorp/terraform-provider-google<%= "-" + version unless version == 'ga'  -%>/v3/google<%= "-" + version unless version == 'ga'  -%>"
 )
 
 func main() {

--- a/third_party/terraform/utils/provider_handwritten_endpoint.go.erb
+++ b/third_party/terraform/utils/provider_handwritten_endpoint.go.erb
@@ -4,7 +4,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform-provider-google-beta/google-beta"
+	"github.com/hashicorp/terraform-provider-google-beta/v3/google-beta"
 	"os"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Related to https://github.com/GoogleCloudPlatform/terraform-validator/issues/158. TLDR we need to do [semantic versioning](https://github.com/golang/go/wiki/Modules#semantic-import-versioning) for the providers so that they can be imported as libraries (specifically by terraform-validator.) There are just a couple of spots in magic-modules that reference a package version, so we need to update those; otherwise, go will try to install v1 of the package alongside v3.

This has two companion PRs that update the module name for the two providers:

- https://github.com/hashicorp/terraform-provider-google/pull/7982
- https://github.com/hashicorp/terraform-provider-google-beta/pull/2770

This will not break people using the providers, because those are specially built binaries rather than terraform using the package as a library.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
