### PR TITLE
Add EncryptionConfig to Cloud Composer's EnvironmentConfig

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -56,9 +56,7 @@ var (
 <% unless version == "ga" -%>
 		"config.0.database_config",
 		"config.0.web_server_config",
-<% end -%>
-<% unless version == "ga" -%>
-                "config.0.encryption_config",
+    "config.0.encryption_config",
 <% end -%>
 	}
 
@@ -436,8 +434,6 @@ func resourceComposerEnvironment() *schema.Resource {
 								},
 							},
 						},
-<% end -%>
-<% unless version == "ga" -%>
 						"encryption_config": {
 							Type:         schema.TypeList,
 							Optional:     true,
@@ -724,18 +720,6 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 			}
 		}
 <% end -%>
-<% unless version == "ga" -%>
-		if d.HasChange("config.0.encryption_config.0.kms_key_name") {
-			patchObj := &composer.Environment{Config: &composer.EnvironmentConfig{}}
-			if config != nil {
-				patchObj.Config.EncryptionConfig = config.EncryptionConfig
-			}
-			err = resourceComposerEnvironmentPatchField("config.encryptionConfig.kmsKeyName", userAgent, patchObj, d, tfConfig)
-			if err != nil {
-				return err
-			}
-		}
-<% end -%>
 	}
 
 	if d.HasChange("labels") {
@@ -860,8 +844,6 @@ func flattenComposerEnvironmentConfig(envCfg *composer.EnvironmentConfig) interf
 <% unless version == "ga" -%>
 	transformed["database_config"] = flattenComposerEnvironmentConfigDatabaseConfig(envCfg.DatabaseConfig)
 	transformed["web_server_config"] = flattenComposerEnvironmentConfigWebServerConfig(envCfg.WebServerConfig)
-<% end -%>
-<% unless version == "ga" -%>
 	transformed["encryption_config"] = flattenComposerEnvironmentConfigEncryptionConfig(envCfg.EncryptionConfig)
 <% end -%>
 
@@ -913,9 +895,7 @@ func flattenComposerEnvironmentConfigWebServerConfig(webServerCfg *composer.WebS
 
 	return []interface{}{transformed}
 }
-<% end -%>
 
-<% unless version == "ga" -%>
 func flattenComposerEnvironmentConfigEncryptionConfig(encryptionCfg *composer.EncryptionConfig) interface{} {
 	if encryptionCfg == nil {
 		return nil
@@ -1056,9 +1036,6 @@ func expandComposerEnvironmentConfig(v interface{}, d *schema.ResourceData, conf
 	}
 	transformed.WebServerConfig = transformedWebServerConfig
 
-<% end -%>
-
-<% unless version == "ga" -%>
 	transformedEncryptionConfig, err := expandComposerEnvironmentConfigEncryptionConfig(original["encryption_config"], d, config)
 	if err != nil {
 		return nil, err

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -724,6 +724,18 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 			}
 		}
 <% end -%>
+<% unless version == "ga" -%>
+		if d.HasChange("config.0.encryption_config.0.kms_key_name") {
+			patchObj := &composer.Environment{Config: &composer.EnvironmentConfig{}}
+			if config != nil {
+				patchObj.Config.EncryptionConfig = config.EncryptionConfig
+			}
+			err = resourceComposerEnvironmentPatchField("config.encryptionConfig.kmsKeyName", userAgent, patchObj, d, tfConfig)
+			if err != nil {
+				return err
+			}
+		}
+<% end -%>
 	}
 
 	if d.HasChange("labels") {
@@ -850,7 +862,7 @@ func flattenComposerEnvironmentConfig(envCfg *composer.EnvironmentConfig) interf
 	transformed["web_server_config"] = flattenComposerEnvironmentConfigWebServerConfig(envCfg.WebServerConfig)
 <% end -%>
 <% unless version == "ga" -%>
-	transformed["encryption_config"] = flattenComposerEnvironmentConfigEncryptionConfig(envCfg.DatabaseConfig)
+	transformed["encryption_config"] = flattenComposerEnvironmentConfigEncryptionConfig(envCfg.EncryptionConfig)
 <% end -%>
 
 	return []interface{}{transformed}

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -57,6 +57,9 @@ var (
 		"config.0.database_config",
 		"config.0.web_server_config",
 <% end -%>
+<% unless version == "ga" -%>
+                "config.0.encryption_config",
+<% end -%>
 	}
 
 <% unless version == "ga" -%>
@@ -429,6 +432,25 @@ func resourceComposerEnvironment() *schema.Resource {
 										Type:         schema.TypeString,
 										Required:     true,
 										Description: `Optional. Machine type on which Airflow web server is running. It has to be one of: composer-n1-webserver-2, composer-n1-webserver-4 or composer-n1-webserver-8. If not specified, composer-n1-webserver-2 will be used. Value custom is returned only in response, if Airflow web server parameters were manually changed to a non-standard values.`,
+									},
+								},
+							},
+						},
+<% end -%>
+<% unless version == "ga" -%>
+						"encryption_config": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							Computed:     true,
+							AtLeastOneOf: composerConfigKeys,
+							MaxItems:     1,
+							Description:  `The encryption options for the Composer environment and its dependencies.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"kms_key_name": {
+										Type:         schema.TypeString,
+										Required:     true,
+										Description: `Optional. Customer-managed Encryption Key available through Google's Key Management Service. Cannot be updated.`,
 									},
 								},
 							},
@@ -827,6 +849,9 @@ func flattenComposerEnvironmentConfig(envCfg *composer.EnvironmentConfig) interf
 	transformed["database_config"] = flattenComposerEnvironmentConfigDatabaseConfig(envCfg.DatabaseConfig)
 	transformed["web_server_config"] = flattenComposerEnvironmentConfigWebServerConfig(envCfg.WebServerConfig)
 <% end -%>
+<% unless version == "ga" -%>
+	transformed["encryption_config"] = flattenComposerEnvironmentConfigEncryptionConfig(envCfg.DatabaseConfig)
+<% end -%>
 
 	return []interface{}{transformed}
 }
@@ -873,6 +898,19 @@ func flattenComposerEnvironmentConfigWebServerConfig(webServerCfg *composer.WebS
 
 	transformed := make(map[string]interface{})
 	transformed["machine_type"] = webServerCfg.MachineType
+
+	return []interface{}{transformed}
+}
+<% end -%>
+
+<% unless version == "ga" -%>
+func flattenComposerEnvironmentConfigEncryptionConfig(encryptionCfg *composer.EncryptionConfig) interface{} {
+	if encryptionCfg == nil {
+		return nil
+	}
+
+	transformed := make(map[string]interface{})
+	transformed["kms_key_name"] = encryptionCfg.KmsKeyName
 
 	return []interface{}{transformed}
 }
@@ -1007,6 +1045,15 @@ func expandComposerEnvironmentConfig(v interface{}, d *schema.ResourceData, conf
 	transformed.WebServerConfig = transformedWebServerConfig
 
 <% end -%>
+
+<% unless version == "ga" -%>
+	transformedEncryptionConfig, err := expandComposerEnvironmentConfigEncryptionConfig(original["encryption_config"], d, config)
+	if err != nil {
+		return nil, err
+	}
+	transformed.EncryptionConfig = transformedEncryptionConfig
+
+<% end -%>
 	return transformed, nil
 }
 
@@ -1074,6 +1121,23 @@ func expandComposerEnvironmentConfigWebServerConfig(v interface{}, d *schema.Res
 
 	transformed := &composer.WebServerConfig{}
 	transformed.MachineType = original["machine_type"].(string)
+
+	return transformed, nil
+}
+
+<% end -%>
+
+<% unless version == "ga" -%>
+func expandComposerEnvironmentConfigEncryptionConfig(v interface{}, d *schema.ResourceData, config *Config) (*composer.EncryptionConfig, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+
+	transformed := &composer.EncryptionConfig{}
+	transformed.KmsKeyName = original["kms_key_name"].(string)
 
 	return transformed, nil
 }

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -446,6 +446,7 @@ func resourceComposerEnvironment() *schema.Resource {
 									"kms_key_name": {
 										Type:         schema.TypeString,
 										Required:     true,
+										ForceNew:     true,
 										Description: `Optional. Customer-managed Encryption Key available through Google's Key Management Service. Cannot be updated.`,
 									},
 								},

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -294,6 +294,41 @@ func TestAccComposerEnvironment_withWebServerConfig(t *testing.T) {
 		},
 	})
 }
+
+func TestAccComposerEnvironment_withEncryptionConfig(t *testing.T) {
+	t.Parallel()
+
+        kms := BootstrapKMSKey(t)
+        pid := getTestProjectFromEnv()
+	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
+	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
+	subnetwork := network + "-1"
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccComposerEnvironmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComposerEnvironment_encryptionCfg(envName, network, subnetwork),
+			},
+			{
+				ResourceName:      "google_composer_environment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// This is a terrible clean-up step in order to get destroy to succeed,
+			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
+			// TODO(emilyye): Remove this check if firewall rules bug gets fixed by Composer.
+			{
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+				Config:             testAccComposerEnvironment_encryptionCfgUpdated(envName, network, subnetwork),
+				Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
+			},
+		},
+	})
+}
 <% end -%>
 // Checks behavior of node config, including dependencies on Compute resources.
 func TestAccComposerEnvironment_withNodeConfig(t *testing.T) {
@@ -735,6 +770,80 @@ resource "google_compute_subnetwork" "test" {
 `, name, network, subnetwork)
 }
 
+func testAccComposerEnvironment_encryptionCfg(pid, name, kmsKey, network, subnetwork string) string {
+	return fmt.Sprintf(`
+data "google_project" "project" {
+  project_id = "%s"
+}
+
+resource "google_project_iam_member" "kms-project-binding1" {
+  project = data.google_project.project.project_id
+  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member  = "serviceAccount:service-${data.google_project.project.number}@cloudcomposer-accounts.iam.gserviceaccount.com"
+}
+
+resource "google_project_iam_member" "kms-project-binding2" {
+  project = data.google_project.project.project_id
+  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member  = "serviceAccount:service-${data.google_project.project.number}@compute-system.iam.gserviceaccount.com"
+}
+
+resource "google_project_iam_member" "kms-project-binding3" {
+  project = data.google_project.project.project_id
+  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
+}
+
+resource "google_project_iam_member" "kms-project-binding4" {
+  project = data.google_project.project.project_id
+  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-artifactregistry.iam.gserviceaccount.com"
+}
+
+resource "google_project_iam_member" "kms-project-binding5" {
+  project = data.google_project.project.project_id
+  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+}
+
+resource "google_kms_crypto_key_iam_member" "iam" {
+  crypto_key_id = google_kms_crypto_key.crypto_key.id
+  role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member  = "serviceAccount:service-${data.google_project.project.number}@gs-project-accounts.iam.gserviceaccount.com"
+}
+
+resource "google_composer_environment" "test" {
+	depends_on = [google_project_iam_member.kms-project-binding1]
+
+	name   = "%s"
+	region = "us-central1"
+	config {
+		node_config {
+			network    = google_compute_network.test.self_link
+			subnetwork = google_compute_subnetwork.test.self_link
+			zone       = "us-central1-a"
+		}
+		encryption_config {
+			kms_key_name  = "%s"
+		}
+	}
+}
+
+// use a separate network to avoid conflicts with other tests running in parallel
+// that use the default network/subnet
+resource "google_compute_network" "test" {
+	name                    = "%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+	name          = "%s"
+	ip_cidr_range = "10.2.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.test.self_link
+}
+`, name, kmsKey, network, subnetwork)
+}
 <% end -%>
 func testAccComposerEnvironment_update(name, network, subnetwork string) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -298,8 +298,8 @@ func TestAccComposerEnvironment_withWebServerConfig(t *testing.T) {
 func TestAccComposerEnvironment_withEncryptionConfig(t *testing.T) {
 	t.Parallel()
 
-        kms := BootstrapKMSKey(t)
-        pid := getTestProjectFromEnv()
+  kms := BootstrapKMSKey(t)
+  pid := getTestProjectFromEnv()
 	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
 	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
 	subnetwork := network + "-1"
@@ -310,7 +310,7 @@ func TestAccComposerEnvironment_withEncryptionConfig(t *testing.T) {
 		CheckDestroy: testAccComposerEnvironmentDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComposerEnvironment_encryptionCfg(envName, network, subnetwork),
+				Config: testAccComposerEnvironment_encryptionCfg(pid, envName, kms.CryptoKey.Name, network, subnetwork),
 			},
 			{
 				ResourceName:      "google_composer_environment.test",
@@ -320,12 +320,12 @@ func TestAccComposerEnvironment_withEncryptionConfig(t *testing.T) {
 			// This is a terrible clean-up step in order to get destroy to succeed,
 			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
 			// TODO(emilyye): Remove this check if firewall rules bug gets fixed by Composer.
-			{
-				PlanOnly:           true,
-				ExpectNonEmptyPlan: false,
-				Config:             testAccComposerEnvironment_encryptionCfgUpdated(envName, network, subnetwork),
-				Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
-			},
+//			{
+//				PlanOnly:           true,
+//				ExpectNonEmptyPlan: false,
+//				Config:             testAccComposerEnvironment_encryptionCfgUpdated(envName, network, subnetwork),
+//				Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
+//			},
 		},
 	})
 }

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -296,38 +296,38 @@ func TestAccComposerEnvironment_withWebServerConfig(t *testing.T) {
 }
 
 func TestAccComposerEnvironment_withEncryptionConfig(t *testing.T) {
-	t.Parallel()
+  t.Parallel()
 
-  kms := BootstrapKMSKey(t)
+  kms := BootstrapKMSKeyInLocation(t, "us-central1")
   pid := getTestProjectFromEnv()
-	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
-	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
-	subnetwork := network + "-1"
+  envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
+  network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
+  subnetwork := network + "-1"
 
-	vcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccComposerEnvironmentDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccComposerEnvironment_encryptionCfg(pid, envName, kms.CryptoKey.Name, network, subnetwork),
-			},
-			{
-				ResourceName:      "google_composer_environment.test",
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-			// This is a terrible clean-up step in order to get destroy to succeed,
-			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
-			// TODO(emilyye): Remove this check if firewall rules bug gets fixed by Composer.
-//			{
-//				PlanOnly:           true,
-//				ExpectNonEmptyPlan: false,
-//				Config:             testAccComposerEnvironment_encryptionCfgUpdated(envName, network, subnetwork),
-//				Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
-//			},
-		},
-	})
+  vcrTest(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testAccComposerEnvironmentDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccComposerEnvironment_encryptionCfg(pid, envName, kms.CryptoKey.Name, network, subnetwork),
+      },
+      {
+        ResourceName:      "google_composer_environment.test",
+        ImportState:       true,
+        ImportStateVerify: true,
+      },
+      // This is a terrible clean-up step in order to get destroy to succeed,
+      // due to dangling firewall rules left by the Composer Environment blocking network deletion.
+      // TODO(dzarmola): Remove this check if firewall rules bug gets fixed by Composer.
+      {
+        PlanOnly:           true,
+        ExpectNonEmptyPlan: false,
+        Config:             testAccComposerEnvironment_encryptionCfg(pid, envName, kms.CryptoKey.Name, network, subnetwork),
+        Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
+      },
+    },
+  })
 }
 <% end -%>
 // Checks behavior of node config, including dependencies on Compute resources.
@@ -771,78 +771,70 @@ resource "google_compute_subnetwork" "test" {
 }
 
 func testAccComposerEnvironment_encryptionCfg(pid, name, kmsKey, network, subnetwork string) string {
-	return fmt.Sprintf(`
+  return fmt.Sprintf(`
 data "google_project" "project" {
   project_id = "%s"
 }
-
 resource "google_project_iam_member" "kms-project-binding1" {
   project = data.google_project.project.project_id
   role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member  = "serviceAccount:service-${data.google_project.project.number}@cloudcomposer-accounts.iam.gserviceaccount.com"
 }
-
 resource "google_project_iam_member" "kms-project-binding2" {
   project = data.google_project.project.project_id
   role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member  = "serviceAccount:service-${data.google_project.project.number}@compute-system.iam.gserviceaccount.com"
 }
-
 resource "google_project_iam_member" "kms-project-binding3" {
   project = data.google_project.project.project_id
   role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
 }
-
 resource "google_project_iam_member" "kms-project-binding4" {
   project = data.google_project.project.project_id
   role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-artifactregistry.iam.gserviceaccount.com"
 }
-
 resource "google_project_iam_member" "kms-project-binding5" {
   project = data.google_project.project.project_id
   role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member  = "serviceAccount:service-${data.google_project.project.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
 }
-
 resource "google_kms_crypto_key_iam_member" "iam" {
-  crypto_key_id = google_kms_crypto_key.crypto_key.id
+  crypto_key_id = "%s"
   role    = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
   member  = "serviceAccount:service-${data.google_project.project.number}@gs-project-accounts.iam.gserviceaccount.com"
 }
-
 resource "google_composer_environment" "test" {
-	depends_on = [google_project_iam_member.kms-project-binding1]
-
-	name   = "%s"
-	region = "us-central1"
-	config {
-		node_config {
-			network    = google_compute_network.test.self_link
-			subnetwork = google_compute_subnetwork.test.self_link
-			zone       = "us-central1-a"
-		}
-		encryption_config {
-			kms_key_name  = "%s"
-		}
-	}
+  depends_on = [google_project_iam_member.kms-project-binding1, google_project_iam_member.kms-project-binding2,
+  google_project_iam_member.kms-project-binding3, google_project_iam_member.kms-project-binding4,
+  google_project_iam_member.kms-project-binding5, google_kms_crypto_key_iam_member.iam]
+  name   = "%s"
+  region = "us-central1"
+  config {
+    node_config {
+      network    = google_compute_network.test.self_link
+      subnetwork = google_compute_subnetwork.test.self_link
+      zone       = "us-central1-a"
+    }
+    encryption_config {
+      kms_key_name  = "%s"
+    }
+  }
 }
-
 // use a separate network to avoid conflicts with other tests running in parallel
 // that use the default network/subnet
 resource "google_compute_network" "test" {
-	name                    = "%s"
-	auto_create_subnetworks = false
+  name                    = "%s"
+  auto_create_subnetworks = false
 }
-
 resource "google_compute_subnetwork" "test" {
-	name          = "%s"
-	ip_cidr_range = "10.2.0.0/16"
-	region        = "us-central1"
-	network       = google_compute_network.test.self_link
+  name          = "%s"
+  ip_cidr_range = "10.2.0.0/16"
+  region        = "us-central1"
+  network       = google_compute_network.test.self_link
 }
-`, name, kmsKey, network, subnetwork)
+`, pid, kmsKey, name, kmsKey, network, subnetwork)
 }
 <% end -%>
 func testAccComposerEnvironment_update(name, network, subnetwork string) string {

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -179,6 +179,10 @@ The `config` block supports:
   (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
   The configuration settings for the Airflow web server App Engine instance.
 
+* `encryption_config` -
+  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  The encryption options for the Cloud Composer environment and its dependencies.
+
 The `node_config` block supports:
 
 * `zone` -
@@ -390,6 +394,13 @@ The `web_server_config` block supports:
   Value custom is returned only in response, if Airflow web server parameters were
   manually changed to a non-standard values.
 
+The `encryption_config` block supports:
+
+* `kms_key_name` -
+  (Required)
+  Customer-managed Encryption Key available through Google's Key Management Service. It must
+  be the fully qualified resource name, 
+  i.e. projects/project-id/locations/location/keyRings/keyring/cryptoKeys/key. Cannot be updated.
 
 
 ## Attributes Reference


### PR DESCRIPTION
Add a new section (EncryptionConfig) to Cloud Composer's EnvironmentConfig used for environment creation and updating


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
composer: added `encryption_config`  to `google_composer_environment` resource (TPGB only)
```
