### PR TITLE
Corrected generateUserAgentString usage

### DIFF
--- a/templates/terraform/custom_expand/route_instance.erb
+++ b/templates/terraform/custom_expand/route_instance.erb
@@ -7,7 +7,7 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d T
 				return nil, err
 		}
 
-		userAgent, err := generateUserAgentString(d.(*schema.ResourceData), config.userAgent)
+		userAgent, err := generateUserAgentString(d, config.userAgent)
 		if err != nil {
 			return nil, err
 		}

--- a/templates/terraform/custom_expand/secret_version_enable.go.erb
+++ b/templates/terraform/custom_expand/secret_version_enable.go.erb
@@ -32,7 +32,7 @@ func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d T
 	parts := strings.Split(name, "/")
 	project := parts[1]
 
-	userAgent, err := generateUserAgentString(d.(*schema.ResourceData), config.userAgent)
+	userAgent, err := generateUserAgentString(d, config.userAgent)
 	if err != nil {
 		return nil, err
 	}

--- a/third_party/validator/compute_instance.go
+++ b/third_party/validator/compute_instance.go
@@ -15,8 +15,6 @@ import (
 
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/googleapi"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func GetComputeInstanceCaiObject(d TerraformResourceData, config *Config) (Asset, error) {

--- a/third_party/validator/compute_instance.go
+++ b/third_party/validator/compute_instance.go
@@ -236,7 +236,7 @@ func expandInstanceGuestAccelerators(d TerraformResourceData, config *Config) ([
 }
 
 func expandBootDisk(d TerraformResourceData, config *Config, project string) (*computeBeta.AttachedDisk, error) {
-	userAgent, err := generateUserAgentString(d.(*schema.ResourceData), config.userAgent)
+	userAgent, err := generateUserAgentString(d, config.userAgent)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The signature of generateUserAgentString was changed in https://github.com/GoogleCloudPlatform/magic-modules/pull/4237 but a few usages in examples and terraform-google-conversion code had not yet been updated accordingly.

Related to https://github.com/GoogleCloudPlatform/terraform-validator/issues/158

I'm a little perplexed as to how this wasn't caught sooner; these templates translate into code that was being compiled during tests, and that compilation seems like it should have failed type checks.




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
