### PR TITLE
Remove TestAccComputeBackendService_backendServiceCacheExample from tpg.

### DIFF
--- a/products/compute/terraform.yaml
+++ b/products/compute/terraform.yaml
@@ -196,7 +196,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           backend_service_name: "backend-service"
           http_health_check_name: "health-check"
       - !ruby/object:Provider::Terraform::Examples
+        name: "backend_service_cache_simple"
+        primary_resource_id: "default"
+        vars:
+          backend_service_name: "backend-service"
+          http_health_check_name: "health-check"
+      - !ruby/object:Provider::Terraform::Examples
         name: "backend_service_cache"
+        min_version: beta
         primary_resource_id: "default"
         vars:
           backend_service_name: "backend-service"

--- a/templates/terraform/examples/backend_service_cache_simple.tf.erb
+++ b/templates/terraform/examples/backend_service_cache_simple.tf.erb
@@ -1,0 +1,15 @@
+resource "google_compute_backend_service" "<%= ctx[:primary_resource_id] %>" {
+  name          = "<%= ctx[:vars]['backend_service_name'] %>"
+  health_checks = [google_compute_http_health_check.default.id]
+  enable_cdn  = true
+  cdn_policy {
+    signed_url_cache_max_age_sec = 7200
+  }
+}
+
+resource "google_compute_http_health_check" "default" {
+  name               = "<%= ctx[:vars]['http_health_check_name'] %>"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

TestAccComputeBackendService_backendServiceCacheExample was using beta only fields causing the [tpg test to fail](https://ci-oss.hashicorp.engineering/viewLog.html?buildId=163035&buildTypeId=GoogleCloud_ProviderGoogleCloudGoogleProject). I've now made this test beta only and have added a new test for some ga functionality.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
