### PR TITLE
Fix reading connection_id from API

### DIFF
--- a/products/bigqueryconnection/api.yaml
+++ b/products/bigqueryconnection/api.yaml
@@ -51,7 +51,6 @@ objects:
           Optional connection id that should be assigned to the created connection. 
         required: false
         input: true
-        url_param_only: true
       - !ruby/object:Api::Type::String
         name: 'location'
         required: false

--- a/products/bigqueryconnection/terraform.yaml
+++ b/products/bigqueryconnection/terraform.yaml
@@ -20,8 +20,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_flatten: 'templates/terraform/custom_flatten/bigquery_connection_flatten.go.erb'
       cloudSql.credential.password: !ruby/object:Overrides::Terraform::PropertyOverride
         sensitive: true
+      connection_id: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+        custom_flatten: "templates/terraform/custom_flatten/id_from_name.erb"
     id_format: "projects/{{project}}/locations/{{location}}/connections/{{connection_id}}"
     import_format: ["projects/{{project}}/locations/{{location}}/connections/{{connection_id}}", "{{project}}/{{location}}/{{connection_id}}", "{{location}}/{{connection_id}}"]
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      post_create: templates/terraform/post_create/bigquery_connection_id.go.erb
+      encoder: templates/terraform/encoders/bigquery_connection.go.erb
     examples:
       - !ruby/object:Provider::Terraform::Examples
         min_version: beta

--- a/templates/terraform/encoders/bigquery_connection.go.erb
+++ b/templates/terraform/encoders/bigquery_connection.go.erb
@@ -1,0 +1,3 @@
+	// connection_id is needed to qualify the URL but cannot be sent in the body
+	delete(obj, "connection_id")
+	return obj, nil

--- a/templates/terraform/post_create/bigquery_connection_id.go.erb
+++ b/templates/terraform/post_create/bigquery_connection_id.go.erb
@@ -1,0 +1,7 @@
+if isEmptyValue(reflect.ValueOf(d.Get("connection_id"))) {
+	// connection id is set by API when unset and required to GET the connection
+	// it is set by reading the "name" field rather than a field in the response
+	if err := d.Set("connection_id", flattenBigqueryConnectionConnectionConnectionId("", d, config)); err != nil {
+		return fmt.Errorf("Error reading Connection: %s", err)
+	}
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/7955

This behavior was introduced in https://github.com/GoogleCloudPlatform/magic-modules/pull/4159

I couldn't figure out a better way to represent this. Basically the `connection_id` field needs to only be sent in the URL, but then needs to be set to a modified version of the computed `name` field.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquery: fixed a bug in `google_bigquery_connection` that caused the resource to function incorrectly when `connection_id` was unset
```
