### PR TITLE
Removed trailing references to kubernetes_dashboard

### DIFF
--- a/third_party/inspec/custom_functions/google_container_cluster.erb
+++ b/third_party/inspec/custom_functions/google_container_cluster.erb
@@ -32,13 +32,6 @@ def has_resource_labels?
   true
 end
 
-def has_kubernetes_dashboard_disabled?
-  return false if !defined?(@addons_config.kubernetes_dashboard)
-  return false if @addons_config.kubernetes_dashboard.to_h.empty?
-  return true if  @addons_config.kubernetes_dashboard.to_h=={ 'disabled': true }
-  false
-end
-
 def has_basic_authorization?
   return false if @master_auth.username.nil? and @master_auth.password.nil?
   true

--- a/third_party/validator/container.go
+++ b/third_party/validator/container.go
@@ -835,13 +835,6 @@ func expandContainerClusterAddonsConfig(v interface{}, d TerraformResourceData, 
 		transformed["horizontalPodAutoscaling"] = transformedHorizontalPodAutoscaling
 	}
 
-	transformedKubernetesDashboard, err := expandContainerClusterAddonsConfigKubernetesDashboard(original["kubernetes_dashboard"], d, config)
-	if err != nil {
-		return nil, err
-	} else if val := reflect.ValueOf(transformedKubernetesDashboard); val.IsValid() && !isEmptyValue(val) {
-		transformed["kubernetesDashboard"] = transformedKubernetesDashboard
-	}
-
 	transformedNetworkPolicyConfig, err := expandContainerClusterAddonsConfigNetworkPolicyConfig(original["network_policy_config"], d, config)
 	if err != nil {
 		return nil, err
@@ -895,29 +888,6 @@ func expandContainerClusterAddonsConfigHorizontalPodAutoscaling(v interface{}, d
 }
 
 func expandContainerClusterAddonsConfigHorizontalPodAutoscalingDisabled(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
-	return v, nil
-}
-
-func expandContainerClusterAddonsConfigKubernetesDashboard(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
-	l := v.([]interface{})
-	if len(l) == 0 || l[0] == nil {
-		return nil, nil
-	}
-	raw := l[0]
-	original := raw.(map[string]interface{})
-	transformed := make(map[string]interface{})
-
-	transformedDisabled, err := expandContainerClusterAddonsConfigKubernetesDashboardDisabled(original["disabled"], d, config)
-	if err != nil {
-		return nil, err
-	} else if val := reflect.ValueOf(transformedDisabled); val.IsValid() && !isEmptyValue(val) {
-		transformed["disabled"] = transformedDisabled
-	}
-
-	return transformed, nil
-}
-
-func expandContainerClusterAddonsConfigKubernetesDashboardDisabled(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
 	return v, nil
 }
 


### PR DESCRIPTION
`kubernetes_dashboard` was removed in https://github.com/GoogleCloudPlatform/magic-modules/pull/2551 as one of the v3 breaking changes. However, a few trailing references remained in the repository. Removing those should bring us back in line and will resolve some broken tests in terraform-validator.

Related to https://github.com/GoogleCloudPlatform/terraform-validator/issues/158

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
