### PR TITLE
Add support for Context Aware Access UserAccessBinding resource

### DIFF
--- a/products/accesscontextmanager/api.yaml
+++ b/products/accesscontextmanager/api.yaml
@@ -1269,13 +1269,23 @@ objects:
         input: true
   - !ruby/object:Api::Resource
     name: 'GcpUserAccessBinding'
-    base_url: "{{parent}}/gcpUserAccessBindings"
+    base_url: "organizations/{{organization_id}}/gcpUserAccessBindings"
     update_verb: :PATCH
     update_mask: true
     description: |
       Restricts access to Cloud Console and Google Cloud APIs for a set of users using Context-Aware Access.
     references: !ruby/object:Api::Resource::ReferenceLinks
       api: 'https://cloud.google.com/access-context-manager/docs/reference/rest/v1/organizations.gcpUserAccessBindings'
+    parameters:
+      # Parent is a path parameter that _cannot_ be read or sent in the request at all.
+      # This must be done at the provider level.
+      - !ruby/object:Api::Type::String
+        name: organization_id
+        input: true
+        required: true
+        url_param_only: true
+        description: |
+          Required. ID of the parent organization.
     properties:
       - !ruby/object:Api::Type::String
         name: 'name'

--- a/products/accesscontextmanager/api.yaml
+++ b/products/accesscontextmanager/api.yaml
@@ -1267,3 +1267,31 @@ objects:
               Format: projects/{project_number}
         required: true
         input: true
+  - !ruby/object:Api::Resource
+    name: 'GcpUserAccessBinding'
+    base_url: "{{parent}}/gcpUserAccessBindings"
+    update_verb: :PATCH
+    update_mask: true
+    description: |
+      Restricts access to Cloud Console and Google Cloud APIs for a set of users using Context-Aware Access.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      api: 'https://cloud.google.com/access-context-manager/docs/reference/rest/v1/organizations.gcpUserAccessBindings'
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        output: true
+        description: |
+          Immutable. Assigned by the server during creation. The last segment has an arbitrary length and has only URI unreserved characters (as defined by RFC 3986 Section 2.3). Should not be specified by the client during creation. Example: "organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N"
+      - !ruby/object:Api::Type::String
+        name: 'group_key'
+        required: true
+        description: |
+          Required. Immutable. Google Group id whose members are subject to this binding's restrictions. See "id" in the G Suite Directory API's Groups resource. If a group's email address/alias is changed, this resource will continue to point at the changed group. This field does not accept group email addresses or aliases. Example: "01d520gv4vjcrht"
+      - !ruby/object:Api::Type::Array
+        name: 'access_levels'
+        item_type: Api::Type::String
+        required: true
+        min_size: 1
+        max_size: 1
+        description: |
+          Required. Access level that a user must have to be granted access. Only one access level is supported, not multiple. This repeated field must have exactly one element. Example: "accessPolicies/9522/accessLevels/device_trusted"

--- a/products/accesscontextmanager/inspec.yaml
+++ b/products/accesscontextmanager/inspec.yaml
@@ -46,3 +46,5 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     exclude: true
   ServicePerimeterResource: !ruby/object:Overrides::Inspec::ResourceOverride
     exclude: true
+  GcpUserAccessBinding: !ruby/object:Overrides::Inspec::ResourceOverride
+    exclude: true

--- a/products/accesscontextmanager/terraform.yaml
+++ b/products/accesscontextmanager/terraform.yaml
@@ -238,9 +238,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     autogen_async: true
     exclude_validator: true
     examples:
-    - !ruby/object:Provider::Terraform::Examples
-      name: "access_context_manager_gcp_user_access_binding_basic"
-      primary_resource_id: "gcp_user_access_binding"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "access_context_manager_gcp_user_access_binding_basic"
+        primary_resource_id: "gcp_user_access_binding"
+        vars:
+          group_id: "my-identity-group"
+          access_level_id: "access_level_id_for_user_access_binding"
+          access_level_name: "chromeos_no_lock"
+        test_env_vars:
+          org_id: :ORG_ID
+          org_domain: :ORG_DOMAIN
+          cust_id: :CUST_ID
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/products/accesscontextmanager/terraform.yaml
+++ b/products/accesscontextmanager/terraform.yaml
@@ -240,6 +240,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "access_context_manager_gcp_user_access_binding_basic"
+        # Has a handwritten test due to AccessPolicy-related tests needing to run synchronously
+        skip_test: true
         primary_resource_id: "gcp_user_access_binding"
         vars:
           group_id: "my-identity-group"

--- a/products/accesscontextmanager/terraform.yaml
+++ b/products/accesscontextmanager/terraform.yaml
@@ -233,6 +233,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           service_perimeter_name: "restrict_all"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/access_context_manager_service_perimeter_resource.go.erb
+  GcpUserAccessBinding: !ruby/object:Overrides::Terraform::ResourceOverride
+    id_format: "{{name}}"
+    autogen_async: true
+    exclude_validator: true
+    examples:
+    - !ruby/object:Provider::Terraform::Examples
+      name: "access_context_manager_gcp_user_access_binding_basic"
+      primary_resource_id: "gcp_user_access_binding"
+
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.

--- a/templates/terraform/examples/access_context_manager_gcp_user_access_binding_basic.tf.erb
+++ b/templates/terraform/examples/access_context_manager_gcp_user_access_binding_basic.tf.erb
@@ -1,6 +1,47 @@
+resource "google_cloud_identity_group" "group" {
+  display_name = "<%= ctx[:vars]['group_id'] %>"
+
+  parent = "customers/<%= ctx[:test_env_vars]['cust_id'] %>"
+
+  group_key {
+    id = "<%= ctx[:vars]['group_id'] %>@<%= ctx[:test_env_vars]['org_domain'] %>"
+  }
+
+  labels = {
+    "cloudidentity.googleapis.com/groups.discussion_forum" = ""
+  }
+}
+
+resource "google_access_context_manager_access_level" "<%= ctx[:vars]['access_level_id'] %>" {
+  parent = "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}"
+  name   = "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}/accessLevels/<%= ctx[:vars]['access_level_name'] %>"
+  title  = "<%= ctx[:vars]['access_level_name'] %>"
+  basic {
+    conditions {
+      device_policy {
+        require_screen_lock = true
+        os_constraints {
+          os_type = "DESKTOP_CHROME_OS"
+        }
+      }
+      regions = [
+  "US",
+      ]
+    }
+  }
+}
+
+resource "google_access_context_manager_access_policy" "access-policy" {
+  parent = "organizations/123456789"
+  title  = "my policy"
+}
+
+
+
 resource "google_access_context_manager_gcp_user_access_binding" "<%= ctx[:primary_resource_id] %>" {
-  group_key = "01d520gv4vjcrht"
-  access_levels = [
-    "accessPolicies/9522/accessLevels/device_trusted",
+  organization_id = "<%= ctx[:test_env_vars]['org_id'] %>"
+  group_key       = google_cloud_identity_group.group.id
+  access_levels   = [
+    google_access_context_manager_access_level.<%= ctx[:vars]['access_level_id'] %>.name,
   ]
 }

--- a/templates/terraform/examples/access_context_manager_gcp_user_access_binding_basic.tf.erb
+++ b/templates/terraform/examples/access_context_manager_gcp_user_access_binding_basic.tf.erb
@@ -32,7 +32,7 @@ resource "google_access_context_manager_access_level" "<%= ctx[:vars]['access_le
 }
 
 resource "google_access_context_manager_access_policy" "access-policy" {
-  parent = "organizations/123456789"
+  parent = "organizations/<%= ctx[:test_env_vars]['org_id'] %>"
   title  = "my policy"
 }
 

--- a/templates/terraform/examples/access_context_manager_gcp_user_access_binding_basic.tf.erb
+++ b/templates/terraform/examples/access_context_manager_gcp_user_access_binding_basic.tf.erb
@@ -40,7 +40,7 @@ resource "google_access_context_manager_access_policy" "access-policy" {
 
 resource "google_access_context_manager_gcp_user_access_binding" "<%= ctx[:primary_resource_id] %>" {
   organization_id = "<%= ctx[:test_env_vars]['org_id'] %>"
-  group_key       = google_cloud_identity_group.group.id
+  group_key       = trimprefix(google_cloud_identity_group.group.id, "groups/")
   access_levels   = [
     google_access_context_manager_access_level.<%= ctx[:vars]['access_level_id'] %>.name,
   ]

--- a/templates/terraform/examples/access_context_manager_gcp_user_access_binding_basic.tf.erb
+++ b/templates/terraform/examples/access_context_manager_gcp_user_access_binding_basic.tf.erb
@@ -1,0 +1,6 @@
+resource "google_access_context_manager_gcp_user_access_binding" "<%= ctx[:primary_resource_id] %>" {
+  group_key = "01d520gv4vjcrht"
+  access_levels = [
+    "accessPolicies/9522/accessLevels/device_trusted",
+  ]
+}

--- a/third_party/terraform/tests/resource_access_approval_folder_settings_test.go
+++ b/third_party/terraform/tests/resource_access_approval_folder_settings_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Since access approval settings are heirarchical, and only one can exist per folder/project/org,
-// and all refer to the same organization, they need to be ran serially
+// and all refer to the same organization, they need to be run serially
 // See AccessApprovalOrganizationSettings for the test runner.
 func testAccAccessApprovalFolderSettings(t *testing.T) {
 	context := map[string]interface{}{

--- a/third_party/terraform/tests/resource_access_approval_organization_settings_test.go
+++ b/third_party/terraform/tests/resource_access_approval_organization_settings_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Since access approval settings are heirarchical, and only one can exist per folder/project/org,
-// and all refer to the same organization, they need to be ran serially
+// and all refer to the same organization, they need to be run serially
 func TestAccAccessApprovalSettings(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		"folder":       testAccAccessApprovalFolderSettings,

--- a/third_party/terraform/tests/resource_access_approval_project_settings_test.go
+++ b/third_party/terraform/tests/resource_access_approval_project_settings_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Since access approval settings are heirarchical, and only one can exist per folder/project/org,
-// and all refer to the same organization, they need to be ran serially.
+// and all refer to the same organization, they need to be run serially.
 // See AccessApprovalOrganizationSettings for the test runner.
 func testAccAccessApprovalProjectSettings(t *testing.T) {
 	context := map[string]interface{}{

--- a/third_party/terraform/tests/resource_access_context_manager_access_level_condition_test.go
+++ b/third_party/terraform/tests/resource_access_context_manager_access_level_condition_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Since each test here is acting on the same organization and only one AccessPolicy
-// can exist, they need to be ran serially. See AccessPolicy for the test runner.
+// can exist, they need to be run serially. See AccessPolicy for the test runner.
 
 func testAccAccessContextManagerAccessLevelCondition_basicTest(t *testing.T) {
 	org := getTestOrgFromEnv(t)

--- a/third_party/terraform/tests/resource_access_context_manager_access_level_test.go.erb
+++ b/third_party/terraform/tests/resource_access_context_manager_access_level_test.go.erb
@@ -10,7 +10,7 @@ import (
 )
 
 // Since each test here is acting on the same organization and only one AccessPolicy
-// can exist, they need to be ran serially. See AccessPolicy for the test runner.
+// can exist, they need to be run serially. See AccessPolicy for the test runner.
 
 func testAccAccessContextManagerAccessLevel_basicTest(t *testing.T) {
 	org := getTestOrgFromEnv(t)

--- a/third_party/terraform/tests/resource_access_context_manager_access_levels_test.go
+++ b/third_party/terraform/tests/resource_access_context_manager_access_levels_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Since each test here is acting on the same organization and only one AccessPolicy
-// can exist, they need to be ran serially. See AccessPolicy for the test runner.
+// can exist, they need to be run serially. See AccessPolicy for the test runner.
 
 func testAccAccessContextManagerAccessLevels_basicTest(t *testing.T) {
 	org := getTestOrgFromEnv(t)

--- a/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
+++ b/third_party/terraform/tests/resource_access_context_manager_access_policy_test.go.erb
@@ -75,7 +75,7 @@ func testSweepAccessContextManagerPolicies(region string) error {
 }
 
 // Since each test here is acting on the same organization and only one AccessPolicy
-// can exist, they need to be ran serially
+// can exist, they need to be run serially
 func TestAccAccessContextManager(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		"access_policy":              testAccAccessContextManagerAccessPolicy_basicTest,
@@ -88,6 +88,7 @@ func TestAccAccessContextManager(t *testing.T) {
 		"access_levels":              testAccAccessContextManagerAccessLevels_basicTest,
 		"access_level_condition":     testAccAccessContextManagerAccessLevelCondition_basicTest,
 		"service_perimeters":         testAccAccessContextManagerServicePerimeters_basicTest,
+		"gcp_user_access_binding":    testAccAccessContextManagerGcpUserAccessBinding_basicTest,
 	}
 
 	for name, tc := range testCases {

--- a/third_party/terraform/tests/resource_access_context_manager_gcp_user_access_binding_test.go
+++ b/third_party/terraform/tests/resource_access_context_manager_gcp_user_access_binding_test.go
@@ -87,7 +87,7 @@ resource "google_access_context_manager_access_policy" "access-policy" {
 
 resource "google_access_context_manager_gcp_user_access_binding" "gcp_user_access_binding" {
   organization_id = "%{org_id}"
-  group_key       = google_cloud_identity_group.group.id
+  group_key       = trimprefix("groups/", google_cloud_identity_group.group.id)
   access_levels   = [
     google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
   ]

--- a/third_party/terraform/tests/resource_access_context_manager_gcp_user_access_binding_test.go
+++ b/third_party/terraform/tests/resource_access_context_manager_gcp_user_access_binding_test.go
@@ -87,7 +87,7 @@ resource "google_access_context_manager_access_policy" "access-policy" {
 
 resource "google_access_context_manager_gcp_user_access_binding" "gcp_user_access_binding" {
   organization_id = "%{org_id}"
-  group_key       = trimprefix("groups/", google_cloud_identity_group.group.id)
+  group_key       = trimprefix(google_cloud_identity_group.group.id, "groups/")
   access_levels   = [
     google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
   ]

--- a/third_party/terraform/tests/resource_access_context_manager_gcp_user_access_binding_test.go
+++ b/third_party/terraform/tests/resource_access_context_manager_gcp_user_access_binding_test.go
@@ -1,0 +1,123 @@
+package google
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// Since each test here is acting on the same organization and only one AccessPolicy
+// can exist, they need to be run serially. See AccessPolicy for the test runner.
+
+func testAccAccessContextManagerGcpUserAccessBinding_basicTest(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":        getTestOrgFromEnv(t),
+		"org_domain":    getTestOrgDomainFromEnv(t),
+		"cust_id":       getTestCustIdFromEnv(t),
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {},
+		},
+		CheckDestroy: testAccCheckAccessContextManagerGcpUserAccessBindingDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingBasicExample(context),
+			},
+			{
+				ResourceName:            "google_access_context_manager_gcp_user_access_binding.gcp_user_access_binding",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"organization_id"},
+			},
+		},
+	})
+}
+
+func testAccAccessContextManagerGcpUserAccessBinding_accessContextManagerGcpUserAccessBindingBasicExample(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_cloud_identity_group" "group" {
+  display_name = "tf-test-my-identity-group%{random_suffix}"
+
+  parent = "customers/%{cust_id}"
+
+  group_key {
+    id = "tf-test-my-identity-group%{random_suffix}@%{org_domain}"
+  }
+
+  labels = {
+    "cloudidentity.googleapis.com/groups.discussion_forum" = ""
+  }
+}
+
+resource "google_access_context_manager_access_level" "tf_test_access_level_id_for_user_access_binding%{random_suffix}" {
+  parent = "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}"
+  name   = "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}/accessLevels/tf_test_chromeos_no_lock%{random_suffix}"
+  title  = "tf_test_chromeos_no_lock%{random_suffix}"
+  basic {
+    conditions {
+      device_policy {
+        require_screen_lock = true
+        os_constraints {
+          os_type = "DESKTOP_CHROME_OS"
+        }
+      }
+      regions = [
+  "US",
+      ]
+    }
+  }
+}
+
+resource "google_access_context_manager_access_policy" "access-policy" {
+  parent = "organizations/%{org_id}"
+  title  = "my policy"
+}
+
+
+
+resource "google_access_context_manager_gcp_user_access_binding" "gcp_user_access_binding" {
+  organization_id = "%{org_id}"
+  group_key       = google_cloud_identity_group.group.id
+  access_levels   = [
+    google_access_context_manager_access_level.tf_test_access_level_id_for_user_access_binding%{random_suffix}.name,
+  ]
+}
+`, context)
+}
+
+func testAccCheckAccessContextManagerGcpUserAccessBindingDestroyProducer(t *testing.T) func(s *terraform.State) error {
+	return func(s *terraform.State) error {
+		for name, rs := range s.RootModule().Resources {
+			if rs.Type != "google_access_context_manager_gcp_user_access_binding" {
+				continue
+			}
+			if strings.HasPrefix(name, "data.") {
+				continue
+			}
+
+			config := googleProviderConfig(t)
+
+			url, err := replaceVarsForTest(config, rs, "{{AccessContextManagerBasePath}}organizations/{{organization_id}}/gcpUserAccessBindings/{{name}}")
+			if err != nil {
+				return err
+			}
+
+			_, err = sendRequest(config, "GET", "", url, config.userAgent, nil)
+			if err == nil {
+				return fmt.Errorf("AccessContextManagerGcpUserAccessBinding still exists at %s", url)
+			}
+		}
+
+		return nil
+	}
+}

--- a/third_party/terraform/tests/resource_access_context_manager_service_perimeter_resource_test.go
+++ b/third_party/terraform/tests/resource_access_context_manager_service_perimeter_resource_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Since each test here is acting on the same organization and only one AccessPolicy
-// can exist, they need to be ran serially. See AccessPolicy for the test runner.
+// can exist, they need to be run serially. See AccessPolicy for the test runner.
 
 func testAccAccessContextManagerServicePerimeterResource_basicTest(t *testing.T) {
 	// Multiple fine-grained resources

--- a/third_party/terraform/tests/resource_access_context_manager_service_perimeter_test.go.erb
+++ b/third_party/terraform/tests/resource_access_context_manager_service_perimeter_test.go.erb
@@ -10,7 +10,7 @@ import (
 )
 
 // Since each test here is acting on the same organization and only one AccessPolicy
-// can exist, they need to be ran serially. See AccessPolicy for the test runner.
+// can exist, they need to be run serially. See AccessPolicy for the test runner.
 func testAccAccessContextManagerServicePerimeter_basicTest(t *testing.T) {
 	org := getTestOrgFromEnv(t)
 

--- a/third_party/terraform/tests/resource_access_context_manager_services_perimeters_test.go
+++ b/third_party/terraform/tests/resource_access_context_manager_services_perimeters_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Since each test here is acting on the same organization and only one AccessPolicy
-// can exist, they need to be ran serially. See AccessPolicy for the test runner.
+// can exist, they need to be run serially. See AccessPolicy for the test runner.
 func testAccAccessContextManagerServicePerimeters_basicTest(t *testing.T) {
 	org := getTestOrgFromEnv(t)
 

--- a/third_party/terraform/tests/resource_bigquery_data_transfer_config_test.go
+++ b/third_party/terraform/tests/resource_bigquery_data_transfer_config_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 // The service account TF uses needs the permission granted in the configs
-// but it will get deleted by parallel tests, so they need to be ran serially.
+// but it will get deleted by parallel tests, so they need to be run serially.
 func TestAccBigqueryDataTransferConfig(t *testing.T) {
 	testCases := map[string]func(t *testing.T){
 		"basic":           testAccBigqueryDataTransferConfig_scheduledQuery_basic,


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Resolved https://github.com/hashicorp/terraform-provider-google/issues/7501


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
      ^ --- I'm not able to run acceptance tests (TestAccAccessContextManager) locally because they require a CUST_ID. However, you can see the results in the teamcity tests.
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
accesscontextmanager: Added support for `google_access_context_manager_gcp_user_access_binding`
```
