### PR TITLE
Compute: add support for instance reservation_affinity

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -615,6 +615,51 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 				Set:         schema.HashString,
 				Description: `A set of key/value label pairs to assign to instances created from this template,`,
 			},
+
+			"reservation_affinity": {
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				ForceNew:    true,
+				Description: `Specifies the reservations that this instance can consume from.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice([]string{"ANY_RESERVATION", "SPECIFIC_RESERVATION", "NO_RESERVATION"}, false),
+							Description:  `The type of reservation from which this instance can consume resources.`,
+						},
+
+						"specific_reservation": {
+							Type:        schema.TypeList,
+							MaxItems:    1,
+							Optional:    true,
+							ForceNew:    true,
+							Description: `Specifies the label selector for the reservation to use.`,
+
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:        schema.TypeString,
+										Required:    true,
+										ForceNew:    true,
+										Description: `Corresponds to the label key of a reservation resource. To target a SPECIFIC_RESERVATION by name, specify compute.googleapis.com/reservation-name as the key and specify the name of your reservation as the only value.`,
+									},
+									"values": {
+										Type:        schema.TypeList,
+										Elem:        &schema.Schema{Type: schema.TypeString},
+										Required:    true,
+										ForceNew:    true,
+										Description: `Corresponds to the label values of a reservation resource.`,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 		UseJSONNumber: true,
 	}
@@ -872,6 +917,11 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 		return err
 	}
 
+	reservationAffinity, err := expandReservationAffinity(d)
+	if err != nil {
+		return err
+	}
+
 	instanceProperties := &computeBeta.InstanceProperties{
 		CanIpForward:               d.Get("can_ip_forward").(bool),
 		Description:                d.Get("instance_description").(string),
@@ -887,6 +937,7 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 		ConfidentialInstanceConfig: expandConfidentialInstanceConfig(d),
 		ShieldedInstanceConfig:     expandShieldedVmConfigs(d),
 		DisplayDevice:              expandDisplayDevice(d),
+		ReservationAffinity:        reservationAffinity,
 	}
 
 	if _, ok := d.GetOk("labels"); ok {
@@ -1281,6 +1332,13 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 			return fmt.Errorf("Error setting enable_display: %s", err)
 		}
 	}
+
+	if reservationAffinity := instanceTemplate.Properties.ReservationAffinity; reservationAffinity != nil {
+		if err = d.Set("reservation_affinity", flattenReservationAffinity(reservationAffinity)); err != nil {
+			return fmt.Errorf("Error setting reservation_affinity: %s", err)
+		}
+	}
+
 	return nil
 }
 

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
@@ -747,7 +747,7 @@ func TestAccComputeInstanceTemplate_reservationAffinities(t *testing.T) {
 		CheckDestroy: testAccCheckComputeInstanceTemplateDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate(templateName, "NO_RESERVATION"),
+				Config: testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate_nonSpecificReservation(templateName, "NO_RESERVATION"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(t, "google_compute_instance_template.foobar", &template),
 					testAccCheckComputeInstanceTemplateHasReservationAffinity(&template, "NO_RESERVATION"),
@@ -759,7 +759,7 @@ func TestAccComputeInstanceTemplate_reservationAffinities(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate(templateName, "ANY_RESERVATION"),
+				Config: testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate_nonSpecificReservation(templateName, "ANY_RESERVATION"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(t, "google_compute_instance_template.foobar", &template),
 					testAccCheckComputeInstanceTemplateHasReservationAffinity(&template, "ANY_RESERVATION"),
@@ -771,7 +771,7 @@ func TestAccComputeInstanceTemplate_reservationAffinities(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate(templateName, "SPECIFIC_RESERVATION"),
+				Config: testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate_specificReservation(templateName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(t, "google_compute_instance_template.foobar", &template),
 					testAccCheckComputeInstanceTemplateHasReservationAffinity(&template, "SPECIFIC_RESERVATION", templateName),
@@ -2221,17 +2221,7 @@ resource "google_compute_instance_template" "foobar" {
 `, suffix)
 }
 
-func testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate(templateName, consumeReservationType string) string {
-	var reservationInstanceCfgSection string
-
-	if consumeReservationType == "SPECIFIC_RESERVATION" {
-		reservationInstanceCfgSection = fmt.Sprintf(`
-	specific_reservation {
-		key = "compute.googleapis.com/reservation-name"
-		values = ["%s"]
-	}`, templateName)
-	}
-
+func testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate_nonSpecificReservation(templateName, consumeReservationType string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family  = "debian-9"
@@ -2255,11 +2245,43 @@ resource "google_compute_instance_template" "foobar" {
 
   reservation_affinity {
     type = "%s"
-
-    %s
   }
 }
-`, templateName, consumeReservationType, reservationInstanceCfgSection)
+`, templateName, consumeReservationType)
+}
+
+func testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate_specificReservation(templateName string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name           = "instancet-test-%s"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  reservation_affinity {
+    type = "SPECIFIC_RESERVATION"
+
+	specific_reservation {
+		key = "compute.googleapis.com/reservation-name"
+		values = ["%s"]
+	}
+  }
+}
+`, templateName, templateName)
 }
 
 func testAccComputeInstanceTemplate_shieldedVmConfig(suffix string, enableSecureBoot bool, enableVtpm bool, enableIntegrityMonitoring bool) string {

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
@@ -735,6 +735,57 @@ func TestAccComputeInstanceTemplate_soleTenantNodeAffinities(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstanceTemplate_reservationAffinities(t *testing.T) {
+	t.Parallel()
+
+	var template computeBeta.InstanceTemplate
+	var templateName = randString(t, 10)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate(templateName, "NO_RESERVATION"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(t, "google_compute_instance_template.foobar", &template),
+					testAccCheckComputeInstanceTemplateHasReservationAffinity(&template, "NO_RESERVATION"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate(templateName, "ANY_RESERVATION"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(t, "google_compute_instance_template.foobar", &template),
+					testAccCheckComputeInstanceTemplateHasReservationAffinity(&template, "ANY_RESERVATION"),
+				),
+			},
+			{
+				ResourceName:      "google_compute_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate(templateName, "SPECIFIC_RESERVATION"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(t, "google_compute_instance_template.foobar", &template),
+					testAccCheckComputeInstanceTemplateHasReservationAffinity(&template, "SPECIFIC_RESERVATION", templateName),
+				),
+			},
+			{
+				ResourceName:      "google_compute_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeInstanceTemplate_shieldedVmConfig1(t *testing.T) {
 	t.Parallel()
 
@@ -1259,6 +1310,36 @@ func testAccCheckComputeInstanceTemplateHasMinCpuPlatform(instanceTemplate *comp
 	return func(s *terraform.State) error {
 		if instanceTemplate.Properties.MinCpuPlatform != minCpuPlatform {
 			return fmt.Errorf("Wrong minimum CPU platform: expected %s, got %s", minCpuPlatform, instanceTemplate.Properties.MinCpuPlatform)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeInstanceTemplateHasReservationAffinity(instanceTemplate *computeBeta.InstanceTemplate, consumeReservationType string, specificReservationNames ...string) resource.TestCheckFunc {
+	if len(specificReservationNames) > 1 {
+		panic("too many specificReservationNames in test")
+	}
+
+	return func(*terraform.State) error {
+		if instanceTemplate.Properties.ReservationAffinity == nil {
+			return fmt.Errorf("expected template to have reservation affinity, but it was nil")
+		}
+
+		if actualReservationType := instanceTemplate.Properties.ReservationAffinity.ConsumeReservationType; actualReservationType != consumeReservationType {
+			return fmt.Errorf("Wrong reservationAffinity consumeReservationType: expected %s, got, %s", consumeReservationType, actualReservationType)
+		}
+
+		if len(specificReservationNames) > 0 {
+			const reservationNameKey = "compute.googleapis.com/reservation-name"
+			if actualKey := instanceTemplate.Properties.ReservationAffinity.Key; actualKey != reservationNameKey {
+				return fmt.Errorf("Wrong reservationAffinity key: expected %s, got, %s", reservationNameKey, actualKey)
+			}
+
+			reservationAffinityValues := instanceTemplate.Properties.ReservationAffinity.Values
+			if len(reservationAffinityValues) != 1 || reservationAffinityValues[0] != specificReservationNames[0] {
+				return fmt.Errorf("Wrong reservationAffinity values: expected %s, got, %s", specificReservationNames, reservationAffinityValues)
+			}
 		}
 
 		return nil
@@ -2138,6 +2219,47 @@ resource "google_compute_instance_template" "foobar" {
   }
 }
 `, suffix)
+}
+
+func testAccComputeInstanceTemplate_reservationAffinityInstanceTemplate(templateName, consumeReservationType string) string {
+	var reservationInstanceCfgSection string
+
+	if consumeReservationType == "SPECIFIC_RESERVATION" {
+		reservationInstanceCfgSection = fmt.Sprintf(`
+	specific_reservation {
+		key = "compute.googleapis.com/reservation-name"
+		values = ["%s"]
+	}`, templateName)
+	}
+
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name           = "instancet-test-%s"
+  machine_type   = "e2-medium"
+  can_ip_forward = false
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+    auto_delete  = true
+    boot         = true
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  reservation_affinity {
+    type = "%s"
+
+    %s
+  }
+}
+`, templateName, consumeReservationType, reservationInstanceCfgSection)
 }
 
 func testAccComputeInstanceTemplate_shieldedVmConfig(suffix string, enableSecureBoot bool, enableVtpm bool, enableIntegrityMonitoring bool) string {

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go
@@ -956,6 +956,45 @@ func TestAccComputeInstance_soleTenantNodeAffinities(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_reservationAffinities(t *testing.T) {
+	t.Parallel()
+
+	var instance computeBeta.Instance
+	var instanceName = fmt.Sprintf("tf-test-resaffinity-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_reservationAffinityConfig(instanceName, "NO_RESERVATION"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasReservationAffinity(&instance, "NO_RESERVATION"),
+				),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+			{
+				Config: testAccComputeInstance_reservationAffinityConfig(instanceName, "ANY_RESERVATION"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasReservationAffinity(&instance, "ANY_RESERVATION"),
+				),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+			{
+				Config: testAccComputeInstance_reservationAffinityConfig(instanceName, "SPECIFIC_RESERVATION"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceHasReservationAffinity(&instance, "SPECIFIC_RESERVATION", instanceName),
+				),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{}),
+		},
+	})
+}
+
 func TestAccComputeInstance_subnet_auto(t *testing.T) {
 	t.Parallel()
 
@@ -2736,6 +2775,34 @@ func testAccCheckComputeInstanceHasConfiguredDeletionProtection(instance *comput
 	return func(s *terraform.State) error {
 		if instance.DeletionProtection != configuredDeletionProtection {
 			return fmt.Errorf("Wrong deletion protection flag: expected %t, got %t", configuredDeletionProtection, instance.DeletionProtection)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckComputeInstanceHasReservationAffinity(instance *computeBeta.Instance, reservationType string, specificReservationNames ...string) resource.TestCheckFunc {
+	if len(specificReservationNames) > 1 {
+		panic("too many specificReservationNames provided in test")
+	}
+
+	return func(*terraform.State) error {
+		if instance.ReservationAffinity == nil {
+			return fmt.Errorf("expected instance to have reservation affinity, but it was nil")
+		}
+
+		if instance.ReservationAffinity.ConsumeReservationType != reservationType {
+			return fmt.Errorf("Wrong reservationAffinity consumeReservationType: expected %s, got, %s", reservationType, instance.ReservationAffinity.ConsumeReservationType)
+		}
+
+		if len(specificReservationNames) > 0 {
+			const reservationNameKey = "compute.googleapis.com/reservation-name"
+			if instance.ReservationAffinity.Key != reservationNameKey {
+				return fmt.Errorf("Wrong reservationAffinity key: expected %s, got, %s", reservationNameKey, instance.ReservationAffinity.Key)
+			}
+			if len(instance.ReservationAffinity.Values) != 1 || instance.ReservationAffinity.Values[0] != specificReservationNames[0] {
+				return fmt.Errorf("Wrong reservationAffinity values: expected %s, got, %s", specificReservationNames, instance.ReservationAffinity.Values)
+			}
 		}
 
 		return nil
@@ -5070,6 +5137,63 @@ resource "google_compute_node_group" "nodes" {
   node_template = google_compute_node_template.nodetmpl.self_link
 }
 `, instance, nodeTemplate, nodeGroup)
+}
+
+func testAccComputeInstance_reservationAffinityConfig(instanceName, reservationType string) string {
+	var reservationCfg, reservationInstanceCfgSection string
+
+	if reservationType == "SPECIFIC_RESERVATION" {
+		reservationCfg = fmt.Sprintf(`
+resource "google_compute_reservation" "reservation" {
+  name = "%s"
+  zone = "us-central1-a"
+
+  specific_reservation {
+    count = 1
+    instance_properties {
+      machine_type = "n1-standard-1"
+    }
+  }
+
+  specific_reservation_required = true
+}`, instanceName)
+
+		reservationInstanceCfgSection = fmt.Sprintf(`
+	specific_reservation {
+		key = "compute.googleapis.com/reservation-name"
+		values = ["%s"]
+	}`, instanceName)
+	}
+
+	instanceCfg := fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "n1-standard-1"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  reservation_affinity {
+    type = "%s"
+
+    %s
+  }
+}`, instanceName, reservationType, reservationInstanceCfgSection)
+
+	return strings.Join([]string{reservationCfg, instanceCfg}, "\n")
 }
 
 func testAccComputeInstance_shieldedVmConfig(instance string, enableSecureBoot bool, enableVtpm bool, enableIntegrityMonitoring bool) string {

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go
@@ -5168,7 +5168,7 @@ resource "google_compute_instance" "foobar" {
 }
 
 func testAccComputeInstance_reservationAffinity_specificReservationConfig(instanceName string) string {
-	return `
+	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family  = "debian-9"
   project = "debian-cloud"

--- a/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
@@ -444,3 +444,54 @@ func hasNodeAffinitiesChanged(oScheduling, newScheduling map[string]interface{})
 
 	return false
 }
+
+func expandReservationAffinity(d *schema.ResourceData) (*computeBeta.ReservationAffinity, error) {
+	_, ok := d.GetOk("reservation_affinity")
+	if !ok {
+		return nil, nil
+	}
+
+	prefix := "reservation_affinity.0"
+	reservationAffinityType := d.Get(prefix + ".type").(string)
+
+	affinity := computeBeta.ReservationAffinity{
+		ConsumeReservationType: reservationAffinityType,
+		ForceSendFields:        []string{"ConsumeReservationType"},
+	}
+
+	_, hasSpecificReservation := d.GetOk(prefix + ".specific_reservation")
+	if (reservationAffinityType == "SPECIFIC_RESERVATION") != hasSpecificReservation {
+		return nil, fmt.Errorf("specific_reservation must be set when reservation_affinity is SPECIFIC_RESERVATION, and not set otherwise")
+	}
+
+	prefix = prefix + ".specific_reservation.0"
+	if hasSpecificReservation {
+		affinity.Key = d.Get(prefix + ".key").(string)
+		affinity.ForceSendFields = append(affinity.ForceSendFields, "Key", "Values")
+
+		for _, v := range d.Get(prefix + ".values").([]interface{}) {
+			affinity.Values = append(affinity.Values, v.(string))
+		}
+	}
+
+	return &affinity, nil
+}
+
+func flattenReservationAffinity(affinity *computeBeta.ReservationAffinity) []map[string]interface{} {
+	if affinity == nil {
+		return nil
+	}
+
+	flattened := map[string]interface{}{
+		"type": affinity.ConsumeReservationType,
+	}
+
+	if affinity.ConsumeReservationType == "SPECIFIC_RESERVATION" {
+		flattened["specific_reservation"] = []map[string]interface{}{{
+			"key":    affinity.Key,
+			"values": affinity.Values,
+		}}
+	}
+
+	return []map[string]interface{}{flattened}
+}


### PR DESCRIPTION
reservation_affinity controls how instances or instances created from
templates consume Compute Engine resource reservations.

Fixes hashicorp/terraform-provider-google#4593

This hoists my PR from hashicorp/terraform-provider-google#7669 up to magic-modules so this effort is not on someone else to do.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests. – I ran the subset of tests relating to added functionality
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests). - tests added
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know). - ran the specific subset of tests added for this functionality
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `reservation_affinity` to `google_compute_instance` and `google_compute_instance_template`
```
