### PR TITLE
Add restoreBackup support for sql db instance

### DIFF
--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -1084,7 +1084,8 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	if r, ok := d.GetOk("restore_backup_context"); ok {
+	if d.HasChange("restore_backup_context") {
+		r := d.Get("restore_backup_context")
 		err = sqlDatabaseInstanceRestoreFromBackup(d, config, userAgent, project, d.Get("name").(string), r)
 		if err != nil {
 			return err
@@ -1397,7 +1398,7 @@ func expandRestoreBackupContext(configured []interface{}) *sqladmin.RestoreBacku
 	}
 }
 
-func sqlDatabaseInstanceRestoreFromBackup(d *schema.ResourceData, config *Config, userAgent, project, instanceId string, r []interface{}) error {
+func sqlDatabaseInstanceRestoreFromBackup(d *schema.ResourceData, config *Config, userAgent, project, instanceId string, r interface{}) error {
 	log.Printf("[DEBUG] Initiating SQL database instance backup restore")
 	restoreContext := r.([]interface{})
 

--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -780,6 +780,7 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
+	// Perform a backup restore if the backup context exists
 	if r, ok := d.GetOk("restore_backup_context"); ok {
 		err = sqlDatabaseInstanceRestoreFromBackup(d, config, userAgent, project, name, r)
 		if err != nil {
@@ -1082,6 +1083,7 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
+	// Perform a backup restore if the backup context exists and has changed
 	if r, ok := d.GetOk("restore_backup_context"); ok {
 		if d.HasChange("restore_backup_context") {
 			err = sqlDatabaseInstanceRestoreFromBackup(d, config, userAgent, project, d.Get("name").(string), r)

--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -1056,8 +1056,6 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	// TODO if d.HasChange("settings") doesn't work, so we just send an empty request if only restoring from backup
-
 	// Update only updates the settings, so they are all we need to set.
 	instance := &sqladmin.DatabaseInstance{
 		Settings: expandSqlDatabaseInstanceSettings(d.Get("settings").([]interface{}), !isFirstGen(d)),

--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -1084,11 +1084,12 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	if d.HasChange("restore_backup_context") {
-		r := d.Get("restore_backup_context")
-		err = sqlDatabaseInstanceRestoreFromBackup(d, config, userAgent, project, d.Get("name").(string), r)
-		if err != nil {
-			return err
+	if r, ok := d.GetOk("restore_backup_context"); ok {
+		if d.HasChange("restore_backup_context") {
+			err = sqlDatabaseInstanceRestoreFromBackup(d, config, userAgent, project, d.Get("name").(string), r)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -583,6 +583,30 @@ settings.backup_configuration.binary_log_enabled are both set to true.`,
 				Computed:    true,
 				Description: `The URI of the created resource.`,
 			},
+			"restore_backup_context": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"backup_run_id": {
+							Type:        schema.TypeInt,
+							Required:    true,
+							Description: `The ID of the backup run to restore from.`,
+						},
+						"instance_id": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The ID of the instance that the backup was taken from.`,
+						},
+						"project": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Description: `The full project ID of the source instance.`,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -753,6 +777,13 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 					return fmt.Errorf("Error, failed to delete default 'root'@'*' user, but the database was created successfully: %s", err)
 				}
 			}
+		}
+	}
+
+	if r, ok := d.GetOk("restore_backup_context"); ok {
+		err = sqlDatabaseInstanceRestoreFromBackup(d, config, userAgent, project, name, r)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -1025,6 +1056,8 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
+	// TODO if d.HasChange("settings") doesn't work, so we just send an empty request if only restoring from backup
+
 	// Update only updates the settings, so they are all we need to set.
 	instance := &sqladmin.DatabaseInstance{
 		Settings: expandSqlDatabaseInstanceSettings(d.Get("settings").([]interface{}), !isFirstGen(d)),
@@ -1049,6 +1082,13 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 	err = sqlAdminOperationWaitTime(config, op, project, "Update Instance", userAgent, d.Timeout(schema.TimeoutUpdate))
 	if err != nil {
 		return err
+	}
+
+	if r, ok := d.GetOk("restore_backup_context"); ok {
+		err = sqlDatabaseInstanceRestoreFromBackup(d, config, userAgent, project, d.Get("name").(string), r)
+		if err != nil {
+			return err
+		}
 	}
 
 	return resourceSqlDatabaseInstanceRead(d, meta)
@@ -1342,4 +1382,42 @@ func sqlDatabaseInstanceServiceNetworkPrecheck(d *schema.ResourceData, config *C
 		}
 
 		return nil
+}
+
+func expandRestoreBackupContext(configured []interface{}) *sqladmin.RestoreBackupContext {
+	if len(configured) == 0 || configured[0] == nil {
+		return nil
+	}
+
+	_rc := configured[0].(map[string]interface{})
+	return &sqladmin.RestoreBackupContext{
+		BackupRunId: int64(_rc["backup_run_id"].(int)),
+		InstanceId:  _rc["instance_id"].(string),
+		Project:     _rc["project"].(string),
+	}
+}
+
+func sqlDatabaseInstanceRestoreFromBackup(d *schema.ResourceData, config *Config, userAgent, project, instanceId string, r []interface{}) error {
+	log.Printf("[DEBUG] Initiating SQL database instance backup restore")
+	restoreContext := r.([]interface{})
+
+	backupRequest := &sqladmin.InstancesRestoreBackupRequest{
+		RestoreBackupContext: expandRestoreBackupContext(restoreContext),
+	}
+
+	var op *sqladmin.Operation
+	err := retryTimeDuration(func() (operr error) {
+		op, operr = config.NewSqlAdminClient(userAgent).Instances.RestoreBackup(project, instanceId, backupRequest).Do()
+		return operr
+	}, d.Timeout(schema.TimeoutUpdate), isSqlOperationInProgressError)
+	if err != nil {
+		return fmt.Errorf("Error, failed to restore instance from backup %s: %s", instanceId, err)
+	}
+
+	err = sqlAdminOperationWaitTime(config, op, project, "Restore Backup", userAgent, d.Timeout(schema.TimeoutUpdate))
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -665,7 +665,7 @@ func TestAccSqlDatabaseInstance_basic_with_user_labels(t *testing.T) {
 }
 
 <% unless version == 'ga' -%>
-<%# This test doesn't work in GA yet because service networking is still in beta -%>
+<%# This test does not work in GA yet because service networking is still in beta -%>
 func TestAccSqlDatabaseInstance_withPrivateNetwork(t *testing.T) {
 	t.Parallel()
 
@@ -691,6 +691,71 @@ func TestAccSqlDatabaseInstance_withPrivateNetwork(t *testing.T) {
 	})
 }
 <% end -%>
+
+func TestAccSqlDatabaseInstance_createFromBackup(t *testing.T) {
+	// Sqladmin client
+	skipIfVcr(t)
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix":    randString(t, 10),
+		"original_db_name": BootstrapSharedSQLInstanceBackupRun(t),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSqlDatabaseInstance_restoreFromBackup(context),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "restore_backup_context"},
+			},
+		},
+	})
+}
+
+func TestAccSqlDatabaseInstance_backupUpdate(t *testing.T) {
+	// Sqladmin client
+	skipIfVcr(t)
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix":    randString(t, 10),
+		"original_db_name": BootstrapSharedSQLInstanceBackupRun(t),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSqlDatabaseInstance_beforeBackup(context),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config: testAccSqlDatabaseInstance_restoreFromBackup(context),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "restore_backup_context"},
+			},
+		},
+	})
+}
 
 func testAccSqlDatabaseInstanceDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
@@ -855,7 +920,7 @@ resource "google_sql_database_instance" "instance-failover" {
 }
 
 <% unless version == 'ga' -%>
-<%# This test doesn't work in GA yet because service networking is still in beta -%>
+<%# This test does not work in GA yet because service networking is still in beta -%>
 func testAccSqlDatabaseInstance_withPrivateNetwork(databaseName, networkName, addressRangeName string) string {
 	return fmt.Sprintf(`
 data "google_compute_network" "servicenet" {
@@ -1218,4 +1283,52 @@ resource "google_sql_database_instance" "instance" {
   }
 }
 `, masterID, pointInTimeRecoveryEnabled)
+}
+
+func testAccSqlDatabaseInstance_beforeBackup(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_sql_database_instance" "instance" {
+  name             = "tf-test-%{random_suffix}"
+  database_version = "POSTGRES_11"
+  region           = "us-central1"
+
+  settings {
+	tier = "db-f1-micro"
+	backup_configuration {
+		enabled            = "false"
+	}
+  }
+
+  deletion_protection = false
+}
+`, context)
+}
+
+func testAccSqlDatabaseInstance_restoreFromBackup(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_sql_database_instance" "instance" {
+  name             = "tf-test-%{random_suffix}"
+  database_version = "POSTGRES_11"
+  region           = "us-central1"
+
+  settings {
+	tier = "db-f1-micro"
+	backup_configuration {
+		enabled            = "false"
+	}
+  }
+
+  restore_backup_context {
+    backup_run_id = data.google_sql_backup_run.backup.backup_id
+    instance_id = data.google_sql_backup_run.backup.instance
+  }
+
+  deletion_protection = false
+}
+
+data "google_sql_backup_run" "backup" {
+	instance = "%{original_db_name}"
+	most_recent = true
+}
+`, context)
 }

--- a/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -234,6 +234,11 @@ includes an up-to-date reference of supported versions.
 * `deletion_protection` - (Optional, Default: `true` ) Whether or not to allow Terraform to destroy the instance. Unless this field is set to false
 in Terraform state, a `terraform destroy` or `terraform apply` command that deletes the instance will fail.
 
+* `restore_backup_context` - (optional) The context needed to restore the database to a backup run. This field will
+    cause Terraform to trigger the database to restore from the backup run indicated. The configuration is detailed below.
+    **NOTE:** Restoring from a backup is an imperative action and not recommended via Terraform. Adding or modifying this
+    block during resource creation/update will trigger the restore action after the resource is created/updated. 
+
 The required `settings` block supports:
 
 * `tier` - (Required) The machine type to use. See [tiers](https://cloud.google.com/sql/docs/admin-api/v1beta4/tiers)
@@ -372,6 +377,16 @@ to work, cannot be updated, and supports:
 
 * `verify_server_certificate` - (Optional) True if the master's common name
     value is checked during the SSL handshake.
+
+The optional `restore_backup_context` block supports:
+**NOTE:** Restoring from a backup is an imperative action and not recommended via Terraform. Adding or modifying this
+block during resource creation/update will trigger the restore action after the resource is created/updated. 
+
+* `backup_run_id` - (Required) The ID of the backup run to restore from.
+
+* `instance_id` - (Optional) The ID of the instance that the backup was taken from.
+
+* `project` - (Optional) The full project ID of the source instance.`
 
 ## Attributes Reference
 

--- a/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -384,7 +384,8 @@ block during resource creation/update will trigger the restore action after the 
 
 * `backup_run_id` - (Required) The ID of the backup run to restore from.
 
-* `instance_id` - (Optional) The ID of the instance that the backup was taken from.
+* `instance_id` - (Optional) The ID of the instance that the backup was taken from. If left empty,
+    this instance's ID will be used.
 
 * `project` - (Optional) The full project ID of the source instance.`
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/2446

Add support for the very imperative [restoreBackup](https://cloud.google.com/sql/docs/mysql/admin-api/rest/v1beta4/instances/restoreBackup) action. This change essentially triggers the restoreBackup action:

1. After the resource is created and `restore_backup_context` is set
2. At the end of update if `restore_backup_context` has a change

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
sql: added restore from backup support to `google_sql_database_instance`
```
