### PR TITLE
Add diff suppress for max retry 0s on google_cloud_tasks_queue.retry_config.max_retry_duration

### DIFF
--- a/compiler.rb
+++ b/compiler.rb
@@ -178,7 +178,7 @@ all_product_files.each do |product_name|
 
   unless product_api.exists_at_version_or_lower(version)
     Google::LOGGER.info \
-      "'#{product_name}' does not have a '#{version}' version, skipping"
+      "#{product_name} does not have a '#{version}' version, skipping"
     next
   end
 

--- a/products/cloudtasks/terraform.yaml
+++ b/products/cloudtasks/terraform.yaml
@@ -15,6 +15,8 @@
 overrides: !ruby/object:Overrides::ResourceOverrides
   Queue: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: "projects/{{project}}/locations/{{location}}/queues/{{name}}"
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      constants: "templates/terraform/constants/cloud_tasks_retry_config_custom_diff.go"
     docs: !ruby/object:Provider::Terraform::Docs
       warning: |
         This resource requires an App Engine application to be created on the
@@ -44,6 +46,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       retryConfig.maxRetryDuration: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+        diff_suppress_func: 'suppressOmittedMaxDuration'
       retryConfig.minBackoff: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       retryConfig.maxBackoff: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/provider/file_template.rb
+++ b/provider/file_template.rb
@@ -39,8 +39,8 @@ module Provider
       # If we've modified a file since starting an MM run, it's a reasonable
       # assumption that it was this run that modified it.
       if File.exist?(path) && File.mtime(path) > @env[:start_time]
-        raise "#{path} was already modified during this run.. check to see if" +
-        " there is both a .go and .go.erb version of this file"
+        raise "#{path} was already modified during this run.. check to see if"\
+              " there is both a .go and .go.erb version of this file"
       end
 
       # You're looking at some magic here!

--- a/provider/file_template.rb
+++ b/provider/file_template.rb
@@ -39,7 +39,7 @@ module Provider
       # If we've modified a file since starting an MM run, it's a reasonable
       # assumption that it was this run that modified it.
       if File.exist?(path) && File.mtime(path) > @env[:start_time]
-        raise "#{path} was already modified during this run.. check to see if there is both a .go and .goerb version of this file"
+        raise "#{path} was already modified during this run.. check to see if there is both a .go and .go.erb version of this file"
       end
 
       # You're looking at some magic here!

--- a/provider/file_template.rb
+++ b/provider/file_template.rb
@@ -39,7 +39,8 @@ module Provider
       # If we've modified a file since starting an MM run, it's a reasonable
       # assumption that it was this run that modified it.
       if File.exist?(path) && File.mtime(path) > @env[:start_time]
-        raise "#{path} was already modified during this run.. check to see if there is both a .go and .go.erb version of this file"
+        raise "#{path} was already modified during this run.. check to see if" +
+        " there is both a .go and .go.erb version of this file"
       end
 
       # You're looking at some magic here!

--- a/provider/file_template.rb
+++ b/provider/file_template.rb
@@ -39,7 +39,7 @@ module Provider
       # If we've modified a file since starting an MM run, it's a reasonable
       # assumption that it was this run that modified it.
       if File.exist?(path) && File.mtime(path) > @env[:start_time]
-        raise "#{path} was already modified during this run"
+        raise "#{path} was already modified during this run.. check to see if there is both a .go and .goerb version of this file"
       end
 
       # You're looking at some magic here!

--- a/provider/file_template.rb
+++ b/provider/file_template.rb
@@ -40,7 +40,7 @@ module Provider
       # assumption that it was this run that modified it.
       if File.exist?(path) && File.mtime(path) > @env[:start_time]
         raise "#{path} was already modified during this run.. check to see if"\
-              " there is both a .go and .go.erb version of this file"
+              ' there is both a .go and .go.erb version of this file'
       end
 
       # You're looking at some magic here!

--- a/templates/terraform/constants/cloud_tasks_retry_config_custom_diff.go
+++ b/templates/terraform/constants/cloud_tasks_retry_config_custom_diff.go
@@ -1,0 +1,7 @@
+func suppressOmittedMaxDuration(_, old, new string, _ *schema.ResourceData) bool {
+	if old == "" && new == "0s" {
+		log.Printf("[INFO] max retry is 0s and api omitted field, supressing diff")
+		return true
+	}
+	return false
+}

--- a/third_party/terraform/tests/resource_cloud_tasks_queue_test.go.erb
+++ b/third_party/terraform/tests/resource_cloud_tasks_queue_test.go.erb
@@ -70,6 +70,26 @@ func TestAccCloudTasksQueue_update2Basic(t *testing.T) {
 	})
 }
 
+func TestAccCloudTasksQueue_MaxRetryDiffSuppress0s(t *testing.T) {
+	t.Parallel()
+	testID := randString(t, 10)
+	cloudTaskName := fmt.Sprintf("tf-test-%s", testID)
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudtasksQueueMaxRetry0s(cloudTaskName),
+			},
+			{
+				ResourceName:      "google_cloud_tasks_queue.default",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCloudTasksQueue_basic(name string) string {
 	return fmt.Sprintf(`
 resource "google_cloud_tasks_queue" "default" {
@@ -146,4 +166,21 @@ resource "google_cloud_tasks_queue" "default" {
 	}
 }
 `, name)
+}
+
+func testAccCloudtasksQueueMaxRetry0s(cloudTaskName string) string {
+	return fmt.Sprintf(`
+	resource "google_cloud_tasks_queue" "default" {
+		name = "%s"
+		location = "us-central1"
+
+		retry_config {
+							max_attempts       = -1
+							max_backoff        = "3600s"
+							max_doublings      = 16
+							max_retry_duration = "0s"
+							min_backoff        = "0.100s"
+		}
+	}
+`, cloudTaskName)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

resolves [8028](https://github.com/hashicorp/terraform-provider-google/issues/8028)

Adding diff suppress for max retry 0s on google_cloud_tasks_queue.retry_config.max_retry_duration
If the user specifies 0s the api omits this field in the response.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
cloud_tasks: fixed permadiff on retry_config.max_retry_duration for `google_cloud_tasks_queue` when the 0s is supplied
```
