### PR TITLE
Fixed google_logging_project_sink.disabled can not updated

### DIFF
--- a/third_party/terraform/resources/resource_logging_sink.go
+++ b/third_party/terraform/resources/resource_logging_sink.go
@@ -152,7 +152,8 @@ func expandResourceLoggingSinkForUpdate(d *schema.ResourceData) (sink *logging.L
 	sink = &logging.LogSink{
 		Destination:     d.Get("destination").(string),
 		Filter:          d.Get("filter").(string),
-		ForceSendFields: []string{"Destination", "Filter"},
+		Disabled:        d.Get("disabled").(bool),
+		ForceSendFields: []string{"Destination", "Filter", "Disabled"},
 	}
 
 	updateFields := []string{}

--- a/third_party/terraform/tests/resource_logging_project_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_project_sink_test.go
@@ -241,6 +241,43 @@ func TestLoggingProjectSink_bigqueryOptionCustomizedDiff(t *testing.T) {
 	}
 }
 
+func TestAccLoggingProjectSink_disabled_update(t *testing.T) {
+	t.Parallel()
+
+	sinkName := "tf-test-sink-" + randString(t, 10)
+	bucketName := "tf-test-sink-bucket-" + randString(t, 10)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLoggingProjectSinkDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLoggingProjectSink_disabled_update(sinkName, getTestProjectFromEnv(), bucketName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_logging_project_sink.disabled", "disabled", "true"),
+				),
+			},
+			{
+				ResourceName:      "google_logging_project_sink.disabled",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccLoggingProjectSink_disabled_update(sinkName, getTestProjectFromEnv(), bucketName, "false"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_logging_project_sink.disabled", "disabled", "false"),
+				),
+			},
+			{
+				ResourceName:      "google_logging_project_sink.disabled",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckLoggingProjectSinkDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		config := googleProviderConfig(t)
@@ -313,6 +350,24 @@ resource "google_storage_bucket" "log-bucket" {
   name = "%s"
 }
 `, name, project, project, bucketName)
+}
+
+func testAccLoggingProjectSink_disabled_update(name, project, bucketName, disbaled string) string {
+	return fmt.Sprintf(`
+resource "google_logging_project_sink" "disabled" {
+  name        = "%s"
+  project     = "%s"
+  destination = "storage.googleapis.com/${google_storage_bucket.log-bucket.name}"
+  filter      = "logName=\"projects/%s/logs/compute.googleapis.com%%2Factivity_log\" AND severity>=ERROR"
+  disabled    = "%s"
+
+  unique_writer_identity = true
+}
+
+resource "google_storage_bucket" "log-bucket" {
+  name = "%s"
+}
+`, name, project, project, disbaled, bucketName)
 }
 
 func testAccLoggingProjectSink_uniqueWriter(name, bucketName string) string {

--- a/third_party/terraform/tests/resource_logging_project_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_project_sink_test.go
@@ -352,7 +352,7 @@ resource "google_storage_bucket" "log-bucket" {
 `, name, project, project, bucketName)
 }
 
-func testAccLoggingProjectSink_disabled_update(name, project, bucketName, disbaled string) string {
+func testAccLoggingProjectSink_disabled_update(name, project, bucketName, disabled string) string {
 	return fmt.Sprintf(`
 resource "google_logging_project_sink" "disabled" {
   name        = "%s"
@@ -367,7 +367,7 @@ resource "google_logging_project_sink" "disabled" {
 resource "google_storage_bucket" "log-bucket" {
   name = "%s"
 }
-`, name, project, project, disbaled, bucketName)
+`, name, project, project, disabled, bucketName)
 }
 
 func testAccLoggingProjectSink_uniqueWriter(name, bucketName string) string {

--- a/third_party/terraform/tests/resource_logging_project_sink_test.go
+++ b/third_party/terraform/tests/resource_logging_project_sink_test.go
@@ -274,6 +274,17 @@ func TestAccLoggingProjectSink_disabled_update(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
+			{
+				Config: testAccLoggingProjectSink_disabled_update(sinkName, getTestProjectFromEnv(), bucketName, "true"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("google_logging_project_sink.disabled", "disabled", "true"),
+				),
+			},
+			{
+				ResourceName:      "google_logging_project_sink.disabled",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
…to true

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/8035


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Logging: fixed updating on disabled in `google_logging_project_sink`
```
