### PR TITLE
Add ga version of bigquery reservation

### DIFF
--- a/products/bigqueryreservation/api.yaml
+++ b/products/bigqueryreservation/api.yaml
@@ -18,6 +18,9 @@ versions:
   - !ruby/object:Api::Product::Version
     name: beta
     base_url: https://bigqueryreservation.googleapis.com/v1beta1/
+  - !ruby/object:Api::Product::Version
+    name: ga
+    base_url: https://bigqueryreservation.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/bigquery
 apis_required:

--- a/products/bigqueryreservation/terraform.yaml
+++ b/products/bigqueryreservation/terraform.yaml
@@ -17,7 +17,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   Reservation: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples
-        min_version: beta
         name: "bigquery_reservation_basic"
         primary_resource_id: "reservation"
         vars:

--- a/templates/terraform/examples/bigquery_reservation_basic.tf.erb
+++ b/templates/terraform/examples/bigquery_reservation_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_bigquery_reservation" "<%= ctx[:primary_resource_id] %>" {
-	provider       = google-beta
 	name           = "<%= ctx[:vars]['name'] %>"
 	location       = "asia-northeast1"
 	// Set to 0 for testing purposes


### PR DESCRIPTION
https://cloud.google.com/bigquery/docs/release-notes#April_16_2020

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Moves bigqueryreservation to GA.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/8058.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: promoted bigquery reservation to GA.
```
