### PR TITLE
sync handwritten validator storage bucket with the provider version

### DIFF
--- a/third_party/validator/storage_bucket.go
+++ b/third_party/validator/storage_bucket.go
@@ -283,12 +283,34 @@ func resourceGCSBucketLifecycleCreateOrUpdate(d TerraformResourceData, sb *stora
 	return nil
 }
 
+// remove this on next major release of the provider.
 func expandIamConfiguration(d TerraformResourceData) *storage.BucketIamConfiguration {
+	// We are checking for a change because the last else block is only executed on Create.
+	enabled := false
+	if d.HasChange("bucket_policy_only") {
+		enabled = d.Get("bucket_policy_only").(bool)
+	} else if d.HasChange("uniform_bucket_level_access") {
+		enabled = d.Get("uniform_bucket_level_access").(bool)
+	} else {
+		enabled = d.Get("bucket_policy_only").(bool) || d.Get("uniform_bucket_level_access").(bool)
+	}
+
 	return &storage.BucketIamConfiguration{
-		ForceSendFields: []string{"BucketPolicyOnly"},
-		BucketPolicyOnly: &storage.BucketIamConfigurationBucketPolicyOnly{
-			Enabled:         d.Get("bucket_policy_only").(bool),
+		ForceSendFields: []string{"UniformBucketLevelAccess"},
+		UniformBucketLevelAccess: &storage.BucketIamConfigurationUniformBucketLevelAccess{
+			Enabled:         enabled,
 			ForceSendFields: []string{"Enabled"},
 		},
 	}
 }
+
+// Uncomment once the previous function is removed.
+// func expandIamConfiguration(d TerraformResourceData) *storage.BucketIamConfiguration {
+// 	return &storage.BucketIamConfiguration{
+// 		ForceSendFields: []string{"UniformBucketLevelAccess"},
+// 		UniformBucketLevelAccess: &storage.BucketIamConfigurationUniformBucketLevelAccess{
+// 			Enabled:         d.Get("uniform_bucket_level_access").(bool),
+// 			ForceSendFields: []string{"Enabled"},
+// 		},
+// 	}
+// }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR syncs the handwritten storage bucket resource for terrafrom-google-conversion (validator) with the [handwritten version](https://github.com/GoogleCloudPlatform/magic-modules/blob/6daa834e4b35f20fe690c316d3b358cd14f42b00/third_party/terraform/resources/resource_storage_bucket.go#L1111) used in the terraform Google provider that was  updated to use `uniform-bucket-level-access` since `bucket_policy_only` was deprecated.

Provider version of the code:
https://github.com/GoogleCloudPlatform/magic-modules/blob/6daa834e4b35f20fe690c316d3b358cd14f42b00/third_party/terraform/resources/resource_storage_bucket.go#L1111

Closes https://github.com/GoogleCloudPlatform/terraform-google-conversion/issues/591

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
Sync handwritten validator storage bucket with the provider version
```
