### PR TITLE
Fix some network / firewall prefixes to allow sweeping

### DIFF
--- a/third_party/terraform/tests/data_source_google_compute_subnetwork_test.go
+++ b/third_party/terraform/tests/data_source_google_compute_subnetwork_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceGoogleSubnetwork(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceGoogleSubnetwork(fmt.Sprintf("network-test-%d", randInt(t))),
+				Config: testAccDataSourceGoogleSubnetwork(fmt.Sprintf("tf-test-subnetwork-ds-%d", randInt(t))),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceGoogleSubnetworkCheck("data.google_compute_subnetwork.my_subnetwork", "google_compute_subnetwork.foobar"),
 					testAccDataSourceGoogleSubnetworkCheck("data.google_compute_subnetwork.my_subnetwork_self_link", "google_compute_subnetwork.foobar"),
@@ -73,7 +73,7 @@ func testAccDataSourceGoogleSubnetworkCheck(data_source_name string, resource_na
 	}
 }
 
-func testAccDataSourceGoogleSubnetwork(networkName string) string {
+func testAccDataSourceGoogleSubnetwork(name string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "foobar" {
   name        = "%s"
@@ -81,7 +81,7 @@ resource "google_compute_network" "foobar" {
 }
 
 resource "google_compute_subnetwork" "foobar" {
-  name                     = "subnetwork-test"
+  name                     = "%s"
   description              = "my-description"
   ip_cidr_range            = "10.0.0.0/24"
   network                  = google_compute_network.foobar.self_link
@@ -99,5 +99,5 @@ data "google_compute_subnetwork" "my_subnetwork" {
 data "google_compute_subnetwork" "my_subnetwork_self_link" {
   self_link = google_compute_subnetwork.foobar.self_link
 }
-`, networkName)
+`, name, name)
 }

--- a/third_party/terraform/tests/resource_compute_firewall_test.go.erb
+++ b/third_party/terraform/tests/resource_compute_firewall_test.go.erb
@@ -11,8 +11,8 @@ import (
 func TestAccComputeFirewall_update(t *testing.T) {
 	t.Parallel()
 
-	networkName := fmt.Sprintf("firewall-test-%s", randString(t, 10))
-	firewallName := fmt.Sprintf("firewall-test-%s", randString(t, 10))
+	networkName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
+	firewallName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -50,8 +50,8 @@ func TestAccComputeFirewall_update(t *testing.T) {
 func TestAccComputeFirewall_priority(t *testing.T) {
 	t.Parallel()
 
-	networkName := fmt.Sprintf("firewall-test-%s", randString(t, 10))
-	firewallName := fmt.Sprintf("firewall-test-%s", randString(t, 10))
+	networkName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
+	firewallName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -73,8 +73,8 @@ func TestAccComputeFirewall_priority(t *testing.T) {
 func TestAccComputeFirewall_noSource(t *testing.T) {
 	t.Parallel()
 
-	networkName := fmt.Sprintf("firewall-test-%s", randString(t, 10))
-	firewallName := fmt.Sprintf("firewall-test-%s", randString(t, 10))
+	networkName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
+	firewallName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -96,8 +96,8 @@ func TestAccComputeFirewall_noSource(t *testing.T) {
 func TestAccComputeFirewall_denied(t *testing.T) {
 	t.Parallel()
 
-	networkName := fmt.Sprintf("firewall-test-%s", randString(t, 10))
-	firewallName := fmt.Sprintf("firewall-test-%s", randString(t, 10))
+	networkName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
+	firewallName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -119,8 +119,8 @@ func TestAccComputeFirewall_denied(t *testing.T) {
 func TestAccComputeFirewall_egress(t *testing.T) {
 	t.Parallel()
 
-	networkName := fmt.Sprintf("firewall-test-%s", randString(t, 10))
-	firewallName := fmt.Sprintf("firewall-test-%s", randString(t, 10))
+	networkName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
+	firewallName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -142,11 +142,11 @@ func TestAccComputeFirewall_egress(t *testing.T) {
 func TestAccComputeFirewall_serviceAccounts(t *testing.T) {
 	t.Parallel()
 
-	networkName := fmt.Sprintf("firewall-test-%s", randString(t, 10))
-	firewallName := fmt.Sprintf("firewall-test-%s", randString(t, 10))
+	networkName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
+	firewallName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
 
-	sourceSa := fmt.Sprintf("firewall-test-%s", randString(t, 10))
-	targetSa := fmt.Sprintf("firewall-test-%s", randString(t, 10))
+	sourceSa := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
+	targetSa := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -168,8 +168,8 @@ func TestAccComputeFirewall_serviceAccounts(t *testing.T) {
 func TestAccComputeFirewall_disabled(t *testing.T) {
 	t.Parallel()
 
-	networkName := fmt.Sprintf("firewall-test-%s", randString(t, 10))
-	firewallName := fmt.Sprintf("firewall-test-%s", randString(t, 10))
+	networkName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
+	firewallName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -199,8 +199,8 @@ func TestAccComputeFirewall_disabled(t *testing.T) {
 func TestAccComputeFirewall_enableLogging(t *testing.T) {
 	t.Parallel()
 
-	networkName := fmt.Sprintf("firewall-test-%s", randString(t, 10))
-	firewallName := fmt.Sprintf("firewall-test-%s", randString(t, 10))
+	networkName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
+	firewallName := fmt.Sprintf("tf-test-firewall-%s", randString(t, 10))
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/third_party/terraform/tests/resource_compute_network_peering_test.go
+++ b/third_party/terraform/tests/resource_compute_network_peering_test.go
@@ -11,7 +11,7 @@ import (
 func TestAccComputeNetworkPeering_basic(t *testing.T) {
 	t.Parallel()
 
-	primaryNetworkName := fmt.Sprintf("network-test-1-%d", randInt(t))
+	primaryNetworkName := fmt.Sprintf("tf-test-network-peering-1-%d", randInt(t))
 	peeringName := fmt.Sprintf("peering-test-1-%d", randInt(t))
 	importId := fmt.Sprintf("%s/%s/%s", getTestProjectFromEnv(), primaryNetworkName, peeringName)
 
@@ -37,7 +37,7 @@ func TestAccComputeNetworkPeering_basic(t *testing.T) {
 func TestAccComputeNetworkPeering_subnetRoutes(t *testing.T) {
 	t.Parallel()
 
-	primaryNetworkName := fmt.Sprintf("network-test-1-%d", randInt(t))
+	primaryNetworkName := fmt.Sprintf("tf-test-network-peering-1-%d", randInt(t))
 	peeringName := fmt.Sprintf("peering-test-%d", randInt(t))
 	importId := fmt.Sprintf("%s/%s/%s", getTestProjectFromEnv(), primaryNetworkName, peeringName)
 
@@ -62,7 +62,7 @@ func TestAccComputeNetworkPeering_subnetRoutes(t *testing.T) {
 func TestAccComputeNetworkPeering_customRoutesUpdate(t *testing.T) {
 	t.Parallel()
 
-	primaryNetworkName := fmt.Sprintf("network-test-1-%d", randInt(t))
+	primaryNetworkName := fmt.Sprintf("tf-test-network-peering-1-%d", randInt(t))
 	peeringName := fmt.Sprintf("peering-test-%d", randInt(t))
 	importId := fmt.Sprintf("%s/%s/%s", getTestProjectFromEnv(), primaryNetworkName, peeringName)
 	suffix := randString(t, 10)
@@ -128,7 +128,7 @@ resource "google_compute_network_peering" "foo" {
 }
 
 resource "google_compute_network" "network2" {
-  name                    = "network-test-2-%s"
+  name                    = "tf-test-network-peering-2-%s"
   auto_create_subnetworks = false
 }
 
@@ -150,7 +150,7 @@ resource "google_compute_network" "network1" {
 }
 
 resource "google_compute_network" "network2" {
-  name                    = "network-test-2-%s"
+  name                    = "tf-test-network-peering-2-%s"
   auto_create_subnetworks = false
 }
 
@@ -178,7 +178,7 @@ resource "google_compute_network_peering" "foo" {
 }
 
 resource "google_compute_network" "network2" {
-  name                    = "network-test-2-%s"
+  name                    = "tf-test-network-peering-2-%s"
   auto_create_subnetworks = false
 }
 

--- a/third_party/terraform/tests/resource_compute_network_test.go
+++ b/third_party/terraform/tests/resource_compute_network_test.go
@@ -278,7 +278,7 @@ func testAccCheckComputeNetworkHasRoutingMode(t *testing.T, n string, network *c
 func testAccComputeNetwork_basic(suffix string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "bar" {
-  name                    = "network-test-%s"
+  name                    = "tf-test-network-basic-%s"
   auto_create_subnetworks = true
 }
 `, suffix)
@@ -287,7 +287,7 @@ resource "google_compute_network" "bar" {
 func testAccComputeNetwork_custom_subnet(suffix string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "baz" {
-  name                    = "network-test-%s"
+  name                    = "tf-test-network-custom-sn-%s"
   auto_create_subnetworks = false
 }
 `, suffix)
@@ -296,7 +296,7 @@ resource "google_compute_network" "baz" {
 func testAccComputeNetwork_routing_mode(network, routingMode string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "acc_network_routing_mode" {
-  name         = "network-test-%s"
+  name         = "tf-test-network-routing-mode-%s"
   routing_mode = "%s"
 }
 `, network, routingMode)
@@ -305,7 +305,7 @@ resource "google_compute_network" "acc_network_routing_mode" {
 func testAccComputeNetwork_deleteDefaultRoute(suffix string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "bar" {
-  name                            = "network-test-%s"
+  name                            = "tf-test-network-delete-default-routes-%s"
   delete_default_routes_on_create = true
   auto_create_subnetworks         = false
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
