### PR TITLE
Added support for Private Services Connect for Google APIs

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -3983,7 +3983,8 @@ objects:
           The prefix length of the IP range. If not present, it means the
           address field is a single IP address.
 
-          This field is not applicable to addresses with addressType=EXTERNAL.
+          This field is not applicable to addresses with addressType=EXTERNAL,
+          or addressType=INTERNAL when purpose=PRIVATE_SERVICE_CONNECT
       - !ruby/object:Api::Type::Enum
         name: 'addressType'
         description: |
@@ -4001,10 +4002,12 @@ objects:
           The purpose of the resource. For global internal addresses it can be
 
           * VPC_PEERING - for peer networks
+          * PRIVATE_SERVICE_CONNECT - for ([Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) only) Private Service Connect networks
 
           This should only be set when using an Internal address.
         values:
         - :VPC_PEERING
+        - :PRIVATE_SERVICE_CONNECT
       - !ruby/object:Api::Type::ResourceRef
         name: 'network'
         resource: 'Network'
@@ -4082,6 +4085,10 @@ objects:
           static IP address), with a purpose of GCE_END_POINT and addressType
           of INTERNAL.
 
+          ([Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) only) This must be a URL reference to an existing Address
+          resource (internal global static IP address), with a purpose of
+          PRIVATE_SERVICE_CONNECT and addressType of INTERNAL.
+
           An address can be specified either by a literal IP address or a URL
           reference to an existing Address resource. The following examples are
           all valid:
@@ -4097,7 +4104,9 @@ objects:
         name: 'IPProtocol'
         description: |
           The IP protocol to which this rule applies. When the load balancing scheme is
-          INTERNAL_SELF_MANAGED, only TCP is valid.
+          INTERNAL_SELF_MANAGED, only TCP is valid. This field must not be set if the
+          global address is configured as a purpose of PRIVATE_SERVICE_CONNECT
+          and addressType of INTERNAL
         values:
           - :TCP
           - :UDP
@@ -4136,8 +4145,8 @@ objects:
           will be used for External Global Load Balancing (HTTP(S) LB,
           External TCP/UDP LB, SSL Proxy)
 
-          NOTE: Currently global forwarding rules cannot be used for INTERNAL
-          load balancing.
+          ([Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) only) Note: This field must be set "" if the global address is
+          configured as a purpose of PRIVATE_SERVICE_CONNECT and addressType of INTERNAL.
         default_value: :EXTERNAL
         values:
           - :EXTERNAL
@@ -4260,6 +4269,9 @@ objects:
           The forwarded traffic must be of a type appropriate to the target object.
           For INTERNAL_SELF_MANAGED load balancing, only HTTP and HTTPS targets
           are valid.
+
+          ([Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) only) For global address with a purpose of PRIVATE_SERVICE_CONNECT and
+          addressType of INTERNAL, only "all-apis" and "vpc-sc" are valid.
         update_verb: :POST
         update_url: 'projects/{{project}}/global/forwardingRules/{{name}}/setTarget'
   - !ruby/object:Api::Resource

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -762,6 +762,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "default"
         vars:
           global_address_name: "global-appserver-ip"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "global_address_private_services_connect"
+        min_version: beta
+        primary_resource_id: "default"
+        vars:
+          global_address_name: "global-psconnect-ip"
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
@@ -795,6 +801,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           http_proxy_name: "target-proxy"
           backend_service_name: "backend"
           igm_name: "igm-internal"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "global_forwarding_rule_private_services_connect"
+        min_version: beta
+        primary_resource_id: "default"
+        vars:
+          global_address_name: "global-psconnect-ip"
+          forwarding_rule_name: "globalrule"
     properties:
       creationTimestamp: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
@@ -802,8 +815,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         exclude: true
       IPAddress: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
-        validation: !ruby/object:Provider::Terraform::Validation
-          function: 'validateIpAddress'
+        diff_suppress_func: 'internalIpDiffSuppress'
         description: |
           The IP address that this forwarding rule is serving on behalf of.
 

--- a/mmv1/templates/terraform/examples/global_address_private_services_connect.tf.erb
+++ b/mmv1/templates/terraform/examples/global_address_private_services_connect.tf.erb
@@ -3,11 +3,12 @@ resource "google_compute_global_address" "default" {
   name          = "<%= ctx[:vars]['global_address_name'] %>"
   address_type  = "INTERNAL"
   purpose       = "PRIVATE_SERVICE_CONNECT"
-  network       = data.google_compute_network.network.id
+  network       = google_compute_network.network.id
   address       = "100.100.100.105"
 }
 
-data "google_compute_network" "network" {
+resource "google_compute_network" "network" {
   provider      = google-beta
-  name          = "default"
+  name          = "tf-test%{random_suffix}"
+  auto_create_subnetworks = false
 }

--- a/mmv1/templates/terraform/examples/global_address_private_services_connect.tf.erb
+++ b/mmv1/templates/terraform/examples/global_address_private_services_connect.tf.erb
@@ -1,0 +1,13 @@
+resource "google_compute_global_address" "default" {
+  provider      = google-beta
+  name          = "<%= ctx[:vars]['global_address_name'] %>"
+  address_type  = "INTERNAL"
+  purpose       = "PRIVATE_SERVICE_CONNECT"
+  network       = data.google_compute_network.network.id
+  address       = "100.100.100.105"
+}
+
+data "google_compute_network" "network" {
+  provider      = google-beta
+  name          = "default"
+}

--- a/mmv1/templates/terraform/examples/global_forwarding_rule_private_services_connect.tf.erb
+++ b/mmv1/templates/terraform/examples/global_forwarding_rule_private_services_connect.tf.erb
@@ -1,0 +1,22 @@
+resource "google_compute_global_address" "default" {
+  provider      = google-beta
+  name          = "<%= ctx[:vars]['global_address_name'] %>"
+  address_type  = "INTERNAL"
+  purpose       = "PRIVATE_SERVICE_CONNECT"
+  network       = data.google_compute_network.network.id
+  address       = "100.100.100.106"
+}
+
+resource "google_compute_global_forwarding_rule" "default" {
+  provider      = google-beta
+  name          = "<%= ctx[:vars]['forwarding_rule_name'] %>"
+  target        = "all-apis"
+  network       = data.google_compute_network.network.id
+  ip_address    = google_compute_global_address.default.id
+  load_balancing_scheme = ""
+}
+
+data "google_compute_network" "network" {
+  provider      = google-beta
+  name          = "default"
+}

--- a/mmv1/templates/terraform/examples/global_forwarding_rule_private_services_connect.tf.erb
+++ b/mmv1/templates/terraform/examples/global_forwarding_rule_private_services_connect.tf.erb
@@ -3,7 +3,7 @@ resource "google_compute_global_address" "default" {
   name          = "<%= ctx[:vars]['global_address_name'] %>"
   address_type  = "INTERNAL"
   purpose       = "PRIVATE_SERVICE_CONNECT"
-  network       = data.google_compute_network.network.id
+  network       = google_compute_network.network.id
   address       = "100.100.100.106"
 }
 
@@ -11,12 +11,13 @@ resource "google_compute_global_forwarding_rule" "default" {
   provider      = google-beta
   name          = "<%= ctx[:vars]['forwarding_rule_name'] %>"
   target        = "all-apis"
-  network       = data.google_compute_network.network.id
+  network       = google_compute_network.network.id
   ip_address    = google_compute_global_address.default.id
   load_balancing_scheme = ""
 }
 
-data "google_compute_network" "network" {
+resource "google_compute_network" "network" {
   provider      = google-beta
-  name          = "default"
+  name          = "tf-test%{random_suffix}"
+  auto_create_subnetworks = false
 }

--- a/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
@@ -159,3 +159,9 @@ func timestampDiffSuppress(format string) schema.SchemaDiffSuppressFunc {
 		return oldT == newT
 	}
 }
+
+// suppress diff when saved is Ipv4 format while new is required a reference
+// this happens for an internal ip for Private Services Connect
+func internalIpDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
+	return (net.ParseIP(old) != nil) && (net.ParseIP(new) == nil)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/8018


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added support for Private Services Connect for Google APIs in `google_compute_global_address `
compute: Added support for Private Services Connect for Google APIs` in `google_compute_global_forwarding_rule `
```
