### PR TITLE
Sweep vpc connector

### DIFF
--- a/products/vpcaccess/terraform.yaml
+++ b/products/vpcaccess/terraform.yaml
@@ -24,7 +24,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "vpc_access_connector"
         primary_resource_id: "connector"
         vars:
-          name: "tf-test-vpcon"
+          name: "vpc-con"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       encoder: templates/terraform/encoders/no_send_name.go.erb
       post_create: templates/terraform/post_create/sleep.go.erb

--- a/products/vpcaccess/terraform.yaml
+++ b/products/vpcaccess/terraform.yaml
@@ -24,9 +24,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "vpc_access_connector"
         primary_resource_id: "connector"
         vars:
-          # The VPC connector has a name limit of 25 characters
-          # and we add "tf-test" (len 7) prefix and random suffix (len = 10)
-          name: "vpcconn"
+          name: "tf-test-vpcon"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       encoder: templates/terraform/encoders/no_send_name.go.erb
       post_create: templates/terraform/post_create/sleep.go.erb


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Firewall rules from these seem to be filling up the CI project



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
