### PR TITLE
Updated tgc-test docker container to be built with go 1.14, which is required by terraform-google-conversion

### DIFF
--- a/.ci/containers/terraform-google-conversion-tester/Dockerfile
+++ b/.ci/containers/terraform-google-conversion-tester/Dockerfile
@@ -1,4 +1,4 @@
-from golang:1.13-stretch as resource
+from golang:1.14-stretch as resource
 SHELL ["/bin/bash", "-c"]
 # Set up Github SSH cloning.
 RUN ssh-keyscan github.com >> /known_hosts


### PR DESCRIPTION
Technically this is not necessary but it was a bit of a red herring to see in the logs so I figured it might be good to fix.
Related to https://github.com/GoogleCloudPlatform/magic-modules/pull/4356

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
