### PR TITLE
Fix wrong initialization of maintenance_exclusion

### DIFF
--- a/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -2906,16 +2906,19 @@ func expandMaintenancePolicy(d *schema.ResourceData, meta interface{}) *containe
 	}
 	cluster, _ := clusterGetCall.Do()
 	resourceVersion := ""
-	// If the cluster doesn't exist or if there is a read error of any kind, we will pass in an empty
-	// resourceVersion.  If there happens to be a change to maintenance policy, we will fail at that
-	// point.  This is a compromise between code cleanliness and a slightly worse user experience in
-	// an unlikely error case - we choose code cleanliness.
-	if cluster != nil && cluster.MaintenancePolicy != nil {
-		resourceVersion = cluster.MaintenancePolicy.ResourceVersion
-	}
 	exclusions := make(map[string]containerBeta.TimeWindow)
-	if cluster != nil && cluster.MaintenancePolicy != nil && cluster.MaintenancePolicy.Window != nil {
-		exclusions = cluster.MaintenancePolicy.Window.MaintenanceExclusions
+	if cluster != nil && cluster.MaintenancePolicy != nil {
+		// If the cluster doesn't exist or if there is a read error of any kind, we will pass in an empty
+		// resourceVersion.  If there happens to be a change to maintenance policy, we will fail at that
+		// point.  This is a compromise between code cleanliness and a slightly worse user experience in
+		// an unlikely error case - we choose code cleanliness.
+		resourceVersion = cluster.MaintenancePolicy.ResourceVersion
+
+		// Having a MaintenancePolicy doesn't mean that you need MaintenanceExclusions, but if they were set,
+		// they need to be assigned to exclusions.
+		if cluster.MaintenancePolicy.Window != nil && cluster.MaintenancePolicy.Window.MaintenanceExclusions != nil {
+			exclusions = cluster.MaintenancePolicy.Window.MaintenanceExclusions
+		}
 	}
 
 	configured := d.Get("maintenance_policy")


### PR DESCRIPTION
This PR fixes hashicorp/terraform-provider-google/issues/8112


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: Fix crash due to nil exclusions object when updating an existent cluster with maintenance_policy but without exclusions
```
