### PR TITLE
Fix dataproc tests

### DIFF
--- a/third_party/terraform/tests/resource_dataproc_job_test.go
+++ b/third_party/terraform/tests/resource_dataproc_job_test.go
@@ -352,7 +352,7 @@ func testAccCheckDataprocJobCompletesSuccessfully(t *testing.T, n string, job *d
 				log.Printf("[ERROR] Job failed, driver logs:\n%s", body)
 			}
 			return fmt.Errorf("Job completed in ERROR state, check logs for details")
-		} else if completeJob.Status.State != "DONE" {
+		} else if completeJob.Status.State != "DONE" && completeJob.Status.State != "RUNNING" {
 			return fmt.Errorf("Job did not complete successfully, instead status: %s", completeJob.Status.State)
 		}
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/8152

After https://github.com/GoogleCloudPlatform/magic-modules/pull/4341 , acceptable completed job statuses include `RUNNING`


```release-note:none
```
