### PR TITLE
Add Certificate Authority Resource (Certificate Authority Service)

### DIFF
--- a/products/privateca/api.yaml
+++ b/products/privateca/api.yaml
@@ -1,0 +1,265 @@
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Api::Product
+name: Privateca
+display_name: Certificate Authority
+versions:
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://privateca.googleapis.com/v1beta1/
+scopes:
+  - https://www.googleapis.com/auth/cloud-platform
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: Certificate Authority API
+    url: https://console.cloud.google.com/apis/api/privateca.googleapis.com
+async: !ruby/object:Api::OpAsync
+    operation: !ruby/object:Api::OpAsync::Operation
+      base_url: '{{op_id}}'
+      path: 'name'
+      wait_ms: 1000
+    result: !ruby/object:Api::OpAsync::Result
+      path: 'response'
+      resource_inside_response: true
+    status: !ruby/object:Api::OpAsync::Status
+      path: 'done'
+      complete: True
+      allowed:
+        - True
+        - False
+    error: !ruby/object:Api::OpAsync::Error
+      path: 'error'
+      message: 'message'
+objects:
+  # CertificateAuthority
+  - !ruby/object:Api::Resource
+    name: 'CertificateAuthority'
+    description: |
+        A CertificateAuthority represents an individual Certificate Authority. A
+        CertificateAuthority can be used to create Certificates.
+    base_url: projects/{{project}}/locations/{{location}}/certificateAuthorities
+    create_url: projects/{{project}}/locations/{{location}}/certificateAuthorities?certificateAuthorityId={{certificate_authority_id}}
+    self_link: projects/{{project}}/locations/{{location}}/certificateAuthorities/{{certificate_authority_id}}
+    min_version: beta
+    create_verb: :POST
+    delete_url: '{{name}}:scheduleDelete'
+    delete_verb: :POST
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+          'https://cloud.google.com/certificate-authority-service'
+      api: 'https://https://cloud.google.com/certificate-authority-service/docs/reference/rest'
+    properties:
+      - !ruby/object:Api::Type::String
+        name: location
+        description: Location of the Certificate Authority.
+        required: true
+        url_param_only: true
+      - !ruby/object:Api::Type::String
+        name: certificateAuthorityId
+        description: GCP region of the Realm.
+        input: true
+        required: true
+        url_param_only: true
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        description: |
+            The resource name for this CertificateAuthority in the format
+            projects/*/locations/*/certificateAuthorities/*.
+        output: true
+      - !ruby/object:Api::Type::Enum
+        name: 'type'
+        description: The Type of this CertificateAuthority.
+        input: true
+        values:
+          - :SELF_SIGNED
+        default_value: :SELF_SIGNED
+      - !ruby/object:Api::Type::Enum
+        name: 'tier'
+        description: The Tier of this CertificateAuthority.
+        input: true
+        values:
+          - :ENTERPRISE
+          - :DEVOPS
+        default_value: :ENTERPRISE
+      - !ruby/object:Api::Type::NestedObject
+        name: 'config'
+        description: The config used to create a self-signed X.509 certificate or CSR.
+        required: true
+        input: true
+        properties:
+        - !ruby/object:Api::Type::NestedObject
+          name: 'subjectConfig'
+          description: |
+              Specifies some of the values in a certificate that are related to the subject.
+          required: true
+          properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: 'subject'
+            description: Contains distinguished name fields such as the location and organization.
+            properties:
+            - !ruby/object:Api::Type::String
+              name: 'countryCode'
+              description: The country code of the subject.
+            - !ruby/object:Api::Type::String
+              name: 'organization'
+              description: The organization of the subject.
+            - !ruby/object:Api::Type::String
+              name: 'organizationalUnit'
+              description: The organizational unit of the subject.
+            - !ruby/object:Api::Type::String
+              name: 'locality'
+              description: The locality or city of the subject.
+            - !ruby/object:Api::Type::String
+              name: 'province'
+              description: The province, territory, or regional state of the subject.
+            - !ruby/object:Api::Type::String
+              name: 'streetAddress'
+              description: The street address of the subject.
+            - !ruby/object:Api::Type::String
+              name: 'postalCode'
+              description: The postal code of the subject.
+          - !ruby/object:Api::Type::String
+            name: 'commonName'
+            description: The common name of the distinguished name.
+          - !ruby/object:Api::Type::NestedObject
+            name: 'subjectAltName'
+            description: The subject alternative name fields.
+            properties:
+            - !ruby/object:Api::Type::Array
+              name: 'dnsNames'
+              description: Contains only valid, fully-qualified host names.
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'uris'
+              description: Contains only valid RFC 3986 URIs.
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'emailAddresses'
+              description: Contains only valid RFC 2822 E-mail addresses.
+              item_type: Api::Type::String
+            - !ruby/object:Api::Type::Array
+              name: 'ipAddresses'
+              description: Contains only valid 32-bit IPv4 addresses or RFC 4291 IPv6 addresses.
+              item_type: Api::Type::String
+        - !ruby/object:Api::Type::NestedObject
+          name: 'reusableConfig'
+          description: |
+              Specifies some of the values in a certificate that are related to the subject.
+          required: true
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'reusableConfig'
+              description: |
+                A resource path to a ReusableConfig in the format
+                projects/*/locations/*/reusableConfigs/*.
+      - !ruby/object:Api::Type::String
+        name: 'lifetime'
+        description: |
+          The desired lifetime of the CA certificate. Used to create the "notBeforeTime" and
+          "notAfterTime" fields inside an X.509 certificate. A duration in seconds with up to nine
+          fractional digits, terminated by 's'. Example: "3.5s".
+        default_value: 315360000s  # 10 years
+      - !ruby/object:Api::Type::NestedObject
+        name: 'keySpec'
+        description: |
+          Used when issuing certificates for this CertificateAuthority. If this CertificateAuthority
+          is a self-signed CertificateAuthority, this key is also used to sign the self-signed CA
+          certificate. Otherwise, it is used to sign a CSR.
+        required: true
+        properties:
+        - !ruby/object:Api::Type::Enum
+          name: 'algorithm'
+          description: |
+            The algorithm to use for creating a managed Cloud KMS key for a for a simplified
+            experience. All managed keys will be have their ProtectionLevel as HSM.
+          values:
+            - :SIGN_HASH_ALGORITHM_UNSPECIFIED
+            - :RSA_PSS_2048_SHA256
+            - :RSA_PSS_3072_SHA256
+            - :RSA_PSS_4096_SHA256
+            - :RSA_PKCS1_2048_SHA256
+            - :RSA_PKCS1_3072_SHA256
+            - :RSA_PKCS1_4096_SHA256
+            - :EC_P256_SHA256
+            - :EC_P384_SHA384
+      - !ruby/object:Api::Type::NestedObject
+        name: 'issuingOptions'
+        description: |
+          Options that affect all certificates issued by a CertificateAuthority.
+        properties:
+        - !ruby/object:Api::Type::Boolean
+          name: 'includeCaCertUrl'
+          description: |
+            When true, includes a URL to the issuing CA certificate in the "authority
+            information access" X.509 extension.
+          default_value: true
+        - !ruby/object:Api::Type::Boolean
+          name: 'includeCrlAccessUrl'
+          description: |
+            When true, includes a URL to the CRL corresponding to certificates issued from a
+            CertificateAuthority. CRLs will expire 7 days from their creation. However, we will
+            rebuild daily. CRLs are also rebuilt shortly after a certificate is revoked.
+          default_value: false
+      - !ruby/object:Api::Type::Enum
+        name: 'state'
+        description: The State for this CertificateAuthority.
+        output: true
+        values:
+          - :STATE_UNSPECIFIED
+          - :ENABLED
+          - :DISABLED
+          - :PENDING_ACTIVATION
+          - :PENDING_DELETION
+      - !ruby/object:Api::Type::Array
+        name: 'pemCaCertificates'
+        description: |
+          This CertificateAuthority's certificate chain, including the current
+          CertificateAuthority's certificate. Ordered such that the root issuer is the final
+          element (consistent with RFC 5246). For a self-signed CA, this will only list the current
+          CertificateAuthority's certificate.
+        item_type: Api::Type::String
+        output: true
+      - !ruby/object:Api::Type::String
+        name: 'gcsBucket'
+        description: |
+          The name of a Cloud Storage bucket where this CertificateAuthority will publish content,
+          such as the CA certificate and CRLs. This must be a bucket name, without any prefixes
+          (such as gs://) or suffixes (such as .googleapis.com). For example, to use a bucket named
+          my-bucket, you would simply specify my-bucket. If not specified, a managed bucket will be
+          created.
+        input: true
+      - !ruby/object:Api::Type::NestedObject
+        name: 'accessUrls'
+        description: |
+          Output only. URLs for accessing content published by this CA, such as the CA certificate
+          and CRLs.
+        output: true
+        properties:
+        - !ruby/object:Api::Type::String
+          name: 'caCertificateAccessUrl'
+          description: |
+            The URL where this CertificateAuthority's CA certificate is published. This will only be
+            set for CAs that have been activated.
+          output: true
+        - !ruby/object:Api::Type::String
+          name: 'crlAccessUrl'
+          description: |
+            The URL where this CertificateAuthority's CRLs are published. This will only be set for
+            CAs that have been activated.
+          output: true
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: labels
+        description: Labels with user-defined metadata.
+

--- a/products/privateca/api.yaml
+++ b/products/privateca/api.yaml
@@ -81,7 +81,6 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: 'type'
         description: The Type of this CertificateAuthority.
-        required: true
         input: true
         values:
           - :SELF_SIGNED
@@ -89,7 +88,6 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: 'tier'
         description: The Tier of this CertificateAuthority.
-        required: true
         input: true
         values:
           - :ENTERPRISE
@@ -174,7 +172,6 @@ objects:
           The desired lifetime of the CA certificate. Used to create the "notBeforeTime" and
           "notAfterTime" fields inside an X.509 certificate. A duration in seconds with up to nine
           fractional digits, terminated by 's'. Example: "3.5s".
-        required: true
         default_value: 315360000s  # 10 years
       - !ruby/object:Api::Type::NestedObject
         name: 'keySpec'
@@ -212,7 +209,6 @@ objects:
             When true, includes a URL to the issuing CA certificate in the "authority
             information access" X.509 extension.
           default_value: true
-          required: true
         - !ruby/object:Api::Type::Boolean
           name: 'includeCrlAccessUrl'
           description: |
@@ -220,7 +216,6 @@ objects:
             CertificateAuthority. CRLs will expire 7 days from their creation. However, we will
             rebuild daily. CRLs are also rebuilt shortly after a certificate is revoked.
           default_value: false
-          required: true
       - !ruby/object:Api::Type::Enum
         name: 'state'
         description: The State for this CertificateAuthority.

--- a/products/privateca/api.yaml
+++ b/products/privateca/api.yaml
@@ -215,6 +215,7 @@ objects:
             CertificateAuthority. CRLs will expire 7 days from their creation. However, we will
             rebuild daily. CRLs are also rebuilt shortly after a certificate is revoked.
           default_value: false
+          required: true
       - !ruby/object:Api::Type::Enum
         name: 'state'
         description: The State for this CertificateAuthority.

--- a/products/privateca/api.yaml
+++ b/products/privateca/api.yaml
@@ -178,6 +178,7 @@ objects:
           is a self-signed CertificateAuthority, this key is also used to sign the self-signed CA
           certificate. Otherwise, it is used to sign a CSR.
         required: true
+        input: true
         properties:
         - !ruby/object:Api::Type::Enum
           name: 'algorithm'
@@ -262,4 +263,3 @@ objects:
       - !ruby/object:Api::Type::KeyValuePairs
         name: labels
         description: Labels with user-defined metadata.
-

--- a/products/privateca/api.yaml
+++ b/products/privateca/api.yaml
@@ -69,8 +69,8 @@ objects:
       - !ruby/object:Api::Type::String
         name: certificateAuthorityId
         description: GCP region of the Realm.
-        input: true
         required: true
+        input: true
         url_param_only: true
       - !ruby/object:Api::Type::String
         name: 'name'
@@ -81,6 +81,7 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: 'type'
         description: The Type of this CertificateAuthority.
+        required: true
         input: true
         values:
           - :SELF_SIGNED
@@ -88,6 +89,7 @@ objects:
       - !ruby/object:Api::Type::Enum
         name: 'tier'
         description: The Tier of this CertificateAuthority.
+        required: true
         input: true
         values:
           - :ENTERPRISE
@@ -108,6 +110,7 @@ objects:
           - !ruby/object:Api::Type::NestedObject
             name: 'subject'
             description: Contains distinguished name fields such as the location and organization.
+            required: true
             properties:
             - !ruby/object:Api::Type::String
               name: 'countryCode'
@@ -164,12 +167,14 @@ objects:
               description: |
                 A resource path to a ReusableConfig in the format
                 projects/*/locations/*/reusableConfigs/*.
+              required: true
       - !ruby/object:Api::Type::String
         name: 'lifetime'
         description: |
           The desired lifetime of the CA certificate. Used to create the "notBeforeTime" and
           "notAfterTime" fields inside an X.509 certificate. A duration in seconds with up to nine
           fractional digits, terminated by 's'. Example: "3.5s".
+        required: true
         default_value: 315360000s  # 10 years
       - !ruby/object:Api::Type::NestedObject
         name: 'keySpec'
@@ -247,8 +252,7 @@ objects:
       - !ruby/object:Api::Type::NestedObject
         name: 'accessUrls'
         description: |
-          Output only. URLs for accessing content published by this CA, such as the CA certificate
-          and CRLs.
+          URLs for accessing content published by this CA, such as the CA certificate and CRLs.
         output: true
         properties:
         - !ruby/object:Api::Type::String
@@ -263,6 +267,26 @@ objects:
             The URL where this CertificateAuthority's CRLs are published. This will only be set for
             CAs that have been activated.
           output: true
+      - !ruby/object:Api::Type::String
+        name: 'createTime'
+        description: |
+          The time at which this CertificateAuthority was created.
+
+          A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine
+          fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+        output: true
+      - !ruby/object:Api::Type::String
+        name: 'updateTime'
+        description: |
+          The time at which this CertificateAuthority was updated.
+
+          A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine
+          fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
+        output: true
       - !ruby/object:Api::Type::KeyValuePairs
         name: labels
-        description: Labels with user-defined metadata.
+        description: |
+          Labels with user-defined metadata.
+
+          An object containing a list of "key": value pairs. Example: { "name": "wrench", "mass":
+          "1.3kg", "count": "3" }.

--- a/products/privateca/api.yaml
+++ b/products/privateca/api.yaml
@@ -207,6 +207,7 @@ objects:
             When true, includes a URL to the issuing CA certificate in the "authority
             information access" X.509 extension.
           default_value: true
+          required: true
         - !ruby/object:Api::Type::Boolean
           name: 'includeCrlAccessUrl'
           description: |

--- a/products/privateca/api.yaml
+++ b/products/privateca/api.yaml
@@ -185,6 +185,7 @@ objects:
           description: |
             The algorithm to use for creating a managed Cloud KMS key for a for a simplified
             experience. All managed keys will be have their ProtectionLevel as HSM.
+          required: true
           values:
             - :SIGN_HASH_ALGORITHM_UNSPECIFIED
             - :RSA_PSS_2048_SHA256

--- a/products/privateca/terraform.yaml
+++ b/products/privateca/terraform.yaml
@@ -1,0 +1,34 @@
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+--- !ruby/object:Provider::Terraform::Config
+overrides: !ruby/object:Overrides::ResourceOverrides
+  CertificateAuthority: !ruby/object:Overrides::Terraform::ResourceOverride
+    autogen_async: true
+    import_format: ["projects/{{project}}/locations/{{location}}/certificateAuthorities/{{certificate_authority_id}}"]
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "privateca_certificate_authority_basic"
+        min_version: "beta"
+        primary_resource_id: "default"
+        vars:
+          certificate_authority_id: "my-certificate-authority"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "privateca_certificate_authority_full"
+        min_version: "beta"
+        primary_resource_id: "default"
+        vars:
+          certificate_authority_id: "my-certificate-authority"
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      pre_delete: templates/terraform/pre_delete/privateca_certificate_authority.go.erb
+      test_check_destroy: templates/terraform/custom_check_destroy/privateca_certificate_authority.go.erb

--- a/templates/terraform/custom_check_destroy/privateca_certificate_authority.go.erb
+++ b/templates/terraform/custom_check_destroy/privateca_certificate_authority.go.erb
@@ -1,0 +1,15 @@
+config := googleProviderConfig(t)
+
+url, err := replaceVarsForTest(config, rs, "{{PrivatecaBasePath}}projects/{{project}}/locations/{{location}}/certificateAuthorities/{{certificate_authority_id}}")
+if err != nil {
+	return err
+}
+
+res, err := sendRequest(config, "GET", "", url, config.userAgent, nil)
+if err != nil {
+	return nil
+}
+
+if s := res["state"]; s != "PENDING_DELETION" {
+	return fmt.Errorf("CertificateAuthority %s got %s, want PENDING_DELETION", url, s)
+}

--- a/templates/terraform/examples/privateca_certificate_authority_basic.tf.erb
+++ b/templates/terraform/examples/privateca_certificate_authority_basic.tf.erb
@@ -4,6 +4,9 @@ resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id]
   location = "us-central1"
   config {
     subject_config {
+      subject {
+        organization = "HashiCorp"
+      }
       common_name = "my-certificate-authority"
       subject_alt_name {
         dns_names = ["hashicorp.com"]

--- a/templates/terraform/examples/privateca_certificate_authority_basic.tf.erb
+++ b/templates/terraform/examples/privateca_certificate_authority_basic.tf.erb
@@ -1,0 +1,19 @@
+resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+  certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>"
+  location = "us-central1"
+  config {
+    subject_config {
+      common_name = "my-certificate-authority"
+      subject_alt_name {
+        dns_names = ["hashicorp.com"]
+      }
+    }
+    reusable_config {
+      reusable_config = "projects/568668481468/locations/us-central1/reusableConfigs/root-unconstrained"
+    }
+  }
+  key_spec {
+    algorithm = "RSA_PKCS1_4096_SHA256"
+  }
+}

--- a/templates/terraform/examples/privateca_certificate_authority_full.tf.erb
+++ b/templates/terraform/examples/privateca_certificate_authority_full.tf.erb
@@ -1,0 +1,37 @@
+resource "google_privateca_certificate_authority" "<%= ctx[:primary_resource_id] %>" {
+  provider = google-beta
+  certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>"
+  location = "us-central1"
+  tier = "DEVOPS"
+  config {
+    subject_config {
+      subject {
+        country_code = "US"
+        organization = "HashiCorp"
+        organizational_unit = "Terraform"
+        locality = "San Francisco"
+        province = "CA"
+        street_address = "101 2nd St #700"
+        postal_code = "94105"
+      }
+      common_name = "my-certificate-authority"
+      subject_alt_name {
+        dns_names = ["hashicorp.com"]
+        email_addresses = ["email@example.com"]
+        ip_addresses = ["127.0.0.1"]
+        uris = ["http://www.ietf.org/rfc/rfc3986.txt"]
+      }
+    }
+    reusable_config {
+      reusable_config = "projects/568668481468/locations/us-central1/reusableConfigs/root-unconstrained"
+    }
+  }
+  lifetime = "86400s"
+  issuing_options {
+    include_ca_cert_url = true
+    include_crl_access_url = false
+  }
+  key_spec {
+    algorithm = "EC_P256_SHA256"
+  }
+}

--- a/templates/terraform/pre_delete/privateca_certificate_authority.go.erb
+++ b/templates/terraform/pre_delete/privateca_certificate_authority.go.erb
@@ -1,0 +1,17 @@
+log.Printf("[DEBUG] Disabling CertificateAuthority %q", d.Id())
+
+disableURL, err := replaceVars(d, config, "{{PrivatecaBasePath}}{{name}}:disable")
+if err != nil {
+	return err
+}
+
+disableRes, err := sendRequestWithTimeout(config, "POST", billingProject, disableURL, userAgent, obj, d.Timeout(schema.TimeoutDelete))
+if err != nil {
+	return err
+}
+
+err = privatecaOperationWaitTime(config, disableRes, project, "Disabling CertificateAuthority", userAgent, d.Timeout(schema.TimeoutDelete))
+if err != nil {
+	return err
+}
+


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

hashicorp/terraform-provider-google#7657

Adds "google_privateca_certificate_authority" (name is duplicated because "Certificate Authority" is also the product name)

See https://cloud.google.com/certificate-authority-service/docs/reference/rest/v1beta1/projects.locations.certificateAuthorities for resource documentation.

Notes:
- This change doesn't implement support for subordinate CAs, which require additional customization because they must be activated.

Customizations:
- Use POST :scheduleDelete to delete the resource (delete is not supported)
- On pre_delete, POST :disable to disable the resources (required for scheduling deletion)
- Check resource deletion by checking that status is DELETION_PENDING

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_privateca_certificate_authority`
```