### PR TITLE
Depends on breaks old TF version

### DIFF
--- a/templates/terraform/examples/notebook_environment_basic.tf.erb
+++ b/templates/terraform/examples/notebook_environment_basic.tf.erb
@@ -1,5 +1,4 @@
 resource "google_notebooks_environment" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   name = "<%= ctx[:vars]["environment_name"] %>"
   location = "us-west1-a"  
   container_image {

--- a/third_party/terraform/tests/data_source_storage_bucket_object_content_test.go
+++ b/third_party/terraform/tests/data_source_storage_bucket_object_content_test.go
@@ -31,22 +31,18 @@ func testAccDataSourceStorageBucketObjectContent_Basic(content, bucket string) s
 	return fmt.Sprintf(`
 data "google_storage_bucket_object_content" "default" {
 	bucket = google_storage_bucket.contenttest.name
-        name = google_storage_bucket_object.object.name
-        depends_on =  [
-          google_storage_bucket_object.object,
-          google_storage_bucket.contenttest, 
-        ]         
+	name = google_storage_bucket_object.object.name      
 }
 
 resource "google_storage_bucket_object" "object" {
-        name = "butterfly01"
-        content = "%s"
-        bucket = google_storage_bucket.contenttest.name
+	name = "butterfly01"
+	content = "%s"
+	bucket = google_storage_bucket.contenttest.name
 }
 
 resource "google_storage_bucket" "contenttest" {
-        name = "%s"
-        location = "US"
-        force_destroy = true
+	name = "%s"
+	location = "US"
+	force_destroy = true
 }`, content, bucket)
 }

--- a/third_party/terraform/tests/resource_compute_instance_migrate_test.go
+++ b/third_party/terraform/tests/resource_compute_instance_migrate_test.go
@@ -753,7 +753,8 @@ func TestAccComputeInstanceMigrateState_scratchDisk(t *testing.T) {
 				},
 			},
 		},
-		MachineType: "zones/" + zone + "/machineTypes/e2-medium",
+		// can't be e2 because of local-ssd
+		MachineType: "zones/" + zone + "/machineTypes/n1-standard-1",
 		NetworkInterfaces: []*compute.NetworkInterface{
 			{
 				Network: "global/networks/default",


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/8144

Dependencies are already implied, no need for explicit


Fixes: https://github.com/hashicorp/terraform-provider-google/issues/8148

Consolidating some test fixes

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
