### PR TITLE
Fix depends_on in test

### DIFF
--- a/third_party/terraform/tests/data_source_google_compute_instance_template_test.go
+++ b/third_party/terraform/tests/data_source_google_compute_instance_template_test.go
@@ -155,7 +155,7 @@ resource "google_compute_instance_template" "c" {
 }
 
 data "google_compute_instance_template" "default" {
-  // Hack to prevent depends_on bug triggering datasource recreate
+  // Hack to prevent depends_on bug triggering datasource recreate due to https://github.com/hashicorp/terraform/issues/11806
   project = "%{project}${replace(google_compute_instance_template.a.id, "/.*/", "")}${replace(google_compute_instance_template.b.id, "/.*/", "")}${replace(google_compute_instance_template.c.id, "/.*/", "")}"
   filter  = "name eq test-template-c-.*"
 }
@@ -229,7 +229,7 @@ resource "google_compute_instance_template" "c" {
 }
 
 data "google_compute_instance_template" "default" {
-  // Hack to prevent depends_on bug triggering datasource recreate
+  // Hack to prevent depends_on bug triggering datasource recreate due to https://github.com/hashicorp/terraform/issues/11806
   project = "%{project}${replace(google_compute_instance_template.c.id, "/.*/", "")}"
   filter      = "name eq test-template-.*"
   most_recent = true

--- a/third_party/terraform/tests/data_source_google_compute_instance_template_test.go
+++ b/third_party/terraform/tests/data_source_google_compute_instance_template_test.go
@@ -155,14 +155,9 @@ resource "google_compute_instance_template" "c" {
 }
 
 data "google_compute_instance_template" "default" {
-  project = "%{project}"
+  // Hack to prevent depends_on bug triggering datasource recreate
+  project = "%{project}${replace(google_compute_instance_template.a.id, "/.*/", "")}${replace(google_compute_instance_template.b.id, "/.*/", "")}${replace(google_compute_instance_template.c.id, "/.*/", "")}"
   filter  = "name eq test-template-c-.*"
-
-  depends_on = [
-    google_compute_instance_template.a,
-    google_compute_instance_template.b,
-    google_compute_instance_template.c,
-  ]
 }
 `, map[string]interface{}{"project": project, "suffix": suffix})
 }
@@ -234,15 +229,10 @@ resource "google_compute_instance_template" "c" {
 }
 
 data "google_compute_instance_template" "default" {
-  project = "%{project}"
+  // Hack to prevent depends_on bug triggering datasource recreate
+  project = "%{project}${replace(google_compute_instance_template.c.id, "/.*/", "")}"
   filter      = "name eq test-template-.*"
   most_recent = true
-
-  depends_on = [
-    google_compute_instance_template.a,
-    google_compute_instance_template.b,
-    google_compute_instance_template.c,
-  ]
 }
 `, map[string]interface{}{"project": project, "suffix": suffix})
 }

--- a/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -322,7 +322,7 @@ func TestAccContainerNodePool_withInvalidKubeletCpuManagerPolicy(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccContainerNodePool_withKubeletConfig(cluster, np, "dontexist", "100us", true),
-				ExpectError: regexp.MustCompile(`.*to be one of \[static none\].*`),
+				ExpectError: regexp.MustCompile(`.*to be one of \[static none \].*`),
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes 2 tests. Datasources cannot use depends_on due to: https://github.com/hashicorp/terraform/issues/11806



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
