### PR TITLE
bigquery_table - add customized diff for specific properties and changes on schema

### DIFF
--- a/third_party/terraform/resources/resource_bigquery_table.go
+++ b/third_party/terraform/resources/resource_bigquery_table.go
@@ -148,10 +148,6 @@ func bigQueryTableModeEq(old, new interface{}) bool {
 	return eq
 }
 
-func bigQueryTableTypeDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
-	return bigQueryTableTypeEq(old, new)
-}
-
 func bigQueryTableModeIsForceNew(old, new interface{}) bool {
 	eq := bigQueryTableModeEq(old, new)
 	reqToNull := old == "REQUIRED" && new == "NULLABLE"
@@ -231,15 +227,6 @@ func resourceBigQueryTableSchemaIsChangeable(old, new interface{}) (bool, error)
 
 func resourceBigQueryTableSchemaCustomizeDiffFunc(d TerraformResourceDiff) error {
 	if _, hasSchema := d.GetOk("schema"); hasSchema {
-		if _, hasfield := d.GetOk("field.#"); hasfield {
-			if err := d.ForceNew("schema"); err != nil {
-				return err
-			}
-			if err := d.ForceNew("field.#"); err != nil {
-				return err
-			}
-			return nil
-		}
 		oldSchema, newSchema := d.GetChange("schema")
 		oldSchemaText := oldSchema.(string)
 		newSchemaText := newSchema.(string)
@@ -264,23 +251,6 @@ func resourceBigQueryTableSchemaCustomizeDiffFunc(d TerraformResourceDiff) error
 			}
 		}
 		return nil
-	} else if _, hasfield := d.GetOk("field.#"); hasfield {
-		oldCount, newCount := d.GetChange("field.#")
-		if oldCount.(int) > newCount.(int) {
-			// if array is shrinking not changeable
-			if err := d.ForceNew("field.#"); err != nil {
-				return err
-			}
-		}
-		for i := 0; i < oldCount.(int); i++ {
-			modeKey := fmt.Sprintf("field.%d.mode", i)
-			oldMode, newMode := d.GetChange(modeKey)
-			if bigQueryTableModeIsForceNew(oldMode, newMode) {
-				if err := d.ForceNew(modeKey); err != nil {
-					return err
-				}
-			}
-		}
 	}
 	return nil
 }
@@ -581,39 +551,6 @@ func resourceBigQueryTable() *schema.Resource {
 				},
 				DiffSuppressFunc: bigQueryTableSchemaDiffSuppress,
 				Description:      `A JSON schema for the table.`,
-				ConflictsWith:    []string{"field"},
-			},
-			// Field: A field in the table's schema.
-			"field": {
-				Type:          schema.TypeList,
-				Optional:      true,
-				ConflictsWith: []string{"schema"},
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"name": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
-						"type": {
-							Type:             schema.TypeString,
-							Required:         true,
-							DiffSuppressFunc: bigQueryTableTypeDiffSuppress,
-							ForceNew:         true,
-						},
-						"description": {
-							Type:     schema.TypeString,
-							Computed: true,
-							Optional: true,
-						},
-						"mode": {
-							Type:         schema.TypeString,
-							Optional:     true,
-							Default:      "NULLABLE",
-							ValidateFunc: validation.StringInSlice([]string{"NULLABLE", "REQUIRED", "REPEATED"}, false),
-						},
-					},
-				},
 			},
 			// View: [Optional] If specified, configures this table as a view.
 			"view": {
@@ -954,12 +891,6 @@ func resourceTable(d *schema.ResourceData, meta interface{}) (*bigquery.Table, e
 			return nil, err
 		}
 		table.Schema = schema
-	} else if v, ok := d.GetOk("field"); ok {
-		schema, err := expandFields(v)
-		if err != nil {
-			return nil, err
-		}
-		table.Schema = schema
 	}
 
 	if v, ok := d.GetOk("time_partitioning"); ok {
@@ -1141,20 +1072,12 @@ func resourceBigQueryTableRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if res.Schema != nil {
-		_, hasSchema := d.GetOk("schema")
-		_, hasFields := d.GetOk("field.#")
-		if hasSchema || !hasFields {
-			schema, err := flattenSchema(res.Schema)
-			if err != nil {
-				return err
-			}
-			if err := d.Set("schema", schema); err != nil {
-				return fmt.Errorf("Error setting schema: %s", err)
-			}
-		} else {
-			if err := d.Set("field", flattenTableFields(res.Schema.Fields)); err != nil {
-				return fmt.Errorf("Error setting fields: %s", err)
-			}
+		schema, err := flattenSchema(res.Schema)
+		if err != nil {
+			return err
+		}
+		if err := d.Set("schema", schema); err != nil {
+			return fmt.Errorf("Error setting schema: %s", err)
 		}
 	}
 
@@ -1490,31 +1413,6 @@ func expandTimePartitioning(configured interface{}) *bigquery.TimePartitioning {
 	return tp
 }
 
-func expandFields(raw interface{}) (*bigquery.TableSchema, error) {
-	fields, ok := raw.([]interface{})
-	if !ok {
-		log.Printf("[DEBUG] - unable to cast schema fields to array")
-		return nil, errors.New("unable to cast schema fields to array")
-	}
-	tableSchema := &bigquery.TableSchema{}
-	tableSchema.Fields = make([]*bigquery.TableFieldSchema, len(fields))
-	for i, v := range fields {
-		field, ok := v.(map[string]interface{})
-		if !ok {
-			log.Printf("[DEBUG] - unable to cast schema field to map")
-			return nil, errors.New("unable to cast schema field to map")
-		}
-		log.Printf("[DEBUG] - raw - %s, cast - %s", raw, fields)
-		tableSchema.Fields[i] = &bigquery.TableFieldSchema{
-			Name:        field["name"].(string),
-			Type:        field["type"].(string),
-			Description: field["description"].(string),
-			Mode:        field["mode"].(string),
-		}
-	}
-	return tableSchema, nil
-}
-
 func expandRangePartitioning(configured interface{}) (*bigquery.RangePartitioning, error) {
 	if configured == nil {
 		return nil, nil
@@ -1627,19 +1525,6 @@ func flattenMaterializedView(mvd *bigquery.MaterializedViewDefinition) []map[str
 	result["refresh_interval_ms"] = mvd.RefreshIntervalMs
 
 	return []map[string]interface{}{result}
-}
-
-func flattenTableFields(fields []*bigquery.TableFieldSchema) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0, len(fields))
-	for _, field := range fields {
-		fieldMap := make(map[string]interface{})
-		fieldMap["name"] = field.Name
-		fieldMap["type"] = field.Type
-		fieldMap["description"] = field.Description
-		fieldMap["mode"] = field.Mode
-		result = append(result, fieldMap)
-	}
-	return result
 }
 
 func resourceBigQueryTableImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/third_party/terraform/resources/resource_bigquery_table.go
+++ b/third_party/terraform/resources/resource_bigquery_table.go
@@ -164,13 +164,14 @@ func resourceBigQueryTableSchemaIsChangeable(old, new interface{}) (bool, error)
 		if !ok {
 			// if not both arrays not changeable
 			return false, nil
-		} else if len(arrayOld) > len(arrayNew) {
+		}
+		if len(arrayOld) > len(arrayNew) {
 			// if not growing not changeable
 			return false, nil
 		}
 		for i := range arrayOld {
-			isChangable, err := resourceBigQueryTableSchemaIsChangeable(arrayOld[i], arrayNew[i])
-			if err != nil || !isChangable {
+			if isChangable, err :=
+				resourceBigQueryTableSchemaIsChangeable(arrayOld[i], arrayNew[i]); err != nil || !isChangable {
 				return false, err
 			}
 		}
@@ -237,15 +238,17 @@ func resourceBigQueryTableSchemaCustomizeDiffFunc(d TerraformResourceDiff) error
 		var old, new interface{}
 		if err := json.Unmarshal([]byte(oldSchemaText), &old); err != nil {
 			log.Printf("[DEBUG] unable to unmarshal json customized diff - %v", err)
+			return err
 		}
 		if err := json.Unmarshal([]byte(newSchemaText), &new); err != nil {
 			log.Printf("[DEBUG] unable to unmarshal json customized diff - %v", err)
+			return err
 		}
-		isChangable, err := resourceBigQueryTableSchemaIsChangeable(old, new)
+		isChangeable, err := resourceBigQueryTableSchemaIsChangeable(old, new)
 		if err != nil {
 			return err
 		}
-		if !isChangable {
+		if !isChangeable {
 			if err := d.ForceNew("schema"); err != nil {
 				return err
 			}

--- a/third_party/terraform/resources/resource_bigquery_table.go
+++ b/third_party/terraform/resources/resource_bigquery_table.go
@@ -237,12 +237,13 @@ func resourceBigQueryTableSchemaCustomizeDiffFunc(d TerraformResourceDiff) error
 		}
 		var old, new interface{}
 		if err := json.Unmarshal([]byte(oldSchemaText), &old); err != nil {
+			// don't return error, its possible we are going from no schema to schema
+			// this case will be cover on the conparision regardless.
 			log.Printf("[DEBUG] unable to unmarshal json customized diff - %v", err)
-			return err
 		}
 		if err := json.Unmarshal([]byte(newSchemaText), &new); err != nil {
+			// same as above
 			log.Printf("[DEBUG] unable to unmarshal json customized diff - %v", err)
-			return err
 		}
 		isChangeable, err := resourceBigQueryTableSchemaIsChangeable(old, new)
 		if err != nil {

--- a/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -535,7 +535,7 @@ func TestUnitBigQueryDataTable_schemaIsChangable(t *testing.T) {
 			testcase.name + "Nested",
 			fmt.Sprintf("[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"fields\" : %s }]", testcase.jsonOld),
 			fmt.Sprintf("[{\"name\": \"someValue\", \"type\" : \"INT64\", \"fields\" : %s }]", testcase.jsonNew),
-			testcase.changable,
+			testcase.changeable,
 		}
 		testcaseNested.check(t)
 	}
@@ -546,12 +546,12 @@ func TestUnitBigQueryDataTable_customizedDiffSchema(t *testing.T) {
 
 	tcs := testUnitBigQueryDataCustomDiffFieldChangeTestcases
 
-	for _, changableTestcase := range testUnitBigQueryDataTableIsChangableTestCases {
+	for _, changeableTestcase := range testUnitBigQueryDataTableIsChangableTestCases {
 		extraTestcase := testUnitBigQueryDataCustomDiffFieldChangeTestcase{
-			name:           changableTestcase.name,
-			schemaBefore:   changableTestcase.jsonOld,
-			schemaAfter:    changableTestcase.jsonNew,
-			shouldForceNew: !changableTestcase.changable,
+			name:           changeableTestcase.name,
+			schemaBefore:   changeableTestcase.jsonOld,
+			schemaAfter:    changeableTestcase.jsonNew,
+			shouldForceNew: !changeableTestcase.changeable,
 		}
 		tcs = append(tcs, extraTestcase)
 	}
@@ -571,7 +571,7 @@ type testUnitBigQueryDataTableJSONChangeableTestCase struct {
 	name      string
 	jsonOld   string
 	jsonNew   string
-	changable bool
+	changeable bool
 }
 
 type testUnitBigQueryDataCustomDiffField struct {
@@ -596,12 +596,12 @@ func (testcase *testUnitBigQueryDataTableJSONChangeableTestCase) check(t *testin
 	if err := json.Unmarshal([]byte(testcase.jsonNew), &new); err != nil {
 		panic(fmt.Sprintf("unable to unmarshal json - %v", err))
 	}
-	changable, err := resourceBigQueryTableSchemaIsChangable(old, new)
+	changeable, err := resourceBigQueryTableSchemaIsChangable(old, new)
 	if err != nil {
 		t.Errorf("ahhhh an error I did not expect this! especially not on testscase %s - %s", testcase.name, err)
 	}
-	if changable != testcase.changable {
-		t.Errorf("expected changable result of %v but got %v for testcase %s", testcase.changable, changable, testcase.name)
+	if changeable != testcase.changeable {
+		t.Errorf("expected changeable result of %v but got %v for testcase %s", testcase.changeable, changeable, testcase.name)
 	}
 }
 

--- a/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -501,14 +501,14 @@ type testUnitBigQueryDataTableJSONChangeableTestCase struct {
 func (testcase *testUnitBigQueryDataTableJSONChangeableTestCase) check(t *testing.T) {
 	var old, new interface{}
 	if err := json.Unmarshal([]byte(testcase.jsonOld), &old); err != nil {
-		panic(fmt.Sprintf("unable to unmarshal json - %v", err))
+		t.Fatalf("unable to unmarshal json - %v", err)
 	}
 	if err := json.Unmarshal([]byte(testcase.jsonNew), &new); err != nil {
-		panic(fmt.Sprintf("unable to unmarshal json - %v", err))
+		t.Fatalf("unable to unmarshal json - %v", err)
 	}
 	changeable, err := resourceBigQueryTableSchemaIsChangeable(old, new)
 	if err != nil {
-		t.Errorf("ahhhh an error I did not expect this! especially not on testscase %s - %s", testcase.name, err)
+		t.Errorf("%s failed unexpectedly: %s", testcase.name, err)
 	}
 	if changeable != testcase.changeable {
 		t.Errorf("expected changeable result of %v but got %v for testcase %s", testcase.changeable, changeable, testcase.name)
@@ -533,70 +533,70 @@ func (testcase *testUnitBigQueryDataTableJSONChangeableTestCase) check(t *testin
 
 var testUnitBigQueryDataTableIsChangableTestCases = []testUnitBigQueryDataTableJSONChangeableTestCase{
 	{
-		"defaultEquality",
-		"[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
-		"[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
-		true,
+		name:       "defaultEquality",
+		jsonOld:    "[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
+		jsonNew:    "[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
+		changeable: true,
 	},
 	{
-		"arraySizeIncreases",
-		"[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
-		"[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }, {\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
-		true,
+		name:       "arraySizeIncreases",
+		jsonOld:    "[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
+		jsonNew:    "[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }, {\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
+		changeable: true,
 	},
 	{
-		"arraySizeDecreases",
-		"[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }, {\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
-		"[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
-		false,
+		name:       "arraySizeDecreases",
+		jsonOld:    "[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }, {\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
+		jsonNew:    "[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
+		changeable: false,
 	},
 	{
-		"descriptionChanges",
-		"[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
-		"[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"some new value\" }]",
-		true,
+		name:       "descriptionChanges",
+		jsonOld:    "[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
+		jsonNew:    "[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"some new value\" }]",
+		changeable: true,
 	},
 	{
-		"typeInteger",
-		"[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
-		"[{\"name\": \"someValue\", \"type\" : \"INT64\", \"mode\" : \"NULLABLE\", \"description\" : \"some new value\" }]",
-		true,
+		name:       "typeInteger",
+		jsonOld:    "[{\"name\": \"someValue\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
+		jsonNew:    "[{\"name\": \"someValue\", \"type\" : \"INT64\", \"mode\" : \"NULLABLE\", \"description\" : \"some new value\" }]",
+		changeable: true,
 	},
 	{
-		"typeFloat",
-		"[{\"name\": \"someValue\", \"type\" : \"FLOAT\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
-		"[{\"name\": \"someValue\", \"type\" : \"FLOAT64\", \"mode\" : \"NULLABLE\", \"description\" : \"some new value\" }]",
-		true,
+		name:       "typeFloat",
+		jsonOld:    "[{\"name\": \"someValue\", \"type\" : \"FLOAT\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
+		jsonNew:    "[{\"name\": \"someValue\", \"type\" : \"FLOAT64\", \"mode\" : \"NULLABLE\", \"description\" : \"some new value\" }]",
+		changeable: true,
 	},
 	{
-		"typeBool",
-		"[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
-		"[{\"name\": \"someValue\", \"type\" : \"BOOL\", \"mode\" : \"NULLABLE\", \"description\" : \"some new value\" }]",
-		true,
+		name:       "typeBool",
+		jsonOld:    "[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
+		jsonNew:    "[{\"name\": \"someValue\", \"type\" : \"BOOL\", \"mode\" : \"NULLABLE\", \"description\" : \"some new value\" }]",
+		changeable: true,
 	},
 	{
-		"typeRandom",
-		"[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
-		"[{\"name\": \"someValue\", \"type\" : \"DATETIME\", \"mode\" : \"NULLABLE\", \"description\" : \"some new value\" }]",
-		false,
+		name:       "typeChangeIncompatible",
+		jsonOld:    "[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
+		jsonNew:    "[{\"name\": \"someValue\", \"type\" : \"DATETIME\", \"mode\" : \"NULLABLE\", \"description\" : \"some new value\" }]",
+		changeable: false,
 	},
 	{
-		"typeModeReqToNull",
-		"[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"mode\" : \"REQUIRED\", \"description\" : \"someVal\" }]",
-		"[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"mode\" : \"NULLABLE\", \"description\" : \"some new value\" }]",
-		true,
+		name:       "typeModeReqToNull",
+		jsonOld:    "[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"mode\" : \"REQUIRED\", \"description\" : \"someVal\" }]",
+		jsonNew:    "[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"mode\" : \"NULLABLE\", \"description\" : \"some new value\" }]",
+		changeable: true,
 	},
 	{
-		"typeModeRandom",
-		"[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"mode\" : \"REQUIRED\", \"description\" : \"someVal\" }]",
-		"[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"mode\" : \"REPEATED\", \"description\" : \"some new value\" }]",
-		false,
+		name:       "typeModeIncompatible",
+		jsonOld:    "[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"mode\" : \"REQUIRED\", \"description\" : \"someVal\" }]",
+		jsonNew:    "[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"mode\" : \"REPEATED\", \"description\" : \"some new value\" }]",
+		changeable: false,
 	},
 	{
-		"typeModeOmission",
-		"[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"mode\" : \"REQUIRED\", \"description\" : \"someVal\" }]",
-		"[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"description\" : \"some new value\" }]",
-		false,
+		name:       "typeModeOmission",
+		jsonOld:    "[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"mode\" : \"REQUIRED\", \"description\" : \"someVal\" }]",
+		jsonNew:    "[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"description\" : \"some new value\" }]",
+		changeable: false,
 	},
 }
 

--- a/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -450,62 +450,6 @@ func TestAccBigQueryDataTable_jsonEquivalency(t *testing.T) {
 	})
 }
 
-func TestAccBigQueryDataTable_schemaToFieldsAndBack(t *testing.T) {
-	t.Parallel()
-
-	datasetID := fmt.Sprintf("tf_test_%s", randString(t, 10))
-	tableID := fmt.Sprintf("tf_test_%s", randString(t, 10))
-
-	vcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckBigQueryTableDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccBigQueryTable_jsonEq(datasetID, tableID),
-			},
-			{
-				ResourceName:            "google_bigquery_table.test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "last_modified_time"},
-			},
-			{
-				Config: testAccBigQueryTable_fields(datasetID, tableID),
-				Check:  testAccCheckBigQueryTableFields(t),
-			},
-			{
-				Config: testAccBigQueryTable_jsonEq(datasetID, tableID),
-			},
-			{
-				ResourceName:            "google_bigquery_table.test",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "last_modified_time"},
-			},
-		},
-	})
-}
-
-func TestAccBigQueryDataTable_fields(t *testing.T) {
-	t.Parallel()
-
-	datasetID := fmt.Sprintf("tf_test_%s", randString(t, 10))
-	tableID := fmt.Sprintf("tf_test_%s", randString(t, 10))
-
-	vcrTest(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckBigQueryTableDestroyProducer(t),
-		Steps: []resource.TestStep{
-			{
-				Config: testAccBigQueryTable_fields(datasetID, tableID),
-				Check:  testAccCheckBigQueryTableFields(t),
-			},
-		},
-	})
-}
-
 func TestUnitBigQueryDataTable_jsonEquivalency(t *testing.T) {
 	t.Parallel()
 
@@ -541,26 +485,6 @@ func TestUnitBigQueryDataTable_schemaIsChangable(t *testing.T) {
 	}
 }
 
-func TestUnitBigQueryDataTable_customizedDiffSchema(t *testing.T) {
-	t.Parallel()
-
-	tcs := testUnitBigQueryDataCustomDiffFieldChangeTestcases
-
-	for _, changeableTestcase := range testUnitBigQueryDataTableIsChangableTestCases {
-		extraTestcase := testUnitBigQueryDataCustomDiffFieldChangeTestcase{
-			name:           changeableTestcase.name,
-			schemaBefore:   changeableTestcase.jsonOld,
-			schemaAfter:    changeableTestcase.jsonNew,
-			shouldForceNew: !changeableTestcase.changeable,
-		}
-		tcs = append(tcs, extraTestcase)
-	}
-
-	for _, testcase := range tcs {
-		testcase.check(t)
-	}
-}
-
 type testUnitBigQueryDataTableJSONEquivalencyTestCase struct {
 	jsonA      string
 	jsonB      string
@@ -572,20 +496,6 @@ type testUnitBigQueryDataTableJSONChangeableTestCase struct {
 	jsonOld    string
 	jsonNew    string
 	changeable bool
-}
-
-type testUnitBigQueryDataCustomDiffField struct {
-	mode        string
-	description string
-}
-
-type testUnitBigQueryDataCustomDiffFieldChangeTestcase struct {
-	name           string
-	fieldBefore    []testUnitBigQueryDataCustomDiffField
-	fieldAfter     []testUnitBigQueryDataCustomDiffField
-	schemaBefore   string
-	schemaAfter    string
-	shouldForceNew bool
 }
 
 func (testcase *testUnitBigQueryDataTableJSONChangeableTestCase) check(t *testing.T) {
@@ -603,40 +513,21 @@ func (testcase *testUnitBigQueryDataTableJSONChangeableTestCase) check(t *testin
 	if changeable != testcase.changeable {
 		t.Errorf("expected changeable result of %v but got %v for testcase %s", testcase.changeable, changeable, testcase.name)
 	}
-}
 
-func (testcase *testUnitBigQueryDataCustomDiffFieldChangeTestcase) check(t *testing.T) {
 	d := &ResourceDiffMock{
 		Before: map[string]interface{}{},
 		After:  map[string]interface{}{},
 	}
-	if testcase.fieldBefore != nil {
-		d.Before["field.#"] = len(testcase.fieldBefore)
-		for i, f := range testcase.fieldBefore {
-			d.Before[fmt.Sprintf("field.%d.mode", i)] = f.mode
-			d.Before[fmt.Sprintf("field.%d.description", i)] = f.description
-		}
-	}
-	if testcase.fieldAfter != nil {
-		d.After["field.#"] = len(testcase.fieldAfter)
-		for i, f := range testcase.fieldAfter {
-			d.After[fmt.Sprintf("field.%d.mode", i)] = f.mode
-			d.After[fmt.Sprintf("field.%d.description", i)] = f.description
-		}
-	}
-	if testcase.schemaBefore != "" {
-		d.Before["schema"] = testcase.schemaBefore
-	}
-	if testcase.schemaAfter != "" {
-		d.After["schema"] = testcase.schemaAfter
-	}
 
-	err := resourceBigQueryTableSchemaCustomizeDiffFunc(d)
+	d.Before["schema"] = testcase.jsonOld
+	d.After["schema"] = testcase.jsonNew
+
+	err = resourceBigQueryTableSchemaCustomizeDiffFunc(d)
 	if err != nil {
 		t.Errorf("error on testcase %s - %w", testcase.name, err)
 	}
-	if testcase.shouldForceNew != d.IsForceNew {
-		t.Errorf("%s: expected d.IsForceNew to be %v, but was %v", testcase.name, testcase.shouldForceNew, d.IsForceNew)
+	if !testcase.changeable != d.IsForceNew {
+		t.Errorf("%s: expected d.IsForceNew to be %v, but was %v", testcase.name, !testcase.changeable, d.IsForceNew)
 	}
 }
 
@@ -706,89 +597,6 @@ var testUnitBigQueryDataTableIsChangableTestCases = []testUnitBigQueryDataTableJ
 		"[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"mode\" : \"REQUIRED\", \"description\" : \"someVal\" }]",
 		"[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"description\" : \"some new value\" }]",
 		false,
-	},
-}
-
-var testUnitBigQueryDataCustomDiffFieldChangeTestcases = []testUnitBigQueryDataCustomDiffFieldChangeTestcase{
-	{
-		name: "control",
-		fieldBefore: []testUnitBigQueryDataCustomDiffField{{
-			mode:        "Nullable",
-			description: "someValue",
-		}},
-		fieldAfter: []testUnitBigQueryDataCustomDiffField{{
-			mode:        "Nullable",
-			description: "someValue",
-		}},
-		shouldForceNew: false,
-	},
-	{
-		name: "requiredToNullable",
-		fieldBefore: []testUnitBigQueryDataCustomDiffField{{
-			mode:        "REQUIRED",
-			description: "someValue",
-		}},
-		fieldAfter: []testUnitBigQueryDataCustomDiffField{{
-			mode:        "NULLABLE",
-			description: "someValue",
-		}},
-		shouldForceNew: false,
-	},
-	{
-		name: "descriptionChanged",
-		fieldBefore: []testUnitBigQueryDataCustomDiffField{{
-			mode:        "REQUIRED",
-			description: "someValue",
-		}},
-		fieldAfter: []testUnitBigQueryDataCustomDiffField{{
-			mode:        "REQUIRED",
-			description: "some other value",
-		}},
-		shouldForceNew: false,
-	},
-	{
-		name: "nullToRequired",
-		fieldBefore: []testUnitBigQueryDataCustomDiffField{{
-			mode:        "NULLABLE",
-			description: "someValue",
-		}},
-		fieldAfter: []testUnitBigQueryDataCustomDiffField{{
-			mode:        "REQUIRED",
-			description: "someValue",
-		}},
-		shouldForceNew: true,
-	},
-	{
-		name: "arraySizeIncreases",
-		fieldBefore: []testUnitBigQueryDataCustomDiffField{{
-			mode:        "REQUIRED",
-			description: "someValue",
-		}},
-		fieldAfter: []testUnitBigQueryDataCustomDiffField{{
-			mode:        "REQUIRED",
-			description: "someValue",
-		},
-			{
-				mode:        "REQUIRED",
-				description: "some other value",
-			}},
-		shouldForceNew: false,
-	},
-	{
-		name: "arraySizeDecreases",
-		fieldBefore: []testUnitBigQueryDataCustomDiffField{{
-			mode:        "REQUIRED",
-			description: "someValue",
-		},
-			{
-				mode:        "REQUIRED",
-				description: "someValue",
-			}},
-		fieldAfter: []testUnitBigQueryDataCustomDiffField{{
-			mode:        "REQUIRED",
-			description: "someValue",
-		}},
-		shouldForceNew: true,
 	},
 }
 
@@ -907,25 +715,6 @@ func testAccCheckBigQueryTableDestroyProducer(t *testing.T) func(s *terraform.St
 			}
 		}
 
-		return nil
-	}
-}
-
-func testAccCheckBigQueryTableFields(t *testing.T) func(s *terraform.State) error {
-	return func(s *terraform.State) error {
-		for _, rs := range s.RootModule().Resources {
-			if rs.Type != "google_bigquery_table" {
-				continue
-			}
-			config := googleProviderConfig(t)
-			bqt, err := config.NewBigQueryClient(config.userAgent).Tables.Get(config.Project, rs.Primary.Attributes["dataset_id"], rs.Primary.Attributes["table_id"]).Do()
-			if err != nil {
-				return err
-			}
-			if bqt.Schema.Fields[1].Description != "testegg" {
-				t.Errorf("schema field not set to testegg for fields scenario")
-			}
-		}
 		return nil
 	}
 }
@@ -1577,37 +1366,6 @@ resource "google_bigquery_table" "test" {
         type        = "TIMESTAMP"
       },
     ])
-}
-`, datasetID, tableID)
-}
-
-func testAccBigQueryTable_fields(datasetID, tableID string) string {
-	return fmt.Sprintf(`
-resource "google_bigquery_dataset" "test" {
-  dataset_id = "%s"
-}
-
-resource "google_bigquery_table" "test" {
-  table_id   = "%s"
-  dataset_id = google_bigquery_dataset.test.dataset_id
-
-  friendly_name = "bigquerytest"
-  labels = {
-    "terrafrom_managed" = "true"
-	}
-
-	field {
-		description = "Time snapshot was taken, in Epoch milliseconds. Same across all rows and all tables in the snapshot, and uniquely defines a particular snapshot."
-		name        = "snapshot_timestamp"
-		mode        = "NULLABLE"
-		type        = "INTEGER"
-	}
-
-	field {
-		description = "testegg"
-		name        = "creation_time"
-		type        = "TIMESTAMP"
-	}
 }
 `, datasetID, tableID)
 }

--- a/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -596,7 +596,7 @@ func (testcase *testUnitBigQueryDataTableJSONChangeableTestCase) check(t *testin
 	if err := json.Unmarshal([]byte(testcase.jsonNew), &new); err != nil {
 		panic(fmt.Sprintf("unable to unmarshal json - %v", err))
 	}
-	changeable, err := resourceBigQueryTableSchemaIsChangable(old, new)
+	changeable, err := resourceBigQueryTableSchemaIsChangeable(old, new)
 	if err != nil {
 		t.Errorf("ahhhh an error I did not expect this! especially not on testscase %s - %s", testcase.name, err)
 	}

--- a/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -568,9 +568,9 @@ type testUnitBigQueryDataTableJSONEquivalencyTestCase struct {
 }
 
 type testUnitBigQueryDataTableJSONChangeableTestCase struct {
-	name      string
-	jsonOld   string
-	jsonNew   string
+	name       string
+	jsonOld    string
+	jsonNew    string
 	changeable bool
 }
 

--- a/third_party/terraform/utils/test_utils.go
+++ b/third_party/terraform/utils/test_utils.go
@@ -39,6 +39,11 @@ func (d *ResourceDataMock) GetOk(key string) (interface{}, bool) {
 	}
 }
 
+func (d *ResourceDiffMock) GetOk(key string) (interface{}, bool) {
+	v, ok := d.After[key]
+	return v, ok
+}
+
 func (d *ResourceDataMock) GetOkExists(key string) (interface{}, bool) {
 	for k, v := range d.FieldsInSchema {
 		if key == k {

--- a/third_party/terraform/utils/test_utils.go
+++ b/third_party/terraform/utils/test_utils.go
@@ -39,11 +39,6 @@ func (d *ResourceDataMock) GetOk(key string) (interface{}, bool) {
 	}
 }
 
-func (d *ResourceDiffMock) GetOk(key string) (interface{}, bool) {
-	v, ok := d.After[key]
-	return v, ok
-}
-
 func (d *ResourceDataMock) GetOkExists(key string) (interface{}, bool) {
 	for k, v := range d.FieldsInSchema {
 		if key == k {
@@ -89,6 +84,11 @@ func (d *ResourceDiffMock) HasChange(key string) bool {
 
 func (d *ResourceDiffMock) Get(key string) interface{} {
 	return d.After[key]
+}
+
+func (d *ResourceDiffMock) GetOk(key string) (interface{}, bool) {
+	v, ok := d.After[key]
+	return v, ok
 }
 
 func (d *ResourceDiffMock) Clear(key string) error {

--- a/third_party/terraform/utils/utils.go.erb
+++ b/third_party/terraform/utils/utils.go.erb
@@ -35,6 +35,7 @@ type TerraformResourceDiff interface {
 	HasChange(string) bool
 	GetChange(string) (interface{}, interface{})
 	Get(string) interface{}
+	GetOk(string) (interface{}, bool)
 	Clear(string) error
 	ForceNew(string) error
 }

--- a/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -14,7 +14,7 @@ Creates a table resource in a dataset for Google BigQuery. For more information 
 [API](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables).
 
 
-## Example Usage
+## Example Usage - field implementation
 
 ```hcl
 resource "google_bigquery_dataset" "default" {
@@ -55,6 +55,22 @@ resource "google_bigquery_table" "default" {
     description = "State where the head office is located"
   }
 }
+```
+
+## Example Usage - schema implementation
+
+```hcl
+resource "google_bigquery_dataset" "default" {
+  dataset_id                  = "foo"
+  friendly_name               = "test"
+  description                 = "This is a test description"
+  location                    = "EU"
+  default_table_expiration_ms = 3600000
+
+  labels = {
+    env = "default"
+  }
+}
 
 resource "google_bigquery_table" "default_schema_implementation" {
   dataset_id = google_bigquery_dataset.default.dataset_id
@@ -68,23 +84,37 @@ resource "google_bigquery_table" "default_schema_implementation" {
     env = "default"
   }
 
-  schema = <<EOF
-[
-  {
-    "name": "permalink",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "The Permalink"
-  },
-  {
-    "name": "state",
-    "type": "STRING",
-    "mode": "NULLABLE",
-    "description": "State where the head office is located"
-  }
-]
-EOF
+  schema = jsonencode(
+    [
+      {
+        name        = "permalink"
+        type        = "STRING"
+        mode        = "NULLABLE"
+        description = "The Permalink"
+      },
+      {
+        name        = "state",
+        type        = "STRING",
+        mode        = "NULLABLE",
+        description = "State where the head office is located"
+      }
+    ])
+}
+```
 
+## Example Usage - external data configuration implementation
+
+```hcl
+resource "google_bigquery_dataset" "default" {
+  dataset_id                  = "foo"
+  friendly_name               = "test"
+  description                 = "This is a test description"
+  location                    = "EU"
+  default_table_expiration_ms = 3600000
+
+  labels = {
+    env = "default"
+  }
 }
 
 resource "google_bigquery_table" "sheet" {

--- a/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -41,6 +41,33 @@ resource "google_bigquery_table" "default" {
     env = "default"
   }
 
+  field {
+    name        = "permalink"
+    type        = "STRING"
+    mode        = "NULLABLE"
+    description = "The Permalink"
+  }
+
+  field {
+    name        = "state"
+    type        = "STRING"
+    mode        = "NULLABLE"
+    description = "State where the head office is located"
+  }
+}
+
+resource "google_bigquery_table" "default_schema_implementation" {
+  dataset_id = google_bigquery_dataset.default.dataset_id
+  table_id   = "bar"
+
+  time_partitioning {
+    type = "DAY"
+  }
+
+  labels = {
+    env = "default"
+  }
+
   schema = <<EOF
 [
   {
@@ -92,7 +119,7 @@ The following arguments are supported:
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
 
-* `description` - (Optional) The field description.
+* `description` - (Optional) A description of the table.
 
 * `expiration_time` - (Optional) The time when this table expires, in
     milliseconds since the epoch. If not present, the table will persist
@@ -176,7 +203,11 @@ The `external_data_configuration` block supports:
     any changes on the configured value will force the table to be recreated.
     This schema is effectively only applied when creating a table from an external
     datasource, after creation the computed schema will be stored in
-    `google_bigquery_table.schema`
+    `google_bigquery_table.schema`. Conflicts with `field`.
+
+* `field` (Optional) - A nested configuration block (described below)
+  defining a field in the table's schema. Multiple `field` arguments are supported.
+  Conflicts with `schema`.
 
 * `source_format` (Required) - The data format. Supported values are:
     "CSV", "GOOGLE_SHEETS", "NEWLINE_DELIMITED_JSON", "AVRO", "PARQUET", "ORC"
@@ -258,6 +289,18 @@ The `time_partitioning` block supports:
 * `require_partition_filter` - (Optional) If set to true, queries over this table
     require a partition filter that can be used for partition elimination to be
     specified.
+
+The `field` block supports:
+
+* `name` - (Required) The name of the field. The name must contain only letters (a-z, A-Z),
+    numbers (0-9), or underscores (_), and must start with a letter or underscore. The maximum length is 128 characters.
+
+* `type` - (Required) The type of the field. Must be a
+  [valid BigQuery data type](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types).
+
+* `mode` - (Optional) One of `NULLABLE`, `REQUIRED`, or `REPEATED`. Default is `NULLABLE`.
+
+* `description` - (Optional) The field's description. The maximum length is 1,024 characters.
 
 The `range_partitioning` block supports:
 

--- a/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -14,7 +14,7 @@ Creates a table resource in a dataset for Google BigQuery. For more information 
 [API](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables).
 
 
-## Example Usage - field implementation
+## Example Usage
 
 ```hcl
 resource "google_bigquery_dataset" "default" {
@@ -41,80 +41,23 @@ resource "google_bigquery_table" "default" {
     env = "default"
   }
 
-  field {
-    name        = "permalink"
-    type        = "STRING"
-    mode        = "NULLABLE"
-    description = "The Permalink"
+  schema = <<EOF
+[
+  {
+    "name": "permalink",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "The Permalink"
+  },
+  {
+    "name": "state",
+    "type": "STRING",
+    "mode": "NULLABLE",
+    "description": "State where the head office is located"
   }
+]
+EOF
 
-  field {
-    name        = "state"
-    type        = "STRING"
-    mode        = "NULLABLE"
-    description = "State where the head office is located"
-  }
-}
-```
-
-## Example Usage - schema implementation
-
-```hcl
-resource "google_bigquery_dataset" "default" {
-  dataset_id                  = "foo"
-  friendly_name               = "test"
-  description                 = "This is a test description"
-  location                    = "EU"
-  default_table_expiration_ms = 3600000
-
-  labels = {
-    env = "default"
-  }
-}
-
-resource "google_bigquery_table" "default_schema_implementation" {
-  dataset_id = google_bigquery_dataset.default.dataset_id
-  table_id   = "bar"
-
-  time_partitioning {
-    type = "DAY"
-  }
-
-  labels = {
-    env = "default"
-  }
-
-  schema = jsonencode(
-    [
-      {
-        name        = "permalink"
-        type        = "STRING"
-        mode        = "NULLABLE"
-        description = "The Permalink"
-      },
-      {
-        name        = "state",
-        type        = "STRING",
-        mode        = "NULLABLE",
-        description = "State where the head office is located"
-      }
-    ])
-}
-```
-
-## Example Usage - external data configuration implementation
-
-```hcl
-resource "google_bigquery_dataset" "default" {
-  dataset_id                  = "foo"
-  friendly_name               = "test"
-  description                 = "This is a test description"
-  location                    = "EU"
-  default_table_expiration_ms = 3600000
-
-  labels = {
-    env = "default"
-  }
 }
 
 resource "google_bigquery_table" "sheet" {
@@ -149,7 +92,7 @@ The following arguments are supported:
 * `project` - (Optional) The ID of the project in which the resource belongs. If it
     is not provided, the provider project is used.
 
-* `description` - (Optional) A description of the table.
+* `description` - (Optional) The field description.
 
 * `expiration_time` - (Optional) The time when this table expires, in
     milliseconds since the epoch. If not present, the table will persist
@@ -233,11 +176,7 @@ The `external_data_configuration` block supports:
     any changes on the configured value will force the table to be recreated.
     This schema is effectively only applied when creating a table from an external
     datasource, after creation the computed schema will be stored in
-    `google_bigquery_table.schema`. Conflicts with `field`.
-
-* `field` (Optional) - A nested configuration block (described below)
-  defining a field in the table's schema. Multiple `field` arguments are supported.
-  Conflicts with `schema`.
+    `google_bigquery_table.schema`
 
 * `source_format` (Required) - The data format. Supported values are:
     "CSV", "GOOGLE_SHEETS", "NEWLINE_DELIMITED_JSON", "AVRO", "PARQUET", "ORC"
@@ -319,18 +258,6 @@ The `time_partitioning` block supports:
 * `require_partition_filter` - (Optional) If set to true, queries over this table
     require a partition filter that can be used for partition elimination to be
     specified.
-
-The `field` block supports:
-
-* `name` - (Required) The name of the field. The name must contain only letters (a-z, A-Z),
-    numbers (0-9), or underscores (_), and must start with a letter or underscore. The maximum length is 128 characters.
-
-* `type` - (Required) The type of the field. Must be a
-  [valid BigQuery data type](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types).
-
-* `mode` - (Optional) One of `NULLABLE`, `REQUIRED`, or `REPEATED`. Default is `NULLABLE`.
-
-* `description` - (Optional) The field's description. The maximum length is 1,024 characters.
 
 The `range_partitioning` block supports:
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

resolves [1144](https://github.com/hashicorp/terraform-provider-google/issues/1144)


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: made incompatible changes to the `google_bigquery_table.schema` field cause the resource to be recreated
```
