### PR TITLE
fix diff on currency_code in google_billing_budget

### DIFF
--- a/products/billingbudget/terraform.yaml
+++ b/products/billingbudget/terraform.yaml
@@ -76,6 +76,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       amount.lastPeriodAmount: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_expand: 'templates/terraform/custom_expand/bool_to_object.go.erb'
         custom_flatten: 'templates/terraform/custom_flatten/object_to_bool.go.erb'
+      amount.specifiedAmount.currencyCode: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
 
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files

--- a/third_party/terraform/tests/resource_billing_budget_test.go
+++ b/third_party/terraform/tests/resource_billing_budget_test.go
@@ -25,8 +25,6 @@ func TestAccBillingBudget_billingBudgetCurrencycode(t *testing.T) {
 			{
 				Config: testAccBillingBudget_billingBudgetCurrencycode(context),
 				Check: resource.ComposeTestCheckFunc(
-					// currency_code is returned when it is not included in the request
-					resource.TestCheckResourceAttrSet("google_billing_budget.budget", "amount.0.specified_amount.0.currency_code"),
 				),
 			},
 		},

--- a/third_party/terraform/tests/resource_billing_budget_test.go
+++ b/third_party/terraform/tests/resource_billing_budget_test.go
@@ -24,8 +24,7 @@ func TestAccBillingBudget_billingBudgetCurrencycode(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccBillingBudget_billingBudgetCurrencycode(context),
-				Check: resource.ComposeTestCheckFunc(
-				),
+				Check:  resource.ComposeTestCheckFunc(),
 			},
 		},
 	})

--- a/third_party/terraform/tests/resource_billing_budget_test.go
+++ b/third_party/terraform/tests/resource_billing_budget_test.go
@@ -1,0 +1,68 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccBillingBudget_billingBudgetCurrencycode(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"billing_acct":  getTestBillingAccountFromEnv(t),
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"random": {},
+		},
+		CheckDestroy: testAccCheckBillingBudgetDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBillingBudget_billingBudgetCurrencycode(context),
+				Check: resource.ComposeTestCheckFunc(
+					// currency_code is returned when it is not included in the request
+					resource.TestCheckResourceAttrSet("google_billing_budget.budget", "amount.0.specified_amount.0.currency_code"),
+				),
+			},
+		},
+	})
+}
+
+func testAccBillingBudget_billingBudgetCurrencycode(context map[string]interface{}) string {
+	return Nprintf(`
+data "google_billing_account" "account" {
+  billing_account = "%{billing_acct}"
+}
+
+data "google_project" "project" {
+}
+
+resource "google_billing_budget" "budget" {
+  billing_account = data.google_billing_account.account.id
+  display_name    = "Example Billing Budget%{random_suffix}"
+
+  budget_filter {
+    projects = ["projects/${data.google_project.project.number}"]
+  }
+
+  amount {
+    specified_amount {
+      units         = "100000"
+    }
+  }
+
+  threshold_rules {
+    threshold_percent = 1.0
+  }
+  threshold_rules {
+    threshold_percent = 1.0
+    spend_basis       = "FORECASTED_SPEND"
+  }
+}
+`, context)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/8228


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
billing: fixed perma-diff on currency_code in `google_billing_budget`
```
