### PR TITLE
Generated iam policy updaters for terraform-google-conversion

### DIFF
--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -59,6 +59,8 @@ module Provider
                            'third_party/terraform/utils/compute_operation.go.erb'],
                           ['google/config.go',
                            'third_party/terraform/utils/config.go.erb'],
+                          ['google/iam.go',
+                           'third_party/terraform/utils/iam.go.erb'],
                           ['google/utils.go',
                            'third_party/terraform/utils/utils.go.erb'],
                           ['google/compute_instance_helpers.go',

--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -165,7 +165,34 @@ module Provider
 
     def generate_resource_tests(pwd, data) end
 
-    def generate_iam_policy(pwd, data, generate_code, generate_docs) end
+    # Generate the IAM policy for this object. This is used to query and test
+    # IAM policies separately from the resource itself
+    # Docs are generated for the terraform provider, not here.
+    def generate_iam_policy(pwd, data, generate_code, generate_docs)
+      if generate_code
+        target_folder = File.join(data.output_folder, 'google')
+        name = data.object.filename_override || data.object.name.underscore
+        product_name = data.product.name.underscore
+
+        FileUtils.mkpath target_folder unless Dir.exist?(target_folder)
+        data.generate(pwd,
+                      'templates/terraform/iam_policy.go.erb',
+                      "#{target_folder}/iam_#{product_name}_#{name}.go",
+                      self)
+
+        # Only generate test if testable examples exist.
+        unless data.object.examples.reject(&:skip_test).empty?
+          data.generate(
+            pwd,
+            'templates/terraform/examples/base_configs/iam_test_file.go.erb',
+            "#{target_folder}/iam_#{product_name}_#{name}_generated_test.go",
+            self
+          )
+        end
+      end
+
+      return
+    end
 
     def generate_resource_sweepers(pwd, data) end
   end

--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -114,6 +114,8 @@ module Provider
                         'third_party/validator/monitoring_slo_helper.go'],
                        ['google/image.go',
                         'third_party/terraform/utils/image.go'],
+                       ['google/import.go',
+                        'third_party/terraform/utils/import.go'],
                        ['google/disk_type.go',
                         'third_party/terraform/utils/disk_type.go'],
                        ['google/validation.go',

--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -184,15 +184,8 @@ module Provider
                       "#{target_folder}/iam_#{product_name}_#{name}.go",
                       self)
 
-        # Only generate test if testable examples exist.
-        unless data.object.examples.reject(&:skip_test).empty?
-          data.generate(
-            pwd,
-            'templates/terraform/examples/base_configs/iam_test_file.go.erb',
-            "#{target_folder}/iam_#{product_name}_#{name}_generated_test.go",
-            self
-          )
-        end
+        # Don't generate tests - we can rely on the terraform provider
+        # to test these.
       end
 
       return


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Related to https://github.com/hashicorp/terraform-provider-google/issues/7797. This PR adds IAM Updaters to terraform-google-conversion. These provide the logic for fetching IAM policies from Google Cloud, which we need in order to properly resolve the linked issue.

I am doing this in a separate PR because it will generate a very large downstream diff that isn't very useful for understanding what the actual solution to the linked ticket is doing.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
