### PR TITLE
Support cloud scheduler update

### DIFF
--- a/products/cloudscheduler/api.yaml
+++ b/products/cloudscheduler/api.yaml
@@ -20,6 +20,10 @@ versions:
     base_url: https://cloudscheduler.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
+apis_required:
+  - !ruby/object:Api::Product::ApiReference
+    name: Cloud Scheduler
+    url: https://console.cloud.google.com/apis/library/cloudscheduler.googleapis.com/
 objects:
   - !ruby/object:Api::Resource
     name: 'Job'

--- a/products/cloudscheduler/api.yaml
+++ b/products/cloudscheduler/api.yaml
@@ -29,7 +29,7 @@ objects:
     name: 'Job'
     base_url: projects/{{project}}/locations/{{region}}/jobs
     self_link: projects/{{project}}/locations/{{region}}/jobs/{{name}}
-    input: true
+    update_verb: :PATCH
     description: |
       A scheduled job that can publish a pubsub message or a http request
       every X interval of time, using crontab format string.
@@ -62,20 +62,17 @@ objects:
           A human-readable description for the job. 
           This string must not contain more than 500 characters.
         required: false
-        input: true
       - !ruby/object:Api::Type::String
         name: schedule
         description: |
           Describes the schedule on which the job will be executed.
         required: false
-        input: true
       - !ruby/object:Api::Type::String
         name: timeZone
         description: |
           Specifies the time zone to be used in interpreting schedule.
           The value of this field must be a time zone name from the tz database.
         required: false
-        input: true
         default_value: 'Etc/UTC'
       - !ruby/object:Api::Type::String
         name: attemptDeadline
@@ -89,7 +86,6 @@ objects:
           * **Note**: For PubSub targets, this field is ignored - setting it will introduce an unresolvable diff.
           A duration in seconds with up to nine fractional digits, terminated by 's'. Example: "3.5s"
         required: false
-        input: true
         default_value: '180s'
       - !ruby/object:Api::Type::NestedObject
         name: retryConfig
@@ -98,7 +94,6 @@ objects:
           meaning that an acknowledgement is not received from the handler, 
           then it will be retried with exponential backoff according to the settings
         required: false
-        input: true
         properties:
           - !ruby/object:Api::Type::Integer
             name: retryCount
@@ -107,7 +102,6 @@ objects:
               job using the exponential backoff procedure described by maxDoublings.
               Values greater than 5 and negative values are not allowed.
             required: false
-            input: true
             at_least_one_of:
               - retry_config.0.retry_count
               - retry_config.0.max_retry_duration
@@ -121,7 +115,6 @@ objects:
               If specified with retryCount, the job will be retried until both limits are reached.
               A duration in seconds with up to nine fractional digits, terminated by 's'.
             required: false
-            input: true
             at_least_one_of:
               - retry_config.0.retry_count
               - retry_config.0.max_retry_duration
@@ -134,7 +127,6 @@ objects:
               The minimum amount of time to wait before retrying a job after it fails.
               A duration in seconds with up to nine fractional digits, terminated by 's'.
             required: false
-            input: true
             at_least_one_of:
               - retry_config.0.retry_count
               - retry_config.0.max_retry_duration
@@ -147,7 +139,6 @@ objects:
               The maximum amount of time to wait before retrying a job after it fails.
               A duration in seconds with up to nine fractional digits, terminated by 's'.
             required: false
-            input: true
             at_least_one_of:
               - retry_config.0.retry_count
               - retry_config.0.max_retry_duration
@@ -162,7 +153,6 @@ objects:
               then doubles maxDoublings times, then increases linearly, 
               and finally retries retries at intervals of maxBackoffDuration up to retryCount times.
             required: false
-            input: true
             at_least_one_of:
               - retry_config.0.retry_count
               - retry_config.0.max_retry_duration
@@ -175,7 +165,6 @@ objects:
           Pub/Sub target
           If the job providers a Pub/Sub target the cron will publish
           a message to the provided topic
-        input: true
         exactly_one_of:
           - pubsub_target
           - http_target
@@ -189,28 +178,24 @@ objects:
               The topic name must be in the same format as required by PubSub's
               PublishRequest.name, e.g. `projects/my-project/topics/my-topic`.
             required: true
-            input: true
           - !ruby/object:Api::Type::String
             name: data
             description: |
               The message payload for PubsubMessage.
               Pubsub message must contain either non-empty data, or at least one attribute.
             required: false
-            input: true
           - !ruby/object:Api::Type::KeyValuePairs
             name: attributes
             description: |
               Attributes for PubsubMessage.
               Pubsub message must contain either non-empty data, or at least one attribute.
             required: false
-            input: true
       - !ruby/object:Api::Type::NestedObject
         name: appEngineHttpTarget
         description: |
           App Engine HTTP target.
           If the job providers a App Engine HTTP target the cron will 
           send a request to the service instance
-        input: true
         exactly_one_of:
           - pubsub_target
           - http_target
@@ -221,13 +206,11 @@ objects:
             description: |
               Which HTTP method to use for the request.
             required: false
-            input: true
           - !ruby/object:Api::Type::NestedObject
             name: appEngineRouting
             description: |
               App Engine Routing setting for the job.
             required: false
-            input: true
             properties:
               - !ruby/object:Api::Type::String
                 name: service
@@ -239,7 +222,6 @@ objects:
                   - app_engine_http_target.0.app_engine_routing.0.version
                   - app_engine_http_target.0.app_engine_routing.0.instance
                 required: false
-                input: true
               - !ruby/object:Api::Type::String
                 name: version
                 description: |
@@ -250,7 +232,6 @@ objects:
                   - app_engine_http_target.0.app_engine_routing.0.version
                   - app_engine_http_target.0.app_engine_routing.0.instance
                 required: false
-                input: true
               - !ruby/object:Api::Type::String
                 name: instance
                 description: |
@@ -261,7 +242,6 @@ objects:
                   - app_engine_http_target.0.app_engine_routing.0.version
                   - app_engine_http_target.0.app_engine_routing.0.instance
                 required: false
-                input: true
           - !ruby/object:Api::Type::String
             name: relativeUri
             description: |
@@ -280,7 +260,6 @@ objects:
 
               A base64-encoded string.
             required: false
-            input: true
           - !ruby/object:Api::Type::KeyValuePairs
             name: headers
             description: |
@@ -288,14 +267,12 @@ objects:
               This map contains the header field names and values. 
               Headers can be set when the job is created.
             required: false
-            input: true
       - !ruby/object:Api::Type::NestedObject
         name: httpTarget
         description: |
           HTTP target.
           If the job providers a http_target the cron will 
           send a request to the targeted url
-        input: true
         exactly_one_of:
           - pubsub_target
           - http_target
@@ -331,7 +308,6 @@ objects:
             description: |
               Contains information needed for generating an OAuth token.
               This type of authorization should be used when sending requests to a GCP endpoint.
-            input: true
             properties:
               - !ruby/object:Api::Type::String
                 name: serviceAccountEmail
@@ -349,7 +325,6 @@ objects:
             description: |
               Contains information needed for generating an OpenID Connect token.
               This type of authorization should be used when sending requests to third party endpoints or Cloud Run.
-            input: true
             properties:
               - !ruby/object:Api::Type::String
                 name: serviceAccountEmail


### PR DESCRIPTION
This PR makes it possible to update cloud scheduler and fixes https://github.com/hashicorp/terraform-provider-google/issues/8159

If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudscheduler: Fixed unnecessary recreate for `google_cloud_scheduler_job`
```
