### PR TITLE
Revert "Generated iam policy updaters for terraform-google-conversion"

### DIFF
--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -59,8 +59,6 @@ module Provider
                            'third_party/terraform/utils/compute_operation.go.erb'],
                           ['google/config.go',
                            'third_party/terraform/utils/config.go.erb'],
-                          ['google/iam.go',
-                           'third_party/terraform/utils/iam.go.erb'],
                           ['google/utils.go',
                            'third_party/terraform/utils/utils.go.erb'],
                           ['google/compute_instance_helpers.go',
@@ -114,8 +112,6 @@ module Provider
                         'third_party/validator/monitoring_slo_helper.go'],
                        ['google/image.go',
                         'third_party/terraform/utils/image.go'],
-                       ['google/import.go',
-                        'third_party/terraform/utils/import.go'],
                        ['google/disk_type.go',
                         'third_party/terraform/utils/disk_type.go'],
                        ['google/validation.go',
@@ -169,27 +165,7 @@ module Provider
 
     def generate_resource_tests(pwd, data) end
 
-    # Generate the IAM policy for this object. This is used to query and test
-    # IAM policies separately from the resource itself
-    # Docs are generated for the terraform provider, not here.
-    def generate_iam_policy(pwd, data, generate_code, generate_docs)
-      if generate_code
-        target_folder = File.join(data.output_folder, 'google')
-        name = data.object.filename_override || data.object.name.underscore
-        product_name = data.product.name.underscore
-
-        FileUtils.mkpath target_folder unless Dir.exist?(target_folder)
-        data.generate(pwd,
-                      'templates/terraform/iam_policy.go.erb',
-                      "#{target_folder}/iam_#{product_name}_#{name}.go",
-                      self)
-
-        # Don't generate tests - we can rely on the terraform provider
-        # to test these.
-      end
-
-      return
-    end
+    def generate_iam_policy(pwd, data, generate_code, generate_docs) end
 
     def generate_resource_sweepers(pwd, data) end
   end


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#4406

After merging this, I realized that we will already have access to the terraform provider for google as a go dependency of terraform-validator - and the relevant code we need is exported. So, we can use it directly from terraform-provider-google instead of copying it into terraform-google-conversion.

Sorry for the churn!

```release-note:none
```