### PR TITLE
Revert "Revert "Generated iam policy updaters for terraform-google-conversion""

### DIFF
--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -172,7 +172,7 @@ module Provider
     # Generate the IAM policy for this object. This is used to query and test
     # IAM policies separately from the resource itself
     # Docs are generated for the terraform provider, not here.
-    def generate_iam_policy(pwd, data, generate_code, generate_docs)
+    def generate_iam_policy(pwd, data, generate_code, _generate_docs)
       if generate_code
         target_folder = File.join(data.output_folder, 'google')
         name = data.object.filename_override || data.object.name.underscore
@@ -187,8 +187,6 @@ module Provider
         # Don't generate tests - we can rely on the terraform provider
         # to test these.
       end
-
-      return
     end
 
     def generate_resource_sweepers(pwd, data) end

--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -59,6 +59,8 @@ module Provider
                            'third_party/terraform/utils/compute_operation.go.erb'],
                           ['google/config.go',
                            'third_party/terraform/utils/config.go.erb'],
+                          ['google/iam.go',
+                           'third_party/terraform/utils/iam.go.erb'],
                           ['google/utils.go',
                            'third_party/terraform/utils/utils.go.erb'],
                           ['google/compute_instance_helpers.go',
@@ -112,6 +114,8 @@ module Provider
                         'third_party/validator/monitoring_slo_helper.go'],
                        ['google/image.go',
                         'third_party/terraform/utils/image.go'],
+                       ['google/import.go',
+                        'third_party/terraform/utils/import.go'],
                        ['google/disk_type.go',
                         'third_party/terraform/utils/disk_type.go'],
                        ['google/validation.go',
@@ -165,7 +169,27 @@ module Provider
 
     def generate_resource_tests(pwd, data) end
 
-    def generate_iam_policy(pwd, data, generate_code, generate_docs) end
+    # Generate the IAM policy for this object. This is used to query and test
+    # IAM policies separately from the resource itself
+    # Docs are generated for the terraform provider, not here.
+    def generate_iam_policy(pwd, data, generate_code, generate_docs)
+      if generate_code
+        target_folder = File.join(data.output_folder, 'google')
+        name = data.object.filename_override || data.object.name.underscore
+        product_name = data.product.name.underscore
+
+        FileUtils.mkpath target_folder unless Dir.exist?(target_folder)
+        data.generate(pwd,
+                      'templates/terraform/iam_policy.go.erb',
+                      "#{target_folder}/iam_#{product_name}_#{name}.go",
+                      self)
+
+        # Don't generate tests - we can rely on the terraform provider
+        # to test these.
+      end
+
+      return
+    end
 
     def generate_resource_sweepers(pwd, data) end
   end

--- a/provider/terraform_object_library.rb
+++ b/provider/terraform_object_library.rb
@@ -173,20 +173,20 @@ module Provider
     # IAM policies separately from the resource itself
     # Docs are generated for the terraform provider, not here.
     def generate_iam_policy(pwd, data, generate_code, _generate_docs)
-      if generate_code
-        target_folder = File.join(data.output_folder, 'google')
-        name = data.object.filename_override || data.object.name.underscore
-        product_name = data.product.name.underscore
+      return unless generate_code
 
-        FileUtils.mkpath target_folder unless Dir.exist?(target_folder)
-        data.generate(pwd,
-                      'templates/terraform/iam_policy.go.erb',
-                      "#{target_folder}/iam_#{product_name}_#{name}.go",
-                      self)
+      target_folder = File.join(data.output_folder, 'google')
+      name = data.object.filename_override || data.object.name.underscore
+      product_name = data.product.name.underscore
 
-        # Don't generate tests - we can rely on the terraform provider
-        # to test these.
-      end
+      FileUtils.mkpath target_folder unless Dir.exist?(target_folder)
+      data.generate(pwd,
+                    'templates/terraform/iam_policy.go.erb',
+                    "#{target_folder}/iam_#{product_name}_#{name}.go",
+                    self)
+
+      # Don't generate tests - we can rely on the terraform provider
+      # to test these.
     end
 
     def generate_resource_sweepers(pwd, data) end


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#4413

I am definitely feeling a bit ridiculous for this one. I waited on merging the last PR until I was feeling pretty sure that I could eliminate the remaining references to Config - but the more progress I made, the more issues I ran into. In particular, there are a number of references to private variables on the Config struct that would not be easy to eliminate. I didn't realize that variables on structs were also governed by the export rules.

So, TLDR, it seems like we should copy over these thousands of lines of code for now. Once the CAI conversion is done through the DCL we will be able to eliminate this, but in the meantime...

If this looks good I'll also do a force push on the terraform-google conversion master branch to eliminate a few large commits I made towards trying to use the provider config struct.

```release_note:none
```