### PR TITLE
Made iam updaters accept TerraformResourceData interface

### DIFF
--- a/mmv1/templates/terraform/iam_policy.go.erb
+++ b/mmv1/templates/terraform/iam_policy.go.erb
@@ -64,12 +64,12 @@ type <%= resource_name -%>IamUpdater struct {
 <% resource_params.each do |param| -%>
 	<%= param.camelize(:lower) -%> string
 <% end # resource_params.each -%>
-	d       *schema.ResourceData
+	d       TerraformResourceData
 	Config  *Config
 }
 
 <% provider_default_values = ['project', 'location', 'region', 'zone'] -%>
-func <%= resource_name -%>IamUpdaterProducer(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func <%= resource_name -%>IamUpdaterProducer(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	values := make(map[string]string)
 
 <% resource_params.each do |param| -%>

--- a/mmv1/third_party/terraform/utils/iam.go.erb
+++ b/mmv1/third_party/terraform/utils/iam.go.erb
@@ -45,7 +45,7 @@ type (
 	}
 
 	// Factory for generating ResourceIamUpdater for given ResourceData resource
-	newResourceIamUpdaterFunc func(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error)
+	newResourceIamUpdaterFunc func(d *TerraformResourceData, config *Config) (ResourceIamUpdater, error)
 
 	// Describes how to modify a policy for a given Terraform IAM (_policy/_member/_binding/_audit_config) resource
 	iamPolicyModifyFunc func(p *cloudresourcemanager.Policy) error

--- a/mmv1/third_party/terraform/utils/iam.go.erb
+++ b/mmv1/third_party/terraform/utils/iam.go.erb
@@ -45,7 +45,7 @@ type (
 	}
 
 	// Factory for generating ResourceIamUpdater for given ResourceData resource
-	newResourceIamUpdaterFunc func(d *TerraformResourceData, config *Config) (ResourceIamUpdater, error)
+	newResourceIamUpdaterFunc func(d TerraformResourceData, config *Config) (ResourceIamUpdater, error)
 
 	// Describes how to modify a policy for a given Terraform IAM (_policy/_member/_binding/_audit_config) resource
 	iamPolicyModifyFunc func(p *cloudresourcemanager.Policy) error

--- a/mmv1/third_party/terraform/utils/iam_bigquery_dataset.go
+++ b/mmv1/third_party/terraform/utils/iam_bigquery_dataset.go
@@ -33,11 +33,11 @@ var bigqueryAccessPrimitiveToRoleMap = map[string]string{
 type BigqueryDatasetIamUpdater struct {
 	project   string
 	datasetId string
-	d         *schema.ResourceData
+	d         TerraformResourceData
 	Config    *Config
 }
 
-func NewBigqueryDatasetIamUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewBigqueryDatasetIamUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	project, err := getProject(d, config)
 	if err != nil {
 		return nil, err

--- a/mmv1/third_party/terraform/utils/iam_bigtable_instance.go
+++ b/mmv1/third_party/terraform/utils/iam_bigtable_instance.go
@@ -26,11 +26,11 @@ var IamBigtableInstanceSchema = map[string]*schema.Schema{
 type BigtableInstanceIamUpdater struct {
 	project  string
 	instance string
-	d        *schema.ResourceData
+	d        TerraformResourceData
 	Config   *Config
 }
 
-func NewBigtableInstanceUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewBigtableInstanceUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	project, err := getProject(d, config)
 	if err != nil {
 		return nil, err

--- a/mmv1/third_party/terraform/utils/iam_bigtable_table.go
+++ b/mmv1/third_party/terraform/utils/iam_bigtable_table.go
@@ -33,11 +33,11 @@ type BigtableTableIamUpdater struct {
 	project  string
 	instance string
 	table    string
-	d        *schema.ResourceData
+	d        TerraformResourceData
 	Config   *Config
 }
 
-func NewBigtableTableUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewBigtableTableUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	project, err := getProject(d, config)
 	if err != nil {
 		return nil, err

--- a/mmv1/third_party/terraform/utils/iam_billing_account.go
+++ b/mmv1/third_party/terraform/utils/iam_billing_account.go
@@ -18,11 +18,11 @@ var IamBillingAccountSchema = map[string]*schema.Schema{
 
 type BillingAccountIamUpdater struct {
 	billingAccountId string
-	d                *schema.ResourceData
+	d                TerraformResourceData
 	Config           *Config
 }
 
-func NewBillingAccountIamUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewBillingAccountIamUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	return &BillingAccountIamUpdater{
 		billingAccountId: canonicalBillingAccountId(d.Get("billing_account_id").(string)),
 		d:                d,

--- a/mmv1/third_party/terraform/utils/iam_dataproc_cluster.go
+++ b/mmv1/third_party/terraform/utils/iam_dataproc_cluster.go
@@ -33,11 +33,11 @@ type DataprocClusterIamUpdater struct {
 	project string
 	region  string
 	cluster string
-	d       *schema.ResourceData
+	d       TerraformResourceData
 	Config  *Config
 }
 
-func NewDataprocClusterUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewDataprocClusterUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	project, err := getProject(d, config)
 	if err != nil {
 		return nil, err

--- a/mmv1/third_party/terraform/utils/iam_dataproc_job.go
+++ b/mmv1/third_party/terraform/utils/iam_dataproc_job.go
@@ -33,11 +33,11 @@ type DataprocJobIamUpdater struct {
 	project string
 	region  string
 	jobId   string
-	d       *schema.ResourceData
+	d       TerraformResourceData
 	Config  *Config
 }
 
-func NewDataprocJobUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewDataprocJobUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	project, err := getProject(d, config)
 	if err != nil {
 		return nil, err

--- a/mmv1/third_party/terraform/utils/iam_folder.go
+++ b/mmv1/third_party/terraform/utils/iam_folder.go
@@ -20,11 +20,11 @@ var IamFolderSchema = map[string]*schema.Schema{
 
 type FolderIamUpdater struct {
 	folderId string
-	d        *schema.ResourceData
+	d        TerraformResourceData
 	Config   *Config
 }
 
-func NewFolderIamUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewFolderIamUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	return &FolderIamUpdater{
 		folderId: canonicalFolderId(d.Get("folder").(string)),
 		d:        d,

--- a/mmv1/third_party/terraform/utils/iam_healthcare_dataset.go
+++ b/mmv1/third_party/terraform/utils/iam_healthcare_dataset.go
@@ -20,11 +20,11 @@ var IamHealthcareDatasetSchema = map[string]*schema.Schema{
 
 type HealthcareDatasetIamUpdater struct {
 	resourceId string
-	d          *schema.ResourceData
+	d          TerraformResourceData
 	Config     *Config
 }
 
-func NewHealthcareDatasetIamUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewHealthcareDatasetIamUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	dataset := d.Get("dataset_id").(string)
 	datasetId, err := parseHealthcareDatasetId(dataset, config)
 

--- a/mmv1/third_party/terraform/utils/iam_healthcare_dicom_store.go
+++ b/mmv1/third_party/terraform/utils/iam_healthcare_dicom_store.go
@@ -20,11 +20,11 @@ var IamHealthcareDicomStoreSchema = map[string]*schema.Schema{
 
 type HealthcareDicomStoreIamUpdater struct {
 	resourceId string
-	d          *schema.ResourceData
+	d          TerraformResourceData
 	Config     *Config
 }
 
-func NewHealthcareDicomStoreIamUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewHealthcareDicomStoreIamUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	dicomStore := d.Get("dicom_store_id").(string)
 	dicomStoreId, err := parseHealthcareDicomStoreId(dicomStore, config)
 

--- a/mmv1/third_party/terraform/utils/iam_healthcare_fhir_store.go
+++ b/mmv1/third_party/terraform/utils/iam_healthcare_fhir_store.go
@@ -20,11 +20,11 @@ var IamHealthcareFhirStoreSchema = map[string]*schema.Schema{
 
 type HealthcareFhirStoreIamUpdater struct {
 	resourceId string
-	d          *schema.ResourceData
+	d          TerraformResourceData
 	Config     *Config
 }
 
-func NewHealthcareFhirStoreIamUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewHealthcareFhirStoreIamUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	fhirStore := d.Get("fhir_store_id").(string)
 	fhirStoreId, err := parseHealthcareFhirStoreId(fhirStore, config)
 

--- a/mmv1/third_party/terraform/utils/iam_healthcare_hl7_v2_store.go
+++ b/mmv1/third_party/terraform/utils/iam_healthcare_hl7_v2_store.go
@@ -20,11 +20,11 @@ var IamHealthcareHl7V2StoreSchema = map[string]*schema.Schema{
 
 type HealthcareHl7V2StoreIamUpdater struct {
 	resourceId string
-	d          *schema.ResourceData
+	d          TerraformResourceData
 	Config     *Config
 }
 
-func NewHealthcareHl7V2StoreIamUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewHealthcareHl7V2StoreIamUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	hl7V2Store := d.Get("hl7_v2_store_id").(string)
 	hl7V2StoreId, err := parseHealthcareHl7V2StoreId(hl7V2Store, config)
 

--- a/mmv1/third_party/terraform/utils/iam_kms_crypto_key.go.erb
+++ b/mmv1/third_party/terraform/utils/iam_kms_crypto_key.go.erb
@@ -20,11 +20,11 @@ var IamKmsCryptoKeySchema = map[string]*schema.Schema{
 
 type KmsCryptoKeyIamUpdater struct {
 	resourceId string
-	d          *schema.ResourceData
+	d          TerraformResourceData
 	Config     *Config
 }
 
-func NewKmsCryptoKeyIamUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewKmsCryptoKeyIamUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	cryptoKey := d.Get("crypto_key_id").(string)
 	cryptoKeyId, err := parseKmsCryptoKeyId(cryptoKey, config)
 

--- a/mmv1/third_party/terraform/utils/iam_kms_key_ring.go.erb
+++ b/mmv1/third_party/terraform/utils/iam_kms_key_ring.go.erb
@@ -20,11 +20,11 @@ var IamKmsKeyRingSchema = map[string]*schema.Schema{
 
 type KmsKeyRingIamUpdater struct {
 	resourceId string
-	d          *schema.ResourceData
+	d          TerraformResourceData
 	Config     *Config
 }
 
-func NewKmsKeyRingIamUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewKmsKeyRingIamUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	keyRing := d.Get("key_ring_id").(string)
 	keyRingId, err := parseKmsKeyRingId(keyRing, config)
 

--- a/mmv1/third_party/terraform/utils/iam_organization.go
+++ b/mmv1/third_party/terraform/utils/iam_organization.go
@@ -18,11 +18,11 @@ var IamOrganizationSchema = map[string]*schema.Schema{
 
 type OrganizationIamUpdater struct {
 	resourceId string
-	d          *schema.ResourceData
+	d          TerraformResourceData
 	Config     *Config
 }
 
-func NewOrganizationIamUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewOrganizationIamUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	return &OrganizationIamUpdater{
 		resourceId: d.Get("org_id").(string),
 		d:          d,
@@ -30,7 +30,7 @@ func NewOrganizationIamUpdater(d *schema.ResourceData, config *Config) (Resource
 	}, nil
 }
 
-func OrgIdParseFunc(d *schema.ResourceData, _ *Config) error {
+func OrgIdParseFunc(d TerraformResourceData, _ *Config) error {
 	if err := d.Set("org_id", d.Id()); err != nil {
 		return fmt.Errorf("Error setting org_id: %s", err)
 	}

--- a/mmv1/third_party/terraform/utils/iam_organization.go
+++ b/mmv1/third_party/terraform/utils/iam_organization.go
@@ -30,7 +30,7 @@ func NewOrganizationIamUpdater(d TerraformResourceData, config *Config) (Resourc
 	}, nil
 }
 
-func OrgIdParseFunc(d TerraformResourceData, _ *Config) error {
+func OrgIdParseFunc(d *schema.ResourceData, _ *Config) error {
 	if err := d.Set("org_id", d.Id()); err != nil {
 		return fmt.Errorf("Error setting org_id: %s", err)
 	}

--- a/mmv1/third_party/terraform/utils/iam_project.go
+++ b/mmv1/third_party/terraform/utils/iam_project.go
@@ -31,11 +31,11 @@ var IamPolicyProjectSchema = map[string]*schema.Schema{
 
 type ProjectIamUpdater struct {
 	resourceId string
-	d          *schema.ResourceData
+	d          TerraformResourceData
 	Config     *Config
 }
 
-func NewProjectIamUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewProjectIamUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	pid, err := getProject(d, config)
 	if err != nil {
 		return nil, err
@@ -54,7 +54,7 @@ func NewProjectIamUpdater(d *schema.ResourceData, config *Config) (ResourceIamUp
 
 // NewProjectIamPolicyUpdater is similar to NewProjectIamUpdater, except that it
 // doesn't call getProject and only uses an explicitly set project.
-func NewProjectIamPolicyUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewProjectIamPolicyUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	return &ProjectIamUpdater{
 		resourceId: d.Get("project").(string),
 		d:          d,

--- a/mmv1/third_party/terraform/utils/iam_pubsub_subscription.go
+++ b/mmv1/third_party/terraform/utils/iam_pubsub_subscription.go
@@ -26,11 +26,11 @@ var IamPubsubSubscriptionSchema = map[string]*schema.Schema{
 
 type PubsubSubscriptionIamUpdater struct {
 	subscription string
-	d            *schema.ResourceData
+	d            TerraformResourceData
 	Config       *Config
 }
 
-func NewPubsubSubscriptionIamUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewPubsubSubscriptionIamUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	project, err := getProject(d, config)
 	if err != nil {
 		return nil, err

--- a/mmv1/third_party/terraform/utils/iam_service_account.go.erb
+++ b/mmv1/third_party/terraform/utils/iam_service_account.go.erb
@@ -21,11 +21,11 @@ var IamServiceAccountSchema = map[string]*schema.Schema{
 
 type ServiceAccountIamUpdater struct {
 	serviceAccountId string
-	d                *schema.ResourceData
+	d                TerraformResourceData
 	Config           *Config
 }
 
-func NewServiceAccountIamUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewServiceAccountIamUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	return &ServiceAccountIamUpdater{
 		serviceAccountId: d.Get("service_account_id").(string),
 		d:                d,

--- a/mmv1/third_party/terraform/utils/iam_spanner_database.go
+++ b/mmv1/third_party/terraform/utils/iam_spanner_database.go
@@ -33,11 +33,11 @@ type SpannerDatabaseIamUpdater struct {
 	project  string
 	instance string
 	database string
-	d        *schema.ResourceData
+	d        TerraformResourceData
 	Config   *Config
 }
 
-func NewSpannerDatabaseIamUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewSpannerDatabaseIamUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	project, err := getProject(d, config)
 	if err != nil {
 		return nil, err

--- a/mmv1/third_party/terraform/utils/iam_spanner_instance.go
+++ b/mmv1/third_party/terraform/utils/iam_spanner_instance.go
@@ -29,11 +29,11 @@ var IamSpannerInstanceSchema = map[string]*schema.Schema{
 type SpannerInstanceIamUpdater struct {
 	project  string
 	instance string
-	d        *schema.ResourceData
+	d        TerraformResourceData
 	Config   *Config
 }
 
-func NewSpannerInstanceIamUpdater(d *schema.ResourceData, config *Config) (ResourceIamUpdater, error) {
+func NewSpannerInstanceIamUpdater(d TerraformResourceData, config *Config) (ResourceIamUpdater, error) {
 	project, err := getProject(d, config)
 	if err != nil {
 		return nil, err

--- a/mmv1/third_party/terraform/utils/regional_utils.go
+++ b/mmv1/third_party/terraform/utils/regional_utils.go
@@ -3,8 +3,6 @@ package google
 import (
 	"fmt"
 	"strings"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 //These functions are used by both the `resource_container_node_pool` and `resource_container_cluster` for handling regional clusters
@@ -13,7 +11,7 @@ func isZone(location string) bool {
 	return len(strings.Split(location, "-")) == 3
 }
 
-func getLocation(d *schema.ResourceData, config *Config) (string, error) {
+func getLocation(d TerraformResourceData, config *Config) (string, error) {
 	if v, ok := d.GetOk("location"); ok {
 		return v.(string), nil
 	} else if v, isRegionalCluster := d.GetOk("region"); isRegionalCluster {

--- a/mmv1/third_party/terraform/utils/test_utils.go
+++ b/mmv1/third_party/terraform/utils/test_utils.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -64,6 +65,10 @@ func (d *ResourceDataMock) Id() string {
 
 func (d *ResourceDataMock) GetProviderMeta(dst interface{}) error {
 	return nil
+}
+
+func (d *ResourceDataMock) Timeout(key string) time.Duration {
+	return time.Duration(1)
 }
 
 type ResourceDiffMock struct {

--- a/mmv1/third_party/terraform/utils/utils.go.erb
+++ b/mmv1/third_party/terraform/utils/utils.go.erb
@@ -29,6 +29,7 @@ type TerraformResourceData interface {
 	SetId(string)
 	Id() string
 	GetProviderMeta(interface{}) error
+	Timeout(key string) time.Duration
 }
 
 type TerraformResourceDiff interface {


### PR DESCRIPTION
This allows for easier interoperability with terraform-validator, and is currently the standard for other functions used by terraform-google-conversion

Related to https://github.com/hashicorp/terraform-provider-google/issues/7797

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
