### PR TITLE
Implemented a simple PascalCase function to remove strcase dependency

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance_from_machine_image.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_from_machine_image.go.erb
@@ -7,7 +7,6 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	strcase "github.com/stoewer/go-strcase"
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	compute "google.golang.org/api/compute/v1"
 )
@@ -158,7 +157,7 @@ func resourceComputeInstanceFromMachineImageCreate(d *schema.ResourceData, meta 
 			// Assume for now that all fields are exact snake_case versions of the API fields.
 			// This won't necessarily always be true, but it serves as a good approximation and
 			// can be adjusted later as we discover issues.
-			instance.ForceSendFields = append(instance.ForceSendFields, strcase.UpperCamelCase(f))
+			instance.ForceSendFields = append(instance.ForceSendFields, PascalCase(f))
 		}
 	}
 

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_from_machine_image.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_from_machine_image.go.erb
@@ -157,7 +157,7 @@ func resourceComputeInstanceFromMachineImageCreate(d *schema.ResourceData, meta 
 			// Assume for now that all fields are exact snake_case versions of the API fields.
 			// This won't necessarily always be true, but it serves as a good approximation and
 			// can be adjusted later as we discover issues.
-			instance.ForceSendFields = append(instance.ForceSendFields, PascalCase(f))
+			instance.ForceSendFields = append(instance.ForceSendFields, SnakeToPascalCase(f))
 		}
 	}
 

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_from_template.go
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_from_template.go
@@ -153,7 +153,7 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 			// Assume for now that all fields are exact snake_case versions of the API fields.
 			// This won't necessarily always be true, but it serves as a good approximation and
 			// can be adjusted later as we discover issues.
-			instance.ForceSendFields = append(instance.ForceSendFields, PascalCase(f))
+			instance.ForceSendFields = append(instance.ForceSendFields, SnakeToPascalCase(f))
 		}
 	}
 

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_from_template.go
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_from_template.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	strcase "github.com/stoewer/go-strcase"
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	compute "google.golang.org/api/compute/v1"
 )
@@ -154,7 +153,7 @@ func resourceComputeInstanceFromTemplateCreate(d *schema.ResourceData, meta inte
 			// Assume for now that all fields are exact snake_case versions of the API fields.
 			// This won't necessarily always be true, but it serves as a good approximation and
 			// can be adjusted later as we discover issues.
-			instance.ForceSendFields = append(instance.ForceSendFields, strcase.UpperCamelCase(f))
+			instance.ForceSendFields = append(instance.ForceSendFields, PascalCase(f))
 		}
 	}
 

--- a/mmv1/third_party/terraform/utils/utils.go.erb
+++ b/mmv1/third_party/terraform/utils/utils.go.erb
@@ -479,7 +479,7 @@ func generateUserAgentString(d TerraformResourceData, currentUserAgent string) (
 }
 
 
-func PascalCase(s string) (string) {
+func SnakeToPascalCase(s string) (string) {
 	split := strings.Split(s, "_")
 	for i := range split {
 		split[i] = strings.Title(split[i])

--- a/mmv1/third_party/terraform/utils/utils.go.erb
+++ b/mmv1/third_party/terraform/utils/utils.go.erb
@@ -477,3 +477,12 @@ func generateUserAgentString(d TerraformResourceData, currentUserAgent string) (
 
 	return currentUserAgent, nil
 }
+
+
+func PascalCase(s string) (string) {
+	split := strings.Split(s, "_")
+	for i := range split {
+		split[i] = strings.Title(split[i])
+	}
+	return strings.Join(split, "")
+}

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -598,10 +598,10 @@ func TestConflictError(t *testing.T) {
 	// skipping negative tests as other cases may be added later.
 }
 
-func TestPascalCase(t *testing.T) {
+func TestSnakeToPascalCase(t *testing.T) {
 	input := "boot_disk"
 	expected := "BootDisk"
-	actual := PascalCase(input)
+	actual := SnakeToPascalCase(input)
 
 	if actual != expected {
 		t.Fatalf("(%s) did not match expected value: %s", actual, expected)

--- a/mmv1/third_party/terraform/utils/utils_test.go
+++ b/mmv1/third_party/terraform/utils/utils_test.go
@@ -597,3 +597,13 @@ func TestConflictError(t *testing.T) {
 	}
 	// skipping negative tests as other cases may be added later.
 }
+
+func TestPascalCase(t *testing.T) {
+	input := "boot_disk"
+	expected := "BootDisk"
+	actual := PascalCase(input)
+
+	if actual != expected {
+		t.Fatalf("(%s) did not match expected value: %s", actual, expected)
+	}
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Related to https://github.com/hashicorp/terraform-provider-google/issues/8166. I manually tested sample input / output:

```go
package main

import (
	"fmt"
	"strings"
	strcase "github.com/stoewer/go-strcase"
)


func PascalCase(s string) (string) {
	split := strings.Split(s, "_")
	for i := range split {
		split[i] = strings.Title(split[i])
	}
	return strings.Join(split, "")
}


func main() {
	f := "boot_disk"
	fmt.Println(f)
	fmt.Println(strcase.UpperCamelCase(f))
	fmt.Println(PascalCase(f))
}

```

Output:
```
$ go run test.go
boot_disk
BootDisk
BootDisk
```


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
