### PR TITLE
Add point-in-time-recovery to sql database instance

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -72,6 +72,11 @@ var (
 		"replica_configuration.0.username",
 		"replica_configuration.0.verify_server_certificate",
 	}
+
+	pointInTimeRestoreConfigurationKeys = []string{
+		"clone.0.pitr_timestamp_ms",
+		"clone.0.source_instance_name",
+	}
 )
 
 func resourceSqlDatabaseInstance() *schema.Resource {
@@ -111,7 +116,8 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 			},
 			"settings": {
 				Type:     schema.TypeList,
-				Required: true,
+				Optional:     true,
+				AtLeastOneOf: []string{"settings", "clone"},
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -608,6 +614,28 @@ settings.backup_configuration.binary_log_enabled are both set to true.`,
 				},
 			},
 		},
+		"clone": {
+			Type:        schema.TypeList,
+			Optional:    true,
+			Computed:    false,
+			Description: `Configuration for creating a new instance as a clone of another instance.`,
+			MaxItems:    1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"source_instance_name": {
+						Type:        schema.TypeString,
+						Required:    true,
+						Description: `The name of the instance from which the point in time should be restored.`,
+					},
+					"pitr_timestamp_ms": {
+						Type:         schema.TypeInt,
+						Optional:     true,
+						RequiredWith: pointInTimeRestoreConfigurationKeys,
+						Description:  `The timestamp of the point in time that should be restored.`,
+					},
+				},
+			},
+		},
 		UseJSONNumber: true,
 	}
 }
@@ -702,10 +730,27 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 	instance := &sqladmin.DatabaseInstance{
 		Name:                 name,
 		Region:               region,
-		Settings:             expandSqlDatabaseInstanceSettings(d.Get("settings").([]interface{}), !isFirstGen(d)),
 		DatabaseVersion:      d.Get("database_version").(string),
 		MasterInstanceName:   d.Get("master_instance_name").(string),
-		ReplicaConfiguration: expandReplicaConfiguration(d.Get("replica_configuration").([]interface{})),
+	}
+
+	cloneContext, cloneSource := expandCloneContext(d.Get("clone").([]interface{}))
+
+	instance := &sqladmin.DatabaseInstance{
+		Name:               name,
+		Region:             region,
+		DatabaseVersion:    d.Get("database_version").(string),
+		MasterInstanceName: d.Get("master_instance_name").(string),
+	}
+
+	desiredSettings := expandSqlDatabaseInstanceSettings(d.Get("settings").([]interface{}), !isFirstGen(d))
+
+	if len(d.Get("settings").([]interface{})) != 0 {
+		instance.Settings = desiredSettings
+	}
+
+	if len(d.Get("replica_configuration").([]interface{})) != 0 {
+		instance.ReplicaConfiguration = expandReplicaConfiguration(d.Get("replica_configuration").([]interface{}))
 	}
 
 	// MSSQL Server require rootPassword to be set
@@ -752,6 +797,29 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 	err = resourceSqlDatabaseInstanceRead(d, meta)
 	if err != nil {
 		return err
+	}
+
+	// If we've created an instance as a clone, we need to update it to set the correct settings
+	if cloneContext != nil && len(d.Get("settings").([]interface{})) != 0 {
+		// Update only updates the settings, so they are all we need to set.
+		instance := &sqladmin.DatabaseInstance{
+			Settings: desiredSettings,
+		}
+		_settings := d.Get("settings").([]interface{})[0].(map[string]interface{})
+		instance.Settings.SettingsVersion = int64(_settings["version"].(int))
+		var op *sqladmin.Operation
+		err = retryTimeDuration(func() (rerr error) {
+			op, rerr = config.clientSqlAdmin.Instances.Update(project, name, instance).Do()
+			return rerr
+		}, d.Timeout(schema.TimeoutUpdate), isSqlOperationInProgressError)
+		if err != nil {
+			return fmt.Errorf("Error, failed to update instance settings for %s: %s", instance.Name, err)
+		}
+
+		err = sqlAdminOperationWaitTime(config, op, project, "Update Instance", d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return err
+		}
 	}
 
 	// If a default root user was created with a wildcard ('%') hostname, delete it.
@@ -853,6 +921,18 @@ func expandReplicaConfiguration(configured []interface{}) *sqladmin.ReplicaConfi
 			VerifyServerCertificate: _replicaConfiguration["verify_server_certificate"].(bool),
 		},
 	}
+}
+
+func expandCloneContext(configured []interface{}) (*sqladmin.CloneContext, string) {
+	if len(configured) == 0 || configured[0] == nil {
+		return nil, ""
+	}
+
+	_cloneConfiguration := configured[0].(map[string]interface{})
+
+	return &sqladmin.CloneContext{
+		PitrTimestampMs: int64(_cloneConfiguration["pitr_timestamp_ms"].(int)),
+	}, _cloneConfiguration["source_instance_name"].(string)
 }
 
 func expandMaintenanceWindow(configured []interface{}) *sqladmin.MaintenanceWindow {

--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -613,25 +613,25 @@ settings.backup_configuration.binary_log_enabled are both set to true.`,
 					},
 				},
 			},
-		},
-		"clone": {
-			Type:        schema.TypeList,
-			Optional:    true,
-			Computed:    false,
-			Description: `Configuration for creating a new instance as a clone of another instance.`,
-			MaxItems:    1,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"source_instance_name": {
-						Type:        schema.TypeString,
-						Required:    true,
-						Description: `The name of the instance from which the point in time should be restored.`,
-					},
-					"point_in_time": {
-						Type:         schema.TypeInt,
-						Required:     true,
-						DiffSuppressFunc: timestampDiffSuppress(time.RFC3339Nano),
-						Description:  `The timestamp of the point in time that should be restored.`,
+			"clone": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    false,
+				Description: `Configuration for creating a new instance as a clone of another instance.`,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"source_instance_name": {
+							Type:        schema.TypeString,
+							Required:    true,
+							Description: `The name of the instance from which the point in time should be restored.`,
+						},
+						"point_in_time": {
+							Type:             schema.TypeString,
+							Required:     true,
+							DiffSuppressFunc: timestampDiffSuppress(time.RFC3339Nano),
+							Description:  `The timestamp of the point in time that should be restored.`,
+						},
 					},
 				},
 			},
@@ -737,9 +737,9 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 
 	cloneContext, cloneSource := expandCloneContext(d.Get("clone").([]interface{}))
 
-	desiredSettings := expandSqlDatabaseInstanceSettings(d.Get("settings").([]interface{}), !isFirstGen(d))
-
-	if s, ok := d.GetOk("settings"); ok {
+    s, ok := d.GetOk("settings")
+	desiredSettings := expandSqlDatabaseInstanceSettings(s.([]interface{}), !isFirstGen(d))
+	if ok {
 		instance.Settings = desiredSettings
 	}
 
@@ -796,7 +796,7 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	// If we've created an instance as a clone, we need to update it to set the correct settings
-	if s, ok = d.GetOk("settings"); ok && cloneContext != nil {
+	if s, ok := d.GetOk("settings"); ok && cloneContext != nil {
 		instance := &sqladmin.DatabaseInstance{
 			Settings: desiredSettings,
 		}
@@ -804,14 +804,14 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 		instance.Settings.SettingsVersion = int64(_settings["version"].(int))
 		var op *sqladmin.Operation
 		err = retryTimeDuration(func() (rerr error) {
-			op, rerr = config.clientSqlAdmin.Instances.Update(project, name, instance).Do()
+			op, rerr = config.NewSqlAdminClient(userAgent).Instances.Update(project, name, instance).Do()
 			return rerr
 		}, d.Timeout(schema.TimeoutUpdate), isSqlOperationInProgressError)
 		if err != nil {
 			return fmt.Errorf("Error, failed to update instance settings for %s: %s", instance.Name, err)
 		}
 
-		err = sqlAdminOperationWaitTime(config, op, project, "Update Instance", d.Timeout(schema.TimeoutUpdate))
+		err = sqlAdminOperationWaitTime(config, op, project, "Update Instance", userAgent, d.Timeout(schema.TimeoutUpdate))
 		if err != nil {
 			return err
 		}
@@ -926,7 +926,7 @@ func expandCloneContext(configured []interface{}) (*sqladmin.CloneContext, strin
 	_cloneConfiguration := configured[0].(map[string]interface{})
 
 	return &sqladmin.CloneContext{
-		PointInTime: _cloneConfiguration["pitr_timestamp_ms"].(string),
+		PointInTime: _cloneConfiguration["point_in_time"].(string),
 	}, _cloneConfiguration["source_instance_name"].(string)
 }
 

--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -72,11 +72,6 @@ var (
 		"replica_configuration.0.username",
 		"replica_configuration.0.verify_server_certificate",
 	}
-
-	pointInTimeRestoreConfigurationKeys = []string{
-		"clone.0.point_in_time",
-		"clone.0.source_instance_name",
-	}
 )
 
 func resourceSqlDatabaseInstance() *schema.Resource {

--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -142,6 +142,7 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 						"authorized_gae_applications": {
 							Type:        schema.TypeList,
 							Optional:    true,
+							Computed:    true,
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Deprecated:  "This property is only applicable to First Generation instances, and First Generation instances are now deprecated.",
 							Description: `This property is only applicable to First Generation instances. First Generation instances are now deprecated, see https://cloud.google.com/sql/docs/mysql/deprecation-notice for information on how to upgrade to Second Generation instances. A list of Google App Engine project names that are allowed to access this instance.`,
@@ -353,6 +354,7 @@ settings.backup_configuration.binary_log_enabled are both set to true.`,
 						"user_labels": {
 							Type:        schema.TypeMap,
 							Optional:    true,
+							Computed:    true,
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Description: `A set of key/value user label pairs to assign to the instance.`,
 						},
@@ -800,16 +802,18 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
+	// Refresh settings from read as they may have defaulted from the API
+	s = d.Get("settings")
 	// If we've created an instance as a clone, we need to update it to set the correct settings
-	if s, ok := d.GetOk("settings"); ok && cloneContext != nil {
-		instance := &sqladmin.DatabaseInstance{
+	if len(s.([]interface{})) != 0 && cloneContext != nil {
+		instanceUpdate := &sqladmin.DatabaseInstance{
 			Settings: desiredSettings,
 		}
 		_settings := s.([]interface{})[0].(map[string]interface{})
-		instance.Settings.SettingsVersion = int64(_settings["version"].(int))
+		instanceUpdate.Settings.SettingsVersion = int64(_settings["version"].(int))
 		var op *sqladmin.Operation
 		err = retryTimeDuration(func() (rerr error) {
-			op, rerr = config.NewSqlAdminClient(userAgent).Instances.Update(project, name, instance).Do()
+			op, rerr = config.NewSqlAdminClient(userAgent).Instances.Update(project, name, instanceUpdate).Do()
 			return rerr
 		}, d.Timeout(schema.TimeoutUpdate), isSqlOperationInProgressError)
 		if err != nil {
@@ -817,6 +821,12 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 		}
 
 		err = sqlAdminOperationWaitTime(config, op, project, "Update Instance", userAgent, d.Timeout(schema.TimeoutUpdate))
+		if err != nil {
+			return err
+		}
+
+		// Refresh the state of the instance after updating the settings
+		err = resourceSqlDatabaseInstanceRead(d, meta)
 		if err != nil {
 			return err
 		}

--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -74,7 +74,7 @@ var (
 	}
 
 	pointInTimeRestoreConfigurationKeys = []string{
-		"clone.0.pitr_timestamp_ms",
+		"clone.0.point_in_time",
 		"clone.0.source_instance_name",
 	}
 )
@@ -627,10 +627,10 @@ settings.backup_configuration.binary_log_enabled are both set to true.`,
 						Required:    true,
 						Description: `The name of the instance from which the point in time should be restored.`,
 					},
-					"pitr_timestamp_ms": {
+					"point_in_time": {
 						Type:         schema.TypeInt,
-						Optional:     true,
-						RequiredWith: pointInTimeRestoreConfigurationKeys,
+						Required:     true,
+						DiffSuppressFunc: timestampDiffSuppress(time.RFC3339Nano),
 						Description:  `The timestamp of the point in time that should be restored.`,
 					},
 				},
@@ -732,25 +732,15 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 		Region:               region,
 		DatabaseVersion:      d.Get("database_version").(string),
 		MasterInstanceName:   d.Get("master_instance_name").(string),
+		ReplicaConfiguration: expandReplicaConfiguration(d.Get("replica_configuration").([]interface{})),
 	}
 
 	cloneContext, cloneSource := expandCloneContext(d.Get("clone").([]interface{}))
 
-	instance := &sqladmin.DatabaseInstance{
-		Name:               name,
-		Region:             region,
-		DatabaseVersion:    d.Get("database_version").(string),
-		MasterInstanceName: d.Get("master_instance_name").(string),
-	}
-
 	desiredSettings := expandSqlDatabaseInstanceSettings(d.Get("settings").([]interface{}), !isFirstGen(d))
 
-	if len(d.Get("settings").([]interface{})) != 0 {
+	if s, ok := d.GetOk("settings"); ok {
 		instance.Settings = desiredSettings
-	}
-
-	if len(d.Get("replica_configuration").([]interface{})) != 0 {
-		instance.ReplicaConfiguration = expandReplicaConfiguration(d.Get("replica_configuration").([]interface{}))
 	}
 
 	// MSSQL Server require rootPassword to be set
@@ -775,7 +765,13 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 
 	var op *sqladmin.Operation
 	err = retryTimeDuration(func() (operr error) {
-		op, operr = config.NewSqlAdminClient(userAgent).Instances.Insert(project, instance).Do()
+		if cloneContext != nil {
+			cloneContext.DestinationInstanceName = name
+			clodeReq := sqladmin.InstancesCloneRequest{CloneContext: cloneContext}
+			op, operr = config.NewSqlAdminClient(userAgent).Instances.Clone(project, cloneSource, &clodeReq).Do()
+		} else {
+			op, operr = config.NewSqlAdminClient(userAgent).Instances.Insert(project, instance).Do()
+		}
 		return operr
 	}, d.Timeout(schema.TimeoutCreate), isSqlOperationInProgressError)
 	if err != nil {
@@ -800,12 +796,11 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	// If we've created an instance as a clone, we need to update it to set the correct settings
-	if cloneContext != nil && len(d.Get("settings").([]interface{})) != 0 {
-		// Update only updates the settings, so they are all we need to set.
+	if s, ok = d.GetOk("settings"); ok && cloneContext != nil {
 		instance := &sqladmin.DatabaseInstance{
 			Settings: desiredSettings,
 		}
-		_settings := d.Get("settings").([]interface{})[0].(map[string]interface{})
+		_settings := s.([]interface{})[0].(map[string]interface{})
 		instance.Settings.SettingsVersion = int64(_settings["version"].(int))
 		var op *sqladmin.Operation
 		err = retryTimeDuration(func() (rerr error) {
@@ -931,7 +926,7 @@ func expandCloneContext(configured []interface{}) (*sqladmin.CloneContext, strin
 	_cloneConfiguration := configured[0].(map[string]interface{})
 
 	return &sqladmin.CloneContext{
-		PitrTimestampMs: int64(_cloneConfiguration["pitr_timestamp_ms"].(int)),
+		PointInTime: _cloneConfiguration["pitr_timestamp_ms"].(string),
 	}, _cloneConfiguration["source_instance_name"].(string)
 }
 

--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -117,6 +117,7 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 			"settings": {
 				Type:     schema.TypeList,
 				Optional:     true,
+				Computed:     true,
 				AtLeastOneOf: []string{"settings", "clone"},
 				MaxItems: 1,
 				Elem: &schema.Resource{
@@ -617,6 +618,7 @@ settings.backup_configuration.binary_log_enabled are both set to true.`,
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    false,
+				AtLeastOneOf: []string{"settings", "clone"},
 				Description: `Configuration for creating a new instance as a clone of another instance.`,
 				MaxItems:    1,
 				Elem: &schema.Resource{
@@ -654,6 +656,9 @@ func suppressFirstGen(k, old, new string, d *schema.ResourceData) bool {
 // Detects whether a database is 1st Generation by inspecting the tier name
 func isFirstGen(d *schema.ResourceData) bool {
 	settingsList := d.Get("settings").([]interface{})
+	if len(settingsList) == 0 {
+		return false
+	}
 	settings := settingsList[0].(map[string]interface{})
 	tier := settings["tier"].(string)
 

--- a/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -757,6 +757,34 @@ func TestAccSqlDatabaseInstance_backupUpdate(t *testing.T) {
 	})
 }
 
+func TestAccSqlDatabaseInstance_clone(t *testing.T) {
+	// Sqladmin client
+	skipIfVcr(t)
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix":    randString(t, 10),
+		"original_db_name": BootstrapSharedSQLInstanceBackupRun(t),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSqlDatabaseInstance_clone(context),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "clone"},
+			},
+		},
+	})
+}
+
 func testAccSqlDatabaseInstanceDestroyProducer(t *testing.T) func(s *terraform.State) error {
 	return func(s *terraform.State) error {
 		for _, rs := range s.RootModule().Resources {
@@ -1324,6 +1352,41 @@ resource "google_sql_database_instance" "instance" {
   }
 
   deletion_protection = false
+}
+
+data "google_sql_backup_run" "backup" {
+	instance = "%{original_db_name}"
+	most_recent = true
+}
+`, context)
+}
+
+func testAccSqlDatabaseInstance_clone(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_sql_database_instance" "instance" {
+  name             = "tf-test-%{random_suffix}"
+  database_version = "POSTGRES_11"
+  region           = "us-central1"
+
+  settings {
+	tier = "db-f1-micro"
+	backup_configuration {
+		enabled            = true
+		point_in_time_recovery_enabled = true
+	}
+  }
+
+  clone {
+    source_instance_name = data.google_sql_backup_run.backup.instance
+    point_in_time = data.google_sql_backup_run.backup.start_time
+  }
+
+  deletion_protection = false
+
+  // Ignore changes, since the most recent backup may change during the test
+  lifecycle{
+	ignore_changes = [clone[0].point_in_time]
+  }
 }
 
 data "google_sql_backup_run" "backup" {

--- a/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_sql_database_instance_test.go.erb
@@ -757,7 +757,7 @@ func TestAccSqlDatabaseInstance_backupUpdate(t *testing.T) {
 	})
 }
 
-func TestAccSqlDatabaseInstance_clone(t *testing.T) {
+func TestAccSqlDatabaseInstance_basicClone(t *testing.T) {
 	// Sqladmin client
 	skipIfVcr(t)
 	t.Parallel()
@@ -773,7 +773,35 @@ func TestAccSqlDatabaseInstance_clone(t *testing.T) {
 		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccSqlDatabaseInstance_clone(context),
+				Config: testAccSqlDatabaseInstance_basicClone(context),
+			},
+			{
+				ResourceName:            "google_sql_database_instance.instance",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection", "clone"},
+			},
+		},
+	})
+}
+
+func TestAccSqlDatabaseInstance_cloneWithSettings(t *testing.T) {
+	// Sqladmin client
+	skipIfVcr(t)
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix":    randString(t, 10),
+		"original_db_name": BootstrapSharedSQLInstanceBackupRun(t),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccSqlDatabaseInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSqlDatabaseInstance_cloneWithSettings(context),
 			},
 			{
 				ResourceName:            "google_sql_database_instance.instance",
@@ -1361,7 +1389,34 @@ data "google_sql_backup_run" "backup" {
 `, context)
 }
 
-func testAccSqlDatabaseInstance_clone(context map[string]interface{}) string {
+func testAccSqlDatabaseInstance_basicClone(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_sql_database_instance" "instance" {
+  name             = "tf-test-%{random_suffix}"
+  database_version = "POSTGRES_11"
+  region           = "us-central1"
+
+  clone {
+    source_instance_name = data.google_sql_backup_run.backup.instance
+    point_in_time = data.google_sql_backup_run.backup.start_time
+  }
+
+  deletion_protection = false
+
+  // Ignore changes, since the most recent backup may change during the test
+  lifecycle{
+	ignore_changes = [clone[0].point_in_time]
+  }
+}
+
+data "google_sql_backup_run" "backup" {
+	instance = "%{original_db_name}"
+	most_recent = true
+}
+`, context)
+}
+
+func testAccSqlDatabaseInstance_cloneWithSettings(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_sql_database_instance" "instance" {
   name             = "tf-test-%{random_suffix}"
@@ -1371,8 +1426,7 @@ resource "google_sql_database_instance" "instance" {
   settings {
 	tier = "db-f1-micro"
 	backup_configuration {
-		enabled            = true
-		point_in_time_recovery_enabled = true
+		enabled            = false
 	}
   }
 

--- a/mmv1/third_party/terraform/utils/bootstrap_utils_test.go
+++ b/mmv1/third_party/terraform/utils/bootstrap_utils_test.go
@@ -356,8 +356,14 @@ func BootstrapSharedSQLInstanceBackupRun(t *testing.T) string {
 	if err != nil {
 		if isGoogleApiErrorWithCode(err, 404) {
 			log.Printf("[DEBUG] SQL Instance %q not found, bootstrapping", SharedTestSQLInstanceName)
+
+			backupConfig := &sqladmin.BackupConfiguration{
+				Enabled:                    true,
+				PointInTimeRecoveryEnabled: true,
+			}
 			settings := &sqladmin.Settings{
-				Tier: "db-f1-micro",
+				Tier:                "db-f1-micro",
+				BackupConfiguration: backupConfig,
 			}
 			instance = &sqladmin.DatabaseInstance{
 				Name:            SharedTestSQLInstanceName,

--- a/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
@@ -144,7 +144,6 @@ func absoluteDomainSuppress(k, old, new string, _ *schema.ResourceData) bool {
 	return old == new
 }
 
-<% unless version == 'ga' -%>
 func timestampDiffSuppress(format string) schema.SchemaDiffSuppressFunc {
 	return func(_, old, new string, _ *schema.ResourceData) bool {
 		oldT, err := time.Parse(format, old)
@@ -160,4 +159,3 @@ func timestampDiffSuppress(format string) schema.SchemaDiffSuppressFunc {
 		return oldT == newT
 	}
 }
-<% end -%>

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -243,7 +243,7 @@ in Terraform state, a `terraform destroy` or `terraform apply` command that dele
     resource creation, Terraform will attempt to clone another instance as indicated in the context. The
     configuration is detailed below.
 
-The required `settings` block supports:
+The `settings` block supports:
 
 * `tier` - (Required) The machine type to use. See [tiers](https://cloud.google.com/sql/docs/admin-api/v1beta4/tiers)
     for more details and supported versions. Postgres supports only shared-core machine types such as `db-f1-micro`,
@@ -382,7 +382,7 @@ to work, cannot be updated, and supports:
 * `verify_server_certificate` - (Optional) True if the master's common name
     value is checked during the SSL handshake.
 
-The optional `clone` supports and is required if the settings block is not set:
+The optional `clone` block supports:
 
 * `source_instance_name` - (Required) Name of the source instance which will be cloned.
 

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -382,8 +382,9 @@ The optional `clone` supports and is required if the settings block is not set:
 
 * `source_instance_name` - (Required) Name of the source instance which will be cloned.
 
-* `pitr_timestamp_ms` -  (Optional) Timestamp of the point in time that should be restored,
-    requires the instance to have point in time recovery enabled.
+* `point_in_time` -  (Optional) The timestamp of the point in time that should be restored.
+
+    A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
 
 The optional `restore_backup_context` block supports:
 **NOTE:** Restoring from a backup is an imperative action and not recommended via Terraform. Adding or modifying this

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -378,6 +378,13 @@ to work, cannot be updated, and supports:
 * `verify_server_certificate` - (Optional) True if the master's common name
     value is checked during the SSL handshake.
 
+The optional `clone` supports and is required if the settings block is not set:
+
+* `source_instance_name` - (Required) Name of the source instance which will be cloned.
+
+* `pitr_timestamp_ms` -  (Optional) Timestamp of the point in time that should be restored,
+    requires the instance to have point in time recovery enabled.
+
 The optional `restore_backup_context` block supports:
 **NOTE:** Restoring from a backup is an imperative action and not recommended via Terraform. Adding or modifying this
 block during resource creation/update will trigger the restore action after the resource is created/updated. 

--- a/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/sql_database_instance.html.markdown
@@ -191,10 +191,10 @@ The following arguments are supported:
     region is not supported with Cloud SQL. If you choose not to provide the `region` argument for this resource,
     make sure you understand this.
 
-* `settings` - (Required) The settings to use for the database. The
-    configuration is detailed below.
-
 - - -
+
+* `settings` - (Optional) The settings to use for the database. The
+    configuration is detailed below. Required if `clone` is not set.
 
 * `database_version` - (Optional, Default: `MYSQL_5_6`) The MySQL, PostgreSQL or
 SQL Server (beta) version to use. Supported values include `MYSQL_5_6`,
@@ -238,6 +238,10 @@ in Terraform state, a `terraform destroy` or `terraform apply` command that dele
     cause Terraform to trigger the database to restore from the backup run indicated. The configuration is detailed below.
     **NOTE:** Restoring from a backup is an imperative action and not recommended via Terraform. Adding or modifying this
     block during resource creation/update will trigger the restore action after the resource is created/updated. 
+
+* `clone` - (Optional) The context needed to create this instance as a clone of another instance. When this field is set during 
+    resource creation, Terraform will attempt to clone another instance as indicated in the context. The
+    configuration is detailed below.
 
 The required `settings` block supports:
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/6848
This PR iterates on the discontinued PR https://github.com/hashicorp/terraform-provider-google/pull/6862

See https://cloud.google.com/sql/docs/postgres/admin-api/rest/v1beta4/instances/clone 



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
sql: added support for point-in-time-recovery to `google_sql_database_instance`
```
