### PR TITLE
Fix inspec-gcp #302 - incorrect parsing of Memcached discoveryEndpoint property

### DIFF
--- a/mmv1/products/memcache/api.yaml
+++ b/mmv1/products/memcache/api.yaml
@@ -124,7 +124,7 @@ objects:
         name: 'createTime'
         description: Creation timestamp in RFC3339 text format.
         output: true
-      - !ruby/object:Api::Type::Time
+      - !ruby/object:Api::Type::String
         name: 'discoveryEndpoint'
         description:  Endpoint for Discovery API
         output: true


### PR DESCRIPTION
Fixes https://github.com/inspec/inspec-gcp/issues/302 where the memcached `discoveryEndpoint` property is parsed as a Time instead of as a String in the `google_memcache_instance` and `google_memcache_instances` resources.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
Fixes a problem where inspec-gcp tries to parse the discoveryEndpoint property of a memcached object as a Time instead of a ip:port String.
```

Signed-off-by: Richard Nixon <rnixon@chef.io>
