### PR TITLE
sort array of schema for bigquery_table

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/resources/resource_bigquery_table.go
@@ -15,13 +15,13 @@ import (
 	"google.golang.org/api/bigquery/v2"
 )
 
-func sortArrayByName(array []interface{}) {
+func bigQueryTableSortArrayByName(array []interface{}) {
 	sort.Slice(array, func(i, k int) bool {
 		return array[i].(map[string]interface{})["name"].(string) < array[k].(map[string]interface{})["name"].(string)
 	})
 }
 
-func checkNameExists(jsonList []interface{}) error {
+func bigQueryTablecheckNameExists(jsonList []interface{}) error {
 	for _, m := range jsonList {
 		if _, ok := m.(map[string]interface{})["name"]; !ok {
 			return fmt.Errorf("No name in schema %+v", m)
@@ -44,14 +44,14 @@ func jsonCompareWithMapKeyOverride(a, b interface{}, compareMapKeyVal func(key s
 		} else if len(arrayA) != len(arrayB) {
 			return false, nil
 		}
-		if err := checkNameExists(arrayA); err != nil {
+		if err := bigQueryTablecheckNameExists(arrayA); err != nil {
 			return false, err
 		}
-		sortArrayByName(arrayA)
-		if err := checkNameExists(arrayB); err != nil {
+		bigQueryTableSortArrayByName(arrayA)
+		if err := bigQueryTablecheckNameExists(arrayB); err != nil {
 			return false, err
 		}
-		sortArrayByName(arrayB)
+		bigQueryTableSortArrayByName(arrayB)
 		for i := range arrayA {
 			eq, err := jsonCompareWithMapKeyOverride(arrayA[i], arrayB[i], compareMapKeyVal)
 			if err != nil {
@@ -194,14 +194,14 @@ func resourceBigQueryTableSchemaIsChangeable(old, new interface{}) (bool, error)
 			// if not growing not changeable
 			return false, nil
 		}
-		if err := checkNameExists(arrayOld); err != nil {
+		if err := bigQueryTablecheckNameExists(arrayOld); err != nil {
 			return false, err
 		}
-		sortArrayByName(arrayOld)
-		if err := checkNameExists(arrayNew); err != nil {
+		bigQueryTableSortArrayByName(arrayOld)
+		if err := bigQueryTablecheckNameExists(arrayNew); err != nil {
 			return false, err
 		}
-		sortArrayByName(arrayNew)
+		bigQueryTableSortArrayByName(arrayNew)
 		for i := range arrayOld {
 			if isChangable, err :=
 				resourceBigQueryTableSchemaIsChangeable(arrayOld[i], arrayNew[i]); err != nil || !isChangable {

--- a/mmv1/third_party/terraform/resources/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/resources/resource_bigquery_table.go
@@ -670,6 +670,7 @@ func resourceBigQueryTable() *schema.Resource {
 						"expiration_ms": {
 							Type:        schema.TypeInt,
 							Optional:    true,
+							Computed:    true,
 							Description: `Number of milliseconds for which to keep the storage for a partition.`,
 						},
 

--- a/mmv1/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -598,67 +598,91 @@ var testUnitBigQueryDataTableIsChangableTestCases = []testUnitBigQueryDataTableJ
 		jsonNew:    "[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"description\" : \"some new value\" }]",
 		changeable: false,
 	},
+	{
+		name:       "orderOfArrayChangesAndDescriptionChanges",
+		jsonOld:    "[{\"name\": \"value1\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }, {\"name\": \"value2\", \"type\" : \"BOOLEAN\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
+		jsonNew:    "[{\"name\": \"value2\", \"type\" : \"BOOLEAN\", \"mode\" : \"NULLABLE\", \"description\" : \"newVal\" },  {\"name\": \"value1\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
+		changeable: true,
+	},
+	{
+		name:       "orderOfArrayChangesAndNameChanges",
+		jsonOld:    "[{\"name\": \"value1\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }, {\"name\": \"value2\", \"type\" : \"BOOLEAN\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
+		jsonNew:    "[{\"name\": \"value3\", \"type\" : \"BOOLEAN\", \"mode\" : \"NULLABLE\", \"description\" : \"newVal\" },  {\"name\": \"value1\", \"type\" : \"INTEGER\", \"mode\" : \"NULLABLE\", \"description\" : \"someVal\" }]",
+		changeable: false,
+	},
 }
 
 var testUnitBigQueryDataTableJSONEquivalencyTestCases = []testUnitBigQueryDataTableJSONEquivalencyTestCase{
 	{
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"finalKey\" : {} }]",
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"finalKey\" : {} }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"finalKey\" : {} }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"finalKey\" : {} }]",
 		true,
 	},
 	{
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"finalKey\" : {} }]",
-		"[{\"someKey\": \"someValue\", \"finalKey\" : {} }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"finalKey\" : {} }]",
+		"[{\"name\": \"someValue\", \"finalKey\" : {} }]",
 		false,
 	},
 	{
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"mode\": \"NULLABLE\"  }]",
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\" }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"mode\": \"NULLABLE\"  }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\" }]",
 		true,
 	},
 	{
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"mode\": \"NULLABLE\"  }]",
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"mode\": \"somethingRandom\"  }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"mode\": \"NULLABLE\"  }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"mode\": \"somethingRandom\"  }]",
 		false,
 	},
 	{
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"description\": \"\"  }]",
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\" }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"description\": \"\"  }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\" }]",
 		true,
 	},
 	{
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"description\": \"\"  }]",
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"description\": \"somethingRandom\"  }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"description\": \"\"  }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"description\": \"somethingRandom\"  }]",
 		false,
 	},
 	{
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"INTEGER\"  }]",
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"INT64\"  }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"INTEGER\"  }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"INT64\"  }]",
 		true,
 	},
 	{
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"INTEGER\"  }]",
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"somethingRandom\"  }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"INTEGER\"  }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"somethingRandom\"  }]",
 		false,
 	},
 	{
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"FLOAT\"  }]",
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"FLOAT64\"  }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"FLOAT\"  }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"FLOAT64\"  }]",
 		true,
 	},
 	{
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"FLOAT\"  }]",
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\" }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"FLOAT\"  }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\" }]",
 		false,
 	},
 	{
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"BOOLEAN\"  }]",
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"BOOL\"  }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"BOOLEAN\"  }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"BOOL\"  }]",
 		true,
 	},
 	{
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"BOOLEAN\"  }]",
-		"[{\"someKey\": \"someValue\", \"anotherKey\" : \"anotherValue\" }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"BOOLEAN\"  }]",
+		"[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\" }]",
+		false,
+	},
+	{
+		// order changes, name same
+		"[{\"name\": \"value1\", \"1\" : \"1\"},{\"name\": \"value2\", \"2\" : \"2\" }]",
+		"[{\"name\": \"value2\", \"2\" : \"2\" },{\"name\": \"value1\", \"1\" : \"1\" }]",
+		true,
+	},
+	{
+		// order changes, value different
+		"[{\"name\": \"value1\", \"1\" : \"1\"},{\"name\": \"value2\", \"2\" : \"2\" }]",
+		"[{\"name\": \"value2\", \"2\" : \"random\" },{\"name\": \"value1\", \"1\" : \"1\" }]",
 		false,
 	},
 	{

--- a/mmv1/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -463,7 +463,7 @@ func TestAccBigQueryDataTable_canReorderParameters(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// we don't run any checks because the resource will error out if
-				// it attempts to destory/tear down.
+				// it attempts to destroy/tear down.
 				Config: testAccBigQueryTable_jsonPreventDestroy(datasetID, tableID),
 			},
 			{

--- a/mmv1/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -711,16 +711,6 @@ var testUnitBigQueryDataTableJSONEquivalencyTestCases = []testUnitBigQueryDataTa
 		"[{\"name\": \"value2\", \"2\" : \"random\" },{\"name\": \"value1\", \"1\" : \"1\" }]",
 		false,
 	},
-	{
-		"[1,2,3]",
-		"[1,2,3]",
-		true,
-	},
-	{
-		"[1,2,3]",
-		"[1,2,\"banana\"]",
-		false,
-	},
 }
 
 func testAccCheckBigQueryExtData(t *testing.T, expectedQuoteChar string) resource.TestCheckFunc {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

closes https://github.com/hashicorp/terraform-provider-google/issues/1144
closes https://github.com/hashicorp/terraform-provider-google/issues/8282


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquery: fixed bug where you could not reorder columns on `schema` for resource `google_bigquery_table`
```
