### PR TITLE
add gVNIC support for compute instance

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -297,7 +297,7 @@ func resourceComputeInstance() *schema.Resource {
 							Computed:    true,
 							Description: `The name of the interface`,
 						},
-
+<% unless version == 'ga' -%>
 						"nic_type": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -305,7 +305,7 @@ func resourceComputeInstance() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"GVNIC", "VIRTIO_NET"}, false),
 							Description:  `The type of vNIC to be used on this interface. Possible values:GVNIC, VIRTIO_NET`,
 						},
-
+<% end -%>
 						"access_config": {
 							Type:        schema.TypeList,
 							Optional:    true,

--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -298,6 +298,14 @@ func resourceComputeInstance() *schema.Resource {
 							Description: `The name of the interface`,
 						},
 
+						"nic_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice([]string{"GVNIC", "VIRTIO_NET"}, false),
+							Description:  `The type of vNIC to be used on this interface. Possible values:GVNIC, VIRTIO_NET`,
+						},
+
 						"access_config": {
 							Type:        schema.TypeList,
 							Optional:    true,

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -331,6 +331,14 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 							Description: `The name of the network_interface.`,
 						},
 
+						"nic_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew:     true,
+							ValidateFunc: validation.StringInSlice([]string{"GVNIC", "VIRTIO_NET"}, false),
+							Description:  `The type of vNIC to be used on this interface. Possible values:GVNIC, VIRTIO_NET`,
+						},
+
 						"access_config": {
 							Type:        schema.TypeList,
 							Optional:    true,

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -330,7 +330,7 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 							Computed:    true,
 							Description: `The name of the network_interface.`,
 						},
-
+<% unless version == 'ga' -%>
 						"nic_type": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -338,7 +338,7 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"GVNIC", "VIRTIO_NET"}, false),
 							Description:  `The type of vNIC to be used on this interface. Possible values:GVNIC, VIRTIO_NET`,
 						},
-
+<% end -%>
 						"access_config": {
 							Type:        schema.TypeList,
 							Optional:    true,

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -1053,6 +1053,35 @@ func TestAccComputeInstance_multiNic(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_nictype_update(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	var instanceName = fmt.Sprintf("tf-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_nictype(instanceName, instanceName, "GVNIC"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+				),
+			},
+			{
+				Config: testAccComputeInstance_nictype(instanceName, instanceName, "VIRTIO_NET"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeInstance_guestAccelerator(t *testing.T) {
 	t.Parallel()
 
@@ -4139,6 +4168,62 @@ resource "google_compute_subnetwork" "inst-test-subnetwork" {
 }
 `, instance, network, subnetwork)
 }
+
+func testAccComputeInstance_nictype(image, instance, nictype string) string {
+	return fmt.Sprintf(`
+resource "google_compute_image" "example" {
+	name = "%s"
+	raw_disk {
+		source = "https://storage.googleapis.com/bosh-gce-raw-stemcells/bosh-stemcell-97.98-google-kvm-ubuntu-xenial-go_agent-raw-1557960142.tar.gz"
+	}
+
+	guest_os_features {
+		type = "SECURE_BOOT"
+	}
+
+	guest_os_features {
+		type = "MULTI_IP_SUBNET"
+	}
+
+	guest_os_features {
+		type = "GVNIC"
+	}
+}
+
+resource "google_compute_instance" "foobar" {
+  name           = "%s"
+  machine_type   = "e2-medium"
+  zone           = "us-central1-a"
+  can_ip_forward = false
+  tags           = ["foo", "bar"]
+
+  //deletion_protection = false is implicit in this config due to default value
+
+  boot_disk {
+    initialize_params {
+	  image = google_compute_image.example.id
+    }
+  }
+
+  network_interface {
+	network = "default"
+	nic_type = "%s"
+  }
+
+  metadata = {
+    foo            = "bar"
+    baz            = "qux"
+    startup-script = "echo Hello"
+  }
+
+  labels = {
+    my_key       = "my_value"
+    my_other_key = "my_other_value"
+  }
+}
+`, image, instance, nictype)
+}
+
 
 func testAccComputeInstance_guestAccelerator(instance string, count uint8) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -1052,7 +1052,7 @@ func TestAccComputeInstance_multiNic(t *testing.T) {
 		},
 	})
 }
-
+<% unless version == 'ga' -%>
 func TestAccComputeInstance_nictype_update(t *testing.T) {
 	t.Parallel()
 
@@ -1081,6 +1081,7 @@ func TestAccComputeInstance_nictype_update(t *testing.T) {
 		},
 	})
 }
+<% end -%>
 
 func TestAccComputeInstance_guestAccelerator(t *testing.T) {
 	t.Parallel()
@@ -4169,6 +4170,7 @@ resource "google_compute_subnetwork" "inst-test-subnetwork" {
 `, instance, network, subnetwork)
 }
 
+<% unless version == 'ga' -%>
 func testAccComputeInstance_nictype(image, instance, nictype string) string {
 	return fmt.Sprintf(`
 resource "google_compute_image" "example" {
@@ -4223,7 +4225,7 @@ resource "google_compute_instance" "foobar" {
 }
 `, image, instance, nictype)
 }
-
+<% end -%>
 
 func testAccComputeInstance_guestAccelerator(instance string, count uint8) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
@@ -192,6 +192,7 @@ func flattenNetworkInterfaces(d *schema.ResourceData, config *Config, networkInt
 			"subnetwork_project": subnet.Project,
 			"access_config":      ac,
 			"alias_ip_range":     flattenAliasIpRange(iface.AliasIpRanges),
+			"nic_type":           iface.NicType,
 		}
 		// Instance template interfaces never have names, so they're absent
 		// in the instance template network_interface schema. We want to use the
@@ -254,6 +255,7 @@ func expandNetworkInterfaces(d TerraformResourceData, config *Config) ([]*comput
 			Subnetwork:    sf.RelativeLink(),
 			AccessConfigs: expandAccessConfigs(data["access_config"].([]interface{})),
 			AliasIpRanges: expandAliasIpRanges(data["alias_ip_range"].([]interface{})),
+			NicType:       data["nic_type"].(string),
 		}
 
 	}

--- a/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
@@ -249,13 +249,20 @@ func expandNetworkInterfaces(d TerraformResourceData, config *Config) ([]*comput
 			return nil, fmt.Errorf("cannot determine self_link for subnetwork %q: %s", subnetwork, err)
 		}
 
+		var nt string
+		if data["nic_type"] != nil {
+			nt = data["nic_type"].(string)
+		} else {
+			nt = ""
+		}
+
 		ifaces[i] = &computeBeta.NetworkInterface{
 			NetworkIP:     data["network_ip"].(string),
 			Network:       nf.RelativeLink(),
 			Subnetwork:    sf.RelativeLink(),
 			AccessConfigs: expandAccessConfigs(data["access_config"].([]interface{})),
 			AliasIpRanges: expandAliasIpRanges(data["alias_ip_range"].([]interface{})),
-			NicType:       data["nic_type"].(string),
+			NicType:       nt,
 		}
 
 	}

--- a/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
@@ -192,7 +192,9 @@ func flattenNetworkInterfaces(d *schema.ResourceData, config *Config, networkInt
 			"subnetwork_project": subnet.Project,
 			"access_config":      ac,
 			"alias_ip_range":     flattenAliasIpRange(iface.AliasIpRanges),
+<% unless version == 'ga' -%>
 			"nic_type":           iface.NicType,
+<% end -%>
 		}
 		// Instance template interfaces never have names, so they're absent
 		// in the instance template network_interface schema. We want to use the
@@ -255,19 +257,22 @@ func expandNetworkInterfaces(d TerraformResourceData, config *Config) ([]*comput
 			Subnetwork:    sf.RelativeLink(),
 			AccessConfigs: expandAccessConfigs(data["access_config"].([]interface{})),
 			AliasIpRanges: expandAliasIpRanges(data["alias_ip_range"].([]interface{})),
+<% unless version == 'ga' -%>
 			NicType:       expandNicType(data["nic_type"].(interface{})),
+<% end -%>
 		}
 
 	}
 	return ifaces, nil
 }
-
+<% unless version == 'ga' -%>
 func expandNicType(d interface{}) string {
 	if d == nil {
 		return ""
 	}
 	return d.(string)
 }
+<% end -%>
 
 func flattenServiceAccounts(serviceAccounts []*computeBeta.ServiceAccount) []map[string]interface{} {
 	result := make([]map[string]interface{}, len(serviceAccounts))

--- a/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
@@ -249,24 +249,24 @@ func expandNetworkInterfaces(d TerraformResourceData, config *Config) ([]*comput
 			return nil, fmt.Errorf("cannot determine self_link for subnetwork %q: %s", subnetwork, err)
 		}
 
-		var nt string
-		if data["nic_type"] != nil {
-			nt = data["nic_type"].(string)
-		} else {
-			nt = ""
-		}
-
 		ifaces[i] = &computeBeta.NetworkInterface{
 			NetworkIP:     data["network_ip"].(string),
 			Network:       nf.RelativeLink(),
 			Subnetwork:    sf.RelativeLink(),
 			AccessConfigs: expandAccessConfigs(data["access_config"].([]interface{})),
 			AliasIpRanges: expandAliasIpRanges(data["alias_ip_range"].([]interface{})),
-			NicType:       nt,
+			NicType:       expandNicType(data["nic_type"].(interface{})),
 		}
 
 	}
 	return ifaces, nil
+}
+
+func expandNicType(d interface{}) string {
+	if d == nil {
+		return ""
+	}
+	return d.(string)
 }
 
 func flattenServiceAccounts(serviceAccounts []*computeBeta.ServiceAccount) []map[string]interface{} {

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -276,7 +276,7 @@ The `network_interface` block supports:
     array of alias IP ranges for this network interface. Can only be specified for network
     interfaces on subnet-mode networks. Structure documented below.
 
-* `nic_type` - (Optional) The type of vNIC to be used on this interface.
+* `nic_type` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) The type of vNIC to be used on this interface.
     Possible values: GVNIC, VIRTIO_NET.
 
 The `access_config` block supports:

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -276,6 +276,9 @@ The `network_interface` block supports:
     array of alias IP ranges for this network interface. Can only be specified for network
     interfaces on subnet-mode networks. Structure documented below.
 
+* `nic_type` - (Optional) The type of vNIC to be used on this interface.
+    Possible values: GVNIC, VIRTIO_NET.
+
 The `access_config` block supports:
 
 * `nat_ip` - (Optional) The IP address that will be 1:1 mapped to the instance's

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -359,7 +359,7 @@ The `network_interface` block supports:
     array of alias IP ranges for this network interface. Can only be specified for network
     interfaces on subnet-mode networks. Structure documented below.
 
-* `nic_type` - (Optional) The type of vNIC to be used on this interface.
+* `nic_type` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) The type of vNIC to be used on this interface.
     Possible values: GVNIC, VIRTIO_NET.
 
 The `access_config` block supports:

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -359,6 +359,9 @@ The `network_interface` block supports:
     array of alias IP ranges for this network interface. Can only be specified for network
     interfaces on subnet-mode networks. Structure documented below.
 
+* `nic_type` - (Optional) The type of vNIC to be used on this interface.
+    Possible values: GVNIC, VIRTIO_NET.
+
 The `access_config` block supports:
 
 * `nat_ip` - (Optional) The IP address that will be 1:1 mapped to the instance's


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/7699


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `nic_type` field to `google_compute_instance` resource to support gVNIC
```

```release-note:enhancement
compute: added `nic_type` field to `google_compute_instance_template ` resource to support gVNIC
```
