### PR TITLE
add transit encryption mode support for redis instance resource

### DIFF
--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -192,6 +192,7 @@ objects:
         input: true
       - !ruby/object:Api::Type::Enum
         name: transitEncryptionMode
+        input: true
         description: |
           The TLS mode of the Redis instance, If not provided, TLS is disabled for the instance.
 

--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -190,3 +190,12 @@ objects:
           - :STANDARD_HA
         default_value: :BASIC
         input: true
+      - !ruby/object:Api::Type::Enum
+        name: transitEncryptionMode
+        description: |
+          The TLS mode of the Redis instance, If not provided, TLS is disabled for the instance.
+
+          - SERVER_AUTHENTICATION: Client to Server traffic encryption enabled with server authentcation
+        values:
+          - :SERVER_AUTHENTICATION
+        default_value: :DISABLED

--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -198,4 +198,5 @@ objects:
           - SERVER_AUTHENTICATION: Client to Server traffic encryption enabled with server authentcation
         values:
           - :SERVER_AUTHENTICATION
+          - :DISABLED
         default_value: :DISABLED

--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -192,6 +192,7 @@ objects:
         input: true
       - !ruby/object:Api::Type::Enum
         name: transitEncryptionMode
+        min_version: beta
         input: true
         description: |
           The TLS mode of the Redis instance, If not provided, TLS is disabled for the instance.
@@ -201,3 +202,31 @@ objects:
           - :SERVER_AUTHENTICATION
           - :DISABLED
         default_value: :DISABLED
+      - !ruby/object:Api::Type::Array
+        name: 'serverCaCerts'
+        min_version: beta
+        description: |
+          List of server CA certificates for the instance.
+        output: true
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'serialNumber'
+              description: |
+                Serial number, as extracted from the certificate.
+            - !ruby/object:Api::Type::String
+              name: 'cert'
+              description: |
+                Serial number, as extracted from the certificate.
+            - !ruby/object:Api::Type::String
+              name: 'createTime'
+              description: |
+                The time when the certificate was created.
+            - !ruby/object:Api::Type::String
+              name: 'expireTime'
+              description: |
+                The time when the certificate expires.
+            - !ruby/object:Api::Type::String
+              name: 'sha1Fingerprint'
+              description: |
+                Sha1 Fingerprint of the certificate.

--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -212,21 +212,26 @@ objects:
           properties:
             - !ruby/object:Api::Type::String
               name: 'serialNumber'
+              output: true
               description: |
                 Serial number, as extracted from the certificate.
             - !ruby/object:Api::Type::String
               name: 'cert'
+              output: true
               description: |
                 Serial number, as extracted from the certificate.
             - !ruby/object:Api::Type::String
               name: 'createTime'
+              output: true
               description: |
                 The time when the certificate was created.
             - !ruby/object:Api::Type::String
               name: 'expireTime'
+              output: true
               description: |
                 The time when the certificate expires.
             - !ruby/object:Api::Type::String
               name: 'sha1Fingerprint'
+              output: true
               description: |
                 Sha1 Fingerprint of the certificate.

--- a/mmv1/third_party/terraform/tests/resource_redis_instance_test.go
+++ b/mmv1/third_party/terraform/tests/resource_redis_instance_test.go
@@ -143,6 +143,7 @@ resource "google_redis_instance" "test" {
     maxmemory-policy       = "noeviction"
     notify-keyspace-events = ""
   }
+  transit_encryption_mode = "SERVER_AUTHENTICATION"
 }
 `, name)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
redis: Added support for transit encryption mode for the resource `google_redis_instance`

```
fixes https://github.com/hashicorp/terraform-provider-google/issues/8060
