### PR TITLE
Minor: wording cleanup in Using GKE with Terraform

### DIFF
--- a/mmv1/third_party/terraform/website/docs/guides/using_gke_with_terraform.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/using_gke_with_terraform.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # Using GKE with Terraform
 
--> Visit the [Provision a GKE Cluster (Google Cloud)](https://learn.hashicorp.com/tutorials/terraform/gke?in=terraform/kubernetes&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) Learn tutorial to learn how to provision and interact
+-> Visit the [Provision a GKE Cluster (Google Cloud)](https://learn.hashicorp.com/tutorials/terraform/gke?in=terraform/kubernetes&utm_source=WEBSITE&utm_medium=WEB_IO&utm_offer=ARTICLE_PAGE&utm_content=DOCS) tutorial to learn how to provision and interact
 with a GKE cluster.
 
 This page is a brief overview of GKE usage with Terraform, based on the content


### PR DESCRIPTION
Remove stray word: Learn

Upstreamed from https://github.com/hashicorp/terraform-provider-google/pull/8336. Docs-only change. Doesn't require CLA because third-party only.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
