### PR TITLE
Upstream tpg 8349

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_compute_network.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_compute_network.go
@@ -37,7 +37,7 @@ func dataSourceGoogleComputeNetwork() *schema.Resource {
 			},
 
 			"subnetworks_self_links": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},

--- a/mmv1/third_party/terraform/website/docs/d/compute_network.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_network.html.markdown
@@ -39,6 +39,6 @@ In addition to the arguments listed above, the following attributes are exported
 
 * `gateway_ipv4` - The IP address of the gateway.
 
-* `subnetworks_self_links` - the list of subnetworks which belong to the network
+* `subnetworks_self_links` - the set of subnetworks which belong to the network
 
 * `self_link` - The URI of the resource.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

From https://github.com/hashicorp/terraform-provider-google/pull/8349
> since all subnetworks_self_links should be unique, shouldn't this be a set instead of a list?
> would allow looping through these outputs without conversion

I think this seems reasonable? But lmk if there's an issue I'm not seeing. third_party, so CLA not required.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
