### PR TITLE
Expose `transitEncryptionMode` attribute for `google_redis_instance`

### DIFF
--- a/mmv1/products/redis/api.yaml
+++ b/mmv1/products/redis/api.yaml
@@ -190,3 +190,18 @@ objects:
           - :STANDARD_HA
         default_value: :BASIC
         input: true
+      - !ruby/object:Api::Type::Enum
+        name: transitEncryptionMode
+        description: |
+          The TLS encryption mode of the Redis instance. Must be one of:
+
+          - TRANSIT_ENCRYPTION_MODE_UNSPECIFIED
+          - SERVER_AUTHENTICATION
+          - DISABLED
+        values:
+          - :TRANSIT_ENCRYPTION_MODE_UNSPECIFIED
+          - :SERVER_AUTHENTICATION
+          - :DISABLED
+        default_value: :SERVER_AUTHENTICATION
+        input: true
+        


### PR DESCRIPTION
As requested in https://github.com/inspec/inspec-gcp/issues/305
Adding an Enum for transitEncryptionMode on google_redis_instance.

Impact on Terraform has not been tested... is it more appropriate
to do this in the inspec.yaml to avoid unexpected problems with
existing terraform plans?

Signed-off-by: Richard Nixon <rnixon@chef.io>

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME
As requested in https://github.com/inspec/inspec-gcp/issues/305
Adding an Enum for transitEncryptionMode on google_redis_instance.
```
