### PR TITLE
Add status to bigquery_job

### DIFF
--- a/mmv1/products/bigquery/api.yaml
+++ b/mmv1/products/bigquery/api.yaml
@@ -978,6 +978,50 @@ objects:
             description: |
               The geographic location of the job. The default value is US.
             default_value: 'US'
+      - !ruby/object:Api::Type::NestedObject
+        name: 'status'
+        output: true
+        description: |
+          The status of this job. Examine this value when polling an asynchronous job to see if the job is complete.
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: 'errorResult'
+            output: true
+            description: |
+              Final error result of the job. If present, indicates that the job has completed and was unsuccessful.
+            properties:
+              - !ruby/object:Api::Type::String
+                name: 'reason'
+                description: A short error code that summarizes the error.
+              - !ruby/object:Api::Type::String
+                name: 'location'
+                description: Specifies where the error occurred, if present.
+              - !ruby/object:Api::Type::String
+                name: 'message'
+                description: A human-readable description of the error.
+          - !ruby/object:Api::Type::Array
+            name: 'errors'
+            output: true
+            description: |
+              The first errors encountered during the running of the job. The final message
+              includes the number of errors that caused the process to stop. Errors here do
+              not necessarily mean that the job has not completed or was unsuccessful.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+                - !ruby/object:Api::Type::String
+                  name: 'reason'
+                  description: A short error code that summarizes the error.
+                - !ruby/object:Api::Type::String
+                  name: 'location'
+                  description: Specifies where the error occurred, if present.
+                - !ruby/object:Api::Type::String
+                  name: 'message'
+                  description: A human-readable description of the error.
+          - !ruby/object:Api::Type::String
+            name: 'state'
+            output: true
+            description: |
+              Running state of the job. Valid states include 'PENDING', 'RUNNING', and 'DONE'.
   - !ruby/object:Api::Resource
     name: 'Table'
     kind: 'bigquery#table'

--- a/mmv1/products/bigquery/terraform.yaml
+++ b/mmv1/products/bigquery/terraform.yaml
@@ -146,6 +146,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           account_name: "bqowner"
         ignore_read_extra:
           - "etag"
+          - "status.0.state"
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_job_query_table_reference"
         primary_resource_id: "job"
@@ -156,6 +157,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - "etag"
           - "query.0.default_dataset.0.dataset_id"
           - "query.0.destination_table.0.table_id"
+          - "status.0.state"
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_job_load"
         primary_resource_id: "job"
@@ -163,6 +165,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           job_id: "job_load"
         ignore_read_extra:
           - "etag"
+          - "status.0.state"
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_job_load_table_reference"
         primary_resource_id: "job"
@@ -171,6 +174,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read_extra:
           - "etag"
           - "load.0.destination_table.0.table_id"
+          - "status.0.state"
         skip_docs: true  # there are a lot of examples for this resource, so omitting some that are similar to others
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_job_copy"
@@ -184,6 +188,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           project: :PROJECT_NAME
         ignore_read_extra:
           - "etag"
+          - "status.0.state"
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_job_copy_table_reference"
         primary_resource_id: "job"
@@ -199,6 +204,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           - "copy.0.destination_table.0.table_id"
           - "copy.0.source_tables.0.table_id"
           - "copy.0.source_tables.1.table_id"
+          - "status.0.state"
         skip_docs: true  # there are a lot of examples for this resource, so omitting some that are similar to others
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_job_extract"
@@ -208,6 +214,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           account_name: "bqowner"
         ignore_read_extra:
           - "etag"
+          - "status.0.state"
       - !ruby/object:Provider::Terraform::Examples
         name: "bigquery_job_extract_table_reference"
         primary_resource_id: "job"
@@ -217,6 +224,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read_extra:
           - "etag"
           - "extract.0.source_table.0.table_id"
+          - "status.0.state"
         skip_docs: true  # there are a lot of examples for this resource, so omitting some that are similar to others
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/third_party/terraform/tests/resource_bigquery_job_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_job_test.go
@@ -33,7 +33,7 @@ func TestAccBigQueryJob_withLocation(t *testing.T) {
 				ImportStateId:           importID,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag"},
+				ImportStateVerifyIgnore: []string{"etag", "status.0.state"},
 			},
 		},
 	})


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/8357

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
bigquery: added `status` field to `google_bigquery_job`
```
