### PR TITLE
job scheduling and max retries support added

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_dataproc_job.go
+++ b/mmv1/third_party/terraform/resources/resource_dataproc_job.go
@@ -209,6 +209,12 @@ func resourceDataprocJobCreate(d *schema.ResourceData, meta interface{}) error {
 	if v, ok := d.GetOk("reference.0.job_id"); ok {
 		submitReq.Job.Reference.JobId = v.(string)
 	}
+
+	if v, ok := d.GetOk("scheduling.0.max_failures_per_hour"); ok {
+		submitReq.Job.Scheduling = &dataproc.JobScheduling{
+			MaxFailuresPerHour: int64(v.(int)),
+		}
+	}
 	if _, ok := d.GetOk("labels"); ok {
 		submitReq.Job.Labels = expandLabels(d)
 	}
@@ -302,6 +308,9 @@ func resourceDataprocJobRead(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error setting status: %s", err)
 	}
 	if err := d.Set("reference", flattenJobReference(job.Reference)); err != nil {
+		return fmt.Errorf("Error setting reference: %s", err)
+	}
+	if err := d.Set("scheduling", flattenJobScheduling(job.Scheduling)); err != nil {
 		return fmt.Errorf("Error setting reference: %s", err)
 	}
 	if err := d.Set("project", project); err != nil {
@@ -1109,6 +1118,15 @@ func flattenJobReference(r *dataproc.JobReference) []map[string]interface{} {
 			"job_id": r.JobId,
 		},
 	}
+}
+
+func flattenJobScheduling(r *dataproc.JobScheduling) []map[string]interface{} {
+	jobScheduling := []map[string]interface{}{}
+
+	if r != nil {
+		jobScheduling = append(jobScheduling, map[string]interface{}{"max_failures_per_hour": r.MaxFailuresPerHour})
+	}
+	return jobScheduling
 }
 
 func flattenJobStatus(s *dataproc.JobStatus) []map[string]interface{} {

--- a/mmv1/third_party/terraform/tests/resource_dataproc_job_test.go
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_job_test.go
@@ -92,6 +92,7 @@ func TestAccDataprocJob_PySpark(t *testing.T) {
 					resource.TestCheckResourceAttrSet("google_dataproc_job.pyspark", "status.0.state"),
 					resource.TestCheckResourceAttrSet("google_dataproc_job.pyspark", "status.0.state_start_time"),
 					resource.TestCheckResourceAttr("google_dataproc_job.pyspark", "scheduling.0.max_failures_per_hour", "1"),
+					resource.TestCheckResourceAttr("google_dataproc_job.pyspark", "scheduling.0.max_failures_total", "20"),
 					resource.TestCheckResourceAttr("google_dataproc_job.pyspark", "labels.one", "1"),
 
 					// Unique job config
@@ -559,7 +560,8 @@ resource "google_dataproc_job" "pyspark" {
   }
 
   scheduling {
-    max_failures_per_hour = 1
+	max_failures_per_hour = 1
+	max_failures_total=20
   }
 
   labels = {

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_job.html.markdown
@@ -105,7 +105,9 @@ output "pyspark_status" {
 
 * `labels` - (Optional) The list of labels (key/value pairs) to add to the job.
 
-* `scheduling.max_failures_per_hour` - (Required) Maximum number of times per hour a driver may be restarted as a result of driver terminating with non-zero code before job is reported failed.
+* `scheduling.max_failures_per_hour` - (Required) Maximum number of times per hour a driver may be restarted as a result of driver exiting with non-zero code before job is reported failed.
+
+* `scheduling.max_failures_total` - (Required) Maximum number of times in total a driver may be restarted as a result of driver exiting with non-zero code before job is reported failed.
 
 The `pyspark_config` block supports:
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
dataproc : fixed `max_failure_per_hour` not sent in API request for the resource `google_dataproc_job`

```
fixes https://github.com/hashicorp/terraform-provider-google/issues/8319