### PR TITLE
Correct the spelling of heirarchy/hierarchy

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_access_approval_folder_settings_test.go
+++ b/mmv1/third_party/terraform/tests/resource_access_approval_folder_settings_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-// Since access approval settings are heirarchical, and only one can exist per folder/project/org,
+// Since access approval settings are hierarchical, and only one can exist per folder/project/org,
 // and all refer to the same organization, they need to be run serially
 // See AccessApprovalOrganizationSettings for the test runner.
 func testAccAccessApprovalFolderSettings(t *testing.T) {

--- a/mmv1/third_party/terraform/tests/resource_access_approval_organization_settings_test.go
+++ b/mmv1/third_party/terraform/tests/resource_access_approval_organization_settings_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-// Since access approval settings are heirarchical, and only one can exist per folder/project/org,
+// Since access approval settings are hierarchical, and only one can exist per folder/project/org,
 // and all refer to the same organization, they need to be run serially
 func TestAccAccessApprovalSettings(t *testing.T) {
 	testCases := map[string]func(t *testing.T){

--- a/mmv1/third_party/terraform/tests/resource_access_approval_project_settings_test.go
+++ b/mmv1/third_party/terraform/tests/resource_access_approval_project_settings_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-// Since access approval settings are heirarchical, and only one can exist per folder/project/org,
+// Since access approval settings are hierarchical, and only one can exist per folder/project/org,
 // and all refer to the same organization, they need to be run serially.
 // See AccessApprovalOrganizationSettings for the test runner.
 func testAccAccessApprovalProjectSettings(t *testing.T) {


### PR DESCRIPTION
I was asked by Riley Karson to open this spelling fix against this repo, after I originally opened it as https://github.com/hashicorp/terraform-provider-google-beta/pull/2933

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
This only contain a spelling fix in some comments, which doesn't seem worth mentioning in a release note.
```
