### PR TITLE
add deletion protection for big_query_table

### DIFF
--- a/mmv1/templates/terraform/examples/bigquery_bigquery_table.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_bigquery_table.tf.erb
@@ -1,54 +1,54 @@
 resource "google_bigquery_dataset" "test" {
-	dataset_id = "<%= ctx[:vars]['dataset_id'] %>"
+  dataset_id = "<%= ctx[:vars]['dataset_id'] %>"
 }
 
 resource "google_bigquery_table" "test" {
-	deletion_protection = false
-	table_id   = "<%= ctx[:vars]['table_id'] %>"
-	dataset_id = google_bigquery_dataset.test.dataset_id
-	time_partitioning {
-		type = "DAY"
-	}
-	schema = <<EOH
+  deletion_protection = false
+  table_id   = "<%= ctx[:vars]['table_id'] %>"
+  dataset_id = google_bigquery_dataset.test.dataset_id
+  time_partitioning {
+    type = "DAY"
+  }
+  schema = <<EOH
 [
-	{
-		"name": "city",
-		"type": "RECORD",
-		"fields": [
-	{
-		"name": "id",
-		"type": "INTEGER"
-	},
-	{
-		"name": "coord",
-		"type": "RECORD",
-		"fields": [
-		{
-			"name": "lon",
-			"type": "FLOAT"
-		},
-		{
-			"name": "lat",
-			"type": "FLOAT"
-		}
-		]
-	}
-		]
-	},
-	{
-		"name": "country",
-		"type": "RECORD",
-		"fields": [
-	{
-		"name": "id",
-		"type": "INTEGER"
-	},
-	{
-		"name": "name",
-		"type": "STRING"
-	}
-		]
-	}
+  {
+    "name": "city",
+    "type": "RECORD",
+    "fields": [
+  {
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "name": "coord",
+    "type": "RECORD",
+    "fields": [
+    {
+      "name": "lon",
+      "type": "FLOAT"
+    },
+    {
+      "name": "lat",
+      "type": "FLOAT"
+    }
+    ]
+  }
+    ]
+  },
+  {
+    "name": "country",
+    "type": "RECORD",
+    "fields": [
+  {
+    "name": "id",
+    "type": "INTEGER"
+  },
+  {
+    "name": "name",
+    "type": "STRING"
+  }
+    ]
+  }
 ]
 EOH
 }

--- a/mmv1/templates/terraform/examples/bigquery_bigquery_table.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_bigquery_table.tf.erb
@@ -3,6 +3,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
+	deletion_protection = false
 	table_id   = "<%= ctx[:vars]['table_id'] %>"
 	dataset_id = google_bigquery_dataset.test.dataset_id
 	time_partitioning {

--- a/mmv1/templates/terraform/examples/bigquery_dataset_access_view.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_access_view.tf.erb
@@ -16,7 +16,7 @@ resource "google_bigquery_dataset" "public" {
 }
 
 resource "google_bigquery_table" "public" {
-	deletion_protection = false
+  deletion_protection = false
   dataset_id = google_bigquery_dataset.public.dataset_id
   table_id   = "<%= ctx[:vars]['table_id'] %>"
 

--- a/mmv1/templates/terraform/examples/bigquery_dataset_access_view.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_dataset_access_view.tf.erb
@@ -16,6 +16,7 @@ resource "google_bigquery_dataset" "public" {
 }
 
 resource "google_bigquery_table" "public" {
+	deletion_protection = false
   dataset_id = google_bigquery_dataset.public.dataset_id
   table_id   = "<%= ctx[:vars]['table_id'] %>"
 

--- a/mmv1/templates/terraform/examples/bigquery_job_copy.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_copy.tf.erb
@@ -1,5 +1,5 @@
 resource "google_bigquery_table" "source" {
-	deletion_protection = false
+  deletion_protection = false
   count = length(google_bigquery_dataset.source)
 
   dataset_id = google_bigquery_dataset.source[count.index].dataset_id
@@ -36,7 +36,7 @@ resource "google_bigquery_dataset" "source" {
 }
 
 resource "google_bigquery_table" "dest" {
-	deletion_protection = false
+  deletion_protection = false
   dataset_id = google_bigquery_dataset.dest.dataset_id
   table_id   = "<%= ctx[:vars]['job_id'] %>_dest_table"
 

--- a/mmv1/templates/terraform/examples/bigquery_job_copy.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_copy.tf.erb
@@ -1,4 +1,5 @@
 resource "google_bigquery_table" "source" {
+	deletion_protection = false
   count = length(google_bigquery_dataset.source)
 
   dataset_id = google_bigquery_dataset.source[count.index].dataset_id
@@ -35,6 +36,7 @@ resource "google_bigquery_dataset" "source" {
 }
 
 resource "google_bigquery_table" "dest" {
+	deletion_protection = false
   dataset_id = google_bigquery_dataset.dest.dataset_id
   table_id   = "<%= ctx[:vars]['job_id'] %>_dest_table"
 

--- a/mmv1/templates/terraform/examples/bigquery_job_copy_table_reference.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_copy_table_reference.tf.erb
@@ -1,5 +1,5 @@
 resource "google_bigquery_table" "source" {
-	deletion_protection = false
+  deletion_protection = false
   count = length(google_bigquery_dataset.source)
 
   dataset_id = google_bigquery_dataset.source[count.index].dataset_id
@@ -36,7 +36,7 @@ resource "google_bigquery_dataset" "source" {
 }
 
 resource "google_bigquery_table" "dest" {
-	deletion_protection = false
+  deletion_protection = false
   dataset_id = google_bigquery_dataset.dest.dataset_id
   table_id   = "<%= ctx[:vars]['job_id'] %>_dest_table"
 

--- a/mmv1/templates/terraform/examples/bigquery_job_copy_table_reference.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_copy_table_reference.tf.erb
@@ -1,4 +1,5 @@
 resource "google_bigquery_table" "source" {
+	deletion_protection = false
   count = length(google_bigquery_dataset.source)
 
   dataset_id = google_bigquery_dataset.source[count.index].dataset_id
@@ -35,6 +36,7 @@ resource "google_bigquery_dataset" "source" {
 }
 
 resource "google_bigquery_table" "dest" {
+	deletion_protection = false
   dataset_id = google_bigquery_dataset.dest.dataset_id
   table_id   = "<%= ctx[:vars]['job_id'] %>_dest_table"
 

--- a/mmv1/templates/terraform/examples/bigquery_job_extract.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_extract.tf.erb
@@ -1,5 +1,5 @@
 resource "google_bigquery_table" "source-one" {
-	deletion_protection = false
+  deletion_protection = false
   dataset_id = google_bigquery_dataset.source-one.dataset_id
   table_id   = "<%= ctx[:vars]['job_id'] %>_table"
 

--- a/mmv1/templates/terraform/examples/bigquery_job_extract.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_extract.tf.erb
@@ -1,4 +1,5 @@
 resource "google_bigquery_table" "source-one" {
+	deletion_protection = false
   dataset_id = google_bigquery_dataset.source-one.dataset_id
   table_id   = "<%= ctx[:vars]['job_id'] %>_table"
 

--- a/mmv1/templates/terraform/examples/bigquery_job_extract_table_reference.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_extract_table_reference.tf.erb
@@ -1,5 +1,5 @@
 resource "google_bigquery_table" "source-one" {
-	deletion_protection = false
+  deletion_protection = false
   dataset_id = google_bigquery_dataset.source-one.dataset_id
   table_id   = "<%= ctx[:vars]['job_id'] %>_table"
 

--- a/mmv1/templates/terraform/examples/bigquery_job_extract_table_reference.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_extract_table_reference.tf.erb
@@ -1,4 +1,5 @@
 resource "google_bigquery_table" "source-one" {
+	deletion_protection = false
   dataset_id = google_bigquery_dataset.source-one.dataset_id
   table_id   = "<%= ctx[:vars]['job_id'] %>_table"
 

--- a/mmv1/templates/terraform/examples/bigquery_job_load.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_load.tf.erb
@@ -1,4 +1,5 @@
 resource "google_bigquery_table" "foo" {
+	deletion_protection = false
   dataset_id = google_bigquery_dataset.bar.dataset_id
   table_id   = "<%= ctx[:vars]['job_id'] %>_table"
 }

--- a/mmv1/templates/terraform/examples/bigquery_job_load.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_load.tf.erb
@@ -1,5 +1,5 @@
 resource "google_bigquery_table" "foo" {
-	deletion_protection = false
+  deletion_protection = false
   dataset_id = google_bigquery_dataset.bar.dataset_id
   table_id   = "<%= ctx[:vars]['job_id'] %>_table"
 }

--- a/mmv1/templates/terraform/examples/bigquery_job_load_table_reference.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_load_table_reference.tf.erb
@@ -1,4 +1,5 @@
 resource "google_bigquery_table" "foo" {
+	deletion_protection = false
   dataset_id = google_bigquery_dataset.bar.dataset_id
   table_id   = "<%= ctx[:vars]['job_id'] %>_table"
 }

--- a/mmv1/templates/terraform/examples/bigquery_job_load_table_reference.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_load_table_reference.tf.erb
@@ -1,5 +1,5 @@
 resource "google_bigquery_table" "foo" {
-	deletion_protection = false
+  deletion_protection = false
   dataset_id = google_bigquery_dataset.bar.dataset_id
   table_id   = "<%= ctx[:vars]['job_id'] %>_table"
 }

--- a/mmv1/templates/terraform/examples/bigquery_job_query.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_query.tf.erb
@@ -1,4 +1,5 @@
 resource "google_bigquery_table" "foo" {
+	deletion_protection = false
   dataset_id = google_bigquery_dataset.bar.dataset_id
   table_id   = "<%= ctx[:vars]['job_id'] %>_table"
 }

--- a/mmv1/templates/terraform/examples/bigquery_job_query.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_query.tf.erb
@@ -1,5 +1,5 @@
 resource "google_bigquery_table" "foo" {
-	deletion_protection = false
+  deletion_protection = false
   dataset_id = google_bigquery_dataset.bar.dataset_id
   table_id   = "<%= ctx[:vars]['job_id'] %>_table"
 }

--- a/mmv1/templates/terraform/examples/bigquery_job_query_table_reference.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_query_table_reference.tf.erb
@@ -1,4 +1,5 @@
 resource "google_bigquery_table" "foo" {
+	deletion_protection = false
   dataset_id = google_bigquery_dataset.bar.dataset_id
   table_id   = "<%= ctx[:vars]['job_id'] %>_table"
 }

--- a/mmv1/templates/terraform/examples/bigquery_job_query_table_reference.tf.erb
+++ b/mmv1/templates/terraform/examples/bigquery_job_query_table_reference.tf.erb
@@ -1,5 +1,5 @@
 resource "google_bigquery_table" "foo" {
-	deletion_protection = false
+  deletion_protection = false
   dataset_id = google_bigquery_dataset.bar.dataset_id
   table_id   = "<%= ctx[:vars]['job_id'] %>_table"
 }

--- a/mmv1/third_party/terraform/resources/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/resources/resource_bigquery_table.go
@@ -857,6 +857,13 @@ func resourceBigQueryTable() *schema.Resource {
 				Computed:    true,
 				Description: `Describes the table type.`,
 			},
+
+			"deletion_protection": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: `Whether or not to allow Terraform to destroy the instance. Unless this field is set to false in Terraform state, a terraform destroy or terraform apply that would delete the instance will fail.`,
+			},
 		},
 		UseJSONNumber: true,
 	}
@@ -1167,6 +1174,9 @@ func resourceBigQueryTableUpdate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceBigQueryTableDelete(d *schema.ResourceData, meta interface{}) error {
+	if d.Get("deletion_protection").(bool) {
+		return fmt.Errorf("cannot destroy instance without setting deletion_protection=false and running `terraform apply`")
+	}
 	config := meta.(*Config)
 	userAgent, err := generateUserAgentString(d, config.userAgent)
 	if err != nil {

--- a/mmv1/third_party/terraform/resources/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/resources/resource_bigquery_table.go
@@ -1585,6 +1585,11 @@ func resourceBigQueryTableImport(d *schema.ResourceData, meta interface{}) ([]*s
 		return nil, err
 	}
 
+	// Explicitly set virtual fields to default values on import
+	if err := d.Set("deletion_protection", true); err != nil {
+		return nil, fmt.Errorf("Error setting deletion_protection: %s", err)
+	}
+
 	// Replace import id for the resource id
 	id, err := replaceVars(d, config, "projects/{{project}}/datasets/{{dataset_id}}/tables/{{table_id}}")
 	if err != nil {

--- a/mmv1/third_party/terraform/resources/resource_sql_ssl_cert_test.go
+++ b/mmv1/third_party/terraform/resources/resource_sql_ssl_cert_test.go
@@ -100,7 +100,7 @@ func testGoogleSqlClientCert_mysql(instance string) string {
 	resource "google_sql_database_instance" "instance" {
 		name = "%s"
 		region = "us-central1"
-		deletion_protection = false
+	  deletion_protection = false
 		settings {
 			tier = "db-f1-micro"
 		}
@@ -124,7 +124,7 @@ func testGoogleSqlClientCert_postgres(instance string) string {
 		name = "%s"
 		region = "us-central1"
 		database_version = "POSTGRES_9_6"
-		deletion_protection = false
+	  deletion_protection = false
 		settings {
 			tier = "db-f1-micro"
 		}

--- a/mmv1/third_party/terraform/tests/resource_big_query_dataset_test.go
+++ b/mmv1/third_party/terraform/tests/resource_big_query_dataset_test.go
@@ -297,7 +297,7 @@ resource "google_bigquery_dataset" "other_dataset" {
 }
 
 resource "google_bigquery_table" "table_with_view" {
-	deletion_protection = false
+  deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.other_dataset.dataset_id
 

--- a/mmv1/third_party/terraform/tests/resource_big_query_dataset_test.go
+++ b/mmv1/third_party/terraform/tests/resource_big_query_dataset_test.go
@@ -297,6 +297,7 @@ resource "google_bigquery_dataset" "other_dataset" {
 }
 
 resource "google_bigquery_table" "table_with_view" {
+	deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.other_dataset.dataset_id
 

--- a/mmv1/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
@@ -290,7 +290,7 @@ resource "google_bigquery_dataset" "public" {
 }
 
 resource "google_bigquery_table" "public" {
-	deletion_protection = false
+  deletion_protection = false
   dataset_id = google_bigquery_dataset.public.dataset_id
   table_id   = "%s"
 

--- a/mmv1/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_dataset_access_test.go
@@ -290,6 +290,7 @@ resource "google_bigquery_dataset" "public" {
 }
 
 resource "google_bigquery_table" "public" {
+	deletion_protection = false
   dataset_id = google_bigquery_dataset.public.dataset_id
   table_id   = "%s"
 

--- a/mmv1/third_party/terraform/tests/resource_bigquery_job_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_job_test.go
@@ -42,6 +42,7 @@ func TestAccBigQueryJob_withLocation(t *testing.T) {
 func testAccBigQueryJob_withLocation(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_bigquery_table" "foo" {
+	deletion_protection = false
   dataset_id = google_bigquery_dataset.bar.dataset_id
   table_id   = "tf_test_job_query%{random_suffix}_table"
 }

--- a/mmv1/third_party/terraform/tests/resource_bigquery_job_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_job_test.go
@@ -42,7 +42,7 @@ func TestAccBigQueryJob_withLocation(t *testing.T) {
 func testAccBigQueryJob_withLocation(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_bigquery_table" "foo" {
-	deletion_protection = false
+  deletion_protection = false
   dataset_id = google_bigquery_dataset.bar.dataset_id
   table_id   = "tf_test_job_query%{random_suffix}_table"
 }

--- a/mmv1/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -3,6 +3,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -24,17 +25,19 @@ func TestAccBigQueryTable_Basic(t *testing.T) {
 				Config: testAccBigQueryTableTimePartitioning(datasetID, tableID, "DAY"),
 			},
 			{
-				ResourceName:      "google_bigquery_table.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
 				Config: testAccBigQueryTableUpdated(datasetID, tableID),
 			},
 			{
-				ResourceName:      "google_bigquery_table.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -57,9 +60,10 @@ func TestAccBigQueryTable_Kms(t *testing.T) {
 				Config: testAccBigQueryTableKms(cryptoKeyName, datasetID, tableID),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -80,17 +84,19 @@ func TestAccBigQueryTable_HourlyTimePartitioning(t *testing.T) {
 				Config: testAccBigQueryTableTimePartitioning(datasetID, tableID, "HOUR"),
 			},
 			{
-				ResourceName:      "google_bigquery_table.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
 				Config: testAccBigQueryTableUpdated(datasetID, tableID),
 			},
 			{
-				ResourceName:      "google_bigquery_table.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -111,17 +117,19 @@ func TestAccBigQueryTable_MonthlyTimePartitioning(t *testing.T) {
 				Config: testAccBigQueryTableTimePartitioning(datasetID, tableID, "MONTH"),
 			},
 			{
-				ResourceName:      "google_bigquery_table.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
 				Config: testAccBigQueryTableUpdated(datasetID, tableID),
 			},
 			{
-				ResourceName:      "google_bigquery_table.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -142,17 +150,19 @@ func TestAccBigQueryTable_YearlyTimePartitioning(t *testing.T) {
 				Config: testAccBigQueryTableTimePartitioning(datasetID, tableID, "YEAR"),
 			},
 			{
-				ResourceName:      "google_bigquery_table.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
 				Config: testAccBigQueryTableUpdated(datasetID, tableID),
 			},
 			{
-				ResourceName:      "google_bigquery_table.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -174,9 +184,10 @@ func TestAccBigQueryTable_HivePartitioning(t *testing.T) {
 				Config: testAccBigQueryTableHivePartitioning(bucketName, datasetID, tableID),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -201,7 +212,7 @@ func TestAccBigQueryTable_HivePartitioningCustomSchema(t *testing.T) {
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"external_data_configuration.0.schema"},
+				ImportStateVerifyIgnore: []string{"external_data_configuration.0.schema", "deletion_protection"},
 			},
 		},
 	})
@@ -222,9 +233,10 @@ func TestAccBigQueryTable_RangePartitioning(t *testing.T) {
 				Config: testAccBigQueryTableRangePartitioning(datasetID, tableID),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -245,9 +257,10 @@ func TestAccBigQueryTable_View(t *testing.T) {
 				Config: testAccBigQueryTableWithView(datasetID, tableID),
 			},
 			{
-				ResourceName:      "google_bigquery_table.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -268,17 +281,19 @@ func TestAccBigQueryTable_updateView(t *testing.T) {
 				Config: testAccBigQueryTableWithView(datasetID, tableID),
 			},
 			{
-				ResourceName:      "google_bigquery_table.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 			{
 				Config: testAccBigQueryTableWithNewSqlView(datasetID, tableID),
 			},
 			{
-				ResourceName:      "google_bigquery_table.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -304,13 +319,13 @@ func TestAccBigQueryTable_MaterializedView_DailyTimePartioning_Basic(t *testing.
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "last_modified_time"},
+				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection"},
 			},
 			{
 				ResourceName:            "google_bigquery_table.mv_test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "last_modified_time"},
+				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection"},
 			},
 		},
 	})
@@ -340,13 +355,13 @@ func TestAccBigQueryTable_MaterializedView_DailyTimePartioning_Update(t *testing
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "last_modified_time"},
+				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection"},
 			},
 			{
 				ResourceName:            "google_bigquery_table.mv_test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "last_modified_time"},
+				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection"},
 			},
 			{
 				Config: testAccBigQueryTableWithMatViewDailyTimePartitioning(datasetID, tableID, materialized_viewID, enable_refresh, refresh_interval_ms, query),
@@ -355,13 +370,13 @@ func TestAccBigQueryTable_MaterializedView_DailyTimePartioning_Update(t *testing
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "last_modified_time"},
+				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection"},
 			},
 			{
 				ResourceName:            "google_bigquery_table.mv_test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "last_modified_time"},
+				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection"},
 			},
 		},
 	})
@@ -409,9 +424,10 @@ func TestAccBigQueryDataTable_sheet(t *testing.T) {
 				Config: testAccBigQueryTableFromSheet(context),
 			},
 			{
-				ResourceName:      "google_bigquery_table.table",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_bigquery_table.table",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
 			},
 		},
 	})
@@ -435,7 +451,7 @@ func TestAccBigQueryDataTable_jsonEquivalency(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "last_modified_time"},
+				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection"},
 			},
 			{
 				Config: testAccBigQueryTable_jsonEqModeRemoved(datasetID, tableID),
@@ -444,7 +460,7 @@ func TestAccBigQueryDataTable_jsonEquivalency(t *testing.T) {
 				ResourceName:            "google_bigquery_table.test",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "last_modified_time"},
+				ImportStateVerifyIgnore: []string{"etag", "last_modified_time", "deletion_protection"},
 			},
 		},
 	})
@@ -509,6 +525,38 @@ func TestUnitBigQueryDataTable_schemaIsChangable(t *testing.T) {
 		}
 		testcaseNested.check(t)
 	}
+}
+
+func TestAccBigQueryTable_allowDestroy(t *testing.T) {
+	t.Parallel()
+
+	datasetID := fmt.Sprintf("tf_test_%s", randString(t, 10))
+	tableID := fmt.Sprintf("tf_test_%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBigQueryTableDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBigQueryTable_noAllowDestroy(datasetID, tableID),
+			},
+			{
+				ResourceName:            "google_bigquery_table.test",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"deletion_protection"},
+			},
+			{
+				Config:      testAccBigQueryTable_noAllowDestroy(datasetID, tableID),
+				Destroy:     true,
+				ExpectError: regexp.MustCompile("deletion_protection"),
+			},
+			{
+				Config: testAccBigQueryTable_noAllowDestroyUpdated(datasetID, tableID),
+			},
+		},
+	})
 }
 
 type testUnitBigQueryDataTableJSONEquivalencyTestCase struct {
@@ -766,6 +814,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
+	deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -832,6 +881,7 @@ resource "google_kms_crypto_key_iam_member" "allow" {
 }
 
 resource "google_bigquery_table" "test" {
+	deletion_protection = false
   table_id   = "%s"
   dataset_id = "${google_bigquery_dataset.test.dataset_id}"
 
@@ -894,6 +944,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
+	deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -931,6 +982,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
+	deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -969,6 +1021,7 @@ func testAccBigQueryTableRangePartitioning(datasetID, tableID string) string {
   }
 
   resource "google_bigquery_table" "test" {
+		deletion_protection = false
     table_id   = "%s"
     dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1004,6 +1057,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
+	deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1026,6 +1080,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
+	deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1048,6 +1103,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
+	deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1097,6 +1153,7 @@ EOH
 }
 
 resource "google_bigquery_table" "mv_test" {
+	deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1123,6 +1180,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
+	deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1172,6 +1230,7 @@ EOH
 }
 
 resource "google_bigquery_table" "mv_test" {
+	deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1200,6 +1259,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
+	deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1275,6 +1335,7 @@ EOF
 }
 
 resource "google_bigquery_table" "test" {
+	deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
   external_data_configuration {
@@ -1296,6 +1357,7 @@ resource "google_bigquery_table" "test" {
 func testAccBigQueryTableFromSheet(context map[string]interface{}) string {
 	return Nprintf(`
   resource "google_bigquery_table" "table" {
+		deletion_protection = false
     dataset_id = google_bigquery_dataset.dataset.dataset_id
     table_id   = "tf_test_sheet_%{random_suffix}"
 
@@ -1352,6 +1414,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
+	deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1385,6 +1448,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
+	deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1417,6 +1481,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
+	deletion_protection = false
   table_id   = "%s"
 	dataset_id = google_bigquery_dataset.test.dataset_id
 	lifecycle {
@@ -1453,6 +1518,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
+	deletion_protection = false
   table_id   = "%s"
 	dataset_id = google_bigquery_dataset.test.dataset_id
 	lifecycle {
@@ -1476,6 +1542,71 @@ resource "google_bigquery_table" "test" {
         name        = "snapshot_timestamp"
         mode        = "NULLABLE"
         type        = "INTEGER"
+      },
+    ])
+}
+`, datasetID, tableID)
+}
+
+func testAccBigQueryTable_noAllowDestroy(datasetID, tableID string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset" "test" {
+  dataset_id = "%s"
+}
+
+resource "google_bigquery_table" "test" {
+  table_id   = "%s"
+	dataset_id = google_bigquery_dataset.test.dataset_id
+  friendly_name = "bigquerytest"
+  labels = {
+    "terrafrom_managed" = "true"
+  }
+
+  schema = jsonencode(
+    [
+      {
+        description = "Time snapshot was taken, in Epoch milliseconds. Same across all rows and all tables in the snapshot, and uniquely defines a particular snapshot."
+        name        = "snapshot_timestamp"
+        mode        = "NULLABLE"
+        type        = "INTEGER"
+      },
+      {
+        description = "Timestamp of dataset creation"
+        name        = "creation_time"
+        type        = "TIMESTAMP"
+      },
+    ])
+}
+`, datasetID, tableID)
+}
+
+func testAccBigQueryTable_noAllowDestroyUpdated(datasetID, tableID string) string {
+	return fmt.Sprintf(`
+resource "google_bigquery_dataset" "test" {
+  dataset_id = "%s"
+}
+
+resource "google_bigquery_table" "test" {
+	deletion_protection = false
+  table_id   = "%s"
+	dataset_id = google_bigquery_dataset.test.dataset_id
+  friendly_name = "bigquerytest"
+  labels = {
+    "terrafrom_managed" = "true"
+  }
+
+  schema = jsonencode(
+    [
+      {
+        description = "Time snapshot was taken, in Epoch milliseconds. Same across all rows and all tables in the snapshot, and uniquely defines a particular snapshot."
+        name        = "snapshot_timestamp"
+        mode        = "NULLABLE"
+        type        = "INTEGER"
+      },
+      {
+        description = "Timestamp of dataset creation"
+        name        = "creation_time"
+        type        = "TIMESTAMP"
       },
     ])
 }

--- a/mmv1/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -814,7 +814,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
-	deletion_protection = false
+  deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -881,7 +881,7 @@ resource "google_kms_crypto_key_iam_member" "allow" {
 }
 
 resource "google_bigquery_table" "test" {
-	deletion_protection = false
+  deletion_protection = false
   table_id   = "%s"
   dataset_id = "${google_bigquery_dataset.test.dataset_id}"
 
@@ -944,7 +944,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
-	deletion_protection = false
+  deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -982,7 +982,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
-	deletion_protection = false
+  deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1021,7 +1021,7 @@ func testAccBigQueryTableRangePartitioning(datasetID, tableID string) string {
   }
 
   resource "google_bigquery_table" "test" {
-		deletion_protection = false
+	  deletion_protection = false
     table_id   = "%s"
     dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1057,7 +1057,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
-	deletion_protection = false
+  deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1080,7 +1080,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
-	deletion_protection = false
+  deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1103,7 +1103,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
-	deletion_protection = false
+  deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1153,7 +1153,7 @@ EOH
 }
 
 resource "google_bigquery_table" "mv_test" {
-	deletion_protection = false
+  deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1180,7 +1180,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
-	deletion_protection = false
+  deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1230,7 +1230,7 @@ EOH
 }
 
 resource "google_bigquery_table" "mv_test" {
-	deletion_protection = false
+  deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1259,7 +1259,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
-	deletion_protection = false
+  deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1335,7 +1335,7 @@ EOF
 }
 
 resource "google_bigquery_table" "test" {
-	deletion_protection = false
+  deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
   external_data_configuration {
@@ -1357,7 +1357,7 @@ resource "google_bigquery_table" "test" {
 func testAccBigQueryTableFromSheet(context map[string]interface{}) string {
 	return Nprintf(`
   resource "google_bigquery_table" "table" {
-		deletion_protection = false
+	  deletion_protection = false
     dataset_id = google_bigquery_dataset.dataset.dataset_id
     table_id   = "tf_test_sheet_%{random_suffix}"
 
@@ -1414,7 +1414,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
-	deletion_protection = false
+  deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1448,7 +1448,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
-	deletion_protection = false
+  deletion_protection = false
   table_id   = "%s"
   dataset_id = google_bigquery_dataset.test.dataset_id
 
@@ -1481,7 +1481,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
-	deletion_protection = false
+  deletion_protection = false
   table_id   = "%s"
 	dataset_id = google_bigquery_dataset.test.dataset_id
 	lifecycle {
@@ -1518,7 +1518,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
-	deletion_protection = false
+  deletion_protection = false
   table_id   = "%s"
 	dataset_id = google_bigquery_dataset.test.dataset_id
 	lifecycle {
@@ -1587,7 +1587,7 @@ resource "google_bigquery_dataset" "test" {
 }
 
 resource "google_bigquery_table" "test" {
-	deletion_protection = false
+  deletion_protection = false
   table_id   = "%s"
 	dataset_id = google_bigquery_dataset.test.dataset_id
   friendly_name = "bigquerytest"

--- a/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/bigquery_table.html.markdown
@@ -13,6 +13,10 @@ Creates a table resource in a dataset for Google BigQuery. For more information 
 [the official documentation](https://cloud.google.com/bigquery/docs/) and
 [API](https://cloud.google.com/bigquery/docs/reference/rest/v2/tables).
 
+-> **Note**: On newer versions of the provider, you must explicitly set `deletion_protection=false`
+(and run `terraform apply` to write the field to state) in order to destroy an instance.
+It is recommended to not set this field (or set it to true) until you're ready to destroy.
+
 
 ## Example Usage
 
@@ -135,6 +139,9 @@ The following arguments are supported:
 
 * `materialized_view` - (Optional) If specified, configures this table as a materialized view.
     Structure is documented below.
+
+* `deletion_protection` - (Optional) Whether or not to allow Terraform to destroy the instance. Unless this field is set to false
+in Terraform state, a `terraform destroy` or `terraform apply` that would delete the instance will fail.
 
 The `external_data_configuration` block supports:
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

adding deletion protection to stop tables from being accidentally dropped


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
* bigquery: added `deletion_protection` field to `google_bigquery_table` to make deleting them require an explicit intent.
```

```release-note:note
* `google_bigquery_table` resources now cannot be destroyed unless `deletion_protection = false` is set in state for the resource.
```
