### PR TITLE
Interconnect partner provider support

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -7448,7 +7448,6 @@ objects:
           the same region as this InterconnectAttachment. The InterconnectAttachment will
           automatically connect the Interconnect to the network & region within which the
           Cloud Router is configured.
-        required: true
         input: true
       - !ruby/object:Api::Type::Time
         name: 'creationTimestamp'

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -7381,6 +7381,7 @@ objects:
               URL of the Partner's portal for this Attachment. Partners may customise this to be a deep link to the specific resource on the Partner portal. This value may be validated to match approved Partner values.
       - !ruby/object:Api::Type::String
         name: 'pairingKey'
+        input: true
         description: |
           [Output only for type PARTNER. Input only for PARTNER_PROVIDER. Not present for DEDICATED]. The opaque identifier of an PARTNER attachment used to initiate provisioning with a selected partner. Of the form "XXXXX/region/domain"
       - !ruby/object:Api::Type::String

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -7299,7 +7299,6 @@ objects:
       - !ruby/object:Api::Type::Boolean
         name: 'adminEnabled'
         send_empty_value: true
-        default_value: true
         description: |
           Whether the VLAN attachment is enabled or disabled.  When using
           PARTNER type this will Pre-Activate the interconnect attachment
@@ -7360,10 +7359,8 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'pairingKey'
         description: |
-          [Output only for type PARTNER. Not present for DEDICATED]. The opaque
-          identifier of an PARTNER attachment used to initiate provisioning with
-          a selected partner. Of the form "XXXXX/region/domain"
-        output: true
+          [Output only for type PARTNER. Input only for PARTNER_PROVIDER. Not present for DEDICATED]. The opaque identifier of an PARTNER attachment used to initiate provisioning with a selected partner. Of the form "XXXXX/region/domain"
+        input: true
       - !ruby/object:Api::Type::String
         name: 'partnerAsn'
         description: |

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -7366,28 +7366,23 @@ objects:
           Informational metadata about Partner attachments from Partners to display
           to customers. Output only for for PARTNER type, mutable for PARTNER_PROVIDER,
           not available for DEDICATED.
-        input: true
         properties:
           - !ruby/object:Api::Type::String
             name: partnerName
             description: |
               Plain text name of the Partner providing this attachment. This value may be validated to match approved Partner values.
-            input: true
           - !ruby/object:Api::Type::String
             name: interconnectName
             description: |
               Plain text name of the Interconnect this attachment is connected to, as displayed in the Partner's portal. For instance "Chicago 1". This value may be validated to match approved Partner values.
-            input: true
           - !ruby/object:Api::Type::String
             name: portalUrl
             description: |
               URL of the Partner's portal for this Attachment. Partners may customise this to be a deep link to the specific resource on the Partner portal. This value may be validated to match approved Partner values.
-            input: true
       - !ruby/object:Api::Type::String
         name: 'pairingKey'
         description: |
           [Output only for type PARTNER. Input only for PARTNER_PROVIDER. Not present for DEDICATED]. The opaque identifier of an PARTNER attachment used to initiate provisioning with a selected partner. Of the form "XXXXX/region/domain"
-        input: true
       - !ruby/object:Api::Type::String
         name: 'partnerAsn'
         description: |

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -7356,6 +7356,29 @@ objects:
           selected availability domain will be provided to the Partner via the
           pairing key so that the provisioned circuit will lie in the specified
           domain. If not specified, the value will default to AVAILABILITY_DOMAIN_ANY.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'partnerMetadata'
+        description: |
+          Informational metadata about Partner attachments from Partners to display
+          to customers. Output only for for PARTNER type, mutable for PARTNER_PROVIDER,
+          not available for DEDICATED.
+        input: true
+        properties:
+          - !ruby/object:Api::Type::String
+            name: partnerName
+            description: |
+              Plain text name of the Partner providing this attachment. This value may be validated to match approved Partner values.
+            input: true
+          - !ruby/object:Api::Type::String
+            name: interconnectName
+            description: |
+              Plain text name of the Interconnect this attachment is connected to, as displayed in the Partner's portal. For instance "Chicago 1". This value may be validated to match approved Partner values.
+            input: true
+          - !ruby/object:Api::Type::String
+            name: portalUrl
+            description: |
+              URL of the Partner's portal for this Attachment. Partners may customise this to be a deep link to the specific resource on the Partner portal. This value may be validated to match approved Partner values.
+            input: true
       - !ruby/object:Api::Type::String
         name: 'pairingKey'
         description: |

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -7346,7 +7346,7 @@ objects:
           - :BPS_10G
           - :BPS_20G
           - :BPS_50G
-      - !ruby/object:Api::Type::String
+      - !ruby/object:Api::Type::Enum
         name: 'edgeAvailabilityDomain'
         input: true
         description: |
@@ -7357,9 +7357,9 @@ objects:
           pairing key so that the provisioned circuit will lie in the specified
           domain. If not specified, the value will default to AVAILABILITY_DOMAIN_ANY.
         values:
-          - :ZONE_1
-          - :ZONE_2
-          - :ZONE_ANY
+          - :AVAILABILITY_DOMAIN_1
+          - :AVAILABILITY_DOMAIN_2
+          - :AVAILABILITY_DOMAIN_ANY
       - !ruby/object:Api::Type::NestedObject
         name: 'partnerMetadata'
         description: |

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -7356,6 +7356,10 @@ objects:
           selected availability domain will be provided to the Partner via the
           pairing key so that the provisioned circuit will lie in the specified
           domain. If not specified, the value will default to AVAILABILITY_DOMAIN_ANY.
+        values:
+          - :ZONE_1
+          - :ZONE_2
+          - :ZONE_ANY
       - !ruby/object:Api::Type::NestedObject
         name: 'partnerMetadata'
         description: |

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1127,6 +1127,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       candidateSubnets: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true
+      adminEnabled: !ruby/object:Overrides::Terraform::PropertyOverride
+        ignore_read: true
       edgeAvailabilityDomain: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1102,6 +1102,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           regex: '^[a-z]([-a-z0-9]*[a-z0-9])?$'
       pairingKey: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+        diff_suppress_func: 'suppressPartnerProviderPairingKey'
       partnerMetadata: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       region: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1100,6 +1100,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           regex: '^[a-z]([-a-z0-9]*[a-z0-9])?$'
+      pairingKey: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       region: !ruby/object:Overrides::Terraform::PropertyOverride
         required: false
         default_from_api: true

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1102,6 +1102,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           regex: '^[a-z]([-a-z0-9]*[a-z0-9])?$'
       pairingKey: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      partnerMetadata: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       region: !ruby/object:Overrides::Terraform::PropertyOverride
         required: false
         default_from_api: true

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1094,6 +1094,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           interconnect_attachment_name: "on-prem-attachment"
           router_name: "router"
+    docs: !ruby/object:Provider::Terraform::Docs
+      warning: |
+        If you are using the resource with type 'PARTNER_PROVIDER', you will not be able to create a new 
+        interconnect_attachment when passing in a new pairing key. If you want to destroy and create a new 
+        interconnect_attachment, you must also change the name. This only applies when the type is 'PARTNER_PROVIDER'
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1105,6 +1105,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         diff_suppress_func: 'suppressPartnerProviderPairingKey'
       partnerMetadata: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+        properties:
+          partnerName: !ruby/object:Overrides::Terraform::PropertyOverride
+            default_from_api: true
+          interconnectName: !ruby/object:Overrides::Terraform::PropertyOverride
+            default_from_api: true
+          portalUrl: !ruby/object:Overrides::Terraform::PropertyOverride
+            default_from_api: true
       region: !ruby/object:Overrides::Terraform::PropertyOverride
         required: false
         default_from_api: true

--- a/mmv1/third_party/terraform/utils/interconnect_attachment_helpers.go
+++ b/mmv1/third_party/terraform/utils/interconnect_attachment_helpers.go
@@ -1,0 +1,16 @@
+package google
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func suppressPartnerProviderPairingKey(k, old, new string, d *schema.ResourceData) bool {
+	attachmentType := d.Get("type")
+	if state, ok := d.GetOk("state"); ok {
+		if attachmentType == "PARTNER_PROVIDER" && state == "ACTIVE" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/mmv1/third_party/terraform/utils/interconnect_attachment_helpers.go
+++ b/mmv1/third_party/terraform/utils/interconnect_attachment_helpers.go
@@ -5,6 +5,13 @@ import (
 )
 
 func suppressPartnerProviderPairingKey(k, old, new string, d *schema.ResourceData) bool {
+	/*
+		This prevents something like pairing_key from triggering a destroy and update cycle
+		on update when used like:
+		pairing_key = google_compute_interconnect_attachment.attachment_partner.pairing_key
+		This happens because pairing_key gets set to "" after a successful creation when
+		type is `PARTNER_PROVIDER` but subsequent calls try to add the pairing_key
+	*/
 	attachmentType := d.Get("type")
 	if state, ok := d.GetOk("state"); ok {
 		if attachmentType == "PARTNER_PROVIDER" && state == "ACTIVE" {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Does work for https://github.com/hashicorp/terraform-provider-google/issues/8239 to enable usage of type `PARTNER_PROVIDER` in `compute/interconnect_attachments`
Also does the following:

-     allows running terraform apply successively without erroneous flagged updates
-     prevents admin_enabled from being passed as a value during updates
-     prevents pairing_key from triggering updates as partner_provider
-     made edge_availability_zone an enum
-     added partner_metadata field and sub-fields

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: add support for interconnect attachment type 'PARTNER_PROVIDER'
```
