### PR TITLE
Fix bug: artifact_registry_repository update always failing

### DIFF
--- a/mmv1/products/artifactregistry/api.yaml
+++ b/mmv1/products/artifactregistry/api.yaml
@@ -25,6 +25,7 @@ apis_required:
     name: Artifact Registry API
     url: https://console.cloud.google.com/apis/library/artifactregistry.googleapis.com/
 async: !ruby/object:Api::OpAsync
+  actions: ['create', 'delete']
   operation: !ruby/object:Api::OpAsync::Operation
     path: 'name'
     base_url: '{{op_id}}'
@@ -47,6 +48,8 @@ objects:
     base_url: projects/{{project}}/locations/{{location}}/repositories
     create_url: projects/{{project}}/locations/{{location}}/repositories?repository_id={{repository_id}}
     self_link: projects/{{project}}/locations/{{location}}/repositories/{{repository_id}}
+    update_verb: :PATCH
+    update_mask: true
     min_version: beta
     description: A repository for storing artifacts
     references: !ruby/object:Api::Resource::ReferenceLinks

--- a/mmv1/third_party/terraform/tests/resource_artifact_registry_repository_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_artifact_registry_repository_test.go.erb
@@ -1,0 +1,77 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccArtifactRegistryRepository_update(t *testing.T) {
+	t.Parallel()
+
+	repositoryID := fmt.Sprintf("tf-test-%d", randInt(t))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProvidersOiCS,
+		CheckDestroy: testAccCheckArtifactRegistryRepositoryDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccArtifactRegistryRepository_update(repositoryID),
+			},
+			{
+				ResourceName:      "google_artifact_registry_repository.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccArtifactRegistryRepository_update2(repositoryID),
+			},
+			{
+				ResourceName:      "google_artifact_registry_repository.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccArtifactRegistryRepository_update(repositoryID string) string {
+	return fmt.Sprintf(`
+resource "google_artifact_registry_repository" "test" {
+  provider = google-beta
+
+  repository_id = "%s"
+  location = "us-central1"
+  description = "pre-update"
+  format = "DOCKER"
+
+  labels = {
+    my_key    = "my_val"
+    other_key = "other_val"
+  }
+}
+`, repositoryID)
+}
+
+func testAccArtifactRegistryRepository_update2(repositoryID string) string {
+	return fmt.Sprintf(`
+resource "google_artifact_registry_repository" "test" {
+  provider = google-beta
+
+  repository_id = "%s"
+  location = "us-central1"
+  description = "post-update"
+  format = "DOCKER"
+
+  labels = {
+    my_key    = "my_val"
+    other_key = "new_val"
+  }
+}
+`, repositoryID)
+}
+<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR fixes a bug where trying to update a `google_artifact_registry_repository` always failed due to the fact that the resource's Update logic was hitting the wrong API endpoint.

You can reproduce the issue by applying the following configs in succession:

**Original:**
```hcl
resource "google_artifact_registry_repository" "my-repo" {
  provider = google-beta

  location = "us-central1"
  repository_id = "my-repository"
  description = "example docker repository"
  format = "DOCKER"
}
```

**New:**
```hcl
resource "google_artifact_registry_repository" "my-repo" {
  provider = google-beta

  location = "us-central1"
  repository_id = "my-repository"
  description = "example docker repository 2"
  format = "DOCKER"
}
```

Related bugs (with details on impact and priority):
* b/175713067
* https://github.com/GoogleCloudPlatform/k8s-config-connector/issues/348

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
artifactregistry: fixed issue where updating `google_artifact_registry_repository` always failed
```