### PR TITLE
Upstreamed https://github.com/GoogleCloudPlatform/terraform-google-conversion/pull/631

### DIFF
--- a/mmv1/third_party/validator/iam_helpers.go
+++ b/mmv1/third_party/validator/iam_helpers.go
@@ -67,6 +67,7 @@ func mergeIamAssets(
 	return existing
 }
 
+// incoming is the last known state of an asset prior to deletion
 func mergeDeleteIamAssets(
 	existing, incoming Asset,
 	mergeBindings func(existing, incoming []IAMBinding) []IAMBinding,
@@ -111,7 +112,7 @@ func mergeAdditiveBindings(existing, incoming []IAMBinding) []IAMBinding {
 }
 
 // mergeDeleteAdditiveBindings eliminates listed members from roles in the
-// existing list.
+// existing list. incoming is the last known state of the bindings being deleted.
 func mergeDeleteAdditiveBindings(existing, incoming []IAMBinding) []IAMBinding {
 	toDelete := make(map[string]struct{})
 	for _, binding := range incoming {
@@ -167,7 +168,8 @@ func mergeAuthoritativeBindings(existing, incoming []IAMBinding) []IAMBinding {
 }
 
 // mergeDeleteAuthoritativeBindings eliminates any bindings with matching roles
-// in the existing list.
+// in the existing list. incoming is the last known state of the bindings being
+// deleted.
 func mergeDeleteAuthoritativeBindings(existing, incoming []IAMBinding) []IAMBinding {
 	toDelete := make(map[string]struct{})
 	for _, binding := range incoming {

--- a/mmv1/third_party/validator/project_iam.go
+++ b/mmv1/third_party/validator/project_iam.go
@@ -23,8 +23,16 @@ func MergeProjectIamBinding(existing, incoming Asset) Asset {
 	return mergeIamAssets(existing, incoming, mergeAuthoritativeBindings)
 }
 
+func MergeProjectIamBindingDelete(existing, incoming Asset) Asset {
+	return mergeDeleteIamAssets(existing, incoming, mergeDeleteAuthoritativeBindings)
+}
+
 func MergeProjectIamMember(existing, incoming Asset) Asset {
 	return mergeIamAssets(existing, incoming, mergeAdditiveBindings)
+}
+
+func MergeProjectIamMemberDelete(existing, incoming Asset) Asset {
+	return mergeDeleteIamAssets(existing, incoming, mergeDeleteAdditiveBindings)
 }
 
 func newProjectIamAsset(
@@ -43,6 +51,40 @@ func newProjectIamAsset(
 	if err != nil {
 		return Asset{}, err
 	}
+
+	return Asset{
+		Name: name,
+		Type: "cloudresourcemanager.googleapis.com/Project",
+		IAMPolicy: &IAMPolicy{
+			Bindings: bindings,
+		},
+	}, nil
+}
+
+func FetchProjectIamPolicy(d TerraformResourceData, config *Config) (Asset, error) {
+	updater, err := NewProjectIamUpdater(d, config)
+	if err != nil {
+		return Asset{}, err
+	}
+
+	iamPolicy, err := updater.GetResourceIamPolicy()
+	if err != nil {
+		return Asset{}, err
+	}
+
+	var bindings []IAMBinding
+	for _, b := range iamPolicy.Bindings {
+		bindings = append(
+			bindings,
+			IAMBinding{
+				Role:    b.Role,
+				Members: b.Members,
+			},
+		)
+	}
+
+	// We use project_id to be consistent with newProjectIamAsset.
+	name, err := assetName(d, config, "//cloudresourcemanager.googleapis.com/projects/{{project}}")
 
 	return Asset{
 		Name: name,


### PR DESCRIPTION
Upstreamed https://github.com/GoogleCloudPlatform/terraform-google-conversion/pull/631

> This PR adds one set of mergeDelete & fetch functions (for Project IAM) as an example of what they might look like. This is a related PR to GoogleCloudPlatform/terraform-validator#180. After this is merged, I'll make a follow-up PR implementing these functions for the remaining IAM types that terraform-validator currently supports.
>
> Related to hashicorp/terraform-provider-google#7797


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
