### PR TITLE
Add async polling for 403s on cloud identity

### DIFF
--- a/mmv1/products/cloudidentity/terraform.yaml
+++ b/mmv1/products/cloudidentity/terraform.yaml
@@ -14,6 +14,13 @@
 --- !ruby/object:Provider::Terraform::Config
 overrides: !ruby/object:Overrides::ResourceOverrides
   Group: !ruby/object:Overrides::Terraform::ResourceOverride
+    async: !ruby/object:Provider::Terraform::PollAsync
+      check_response_func_existence: PollCheckForExistenceWith403
+      target_occurrences: 10
+      actions: ['create']
+      operation: !ruby/object:Api::Async::Operation
+        timeouts: !ruby/object:Api::Timeouts
+          insert_minutes: 6
     docs: !ruby/object:Provider::Terraform::Docs
       warning: |
         If you are using User ADCs (Application Default Credentials) with this resource,

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -344,11 +344,12 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     }
 
 <%    end -%>
+<% end -%>
+
     log.Printf("[DEBUG] Finished creating <%= object.name -%> %q: %#v", d.Id(), res)
 
     return resource<%= resource_name -%>Read(d, meta)
 <%  end # if custom_create  -%>
-<% end -%>
 }
 
 <%  if object.async&.is_a? Provider::Terraform::PollAsync -%>

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -254,6 +254,8 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     }
     d.SetId(id)
 
+<%= lines(compile(pwd + '/' + object.custom_code.post_create)) if object.custom_code.post_create -%>
+
 <%  if object.async&.allow?('create') -%>
 <%    if object.async.is_a? Provider::Terraform::PollAsync -%>
     err = PollingWaitTime(resource<%= resource_name -%>PollRead(d, meta), <%= object.async.check_response_func_existence -%>, "Creating <%= object.name -%>", d.Timeout(schema.TimeoutCreate), <%= object.async.target_occurrences -%>)
@@ -342,8 +344,6 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <%  end -%>
 
     log.Printf("[DEBUG] Finished creating <%= object.name -%> %q: %#v", d.Id(), res)
-
-<%= lines(compile(pwd + '/' + object.custom_code.post_create)) if object.custom_code.post_create -%>
 
     return resource<%= resource_name -%>Read(d, meta)
 <%  end # if custom_create  -%>

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -254,23 +254,7 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
     }
     d.SetId(id)
 
-<%= lines(compile(pwd + '/' + object.custom_code.post_create)) if object.custom_code.post_create -%>
-
 <%  if object.async&.allow?('create') -%>
-<%    if object.async.is_a? Provider::Terraform::PollAsync -%>
-    err = PollingWaitTime(resource<%= resource_name -%>PollRead(d, meta), <%= object.async.check_response_func_existence -%>, "Creating <%= object.name -%>", d.Timeout(schema.TimeoutCreate), <%= object.async.target_occurrences -%>)
-    if err != nil {
-<%      if object.async.suppress_error -%>
-        log.Printf("[ERROR] Unable to confirm eventually consistent <%= object.name -%> %q finished updating: %q", d.Id(), err)
-<%      else -%>
-<%        if object.custom_code.post_create_failure -%>
-        resource<%= resource_name -%>PostCreateFailure(d, meta)
-<%        end -%>
-        return fmt.Errorf("Error waiting to create <%= object.name -%>: %s", err)
-<%      end -%>
-    }
-
-<%    end -%>
 <%    if object.async.is_a? Api::OpAsync -%>
 <%      if object.async.result.resource_inside_response and not object.identity.empty? -%>
     // Use the resource in the operation response to populate
@@ -343,10 +327,28 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <%  end -%>
 <%  end -%>
 
+<%= lines(compile(pwd + '/' + object.custom_code.post_create)) if object.custom_code.post_create -%>
+
+<%  if object.async&.allow?('create') -%>
+<%    if object.async.is_a? Provider::Terraform::PollAsync -%>
+    err = PollingWaitTime(resource<%= resource_name -%>PollRead(d, meta), <%= object.async.check_response_func_existence -%>, "Creating <%= object.name -%>", d.Timeout(schema.TimeoutCreate), <%= object.async.target_occurrences -%>)
+    if err != nil {
+<%      if object.async.suppress_error -%>
+        log.Printf("[ERROR] Unable to confirm eventually consistent <%= object.name -%> %q finished updating: %q", d.Id(), err)
+<%      else -%>
+<%        if object.custom_code.post_create_failure -%>
+        resource<%= resource_name -%>PostCreateFailure(d, meta)
+<%        end -%>
+        return fmt.Errorf("Error waiting to create <%= object.name -%>: %s", err)
+<%      end -%>
+    }
+
+<%    end -%>
     log.Printf("[DEBUG] Finished creating <%= object.name -%> %q: %#v", d.Id(), res)
 
     return resource<%= resource_name -%>Read(d, meta)
 <%  end # if custom_create  -%>
+<% end -%>
 }
 
 <%  if object.async&.is_a? Provider::Terraform::PollAsync -%>

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -327,8 +327,6 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <%  end -%>
 <%  end -%>
 
-    log.Printf("[DEBUG] Finished creating <%= object.name -%> %q: %#v", d.Id(), res)
-
 <%= lines(compile(pwd + '/' + object.custom_code.post_create)) if object.custom_code.post_create -%>
 
 <%  if object.async&.allow?('create') -%>
@@ -347,6 +345,8 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 
 <%    end -%>
 <% end -%>
+
+    log.Printf("[DEBUG] Finished creating <%= object.name -%> %q: %#v", d.Id(), res)
 
     return resource<%= resource_name -%>Read(d, meta)
 <%  end # if custom_create  -%>

--- a/mmv1/templates/terraform/resource.erb
+++ b/mmv1/templates/terraform/resource.erb
@@ -327,6 +327,8 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 <%  end -%>
 <%  end -%>
 
+    log.Printf("[DEBUG] Finished creating <%= object.name -%> %q: %#v", d.Id(), res)
+
 <%= lines(compile(pwd + '/' + object.custom_code.post_create)) if object.custom_code.post_create -%>
 
 <%  if object.async&.allow?('create') -%>
@@ -345,8 +347,6 @@ func resource<%= resource_name -%>Create(d *schema.ResourceData, meta interface{
 
 <%    end -%>
 <% end -%>
-
-    log.Printf("[DEBUG] Finished creating <%= object.name -%> %q: %#v", d.Id(), res)
 
     return resource<%= resource_name -%>Read(d, meta)
 <%  end # if custom_create  -%>

--- a/mmv1/third_party/terraform/utils/common_polling.go
+++ b/mmv1/third_party/terraform/utils/common_polling.go
@@ -119,7 +119,7 @@ func PollCheckForExistence(_ map[string]interface{}, respErr error) PollResult {
 
 // PollCheckForExistenceWith403 waits for a successful response, continues polling on 404 or 403,
 // and returns any other error.
-func PollCheckForExistence(_ map[string]interface{}, respErr error) PollResult {
+func PollCheckForExistenceWith403(_ map[string]interface{}, respErr error) PollResult {
 	if respErr != nil {
 		if isGoogleApiErrorWithCode(respErr, 404) || isGoogleApiErrorWithCode(respErr, 403) {
 			return PendingStatusPollResult("not found")
@@ -128,7 +128,6 @@ func PollCheckForExistence(_ map[string]interface{}, respErr error) PollResult {
 	}
 	return SuccessPollResult()
 }
-
 
 // PollCheckForAbsence waits for a 404 response, continues polling on a successful
 // response, and returns any other error.

--- a/mmv1/third_party/terraform/utils/common_polling.go
+++ b/mmv1/third_party/terraform/utils/common_polling.go
@@ -117,6 +117,19 @@ func PollCheckForExistence(_ map[string]interface{}, respErr error) PollResult {
 	return SuccessPollResult()
 }
 
+// PollCheckForExistenceWith403 waits for a successful response, continues polling on 404 or 403,
+// and returns any other error.
+func PollCheckForExistence(_ map[string]interface{}, respErr error) PollResult {
+	if respErr != nil {
+		if isGoogleApiErrorWithCode(respErr, 404) || isGoogleApiErrorWithCode(respErr, 403) {
+			return PendingStatusPollResult("not found")
+		}
+		return ErrorPollResult(respErr)
+	}
+	return SuccessPollResult()
+}
+
+
 // PollCheckForAbsence waits for a 404 response, continues polling on a successful
 // response, and returns any other error.
 func PollCheckForAbsence(_ map[string]interface{}, respErr error) PollResult {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/8483

I haven't been able to reproduce the described error, but this should fix it



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
`cloud_identity`: fixed a bug where `google_cloud_identity_group` would periodically fail with a 403
```
