### PR TITLE
added sensitive flag to auth_string field

### DIFF
--- a/mmv1/templates/terraform/extra_schema_entry/redis_instance.erb
+++ b/mmv1/templates/terraform/extra_schema_entry/redis_instance.erb
@@ -3,4 +3,5 @@
 	Description:   "AUTH String set on the instance. This field will only be populated if auth_enabled is true.",
 	Optional:      true,
 	Computed:      true,
+	Sensitive:     true,
 },

--- a/mmv1/templates/terraform/extra_schema_entry/redis_instance.erb
+++ b/mmv1/templates/terraform/extra_schema_entry/redis_instance.erb
@@ -2,9 +2,5 @@
 	Type:          schema.TypeString,
 	Description:   "AUTH String set on the instance. This field will only be populated if auth_enabled is true.",
 	Computed:      true,
-<<<<<<< HEAD
 	Sensitive:     true,
 },
-=======
-},
->>>>>>> e7e9cfe560dc4df4691be6965870a05299ae337b

--- a/mmv1/third_party/terraform/tests/resource_redis_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_redis_instance_test.go.erb
@@ -1,3 +1,5 @@
+<% autogen_exception -%>
+
 package google
 
 import (
@@ -143,7 +145,9 @@ resource "google_redis_instance" "test" {
     maxmemory-policy       = "noeviction"
     notify-keyspace-events = ""
   }
+  <% unless version == 'ga' -%>  
   transit_encryption_mode = "SERVER_AUTHENTICATION"
+  <% end -%>
 }
 `, name)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
redis : marked `auth_string` on the `resource_redis_instance` resource as sensitive
```
fixes https://github.com/hashicorp/terraform-provider-google/issues/8481