### PR TITLE
Use bootstrapped service networking networks for redis, memcache tests

### DIFF
--- a/mmv1/products/memcache/terraform.yaml
+++ b/mmv1/products/memcache/terraform.yaml
@@ -27,6 +27,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           instance_name: "test-instance"
           network_name: "test-network"
+          address_name: "address"
         test_vars_overrides:
           network_name: 'BootstrapSharedTestNetwork(t, "memcache-private")'
     properties:

--- a/mmv1/products/memcache/terraform.yaml
+++ b/mmv1/products/memcache/terraform.yaml
@@ -22,6 +22,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     examples:
       - !ruby/object:Provider::Terraform::Examples
         min_version: beta
+        # Temporary as CI has used up servicenetworking quota
+        skip_vcr: true
         name: "memcache_instance_basic"
         primary_resource_id: "instance"
         vars:

--- a/mmv1/products/memcache/terraform.yaml
+++ b/mmv1/products/memcache/terraform.yaml
@@ -26,6 +26,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "instance"
         vars:
           instance_name: "test-instance"
+          network_name: "test-network"
+        test_vars_overrides:
+          network_name: 'BootstrapSharedTestNetwork(t, "memcache-private")'
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'

--- a/mmv1/products/redis/terraform.yaml
+++ b/mmv1/products/redis/terraform.yaml
@@ -43,6 +43,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "redis_instance_private_service"
         primary_resource_id: "cache"
+        vars:
+          instance_name: "private-cache"
+          address_name: "address"
+          network_name: "redis-test-network"
+        test_vars_overrides:
+          network_name: 'BootstrapSharedTestNetwork(t, "redis-private")'
     properties:
       alternativeLocationId: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true

--- a/mmv1/products/redis/terraform.yaml
+++ b/mmv1/products/redis/terraform.yaml
@@ -42,6 +42,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           network_name: 'BootstrapSharedTestNetwork(t, "redis-full")'
       - !ruby/object:Provider::Terraform::Examples
         name: "redis_instance_private_service"
+        # Temporary for servicenetworking problems
+        skip_vcr: true
         primary_resource_id: "cache"
         vars:
           instance_name: "private-cache"

--- a/mmv1/templates/terraform/examples/memcache_instance_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/memcache_instance_basic.tf.erb
@@ -1,20 +1,27 @@
-resource "google_compute_network" "network" {
-  provider = google-beta
-  name = "tf-test%{random_suffix}"
+// This example assumes this network already exists.
+// The API creates a tenant network per network authorized for a
+// Redis instance and that network is not deleted when the user-created
+// network (authorized_network) is deleted, so this prevents issues
+// with tenant network quota.
+// If this network hasn't been created and you are using this example in your
+// config, add an additional network resource or change
+// this from "data"to "resource"
+data "google_compute_network" "memcache_network" {
+  name = "<%= ctx[:vars]['network_name'] %>"
 }
 
 resource "google_compute_global_address" "service_range" {
   provider = google-beta
-  name          = "tf-test%{random_suffix}"
+  name          = "<%= ctx[:vars]['address_name'] %>"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.network.id
+  network       = data.google_compute_network.memcache_network.id
 }
 
 resource "google_service_networking_connection" "private_service_connection" {
   provider = google-beta
-  network                 = google_compute_network.network.id
+  network                 = data.google_compute_network.memcache_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.service_range.name]
 }

--- a/mmv1/templates/terraform/examples/redis_instance_private_service.tf.erb
+++ b/mmv1/templates/terraform/examples/redis_instance_private_service.tf.erb
@@ -1,30 +1,38 @@
-resource "google_compute_network" "network" {
-  name = "tf-test%{random_suffix}"
+// This example assumes this network already exists.
+// The API creates a tenant network per network authorized for a
+// Redis instance and that network is not deleted when the user-created
+// network (authorized_network) is deleted, so this prevents issues
+// with tenant network quota.
+// If this network hasn't been created and you are using this example in your
+// config, add an additional network resource or change
+// this from "data"to "resource"
+data "google_compute_network" "redis-network" {
+  name = "<%= ctx[:vars]['network_name'] %>"
 }
 
 resource "google_compute_global_address" "service_range" {
-  name          = "tf-test%{random_suffix}"
+  name          = "<%= ctx[:vars]['address_name'] %>"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.network.id
+  network       = data.google_compute_network.redis-network.id
 }
 
 resource "google_service_networking_connection" "private_service_connection" {
-  network                 = google_compute_network.network.id
+  network                 = data.google_compute_network.redis-network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.service_range.name]
 }
 
 resource "google_redis_instance" "<%= ctx[:primary_resource_id] %>" {
-  name           = "tf-test%{random_suffix}"
+  name           = "<%= ctx[:vars]['instance_name'] %>"
   tier           = "STANDARD_HA"
   memory_size_gb = 1
 
   location_id             = "us-central1-a"
   alternative_location_id = "us-central1-f"
 
-  authorized_network = google_compute_network.network.id
+  authorized_network = data.google_compute_network.redis-network.id
   connect_mode       = "PRIVATE_SERVICE_ACCESS"
 
   redis_version     = "REDIS_4_0"

--- a/mmv1/third_party/terraform/tests/resource_memcache_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_memcache_instance_test.go.erb
@@ -14,6 +14,7 @@ func TestAccMemcacheInstance_update(t *testing.T) {
 
 	prefix := fmt.Sprintf("%d", randInt(t))
 	name := fmt.Sprintf("tf-test-%s", prefix)
+  network := BootstrapSharedTestNetwork(t, "memcache-update")
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,7 +22,7 @@ func TestAccMemcacheInstance_update(t *testing.T) {
 		CheckDestroy: testAccCheckMemcacheInstanceDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccMemcacheInstance_update(prefix, name),
+				Config: testAccMemcacheInstance_update(prefix, name, network),
 			},
 			{
 				ResourceName:      "google_memcache_instance.test",
@@ -29,7 +30,7 @@ func TestAccMemcacheInstance_update(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccMemcacheInstance_update2(prefix, name),
+				Config: testAccMemcacheInstance_update2(prefix, name, network),
 			},
 			{
 				ResourceName:      "google_memcache_instance.test",
@@ -40,22 +41,18 @@ func TestAccMemcacheInstance_update(t *testing.T) {
 	})
 }
 
-func testAccMemcacheInstance_update(prefix, name string) string {
+func testAccMemcacheInstance_update(prefix, name, network string) string {
 	return fmt.Sprintf(`
-resource "google_compute_network" "network" {
-  name = "tf-test%s"
-}
-
 resource "google_compute_global_address" "service_range" {
   name          = "tf-test%s"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.network.id
+  network       = data.google_compute_network.memcache_network.id
 }
 
 resource "google_service_networking_connection" "private_service_connection" {
-  network                 = google_compute_network.network.id
+  network                 = data.google_compute_network.memcache_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.service_range.name]
 }
@@ -78,25 +75,25 @@ resource "google_memcache_instance" "test" {
     }
   }
 }
-`, prefix, prefix, name)
+
+data "google_compute_network" "memcache_network" {
+  name = "%s"
+}
+`, prefix, prefix, name, network)
 }
 
-func testAccMemcacheInstance_update2(prefix, name string) string {
+func testAccMemcacheInstance_update2(prefix, name, network string) string {
 	return fmt.Sprintf(`
-resource "google_compute_network" "network" {
-  name = "tf-test%s"
-}
-
 resource "google_compute_global_address" "service_range" {
   name          = "tf-test%s"
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   prefix_length = 16
-  network       = google_compute_network.network.id
+  network       = data.google_compute_network.memcache_network.id
 }
 
 resource "google_service_networking_connection" "private_service_connection" {
-  network                 = google_compute_network.network.id
+  network                 = data.google_compute_network.memcache_network.id
   service                 = "servicenetworking.googleapis.com"
   reserved_peering_ranges = [google_compute_global_address.service_range.name]
 }
@@ -119,6 +116,10 @@ resource "google_memcache_instance" "test" {
     }
   }
 }
-`, prefix, prefix, name)
+
+data "google_compute_network" "memcache_network" {
+  name = "%s"
+}
+`, prefix, prefix, name, network)
 }
 <% end -%>

--- a/mmv1/third_party/terraform/tests/resource_memcache_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_memcache_instance_test.go.erb
@@ -79,7 +79,7 @@ resource "google_memcache_instance" "test" {
 data "google_compute_network" "memcache_network" {
   name = "%s"
 }
-`, prefix, prefix, name, network)
+`, prefix, name, network)
 }
 
 func testAccMemcacheInstance_update2(prefix, name, network string) string {
@@ -120,6 +120,6 @@ resource "google_memcache_instance" "test" {
 data "google_compute_network" "memcache_network" {
   name = "%s"
 }
-`, prefix, prefix, name, network)
+`, prefix, name, network)
 }
 <% end -%>

--- a/mmv1/third_party/terraform/tests/resource_memcache_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_memcache_instance_test.go.erb
@@ -11,6 +11,8 @@ import (
 
 func TestAccMemcacheInstance_update(t *testing.T) {
 	t.Parallel()
+  // Temporary as CI has used up servicenetworking quota
+  skipIfVcr(t)
 
 	prefix := fmt.Sprintf("%d", randInt(t))
 	name := fmt.Sprintf("tf-test-%s", prefix)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Fixes some tests that run into quota issues because service networking doesn't clean up all resources correctly. Add temporary skip to redis private instance test to stop VCR from complaining



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
