### PR TITLE
ga for gVNIC on google_compute_instance

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -297,7 +297,6 @@ func resourceComputeInstance() *schema.Resource {
 							Computed:    true,
 							Description: `The name of the interface`,
 						},
-<% unless version == 'ga' -%>
 						"nic_type": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -305,7 +304,6 @@ func resourceComputeInstance() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"GVNIC", "VIRTIO_NET"}, false),
 							Description:  `The type of vNIC to be used on this interface. Possible values:GVNIC, VIRTIO_NET`,
 						},
-<% end -%>
 						"access_config": {
 							Type:        schema.TypeList,
 							Optional:    true,

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -1349,3 +1349,75 @@ func resourceComputeInstanceTemplateImportState(d *schema.ResourceData, meta int
 
 	return []*schema.ResourceData{d}, nil
 }
+
+// this func could be replaced by flattenNetworkInterfaces once NicType is supported
+func flattenComputeInstanceTemplateNetworkInterfaces(d *schema.ResourceData, config *Config, networkInterfaces []*computeBeta.NetworkInterface) ([]map[string]interface{}, string, string, string, error) {
+	flattened := make([]map[string]interface{}, len(networkInterfaces))
+	var region, internalIP, externalIP string
+
+	for i, iface := range networkInterfaces {
+		var ac []map[string]interface{}
+		ac, externalIP = flattenAccessConfigs(iface.AccessConfigs)
+
+		subnet, err := ParseSubnetworkFieldValue(iface.Subnetwork, d, config)
+		if err != nil {
+			return nil, "", "", "", err
+		}
+		region = subnet.Region
+
+		flattened[i] = map[string]interface{}{
+			"network_ip":         iface.NetworkIP,
+			"network":            ConvertSelfLinkToV1(iface.Network),
+			"subnetwork":         ConvertSelfLinkToV1(iface.Subnetwork),
+			"subnetwork_project": subnet.Project,
+			"access_config":      ac,
+			"alias_ip_range":     flattenAliasIpRange(iface.AliasIpRanges),
+		}
+		// Instance template interfaces never have names, so they're absent
+		// in the instance template network_interface schema. We want to use the
+		// same flattening code for both resource types, so we avoid trying to
+		// set the name field when it's not set at the GCE end.
+		if iface.Name != "" {
+			flattened[i]["name"] = iface.Name
+		}
+		if internalIP == "" {
+			internalIP = iface.NetworkIP
+		}
+	}
+	return flattened, region, internalIP, externalIP, nil
+}
+
+// this func could be replaced by expandNetworkInterfaces once NicType is supported
+func expandComputeInstanceTemplateNetworkInterfaces(d TerraformResourceData, config *Config) ([]*computeBeta.NetworkInterface, error) {
+	configs := d.Get("network_interface").([]interface{})
+	ifaces := make([]*computeBeta.NetworkInterface, len(configs))
+	for i, raw := range configs {
+		data := raw.(map[string]interface{})
+
+		network := data["network"].(string)
+		subnetwork := data["subnetwork"].(string)
+		if network == "" && subnetwork == "" {
+			return nil, fmt.Errorf("exactly one of network or subnetwork must be provided")
+		}
+
+		nf, err := ParseNetworkFieldValue(network, d, config)
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine self_link for network %q: %s", network, err)
+		}
+
+		subnetProjectField := fmt.Sprintf("network_interface.%d.subnetwork_project", i)
+		sf, err := ParseSubnetworkFieldValueWithProjectField(subnetwork, subnetProjectField, d, config)
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine self_link for subnetwork %q: %s", subnetwork, err)
+		}
+
+		ifaces[i] = &computeBeta.NetworkInterface{
+			NetworkIP:     data["network_ip"].(string),
+			Network:       nf.RelativeLink(),
+			Subnetwork:    sf.RelativeLink(),
+			AccessConfigs: expandAccessConfigs(data["access_config"].([]interface{})),
+			AliasIpRanges: expandAliasIpRanges(data["alias_ip_range"].([]interface{})),
+		}
+	}
+	return ifaces, nil
+}

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -330,15 +330,6 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 							Computed:    true,
 							Description: `The name of the network_interface.`,
 						},
-<% unless version == 'ga' -%>
-						"nic_type": {
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew:     true,
-							ValidateFunc: validation.StringInSlice([]string{"GVNIC", "VIRTIO_NET"}, false),
-							Description:  `The type of vNIC to be used on this interface. Possible values:GVNIC, VIRTIO_NET`,
-						},
-<% end -%>
 						"access_config": {
 							Type:        schema.TypeList,
 							Optional:    true,
@@ -869,7 +860,7 @@ func resourceComputeInstanceTemplateCreate(d *schema.ResourceData, meta interfac
 		return err
 	}
 
-	networks, err := expandNetworkInterfaces(d, config)
+	networks, err := expandComputeInstanceTemplateNetworkInterfaces(d, config)
 	if err != nil {
 		return err
 	}
@@ -1233,7 +1224,7 @@ func resourceComputeInstanceTemplateRead(d *schema.ResourceData, meta interface{
 		return fmt.Errorf("Error setting project: %s", err)
 	}
 	if instanceTemplate.Properties.NetworkInterfaces != nil {
-		networkInterfaces, region, _, _, err := flattenNetworkInterfaces(d, config, instanceTemplate.Properties.NetworkInterfaces)
+		networkInterfaces, region, _, _, err := flattenComputeInstanceTemplateNetworkInterfaces(d, config, instanceTemplate.Properties.NetworkInterfaces)
 		if err != nil {
 			return err
 		}

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -1052,7 +1052,7 @@ func TestAccComputeInstance_multiNic(t *testing.T) {
 		},
 	})
 }
-<% unless version == 'ga' -%>
+
 func TestAccComputeInstance_nictype_update(t *testing.T) {
 	t.Parallel()
 
@@ -1081,7 +1081,6 @@ func TestAccComputeInstance_nictype_update(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccComputeInstance_guestAccelerator(t *testing.T) {
 	t.Parallel()
@@ -4170,7 +4169,6 @@ resource "google_compute_subnetwork" "inst-test-subnetwork" {
 `, instance, network, subnetwork)
 }
 
-<% unless version == 'ga' -%>
 func testAccComputeInstance_nictype(image, instance, nictype string) string {
 	return fmt.Sprintf(`
 resource "google_compute_image" "example" {
@@ -4225,7 +4223,6 @@ resource "google_compute_instance" "foobar" {
 }
 `, image, instance, nictype)
 }
-<% end -%>
 
 func testAccComputeInstance_guestAccelerator(instance string, count uint8) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
@@ -192,9 +192,43 @@ func flattenNetworkInterfaces(d *schema.ResourceData, config *Config, networkInt
 			"subnetwork_project": subnet.Project,
 			"access_config":      ac,
 			"alias_ip_range":     flattenAliasIpRange(iface.AliasIpRanges),
-<% unless version == 'ga' -%>
 			"nic_type":           iface.NicType,
-<% end -%>
+		}
+		// Instance template interfaces never have names, so they're absent
+		// in the instance template network_interface schema. We want to use the
+		// same flattening code for both resource types, so we avoid trying to
+		// set the name field when it's not set at the GCE end.
+		if iface.Name != "" {
+			flattened[i]["name"] = iface.Name
+		}
+		if internalIP == "" {
+			internalIP = iface.NetworkIP
+		}
+	}
+	return flattened, region, internalIP, externalIP, nil
+}
+
+func flattenComputeInstanceTemplateNetworkInterfaces(d *schema.ResourceData, config *Config, networkInterfaces []*computeBeta.NetworkInterface) ([]map[string]interface{}, string, string, string, error) {
+	flattened := make([]map[string]interface{}, len(networkInterfaces))
+	var region, internalIP, externalIP string
+
+	for i, iface := range networkInterfaces {
+		var ac []map[string]interface{}
+		ac, externalIP = flattenAccessConfigs(iface.AccessConfigs)
+
+		subnet, err := ParseSubnetworkFieldValue(iface.Subnetwork, d, config)
+		if err != nil {
+			return nil, "", "", "", err
+		}
+		region = subnet.Region
+
+		flattened[i] = map[string]interface{}{
+			"network_ip":         iface.NetworkIP,
+			"network":            ConvertSelfLinkToV1(iface.Network),
+			"subnetwork":         ConvertSelfLinkToV1(iface.Subnetwork),
+			"subnetwork_project": subnet.Project,
+			"access_config":      ac,
+			"alias_ip_range":     flattenAliasIpRange(iface.AliasIpRanges),
 		}
 		// Instance template interfaces never have names, so they're absent
 		// in the instance template network_interface schema. We want to use the
@@ -257,22 +291,52 @@ func expandNetworkInterfaces(d TerraformResourceData, config *Config) ([]*comput
 			Subnetwork:    sf.RelativeLink(),
 			AccessConfigs: expandAccessConfigs(data["access_config"].([]interface{})),
 			AliasIpRanges: expandAliasIpRanges(data["alias_ip_range"].([]interface{})),
-<% unless version == 'ga' -%>
 			NicType:       expandNicType(data["nic_type"].(interface{})),
-<% end -%>
 		}
-
 	}
 	return ifaces, nil
 }
-<% unless version == 'ga' -%>
+
+func expandComputeInstanceTemplateNetworkInterfaces(d TerraformResourceData, config *Config) ([]*computeBeta.NetworkInterface, error) {
+	configs := d.Get("network_interface").([]interface{})
+	ifaces := make([]*computeBeta.NetworkInterface, len(configs))
+	for i, raw := range configs {
+		data := raw.(map[string]interface{})
+
+		network := data["network"].(string)
+		subnetwork := data["subnetwork"].(string)
+		if network == "" && subnetwork == "" {
+			return nil, fmt.Errorf("exactly one of network or subnetwork must be provided")
+		}
+
+		nf, err := ParseNetworkFieldValue(network, d, config)
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine self_link for network %q: %s", network, err)
+		}
+
+		subnetProjectField := fmt.Sprintf("network_interface.%d.subnetwork_project", i)
+		sf, err := ParseSubnetworkFieldValueWithProjectField(subnetwork, subnetProjectField, d, config)
+		if err != nil {
+			return nil, fmt.Errorf("cannot determine self_link for subnetwork %q: %s", subnetwork, err)
+		}
+
+		ifaces[i] = &computeBeta.NetworkInterface{
+			NetworkIP:     data["network_ip"].(string),
+			Network:       nf.RelativeLink(),
+			Subnetwork:    sf.RelativeLink(),
+			AccessConfigs: expandAccessConfigs(data["access_config"].([]interface{})),
+			AliasIpRanges: expandAliasIpRanges(data["alias_ip_range"].([]interface{})),
+		}
+	}
+	return ifaces, nil
+}
+
 func expandNicType(d interface{}) string {
 	if d == nil {
 		return ""
 	}
 	return d.(string)
 }
-<% end -%>
 
 func flattenServiceAccounts(serviceAccounts []*computeBeta.ServiceAccount) []map[string]interface{} {
 	result := make([]map[string]interface{}, len(serviceAccounts))

--- a/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
@@ -208,42 +208,6 @@ func flattenNetworkInterfaces(d *schema.ResourceData, config *Config, networkInt
 	return flattened, region, internalIP, externalIP, nil
 }
 
-func flattenComputeInstanceTemplateNetworkInterfaces(d *schema.ResourceData, config *Config, networkInterfaces []*computeBeta.NetworkInterface) ([]map[string]interface{}, string, string, string, error) {
-	flattened := make([]map[string]interface{}, len(networkInterfaces))
-	var region, internalIP, externalIP string
-
-	for i, iface := range networkInterfaces {
-		var ac []map[string]interface{}
-		ac, externalIP = flattenAccessConfigs(iface.AccessConfigs)
-
-		subnet, err := ParseSubnetworkFieldValue(iface.Subnetwork, d, config)
-		if err != nil {
-			return nil, "", "", "", err
-		}
-		region = subnet.Region
-
-		flattened[i] = map[string]interface{}{
-			"network_ip":         iface.NetworkIP,
-			"network":            ConvertSelfLinkToV1(iface.Network),
-			"subnetwork":         ConvertSelfLinkToV1(iface.Subnetwork),
-			"subnetwork_project": subnet.Project,
-			"access_config":      ac,
-			"alias_ip_range":     flattenAliasIpRange(iface.AliasIpRanges),
-		}
-		// Instance template interfaces never have names, so they're absent
-		// in the instance template network_interface schema. We want to use the
-		// same flattening code for both resource types, so we avoid trying to
-		// set the name field when it's not set at the GCE end.
-		if iface.Name != "" {
-			flattened[i]["name"] = iface.Name
-		}
-		if internalIP == "" {
-			internalIP = iface.NetworkIP
-		}
-	}
-	return flattened, region, internalIP, externalIP, nil
-}
-
 func expandAccessConfigs(configs []interface{}) []*computeBeta.AccessConfig {
 	acs := make([]*computeBeta.AccessConfig, len(configs))
 	for i, raw := range configs {
@@ -292,40 +256,6 @@ func expandNetworkInterfaces(d TerraformResourceData, config *Config) ([]*comput
 			AccessConfigs: expandAccessConfigs(data["access_config"].([]interface{})),
 			AliasIpRanges: expandAliasIpRanges(data["alias_ip_range"].([]interface{})),
 			NicType:       expandNicType(data["nic_type"].(interface{})),
-		}
-	}
-	return ifaces, nil
-}
-
-func expandComputeInstanceTemplateNetworkInterfaces(d TerraformResourceData, config *Config) ([]*computeBeta.NetworkInterface, error) {
-	configs := d.Get("network_interface").([]interface{})
-	ifaces := make([]*computeBeta.NetworkInterface, len(configs))
-	for i, raw := range configs {
-		data := raw.(map[string]interface{})
-
-		network := data["network"].(string)
-		subnetwork := data["subnetwork"].(string)
-		if network == "" && subnetwork == "" {
-			return nil, fmt.Errorf("exactly one of network or subnetwork must be provided")
-		}
-
-		nf, err := ParseNetworkFieldValue(network, d, config)
-		if err != nil {
-			return nil, fmt.Errorf("cannot determine self_link for network %q: %s", network, err)
-		}
-
-		subnetProjectField := fmt.Sprintf("network_interface.%d.subnetwork_project", i)
-		sf, err := ParseSubnetworkFieldValueWithProjectField(subnetwork, subnetProjectField, d, config)
-		if err != nil {
-			return nil, fmt.Errorf("cannot determine self_link for subnetwork %q: %s", subnetwork, err)
-		}
-
-		ifaces[i] = &computeBeta.NetworkInterface{
-			NetworkIP:     data["network_ip"].(string),
-			Network:       nf.RelativeLink(),
-			Subnetwork:    sf.RelativeLink(),
-			AccessConfigs: expandAccessConfigs(data["access_config"].([]interface{})),
-			AliasIpRanges: expandAliasIpRanges(data["alias_ip_range"].([]interface{})),
 		}
 	}
 	return ifaces, nil

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -276,7 +276,7 @@ The `network_interface` block supports:
     array of alias IP ranges for this network interface. Can only be specified for network
     interfaces on subnet-mode networks. Structure documented below.
 
-* `nic_type` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) The type of vNIC to be used on this interface.
+* `nic_type` - (Optional) The type of vNIC to be used on this interface.
     Possible values: GVNIC, VIRTIO_NET.
 
 The `access_config` block supports:

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -276,8 +276,7 @@ The `network_interface` block supports:
     array of alias IP ranges for this network interface. Can only be specified for network
     interfaces on subnet-mode networks. Structure documented below.
 
-* `nic_type` - (Optional) The type of vNIC to be used on this interface.
-    Possible values: GVNIC, VIRTIO_NET.
+* `nic_type` - (Optional) The type of vNIC to be used on this interface. Possible values: GVNIC, VIRTIO_NET.
 
 The `access_config` block supports:
 

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -359,9 +359,6 @@ The `network_interface` block supports:
     array of alias IP ranges for this network interface. Can only be specified for network
     interfaces on subnet-mode networks. Structure documented below.
 
-* `nic_type` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) The type of vNIC to be used on this interface.
-    Possible values: GVNIC, VIRTIO_NET.
-
 The `access_config` block supports:
 
 * `nat_ip` - (Optional) The IP address that will be 1:1 mapped to the instance's


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/8502


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added support for `nic_type` to `google_compute_instance` (GA only)
```

```release-note_breaking-change
compute: removed `nic_type` field from `google_compute_instance_template`, as it never worked (beta)
```
