### PR TITLE
Revert "GA for gVNIC support (#4511)"

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -297,6 +297,7 @@ func resourceComputeInstance() *schema.Resource {
 							Computed:    true,
 							Description: `The name of the interface`,
 						},
+<% unless version == 'ga' -%>
 						"nic_type": {
 							Type:     schema.TypeString,
 							Optional: true,
@@ -304,6 +305,7 @@ func resourceComputeInstance() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"GVNIC", "VIRTIO_NET"}, false),
 							Description:  `The type of vNIC to be used on this interface. Possible values:GVNIC, VIRTIO_NET`,
 						},
+<% end -%>
 						"access_config": {
 							Type:        schema.TypeList,
 							Optional:    true,

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -1052,7 +1052,7 @@ func TestAccComputeInstance_multiNic(t *testing.T) {
 		},
 	})
 }
-
+<% unless version == 'ga' -%>
 func TestAccComputeInstance_nictype_update(t *testing.T) {
 	t.Parallel()
 
@@ -1081,6 +1081,7 @@ func TestAccComputeInstance_nictype_update(t *testing.T) {
 		},
 	})
 }
+<% end -%>
 
 func TestAccComputeInstance_guestAccelerator(t *testing.T) {
 	t.Parallel()
@@ -4169,6 +4170,7 @@ resource "google_compute_subnetwork" "inst-test-subnetwork" {
 `, instance, network, subnetwork)
 }
 
+<% unless version == 'ga' -%>
 func testAccComputeInstance_nictype(image, instance, nictype string) string {
 	return fmt.Sprintf(`
 resource "google_compute_image" "example" {
@@ -4223,6 +4225,7 @@ resource "google_compute_instance" "foobar" {
 }
 `, image, instance, nictype)
 }
+<% end -%>
 
 func testAccComputeInstance_guestAccelerator(instance string, count uint8) string {
 	return fmt.Sprintf(`

--- a/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
@@ -192,7 +192,9 @@ func flattenNetworkInterfaces(d *schema.ResourceData, config *Config, networkInt
 			"subnetwork_project": subnet.Project,
 			"access_config":      ac,
 			"alias_ip_range":     flattenAliasIpRange(iface.AliasIpRanges),
+<% unless version == 'ga' -%>
 			"nic_type":           iface.NicType,
+<% end -%>
 		}
 		// Instance template interfaces never have names, so they're absent
 		// in the instance template network_interface schema. We want to use the
@@ -255,19 +257,22 @@ func expandNetworkInterfaces(d TerraformResourceData, config *Config) ([]*comput
 			Subnetwork:    sf.RelativeLink(),
 			AccessConfigs: expandAccessConfigs(data["access_config"].([]interface{})),
 			AliasIpRanges: expandAliasIpRanges(data["alias_ip_range"].([]interface{})),
+<% unless version == 'ga' -%>
 			NicType:       expandNicType(data["nic_type"].(interface{})),
+<% end -%>
 		}
 
 	}
 	return ifaces, nil
 }
-
+<% unless version == 'ga' -%>
 func expandNicType(d interface{}) string {
 	if d == nil {
 		return ""
 	}
 	return d.(string)
 }
+<% end -%>
 
 func flattenServiceAccounts(serviceAccounts []*computeBeta.ServiceAccount) []map[string]interface{} {
 	result := make([]map[string]interface{}, len(serviceAccounts))

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -276,7 +276,7 @@ The `network_interface` block supports:
     array of alias IP ranges for this network interface. Can only be specified for network
     interfaces on subnet-mode networks. Structure documented below.
 
-* `nic_type` - (Optional) The type of vNIC to be used on this interface.
+* `nic_type` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) The type of vNIC to be used on this interface.
     Possible values: GVNIC, VIRTIO_NET.
 
 The `access_config` block supports:


### PR DESCRIPTION
This reverts commit d63a4a8ff2b7d89e5a66739d1d3b629c8437074e.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

https://github.com/GoogleCloudPlatform/magic-modules/pull/4511 works fine for Compute Instances, but there is issues with Instance Templates. Reverting for now.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
