### PR TITLE
fix logging bucket config tests

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_logging_bucket_config_test.go
+++ b/mmv1/third_party/terraform/tests/resource_logging_bucket_config_test.go
@@ -30,7 +30,7 @@ func TestAccLoggingBucketConfigFolder_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"folder"},
 			},
 			{
-				Config: testAccLoggingBucketConfigFolder_basic(context, 40),
+				Config: testAccLoggingBucketConfigFolder_basic(context, 20),
 			},
 			{
 				ResourceName:            "google_logging_folder_bucket_config.basic",
@@ -57,6 +57,15 @@ func TestAccLoggingBucketConfigProject_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccLoggingBucketConfigProject_basic(context, 30),
+			},
+			{
+				ResourceName:            "google_logging_project_bucket_config.basic",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"project"},
+			},
+			{
+				Config: testAccLoggingBucketConfigProject_basic(context, 20),
 			},
 			{
 				ResourceName:            "google_logging_project_bucket_config.basic",
@@ -100,7 +109,7 @@ func TestAccLoggingBucketConfigBillingAccount_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"billing_account"},
 			},
 			{
-				Config: testAccLoggingBucketConfigBillingAccount_basic(context, 40),
+				Config: testAccLoggingBucketConfigBillingAccount_basic(context, 20),
 			},
 			{
 				ResourceName:            "google_logging_billing_account_bucket_config.basic",
@@ -134,7 +143,7 @@ func TestAccLoggingBucketConfigOrganization_basic(t *testing.T) {
 				ImportStateVerifyIgnore: []string{"organization"},
 			},
 			{
-				Config: testAccLoggingBucketConfigOrganization_basic(context, 40),
+				Config: testAccLoggingBucketConfigOrganization_basic(context, 20),
 			},
 			{
 				ResourceName:            "google_logging_organization_bucket_config.basic",

--- a/mmv1/third_party/terraform/website/docs/r/logging_billing_account_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_billing_account_bucket_config.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `description` - (Optional) Describes this bucket.
 
-* `retention_days` - (Optional) Logs will be retained by default for this amount of time, after which they will automatically be deleted. The minimum retention period is 1 day. If this value is set to zero at bucket creation time, the default time of 30 days will be used.
+* `retention_days` - (Optional) Logs will be retained by default for this amount of time, after which they will automatically be deleted. The minimum retention period is 1 day. If this value is set to zero at bucket creation time, the default time of 30 days will be used. Bucket retention can not be increased on buckets outside of projects.
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_folder_bucket_config.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `description` - (Optional) Describes this bucket.
 
-* `retention_days` - (Optional) Logs will be retained by default for this amount of time, after which they will automatically be deleted. The minimum retention period is 1 day. If this value is set to zero at bucket creation time, the default time of 30 days will be used.
+* `retention_days` - (Optional) Logs will be retained by default for this amount of time, after which they will automatically be deleted. The minimum retention period is 1 day. If this value is set to zero at bucket creation time, the default time of 30 days will be used. Bucket retention can not be increased on buckets outside of projects.
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/logging_organization_bucket_config.html.markdown
@@ -42,7 +42,7 @@ The following arguments are supported:
 
 * `description` - (Optional) Describes this bucket.
 
-* `retention_days` - (Optional) Logs will be retained by default for this amount of time, after which they will automatically be deleted. The minimum retention period is 1 day. If this value is set to zero at bucket creation time, the default time of 30 days will be used.
+* `retention_days` - (Optional) Logs will be retained by default for this amount of time, after which they will automatically be deleted. The minimum retention period is 1 day. If this value is set to zero at bucket creation time, the default time of 30 days will be used. Bucket retention can not be increased on buckets outside of projects.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/8382

In logging buckets outside of projects, the retention days can no longer be increased. I've updated the tests to follow that rule, and updated the docs to mention this as well.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
