### PR TITLE
make max_age.0.days and max_age.0.duration ForceNew for bigtable_gc_policy

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -64,6 +64,7 @@ func resourceBigtableGCPolicy() *schema.Resource {
 						"days": {
 							Type:         schema.TypeInt,
 							Optional:     true,
+							ForceNew:     true,
 							Deprecated:   "Deprecated in favor of duration",
 							Description:  `Number of days before applying GC policy.`,
 							ExactlyOneOf: []string{"max_age.0.days", "max_age.0.duration"},
@@ -71,6 +72,7 @@ func resourceBigtableGCPolicy() *schema.Resource {
 						"duration": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							ForceNew:     true,
 							Description:  `Duration before applying GC policy`,
 							ValidateFunc: validateDuration(),
 							ExactlyOneOf: []string{"max_age.0.days", "max_age.0.duration"},
@@ -89,6 +91,7 @@ func resourceBigtableGCPolicy() *schema.Resource {
 						"number": {
 							Type:        schema.TypeInt,
 							Required:    true,
+							ForceNew:    true,
 							Description: `Number of version before applying the GC policy.`,
 						},
 					},


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

closes max_age https://github.com/hashicorp/terraform-provider-google/issues/8416

There is no update function for `bigtable_gc_policy` making this fields ForceNew as should be the sdk requirement.



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigtable: required resource recreation if any fields change on `resource_bigtable_gc_policy`
```
