### PR TITLE
Support for google_access_context_manager_service_perimeter ingress/egress policies

### DIFF
--- a/mmv1/products/accesscontextmanager/api.yaml
+++ b/mmv1/products/accesscontextmanager/api.yaml
@@ -1564,6 +1564,220 @@ objects:
                       The list of APIs usable within the Service Perimeter.
                       Must be empty unless `enableRestriction` is True.
                     item_type: Api::Type::String
+                - !ruby/object:Api::Type::Array
+                  name: ingressPolicies
+                  min_version: beta
+                  description: List of IngressPolicies to apply to the perimeter. A perimeter
+                    may have multiple IngressPolicies, each of which is evaluated separately.
+                    Access is granted if any Ingress Policy grants it. Must be empty for a perimeter
+                    bridge.
+                  item_type: !ruby/object:Api::Type::NestedObject
+                    properties:
+                    - !ruby/object:Api::Type::NestedObject
+                      name: ingressTo
+                      description: Defines the conditions on the ApiOperation and request destination
+                        that cause this IngressPolicy to apply.
+                      required: true
+                      properties:
+                      - !ruby/object:Api::Type::Array
+                        name: resources
+                        description: A list of resources, currently only projects in the form
+                          `projects/`, protected by this ServicePerimeter that are allowed to
+                          be accessed by sources defined in the corresponding IngressFrom. A request
+                          matches if it contains a resource in this list. If `*` is specified
+                          for resources, then this IngressTo rule will authorize access to all
+                          resources inside the perimeter, provided that the request also matches
+                          the `operations` field.
+                        required: true
+                        item_type: Api::Type::String
+                      - !ruby/object:Api::Type::Array
+                        name: operations
+                        description: A list of ApiOperations the sources specified in corresponding
+                          IngressFrom are allowed to perform in this ServicePerimeter.
+                        required: true
+                        item_type: !ruby/object:Api::Type::NestedObject
+                          properties:
+                          - !ruby/object:Api::Type::Array
+                            name: methodSelectors
+                            description: API methods or permissions to allow. Method or permission
+                              must belong to the service specified by `service_name` field. A
+                              single MethodSelector entry with `*` specified for the `method`
+                              field will allow all methods AND permissions for the service specified
+                              in `service_name`.
+                            required: true
+                            item_type: !ruby/object:Api::Type::NestedObject
+                              properties:
+                              - !ruby/object:Api::Type::String
+                                name: permission
+                                description: Value for `permission` should be a valid Cloud IAM
+                                  permission for the corresponding `service_name` in ApiOperation.
+                                exactly_one_of:
+                                  - permission
+                                  - method
+                              - !ruby/object:Api::Type::String
+                                name: method
+                                description: Value for `method` should be a valid method name
+                                  for the corresponding `service_name` in ApiOperation. If `*`
+                                  used as value for `method`, then ALL methods and permissions
+                                  are allowed.
+                                exactly_one_of:
+                                  - permission
+                                  - method
+                          - !ruby/object:Api::Type::String
+                            name: serviceName
+                            description: The name of the API whose methods or permissions the
+                              IngressPolicy or EgressPolicy want to allow. A single ApiOperation
+                              with `service_name` field set to `*` will allow all methods AND
+                              permissions for all services.
+                            required: true
+                    - !ruby/object:Api::Type::NestedObject
+                      name: ingressFrom
+                      description: Defines the conditions on the source of a request causing this
+                        IngressPolicy to apply.
+                      required: true
+                      properties:
+                      - !ruby/object:Api::Type::Array
+                        name: identities
+                        description: A list of identities that are allowed access through this
+                          ingress policy. Should be in the format of email address. The email
+                          address should represent individual user or service account only.
+                        exactly_one_of:
+                          - identities
+                          - identity_type
+                        item_type: Api::Type::String
+                      - !ruby/object:Api::Type::Array
+                        name: sources
+                        description: Sources that this IngressPolicy authorizes access from.
+                        required: true
+                        item_type: !ruby/object:Api::Type::NestedObject
+                          properties:
+                          - !ruby/object:Api::Type::String
+                            name: resource
+                            description: 'A Google Cloud resource that is allowed to ingress the
+                              perimeter. Requests from these resources will be allowed to access
+                              perimeter data. Currently only projects are allowed. Format: `projects/{project_number}`
+                              The project may be in any Google Cloud organization, not just the
+                              organization that the perimeter is defined in. `*` is not allowed,
+                              the case of allowing all Google Cloud resources only is not supported.'
+                            exactly_one_of:
+                              - resource
+                              - access_level
+                          - !ruby/object:Api::Type::String
+                            name: accessLevel
+                            description: 'An AccessLevel resource name that allow resources within
+                              the ServicePerimeters to be accessed from the internet. AccessLevels
+                              listed must be in the same policy as this ServicePerimeter. Referencing
+                              a nonexistent AccessLevel will cause an error. If no AccessLevel
+                              names are listed, resources within the perimeter can only be accessed
+                              via Google Cloud calls with request origins within the perimeter.
+                              Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If `*`
+                              is specified, then all IngressSources will be allowed.'
+                            exactly_one_of:
+                              - resource
+                              - access_level
+                      - !ruby/object:Api::Type::Enum
+                        name: identityType
+                        description: Specifies the type of identities that are allowed access
+                          from outside the perimeter. If left unspecified, then members of `identities`
+                          field will be allowed access.
+                        exactly_one_of:
+                          - identities
+                          - identity_type
+                        values:
+                        - :IDENTITY_TYPE_UNSPECIFIED
+                        - :ANY_IDENTITY
+                        - :ANY_USER_ACCOUNT
+                        - :ANY_SERVICE_ACCOUNT
+                - !ruby/object:Api::Type::Array
+                  name: egressPolicies
+                  min_version: beta
+                  description: List of EgressPolicies to apply to the perimeter. A perimeter may
+                    have multiple EgressPolicies, each of which is evaluated separately. Access
+                    is granted if any EgressPolicy grants it. Must be empty for a perimeter bridge.
+                  item_type: !ruby/object:Api::Type::NestedObject
+                    properties:
+                    - !ruby/object:Api::Type::NestedObject
+                      name: egressFrom
+                      description: Defines conditions on the source of a request causing this
+                        EgressPolicy to apply.
+                      required: true
+                      properties:
+                      - !ruby/object:Api::Type::Array
+                        name: identities
+                        description: A list of identities that are allowed access through this
+                          [EgressPolicy]. Should be in the format of email address. The email
+                          address should represent individual user or service account only.
+                        exactly_one_of:
+                          - identities
+                          - identity_type
+                        item_type: Api::Type::String
+                      - !ruby/object:Api::Type::Enum
+                        name: identityType
+                        description: Specifies the type of identities that are allowed access
+                          to outside the perimeter. If left unspecified, then members of `identities`
+                          field will be allowed access.
+                        exactly_one_of:
+                          - identities
+                          - identity_type
+                        values:
+                        - :IDENTITY_TYPE_UNSPECIFIED
+                        - :ANY_IDENTITY
+                        - :ANY_USER_ACCOUNT
+                        - :ANY_SERVICE_ACCOUNT
+                    - !ruby/object:Api::Type::NestedObject
+                      name: egressTo
+                      description: Defines the conditions on the ApiOperation and destination
+                        resources that cause this EgressPolicy to apply.
+                      required: true
+                      properties:
+                      - !ruby/object:Api::Type::Array
+                        name: resources
+                        description: A list of resources, currently only projects in the form
+                          `projects/`, that match this to stanza. A request matches if it contains
+                          a resource in this list. If `*` is specified for resources, then this
+                          EgressTo rule will authorize access to all resources outside the perimeter.
+                        required: true
+                        item_type: Api::Type::String
+                      - !ruby/object:Api::Type::Array
+                        name: operations
+                        description: A list of ApiOperations that this egress rule applies to.
+                          A request matches if it contains an operation/service in this list.
+                        required: true
+                        item_type: !ruby/object:Api::Type::NestedObject
+                          properties:
+                          - !ruby/object:Api::Type::Array
+                            name: methodSelectors
+                            description: API methods or permissions to allow. Method or permission
+                              must belong to the service specified by `service_name` field. A
+                              single MethodSelector entry with `*` specified for the `method`
+                              field will allow all methods AND permissions for the service specified
+                              in `service_name`.
+                            required: true
+                            item_type: !ruby/object:Api::Type::NestedObject
+                              properties:
+                              - !ruby/object:Api::Type::String
+                                name: permission
+                                description: Value for `permission` should be a valid Cloud IAM
+                                  permission for the corresponding `service_name` in ApiOperation.
+                                exactly_one_of:
+                                  - permission
+                                  - method
+                              - !ruby/object:Api::Type::String
+                                name: method
+                                description: Value for `method` should be a valid method name
+                                  for the corresponding `service_name` in ApiOperation. If `*`
+                                  used as value for `method`, then ALL methods and permissions
+                                  are allowed.
+                                exactly_one_of:
+                                  - permission
+                                  - method
+                          - !ruby/object:Api::Type::String
+                            name: serviceName
+                            description: The name of the API whose methods or permissions the
+                              IngressPolicy or EgressPolicy want to allow. A single ApiOperation
+                              with `service_name` field set to `*` will allow all methods AND
+                              permissions for all services.
+                            required: true
             - !ruby/object:Api::Type::NestedObject
               name: 'spec'
               description: |
@@ -1637,6 +1851,220 @@ objects:
                       The list of APIs usable within the Service Perimeter.
                       Must be empty unless `enableRestriction` is True.
                     item_type: Api::Type::String
+                - !ruby/object:Api::Type::Array
+                  name: ingressPolicies
+                  min_version: beta
+                  description: List of IngressPolicies to apply to the perimeter. A perimeter
+                    may have multiple IngressPolicies, each of which is evaluated separately.
+                    Access is granted if any Ingress Policy grants it. Must be empty for a perimeter
+                    bridge.
+                  item_type: !ruby/object:Api::Type::NestedObject
+                    properties:
+                    - !ruby/object:Api::Type::NestedObject
+                      name: ingressTo
+                      description: Defines the conditions on the ApiOperation and request destination
+                        that cause this IngressPolicy to apply.
+                      required: true
+                      properties:
+                      - !ruby/object:Api::Type::Array
+                        name: resources
+                        description: A list of resources, currently only projects in the form
+                          `projects/`, protected by this ServicePerimeter that are allowed to
+                          be accessed by sources defined in the corresponding IngressFrom. A request
+                          matches if it contains a resource in this list. If `*` is specified
+                          for resources, then this IngressTo rule will authorize access to all
+                          resources inside the perimeter, provided that the request also matches
+                          the `operations` field.
+                        required: true
+                        item_type: Api::Type::String
+                      - !ruby/object:Api::Type::Array
+                        name: operations
+                        description: A list of ApiOperations the sources specified in corresponding
+                          IngressFrom are allowed to perform in this ServicePerimeter.
+                        required: true
+                        item_type: !ruby/object:Api::Type::NestedObject
+                          properties:
+                          - !ruby/object:Api::Type::Array
+                            name: methodSelectors
+                            description: API methods or permissions to allow. Method or permission
+                              must belong to the service specified by `service_name` field. A
+                              single MethodSelector entry with `*` specified for the `method`
+                              field will allow all methods AND permissions for the service specified
+                              in `service_name`.
+                            required: true
+                            item_type: !ruby/object:Api::Type::NestedObject
+                              properties:
+                              - !ruby/object:Api::Type::String
+                                name: permission
+                                description: Value for `permission` should be a valid Cloud IAM
+                                  permission for the corresponding `service_name` in ApiOperation.
+                                exactly_one_of:
+                                  - permission
+                                  - method
+                              - !ruby/object:Api::Type::String
+                                name: method
+                                description: Value for `method` should be a valid method name
+                                  for the corresponding `service_name` in ApiOperation. If `*`
+                                  used as value for `method`, then ALL methods and permissions
+                                  are allowed.
+                                exactly_one_of:
+                                  - permission
+                                  - method
+                          - !ruby/object:Api::Type::String
+                            name: serviceName
+                            description: The name of the API whose methods or permissions the
+                              IngressPolicy or EgressPolicy want to allow. A single ApiOperation
+                              with `service_name` field set to `*` will allow all methods AND
+                              permissions for all services.
+                            required: true
+                    - !ruby/object:Api::Type::NestedObject
+                      name: ingressFrom
+                      description: Defines the conditions on the source of a request causing this
+                        IngressPolicy to apply.
+                      required: true
+                      properties:
+                      - !ruby/object:Api::Type::Array
+                        name: identities
+                        description: A list of identities that are allowed access through this
+                          ingress policy. Should be in the format of email address. The email
+                          address should represent individual user or service account only.
+                        exactly_one_of:
+                          - identities
+                          - identity_type
+                        item_type: Api::Type::String
+                      - !ruby/object:Api::Type::Array
+                        name: sources
+                        description: Sources that this IngressPolicy authorizes access from.
+                        required: true
+                        item_type: !ruby/object:Api::Type::NestedObject
+                          properties:
+                          - !ruby/object:Api::Type::String
+                            name: resource
+                            description: 'A Google Cloud resource that is allowed to ingress the
+                              perimeter. Requests from these resources will be allowed to access
+                              perimeter data. Currently only projects are allowed. Format: `projects/{project_number}`
+                              The project may be in any Google Cloud organization, not just the
+                              organization that the perimeter is defined in. `*` is not allowed,
+                              the case of allowing all Google Cloud resources only is not supported.'
+                            exactly_one_of:
+                              - resource
+                              - access_level
+                          - !ruby/object:Api::Type::String
+                            name: accessLevel
+                            description: 'An AccessLevel resource name that allow resources within
+                              the ServicePerimeters to be accessed from the internet. AccessLevels
+                              listed must be in the same policy as this ServicePerimeter. Referencing
+                              a nonexistent AccessLevel will cause an error. If no AccessLevel
+                              names are listed, resources within the perimeter can only be accessed
+                              via Google Cloud calls with request origins within the perimeter.
+                              Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If `*`
+                              is specified, then all IngressSources will be allowed.'
+                            exactly_one_of:
+                              - resource
+                              - access_level
+                      - !ruby/object:Api::Type::Enum
+                        name: identityType
+                        description: Specifies the type of identities that are allowed access
+                          from outside the perimeter. If left unspecified, then members of `identities`
+                          field will be allowed access.
+                        exactly_one_of:
+                          - identities
+                          - identity_type
+                        values:
+                        - :IDENTITY_TYPE_UNSPECIFIED
+                        - :ANY_IDENTITY
+                        - :ANY_USER_ACCOUNT
+                        - :ANY_SERVICE_ACCOUNT
+                - !ruby/object:Api::Type::Array
+                  name: egressPolicies
+                  min_version: beta
+                  description: List of EgressPolicies to apply to the perimeter. A perimeter may
+                    have multiple EgressPolicies, each of which is evaluated separately. Access
+                    is granted if any EgressPolicy grants it. Must be empty for a perimeter bridge.
+                  item_type: !ruby/object:Api::Type::NestedObject
+                    properties:
+                    - !ruby/object:Api::Type::NestedObject
+                      name: egressFrom
+                      description: Defines conditions on the source of a request causing this
+                        EgressPolicy to apply.
+                      required: true
+                      properties:
+                      - !ruby/object:Api::Type::Array
+                        name: identities
+                        description: A list of identities that are allowed access through this
+                          [EgressPolicy]. Should be in the format of email address. The email
+                          address should represent individual user or service account only.
+                        exactly_one_of:
+                          - identities
+                          - identity_type
+                        item_type: Api::Type::String
+                      - !ruby/object:Api::Type::Enum
+                        name: identityType
+                        description: Specifies the type of identities that are allowed access
+                          to outside the perimeter. If left unspecified, then members of `identities`
+                          field will be allowed access.
+                        exactly_one_of:
+                          - identities
+                          - identity_type
+                        values:
+                        - :IDENTITY_TYPE_UNSPECIFIED
+                        - :ANY_IDENTITY
+                        - :ANY_USER_ACCOUNT
+                        - :ANY_SERVICE_ACCOUNT
+                    - !ruby/object:Api::Type::NestedObject
+                      name: egressTo
+                      description: Defines the conditions on the ApiOperation and destination
+                        resources that cause this EgressPolicy to apply.
+                      required: true
+                      properties:
+                      - !ruby/object:Api::Type::Array
+                        name: resources
+                        description: A list of resources, currently only projects in the form
+                          `projects/`, that match this to stanza. A request matches if it contains
+                          a resource in this list. If `*` is specified for resources, then this
+                          EgressTo rule will authorize access to all resources outside the perimeter.
+                        required: true
+                        item_type: Api::Type::String
+                      - !ruby/object:Api::Type::Array
+                        name: operations
+                        description: A list of ApiOperations that this egress rule applies to.
+                          A request matches if it contains an operation/service in this list.
+                        required: true
+                        item_type: !ruby/object:Api::Type::NestedObject
+                          properties:
+                          - !ruby/object:Api::Type::Array
+                            name: methodSelectors
+                            description: API methods or permissions to allow. Method or permission
+                              must belong to the service specified by `service_name` field. A
+                              single MethodSelector entry with `*` specified for the `method`
+                              field will allow all methods AND permissions for the service specified
+                              in `service_name`.
+                            required: true
+                            item_type: !ruby/object:Api::Type::NestedObject
+                              properties:
+                              - !ruby/object:Api::Type::String
+                                name: permission
+                                description: Value for `permission` should be a valid Cloud IAM
+                                  permission for the corresponding `service_name` in ApiOperation.
+                                exactly_one_of:
+                                  - permission
+                                  - method
+                              - !ruby/object:Api::Type::String
+                                name: method
+                                description: Value for `method` should be a valid method name
+                                  for the corresponding `service_name` in ApiOperation. If `*`
+                                  used as value for `method`, then ALL methods and permissions
+                                  are allowed.
+                                exactly_one_of:
+                                  - permission
+                                  - method
+                          - !ruby/object:Api::Type::String
+                            name: serviceName
+                            description: The name of the API whose methods or permissions the
+                              IngressPolicy or EgressPolicy want to allow. A single ApiOperation
+                              with `service_name` field set to `*` will allow all methods AND
+                              permissions for all services.
+                            required: true
             - !ruby/object:Api::Type::Boolean
               name: 'useExplicitDryRunSpec'
               description: |

--- a/mmv1/products/accesscontextmanager/api.yaml
+++ b/mmv1/products/accesscontextmanager/api.yaml
@@ -899,6 +899,175 @@ objects:
                 The list of APIs usable within the Service Perimeter.
                 Must be empty unless `enableRestriction` is True.
               item_type: Api::Type::String
+          - !ruby/object:Api::Type::Array
+            name: ingressPolicies
+            description: List of IngressPolicies to apply to the perimeter. A perimeter
+              may have multiple IngressPolicies, each of which is evaluated separately.
+              Access is granted if any Ingress Policy grants it. Must be empty for a perimeter
+              bridge.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+              - !ruby/object:Api::Type::NestedObject
+                name: ingressTo
+                description: Defines the conditions on the ApiOperation and request destination
+                  that cause this IngressPolicy to apply.
+                properties:
+                - !ruby/object:Api::Type::Array
+                  name: resources
+                  description: A list of resources, currently only projects in the form
+                    `projects/`, protected by this ServicePerimeter that are allowed to
+                    be accessed by sources defined in the corresponding IngressFrom. A request
+                    matches if it contains a resource in this list. If `*` is specified
+                    for resources, then this IngressTo rule will authorize access to all
+                    resources inside the perimeter, provided that the request also matches
+                    the `operations` field.
+                  item_type: Api::Type::String
+                - !ruby/object:Api::Type::Array
+                  name: operations
+                  description: A list of ApiOperations the sources specified in corresponding
+                    IngressFrom are allowed to perform in this ServicePerimeter.
+                  item_type: !ruby/object:Api::Type::NestedObject
+                    properties:
+                    - !ruby/object:Api::Type::Array
+                      name: methodSelectors
+                      description: API methods or permissions to allow. Method or permission
+                        must belong to the service specified by `service_name` field. A
+                        single MethodSelector entry with `*` specified for the `method`
+                        field will allow all methods AND permissions for the service specified
+                        in `service_name`.
+                      item_type: !ruby/object:Api::Type::NestedObject
+                        properties:
+                        - !ruby/object:Api::Type::String
+                          name: permission
+                          description: Value for `permission` should be a valid Cloud IAM
+                            permission for the corresponding `service_name` in ApiOperation.
+                        - !ruby/object:Api::Type::String
+                          name: method
+                          description: Value for `method` should be a valid method name
+                            for the corresponding `service_name` in ApiOperation. If `*`
+                            used as value for `method`, then ALL methods and permissions
+                            are allowed.
+                    - !ruby/object:Api::Type::String
+                      name: serviceName
+                      description: The name of the API whose methods or permissions the
+                        IngressPolicy or EgressPolicy want to allow. A single ApiOperation
+                        with `service_name` field set to `*` will allow all methods AND
+                        permissions for all services.
+              - !ruby/object:Api::Type::NestedObject
+                name: ingressFrom
+                description: Defines the conditions on the source of a request causing this
+                  IngressPolicy to apply.
+                properties:
+                - !ruby/object:Api::Type::Array
+                  name: identities
+                  description: A list of identities that are allowed access through this
+                    ingress policy. Should be in the format of email address. The email
+                    address should represent individual user or service account only.
+                  item_type: Api::Type::String
+                - !ruby/object:Api::Type::Array
+                  name: sources
+                  description: Sources that this IngressPolicy authorizes access from.
+                  item_type: !ruby/object:Api::Type::NestedObject
+                    properties:
+                    - !ruby/object:Api::Type::String
+                      name: resource
+                      description: 'A Google Cloud resource that is allowed to ingress the
+                        perimeter. Requests from these resources will be allowed to access
+                        perimeter data. Currently only projects are allowed. Format: `projects/{project_number}`
+                        The project may be in any Google Cloud organization, not just the
+                        organization that the perimeter is defined in. `*` is not allowed,
+                        the case of allowing all Google Cloud resources only is not supported.'
+                    - !ruby/object:Api::Type::String
+                      name: accessLevel
+                      description: 'An AccessLevel resource name that allow resources within
+                        the ServicePerimeters to be accessed from the internet. AccessLevels
+                        listed must be in the same policy as this ServicePerimeter. Referencing
+                        a nonexistent AccessLevel will cause an error. If no AccessLevel
+                        names are listed, resources within the perimeter can only be accessed
+                        via Google Cloud calls with request origins within the perimeter.
+                        Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If `*`
+                        is specified, then all IngressSources will be allowed.'
+                - !ruby/object:Api::Type::Enum
+                  name: identityType
+                  description: Specifies the type of identities that are allowed access
+                    from outside the perimeter. If left unspecified, then members of `identities`
+                    field will be allowed access.
+                  values:
+                  - :IDENTITY_TYPE_UNSPECIFIED
+                  - :ANY_IDENTITY
+                  - :ANY_USER_ACCOUNT
+                  - :ANY_SERVICE_ACCOUNT
+          - !ruby/object:Api::Type::Array
+            name: egressPolicies
+            description: List of EgressPolicies to apply to the perimeter. A perimeter may
+              have multiple EgressPolicies, each of which is evaluated separately. Access
+              is granted if any EgressPolicy grants it. Must be empty for a perimeter bridge.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+              - !ruby/object:Api::Type::NestedObject
+                name: egressFrom
+                description: Defines conditions on the source of a request causing this
+                  EgressPolicy to apply.
+                properties:
+                - !ruby/object:Api::Type::Array
+                  name: identities
+                  description: A list of identities that are allowed access through this
+                    [EgressPolicy]. Should be in the format of email address. The email
+                    address should represent individual user or service account only.
+                  item_type: Api::Type::String
+                - !ruby/object:Api::Type::Enum
+                  name: identityType
+                  description: Specifies the type of identities that are allowed access
+                    to outside the perimeter. If left unspecified, then members of `identities`
+                    field will be allowed access.
+                  values:
+                  - :IDENTITY_TYPE_UNSPECIFIED
+                  - :ANY_IDENTITY
+                  - :ANY_USER_ACCOUNT
+                  - :ANY_SERVICE_ACCOUNT
+              - !ruby/object:Api::Type::NestedObject
+                name: egressTo
+                description: Defines the conditions on the ApiOperation and destination
+                  resources that cause this EgressPolicy to apply.
+                properties:
+                - !ruby/object:Api::Type::Array
+                  name: resources
+                  description: A list of resources, currently only projects in the form
+                    `projects/`, that match this to stanza. A request matches if it contains
+                    a resource in this list. If `*` is specified for resources, then this
+                    EgressTo rule will authorize access to all resources outside the perimeter.
+                  item_type: Api::Type::String
+                - !ruby/object:Api::Type::Array
+                  name: operations
+                  description: A list of ApiOperations that this egress rule applies to.
+                    A request matches if it contains an operation/service in this list.
+                  item_type: !ruby/object:Api::Type::NestedObject
+                    properties:
+                    - !ruby/object:Api::Type::Array
+                      name: methodSelectors
+                      description: API methods or permissions to allow. Method or permission
+                        must belong to the service specified by `service_name` field. A
+                        single MethodSelector entry with `*` specified for the `method`
+                        field will allow all methods AND permissions for the service specified
+                        in `service_name`.
+                      item_type: !ruby/object:Api::Type::NestedObject
+                        properties:
+                        - !ruby/object:Api::Type::String
+                          name: permission
+                          description: Value for `permission` should be a valid Cloud IAM
+                            permission for the corresponding `service_name` in ApiOperation.
+                        - !ruby/object:Api::Type::String
+                          name: method
+                          description: Value for `method` should be a valid method name
+                            for the corresponding `service_name` in ApiOperation. If `*`
+                            used as value for `method`, then ALL methods and permissions
+                            are allowed.
+                    - !ruby/object:Api::Type::String
+                      name: serviceName
+                      description: The name of the API whose methods or permissions the
+                        IngressPolicy or EgressPolicy want to allow. A single ApiOperation
+                        with `service_name` field set to `*` will allow all methods AND
+                        permissions for all services.
       - !ruby/object:Api::Type::NestedObject
         name: 'spec'
         description: |
@@ -966,6 +1135,175 @@ objects:
                 The list of APIs usable within the Service Perimeter.
                 Must be empty unless `enableRestriction` is True.
               item_type: Api::Type::String
+          - !ruby/object:Api::Type::Array
+            name: ingressPolicies
+            description: List of IngressPolicies to apply to the perimeter. A perimeter
+              may have multiple IngressPolicies, each of which is evaluated separately.
+              Access is granted if any Ingress Policy grants it. Must be empty for a perimeter
+              bridge.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+              - !ruby/object:Api::Type::NestedObject
+                name: ingressTo
+                description: Defines the conditions on the ApiOperation and request destination
+                  that cause this IngressPolicy to apply.
+                properties:
+                - !ruby/object:Api::Type::Array
+                  name: resources
+                  description: A list of resources, currently only projects in the form
+                    `projects/`, protected by this ServicePerimeter that are allowed to
+                    be accessed by sources defined in the corresponding IngressFrom. A request
+                    matches if it contains a resource in this list. If `*` is specified
+                    for resources, then this IngressTo rule will authorize access to all
+                    resources inside the perimeter, provided that the request also matches
+                    the `operations` field.
+                  item_type: Api::Type::String
+                - !ruby/object:Api::Type::Array
+                  name: operations
+                  description: A list of ApiOperations the sources specified in corresponding
+                    IngressFrom are allowed to perform in this ServicePerimeter.
+                  item_type: !ruby/object:Api::Type::NestedObject
+                    properties:
+                    - !ruby/object:Api::Type::Array
+                      name: methodSelectors
+                      description: API methods or permissions to allow. Method or permission
+                        must belong to the service specified by `service_name` field. A
+                        single MethodSelector entry with `*` specified for the `method`
+                        field will allow all methods AND permissions for the service specified
+                        in `service_name`.
+                      item_type: !ruby/object:Api::Type::NestedObject
+                        properties:
+                        - !ruby/object:Api::Type::String
+                          name: permission
+                          description: Value for `permission` should be a valid Cloud IAM
+                            permission for the corresponding `service_name` in ApiOperation.
+                        - !ruby/object:Api::Type::String
+                          name: method
+                          description: Value for `method` should be a valid method name
+                            for the corresponding `service_name` in ApiOperation. If `*`
+                            used as value for `method`, then ALL methods and permissions
+                            are allowed.
+                    - !ruby/object:Api::Type::String
+                      name: serviceName
+                      description: The name of the API whose methods or permissions the
+                        IngressPolicy or EgressPolicy want to allow. A single ApiOperation
+                        with `service_name` field set to `*` will allow all methods AND
+                        permissions for all services.
+              - !ruby/object:Api::Type::NestedObject
+                name: ingressFrom
+                description: Defines the conditions on the source of a request causing this
+                  IngressPolicy to apply.
+                properties:
+                - !ruby/object:Api::Type::Array
+                  name: identities
+                  description: A list of identities that are allowed access through this
+                    ingress policy. Should be in the format of email address. The email
+                    address should represent individual user or service account only.
+                  item_type: Api::Type::String
+                - !ruby/object:Api::Type::Array
+                  name: sources
+                  description: Sources that this IngressPolicy authorizes access from.
+                  item_type: !ruby/object:Api::Type::NestedObject
+                    properties:
+                    - !ruby/object:Api::Type::String
+                      name: resource
+                      description: 'A Google Cloud resource that is allowed to ingress the
+                        perimeter. Requests from these resources will be allowed to access
+                        perimeter data. Currently only projects are allowed. Format: `projects/{project_number}`
+                        The project may be in any Google Cloud organization, not just the
+                        organization that the perimeter is defined in. `*` is not allowed,
+                        the case of allowing all Google Cloud resources only is not supported.'
+                    - !ruby/object:Api::Type::String
+                      name: accessLevel
+                      description: 'An AccessLevel resource name that allow resources within
+                        the ServicePerimeters to be accessed from the internet. AccessLevels
+                        listed must be in the same policy as this ServicePerimeter. Referencing
+                        a nonexistent AccessLevel will cause an error. If no AccessLevel
+                        names are listed, resources within the perimeter can only be accessed
+                        via Google Cloud calls with request origins within the perimeter.
+                        Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If `*`
+                        is specified, then all IngressSources will be allowed.'
+                - !ruby/object:Api::Type::Enum
+                  name: identityType
+                  description: Specifies the type of identities that are allowed access
+                    from outside the perimeter. If left unspecified, then members of `identities`
+                    field will be allowed access.
+                  values:
+                  - :IDENTITY_TYPE_UNSPECIFIED
+                  - :ANY_IDENTITY
+                  - :ANY_USER_ACCOUNT
+                  - :ANY_SERVICE_ACCOUNT
+          - !ruby/object:Api::Type::Array
+            name: egressPolicies
+            description: List of EgressPolicies to apply to the perimeter. A perimeter may
+              have multiple EgressPolicies, each of which is evaluated separately. Access
+              is granted if any EgressPolicy grants it. Must be empty for a perimeter bridge.
+            item_type: !ruby/object:Api::Type::NestedObject
+              properties:
+              - !ruby/object:Api::Type::NestedObject
+                name: egressFrom
+                description: Defines conditions on the source of a request causing this
+                  EgressPolicy to apply.
+                properties:
+                - !ruby/object:Api::Type::Array
+                  name: identities
+                  description: A list of identities that are allowed access through this
+                    [EgressPolicy]. Should be in the format of email address. The email
+                    address should represent individual user or service account only.
+                  item_type: Api::Type::String
+                - !ruby/object:Api::Type::Enum
+                  name: identityType
+                  description: Specifies the type of identities that are allowed access
+                    to outside the perimeter. If left unspecified, then members of `identities`
+                    field will be allowed access.
+                  values:
+                  - :IDENTITY_TYPE_UNSPECIFIED
+                  - :ANY_IDENTITY
+                  - :ANY_USER_ACCOUNT
+                  - :ANY_SERVICE_ACCOUNT
+              - !ruby/object:Api::Type::NestedObject
+                name: egressTo
+                description: Defines the conditions on the ApiOperation and destination
+                  resources that cause this EgressPolicy to apply.
+                properties:
+                - !ruby/object:Api::Type::Array
+                  name: resources
+                  description: A list of resources, currently only projects in the form
+                    `projects/`, that match this to stanza. A request matches if it contains
+                    a resource in this list. If `*` is specified for resources, then this
+                    EgressTo rule will authorize access to all resources outside the perimeter.
+                  item_type: Api::Type::String
+                - !ruby/object:Api::Type::Array
+                  name: operations
+                  description: A list of ApiOperations that this egress rule applies to.
+                    A request matches if it contains an operation/service in this list.
+                  item_type: !ruby/object:Api::Type::NestedObject
+                    properties:
+                    - !ruby/object:Api::Type::Array
+                      name: methodSelectors
+                      description: API methods or permissions to allow. Method or permission
+                        must belong to the service specified by `service_name` field. A
+                        single MethodSelector entry with `*` specified for the `method`
+                        field will allow all methods AND permissions for the service specified
+                        in `service_name`.
+                      item_type: !ruby/object:Api::Type::NestedObject
+                        properties:
+                        - !ruby/object:Api::Type::String
+                          name: permission
+                          description: Value for `permission` should be a valid Cloud IAM
+                            permission for the corresponding `service_name` in ApiOperation.
+                        - !ruby/object:Api::Type::String
+                          name: method
+                          description: Value for `method` should be a valid method name
+                            for the corresponding `service_name` in ApiOperation. If `*`
+                            used as value for `method`, then ALL methods and permissions
+                            are allowed.
+                    - !ruby/object:Api::Type::String
+                      name: serviceName
+                      description: The name of the API whose methods or permissions the
+                        IngressPolicy or EgressPolicy want to allow. A single ApiOperation
+                        with `service_name` field set to `*` will allow all methods AND
+                        permissions for all services.
       - !ruby/object:Api::Type::Boolean
         name: 'useExplicitDryRunSpec'
         description: |

--- a/mmv1/products/accesscontextmanager/api.yaml
+++ b/mmv1/products/accesscontextmanager/api.yaml
@@ -915,6 +915,7 @@ objects:
                 name: ingressTo
                 description: Defines the conditions on the ApiOperation and request destination
                   that cause this IngressPolicy to apply.
+                required: true
                 properties:
                 - !ruby/object:Api::Type::Array
                   name: resources
@@ -925,11 +926,13 @@ objects:
                     for resources, then this IngressTo rule will authorize access to all
                     resources inside the perimeter, provided that the request also matches
                     the `operations` field.
+                  required: true
                   item_type: Api::Type::String
                 - !ruby/object:Api::Type::Array
                   name: operations
                   description: A list of ApiOperations the sources specified in corresponding
                     IngressFrom are allowed to perform in this ServicePerimeter.
+                  required: true
                   item_type: !ruby/object:Api::Type::NestedObject
                     properties:
                     - !ruby/object:Api::Type::Array
@@ -939,38 +942,51 @@ objects:
                         single MethodSelector entry with `*` specified for the `method`
                         field will allow all methods AND permissions for the service specified
                         in `service_name`.
+                      required: true
                       item_type: !ruby/object:Api::Type::NestedObject
                         properties:
                         - !ruby/object:Api::Type::String
                           name: permission
                           description: Value for `permission` should be a valid Cloud IAM
                             permission for the corresponding `service_name` in ApiOperation.
+                          exactly_one_of:
+                            - permission
+                            - method
                         - !ruby/object:Api::Type::String
                           name: method
                           description: Value for `method` should be a valid method name
                             for the corresponding `service_name` in ApiOperation. If `*`
                             used as value for `method`, then ALL methods and permissions
                             are allowed.
+                          exactly_one_of:
+                            - permission
+                            - method
                     - !ruby/object:Api::Type::String
                       name: serviceName
                       description: The name of the API whose methods or permissions the
                         IngressPolicy or EgressPolicy want to allow. A single ApiOperation
                         with `service_name` field set to `*` will allow all methods AND
                         permissions for all services.
+                      required: true
               - !ruby/object:Api::Type::NestedObject
                 name: ingressFrom
                 description: Defines the conditions on the source of a request causing this
                   IngressPolicy to apply.
+                required: true
                 properties:
                 - !ruby/object:Api::Type::Array
                   name: identities
                   description: A list of identities that are allowed access through this
                     ingress policy. Should be in the format of email address. The email
                     address should represent individual user or service account only.
+                  exactly_one_of:
+                    - identities
+                    - identity_type
                   item_type: Api::Type::String
                 - !ruby/object:Api::Type::Array
                   name: sources
                   description: Sources that this IngressPolicy authorizes access from.
+                  required: true
                   item_type: !ruby/object:Api::Type::NestedObject
                     properties:
                     - !ruby/object:Api::Type::String
@@ -981,6 +997,9 @@ objects:
                         The project may be in any Google Cloud organization, not just the
                         organization that the perimeter is defined in. `*` is not allowed,
                         the case of allowing all Google Cloud resources only is not supported.'
+                      exactly_one_of:
+                        - resource
+                        - access_level
                     - !ruby/object:Api::Type::String
                       name: accessLevel
                       description: 'An AccessLevel resource name that allow resources within
@@ -991,11 +1010,17 @@ objects:
                         via Google Cloud calls with request origins within the perimeter.
                         Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If `*`
                         is specified, then all IngressSources will be allowed.'
+                      exactly_one_of:
+                        - resource
+                        - access_level
                 - !ruby/object:Api::Type::Enum
                   name: identityType
                   description: Specifies the type of identities that are allowed access
                     from outside the perimeter. If left unspecified, then members of `identities`
                     field will be allowed access.
+                  exactly_one_of:
+                    - identities
+                    - identity_type
                   values:
                   - :IDENTITY_TYPE_UNSPECIFIED
                   - :ANY_IDENTITY
@@ -1013,18 +1038,25 @@ objects:
                 name: egressFrom
                 description: Defines conditions on the source of a request causing this
                   EgressPolicy to apply.
+                required: true
                 properties:
                 - !ruby/object:Api::Type::Array
                   name: identities
                   description: A list of identities that are allowed access through this
                     [EgressPolicy]. Should be in the format of email address. The email
                     address should represent individual user or service account only.
+                  exactly_one_of:
+                    - identities
+                    - identity_type
                   item_type: Api::Type::String
                 - !ruby/object:Api::Type::Enum
                   name: identityType
                   description: Specifies the type of identities that are allowed access
                     to outside the perimeter. If left unspecified, then members of `identities`
                     field will be allowed access.
+                  exactly_one_of:
+                    - identities
+                    - identity_type
                   values:
                   - :IDENTITY_TYPE_UNSPECIFIED
                   - :ANY_IDENTITY
@@ -1034,6 +1066,7 @@ objects:
                 name: egressTo
                 description: Defines the conditions on the ApiOperation and destination
                   resources that cause this EgressPolicy to apply.
+                required: true
                 properties:
                 - !ruby/object:Api::Type::Array
                   name: resources
@@ -1041,11 +1074,13 @@ objects:
                     `projects/`, that match this to stanza. A request matches if it contains
                     a resource in this list. If `*` is specified for resources, then this
                     EgressTo rule will authorize access to all resources outside the perimeter.
+                  required: true
                   item_type: Api::Type::String
                 - !ruby/object:Api::Type::Array
                   name: operations
                   description: A list of ApiOperations that this egress rule applies to.
                     A request matches if it contains an operation/service in this list.
+                  required: true
                   item_type: !ruby/object:Api::Type::NestedObject
                     properties:
                     - !ruby/object:Api::Type::Array
@@ -1055,24 +1090,32 @@ objects:
                         single MethodSelector entry with `*` specified for the `method`
                         field will allow all methods AND permissions for the service specified
                         in `service_name`.
+                      required: true
                       item_type: !ruby/object:Api::Type::NestedObject
                         properties:
                         - !ruby/object:Api::Type::String
                           name: permission
                           description: Value for `permission` should be a valid Cloud IAM
                             permission for the corresponding `service_name` in ApiOperation.
+                          exactly_one_of:
+                            - permission
+                            - method
                         - !ruby/object:Api::Type::String
                           name: method
                           description: Value for `method` should be a valid method name
                             for the corresponding `service_name` in ApiOperation. If `*`
                             used as value for `method`, then ALL methods and permissions
                             are allowed.
+                          exactly_one_of:
+                            - permission
+                            - method
                     - !ruby/object:Api::Type::String
                       name: serviceName
                       description: The name of the API whose methods or permissions the
                         IngressPolicy or EgressPolicy want to allow. A single ApiOperation
                         with `service_name` field set to `*` will allow all methods AND
                         permissions for all services.
+                      required: true
       - !ruby/object:Api::Type::NestedObject
         name: 'spec'
         description: |
@@ -1153,6 +1196,7 @@ objects:
                 name: ingressTo
                 description: Defines the conditions on the ApiOperation and request destination
                   that cause this IngressPolicy to apply.
+                required: true
                 properties:
                 - !ruby/object:Api::Type::Array
                   name: resources
@@ -1163,11 +1207,13 @@ objects:
                     for resources, then this IngressTo rule will authorize access to all
                     resources inside the perimeter, provided that the request also matches
                     the `operations` field.
+                  required: true
                   item_type: Api::Type::String
                 - !ruby/object:Api::Type::Array
                   name: operations
                   description: A list of ApiOperations the sources specified in corresponding
                     IngressFrom are allowed to perform in this ServicePerimeter.
+                  required: true
                   item_type: !ruby/object:Api::Type::NestedObject
                     properties:
                     - !ruby/object:Api::Type::Array
@@ -1177,38 +1223,51 @@ objects:
                         single MethodSelector entry with `*` specified for the `method`
                         field will allow all methods AND permissions for the service specified
                         in `service_name`.
+                      required: true
                       item_type: !ruby/object:Api::Type::NestedObject
                         properties:
                         - !ruby/object:Api::Type::String
                           name: permission
                           description: Value for `permission` should be a valid Cloud IAM
                             permission for the corresponding `service_name` in ApiOperation.
+                          exactly_one_of:
+                            - permission
+                            - method
                         - !ruby/object:Api::Type::String
                           name: method
                           description: Value for `method` should be a valid method name
                             for the corresponding `service_name` in ApiOperation. If `*`
                             used as value for `method`, then ALL methods and permissions
                             are allowed.
+                          exactly_one_of:
+                            - permission
+                            - method
                     - !ruby/object:Api::Type::String
                       name: serviceName
                       description: The name of the API whose methods or permissions the
                         IngressPolicy or EgressPolicy want to allow. A single ApiOperation
                         with `service_name` field set to `*` will allow all methods AND
                         permissions for all services.
+                      required: true
               - !ruby/object:Api::Type::NestedObject
                 name: ingressFrom
                 description: Defines the conditions on the source of a request causing this
                   IngressPolicy to apply.
+                required: true
                 properties:
                 - !ruby/object:Api::Type::Array
                   name: identities
                   description: A list of identities that are allowed access through this
                     ingress policy. Should be in the format of email address. The email
                     address should represent individual user or service account only.
+                  exactly_one_of:
+                    - identities
+                    - identity_type
                   item_type: Api::Type::String
                 - !ruby/object:Api::Type::Array
                   name: sources
                   description: Sources that this IngressPolicy authorizes access from.
+                  required: true
                   item_type: !ruby/object:Api::Type::NestedObject
                     properties:
                     - !ruby/object:Api::Type::String
@@ -1219,6 +1278,9 @@ objects:
                         The project may be in any Google Cloud organization, not just the
                         organization that the perimeter is defined in. `*` is not allowed,
                         the case of allowing all Google Cloud resources only is not supported.'
+                      exactly_one_of:
+                        - resource
+                        - access_level
                     - !ruby/object:Api::Type::String
                       name: accessLevel
                       description: 'An AccessLevel resource name that allow resources within
@@ -1229,11 +1291,17 @@ objects:
                         via Google Cloud calls with request origins within the perimeter.
                         Example: `accessPolicies/MY_POLICY/accessLevels/MY_LEVEL`. If `*`
                         is specified, then all IngressSources will be allowed.'
+                      exactly_one_of:
+                        - resource
+                        - access_level
                 - !ruby/object:Api::Type::Enum
                   name: identityType
                   description: Specifies the type of identities that are allowed access
                     from outside the perimeter. If left unspecified, then members of `identities`
                     field will be allowed access.
+                  exactly_one_of:
+                    - identities
+                    - identity_type
                   values:
                   - :IDENTITY_TYPE_UNSPECIFIED
                   - :ANY_IDENTITY
@@ -1251,18 +1319,25 @@ objects:
                 name: egressFrom
                 description: Defines conditions on the source of a request causing this
                   EgressPolicy to apply.
+                required: true
                 properties:
                 - !ruby/object:Api::Type::Array
                   name: identities
                   description: A list of identities that are allowed access through this
                     [EgressPolicy]. Should be in the format of email address. The email
                     address should represent individual user or service account only.
+                  exactly_one_of:
+                    - identities
+                    - identity_type
                   item_type: Api::Type::String
                 - !ruby/object:Api::Type::Enum
                   name: identityType
                   description: Specifies the type of identities that are allowed access
                     to outside the perimeter. If left unspecified, then members of `identities`
                     field will be allowed access.
+                  exactly_one_of:
+                    - identities
+                    - identity_type
                   values:
                   - :IDENTITY_TYPE_UNSPECIFIED
                   - :ANY_IDENTITY
@@ -1272,6 +1347,7 @@ objects:
                 name: egressTo
                 description: Defines the conditions on the ApiOperation and destination
                   resources that cause this EgressPolicy to apply.
+                required: true
                 properties:
                 - !ruby/object:Api::Type::Array
                   name: resources
@@ -1279,11 +1355,13 @@ objects:
                     `projects/`, that match this to stanza. A request matches if it contains
                     a resource in this list. If `*` is specified for resources, then this
                     EgressTo rule will authorize access to all resources outside the perimeter.
+                  required: true
                   item_type: Api::Type::String
                 - !ruby/object:Api::Type::Array
                   name: operations
                   description: A list of ApiOperations that this egress rule applies to.
                     A request matches if it contains an operation/service in this list.
+                  required: true
                   item_type: !ruby/object:Api::Type::NestedObject
                     properties:
                     - !ruby/object:Api::Type::Array
@@ -1293,24 +1371,32 @@ objects:
                         single MethodSelector entry with `*` specified for the `method`
                         field will allow all methods AND permissions for the service specified
                         in `service_name`.
+                      required: true
                       item_type: !ruby/object:Api::Type::NestedObject
                         properties:
                         - !ruby/object:Api::Type::String
                           name: permission
                           description: Value for `permission` should be a valid Cloud IAM
                             permission for the corresponding `service_name` in ApiOperation.
+                          exactly_one_of:
+                            - permission
+                            - method
                         - !ruby/object:Api::Type::String
                           name: method
                           description: Value for `method` should be a valid method name
                             for the corresponding `service_name` in ApiOperation. If `*`
                             used as value for `method`, then ALL methods and permissions
                             are allowed.
+                          exactly_one_of:
+                            - permission
+                            - method
                     - !ruby/object:Api::Type::String
                       name: serviceName
                       description: The name of the API whose methods or permissions the
                         IngressPolicy or EgressPolicy want to allow. A single ApiOperation
                         with `service_name` field set to `*` will allow all methods AND
                         permissions for all services.
+                      required: true
       - !ruby/object:Api::Type::Boolean
         name: 'useExplicitDryRunSpec'
         description: |

--- a/mmv1/products/accesscontextmanager/api.yaml
+++ b/mmv1/products/accesscontextmanager/api.yaml
@@ -18,6 +18,9 @@ versions:
   - !ruby/object:Api::Product::Version
     name: ga
     base_url: https://accesscontextmanager.googleapis.com/v1/
+  - !ruby/object:Api::Product::Version
+    name: beta
+    base_url: https://accesscontextmanager.googleapis.com/v1/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 async: !ruby/object:Api::OpAsync
@@ -901,6 +904,7 @@ objects:
               item_type: Api::Type::String
           - !ruby/object:Api::Type::Array
             name: ingressPolicies
+            min_version: beta
             description: List of IngressPolicies to apply to the perimeter. A perimeter
               may have multiple IngressPolicies, each of which is evaluated separately.
               Access is granted if any Ingress Policy grants it. Must be empty for a perimeter
@@ -999,6 +1003,7 @@ objects:
                   - :ANY_SERVICE_ACCOUNT
           - !ruby/object:Api::Type::Array
             name: egressPolicies
+            min_version: beta
             description: List of EgressPolicies to apply to the perimeter. A perimeter may
               have multiple EgressPolicies, each of which is evaluated separately. Access
               is granted if any EgressPolicy grants it. Must be empty for a perimeter bridge.
@@ -1137,6 +1142,7 @@ objects:
               item_type: Api::Type::String
           - !ruby/object:Api::Type::Array
             name: ingressPolicies
+            min_version: beta
             description: List of IngressPolicies to apply to the perimeter. A perimeter
               may have multiple IngressPolicies, each of which is evaluated separately.
               Access is granted if any Ingress Policy grants it. Must be empty for a perimeter
@@ -1235,6 +1241,7 @@ objects:
                   - :ANY_SERVICE_ACCOUNT
           - !ruby/object:Api::Type::Array
             name: egressPolicies
+            min_version: beta
             description: List of EgressPolicies to apply to the perimeter. A perimeter may
               have multiple EgressPolicies, each of which is evaluated separately. Access
               is granted if any EgressPolicy grants it. Must be empty for a perimeter bridge.

--- a/mmv1/products/accesscontextmanager/terraform.yaml
+++ b/mmv1/products/accesscontextmanager/terraform.yaml
@@ -163,6 +163,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "service-perimeter"
         vars:
           service_perimeter_name: "restrict_bigquery_dryrun_storage"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "access_context_manager_service_perimeter_ingress_and_egress_policies"
+        skip_test: true
+        primary_resource_id: "service-perimeter"
+        vars:
+          service_perimeter_name: "ingress_egress_policy_examples"
+          service_perimeter_project_number: "projects/123456789"
+          ingress_project_number: "projects/111111111"
+          egress_project_number: "projects/222222222"
     properties:
       parent: !ruby/object:Overrides::Terraform::PropertyOverride
         ignore_read: true

--- a/mmv1/templates/terraform/examples/access_context_manager_service_perimeter_ingress_and_egress_policies.tf.erb
+++ b/mmv1/templates/terraform/examples/access_context_manager_service_perimeter_ingress_and_egress_policies.tf.erb
@@ -1,0 +1,62 @@
+resource "google_access_context_manager_service_perimeter" "<%= ctx[:primary_resource_id] %>" {
+  parent = "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}"
+  name   = "accessPolicies/${google_access_context_manager_access_policy.access-policy.name}/servicePerimeters/<%= ctx[:vars]['service_perimeter_name'] %>"
+  title  = "<%= ctx[:vars]['service_perimeter_name'] %>"
+
+  status {
+    resources           = ["<%= ctx[:vars]['service_perimeter_project_number'] %>"]
+    restricted_services = ["storage.googleapis.com"]
+    access_levels       = []
+
+    ingress_policies {
+      ingress_from {
+        sources {
+          resource = "<%= ctx[:vars]['ingress_project_number'] %>"
+        }
+        identity_type = "ANY_SERVICE_ACCOUNT"
+      }
+
+      ingress_to {
+        resources = ["<%= ctx[:vars]['service_perimeter_project_number'] %>"]
+
+        operations {
+          service_name = "storage.googleapis.com"
+
+          method_selectors {
+            method = "google.storage.objects.list"
+          }
+          method_selectors {
+            method = "google.storage.objects.get"
+          }
+
+          # This syntax is accepted, but the API does not support any permissions yet.
+          # See https://cloud.google.com/vpc-service-controls/docs/supported-method-restrictions
+          # method_selectors {
+          #   permission = "storage.buckets.list"
+          # }
+        }
+      }
+    }
+
+    egress_policies {
+      egress_from {
+        identities = ["serviceAccount:my-workload@my-project.iam.gserviceaccount.com"]
+      }
+
+      egress_to {
+        resources = ["<%= ctx[:vars]['egress_project_number'] %>"]
+        operations {
+          service_name = "storage.googleapis.com"
+          method_selectors {
+            method = "*"
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "google_access_context_manager_access_policy" "access-policy" {
+  parent = "organizations/123456789"
+  title  = "my policy"
+}


### PR DESCRIPTION
Adds beta support for [egress and ingress policies](https://cloud.google.com/vpc-service-controls/docs/ingress-egress-rules) to VPC Service Control perimeters.

Resolves [Terraform provider Issue 8412](https://github.com/hashicorp/terraform-provider-google/issues/8412).


If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
access_context_manager: added `status.egress_policies`, `status.ingress_policies`,
`spec.egress_policies` and `spec.ingress_policies` fields to
`google_access_context_manager_service_perimeter` resource (beta)
```