### PR TITLE
Change gce-uefi-images image project to default image projects.

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
@@ -1631,7 +1631,7 @@ func testAccComputeInstanceTemplate_withScratchDisk(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
 	family  = "centos-7"
-	project = "gce-uefi-images"
+	project = "centos-cloud"
 }
 resource "google_compute_instance_template" "foobar" {
   name           = "instancet-test-%s"
@@ -2117,7 +2117,7 @@ func testAccComputeInstanceTemplate_shieldedVmConfig(suffix string, enableSecure
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family  = "centos-7"
-  project = "gce-uefi-images"
+  project = "centos-cloud"
 }
 
 resource "google_compute_instance_template" "foobar" {
@@ -2181,7 +2181,7 @@ func testAccComputeInstanceTemplate_enableDisplay(suffix string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family  = "centos-7"
-  project = "gce-uefi-images"
+  project = "centos-cloud"
 }
 
 resource "google_compute_instance_template" "foobar" {
@@ -2207,14 +2207,14 @@ func testAccComputeInstanceTemplate_invalidDiskType(suffix string) string {
 # is resolved.
 # data "google_compute_image" "my_image" {
 # 	family  = "centos-7"
-# 	project = "gce-uefi-images"
+# 	project = "centos-cloud"
 # }
 resource "google_compute_instance_template" "foobar" {
   name           = "instancet-test-%s"
   machine_type   = "e2-medium"
   can_ip_forward = false
   disk {
-    source_image = "https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/centos-7-v20190729"
+    source_image = "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20210217"
     auto_delete  = true
     boot         = true
   }
@@ -2225,7 +2225,7 @@ resource "google_compute_instance_template" "foobar" {
     disk_type    = "local-ssd"
   }
   disk {
-    source_image = "https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/centos-7-v20190729"
+    source_image = "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20210217"
     auto_delete  = true
     type         = "SCRATCH"
   }

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -4693,7 +4693,7 @@ func testAccComputeInstance_shieldedVmConfig(instance string, enableSecureBoot b
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family  = "centos-7"
-  project = "gce-uefi-images"
+  project = "centos-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -4760,7 +4760,7 @@ func testAccComputeInstance_enableDisplay(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family  = "centos-7"
-  project = "gce-uefi-images"
+  project = "centos-cloud"
 }
 
 resource "google_compute_instance" "foobar" {
@@ -4789,7 +4789,7 @@ func testAccComputeInstance_enableDisplayUpdated(instance string) string {
 	return fmt.Sprintf(`
 data "google_compute_image" "my_image" {
   family  = "centos-7"
-  project = "gce-uefi-images"
+  project = "centos-cloud"
 }
 
 resource "google_compute_instance" "foobar" {

--- a/mmv1/third_party/terraform/tests/resource_compute_per_instance_config_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_per_instance_config_test.go
@@ -246,7 +246,7 @@ resource "google_compute_disk" "disk2" {
   name  = "test-disk3-%{random_suffix}"
   type  = "pd-ssd"
   zone  = google_compute_instance_group_manager.igm.zone
-  image = "https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/centos-7-v20190729"
+  image = "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20210217"
   physical_block_size_bytes = 4096
 }
 `, context) + testAccComputePerInstanceConfig_igm(context)

--- a/mmv1/third_party/terraform/tests/resource_compute_region_per_instance_config_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_per_instance_config_test.go
@@ -246,7 +246,7 @@ resource "google_compute_disk" "disk2" {
   name  = "test-disk3-%{random_suffix}"
   type  = "pd-ssd"
   zone  = "us-central1-c"
-  image = "https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/centos-7-v20190729"
+  image = "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20210217"
   physical_block_size_bytes = 4096
 }
 `, context) + testAccComputeRegionPerInstanceConfig_rigm(context)

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance_serial_port.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance_serial_port.html.markdown
@@ -36,7 +36,7 @@ resource "google_compute_instance" "windows" {
 
   boot_disk {
     initialize_params {
-      image = "gce-uefi-images/windows-2019"
+      image = "windows-cloud/windows-2019"
     }
   }
 

--- a/mmv1/third_party/terraform/website/docs/guides/version_3_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_3_upgrade.html.markdown
@@ -761,7 +761,7 @@ fail:
 
 ```hcl
 disk {
-  source_image = "https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/centos-7-v20190729"
+  source_image = "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20210217"
   auto_delete  = true
   type         = "SCRATCH"
 }
@@ -769,7 +769,7 @@ disk {
 
 ```hcl
 disk {
-  source_image = "https://www.googleapis.com/compute/v1/projects/gce-uefi-images/global/images/centos-7-v20190729"
+  source_image = "https://www.googleapis.com/compute/v1/projects/centos-cloud/global/images/centos-7-v20210217"
   auto_delete  = true
   disk_type    = "local-ssd"
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Change the the image project `gce-uefi-images` to the default prod image projects. `gce-uefi-images` project is being deprecated, so we should just use the default image project. People used to use images in `gce-uefi-images` to use Shielded VM features, but now Shielded VM is by default so the `gce-uefi-images` project is not necessary anymore.

Related Issues
fixes https://github.com/hashicorp/terraform-provider-google/issues/8512

`make lint` shows error but probably not related to my change
Some tests are failing probably due to flakiness

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
