### PR TITLE
Set override_value to 0 when not returned by the API

### DIFF
--- a/mmv1/products/serviceusage/terraform.yaml
+++ b/mmv1/products/serviceusage/terraform.yaml
@@ -36,6 +36,15 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_env_vars:
           org_id: :ORG_ID
       - !ruby/object:Provider::Terraform::Examples
+        name: "consumer_quota_override_zero_value"
+        primary_resource_id: "override"
+        min_version: 'beta'
+        skip_docs: true
+        vars:
+          project_id: "quota"
+        test_env_vars:
+          org_id: :ORG_ID
+      - !ruby/object:Provider::Terraform::Examples
         name: "region_consumer_quota_override"
         primary_resource_id: "override"
         min_version: 'beta'

--- a/mmv1/products/serviceusage/terraform.yaml
+++ b/mmv1/products/serviceusage/terraform.yaml
@@ -23,6 +23,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
+      overrideValue: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_flatten: 'templates/terraform/custom_flatten/consumer_quote_override_override_value.go.erb'
   ConsumerQuotaOverride: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples
@@ -47,5 +49,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
+      overrideValue: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_flatten: 'templates/terraform/custom_flatten/consumer_quote_override_override_value.go.erb'
   Service: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true

--- a/mmv1/templates/terraform/custom_flatten/consumer_quote_override_override_value.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/consumer_quote_override_override_value.go.erb
@@ -1,0 +1,20 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2021 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+	if v == nil {
+		return "0"
+	}
+	return v
+}

--- a/mmv1/templates/terraform/examples/consumer_quota_override_zero_value.tf.erb
+++ b/mmv1/templates/terraform/examples/consumer_quota_override_zero_value.tf.erb
@@ -1,0 +1,16 @@
+resource "google_project" "my_project" {
+  provider   = google-beta
+  name       = "tf-test-project"
+  project_id = "<%= ctx[:vars]['project_id'] %>"
+  org_id     = "<%= ctx[:test_env_vars]['org_id'] %>"
+}
+
+resource "google_service_usage_consumer_quota_override" "override" {
+  provider       = google-beta
+  project        = google_project.my_project.project_id
+  service        = "servicemanagement.googleapis.com"
+  metric         = "servicemanagement.googleapis.com%2Fdefault_requests"
+  limit          = "%2Fmin%2Fproject"
+  override_value = "0"
+  force          = true
+}


### PR DESCRIPTION
Upstreams https://github.com/hashicorp/terraform-provider-google-beta/pull/2985

`default_if_empty` custom flattener will not work here since `override_value` is required and has no default value

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
serviceusage: fixed an issue in `google_service_usage_consumer_quota_override` where setting the `override_value` to 0 would result in a permanent diff
```
