### PR TITLE
Add customize diff for deprecated attribute on gc_policy

### DIFF
--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -121,6 +121,7 @@ Dir['products/**/api.yaml'].each do |file_path|
 end
 
 if override_dir
+  Google::LOGGER.info "Using override directory '#{override_dir}'"
   Dir["#{override_dir}/products/**/api.yaml"].each do |file_path|
     product = File.dirname(Pathname.new(file_path).relative_path_from(override_dir))
     all_product_files.push(product) unless all_product_files.include? product

--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -36,8 +36,14 @@ func resourceBigtableGCPolicyCustomizeDiff(_ context.Context, diff *schema.Resou
 		}
 		dn := time.Hour * 24 * time.Duration(oldDays.(int))
 		if do == dn {
-			diff.Clear("max_age.0.days")
+			err := diff.Clear("max_age.0.days")
+			if err != nil {
+				return err
+			}
 			diff.Clear("max_age.0.duration")
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -16,7 +16,7 @@ const (
 	GCPolicyModeUnion        = "UNION"
 )
 
-func resourceBigtableGCPolicyCustomizeDiff(_ context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+func resourceBigtableGCPolicyCustomizeDiffFunc(diff TerraformResourceDiff) error {
 	count := diff.Get("max_age.#").(int)
 	if count < 1 {
 		return nil
@@ -48,6 +48,10 @@ func resourceBigtableGCPolicyCustomizeDiff(_ context.Context, diff *schema.Resou
 	}
 
 	return nil
+}
+
+func resourceBigtableGCPolicyCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	return resourceBigtableGCPolicyCustomizeDiffFunc(d)
 }
 
 func resourceBigtableGCPolicy() *schema.Resource {

--- a/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
+++ b/mmv1/third_party/terraform/resources/resource_bigtable_gc_policy.go
@@ -40,7 +40,7 @@ func resourceBigtableGCPolicyCustomizeDiffFunc(diff TerraformResourceDiff) error
 			if err != nil {
 				return err
 			}
-			diff.Clear("max_age.0.duration")
+			err = diff.Clear("max_age.0.duration")
 			if err != nil {
 				return err
 			}

--- a/mmv1/third_party/terraform/utils/test_utils.go
+++ b/mmv1/third_party/terraform/utils/test_utils.go
@@ -74,7 +74,7 @@ func (d *ResourceDataMock) Timeout(key string) time.Duration {
 type ResourceDiffMock struct {
 	Before     map[string]interface{}
 	After      map[string]interface{}
-	Cleared    map[string]struct{}
+	Cleared    map[string]interface{}
 	IsForceNew bool
 }
 
@@ -98,9 +98,9 @@ func (d *ResourceDiffMock) GetOk(key string) (interface{}, bool) {
 
 func (d *ResourceDiffMock) Clear(key string) error {
 	if d.Cleared == nil {
-		d.Cleared = map[string]struct{}{}
+		d.Cleared = map[string]interface{}{}
 	}
-	d.Cleared[key] = struct{}{}
+	d.Cleared[key] = true
 	return nil
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Adding customize diff when `google_bigtable_gc_policy.max_age.days` is equivalent to `google_bigtable_gc_policy.max_age.duration`. 

resolves https://github.com/hashicorp/terraform-provider-google/issues/8416

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigtable: fixed bug where gc_policy would attempt to recreate the resource when switching from deprecated attribute but maintaining the same value underlying value
```
