### PR TITLE
Suppress diff for COS images

### DIFF
--- a/mmv1/templates/terraform/constants/disk.erb
+++ b/mmv1/templates/terraform/constants/disk.erb
@@ -120,6 +120,10 @@ func diskImageFamilyEquals(imageName, familyName string) bool {
 		return true
 	}
 
+	if suppressCosFamilyDiff(imageName, familyName) {
+		return true
+	}
+
 	if suppressWindowsSqlFamilyDiff(imageName, familyName) {
 		return true
 	}
@@ -136,6 +140,19 @@ func suppressCanonicalFamilyDiff(imageName, familyName string) bool {
 	parts := canonicalUbuntuLtsImage.FindStringSubmatch(imageName)
 	if len(parts) == 3 {
 		f := fmt.Sprintf("ubuntu-%s%s-lts", parts[1], parts[2])
+		if f == familyName {
+			return true
+		}
+	}
+
+	return false
+}
+
+// e.g. image: cos-NN-*, family: cos-NN-lts
+func suppressCosFamilyDiff(imageName, familyName string) bool {
+	parts := cosLtsImage.FindStringSubmatch(imageName)
+	if len(parts) == 2 {
+		f := fmt.Sprintf("cos-%s-lts", parts[1])
 		if f == familyName {
 			return true
 		}

--- a/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_disk_test.go.erb
@@ -127,6 +127,11 @@ func TestDiskImageDiffSuppress(t *testing.T) {
 			New:                "ubuntu-minimal-1804-lts",
 			ExpectDiffSuppress: true,
 		},
+		"matching unconventional image family - cos": {
+			Old:                "https://www.googleapis.com/compute/v1/projects/cos-cloud/global/images/cos-85-13310-1209-17",
+			New:                "cos-85-lts",
+			ExpectDiffSuppress: true,
+		},
 		"different image family": {
 			Old:                "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20171213",
 			New:                "family/debian-7",

--- a/mmv1/third_party/terraform/utils/image.go
+++ b/mmv1/third_party/terraform/utils/image.go
@@ -27,6 +27,7 @@ var (
 
 	windowsSqlImage         = regexp.MustCompile("^sql-(?:server-)?([0-9]{4})-([a-z]+)-windows-(?:server-)?([0-9]{4})(?:-r([0-9]+))?-dc-v[0-9]+$")
 	canonicalUbuntuLtsImage = regexp.MustCompile("^ubuntu-(minimal-)?([0-9]+)-")
+	cosLtsImage             = regexp.MustCompile("^cos-([0-9]+)-")
 )
 
 // built-in projects to look for images/families containing the string


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Resolves https://github.com/hashicorp/terraform-provider-google/issues/8601. Upstreams https://github.com/hashicorp/terraform-provider-google/pull/8602.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added suppress diff func for cos-family disk images
```
