### PR TITLE
Follow redirects when checking github group membership

### DIFF
--- a/.ci/containers/terraform-vcr-community/reverse_check_membership.sh
+++ b/.ci/containers/terraform-vcr-community/reverse_check_membership.sh
@@ -13,13 +13,13 @@ if $(echo $USER | fgrep -wq -e ndmckinley -e danawillow -e emilymye -e megan07 -
 	exit 0
 else
 	echo "Checking GCP org membership"
-	GCP_MEMBER=$(curl -sw '%{http_code}' -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/orgs/GoogleCloudPlatform/members/$USER -o /dev/null)
+	GCP_MEMBER=$(curl -Lsw '%{http_code}' -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/orgs/GoogleCloudPlatform/members/$USER -o /dev/null)
 	if [ "$GCP_MEMBER" != "404" ]; then
 		echo "User is a GCP org member, exiting"
 		exit 0
 	else
 		echo "Checking googlers org membership"
-		GOOGLERS_MEMBER=$(curl -sw '%{http_code}' -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/orgs/googlers/members/$USER -o /dev/null)
+		GOOGLERS_MEMBER=$(curl -Lsw '%{http_code}' -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/orgs/googlers/members/$USER -o /dev/null)
 		if [ "$GOOGLERS_MEMBER" != "404" ]; then
 			echo "User is a googlers org member, exiting"
 			exit 0

--- a/.ci/containers/terraform-vcr-tester/check_membership.sh
+++ b/.ci/containers/terraform-vcr-tester/check_membership.sh
@@ -11,12 +11,12 @@ if $(echo $USER | fgrep -wq -e ndmckinley -e danawillow -e emilymye -e megan07 -
 	echo "User is on the list, not skipping."
 else
 	echo "Checking GCP org membership"
-	GCP_MEMBER=$(curl -sw '%{http_code}' -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/orgs/GoogleCloudPlatform/members/$USER -o /dev/null)
+	GCP_MEMBER=$(curl -Lsw '%{http_code}' -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/orgs/GoogleCloudPlatform/members/$USER -o /dev/null)
 	if [ "$GCP_MEMBER" != "404" ]; then
 		echo "User is a GCP org member, continuing"
 	else
 		echo "Checking googlers org membership"
-		GOOGLERS_MEMBER=$(curl -sw '%{http_code}' -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/orgs/googlers/members/$USER -o /dev/null)
+		GOOGLERS_MEMBER=$(curl -Lsw '%{http_code}' -H "Authorization: token ${GITHUB_TOKEN}" https://api.github.com/orgs/googlers/members/$USER -o /dev/null)
 		if [ "$GOOGLERS_MEMBER" != "404" ]; then
 			echo "User is a googlers org member, continuing"
 		else


### PR DESCRIPTION
It turns out that in some situations, such as missing an auth token (or possibly having an invalid token?) github will redirect the user to a publicly available endpoint. The current logic detects this as a user being present, when it should instead follow the redirect and potentially get a 404.

For example, see https://github.com/GoogleCloudPlatform/magic-modules/pull/4543/checks?check_run_id=2046063751

Oddly in that case the user was detected as a member (so the tests were run) but also detected as a community member (so the community requirement for a manual test run was still in place).

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
