### PR TITLE
Suppressed binary authorization attestor key signature algorithm diffs if the algorithms are equivalent

### DIFF
--- a/mmv1/products/binaryauthorization/terraform.yaml
+++ b/mmv1/products/binaryauthorization/terraform.yaml
@@ -15,6 +15,8 @@
 overrides: !ruby/object:Overrides::ResourceOverrides
   Attestor: !ruby/object:Overrides::Terraform::ResourceOverride
     import_format: ["projects/{{project}}/attestors/{{name}}"]
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      constants: 'templates/terraform/constants/binaryauthorization_attestor.go'
     examples:
      - !ruby/object:Provider::Terraform::Examples
       name: "binary_authorization_attestor_basic"

--- a/mmv1/templates/terraform/constants/binaryauthorization_attestor.go
+++ b/mmv1/templates/terraform/constants/binaryauthorization_attestor.go
@@ -1,0 +1,41 @@
+<%# The license inside this block applies to this file.
+	# Copyright 2020 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func compareSignatureAlgorithm(_, old, new string, _ *schema.ResourceData) bool {
+	// See https://cloud.google.com/binary-authorization/docs/reference/rest/v1/projects.attestors#signaturealgorithm
+	normalizedAlgorithms := map[string]string{
+		"ECDSA_P256_SHA256": "ECDSA_P256_SHA256",
+		"EC_SIGN_P256_SHA256": "ECDSA_P256_SHA256",
+		"ECDSA_P384_SHA384": "ECDSA_P384_SHA384",
+		"EC_SIGN_P384_SHA384": "ECDSA_P384_SHA384",
+		"ECDSA_P521_SHA512": "ECDSA_P521_SHA512",
+		"EC_SIGN_P521_SHA512": "ECDSA_P521_SHA512",
+	}
+
+	normalizedOld := old
+	normalizedNew := new
+
+	if normalized, ok := normalizedAlgorithms[old]; ok {
+		normalizedOld = normalized
+	}
+	if normalized, ok := normalizedAlgorithms[new]; ok {
+		normalizedNew = normalized
+	}
+
+	if normalizedNew == normalizedOld {
+		return true
+	}
+
+	return false
+}

--- a/mmv1/third_party/terraform/tests/resource_binaryauthorization_attestor_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_binaryauthorization_attestor_test.go.erb
@@ -9,6 +9,50 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+func TestSignatureAlgorithmDiffSuppress(t *testing.T) {
+	cases := map[string]struct {
+		Old, New           string
+		ExpectDiffSuppress bool
+	}{
+		"ECDSA_P256 equivalent": {
+			Old:                  "ECDSA_P256_SHA256",
+			New:                  "EC_SIGN_P256_SHA256",
+			ExpectDiffSuppress: true,
+		},
+		"ECDSA_P384 equivalent": {
+			Old:                  "ECDSA_P384_SHA384",
+			New:                  "EC_SIGN_P384_SHA384",
+			ExpectDiffSuppress: true,
+		},
+		"ECDSA_P521 equivalent": {
+			Old:                  "ECDSA_P521_SHA512",
+			New:                  "EC_SIGN_P521_SHA512",
+			ExpectDiffSuppress: true,
+		},
+		"not equivalent 1": {
+			Old:                  "ECDSA_P256",
+			New:                  "EC_SIGN_P384_SHA384",
+			ExpectDiffSuppress: false,
+		},
+		"not equivalent 2": {
+			Old:                  "ECDSA_P384_SHA384",
+			New:                  "EC_SIGN_P521_SHA512",
+			ExpectDiffSuppress: false,
+		},
+		"not equivalent 3": {
+			Old:                  "ECDSA_P521_SHA512",
+			New:                  "EC_SIGN_P256_SHA256",
+			ExpectDiffSuppress: false,
+		},
+	}
+
+	for tn, tc := range cases {
+		if compareSignatureAlgorithm("signature_algorithm", tc.Old, tc.New, nil) != tc.ExpectDiffSuppress {
+			t.Errorf("bad: %s, %q => %q expect DiffSuppress to return %t", tn, tc.Old, tc.New, tc.ExpectDiffSuppress)
+		}
+	}
+}
+
 func TestAccBinaryAuthorizationAttestor_basic(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Resolved https://github.com/hashicorp/terraform-provider-google/issues/8511. Suppressed binary authorization attestor key signature algorithm diffs if the algorithms are equivalent; different ways of getting this key seem to provide different (but equivalent) results.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
binaryauthorization: fixed permadiff in `google_binary_authorization_attestor`
```
