### PR TITLE
Add enable_streaming_engine argument to google_dataflow_job

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_dataflow_job.go
+++ b/mmv1/third_party/terraform/resources/resource_dataflow_job.go
@@ -198,6 +198,12 @@ func resourceDataflowJob() *schema.Resource {
 				Computed:    true,
 				Description: `The unique ID of this job.`,
 			},
+
+			"enable_streaming_engine": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: `Indicates if the job should use the streaming engine feature.`,
+			},
 		},
 		UseJSONNumber: true,
 	}
@@ -540,6 +546,7 @@ func resourceDataflowJobSetupEnv(d *schema.ResourceData, config *Config) (datafl
 		MachineType:           d.Get("machine_type").(string),
 		KmsKeyName:            d.Get("kms_key_name").(string),
 		IpConfiguration:       d.Get("ip_configuration").(string),
+		EnableStreamingEngine: d.Get("enable_streaming_engine").(bool),
 		AdditionalUserLabels:  labels,
 		Zone:                  zone,
 		AdditionalExperiments: additionalExperiments,

--- a/mmv1/third_party/terraform/website/docs/r/dataflow_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataflow_job.html.markdown
@@ -43,7 +43,7 @@ resource "google_dataflow_job" "pubsub_stream" {
 	name = "tf-test-dataflow-job1"
 	template_gcs_path = "gs://my-bucket/templates/template_file"
 	temp_gcs_location = "gs://my-bucket/tmp_dir"
-  enable_streaming_engine = true
+	enable_streaming_engine = true
 	parameters = {
 	  inputFilePattern = "${google_storage_bucket.bucket1.url}/*.json"
 	  outputTopic    = google_pubsub_topic.topic.id
@@ -91,7 +91,7 @@ The following arguments are supported:
 * `kms_key_name` - (Optional) The name for the Cloud KMS key for the job. Key format is: `projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY`
 * `ip_configuration` - (Optional) The configuration for VM IPs.  Options are `"WORKER_IP_PUBLIC"` or `"WORKER_IP_PRIVATE"`.
 * `additional_experiments` - (Optional) List of experiments that should be used by the job. An example value is `["enable_stackdriver_agent_metrics"]`.
-* `enable_streaming_engine` - (Optional) Enable/disable the use of [Streaming Engine](https://cloud.google.com/dataflow/docs/guides/deploying-a-pipeline#streaming-engine) for the job. Note that Streaming engine is enabled by default for pipelines developed against the Beam SDK for Python v2.21.0 or later when using Python 3.
+* `enable_streaming_engine` - (Optional) Enable/disable the use of [Streaming Engine](https://cloud.google.com/dataflow/docs/guides/deploying-a-pipeline#streaming-engine) for the job. Note that Streaming Engine is enabled by default for pipelines developed against the Beam SDK for Python v2.21.0 or later when using Python 3.
 
 ## Attributes Reference
 

--- a/mmv1/third_party/terraform/website/docs/r/dataflow_job.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataflow_job.html.markdown
@@ -43,6 +43,7 @@ resource "google_dataflow_job" "pubsub_stream" {
 	name = "tf-test-dataflow-job1"
 	template_gcs_path = "gs://my-bucket/templates/template_file"
 	temp_gcs_location = "gs://my-bucket/tmp_dir"
+  enable_streaming_engine = true
 	parameters = {
 	  inputFilePattern = "${google_storage_bucket.bucket1.url}/*.json"
 	  outputTopic    = google_pubsub_topic.topic.id
@@ -90,6 +91,7 @@ The following arguments are supported:
 * `kms_key_name` - (Optional) The name for the Cloud KMS key for the job. Key format is: `projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY`
 * `ip_configuration` - (Optional) The configuration for VM IPs.  Options are `"WORKER_IP_PUBLIC"` or `"WORKER_IP_PRIVATE"`.
 * `additional_experiments` - (Optional) List of experiments that should be used by the job. An example value is `["enable_stackdriver_agent_metrics"]`.
+* `enable_streaming_engine` - (Optional) Enable/disable the use of [Streaming Engine](https://cloud.google.com/dataflow/docs/guides/deploying-a-pipeline#streaming-engine) for the job. Note that Streaming engine is enabled by default for pipelines developed against the Beam SDK for Python v2.21.0 or later when using Python 3.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/8649

Note: because `EnableStreamingEngine` is a field of [dataflow.RuntimeEnvironment](https://pkg.go.dev/google.golang.org/api/dataflow/v1b3#RuntimeEnvironment) but _not_ a field of [dataflow.Environment](https://pkg.go.dev/google.golang.org/api/dataflow/v1b3#Environment), there is AFAICT no obvious way to add a unit test for this.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dataflow: added `enable_streaming_engine` argument
```
