### PR TITLE
Remove google_project_service from runtimeconfig test

### DIFF
--- a/mmv1/third_party/terraform/tests/data_source_runtimeconfig_variable_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_runtimeconfig_variable_test.go.erb
@@ -29,15 +29,10 @@ func TestAccRuntimeconfigVariableDatasource_basic(t *testing.T) {
 
 func testAccRuntimeconfigDatasourceVariable(suffix string, name string, text string) string {
 	return fmt.Sprintf(`
-	resource "google_project_service" "default" {
-		service = "runtimeconfig.googleapis.com"
-	}
-
 	resource "google_runtimeconfig_config" "default" {
 		project     = google_project_service.default.project
 		name        = "runtime-%s"
 		description = "runtime-%s"
-		depends_on  = [ google_project_service.default ]
 	}
 
 	resource "google_runtimeconfig_variable" "default" {

--- a/mmv1/third_party/terraform/tests/data_source_runtimeconfig_variable_test.go.erb
+++ b/mmv1/third_party/terraform/tests/data_source_runtimeconfig_variable_test.go.erb
@@ -30,20 +30,17 @@ func TestAccRuntimeconfigVariableDatasource_basic(t *testing.T) {
 func testAccRuntimeconfigDatasourceVariable(suffix string, name string, text string) string {
 	return fmt.Sprintf(`
 	resource "google_runtimeconfig_config" "default" {
-		project     = google_project_service.default.project
 		name        = "runtime-%s"
 		description = "runtime-%s"
 	}
 
 	resource "google_runtimeconfig_variable" "default" {
-		project = google_project_service.default.project
 		parent  = google_runtimeconfig_config.default.name
 		name    = "%s"
 		text    = "%s"
 	}
 
 	data "google_runtimeconfig_variable" "default" {
-		project = google_project_service.default.project
 		name    = google_runtimeconfig_variable.default.name
 		parent  = google_runtimeconfig_config.default.name
 	}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/8659

This enables the service, but also disables it at the end of the test. Since we run most of our tests in one big project with every service we support enabled this kept turning the service off & failing other tests. We could add `disable_on_destroy = false`, but removing it (and assuming the service is enabled) is consistent with the rest of our tests.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
