### PR TITLE
datacatalog: Added `google_data_catalog_tag_template_iam_*`

### DIFF
--- a/mmv1/products/datacatalog/api.yaml
+++ b/mmv1/products/datacatalog/api.yaml
@@ -290,6 +290,12 @@ objects:
       guides:
         'Official Documentation': https://cloud.google.com/data-catalog/docs
       api: https://cloud.google.com/data-catalog/docs/reference/rest/v1/projects.locations.tagTemplates
+    iam_policy: !ruby/object:Api::Resource::IamPolicy
+      method_name_separator: ':'
+      fetch_iam_policy_verb: :POST
+      parent_resource_attribute: 'tag_template'
+      import_format: ["projects/{{project}}/locations/{{region}}/tagTemplates/{{tag_template}}", "{{tag_template}}"]
+      base_url: projects/{{project}}/locations/{{region}}/tagTemplates/{{tag_template}}
     parameters:
       - !ruby/object:Api::Type::String
         name: region

--- a/mmv1/products/datacatalog/terraform.yaml
+++ b/mmv1/products/datacatalog/terraform.yaml
@@ -84,6 +84,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "data_catalog_tag_template_basic"
         primary_resource_id: "basic_tag_template"
+        primary_resource_name: "fmt.Sprintf(\"tf_test_my_template%s\", context[\"random_suffix\"])"
         vars:
           tag_template_id: "my_template"
           force_delete: "false"


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

I added IAM-related resources for Data Catalog TagTemplate so that resource-level IAM can be configured using Terraform.

It's just a quick fix, so I haven't opened an issue.

---
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
datacatalog: Added `google_data_catalog_tag_template_iam_*`
```
