### PR TITLE
Add support for GKE Autopilot in `google_container_cluster` resource

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -128,6 +128,7 @@ func resourceContainerCluster() *schema.Resource {
 			<% unless version == 'ga' -%>
 			customdiff.ForceNewIfChange("enable_l4_ilb_subsetting", isBeenEnabled),
 			<% end -%>
+			containerClusterAutopilotCustomizeDiff,
 		),
 
 		Timeouts: &schema.ResourceTimeout{
@@ -507,8 +508,8 @@ func resourceContainerCluster() *schema.Resource {
 			"enable_shielded_nodes": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
-				Description: `Enable Shielded Nodes features on all nodes in this cluster. Defaults to false.`,
+				Computed: true,
+				Description: `Enable Shielded Nodes features on all nodes in this cluster.`,
 				ConflictsWith: []string{"enable_autopilot"},
 			},
 
@@ -516,7 +517,8 @@ func resourceContainerCluster() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				ForceNew:    true,
-				Description: `Enable Autopilot for this cluster. Defaults to false.`,
+				Description: `Enable Autopilot for this cluster.`,
+				// ConflictsWith: many fields, see https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview#comparison. The conflict is only set one-way, on other fields w/ this field. 
 			},
 
 			"authenticator_groups_config": {
@@ -921,6 +923,7 @@ func resourceContainerCluster() *schema.Resource {
 				Type:          schema.TypeList,
 				MaxItems:      1,
 				ForceNew:      true,
+				Computed:      true,
 				Optional:      true,
 				ConflictsWith: []string{"cluster_ipv4_cidr"},
 				Description:   `Configuration of cluster IP allocation for VPC-native clusters. Adding this block enables IP aliasing, making the cluster VPC-native instead of routes-based.`,
@@ -1093,6 +1096,7 @@ func resourceContainerCluster() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Optional: true,
+				Computed: true,
 				Description: `Configuration for the use of Kubernetes Service Accounts in GCP IAM policies.`,
 				ConflictsWith: []string{"enable_autopilot"},
 				Elem: &schema.Resource{
@@ -1206,11 +1210,9 @@ func resourceContainerCluster() *schema.Resource {
 			"enable_intranode_visibility": {
 			   Type: schema.TypeBool,
 			   Optional: true,
+			   Computed: true,
 			   Description: `Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network.`,
 			   ConflictsWith: []string{"enable_autopilot"},
-<% unless version == 'ga' -%>
-			   Default: false,
-<% end -%>
 			},
 <% unless version == 'ga' -%>
 			"enable_l4_ilb_subsetting": {
@@ -1380,10 +1382,6 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			Enabled:         d.Get("enable_binary_authorization").(bool),
 			ForceSendFields: []string{"Enabled"},
 		},
-		ShieldedNodes: &containerBeta.ShieldedNodes{
-			Enabled:         d.Get("enable_shielded_nodes").(bool),
-			ForceSendFields: []string{"Enabled"},
-		},
 		ReleaseChannel:          expandReleaseChannel(d.Get("release_channel")),
 <% unless version == 'ga' -%>
 		ClusterTelemetry: expandClusterTelemetry(d.Get("cluster_telemetry")),
@@ -1413,15 +1411,17 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			Enabled:         v.(bool),
 			ForceSendFields: []string{"Enabled"},
 		}
-		if v.(bool) == true {
-			// Set preconfigured AutoGKE defaults
-			cluster.ShieldedNodes.Enabled = true
-			cluster.NetworkConfig.EnableIntraNodeVisibility = true
-		}
 	}
 
 	if v, ok := d.GetOk("default_max_pods_per_node"); ok {
 		cluster.DefaultMaxPodsConstraint = expandDefaultMaxPodsConstraint(v)
+	}
+
+	if v, ok := d.GetOk("enable_shielded_nodes"); ok {
+		cluster.ShieldedNodes = &containerBeta.ShieldedNodes{
+			Enabled:         v.(bool),
+			ForceSendFields: []string{"Enabled"},
+		}
 	}
 
 	// Only allow setting node_version on create if it's set to the equivalent master version,
@@ -4082,6 +4082,14 @@ func containerClusterPrivateClusterConfigCustomDiff(_ context.Context, d *schema
 		if block != nil && block != "" {
 			return fmt.Errorf("master_ipv4_cidr_block can only be set if enable_private_nodes is true")
 		}
+	}
+	return nil
+}
+
+// The GKE API requires intranode visibility enabled for autopilot clusters
+func containerClusterAutopilotCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
+	if d.Get("enable_autopilot").(bool) {
+		d.SetNew("enable_intranode_visibility", true)
 	}
 	return nil
 }

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -972,7 +972,6 @@ func resourceContainerCluster() *schema.Resource {
 				},
 			},
 
-<% unless version == 'ga' -%>
 			"networking_mode": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -981,7 +980,6 @@ func resourceContainerCluster() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"VPC_NATIVE", "ROUTES"}, false),
 				Description:  `Determines whether alias IPs or routes will be used for pod IPs in the cluster.`,
 			},
-<% end -%>
 
 			"remove_default_node_pool": {
 				Type:        schema.TypeBool,
@@ -1346,17 +1344,10 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 
 	clusterName := d.Get("name").(string)
 
-<% unless version == 'ga' -%>
 	ipAllocationBlock, err := expandIPAllocationPolicy(d.Get("ip_allocation_policy"), d.Get("networking_mode").(string))
 	if err != nil {
 		return err
 	}
-<% else -%>
-	ipAllocationBlock, err := expandIPAllocationPolicy(d.Get("ip_allocation_policy"))
-	if err != nil {
-		return err
-	}
-<% end -%>
 
 	cluster := &containerBeta.Cluster{
 		Name:                           clusterName,
@@ -2997,18 +2988,12 @@ func expandClusterAddonsConfig(configured interface{}) *containerBeta.AddonsConf
 	return ac
 }
 
-<% unless version == 'ga' -%>
 func expandIPAllocationPolicy(configured interface{}, networkingMode string) (*containerBeta.IPAllocationPolicy, error) {
-<% else -%>
-func expandIPAllocationPolicy(configured interface{}) (*containerBeta.IPAllocationPolicy, error) {
-<% end -%>
 	l := configured.([]interface{})
 	if len(l) == 0 || l[0] == nil {
-<% unless version == 'ga' -%>
 		if networkingMode == "VPC_NATIVE" {
 			return nil, fmt.Errorf("`ip_allocation_policy` block is required for VPC_NATIVE clusters.")
 		}
-<% end -%>
 		return &containerBeta.IPAllocationPolicy{
 			UseIpAliases:    false,
 			ForceSendFields: []string{"UseIpAliases"},
@@ -3017,20 +3002,14 @@ func expandIPAllocationPolicy(configured interface{}) (*containerBeta.IPAllocati
 
 	config := l[0].(map[string]interface{})
 	return &containerBeta.IPAllocationPolicy{
-<% unless version == 'ga' -%>
 		UseIpAliases:          networkingMode == "VPC_NATIVE" || networkingMode == "",
-<% else -%>
-		UseIpAliases:          true,
-<% end -%>
 		ClusterIpv4CidrBlock:  config["cluster_ipv4_cidr_block"].(string),
 		ServicesIpv4CidrBlock: config["services_ipv4_cidr_block"].(string),
 
 		ClusterSecondaryRangeName:  config["cluster_secondary_range_name"].(string),
 		ServicesSecondaryRangeName: config["services_secondary_range_name"].(string),
 		ForceSendFields:            []string{"UseIpAliases"},
-<% unless version == 'ga' -%>
 		UseRoutes:              networkingMode == "ROUTES",
-<% end -%>
 	}, nil
 }
 
@@ -3724,18 +3703,14 @@ func flattenWorkloadIdentityConfig(c *containerBeta.WorkloadIdentityConfig) []ma
 func flattenIPAllocationPolicy(c *containerBeta.Cluster, d *schema.ResourceData, config *Config) ([]map[string]interface{}, error) {
 	// If IP aliasing isn't enabled, none of the values in this block can be set.
 	if c == nil || c.IpAllocationPolicy == nil || !c.IpAllocationPolicy.UseIpAliases {
-<% unless version == 'ga' -%>
 		if err := d.Set("networking_mode", "ROUTES"); err != nil {
 			return nil, fmt.Errorf("Error setting networking_mode: %s", err)
 		}
-<% end -%>
 		return nil, nil
 	}
-<% unless version == 'ga' -%>
 		if err := d.Set("networking_mode", "VPC_NATIVE"); err != nil {
 			return nil, fmt.Errorf("Error setting networking_mode: %s", err)
 		}
-<% end -%>
 
 	p := c.IpAllocationPolicy
 	return []map[string]interface{}{

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -515,7 +515,6 @@ func resourceContainerCluster() *schema.Resource {
 			"enable_autopilot": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
 				ForceNew:    true,
 				Description: `Enable Autopilot for this cluster. Defaults to false.`,
 			},
@@ -1369,6 +1368,10 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			Enabled:         d.Get("enable_legacy_abac").(bool),
 			ForceSendFields: []string{"Enabled"},
 		},
+		ShieldedNodes: &containerBeta.ShieldedNodes{
+			Enabled:         d.Get("enable_shielded_nodes").(bool),
+			ForceSendFields: []string{"Enabled"},
+		},
 		LoggingService:          d.Get("logging_service").(string),
 		MonitoringService:       d.Get("monitoring_service").(string),
 		NetworkPolicy:           expandNetworkPolicy(d.Get("network_policy")),
@@ -1416,13 +1419,6 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 				ForceSendFields: []string{"Enabled"},
 			}
 			cluster.NetworkConfig.EnableIntraNodeVisibility = true
-		}
-	}
-
-	if v, ok := d.GetOk("enable_shielded_nodes"); ok {
-		cluster.ShieldedNodes = &containerBeta.ShieldedNodes{
-			Enabled:         v.(bool),
-			ForceSendFields: []string{"Enabled"},
 		}
 	}
 

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1382,6 +1382,10 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			Enabled:         d.Get("enable_binary_authorization").(bool),
 			ForceSendFields: []string{"Enabled"},
 		},
+		Autopilot: &containerBeta.Autopilot{
+			Enabled:         d.Get("enable_autopilot").(bool),
+			ForceSendFields: []string{"Enabled"},
+		},
 		ReleaseChannel:          expandReleaseChannel(d.Get("release_channel")),
 <% unless version == 'ga' -%>
 		ClusterTelemetry: expandClusterTelemetry(d.Get("cluster_telemetry")),
@@ -1406,8 +1410,8 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		ResourceLabels: expandStringMap(d, "resource_labels"),
 	}
 
-	if v, ok := d.GetOk("enable_autopilot"); ok {
-		cluster.Autopilot = &containerBeta.Autopilot{
+	if v, ok := d.GetOk("enable_shielded_nodes"); ok {
+		cluster.ShieldedNodes = &containerBeta.ShieldedNodes{
 			Enabled:         v.(bool),
 			ForceSendFields: []string{"Enabled"},
 		}
@@ -1415,13 +1419,6 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 
 	if v, ok := d.GetOk("default_max_pods_per_node"); ok {
 		cluster.DefaultMaxPodsConstraint = expandDefaultMaxPodsConstraint(v)
-	}
-
-	if v, ok := d.GetOk("enable_shielded_nodes"); ok {
-		cluster.ShieldedNodes = &containerBeta.ShieldedNodes{
-			Enabled:         v.(bool),
-			ForceSendFields: []string{"Enabled"},
-		}
 	}
 
 	// Only allow setting node_version on create if it's set to the equivalent master version,
@@ -4086,10 +4083,14 @@ func containerClusterPrivateClusterConfigCustomDiff(_ context.Context, d *schema
 	return nil
 }
 
-// The GKE API requires intranode visibility enabled for autopilot clusters
+// Autopilot clusters have preconfigured defaults: https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview#comparison.
+// This function modifies the diff so users can see what these will be during plan time.
 func containerClusterAutopilotCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
-	if d.Get("enable_autopilot").(bool) {
+	if d.HasChange("enable_autopilot") && d.Get("enable_autopilot").(bool) {
 		if err := d.SetNew("enable_intranode_visibility", true); err != nil {
+			return err
+		}
+		if err := d.SetNew("enable_shielded_nodes", true); err != nil {
 			return err
 		}
 	}

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -241,6 +241,7 @@ func resourceContainerCluster() *schema.Resource {
 							AtLeastOneOf: addonsConfigKeys,
 							MaxItems:     1,
 							Description:  `Whether we should enable the network policy addon for the master. This must be enabled in order to enable network policy for the nodes. To enable this, you must also define a network_policy block, otherwise nothing will happen. It can only be disabled if the nodes already do not have network policies enabled. Defaults to disabled; set disabled = false to enable.`,
+							ConflictsWith: []string{"enable_autopilot"},
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"disabled": {
@@ -375,6 +376,7 @@ func resourceContainerCluster() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 				Description: `Per-cluster configuration of Node Auto-Provisioning with Cluster Autoscaler to automatically adjust the size of the cluster and create/delete node pools based on the current needs of the cluster's workload. See the guide to using Node Auto-Provisioning for more details.`,
+				ConflictsWith: []string{"enable_autopilot"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
@@ -474,6 +476,7 @@ func resourceContainerCluster() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: `Enable Binary Authorization for this cluster. If enabled, all container images will be validated by Google Binary Authorization.`,
+				ConflictsWith: []string{"enable_autopilot"},
 			},
 
 			"enable_kubernetes_alpha": {
@@ -506,6 +509,15 @@ func resourceContainerCluster() *schema.Resource {
 				Optional:    true,
 				Default:     false,
 				Description: `Enable Shielded Nodes features on all nodes in this cluster. Defaults to false.`,
+				ConflictsWith: []string{"enable_autopilot"},
+			},
+
+			"enable_autopilot": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    true,
+				Description: `Enable Autopilot for this cluster. Defaults to false.`,
 			},
 
 			"authenticator_groups_config": {
@@ -515,6 +527,7 @@ func resourceContainerCluster() *schema.Resource {
 				ForceNew:    true,
 				MaxItems:    1,
 				Description: `Configuration for the Google Groups for GKE feature.`,
+				ConflictsWith: []string{"enable_autopilot"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"security_group": {
@@ -797,6 +810,7 @@ func resourceContainerCluster() *schema.Resource {
 				Computed:    true,
 				MaxItems:    1,
 				Description: `Configuration options for the NetworkPolicy feature.`,
+				ConflictsWith: []string{"enable_autopilot"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {
@@ -827,6 +841,7 @@ func resourceContainerCluster() *schema.Resource {
 					Schema: schemaNodePool,
 				},
 				Description: `List of node pools associated with this cluster. See google_container_node_pool for schema. Warning: node pools defined inside a cluster can't be changed (or added/removed) after cluster creation without deleting and recreating the entire cluster. Unless you absolutely need the ability to say "these are the only node pools associated with this cluster", use the google_container_node_pool resource instead of this property.`,
+				ConflictsWith: []string{"enable_autopilot"},
 			},
 
 			"node_version": {
@@ -970,6 +985,7 @@ func resourceContainerCluster() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: `If true, deletes the default node pool upon cluster creation. If you're using google_container_node_pool resources with no default node pool, this should be set to true, alongside setting initial_node_count to at least 1.`,
+				ConflictsWith: []string{"enable_autopilot"},
 			},
 
 			"private_cluster_config": {
@@ -1056,6 +1072,7 @@ func resourceContainerCluster() *schema.Resource {
 				ForceNew:    true,
 				Computed:    true,
 				Description: `The default maximum number of pods per node in this cluster. This doesn't work on "routes-based" clusters, clusters that don't have IP Aliasing enabled.`,
+				ConflictsWith: []string{"enable_autopilot"},
 			},
 
 			"vertical_pod_autoscaling": {
@@ -1078,6 +1095,7 @@ func resourceContainerCluster() *schema.Resource {
 				MaxItems: 1,
 				Optional: true,
 				Description: `Configuration for the use of Kubernetes Service Accounts in GCP IAM policies.`,
+				ConflictsWith: []string{"enable_autopilot"},
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"identity_namespace": {
@@ -1190,6 +1208,7 @@ func resourceContainerCluster() *schema.Resource {
 			   Type: schema.TypeBool,
 			   Optional: true,
 			   Description: `Whether Intra-node visibility is enabled for this cluster. This makes same node pod to pod traffic visible for VPC network.`,
+			   ConflictsWith: []string{"enable_autopilot"},
 <% unless version == 'ga' -%>
 			   Default: false,
 <% end -%>
@@ -1362,10 +1381,6 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			Enabled:         d.Get("enable_binary_authorization").(bool),
 			ForceSendFields: []string{"Enabled"},
 		},
-		ShieldedNodes: &containerBeta.ShieldedNodes{
-			Enabled:         d.Get("enable_shielded_nodes").(bool),
-			ForceSendFields: []string{"Enabled"},
-		},
 		ReleaseChannel:          expandReleaseChannel(d.Get("release_channel")),
 <% unless version == 'ga' -%>
 		ClusterTelemetry: expandClusterTelemetry(d.Get("cluster_telemetry")),
@@ -1388,6 +1403,27 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		ConfidentialNodes: expandConfidentialNodes(d.Get("confidential_nodes")),
 <% end -%>
 		ResourceLabels: expandStringMap(d, "resource_labels"),
+	}
+
+	if v, ok := d.GetOk("enable_autopilot"); ok {
+		cluster.Autopilot = &containerBeta.Autopilot{
+			Enabled:         v.(bool),
+			ForceSendFields: []string{"Enabled"},
+		}
+		if v.(bool) == true {
+			cluster.ShieldedNodes = &containerBeta.ShieldedNodes{
+				Enabled:         true,
+				ForceSendFields: []string{"Enabled"},
+			}
+			cluster.NetworkConfig.EnableIntraNodeVisibility = true
+		}
+	}
+
+	if v, ok := d.GetOk("enable_shielded_nodes"); ok {
+		cluster.ShieldedNodes = &containerBeta.ShieldedNodes{
+			Enabled:         v.(bool),
+			ForceSendFields: []string{"Enabled"},
+		}
 	}
 
 	if v, ok := d.GetOk("default_max_pods_per_node"); ok {
@@ -1698,6 +1734,11 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	}
 	if err := d.Set("enable_binary_authorization", cluster.BinaryAuthorization != nil && cluster.BinaryAuthorization.Enabled); err != nil {
 		return fmt.Errorf("Error setting enable_binary_authorization: %s", err)
+	}
+	if cluster.Autopilot != nil {
+		if err := d.Set("enable_autopilot", cluster.Autopilot.Enabled); err != nil {
+			return fmt.Errorf("Error setting enable_autopilot: %s", err)
+		}
 	}
 	if cluster.ShieldedNodes != nil {
 		if err := d.Set("enable_shielded_nodes", cluster.ShieldedNodes.Enabled); err != nil {
@@ -3096,6 +3137,9 @@ func expandMaintenancePolicy(d *schema.ResourceData, meta interface{}) *containe
 func expandClusterAutoscaling(configured interface{}, d *schema.ResourceData) *containerBeta.ClusterAutoscaling {
 	l, ok := configured.([]interface{})
 	if !ok || l == nil || len(l) == 0 || l[0] == nil {
+		if v, ok := d.GetOk("enable_autopilot"); ok && v == true {
+			return nil
+		}
 		return &containerBeta.ClusterAutoscaling{
 			EnableNodeAutoprovisioning: false,
 			ForceSendFields:            []string{"EnableNodeAutoprovisioning"},

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -4089,7 +4089,9 @@ func containerClusterPrivateClusterConfigCustomDiff(_ context.Context, d *schema
 // The GKE API requires intranode visibility enabled for autopilot clusters
 func containerClusterAutopilotCustomizeDiff(_ context.Context, d *schema.ResourceDiff, meta interface{}) error {
 	if d.Get("enable_autopilot").(bool) {
-		d.SetNew("enable_intranode_visibility", true)
+		if err := d.SetNew("enable_intranode_visibility", true); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -1368,10 +1368,6 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			Enabled:         d.Get("enable_legacy_abac").(bool),
 			ForceSendFields: []string{"Enabled"},
 		},
-		ShieldedNodes: &containerBeta.ShieldedNodes{
-			Enabled:         d.Get("enable_shielded_nodes").(bool),
-			ForceSendFields: []string{"Enabled"},
-		},
 		LoggingService:          d.Get("logging_service").(string),
 		MonitoringService:       d.Get("monitoring_service").(string),
 		NetworkPolicy:           expandNetworkPolicy(d.Get("network_policy")),
@@ -1382,6 +1378,10 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		Autoscaling:             expandClusterAutoscaling(d.Get("cluster_autoscaling"), d),
 		BinaryAuthorization: &containerBeta.BinaryAuthorization{
 			Enabled:         d.Get("enable_binary_authorization").(bool),
+			ForceSendFields: []string{"Enabled"},
+		},
+		ShieldedNodes: &containerBeta.ShieldedNodes{
+			Enabled:         d.Get("enable_shielded_nodes").(bool),
 			ForceSendFields: []string{"Enabled"},
 		},
 		ReleaseChannel:          expandReleaseChannel(d.Get("release_channel")),
@@ -1414,10 +1414,8 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			ForceSendFields: []string{"Enabled"},
 		}
 		if v.(bool) == true {
-			cluster.ShieldedNodes = &containerBeta.ShieldedNodes{
-				Enabled:         true,
-				ForceSendFields: []string{"Enabled"},
-			}
+			// Set preconfigured AutoGKE defaults
+			cluster.ShieldedNodes.Enabled = true
 			cluster.NetworkConfig.EnableIntraNodeVisibility = true
 		}
 	}

--- a/mmv1/third_party/terraform/tests/data_source_google_container_cluster_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_container_cluster_test.go
@@ -22,6 +22,7 @@ func TestAccContainerClusterDatasource_zonal(t *testing.T) {
 						"google_container_cluster.kubes",
 						// Remove once https://github.com/hashicorp/terraform/issues/21347 is fixed.
 						map[string]struct{}{
+							"enable_autopilot":             {},
 							"enable_tpu":                   {},
 							"enable_binary_authorization":  {},
 							"pod_security_policy_config.#": {},
@@ -48,6 +49,7 @@ func TestAccContainerClusterDatasource_regional(t *testing.T) {
 						"google_container_cluster.kubes",
 						// Remove once https://github.com/hashicorp/terraform/issues/21347 is fixed.
 						map[string]struct{}{
+							"enable_autopilot":             {},
 							"enable_tpu":                   {},
 							"enable_binary_authorization":  {},
 							"pod_security_policy_config.#": {},

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1684,11 +1684,12 @@ func TestAccContainerCluster_withAutopilot(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:             testAccContainerCluster_withAutopilot(containerNetName, clusterName, true),
-				ExpectNonEmptyPlan: true,
 			},
 			{
 				ResourceName: "google_container_cluster.with_autopilot",
 				ImportState:  true,
+				ImportStateVerify:	 true,
+				ImportStateVerifyIgnore: []string{"min_master_version"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1671,6 +1671,48 @@ func TestAccContainerCluster_withShieldedNodes(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withAutopilot(t *testing.T) {
+	t.Parallel()
+
+	containerNetName := fmt.Sprintf("tf-test-container-net-%s", randString(t, 10))
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccContainerCluster_withAutopilot(containerNetName, clusterName, true),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				ResourceName: "google_container_cluster.with_autopilot",
+				ImportState:  true,
+			},
+		},
+	})
+}
+
+func TestAccContainerCluster_errorAutopilotLocation(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccContainerCluster_withInvalidAutopilotLocation(clusterName, "us-central1-a"),
+				ExpectError: regexp.MustCompile(`Autopilot clusters must be regional clusters.`),
+			},
+		},
+	})
+}
+
+
 func TestAccContainerCluster_withWorkloadIdentityConfig(t *testing.T) {
 	t.Parallel()
 
@@ -4567,4 +4609,69 @@ resource "google_container_cluster" "primary" {
   }
 }
 `, name)
+}
+
+func testAccContainerCluster_withAutopilot(containerNetName string, clusterName string, enabled bool) string {
+	return fmt.Sprintf(`
+resource "google_compute_network" "container_network" {
+	name                    = "%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "container_subnetwork" {
+	name                     = google_compute_network.container_network.name
+	network                  = google_compute_network.container_network.name
+	ip_cidr_range            = "10.0.36.0/24"
+	region                   = "us-central1"
+	private_ip_google_access = true
+  
+	secondary_ip_range {
+	  range_name    = "pod"
+	  ip_cidr_range = "10.0.0.0/19"
+	}
+  
+	secondary_ip_range {
+	  range_name    = "svc"
+	  ip_cidr_range = "10.0.32.0/22"
+	}
+}
+	
+data "google_container_engine_versions" "central1a" {
+	location = "us-central1-a"
+}
+	
+resource "google_container_cluster" "with_autopilot" {
+	name               = "%s"
+	location           = "us-central1"
+	enable_autopilot   = %v
+	min_master_version = "latest"
+	release_channel {
+		channel = "RAPID"
+	}
+	network       = google_compute_network.container_network.name
+	subnetwork    = google_compute_subnetwork.container_subnetwork.name
+	ip_allocation_policy {
+		cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
+		services_secondary_range_name = google_compute_subnetwork.container_subnetwork.secondary_ip_range[1].range_name
+	}
+	addons_config {
+		horizontal_pod_autoscaling {
+			disabled = false
+		}
+	}
+	vertical_pod_autoscaling {
+		enabled = true
+	}
+}
+`, containerNetName, clusterName, enabled)
+}
+
+func testAccContainerCluster_withInvalidAutopilotLocation(clusterName string, location string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "with_invalid_location" {
+  name               = "%s"
+  location           = "%s"
+  enable_autopilot	 = true
+}
+`, clusterName, location)
 }

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1683,7 +1683,7 @@ func TestAccContainerCluster_withAutopilot(t *testing.T) {
 		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
 		Steps: []resource.TestStep{
 			{
-				Config:             testAccContainerCluster_withAutopilot(containerNetName, clusterName, true),
+				Config: testAccContainerCluster_withAutopilot(containerNetName, clusterName, true),
 			},
 			{
 				ResourceName: "google_container_cluster.with_autopilot",
@@ -2864,9 +2864,7 @@ resource "google_container_cluster" "with_authenticator_groups" {
     security_group = "gke-security-groups-test@%s"
   }
 
-<% unless version == 'ga' -%>
   networking_mode = "VPC_NATIVE"
-<% end -%>
   ip_allocation_policy {
     cluster_secondary_range_name  = google_compute_subnetwork.container_subnetwork.secondary_ip_range[0].range_name
     services_secondary_range_name = google_compute_subnetwork.container_subnetwork.secondary_ip_range[1].range_name
@@ -3945,9 +3943,7 @@ resource "google_container_cluster" "with_ip_allocation_policy" {
   network    = google_compute_network.container_network.name
   subnetwork = google_compute_subnetwork.container_subnetwork.name
 
-<% unless version == 'ga' -%>
   networking_mode = "VPC_NATIVE"
-<% end -%>
   initial_node_count = 1
   ip_allocation_policy {
     cluster_secondary_range_name  = "pods"
@@ -3980,9 +3976,7 @@ resource "google_container_cluster" "with_ip_allocation_policy" {
 
   initial_node_count = 1
 
-<% unless version == 'ga' -%>
   networking_mode = "VPC_NATIVE"
-<% end -%>
   ip_allocation_policy {
     cluster_ipv4_cidr_block  = "10.0.0.0/16"
     services_ipv4_cidr_block = "10.1.0.0/16"
@@ -4014,9 +4008,7 @@ resource "google_container_cluster" "with_ip_allocation_policy" {
 
   initial_node_count = 1
 
-<% unless version == 'ga' -%>
   networking_mode = "VPC_NATIVE"
-<% end -%>
   ip_allocation_policy {
     cluster_ipv4_cidr_block  = "/16"
     services_ipv4_cidr_block = "/22"
@@ -4097,9 +4089,7 @@ resource "google_container_cluster" "with_private_cluster" {
   location           = "us-central1-a"
   initial_node_count = 1
 
-<% unless version == 'ga' -%>
   networking_mode = "VPC_NATIVE"
-<% end -%>
   network    = google_compute_network.container_network.name
   subnetwork = google_compute_subnetwork.container_subnetwork.name
 
@@ -4148,9 +4138,7 @@ resource "google_container_cluster" "with_private_cluster" {
   location           = "us-central1-a"
   initial_node_count = 1
 
-<% unless version == 'ga' -%>
   networking_mode = "VPC_NATIVE"
-<% end -%>
   default_snat_status {
     disabled = true
   }
@@ -4427,9 +4415,7 @@ resource "google_container_cluster" "cidr_error_preempt" {
   name     = "%s"
   location = "us-central1-a"
 
-<% unless version == 'ga' -%>
   networking_mode = "VPC_NATIVE"
-<% end -%>
   network    = google_compute_network.container_network.name
   subnetwork = google_compute_subnetwork.container_subnetwork.name
 
@@ -4456,9 +4442,7 @@ resource "google_container_cluster" "cidr_error_overlap" {
 
   initial_node_count = 1
 
-<% unless version == 'ga' -%>
   networking_mode = "VPC_NATIVE"
-<% end -%>
   ip_allocation_policy {
     cluster_ipv4_cidr_block  = "10.0.0.0/16"
     services_ipv4_cidr_block = "10.1.0.0/16"
@@ -4558,9 +4542,7 @@ resource "google_container_cluster" "with_private_cluster" {
   location           = "us-central1-a"
   initial_node_count = 1
 
-<% unless version == 'ga' -%>
   networking_mode = "VPC_NATIVE"
-<% end -%>
   network    = google_compute_network.container_network.name
   subnetwork = google_compute_subnetwork.container_subnetwork.name
 

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -159,6 +159,11 @@ for more information.
 
 * `enable_shielded_nodes` - (Optional) Enable Shielded Nodes features on all nodes in this cluster.  Defaults to `false`.
 
+* `enable_autopilot` - (Optional) Enable Autopilot for this cluster. Defaults to `false`.
+    Note that when this option is enabled, certain features of Standard GKE are not available.
+    See the [official documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview#comparison)
+    for available features.
+
 * `initial_node_count` - (Optional) The number of nodes to create in this
 cluster's default node pool. In regional or multi-zonal clusters, this is the
 number of nodes per zone. Must be set if `node_pool` is not set. If you're using


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform-provider-google/issues/8553
Upstreams https://github.com/hashicorp/terraform-provider-google/pull/8632

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: add support for GKE Autopilot in `google_container_cluster`
container: promoted `networking_mode` to GA in `google_container_cluster`
```
