### PR TITLE
Revert "Allow api_gateway_gateway to change"

### DIFF
--- a/mmv1/products/apigateway/api.yaml
+++ b/mmv1/products/apigateway/api.yaml
@@ -152,7 +152,7 @@ objects:
             required: true
             description: |
               Google Cloud IAM service account used to sign OIDC tokens for backends that have authentication configured
-              (https://cloud.google.com/service-infrastructure/docs/service-management/reference/rest/v1/services.configs#backend).
+              (https://cloud.google.com/service-infrastructure/docs/service-management/reference/rest/v1/services.configs#backend). 
       - !ruby/object:Api::Type::Array
         name: 'openapiDocuments'
         description: |
@@ -219,6 +219,7 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'apiConfig'
         required: true
+        input: true
         description: |
           Resource name of the API Config for this Gateway. Format: projects/{project}/locations/global/apis/{api}/configs/{apiConfig}
       - !ruby/object:Api::Type::String


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#4557

reverting this pull-request as updating the api gateway config to change is difficult, and hard to do in practice. To many conditions to meet.

reopens https://github.com/hashicorp/terraform-provider-google/issues/8532

closes https://github.com/hashicorp/terraform-provider-google/issues/8667#issuecomment-797083299

```release-note:none
Release note
```