### PR TITLE
Add operation retry for exceeded quota group OperationReadGroup

### DIFF
--- a/mmv1/third_party/terraform/utils/common_operation.go
+++ b/mmv1/third_party/terraform/utils/common_operation.go
@@ -111,7 +111,7 @@ func CommonRefreshFunc(w Waiter) resource.StateRefreshFunc {
 		op, err := w.QueryOp()
 		if err != nil {
 			// Retry 404 when getting operation (not resource state)
-			if isRetryableError(err, isNotFoundRetryableError("GET operation")) {
+			if isRetryableError(err, isNotFoundRetryableError("GET operation"), isOperationReadQuotaError) {
 				log.Printf("[DEBUG] Dismissed retryable error on GET operation %q: %s", w.OpName(), err)
 				return nil, "done: false", nil
 			}

--- a/mmv1/third_party/terraform/utils/error_retry_predicates.go
+++ b/mmv1/third_party/terraform/utils/error_retry_predicates.go
@@ -216,6 +216,17 @@ func isBigqueryIAMQuotaError(err error) (bool, string) {
 	return false, ""
 }
 
+// Retry if operation returns a 403 with the message for
+// exceeding the quota limit for 'OperationReadGroup'
+func isOperationReadQuotaError(err error) (bool, string) {
+	if gerr, ok := err.(*googleapi.Error); ok {
+		if gerr.Code == 403 && strings.Contains(gerr.Body, "Quota exceeded for quota group 'OperationReadGroup'") {
+			return true, "Waiting for quota to refresh"
+		}
+	}
+	return false, ""
+}
+
 // Retry if Monitoring operation returns a 409 with a specific message for
 // concurrent operations.
 func isMonitoringConcurrentEditError(err error) (bool, string) {

--- a/mmv1/third_party/terraform/utils/error_retry_predicates_test.go
+++ b/mmv1/third_party/terraform/utils/error_retry_predicates_test.go
@@ -78,3 +78,14 @@ func TestIsCommonRetryableErrorCode_otherError(t *testing.T) {
 		t.Errorf("Error incorrectly detected as retryable")
 	}
 }
+
+func TestIsOperationReadQuotaError_quotaExceeded(t *testing.T) {
+	err := googleapi.Error{
+		Code: 403,
+		Body: "Quota exceeded for quota group 'OperationReadGroup' and limit 'Operation read requests per 100 seconds' of service 'compute.googleapis.com' for consumer 'project_number:11111111'.",
+	}
+	isRetryable, _ := isOperationReadQuotaError(&err)
+	if !isRetryable {
+		t.Errorf("Error not detected as retryable")
+	}
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/8655

The error we need to retry on:
```
{
  "error": {
    "code": 403,
    "message": "Quota exceeded for quota group 'OperationReadGroup' and limit 'Operation read requests per 100 seconds' of service 'compute.googleapis.com' for consumer 'project_number:<>'.",
    "errors": [
      {
        "message": "Quota exceeded for quota group 'OperationReadGroup' and limit 'Operation read requests per 100 seconds' of service 'compute.googleapis.com' for consumer 'project_number:<>'.",
        "domain": "usageLimits",
        "reason": "rateLimitExceeded"
      }
    ],
    "status": "PERMISSION_DENIED"
  }
```

Currently only GCE has a quota group called `OperationReadGroup`, but the compute operations use [CommonRefreshFunc](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/mmv1/third_party/terraform/utils/common_operation.go#L109). Rather than rewrite compute operations to use a non-common refresh function, I just added another retry predicate to the existing one.

Tested by spamming operation reads. Sorry GCE SRE's...

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed an issue where exceeding the operation rate limit would fail without retrying
```
