### PR TITLE
add handling of empty versioning and cors in hand written storage bucket

### DIFF
--- a/mmv1/third_party/validator/storage_bucket.go
+++ b/mmv1/third_party/validator/storage_bucket.go
@@ -107,6 +107,9 @@ func GetStorageBucketApiObject(d TerraformResourceData, config *Config) (map[str
 }
 
 func expandCors(configured []interface{}) []*storage.BucketCors {
+	if len(configured) == 0 || configured[0] == nil {
+		return nil
+	}
 	corsRules := make([]*storage.BucketCors, 0, len(configured))
 	for _, raw := range configured {
 		data := raw.(map[string]interface{})
@@ -156,7 +159,7 @@ func expandBucketLogging(configured interface{}) *storage.BucketLogging {
 
 func expandBucketVersioning(configured interface{}) *storage.BucketVersioning {
 	versionings := configured.([]interface{})
-	if len(versionings) == 0 {
+	if len(versionings) == 0 || versionings[0] == nil  {
 		return nil
 	}
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR  solves the issue [Validator crashes when validating storage resource when versioning is not yet defined](https://github.com/GoogleCloudPlatform/terraform-validator/issues/201) in terraform-validator


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
Fix handling of empty versioning and cors in hand written storage bucket for terraform-google-conversion
```
