### PR TITLE
Factored out fetching of iam policies and added folder iam merge helpers

### DIFF
--- a/mmv1/third_party/validator/folder_iam.go
+++ b/mmv1/third_party/validator/folder_iam.go
@@ -23,8 +23,16 @@ func MergeFolderIamBinding(existing, incoming Asset) Asset {
 	return mergeIamAssets(existing, incoming, mergeAuthoritativeBindings)
 }
 
+func MergeFolderIamBindingDelete(existing, incoming Asset) Asset {
+	return mergeDeleteIamAssets(existing, incoming, mergeDeleteAuthoritativeBindings)
+}
+
 func MergeFolderIamMember(existing, incoming Asset) Asset {
 	return mergeIamAssets(existing, incoming, mergeAdditiveBindings)
+}
+
+func MergeFolderIamMemberDelete(existing, incoming Asset) Asset {
+	return mergeDeleteIamAssets(existing, incoming, mergeDeleteAdditiveBindings)
 }
 
 func newFolderIamAsset(
@@ -50,4 +58,15 @@ func newFolderIamAsset(
 			Bindings: bindings,
 		},
 	}}, nil
+}
+
+func FetchFolderIamPolicy(d TerraformResourceData, config *Config) (Asset, error) {
+	// We use project_id in the asset name template to be consistent with newProjectIamAsset.
+	return fetchIamPolicy(
+		NewProjectIamUpdater,
+		d,
+		config,
+		"//cloudresourcemanager.googleapis.com/{{folder}}",
+		"cloudresourcemanager.googleapis.com/Folder",
+	)
 }

--- a/mmv1/third_party/validator/project_iam.go
+++ b/mmv1/third_party/validator/project_iam.go
@@ -62,35 +62,12 @@ func newProjectIamAsset(
 }
 
 func FetchProjectIamPolicy(d TerraformResourceData, config *Config) (Asset, error) {
-	updater, err := NewProjectIamUpdater(d, config)
-	if err != nil {
-		return Asset{}, err
-	}
-
-	iamPolicy, err := updater.GetResourceIamPolicy()
-	if err != nil {
-		return Asset{}, err
-	}
-
-	var bindings []IAMBinding
-	for _, b := range iamPolicy.Bindings {
-		bindings = append(
-			bindings,
-			IAMBinding{
-				Role:    b.Role,
-				Members: b.Members,
-			},
-		)
-	}
-
-	// We use project_id to be consistent with newProjectIamAsset.
-	name, err := assetName(d, config, "//cloudresourcemanager.googleapis.com/projects/{{project}}")
-
-	return Asset{
-		Name: name,
-		Type: "cloudresourcemanager.googleapis.com/Project",
-		IAMPolicy: &IAMPolicy{
-			Bindings: bindings,
-		},
-	}, nil
+	// We use project_id in the asset name template to be consistent with newProjectIamAsset.
+	return fetchIamPolicy(
+		NewProjectIamUpdater,
+		d,
+		config,
+		"//cloudresourcemanager.googleapis.com/projects/{{project}}",
+		"cloudresourcemanager.googleapis.com/Project",
+	)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Related to https://github.com/hashicorp/terraform-provider-google/issues/7797 - adding support for merging of IAM policies for Folder resources.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
