### PR TITLE
Allow data lookup on google_active_folder without providing a parent

### DIFF
--- a/mmv1/third_party/terraform/data_sources/data_source_google_active_folder.go
+++ b/mmv1/third_party/terraform/data_sources/data_source_google_active_folder.go
@@ -14,7 +14,7 @@ func dataSourceGoogleActiveFolder() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"parent": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"display_name": {
 				Type:     schema.TypeString,
@@ -35,10 +35,16 @@ func dataSourceGoogleActiveFolderRead(d *schema.ResourceData, meta interface{}) 
 		return err
 	}
 
-	parent := d.Get("parent").(string)
 	displayName := d.Get("display_name").(string)
+	queryString := ""
 
-	queryString := fmt.Sprintf("lifecycleState=ACTIVE AND parent=%s AND displayName=\"%s\"", parent, displayName)
+	// parent is optional
+	if parent, ok := d.GetOk("parent"); ok {
+		queryString = fmt.Sprintf("lifecycleState=ACTIVE AND parent=%s AND displayName=\"%s\"", parent.(string), displayName)
+	} else {
+		queryString = fmt.Sprintf("lifecycleState=ACTIVE AND displayName=\"%s\"", displayName)
+	}
+
 	searchRequest := &resourceManagerV2.SearchFoldersRequest{
 		Query: queryString,
 	}

--- a/mmv1/third_party/terraform/tests/data_source_google_active_folder_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_active_folder_test.go
@@ -98,6 +98,26 @@ func testAccDataSourceGoogleActiveFolderCheck(data_source_name string, resource_
 	}
 }
 
+func TestAccDataSourceGoogleActiveFolder_no_parent(t *testing.T) {
+	org := getTestOrgFromEnv(t)
+
+	parent := fmt.Sprintf("organizations/%s", org)
+	displayName := "terraform-test-" + randString(t, 10)
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceGoogleActiveFolderConfig(parent, displayName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceGoogleActiveFolderCheck("data.google_active_folder.my_folder", "google_folder.foobar"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceGoogleActiveFolderConfig(parent string, displayName string) string {
 	return fmt.Sprintf(`
 resource "google_folder" "foobar" {
@@ -107,6 +127,19 @@ resource "google_folder" "foobar" {
 
 data "google_active_folder" "my_folder" {
   parent       = google_folder.foobar.parent
+  display_name = google_folder.foobar.display_name
+}
+`, parent, displayName)
+}
+
+func testAccDataSourceGoogleActiveFolderConfig_no_parent(parent string, displayName string) string {
+	return fmt.Sprintf(`
+resource "google_folder" "foobar" {
+  parent       = "%s"
+  display_name = "%s"
+}
+
+data "google_active_folder" "my_folder" {
   display_name = google_folder.foobar.display_name
 }
 `, parent, displayName)

--- a/mmv1/third_party/terraform/website/docs/d/active_folder.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/active_folder.html.markdown
@@ -13,10 +13,28 @@ Get an active folder within GCP by `display_name` and `parent`.
 
 ## Example Usage
 
+To find a folder by its name:
+
+```tf
+data "google_active_folder" "department1" {
+  display_name = "Department 1"
+}
+```
+
+To find a folder in the organization:
+
 ```tf
 data "google_active_folder" "department1" {
   display_name = "Department 1"
   parent       = "organizations/1234567"
+}
+```
+To find a folder nested in another folder:
+
+```tf
+data "google_active_folder" "department1" {
+  display_name = "Department 1"
+  parent       = "folders/12345"
 }
 ```
 
@@ -26,7 +44,7 @@ The following arguments are supported:
 
 * `display_name` - (Required) The folder's display name.
 
-* `parent` - (Required) The resource name of the parent Folder or Organization.
+* `parent` - (Optional) The resource id of the parent Folder or Organization.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Upstreams https://github.com/hashicorp/terraform-provider-google/pull/7509


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
resourcemanager: added support for parent-less lookups to `data.google_active_folder`
```
