### PR TITLE
fix: Adding a triggers block for alert policy to force recreation - u…

### DIFF
--- a/mmv1/products/monitoring/terraform.yaml
+++ b/mmv1/products/monitoring/terraform.yaml
@@ -28,6 +28,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_import: templates/terraform/custom_import/self_link_as_name.erb
       post_create: templates/terraform/post_create/set_computed_name.erb
+      extra_schema_entry: templates/terraform/extra_schema_entry/alertpolicies_triggers.erb
 
   Group: !ruby/object:Overrides::Terraform::ResourceOverride
     id_format: "{{name}}"

--- a/mmv1/templates/terraform/extra_schema_entry/alertpolicies_triggers.erb
+++ b/mmv1/templates/terraform/extra_schema_entry/alertpolicies_triggers.erb
@@ -1,0 +1,6 @@
+"triggers": {
+  Type:     schema.TypeMap,
+  Optional: true,
+  ForceNew: true,
+  Elem:     &schema.Schema{Type: schema.TypeString},
+},


### PR DESCRIPTION
…seful for external dependency e.g. notification channels

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR is for this feature added to the provider: https://github.com/hashicorp/terraform-provider-google/pull/8794

More details:

Hi, this PR is raised as an inspiration from adamdecaf/terraform-provider-aws@cb8ec65

Currently a terraform failure occurs with alertpolicies when a notification channel requires destruction - the notification channel destruction is blocked by the alertpolicy. After some quick googling I found there isn't a Terraform provided solution as of yet, so a triggers block is best to suffice for now.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Adding a triggers map for forcing alert policy recreation to escape race condition with notification channel
```
