### PR TITLE
Revert "Updated datatype for mtu"

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -7348,7 +7348,7 @@ objects:
         name: 'description'
         description: |
           An optional description of this resource.
-      - !ruby/object:Api::Type::Integer
+      - !ruby/object:Api::Type::String
         name: 'mtu'
         description: |
           Maximum Transmission Unit (MTU), in bytes, of packets passing through

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1109,10 +1109,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       - !ruby/object:Provider::Terraform::Examples
         name: "interconnect_attachment_basic"
         primary_resource_id: "on_prem"
-        skip_test: true
         vars:
           interconnect_attachment_name: "on-prem-attachment"
           router_name: "router"
+          network_name: "network"
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1137,6 +1137,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       edgeAvailabilityDomain: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       mtu: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_flatten: templates/terraform/custom_flatten/float64_to_int_to_string.go.erb
         default_from_api: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/interconnect_attachment.go.erb

--- a/mmv1/templates/terraform/custom_flatten/float64_to_int_to_string.go.erb
+++ b/mmv1/templates/terraform/custom_flatten/float64_to_int_to_string.go.erb
@@ -1,0 +1,7 @@
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+  // Handles int given in float64 format
+  if floatVal, ok := v.(float64); ok {
+    return fmt.Sprintf("%d", int(floatVal))
+  }
+  return v
+}

--- a/mmv1/templates/terraform/examples/interconnect_attachment_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/interconnect_attachment_basic.tf.erb
@@ -1,11 +1,20 @@
 resource "google_compute_interconnect_attachment" "<%= ctx[:primary_resource_id] %>" {
-  name         = "<%= ctx[:vars]['interconnect_attachment_name'] %>"
-  interconnect = "my-interconnect-id"
-  router       = google_compute_router.foobar.id
-  mtu          = 1500
+  name                     = "<%= ctx[:vars]['interconnect_attachment_name'] %>"
+  edge_availability_domain = "AVAILABILITY_DOMAIN_1"
+  type                     = "PARTNER"
+  router                   = google_compute_router.foobar.id
+  mtu                      = 1500
 }
 
 resource "google_compute_router" "foobar" {
   name    = "<%= ctx[:vars]['router_name'] %>"
   network = google_compute_network.foobar.name
+  bgp {
+    asn = 16550
+  }
+}
+
+resource "google_compute_network" "foobar" {
+  name                    = "<%= ctx[:vars]['network_name'] %>"
+  auto_create_subnetworks = false
 }


### PR DESCRIPTION
Reverts GoogleCloudPlatform/magic-modules#4601
closes https://github.com/hashicorp/terraform-provider-google/issues/8791
reopens https://github.com/hashicorp/terraform-provider-google/issues/8707

```release-note:bug
compute: reverted datatype change for `mtu` in `google_compute_interconnect_attachment` as it was incompatible with existing state representation
```