### PR TITLE
Moved check for op name out of create*Waiter

### DIFF
--- a/mmv1/templates/terraform/operation.go.erb
+++ b/mmv1/templates/terraform/operation.go.erb
@@ -29,13 +29,6 @@ func (w *<%= product_name -%>OperationWaiter) QueryOp() (interface{}, error) {
 }
 
 func create<%= product_name %>Waiter(config *Config, op map[string]interface{}, <% if has_project -%> project, <% end -%> activity, userAgent string) (*<%=product_name%>OperationWaiter, error) {
-  if val, ok := op["name"]; !ok || val == "" {
-    // An operation could also be indicated with a "metadata" field.
-    if _, ok := op["metadata"]; !ok {
-      // This was a synchronous call - there is no operation to wait for.
-      return nil, nil
-    }
-  }
   w := &<%= product_name -%>OperationWaiter{
     Config:    config,
     UserAgent: userAgent,
@@ -57,8 +50,7 @@ func create<%= product_name %>Waiter(config *Config, op map[string]interface{}, 
 // nolint: deadcode,unused
 func <%= product_name.camelize(:lower) -%>OperationWaitTimeWithResponse(config *Config, op map[string]interface{}, response *map[string]interface{},<% if has_project -%> project,<% end -%> activity, userAgent string, timeout time.Duration) error {
   w, err := create<%= product_name %>Waiter(config, op, <% if has_project -%> project, <%end-%> activity, userAgent)
-  if err != nil || w == nil {
-      // If w is nil, the op was synchronous.
+  if err != nil {
       return err
   }
   if err := OperationWait(w, activity, timeout, config.PollInterval); err != nil {
@@ -69,8 +61,12 @@ func <%= product_name.camelize(:lower) -%>OperationWaitTimeWithResponse(config *
 <% end -%>
 
 func <%= product_name.camelize(:lower) -%>OperationWaitTime(config *Config, op map[string]interface{}, <% if has_project -%> project,<% end -%> activity, userAgent string, timeout time.Duration) error {
+  if val, ok := op["name"]; !ok || val == "" {
+    // This was a synchronous call - there is no operation to wait for.
+    return nil
+  }
   w, err := create<%= product_name %>Waiter(config, op, <% if has_project -%> project, <%end-%> activity, userAgent)
-  if err != nil || w == nil {
+  if err != nil {
       // If w is nil, the op was synchronous.
       return err
   }


### PR DESCRIPTION
If there is a nested response but the operation is synchronous, there will not be a name - but we still need to run the rest of the logic in order to properly extract the response data.

This is an update to the change made in https://github.com/GoogleCloudPlatform/magic-modules/pull/4368/files#diff-0a9e906091ae6539868494efebdb18f41d945ac77f9dbf6d9be664f71f506028R33. At the time, I thought that the issue was that the operation wasn't being detected. However, the code comment was correct: [the operation _was_ synchronous](https://ci-oss.hashicorp.engineering/repository/download/GoogleCloudBeta_ProviderGoogleCloudBetaMmUpstreamVcr/165464:id/debug-google-beta-bcd14cc-TestAccAccessContextManager__gcp_user_access_binding.log):

<details>
    <summary>Synchronous operation response with metadata (UserAccessBinding)</summary>

```
---[ REQUEST ]---------------------------------------
POST /v1/organizations/<orgId>/gcpUserAccessBindings?alt=json HTTP/1.1
Host: accesscontextmanager.googleapis.com
User-Agent: Terraform/0.12.29 (+https://www.terraform.io) Terraform-Plugin-SDK/2.4.0 terraform-provider-google-beta/dev
Content-Length: 128
Content-Type: application/json
Accept-Encoding: gzip

{
 "access_levels": [
  "accessPolicies/<policyid>/accessLevels/tf_test_chromeos_no_lockgr6qfoohnw"
 ],
 "group_key": "<groupKey>"
}

-----------------------------------------------------
2021/01/05 23:59:17 [DEBUG] Google API Response Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Alt-Svc: h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
Cache-Control: private
Content-Type: application/json; charset=UTF-8
Date: Tue, 05 Jan 2021 23:59:17 GMT
Server: ESF
Vary: Origin
Vary: X-Origin
Vary: Referer
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 0

214
{
  "metadata": {
    "@type": "type.googleapis.com/google.identity.accesscontextmanager.v1.GcpUserAccessBindingOperationMetadata"
  },
  "done": true,
  "response": {
    "@type": "type.googleapis.com/google.identity.accesscontextmanager.v1.GcpUserAccessBinding",
    "name": "organizations/<orgId>/gcpUserAccessBindings/aAQS-YRSPwf-1cEbnsJjq-s-dS6gFsCgWJYdBCp1nMVeRLdFW",
    "groupKey": "<groupKey>",
    "accessLevels": [
"accessPolicies/<policyid>/accessLevels/tf_test_chromeos_no_lockgr6qfoohnw"
    ]
  }
}
```

</details>

The impetus for this PR was that TagBindings _also_ return a synchronous operation, but don't include a name for it, and also don't include a `metadata` key.

<details>
<summary>Synchronous operation response without metadata (TagBinding)</summary>

```
---[ REQUEST ]---------------------------------------
POST /v3/tagBindings?alt=json HTTP/1.1
Host: cloudresourcemanager.googleapis.com
User-Agent: Terraform/0.13.6 (+https://www.terraform.io) Terraform-Plugin-SDK/2.5.0 terraform-provider-google-beta/acc
Content-Length: 109
Content-Type: application/json
Accept-Encoding: gzip

{
 "parent": "//cloudresourcemanager.googleapis.com/projects/107041489576",
 "tagValue": "tagValues/815672295465"
}

-----------------------------------------------------
2021/04/02 10:09:54 [DEBUG] Google API Response Details:
---[ RESPONSE ]--------------------------------------
HTTP/2.0 200 OK
Alt-Svc: h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
Cache-Control: private
Content-Type: application/json; charset=UTF-8
Date: Fri, 02 Apr 2021 17:09:54 GMT
Server: ESF
Vary: Origin
Vary: X-Origin
Vary: Referer
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 0

{
  "done": true,
  "response": {
    "@type": "type.googleapis.com/google.cloud.resourcemanager.v3.TagBinding",
    "name": "tagBindings/%2F%2Fcloudresourcemanager.googleapis.com%2Fprojects%2F107041489576/tagValues/815672295465",
    "parent": "//cloudresourcemanager.googleapis.com/projects/107041489576",
    "tagValue": "tagValues/815672295465"
  }
}
```

</details>

The problem is that for `*WaitResponse`, we need to process synchronous operations, even if they don't have `name` or `metadata` fields. I assume that checking for an operation name _is_ necessary for non-`*WaitResponse` operation handling.

I ran into this while working on https://github.com/hashicorp/terraform-provider-google/issues/8428. TagBinding resources also return a synchronous operation on creation but the operation doesn't contain a "metadata" key, just "done" and "response".

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
