### PR TITLE
add field `maintenance_window.start_time` to `google_compute_node_group`

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -8433,6 +8433,16 @@ objects:
           Specifies how to handle instances when a node in the group undergoes maintenance. Set to one of: DEFAULT, RESTART_IN_PLACE, or MIGRATE_WITHIN_NODE_GROUP. The default value is DEFAULT.
         default_value: DEFAULT
       - !ruby/object:Api::Type::NestedObject
+        name: 'maintenanceWindow'
+        description: |
+          contains properties for the timeframe of maintenance
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'startTime'
+            required: true
+            description: |
+              instances.start time of the window. This must be in UTC format that resolves to one of 00:00, 04:00, 08:00, 12:00, 16:00, or 20:00. For example, both 13:00-5 and 08:00 are valid.
+      - !ruby/object:Api::Type::NestedObject
         name: 'autoscalingPolicy'
         description: |
           If you use sole-tenant nodes for your workloads, you can use the node

--- a/mmv1/templates/terraform/examples/node_group_autoscaling_policy.tf.erb
+++ b/mmv1/templates/terraform/examples/node_group_autoscaling_policy.tf.erb
@@ -6,7 +6,7 @@ resource "google_compute_node_template" "soletenant-tmpl" {
 
 resource "google_compute_node_group" "<%= ctx[:primary_resource_id] %>" {
   name        = "<%= ctx[:vars]['group_name'] %>"
-  zone        = "us-central1-a"
+  zone        = "us-central1-f"
   description = "example google_compute_node_group for Terraform Google Provider"
   maintenance_policy = "RESTART_IN_PLACE"
   maintenance_window {

--- a/mmv1/templates/terraform/examples/node_group_autoscaling_policy.tf.erb
+++ b/mmv1/templates/terraform/examples/node_group_autoscaling_policy.tf.erb
@@ -9,6 +9,9 @@ resource "google_compute_node_group" "<%= ctx[:primary_resource_id] %>" {
   zone        = "us-central1-a"
   description = "example google_compute_node_group for Terraform Google Provider"
   maintenance_policy = "RESTART_IN_PLACE"
+  maintenance_window {
+    start_time = "08:00"
+  }
   size          = 1
   node_template = google_compute_node_template.soletenant-tmpl.id
   autoscaling_policy {

--- a/mmv1/templates/terraform/examples/node_group_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/node_group_basic.tf.erb
@@ -6,7 +6,7 @@ resource "google_compute_node_template" "soletenant-tmpl" {
 
 resource "google_compute_node_group" "<%= ctx[:primary_resource_id] %>" {
   name        = "<%= ctx[:vars]['group_name'] %>"
-  zone        = "us-central1-a"
+  zone        = "us-central1-f"
   description = "example google_compute_node_group for Terraform Google Provider"
 
   size          = 1


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

closes https://github.com/hashicorp/terraform-provider-google/issues/8820



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added field `maintenance_window.start_time` to `google_compute_node_group`
```
