### PR TITLE
Add support for confidential compute instances to the ansible collection

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -6632,6 +6632,13 @@ objects:
             description: Defines whether the instance has integrity monitoring enabled.
             update_verb: :PATCH
             update_url: projects/{{project}}/instances/{{name}}/updateShieldedInstanceConfig
+      - !ruby/object:Api::Type::NestedObject
+        name: 'confidentialInstanceConfig'
+        description: 'Enable confidential instance (requires setting the machine type to any of the n2d-* types).'
+        properties:
+          - !ruby/object:Api::Type::Boolean
+            name: 'enableConfidentialCompute'
+            description: Enables confidential computing
       - !ruby/object:Api::Type::Enum
         name: 'status'
         description: |

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -6634,7 +6634,7 @@ objects:
             update_url: projects/{{project}}/instances/{{name}}/updateShieldedInstanceConfig
       - !ruby/object:Api::Type::NestedObject
         name: 'confidentialInstanceConfig'
-        description: 'Enable confidential instance (requires setting the machine type to any of the n2d-* types).'
+        description: 'Configuration for confidential computing (requires setting the machine type to any of the n2d-* types and a boot disk of type pd-ssd).'
         properties:
           - !ruby/object:Api::Type::Boolean
             name: 'enableConfidentialCompute'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Adds support for [Confidential Computing](https://cloud.google.com/confidential-computing) to the ansible collection.

Adds a new configuration object to the resource compute/instance in the form (in compliance with the API):
```yaml
confidentialComputeConfig: {
  enableConfidentialCompute: true
}
```

Fixes https://github.com/ansible-collections/google.cloud/issues/400

I'm still looking into the tests that come with the ansible collection - I can't say yet if I can run them (depending on the infrastructure/costs that might be involved).

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

---
**I'm still checking, if this affects the terraform module in any way (since it already had support for confidential compute).**
---

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Add support for confidential compute instances**

```release-note:none
# no effect on Terraform
```
