### PR TITLE
allow multiple fields in bgp_peer to be updatable

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -13204,14 +13204,12 @@ objects:
           IP address of the BGP interface outside Google Cloud Platform.
           Only IPv4 is supported.
         required: true
-        input: true
       - !ruby/object:Api::Type::Integer
         name: 'peerAsn'
         description: |
           Peer BGP Autonomous System Number (ASN).
           Each BGP interface may use a different value.
         required: true
-        input: true
       - !ruby/object:Api::Type::Integer
         name: 'advertisedRoutePriority'
         description: |
@@ -13227,7 +13225,6 @@ objects:
           - :DEFAULT
           - :CUSTOM
         default_value: :DEFAULT
-        input: true
       - !ruby/object:Api::Type::Array
         name: advertisedGroups
         description: |
@@ -13245,7 +13242,6 @@ objects:
           Leave this field blank to advertise no custom groups.
         send_empty_value: true
         item_type: Api::Type::String
-        input: true
       - !ruby/object:Api::Type::Array
         name: advertisedIpRanges
         description: |


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
closes https://github.com/hashicorp/terraform-provider-google/issues/7977



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: enabled fields `advertiseMode`, `advertisedGroups`, `peerAsn`, and `peerIpAddress` to be updatable on resource `google_compute_router_peer`
```
