### PR TITLE
Fix min_node_cpus logic in GA

### DIFF
--- a/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
@@ -118,11 +118,9 @@ func expandScheduling(v interface{}) (*computeBeta.Scheduling, error) {
 		}
 	}
 
-<% unless version == 'ga' -%>
 	if v, ok := original["min_node_cpus"]; ok {
 		scheduling.MinNodeCpus = int64(v.(int))
 	}
-<% end -%>
 
 	return scheduling, nil
 }
@@ -131,9 +129,7 @@ func flattenScheduling(resp *computeBeta.Scheduling) []map[string]interface{} {
 	schedulingMap := map[string]interface{}{
 		"on_host_maintenance": resp.OnHostMaintenance,
 		"preemptible":         resp.Preemptible,
-<% unless version == 'ga' -%>
 		"min_node_cpus":       resp.MinNodeCpus,
-<% end -%>
 	}
 
 	if resp.AutomaticRestart != nil {
@@ -338,8 +334,8 @@ func expandConfidentialInstanceConfig(d TerraformResourceData) *computeBeta.Conf
 
 	prefix := "confidential_instance_config.0"
 	return &computeBeta.ConfidentialInstanceConfig{
-		EnableConfidentialCompute:     d.Get(prefix + ".enable_confidential_compute").(bool),
-		ForceSendFields:              []string{"EnableSecureBoot"},
+		EnableConfidentialCompute: d.Get(prefix + ".enable_confidential_compute").(bool),
+		ForceSendFields:           []string{"EnableSecureBoot"},
 	}
 }
 
@@ -349,7 +345,7 @@ func flattenConfidentialInstanceConfig(ConfidentialInstanceConfig *computeBeta.C
 	}
 
 	return []map[string]bool{{
-		"enable_confidential_compute":          ConfidentialInstanceConfig.EnableConfidentialCompute,
+		"enable_confidential_compute": ConfidentialInstanceConfig.EnableConfidentialCompute,
 	}}
 }
 
@@ -408,11 +404,9 @@ func schedulingHasChange(d *schema.ResourceData) bool {
 		return true
 	}
 
-<% unless version == 'ga' -%>
 	if oScheduling["min_node_cpus"] != newScheduling["min_node_cpus"] {
 		return true
 	}
-<% end -%>
 
 	return reflect.DeepEqual(newNa, originalNa)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Ran into this while rebasing https://github.com/GoogleCloudPlatform/magic-modules/pull/4402
Fixes https://github.com/hashicorp/terraform-provider-google/issues/8859

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed an issue in `google_compute_instance` where `min_node_cpus` could not be set
```
