### PR TITLE
Allow referencing IPs by reference in google_compute_forwarding_rule

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -3678,36 +3678,22 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'IPAddress'
         description: |
-          The IP address that this forwarding rule is serving on behalf of.
+          The IP address that this forwarding rule serves. When a client sends
+          traffic to this IP address, the forwarding rule directs the traffic to
+          the target that you specify in the forwarding rule. The
+          loadBalancingScheme and the forwarding rule's target determine the
+          type of IP address that you can use. For detailed information, refer
+          to [IP address specifications](https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
 
-          Addresses are restricted based on the forwarding rule's load balancing
-          scheme (EXTERNAL or INTERNAL) and scope (global or regional).
+          An address can be specified either by a literal IP address or a
+          reference to an existing Address resource. If you don't specify a
+          reserved IP address, an ephemeral IP address is assigned.
 
-          When the load balancing scheme is EXTERNAL, for global forwarding
-          rules, the address must be a global IP, and for regional forwarding
-          rules, the address must live in the same region as the forwarding
-          rule. If this field is empty, an ephemeral IPv4 address from the same
-          scope (global or regional) will be assigned. A regional forwarding
-          rule supports IPv4 only. A global forwarding rule supports either IPv4
-          or IPv6.
+          The value must be set to 0.0.0.0 when the target is a targetGrpcProxy
+          that has validateForProxyless field set to true.
 
-          When the load balancing scheme is INTERNAL, this can only be an RFC
-          1918 IP address belonging to the network/subnet configured for the
-          forwarding rule. By default, if this field is empty, an ephemeral
-          internal IP address will be automatically allocated from the IP range
-          of the subnet or network configured for this forwarding rule.
-
-          An address can be specified either by a literal IP address or a URL
-          reference to an existing Address resource. The following examples are
-          all valid:
-
-          * 100.1.2.3
-          * https://www.googleapis.com/compute/v1/projects/project/regions/
-               region/addresses/address
-          * projects/project/regions/region/addresses/address
-          * regions/region/addresses/address
-          * global/addresses/address
-          * address
+          For Private Service Connect forwarding rules that forward traffic to
+          Google APIs, IP address must be provided.
       - !ruby/object:Api::Type::Enum
         name: 'IPProtocol'
         description: |
@@ -4081,35 +4067,22 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'IPAddress'
         description: |
-          The IP address that this forwarding rule is serving on behalf of.
+          The IP address that this forwarding rule serves. When a client sends
+          traffic to this IP address, the forwarding rule directs the traffic to
+          the target that you specify in the forwarding rule. The
+          loadBalancingScheme and the forwarding rule's target determine the
+          type of IP address that you can use. For detailed information, refer
+          to [IP address specifications](https://cloud.google.com/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
 
-          Addresses are restricted based on the forwarding rule's load balancing
-          scheme (external or internal) and scope (global or regional).
-          The address must be a global IP for external global forwarding rules.
+          An address can be specified either by a literal IP address or a
+          reference to an existing Address resource. If you don't specify a
+          reserved IP address, an ephemeral IP address is assigned.
 
-          If this field is empty, an ephemeral IPv4 address from the same scope
-          (global) is chosen. Global forwarding rules supports either IPv4 or IPv6.
+          The value must be set to 0.0.0.0 when the target is a targetGrpcProxy
+          that has validateForProxyless field set to true.
 
-          When the load balancing scheme is INTERNAL_SELF_MANAGED, this must be
-          a URL reference to an existing Address resource (internal regional
-          static IP address), with a purpose of GCE_END_POINT and addressType
-          of INTERNAL.
-
-          ([Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) only) This must be a URL reference to an existing Address
-          resource (internal global static IP address), with a purpose of
-          PRIVATE_SERVICE_CONNECT and addressType of INTERNAL.
-
-          An address can be specified either by a literal IP address or a URL
-          reference to an existing Address resource. The following examples are
-          all valid:
-
-          * 100.1.2.3
-          * https://www.googleapis.com/compute/v1/projects/project/regions/
-               region/addresses/address
-          * projects/project/regions/region/addresses/address
-          * regions/region/addresses/address
-          * global/addresses/address
-          * address
+          For Private Service Connect forwarding rules that forward traffic to
+          Google APIs, IP address must be provided.
       - !ruby/object:Api::Type::Enum
         name: 'IPProtocol'
         description: |

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -709,33 +709,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       IPAddress: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
-        validation: !ruby/object:Provider::Terraform::Validation
-          function: 'validateIpAddress'
-        description: |
-          The IP address that this forwarding rule is serving on behalf of.
-
-          Addresses are restricted based on the forwarding rule's load balancing
-          scheme (EXTERNAL or INTERNAL) and scope (global or regional).
-
-          When the load balancing scheme is EXTERNAL, for global forwarding
-          rules, the address must be a global IP, and for regional forwarding
-          rules, the address must live in the same region as the forwarding
-          rule. If this field is empty, an ephemeral IPv4 address from the same
-          scope (global or regional) will be assigned. A regional forwarding
-          rule supports IPv4 only. A global forwarding rule supports either IPv4
-          or IPv6.
-
-          When the load balancing scheme is INTERNAL, this can only be an RFC
-          1918 IP address belonging to the network/subnet configured for the
-          forwarding rule. By default, if this field is empty, an ephemeral
-          internal IP address will be automatically allocated from the IP range
-          of the subnet or network configured for this forwarding rule.
-
-          An address must be specified by a literal IP address. ~> **NOTE:** While
-          the API allows you to specify various resource paths for an address resource
-          instead, Terraform requires this to specifically be an IP address to
-          avoid needing to fetching the IP address from resource paths on refresh
-          or unnecessary diffs.
+        diff_suppress_func: 'internalIpDiffSuppress'
       IPProtocol: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'caseDiffSuppress'
         default_from_api: true
@@ -825,31 +799,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       IPAddress: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
         diff_suppress_func: 'internalIpDiffSuppress'
-        description: |
-          The IP address that this forwarding rule is serving on behalf of.
-
-          Addresses are restricted based on the forwarding rule's load balancing
-          scheme (EXTERNAL or INTERNAL) and scope (global or regional).
-
-          When the load balancing scheme is EXTERNAL, for global forwarding
-          rules, the address must be a global IP, and for regional forwarding
-          rules, the address must live in the same region as the forwarding
-          rule. If this field is empty, an ephemeral IPv4 address from the same
-          scope (global or regional) will be assigned. A regional forwarding
-          rule supports IPv4 only. A global forwarding rule supports either IPv4
-          or IPv6.
-
-          When the load balancing scheme is INTERNAL, this can only be an RFC
-          1918 IP address belonging to the network/subnet configured for the
-          forwarding rule. By default, if this field is empty, an ephemeral
-          internal IP address will be automatically allocated from the IP range
-          of the subnet or network configured for this forwarding rule.
-
-          An address must be specified by a literal IP address. ~> **NOTE**: While
-          the API allows you to specify various resource paths for an address resource
-          instead, Terraform requires this to specifically be an IP address to
-          avoid needing to fetching the IP address from resource paths on refresh
-          or unnecessary diffs.
       IPProtocol: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'caseDiffSuppress'
         default_from_api: true

--- a/mmv1/third_party/terraform/tests/resource_compute_forwarding_rule_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_forwarding_rule_test.go.erb
@@ -45,6 +45,8 @@ func TestAccComputeForwardingRule_ip(t *testing.T) {
 	addrName := fmt.Sprintf("tf-%s", randString(t, 10))
 	poolName := fmt.Sprintf("tf-%s", randString(t, 10))
 	ruleName := fmt.Sprintf("tf-%s", randString(t, 10))
+	addressRefFieldRaw := "address"
+	addressRefFieldID := "id"
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -52,7 +54,16 @@ func TestAccComputeForwardingRule_ip(t *testing.T) {
 		CheckDestroy: testAccCheckComputeForwardingRuleDestroyProducer(t),
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeForwardingRule_ip(addrName, poolName, ruleName),
+				Config: testAccComputeForwardingRule_ip(addrName, poolName, ruleName, addressRefFieldID),
+			},
+			resource.TestStep{
+				ResourceName:            "google_compute_forwarding_rule.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"ip_address"}, // ignore ip_address because we've specified it by ID
+			},
+			resource.TestStep{
+				Config: testAccComputeForwardingRule_ip(addrName, poolName, ruleName, addressRefFieldRaw),
 			},
 			resource.TestStep{
 				ResourceName:      "google_compute_forwarding_rule.foobar",
@@ -139,7 +150,7 @@ resource "google_compute_forwarding_rule" "foobar" {
 `, poolName, poolName, ruleName)
 }
 
-func testAccComputeForwardingRule_ip(addrName, poolName, ruleName string) string {
+func testAccComputeForwardingRule_ip(addrName, poolName, ruleName, addressRefFieldValue string) string {
 	return fmt.Sprintf(`
 resource "google_compute_address" "foo" {
   name = "%s"
@@ -153,13 +164,13 @@ resource "google_compute_target_pool" "foobar-tp" {
 
 resource "google_compute_forwarding_rule" "foobar" {
   description = "Resource created for Terraform acceptance testing"
-  ip_address  = google_compute_address.foo.address
+  ip_address  = google_compute_address.foo.%s
   ip_protocol = "TCP"
   name        = "%s"
   port_range  = "80-81"
   target      = google_compute_target_pool.foobar-tp.self_link
 }
-`, addrName, poolName, ruleName)
+`, addrName, poolName, addressRefFieldValue, ruleName)
 }
 
 func testAccComputeForwardingRule_networkTier(poolName, ruleName string) string {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Part of https://github.com/hashicorp/terraform-provider-google/issues/8454

This API only accepts a reference under some circumstances, but returns the raw IP. This adopts the strategy used in `google_compute_global_forwarding_rule` in https://github.com/hashicorp/terraform-provider-google/issues/8018 to resolve that issue. Thinking about it, I don't love the solution- if a user changes the address they're referencing, Terraform won't see a diff- but it's consistent and means if we fix that issue with GFR we can apply the same fix to FR. 

I removed the custom Terraform documentation for each field (adding a note on top of the MMv1 docs) and updated the MMv1 docs at the same time, mostly removing the rules about what IP can be used where & linking the canonical source instead.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added the ability to specify `google_compute_forwarding_rule.ip_address` by a reference in addition to raw IP address
```
