### PR TITLE
Dataproc, container cluster, backend bucket test fixes

### DIFF
--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -167,6 +167,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       cdnPolicy.negativeCaching: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      cdnPolicy.serveWhileStale: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      cdnPolicy.clientTtl: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      cdnPolicy.defaultTtl: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
+      cdnPolicy.maxTtl: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
   BackendBucketSignedUrlKey: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude_import: true
     exclude_validator: true

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -2771,7 +2771,6 @@ resource "google_container_cluster" "with_cluster_telemetry" {
   name               = "%s"
   location           = "us-central1-a"
   initial_node_count = 1
-  min_master_version = "1.15"
 
   cluster_telemetry {
     type = "%s"

--- a/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -569,7 +569,7 @@ func TestAccDataprocCluster_withOptionalComponents(t *testing.T) {
 				Config: testAccDataprocCluster_withOptionalComponents(rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_opt_components", &cluster),
-					testAccCheckDataprocClusterHasOptionalComponents(&cluster, "ANACONDA", "ZOOKEEPER"),
+					testAccCheckDataprocClusterHasOptionalComponents(&cluster, "DOCKER", "ZOOKEEPER"),
 				),
 			},
 		},
@@ -1439,7 +1439,7 @@ resource "google_dataproc_cluster" "with_opt_components" {
 
   cluster_config {
     software_config {
-      optional_components = ["ANACONDA", "ZOOKEEPER"]
+      optional_components = ["DOCKER", "ZOOKEEPER"]
     }
   }
 }

--- a/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -569,7 +569,7 @@ func TestAccDataprocCluster_withOptionalComponents(t *testing.T) {
 				Config: testAccDataprocCluster_withOptionalComponents(rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.with_opt_components", &cluster),
-					testAccCheckDataprocClusterHasOptionalComponents(&cluster, "DOCKER", "ZOOKEEPER"),
+					testAccCheckDataprocClusterHasOptionalComponents(&cluster, "ZOOKEEPER", "DOCKER"),
 				),
 			},
 		},


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
ANACONDA is not supported on Dataproc clusters V2+, miniconda is preinstalled.

Backend bucket fields seem to be coming back from the API now

Container cluster version 1.15 is no longer supported, default should work now?

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
