### PR TITLE
Change address purposes to strings

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -120,22 +120,16 @@ objects:
           following characters must be a dash, lowercase letter, or digit,
           except the last character, which cannot be a dash.
         required: true
-      - !ruby/object:Api::Type::Enum
+      - !ruby/object:Api::Type::String
         name: purpose
         description: |
-          The purpose of this resource, which can be one of the following values:
+          The purpose of this resource. Possible values include:
 
           * GCE_ENDPOINT for addresses that are used by VM instances, alias IP ranges, internal load balancers, and similar resources.
 
           * SHARED_LOADBALANCER_VIP for an address that can be used by multiple internal load balancers.
 
           * VPC_PEERING for addresses that are reserved for VPC peer networks.
-
-          This should only be set when using an Internal address.
-        values:
-          - :GCE_ENDPOINT
-          - :VPC_PEERING
-          - :SHARED_LOADBALANCER_VIP
       - !ruby/object:Api::Type::Enum
         name: 'networkTier'
         description: |
@@ -3992,18 +3986,14 @@ objects:
         - :EXTERNAL
         - :INTERNAL
         default_value: :EXTERNAL
-      - !ruby/object:Api::Type::Enum
+      - !ruby/object:Api::Type::String
         name: 'purpose'
         description: |
-          The purpose of the resource. For global internal addresses it can be
+          The purpose of the resource. Possible values include:
 
           * VPC_PEERING - for peer networks
-          * PRIVATE_SERVICE_CONNECT - for ([Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) only) Private Service Connect networks
 
-          This should only be set when using an Internal address.
-        values:
-        - :VPC_PEERING
-        - :PRIVATE_SERVICE_CONNECT
+          * PRIVATE_SERVICE_CONNECT - for ([Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html) only) Private Service Connect networks
       - !ruby/object:Api::Type::ResourceRef
         name: 'network'
         resource: 'Network'


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

I'm not sure if this actually has any user impact so there's no changelog entry, but we won't block users wanting to adopt new `purpose`s. New ones come up too frequently for me to want to track possible values anymore.

Interestingly, comparing to https://cloud.google.com/compute/docs/reference/rest/beta/addresses and https://cloud.google.com/compute/docs/reference/rest/beta/globalAddresses, we support some purposes that don't appear there and don't support purposes that do. That's an even more clear sign we should get out of the business of tracking these. 

The c.g.c page additionally doesn't disambiguate between what's available in global / regional addresses, and some of them are external so I removed the internal warning in both types.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
