### PR TITLE
fixed empty serviceaccount.scopes in compute instance

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go
@@ -574,10 +574,11 @@ func resourceComputeInstance() *schema.Resource {
 			},
 
 			"service_account": {
-				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
-				Description: `The service account to attach to the instance.`,
+				Type:             schema.TypeList,
+				MaxItems:         1,
+				Optional:         true,
+				DiffSuppressFunc: emptyOrEmptySetDiffSuppress,
+				Description:      `The service account to attach to the instance.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"email": {

--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go
@@ -577,7 +577,7 @@ func resourceComputeInstance() *schema.Resource {
 				Type:             schema.TypeList,
 				MaxItems:         1,
 				Optional:         true,
-				DiffSuppressFunc: emptyOrEmptySetDiffSuppress,
+				DiffSuppressFunc: serviceAccountDiffSuppress,
 				Description:      `The service account to attach to the instance.`,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -2239,4 +2239,29 @@ func hash256(raw string) (string, error) {
 	}
 	h := sha256.Sum256(decoded)
 	return base64.StdEncoding.EncodeToString(h[:]), nil
+}
+
+func serviceAccountDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	o, n := d.GetChange(strings.TrimSuffix(k, ".#"))
+	var l []interface{}
+	if old == "0" && new == "1" {
+		l = n.([]interface{})
+	} else if new == "0" && old == "1" {
+		l = o.([]interface{})
+	} else {
+		// we don't have one set and one unset, so don't suppress the diff
+		return false
+	}
+
+	// suppress changes between { } and {scopes:[]}
+	if l[0] != nil {
+		contents := l[0].(map[string]interface{})
+		if scopes, ok := contents["scopes"]; ok {
+			a := scopes.(*schema.Set).List()
+			if a != nil && len(a) > 0 {
+				return false
+			}
+		}
+	}
+	return true
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go
@@ -800,6 +800,57 @@ func TestAccComputeInstance_serviceAccount(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_serviceAccount_updated(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	var instanceName = fmt.Sprintf("tf-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_serviceAccount_update0(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceScopes(&instance, 0),
+				),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{"allow_stopping_for_update"}),
+			{
+				Config: testAccComputeInstance_serviceAccount_update01(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceScopes(&instance, 0),
+				),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{"allow_stopping_for_update"}),
+			{
+				Config: testAccComputeInstance_serviceAccount_update02(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceScopes(&instance, 0),
+				),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{"allow_stopping_for_update"}),
+			{
+				Config: testAccComputeInstance_serviceAccount_update3(instanceName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeInstanceScopes(&instance, 3),
+				),
+			},
+			computeInstanceImportStep("us-central1-a", instanceName, []string{"allow_stopping_for_update"}),
+		},
+	})
+}
+
 func TestAccComputeInstance_scheduling(t *testing.T) {
 	t.Parallel()
 
@@ -2494,6 +2545,30 @@ func testAccCheckComputeInstanceServiceAccount(instance *compute.Instance, scope
 	}
 }
 
+func testAccCheckComputeInstanceScopes(instance *compute.Instance, scopeCount int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		if count := len(instance.ServiceAccounts); count == 0 {
+			if scopeCount == 0 {
+				return nil
+			} else {
+				return fmt.Errorf("Scope count expected: %s, but got %s", fmt.Sprint(scopeCount), fmt.Sprint(count))
+			}
+		} else {
+			if count := len(instance.ServiceAccounts); count != 1 {
+				return fmt.Errorf("Wrong number of ServiceAccounts: expected 1, got %d", count)
+			}
+
+			if scount := len(instance.ServiceAccounts[0].Scopes); scount == scopeCount {
+				return nil
+			} else {
+				return fmt.Errorf("Scope count expected: %s, but got %s", fmt.Sprint(scopeCount), fmt.Sprint(scount))
+			}
+		}
+		return fmt.Errorf("Scope count not found: %s", fmt.Sprint(scopeCount))
+	}
+}
+
 func testAccCheckComputeInstanceHasSubnet(instance *compute.Instance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, i := range instance.NetworkInterfaces {
@@ -3803,6 +3878,134 @@ resource "google_compute_instance" "foobar" {
       "storage-ro",
     ]
   }
+}
+`, instance)
+}
+
+func testAccComputeInstance_serviceAccount_update0(instance string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+  allow_stopping_for_update = true
+}
+`, instance)
+}
+
+func testAccComputeInstance_serviceAccount_update01(instance string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  service_account {
+    scopes = []
+  }
+  allow_stopping_for_update = true
+}
+
+data "google_compute_default_service_account" "default" {
+}
+`, instance)
+}
+
+func testAccComputeInstance_serviceAccount_update02(instance string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  service_account {
+    email = data.google_compute_default_service_account.default.email
+    scopes = []
+  }
+  allow_stopping_for_update = true
+}
+
+data "google_compute_default_service_account" "default" {
+}
+`, instance)
+}
+
+func testAccComputeInstance_serviceAccount_update3(instance string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  service_account {
+    scopes = [
+      "userinfo-email",
+      "compute-ro",
+      "storage-ro",
+    ]
+  }
+
+  allow_stopping_for_update = true
 }
 `, instance)
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go
@@ -2565,7 +2565,6 @@ func testAccCheckComputeInstanceScopes(instance *compute.Instance, scopeCount in
 				return fmt.Errorf("Scope count expected: %s, but got %s", fmt.Sprint(scopeCount), fmt.Sprint(scount))
 			}
 		}
-		return fmt.Errorf("Scope count not found: %s", fmt.Sprint(scopeCount))
 	}
 }
 

--- a/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
@@ -165,3 +165,32 @@ func timestampDiffSuppress(format string) schema.SchemaDiffSuppressFunc {
 func internalIpDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 	return (net.ParseIP(old) != nil) && (net.ParseIP(new) == nil)
 }
+
+// suppress the diff between { } and {[]}
+func emptyOrEmptySetDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	o, n := d.GetChange(strings.TrimSuffix(k, ".#"))
+	var l []interface{}
+	if old == "0" && new == "1" {
+		l = n.([]interface{})
+	} else if new == "0" && old == "1" {
+		l = o.([]interface{})
+	} else {
+		// we don't have one set and one unset, so don't suppress the diff
+		return false
+	}
+
+	if l[0] != nil {
+		contents := l[0].(map[string]interface{})
+		for _, v := range contents {
+			if reflect.TypeOf(v).String() == "*schema.Set" {
+				a := v.(*schema.Set).List()
+				if len(a) > 0 {
+					return false
+				}
+			} else if !isEmptyValue(reflect.ValueOf(v)) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
@@ -165,32 +165,3 @@ func timestampDiffSuppress(format string) schema.SchemaDiffSuppressFunc {
 func internalIpDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 	return (net.ParseIP(old) != nil) && (net.ParseIP(new) == nil)
 }
-
-// suppress the diff between { } and {[]}
-func emptyOrEmptySetDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
-	o, n := d.GetChange(strings.TrimSuffix(k, ".#"))
-	var l []interface{}
-	if old == "0" && new == "1" {
-		l = n.([]interface{})
-	} else if new == "0" && old == "1" {
-		l = o.([]interface{})
-	} else {
-		// we don't have one set and one unset, so don't suppress the diff
-		return false
-	}
-
-	if l[0] != nil {
-		contents := l[0].(map[string]interface{})
-		for _, v := range contents {
-			if reflect.TypeOf(v).String() == "*schema.Set" {
-				a := v.(*schema.Set).List()
-				if len(a) > 0 {
-					return false
-				}
-			} else if !isEmptyValue(reflect.ValueOf(v)) {
-				return false
-			}
-		}
-	}
-	return true
-}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/8871


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed error when creating empty `scopes` on `google_compute_instance`
```
