### PR TITLE
Adding shielded config values to dataproc_cluster

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_dataproc_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_dataproc_cluster.go.erb
@@ -31,7 +31,14 @@ var (
 		"cluster_config.0.gce_cluster_config.0.service_account",
 		"cluster_config.0.gce_cluster_config.0.service_account_scopes",
 		"cluster_config.0.gce_cluster_config.0.internal_ip_only",
+		"cluster_config.0.gce_cluster_config.0.shielded_instance_config",
 		"cluster_config.0.gce_cluster_config.0.metadata",
+	}
+
+	schieldedInstanceConfigKeys = []string{
+		"cluster_config.0.gce_cluster_config.0.shielded_instance_config.0.enable_secure_boot",
+		"cluster_config.0.gce_cluster_config.0.shielded_instance_config.0.enable_vtpm",
+		"cluster_config.0.gce_cluster_config.0.shielded_instance_config.0.enable_integrity_monitoring",
 	}
 
 	preemptibleWorkerDiskConfigKeys = []string{
@@ -267,6 +274,43 @@ func resourceDataprocCluster() *schema.Resource {
 										Elem:         &schema.Schema{Type: schema.TypeString},
 										ForceNew:     true,
 										Description:  `A map of the Compute Engine metadata entries to add to all instances`,
+									},
+
+									"shielded_instance_config": {
+										Type:         schema.TypeList,
+										Optional:     true,
+										AtLeastOneOf: gceClusterConfigKeys,
+										Computed:     true,
+										MaxItems:     1,
+										Description:  `Shielded Instance Config for clusters using Compute Engine Shielded VMs.`,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"enable_secure_boot": {
+													Type:         schema.TypeBool,
+													Optional:     true,
+													Default:      false,
+													AtLeastOneOf: schieldedInstanceConfigKeys,
+													ForceNew:     true,
+													Description:  `Defines whether instances have Secure Boot enabled.`,
+												},
+												"enable_vtpm": {
+													Type:         schema.TypeBool,
+													Optional:     true,
+													Default:      false,
+													AtLeastOneOf: schieldedInstanceConfigKeys,
+													ForceNew:     true,
+													Description:  `Defines whether instances have the vTPM enabled.`,
+												},
+												"enable_integrity_monitoring": {
+													Type:         schema.TypeBool,
+													Optional:     true,
+													Default:      false,
+													AtLeastOneOf: schieldedInstanceConfigKeys,
+													ForceNew:     true,
+													Description:  `Defines whether instances have integrity monitoring enabled.`,
+												},
+											},
+										},
 									},
 								},
 							},
@@ -971,6 +1015,19 @@ func expandGceClusterConfig(d *schema.ResourceData, config *Config) (*dataproc.G
 	if v, ok := cfg["metadata"]; ok {
 		conf.Metadata = convertStringMap(v.(map[string]interface{}))
 	}
+	if v, ok := d.GetOk("cluster_config.0.gce_cluster_config.0.shielded_instance_config"); ok {
+		cfgSic := v.([]interface{})[0].(map[string]interface{})
+		conf.ShieldedInstanceConfig = &dataproc.ShieldedInstanceConfig{}
+		if v, ok := cfgSic["enable_integrity_monitoring"]; ok {
+			conf.ShieldedInstanceConfig.EnableIntegrityMonitoring = v.(bool)
+		}
+		if v, ok := cfgSic["enable_secure_boot"]; ok {
+			conf.ShieldedInstanceConfig.EnableSecureBoot = v.(bool)
+		}
+		if v, ok := cfgSic["enable_vtpm"]; ok {
+			conf.ShieldedInstanceConfig.EnableVtpm = v.(bool)
+		}
+	}
 	return conf, nil
 }
 
@@ -1354,13 +1411,13 @@ func flattenClusterConfig(d *schema.ResourceData, cfg *dataproc.ClusterConfig) (
 		"bucket":                    cfg.ConfigBucket,
 		"temp_bucket":               cfg.TempBucket,
 		"gce_cluster_config":        flattenGceClusterConfig(d, cfg.GceClusterConfig),
-		"security_config":           flattenSecurityConfig(d, cfg.SecurityConfig),
-		"software_config":           flattenSoftwareConfig(d, cfg.SoftwareConfig),
 		"master_config":             flattenInstanceGroupConfig(d, cfg.MasterConfig),
 		"worker_config":             flattenInstanceGroupConfig(d, cfg.WorkerConfig),
-		"preemptible_worker_config": flattenPreemptibleInstanceGroupConfig(d, cfg.SecondaryWorkerConfig),
+		"software_config":           flattenSoftwareConfig(d, cfg.SoftwareConfig),
 		"encryption_config":         flattenEncryptionConfig(d, cfg.EncryptionConfig),
 		"autoscaling_config":        flattenAutoscalingConfig(d, cfg.AutoscalingConfig),
+		"security_config":           flattenSecurityConfig(d, cfg.SecurityConfig),
+		"preemptible_worker_config": flattenPreemptibleInstanceGroupConfig(d, cfg.SecondaryWorkerConfig),
 <% unless version == 'ga' -%>
 		"lifecycle_config": flattenLifecycleConfig(d, cfg.LifecycleConfig),
 		"endpoint_config":  flattenEndpointConfig(d, cfg.EndpointConfig),
@@ -1527,6 +1584,15 @@ func flattenGceClusterConfig(d *schema.ResourceData, gcc *dataproc.GceClusterCon
 	}
 	if len(gcc.ServiceAccountScopes) > 0 {
 		gceConfig["service_account_scopes"] = schema.NewSet(stringScopeHashcode, convertStringArrToInterface(gcc.ServiceAccountScopes))
+	}
+	if gcc.ShieldedInstanceConfig != nil {
+		gceConfig["shielded_instance_config"] = []map[string]interface{}{
+			{
+				"enable_integrity_monitoring": gcc.ShieldedInstanceConfig.EnableIntegrityMonitoring,
+				"enable_secure_boot":          gcc.ShieldedInstanceConfig.EnableSecureBoot,
+				"enable_vtpm":                 gcc.ShieldedInstanceConfig.EnableVtpm,
+			},
+		}
 	}
 
 	return []map[string]interface{}{gceConfig}

--- a/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dataproc_cluster_test.go.erb
@@ -282,7 +282,7 @@ func testAccCheckDataprocClusterAccelerator(cluster *dataproc.Cluster, project s
 	}
 }
 
-func TestAccDataprocCluster_withInternalIpOnlyTrue(t *testing.T) {
+func TestAccDataprocCluster_withInternalIpOnlyTrueAndShieldedConfig(t *testing.T) {
 	t.Parallel()
 
 	var cluster dataproc.Cluster
@@ -293,12 +293,15 @@ func TestAccDataprocCluster_withInternalIpOnlyTrue(t *testing.T) {
 		CheckDestroy: testAccCheckDataprocClusterDestroy(t),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataprocCluster_withInternalIpOnlyTrue(rnd),
+				Config: testAccDataprocCluster_withInternalIpOnlyTrueAndShieldedConfig(rnd),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDataprocClusterExists(t, "google_dataproc_cluster.basic", &cluster),
 
 					// Testing behavior for Dataproc to use only internal IP addresses
 					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.internal_ip_only", "true"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.shielded_instance_config.0.enable_integrity_monitoring", "true"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.shielded_instance_config.0.enable_secure_boot", "true"),
+					resource.TestCheckResourceAttr("google_dataproc_cluster.basic", "cluster_config.0.gce_cluster_config.0.shielded_instance_config.0.enable_vtpm", "true"),
 				),
 			},
 		},
@@ -1074,7 +1077,7 @@ resource "google_dataproc_cluster" "accelerated_cluster" {
 `, rnd, zone, acceleratorType, acceleratorType)
 }
 
-func testAccDataprocCluster_withInternalIpOnlyTrue(rnd string) string {
+func testAccDataprocCluster_withInternalIpOnlyTrueAndShieldedConfig(rnd string) string {
 	return fmt.Sprintf(`
 variable "subnetwork_cidr" {
   default = "10.0.0.0/16"
@@ -1135,6 +1138,11 @@ resource "google_dataproc_cluster" "basic" {
     gce_cluster_config {
       subnetwork       = google_compute_subnetwork.dataproc_subnetwork.name
       internal_ip_only = true
+      shielded_instance_config{
+        enable_integrity_monitoring = true
+        enable_secure_boot          = true
+        enable_vtpm                 = true
+      }
     }
   }
 }

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -286,7 +286,7 @@ cluster_config{
 
 * `enable_secure_boot` - (Optional) Defines whether instances have Secure Boot enabled.
 
-* `enable_vtpm` - (Optional) Defines whether instances have the vTPM enabled.
+* `enable_vtpm` - (Optional) Defines whether instances have the [vTPM](https://cloud.google.com/security/shielded-cloud/shielded-vm#vtpm) enabled.
 
 * `enable_integrity_monitoring` - (Optional) Defines whether instances have integrity monitoring enabled.
 

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -284,7 +284,7 @@ cluster_config{
 }
 ```
 
-* `enable_secure_boot` - (Optional) efines whether instances have Secure Boot enabled.
+* `enable_secure_boot` - (Optional) Defines whether instances have Secure Boot enabled.
 
 * `enable_vtpm` - (Optional) Defines whether instances have the vTPM enabled.
 

--- a/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/dataproc_cluster.html.markdown
@@ -265,6 +265,31 @@ The `cluster_config.gce_cluster_config` block supports:
 * `metadata` - (Optional) A map of the Compute Engine metadata entries to add to all instances
    (see [Project and instance metadata](https://cloud.google.com/compute/docs/storing-retrieving-metadata#project_and_instance_metadata)).
 
+* `shielded_instance_config` (Optional) Shielded Instance Config for clusters using [Compute Engine Shielded VMs](https://cloud.google.com/security/shielded-cloud/shielded-vm).
+
+- - -
+
+
+The `cluster_config.gce_cluster_config.shielded_instance_config` block supports:
+
+```hcl
+cluster_config{
+  gce_cluster_config{
+    shielded_instance_config{
+      enable_secure_boot          = true
+      enable_vtpm                 = true
+      enable_integrity_monitoring = true
+    }
+  }
+}
+```
+
+* `enable_secure_boot` - (Optional) efines whether instances have Secure Boot enabled.
+
+* `enable_vtpm` - (Optional) Defines whether instances have the vTPM enabled.
+
+* `enable_integrity_monitoring` - (Optional) Defines whether instances have integrity monitoring enabled.
+
 - - -
 
 The `cluster_config.master_config` block supports:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

closes https://github.com/hashicorp/terraform-provider-google/issues/8092

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dataproc: added `shielded_instance_config` fields to `google_dataproc_cluster`
```
