### PR TITLE
Fix the provider.go imports

### DIFF
--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-provider-google-beta/version"
 
 	googleoauth "golang.org/x/oauth2/google"
 )

--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -2,13 +2,14 @@
 package google
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-provider-google-beta/version"
 
 	googleoauth "golang.org/x/oauth2/google"
 )


### PR DESCRIPTION
This now matches what is currently used in the file and used in the generated terraform provider.go files

As of now when you run the bundle command as described in the contributing section (https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools) it generates code with the following errors:

```
make build
==> Checking source code against gofmt...                                                                                                                                                                            
==> Checking that code complies with gofmt requirements...                                                                                                                                                           
go generate  ./...                                                                                                                                                                                                   
go install                                                                                                                                                                                                           
# github.com/hashicorp/terraform-provider-google-beta/google-beta                                                                                                                                                    
google-beta/provider.go:4:2: imported and not used: "encoding/json"                                                                                                                                                  
google-beta/provider.go:10:2: imported and not used: "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"                                                                                                        
google-beta/provider.go:831:43: undefined: context                                                                                                                                                                   
google-beta/provider.go:1328:28: undefined: context                                                                                                                                                                  
google-beta/provider.go:1335:70: undefined: version
google-beta/provider.go:1346:32: undefined: time                                                          
google-beta/provider.go:1508:47: undefined: context                                                       
make: *** [GNUmakefile:9: build] Error 2      
```

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
  There are a few unrelated files that are broken and a lot of already existing lint errors.

- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
