### PR TITLE
added more gcs bucket lifecycle conditions

### DIFF
--- a/mmv1/products/storage/ansible_version_added.yaml
+++ b/mmv1/products/storage/ansible_version_added.yaml
@@ -63,10 +63,18 @@
             :version_added: '2.6'
           :createdBefore:
             :version_added: '2.6'
+          :customTimeBefore:
+            :version_added: '2.10'
+          :daysSinceCustomTime:
+            :version_added: '2.10'
+          :daysSinceNoncurrentTime:
+            :version_added: '2.10'
           :isLive:
             :version_added: '2.6'
           :matchesStorageClass:
             :version_added: '2.6'
+          :noncurrentTimeBefore:
+            :version_added: '2.10'
           :numNewerVersions:
             :version_added: '2.6'
     :location:
@@ -97,6 +105,8 @@
         :version_added: '2.6'
       :notFoundPage:
         :version_added: '2.6'
+    :labels:
+      :version_added: '2.10'
     :project:
       :version_added: '2.6'
     :predefinedDefaultObjectAcl:

--- a/mmv1/products/storage/api.yaml
+++ b/mmv1/products/storage/api.yaml
@@ -289,6 +289,26 @@ objects:
                         instance, "2013-01-15"). This condition is satisfied
                         when an object is created before midnight of the
                         specified date in UTC.
+                    - !ruby/object:Api::Type::Time
+                      name: 'customTimeBefore'
+                      description: |
+                        A date in the RFC 3339 format YYYY-MM-DD. This condition
+                        is satisfied when the customTime metadata for the object
+                        is set to an earlier date than the date used in
+                        this lifecycle condition.
+                    - !ruby/object:Api::Type::Integer
+                      name: 'daysSinceCustomTime'
+                      description: |
+                        Days since the date set in the customTime metadata for the
+                        object. This condition is satisfied when the current date
+                        and time is at least the specified number of days after
+                        the customTime.
+                    - !ruby/object:Api::Type::Integer
+                      name: 'daysSinceNoncurrentTime'
+                      description: |
+                        Relevant only for versioned objects. This condition is
+                        satisfied when an object has been noncurrent for more than
+                        the specified number of days.
                     - !ruby/object:Api::Type::Boolean
                       name: 'isLive'
                       description: |
@@ -303,6 +323,13 @@ objects:
                         MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE,
                         STANDARD, and DURABLE_REDUCED_AVAILABILITY.
                       item_type: Api::Type::String
+                    - !ruby/object:Api::Type::Time
+                      name: 'noncurrentTimeBefore'
+                      description: |
+                        Relevant only for versioned objects. A date in the
+                        RFC 3339 format YYYY-MM-DD. This condition is satisfied
+                        for objects that became noncurrent on a date prior to the
+                        one specified in this condition.
                     - !ruby/object:Api::Type::Integer
                       name: 'numNewerVersions'
                       description: |


### PR DESCRIPTION
Signed-off-by: Denis Dabischa <denis.dabischa@kloeckner.com>

Added more lifecycle conditions: noncurrentTimeBefore, daysSinceNoncurrentTime, daysSinceCustomTime, customTimeBefore

If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

*PR is not for Terraform, Terraform was already solved in PR #4221*


```release-note:enhancement
storage: added more lifecycle conditions to `google_storage_bucket` resource
```
