### PR TITLE
Switched tests relying on HTTP protocol to use INTERNAL_MANAGED load balancing

### DIFF
--- a/mmv1/templates/terraform/examples/region_ssl_certificate_target_https_proxies.tf.erb
+++ b/mmv1/templates/terraform/examples/region_ssl_certificate_target_https_proxies.tf.erb
@@ -53,6 +53,7 @@ resource "google_compute_region_backend_service" "default" {
   region      = "us-central1"
   name        = "<%= ctx[:vars]['region_backend_service_name'] %>"
   protocol    = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
   timeout_sec = 10
 
   health_checks = [google_compute_region_health_check.default.id]

--- a/mmv1/templates/terraform/examples/region_target_https_proxy_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/region_target_https_proxy_basic.tf.erb
@@ -39,6 +39,7 @@ resource "google_compute_region_backend_service" "default" {
   region      = "us-central1"
   name        = "<%= ctx[:vars]['region_backend_service_name'] %>"
   protocol    = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
   timeout_sec = 10
 
   health_checks = [google_compute_region_health_check.default.id]

--- a/mmv1/templates/terraform/examples/region_url_map_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/region_url_map_basic.tf.erb
@@ -38,6 +38,7 @@ resource "google_compute_region_backend_service" "login" {
 
   name        = "<%= ctx[:vars]['login_region_backend_service_name'] %>"
   protocol    = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
   timeout_sec = 10
 
   health_checks = [google_compute_region_health_check.default.id]
@@ -48,6 +49,7 @@ resource "google_compute_region_backend_service" "home" {
 
   name        = "<%= ctx[:vars]['home_region_backend_service_name'] %>"
   protocol    = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
   timeout_sec = 10
 
   health_checks = [google_compute_region_health_check.default.id]

--- a/mmv1/third_party/terraform/tests/resource_compute_region_target_http_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_target_http_proxy_test.go.erb
@@ -54,6 +54,7 @@ resource "google_compute_region_backend_service" "foobar" {
   name          = "%s"
   health_checks = [google_compute_region_health_check.zero.self_link]
   protocol      = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
 }
 
 resource "google_compute_region_health_check" "zero" {
@@ -121,6 +122,7 @@ resource "google_compute_region_backend_service" "foobar" {
   name          = "%s"
   health_checks = [google_compute_region_health_check.zero.self_link]
   protocol      = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
 }
 
 resource "google_compute_region_health_check" "zero" {

--- a/mmv1/third_party/terraform/tests/resource_compute_region_target_https_proxy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_target_https_proxy_test.go.erb
@@ -51,12 +51,14 @@ resource "google_compute_region_backend_service" "foobar1" {
   name          = "httpsproxy-test-backend1-%s"
   health_checks = [google_compute_region_health_check.zero.self_link]
   protocol      = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
 }
 
 resource "google_compute_region_backend_service" "foobar2" {
   name          = "httpsproxy-test-backend2-%s"
   health_checks = [google_compute_region_health_check.one.self_link]
   protocol      = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
 }
 
 resource "google_compute_region_health_check" "zero" {
@@ -149,12 +151,14 @@ resource "google_compute_region_backend_service" "foobar1" {
   name          = "httpsproxy-test-backend1-%s"
   health_checks = [google_compute_region_health_check.zero.self_link]
   protocol      = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
 }
 
 resource "google_compute_region_backend_service" "foobar2" {
   name          = "httpsproxy-test-backend2-%s"
   health_checks = [google_compute_region_health_check.one.self_link]
   protocol      = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
 }
 
 resource "google_compute_region_health_check" "zero" {

--- a/mmv1/third_party/terraform/tests/resource_compute_region_url_map_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_url_map_test.go.erb
@@ -209,6 +209,7 @@ resource "google_compute_region_backend_service" "foobar" {
   region        = "us-central1"
   name          = "regionurlmap-test-%s"
   protocol      = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
   health_checks = [google_compute_region_health_check.zero.self_link]
 }
 
@@ -255,6 +256,7 @@ resource "google_compute_region_backend_service" "foobar" {
   region        = "us-central1"
   name          = "regionurlmap-test-%s"
   protocol      = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
   health_checks = [google_compute_region_health_check.zero.self_link]
 }
 
@@ -301,6 +303,7 @@ resource "google_compute_region_backend_service" "foobar" {
   region        = "us-central1"
   name          = "regionurlmap-test-%s"
   protocol      = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
   health_checks = [google_compute_region_health_check.zero.self_link]
 }
 
@@ -356,6 +359,7 @@ resource "google_compute_region_backend_service" "foobar" {
   region        = "us-central1"
   name          = "regionurlmap-test-%s"
   protocol      = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
   health_checks = [google_compute_region_health_check.zero.self_link]
 }
 
@@ -431,6 +435,7 @@ resource "google_compute_region_backend_service" "foobar" {
   region        = "us-central1"
   name          = "regionurlmap-test-%s"
   protocol      = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
   health_checks = [google_compute_region_health_check.zero.self_link]
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The altered tests rely on the HTTP protocol; this used to be supported by INTERNAL load balancing (the default) but that seems to no longer be the case. https://cloud.google.com/load-balancing/docs/choosing-load-balancer#summary-of-google-cloud-load-balancers I've updated the tests to use INTERNAL_MANAGED instead.

It looks like the relevant docs are auto-generated and don't need to be updated manually.

Resolved https://github.com/hashicorp/terraform-provider-google/issues/8925


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
