### PR TITLE
Updated usage of " eq " in instance template filters

### DIFF
--- a/mmv1/third_party/terraform/tests/data_source_google_compute_instance_template_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_compute_instance_template_test.go
@@ -157,7 +157,7 @@ resource "google_compute_instance_template" "c" {
 data "google_compute_instance_template" "default" {
   // Hack to prevent depends_on bug triggering datasource recreate due to https://github.com/hashicorp/terraform/issues/11806
   project = "%{project}${replace(google_compute_instance_template.a.id, "/.*/", "")}${replace(google_compute_instance_template.b.id, "/.*/", "")}${replace(google_compute_instance_template.c.id, "/.*/", "")}"
-  filter  = "name eq tf-test-template-c-.*"
+  filter  = "name = tf-test-template-c-%{suffix}"
 }
 `, map[string]interface{}{"project": project, "suffix": suffix})
 }
@@ -231,7 +231,7 @@ resource "google_compute_instance_template" "c" {
 data "google_compute_instance_template" "default" {
   // Hack to prevent depends_on bug triggering datasource recreate due to https://github.com/hashicorp/terraform/issues/11806
   project = "%{project}${replace(google_compute_instance_template.b.id, "/.*/", "")}"
-  filter      = "name eq tf-test-template-.*"
+  filter      = "name != tf-test-template-%{suffix}-b"
   most_recent = true
 }
 `, map[string]interface{}{"project": project, "suffix": suffix})

--- a/mmv1/third_party/terraform/tests/data_source_google_compute_instance_template_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_compute_instance_template_test.go
@@ -202,6 +202,7 @@ resource "google_compute_instance_template" "b" {
 
   depends_on = [
     google_compute_instance_template.a,
+    google_compute_instance_template.c,
   ]
 }
 resource "google_compute_instance_template" "c" {
@@ -224,13 +225,12 @@ resource "google_compute_instance_template" "c" {
 
   depends_on = [
     google_compute_instance_template.a,
-    google_compute_instance_template.b,
   ]
 }
 
 data "google_compute_instance_template" "default" {
   // Hack to prevent depends_on bug triggering datasource recreate due to https://github.com/hashicorp/terraform/issues/11806
-  project = "%{project}${replace(google_compute_instance_template.c.id, "/.*/", "")}"
+  project = "%{project}${replace(google_compute_instance_template.b.id, "/.*/", "")}"
   filter      = "name eq tf-test-template-.*"
   most_recent = true
 }

--- a/mmv1/third_party/terraform/website/docs/d/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/d/compute_instance_template.html.markdown
@@ -24,7 +24,7 @@ data "google_compute_instance_template" "generic" {
 
 # using a filter
 data "google_compute_instance_template" "generic-regex" {
-  filter      = "name eq generic-tpl-.*"
+  filter      = "name != generic-tpl-20200107"
   most_recent = true
 }
 ```


### PR DESCRIPTION
Resolved https://github.com/hashicorp/terraform-provider-google/issues/8936

When the google compute instance template API was first introduced, it allowed filtering based on the eq keyword; however, that has not been a documented keyword for ~3 years, and ~seems to no longer work~. Additionally, the new filters don't support regular expressions.

> UPDATE: It looks like I was incorrect about the root cause. Here's an example failure: https://ci-oss.hashicorp.engineering/repository/download/GoogleCloudBeta_ProviderGoogleCloudBetaGoogleProject/183032:id/debug-google-beta-309e845-TestAccInstanceTemplateDatasource_filter.log The failure was not due to all three templates (a, b, c) being available, but rather due to there actually being 3 instances that matched, presumably due to concurrent test runs.
>
> That being said, I still believe we should make this update, since it brings us in line with the currently-documented behavior. Also, by ensuring that the most recent instance template with / without filtering are different, we can make sure that if filtering does break in the future, we will catch it.

Test run demonstrating failures after first commit: https://ci-oss.hashicorp.engineering/buildConfiguration/GoogleCloudBeta_ProviderGoogleCloudBetaMmUpstream/183267



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
