### PR TITLE
Made project_service.service validation reject invalid service domains

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_google_project_service.go
+++ b/mmv1/third_party/terraform/resources/resource_google_project_service.go
@@ -56,6 +56,21 @@ var renamedServicesByOldAndNewServiceNames = mergeStringMaps(renamedServices, re
 
 const maxServiceUsageBatchSize = 20
 
+func validateProjectServiceService(val interface{}, key string) (warns []string, errs []error) {
+	bannedServicesFunc := StringNotInSlice(append(ignoredProjectServices, bannedProjectServices...), false)
+	warns, errs = bannedServicesFunc(val, key)
+	if len(errs) > 0 {
+		return
+	}
+
+	// StringNotInSlice already validates that this is a string
+	v, _ := val.(string)
+	if !strings.Contains(v, ".") {
+		errs = append(errs, fmt.Errorf("expected %s to be a domain like serviceusage.googleapis.com", v))
+	}
+	return
+}
+
 func resourceGoogleProjectService() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceGoogleProjectServiceCreate,
@@ -79,7 +94,7 @@ func resourceGoogleProjectService() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
-				ValidateFunc: StringNotInSlice(append(ignoredProjectServices, bannedProjectServices...), false),
+				ValidateFunc: validateProjectServiceService,
 			},
 			"project": {
 				Type:             schema.TypeString,

--- a/mmv1/third_party/terraform/tests/resource_google_project_service_test.go
+++ b/mmv1/third_party/terraform/tests/resource_google_project_service_test.go
@@ -10,6 +10,44 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
+func TestProjectServiceServiceValidateFunc(t *testing.T) {
+	cases := map[string]struct {
+		val                   interface{}
+		ExpectValidationError bool
+	}{
+		"ignoredProjectService": {
+			val:                   "dataproc-control.googleapis.com",
+			ExpectValidationError: true,
+		},
+		"bannedProjectService": {
+			val:                   "bigquery-json.googleapis.com",
+			ExpectValidationError: true,
+		},
+		"third party API": {
+			val:                   "whatever.example.com",
+			ExpectValidationError: false,
+		},
+		"not a domain": {
+			val:                   "monitoring",
+			ExpectValidationError: true,
+		},
+		"not a string": {
+			val:                   5,
+			ExpectValidationError: true,
+		},
+	}
+
+	for tn, tc := range cases {
+		_, errs := validateProjectServiceService(tc.val, "service")
+		if tc.ExpectValidationError && len(errs) == 0 {
+			t.Errorf("bad: %s, %q passed validation but was expected to fail", tn, tc.val)
+		}
+		if !tc.ExpectValidationError && len(errs) > 0 {
+			t.Errorf("bad: %s, %q failed validation but was expected to pass. errs: %q", tn, tc.val, errs)
+		}
+	}
+}
+
 // Test that services can be enabled and disabled on a project
 func TestAccProjectService_basic(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Resolved https://github.com/hashicorp/terraform-provider-google/issues/8875

There are a variety of supported domains (and more may be added). I think adding a simple check for the domain being plausible (i.e. "does it contain a period") should catch simple typos like the one in the linked issue while also being future-proof.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
serviceusage: Made `google_project_service.service` validation reject invalid service domains that don't contain a period
```
