### PR TITLE
Made deletion of all budget filter projects be recognized

### DIFF
--- a/mmv1/products/billingbudget/api.yaml
+++ b/mmv1/products/billingbudget/api.yaml
@@ -29,7 +29,7 @@ objects:
   - !ruby/object:Api::Resource
     name: Budget
     base_url: billingAccounts/{{billing_account}}/budgets
-    self_link: '{{name}}'
+    self_link: 'billingAccounts/{{billing_account}}/budgets/{{name}}'
     update_verb: :PATCH
     # TODO: investigate why updates are not being handled by the API when this
     # is enabled.

--- a/mmv1/products/billingbudget/api.yaml
+++ b/mmv1/products/billingbudget/api.yaml
@@ -31,9 +31,7 @@ objects:
     base_url: billingAccounts/{{billing_account}}/budgets
     self_link: 'billingAccounts/{{billing_account}}/budgets/{{name}}'
     update_verb: :PATCH
-    # TODO: investigate why updates are not being handled by the API when this
-    # is enabled.
-    # update_mask: true
+    update_mask: true
     description: |
       Budget configuration for a billing account.
     references: !ruby/object:Api::Resource::ReferenceLinks

--- a/mmv1/products/billingbudget/terraform.yaml
+++ b/mmv1/products/billingbudget/terraform.yaml
@@ -21,8 +21,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         in the provider configuration. Otherwise the Billing Budgets API will return a 403 error.
         Your account must have the `serviceusage.services.use` permission on the
         `billing_project` you defined.
-    id_format: '{{name}}'
-    exclude_import: true
+    id_format: 'billingAccounts/{{billing_account}}/budgets/{{name}}'
+    import_format: ["billingAccounts/{{billing_account}}/budgets/{{name}}", "{{name}}"]
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: 'billing_budget_basic'
@@ -31,7 +31,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           display_name: 'Example Billing Budget'
         test_env_vars:
           billing_acct: :BILLING_ACCT
-        skip_import_test: true
       - !ruby/object:Provider::Terraform::Examples
         name: 'billing_budget_lastperiod'
         primary_resource_id: 'budget'
@@ -39,7 +38,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           display_name: 'Example Billing Budget'
         test_env_vars:
           billing_acct: :BILLING_ACCT
-        skip_import_test: true
       - !ruby/object:Provider::Terraform::Examples
         name: 'billing_budget_filter'
         primary_resource_id: 'budget'
@@ -47,7 +45,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           display_name: 'Example Billing Budget'
         test_env_vars:
           billing_acct: :BILLING_ACCT
-        skip_import_test: true
       - !ruby/object:Provider::Terraform::Examples
         name: 'billing_budget_notify'
         primary_resource_id: 'budget'
@@ -56,11 +53,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           channel_name: 'Example Notification Channel'
         test_env_vars:
           billing_acct: :BILLING_ACCT
-        skip_import_test: true
-    custom_code: !ruby/object:Provider::Terraform::CustomCode
-      custom_import: templates/terraform/custom_import/self_link_as_name.erb
-      post_create: templates/terraform/post_create/set_computed_name.erb
     properties:
+      name: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
       allUpdatesRule.schemaVersion: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/default_if_empty.erb
       budgetFilter.creditTypes: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/products/billingbudget/terraform.yaml
+++ b/mmv1/products/billingbudget/terraform.yaml
@@ -23,6 +23,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         `billing_project` you defined.
     id_format: 'billingAccounts/{{billing_account}}/budgets/{{name}}'
     import_format: ["billingAccounts/{{billing_account}}/budgets/{{name}}", "{{name}}"]
+    schema_version: 1
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: 'billing_budget_basic'

--- a/mmv1/products/billingbudget/terraform.yaml
+++ b/mmv1/products/billingbudget/terraform.yaml
@@ -62,6 +62,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       budgetFilter: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+        update_mask_fields:
+          - "budgetFilter.projects"
       budgetFilter.services: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       budgetFilter.subaccounts: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/templates/terraform/state_migrations/billing_budget.go.erb
+++ b/mmv1/templates/terraform/state_migrations/billing_budget.go.erb
@@ -1,0 +1,251 @@
+func resourceBillingBudgetResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"amount": {
+				Type:        schema.TypeList,
+				Required:    true,
+				Description: `The budgeted amount for each usage period.`,
+				MaxItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"last_period_amount": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Description: `Configures a budget amount that is automatically set to 100% of
+last period's spend.
+Boolean. Set value to true to use. Do not set to false, instead
+use the 'specified_amount' block.`,
+							ExactlyOneOf: []string{"amount.0.specified_amount", "amount.0.last_period_amount"},
+						},
+						"specified_amount": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Description: `A specified amount to use as the budget. currencyCode is
+optional. If specified, it must match the currency of the
+billing account. The currencyCode is provided on output.`,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"currency_code": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Optional:    true,
+										Description: `The 3-letter currency code defined in ISO 4217.`,
+									},
+									"nanos": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Description: `Number of nano (10^-9) units of the amount.
+The value must be between -999,999,999 and +999,999,999
+inclusive. If units is positive, nanos must be positive or
+zero. If units is zero, nanos can be positive, zero, or
+negative. If units is negative, nanos must be negative or
+zero. For example $-1.75 is represented as units=-1 and
+nanos=-750,000,000.`,
+									},
+									"units": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Description: `The whole units of the amount. For example if currencyCode
+is "USD", then 1 unit is one US dollar.`,
+									},
+								},
+							},
+							ExactlyOneOf: []string{"amount.0.specified_amount", "amount.0.last_period_amount"},
+						},
+					},
+				},
+			},
+			"billing_account": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: `ID of the billing account to set a budget on.`,
+			},
+			"threshold_rules": {
+				Type:     schema.TypeList,
+				Required: true,
+				Description: `Rules that trigger alerts (notifications of thresholds being
+crossed) when spend exceeds the specified percentages of the
+budget.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"threshold_percent": {
+							Type:     schema.TypeFloat,
+							Required: true,
+							Description: `Send an alert when this threshold is exceeded. This is a
+1.0-based percentage, so 0.5 = 50%. Must be >= 0.`,
+						},
+						"spend_basis": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"CURRENT_SPEND", "FORECASTED_SPEND", ""}, false),
+							Description: `The type of basis used to determine if spend has passed
+the threshold. Default value: "CURRENT_SPEND" Possible values: ["CURRENT_SPEND", "FORECASTED_SPEND"]`,
+							Default: "CURRENT_SPEND",
+						},
+					},
+				},
+			},
+			"all_updates_rule": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Description: `Defines notifications that are sent on every update to the
+billing account's spend, regardless of the thresholds defined
+using threshold rules.`,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"disable_default_iam_recipients": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Description: `Boolean. When set to true, disables default notifications sent
+when a threshold is exceeded. Default recipients are
+those with Billing Account Administrators and Billing
+Account Users IAM roles for the target account.`,
+							Default: false,
+						},
+						"monitoring_notification_channels": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Description: `The full resource name of a monitoring notification
+channel in the form
+projects/{project_id}/notificationChannels/{channel_id}.
+A maximum of 5 channels are allowed.`,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							AtLeastOneOf: []string{"all_updates_rule.0.pubsub_topic", "all_updates_rule.0.monitoring_notification_channels"},
+						},
+						"pubsub_topic": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Description: `The name of the Cloud Pub/Sub topic where budget related
+messages will be published, in the form
+projects/{project_id}/topics/{topic_id}. Updates are sent
+at regular intervals to the topic.`,
+							AtLeastOneOf: []string{"all_updates_rule.0.pubsub_topic", "all_updates_rule.0.monitoring_notification_channels"},
+						},
+						"schema_version": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Description: `The schema version of the notification. Only "1.0" is
+accepted. It represents the JSON schema as defined in
+https://cloud.google.com/billing/docs/how-to/budgets#notification_format.`,
+							Default: "1.0",
+						},
+					},
+				},
+			},
+			"budget_filter": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Optional: true,
+				Description: `Filters that define which resources are used to compute the actual
+spend against the budget.`,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"credit_types": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Optional: true,
+							Description: `A set of subaccounts of the form billingAccounts/{account_id},
+specifying that usage from only this set of subaccounts should
+be included in the budget. If a subaccount is set to the name of
+the parent account, usage from the parent account will be included.
+If the field is omitted, the report will include usage from the parent
+account and all subaccounts, if they exist.`,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							AtLeastOneOf: []string{"budget_filter.0.projects", "budget_filter.0.credit_types_treatment", "budget_filter.0.services", "budget_filter.0.subaccounts", "budget_filter.0.labels"},
+						},
+						"credit_types_treatment": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"INCLUDE_ALL_CREDITS", "EXCLUDE_ALL_CREDITS", "INCLUDE_SPECIFIED_CREDITS", ""}, false),
+							Description: `Specifies how credits should be treated when determining spend
+for threshold calculations. Default value: "INCLUDE_ALL_CREDITS" Possible values: ["INCLUDE_ALL_CREDITS", "EXCLUDE_ALL_CREDITS", "INCLUDE_SPECIFIED_CREDITS"]`,
+							Default:      "INCLUDE_ALL_CREDITS",
+							AtLeastOneOf: []string{"budget_filter.0.projects", "budget_filter.0.credit_types_treatment", "budget_filter.0.services", "budget_filter.0.subaccounts", "budget_filter.0.labels"},
+						},
+						"labels": {
+							Type:     schema.TypeMap,
+							Computed: true,
+							Optional: true,
+							Description: `A single label and value pair specifying that usage from only
+this set of labeled resources should be included in the budget.`,
+							Elem:         &schema.Schema{Type: schema.TypeString},
+							AtLeastOneOf: []string{"budget_filter.0.projects", "budget_filter.0.credit_types_treatment", "budget_filter.0.services", "budget_filter.0.subaccounts", "budget_filter.0.labels"},
+						},
+						"projects": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Description: `A set of projects of the form projects/{project_number},
+specifying that usage from only this set of projects should be
+included in the budget. If omitted, the report will include
+all usage for the billing account, regardless of which project
+the usage occurred on.`,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							AtLeastOneOf: []string{"budget_filter.0.projects", "budget_filter.0.credit_types_treatment", "budget_filter.0.services", "budget_filter.0.subaccounts", "budget_filter.0.labels"},
+						},
+						"services": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Optional: true,
+							Description: `A set of services of the form services/{service_id},
+specifying that usage from only this set of services should be
+included in the budget. If omitted, the report will include
+usage for all the services. The service names are available
+through the Catalog API:
+https://cloud.google.com/billing/v1/how-tos/catalog-api.`,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							AtLeastOneOf: []string{"budget_filter.0.projects", "budget_filter.0.credit_types_treatment", "budget_filter.0.services", "budget_filter.0.subaccounts", "budget_filter.0.labels"},
+						},
+						"subaccounts": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Optional: true,
+							Description: `A set of subaccounts of the form billingAccounts/{account_id},
+specifying that usage from only this set of subaccounts should
+be included in the budget. If a subaccount is set to the name of
+the parent account, usage from the parent account will be included.
+If the field is omitted, the report will include usage from the parent
+account and all subaccounts, if they exist.`,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							AtLeastOneOf: []string{"budget_filter.0.projects", "budget_filter.0.credit_types_treatment", "budget_filter.0.services", "budget_filter.0.subaccounts", "budget_filter.0.labels"},
+						},
+					},
+				},
+			},
+			"display_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: `User data for display name in UI. Must be <= 60 chars.`,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Description: `Resource name of the budget. The resource name
+implies the scope of a budget. Values are of the form
+billingAccounts/{billingAccountId}/budgets/{budgetId}.`,
+			},
+		},
+	}
+}
+
+func resourceBillingBudgetUpgradeV0(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	log.Printf("[DEBUG] Attributes before migration: %#v", rawState)
+
+	rawState["name"] = GetResourceNameFromSelfLink(rawState["name"].(string))
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", rawState)
+	return rawState, nil
+}

--- a/mmv1/third_party/terraform/tests/resource_billing_budget_test.go
+++ b/mmv1/third_party/terraform/tests/resource_billing_budget_test.go
@@ -60,3 +60,106 @@ resource "google_billing_budget" "budget" {
 }
 `, context)
 }
+
+func TestAccBillingBudget_billingBudgetUpdateRemoveFilter(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"billing_acct":  getTestBillingAccountFromEnv(t),
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBillingBudgetDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccBillingBudget_billingBudgetUpdateRemoveFilterStart(context),
+			},
+			{
+				ResourceName:      "google_billing_budget.budget",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccBillingBudget_billingBudgetUpdateRemoveFilterEnd(context),
+			},
+			{
+				ResourceName:      "google_billing_budget.budget",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccBillingBudget_billingBudgetUpdateRemoveFilterStart(context map[string]interface{}) string {
+	return Nprintf(`
+data "google_billing_account" "account" {
+  billing_account = "%{billing_acct}"
+}
+
+data "google_project" "project" {
+}
+
+resource "google_billing_budget" "budget" {
+  billing_account = data.google_billing_account.account.id
+  display_name = "Example Billing Budget%{random_suffix}"
+
+  budget_filter {
+    projects = ["projects/${data.google_project.project.number}"]
+  }
+
+  amount {
+    specified_amount {
+      currency_code = "USD"
+      units = "100000"
+    }
+  }
+
+  threshold_rules {
+    threshold_percent = 0.5
+  }
+  threshold_rules {
+    threshold_percent = 0.9
+    spend_basis = "FORECASTED_SPEND"
+  }
+}
+`, context)
+}
+
+func testAccBillingBudget_billingBudgetUpdateRemoveFilterEnd(context map[string]interface{}) string {
+	return Nprintf(`
+data "google_billing_account" "account" {
+  billing_account = "%{billing_acct}"
+}
+
+data "google_project" "project" {
+}
+
+resource "google_billing_budget" "budget" {
+  billing_account = data.google_billing_account.account.id
+  display_name = "Example Billing Budget%{random_suffix}"
+
+  budget_filter {
+    projects = []
+  }
+
+  amount {
+    specified_amount {
+      currency_code = "USD"
+      units = "100000"
+    }
+  }
+
+  threshold_rules {
+    threshold_percent = 0.5
+  }
+  threshold_rules {
+    threshold_percent = 0.9
+    spend_basis = "FORECASTED_SPEND"
+  }
+}
+`, context)
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Resolved https://github.com/hashicorp/terraform-provider-google/issues/8888.

In order to test that this was working properly, I also had to get imports working. This resource was made GA in https://github.com/GoogleCloudPlatform/magic-modules/pull/4273; imports had apparently not been working properly at the time, and were disabled.

I believe this addresses the issues & allows importing to work as expected. I am a little paranoid that changing the import logic would result in the resources not being recognized from state, but I think it should be fine?

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
billingbudget: Added support for import of `google_billing_budget`
```
