### PR TITLE
master_ipv4_cidr_block should be in line with documentation

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -330,7 +330,7 @@ func resourceComposerEnvironment() *schema.Resource {
 										Default:  true,
 										AtLeastOneOf: []string{
 											"config.0.private_environment_config.0.enable_private_endpoint",
-											"config.0.private_environment_config.0.//_ipv4_cidr_block",
+											"config.0.private_environment_config.0._ipv4_cidr_block",
 											"config.0.private_environment_config.0.cloud_sql_ipv4_cidr_block",
 											"config.0.private_environment_config.0.web_server_ipv4_cidr_block",
 										},

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -330,7 +330,7 @@ func resourceComposerEnvironment() *schema.Resource {
 										Default:  true,
 										AtLeastOneOf: []string{
 											"config.0.private_environment_config.0.enable_private_endpoint",
-											"config.0.private_environment_config.0._ipv4_cidr_block",
+											"config.0.private_environment_config.0.master_ipv4_cidr_block",
 											"config.0.private_environment_config.0.cloud_sql_ipv4_cidr_block",
 											"config.0.private_environment_config.0.web_server_ipv4_cidr_block",
 										},

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -330,7 +330,7 @@ func resourceComposerEnvironment() *schema.Resource {
 										Default:  true,
 										AtLeastOneOf: []string{
 											"config.0.private_environment_config.0.enable_private_endpoint",
-											"config.0.private_environment_config.0.master_ipv4_cidr_block",
+											"config.0.private_environment_config.0.//_ipv4_cidr_block",
 											"config.0.private_environment_config.0.cloud_sql_ipv4_cidr_block",
 											"config.0.private_environment_config.0.web_server_ipv4_cidr_block",
 										},
@@ -340,6 +340,7 @@ func resourceComposerEnvironment() *schema.Resource {
 									"master_ipv4_cidr_block": {
 										Type:     schema.TypeString,
 										Optional: true,
+					     					Computed: true,
 										AtLeastOneOf: []string{
 											"config.0.private_environment_config.0.enable_private_endpoint",
 											"config.0.private_environment_config.0.master_ipv4_cidr_block",
@@ -347,7 +348,6 @@ func resourceComposerEnvironment() *schema.Resource {
 											"config.0.private_environment_config.0.web_server_ipv4_cidr_block",
 										},
 										ForceNew:    true,
-										Default:     "172.16.0.0/23",
 										Description: `The IP range in CIDR notation to use for the hosted master network. This range is used for assigning internal IP addresses to the cluster master or set of masters and to the internal load balancer virtual IP. This range must not overlap with any other ranges in use within the cluster's network. If left blank, the default value of '172.16.0.0/28' is used.`,
 									},
 									"web_server_ipv4_cidr_block": {

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -347,7 +347,7 @@ func resourceComposerEnvironment() *schema.Resource {
 											"config.0.private_environment_config.0.web_server_ipv4_cidr_block",
 										},
 										ForceNew:    true,
-										Default:     "172.16.0.0/28",
+										Default:     "172.16.0.0/23",
 										Description: `The IP range in CIDR notation to use for the hosted master network. This range is used for assigning internal IP addresses to the cluster master or set of masters and to the internal load balancer virtual IP. This range must not overlap with any other ranges in use within the cluster's network. If left blank, the default value of '172.16.0.0/28' is used.`,
 									},
 									"web_server_ipv4_cidr_block": {

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -340,7 +340,7 @@ func resourceComposerEnvironment() *schema.Resource {
 									"master_ipv4_cidr_block": {
 										Type:     schema.TypeString,
 										Optional: true,
-					     				Computed: true,
+										Computed: true,
 										AtLeastOneOf: []string{
 											"config.0.private_environment_config.0.enable_private_endpoint",
 											"config.0.private_environment_config.0.master_ipv4_cidr_block",

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -340,7 +340,7 @@ func resourceComposerEnvironment() *schema.Resource {
 									"master_ipv4_cidr_block": {
 										Type:     schema.TypeString,
 										Optional: true,
-					     					Computed: true,
+					     				Computed: true,
 										AtLeastOneOf: []string{
 											"config.0.private_environment_config.0.enable_private_endpoint",
 											"config.0.private_environment_config.0.master_ipv4_cidr_block",

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -313,7 +313,7 @@ See [documentation](https://cloud.google.com/composer/docs/how-to/managing/confi
   for assigning internal IP addresses to the cluster master or set of masters and to the
   internal load balancer virtual IP. This range must not overlap with any other ranges
   in use within the cluster's network.
-  If left blank, the default value of '172.16.0.0/28' is used.
+  If left blank, the default value of '172.16.0.0/23' is used.
 
 * `cloud_sql_ipv4_cidr_block` -
   (Optional)

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -313,7 +313,7 @@ See [documentation](https://cloud.google.com/composer/docs/how-to/managing/confi
   for assigning internal IP addresses to the cluster master or set of masters and to the
   internal load balancer virtual IP. This range must not overlap with any other ranges
   in use within the cluster's network.
-  If left blank, the default value of '172.16.0.0/23' is used.
+  If left blank, the default value of is used. See [documentation](https://cloud.google.com/composer/docs/how-to/managing/configuring-private-ip#defaults) for default values per region. 
 
 * `cloud_sql_ipv4_cidr_block` -
   (Optional)


### PR DESCRIPTION
As per https://cloud.google.com/composer/docs/reference/rest/v1beta1/projects.locations.environments#PrivateClusterConfig masterIpv4CidrBlock is Optional. The CIDR block from which IPv4 range for GKE master will be reserved. If left blank, the default value of '172.16.0.0/23' is used. Suggesting change default value to be in line with docs or remove it so it's assigned/computed by API.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
composer: changed master_ipv4_cidr_block to draw default from the API
```
