### PR TITLE
Add support for InitialGroupConfig to google_cloud_identity_group

### DIFF
--- a/mmv1/products/cloudidentity/api.yaml
+++ b/mmv1/products/cloudidentity/api.yaml
@@ -30,7 +30,7 @@ apis_required:
 objects:
   - !ruby/object:Api::Resource
     name: 'Group'
-    base_url: groups?initialGroupConfig=EMPTY
+    base_url: 'groups?initialGroupConfig={{initial_group_config}}'
     update_url: '{{name}}'
     self_link: '{{name}}'
     update_verb: :PATCH
@@ -42,6 +42,22 @@ objects:
         'Official Documentation':
           'https://cloud.google.com/identity/docs/how-to/setup'
       api: 'https://cloud.google.com/identity/docs/reference/rest/v1beta1/groups'
+    parameters:
+      - !ruby/object:Api::Type::Enum
+        name: 'initialGroupConfig'
+        input: true
+        description: |
+          The initial configuration options for creating a Group.
+
+          See the
+          [API reference](https://cloud.google.com/identity/docs/reference/rest/v1beta1/groups/create#initialgroupconfig)
+          for possible values.
+        values:
+          - "INITIAL_GROUP_CONFIG_UNSPECIFIED"
+          - "WITH_INITIAL_OWNER"
+          - "EMPTY"
+        default_value: :EMPTY
+        url_param_only: true
     properties:
       - !ruby/object:Api::Type::String
         name: 'name'

--- a/mmv1/templates/terraform/examples/cloud_identity_groups_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_identity_groups_basic.tf.erb
@@ -1,5 +1,6 @@
 resource "google_cloud_identity_group" "<%= ctx[:primary_resource_id] %>" {
-  display_name = "<%= ctx[:vars]['id_group'] %>"
+  display_name         = "<%= ctx[:vars]['id_group'] %>"
+  initial_group_config = "WITH_INITIAL_OWNER"
 
   parent = "customers/<%= ctx[:test_env_vars]['cust_id'] %>"
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->



Fixes https://github.com/hashicorp/terraform-provider-google/issues/7986.

If you change the value of `initial_group_config` after creation, as this PR is written, the group will be destroyed and recreated. Let me know if you'd like me to look at alternative behaviors here (e.g., being a no-op).

Thanks!

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).

  :arrow_forward: I had trouble figuring out if the acceptance tests support selecting a billing project to use and our service accounts don't have permissions to create groups. However, I tested this change by hand in a separate module and it works.
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloud_identity: add support for `initial_group_config` to the google_cloud_identity_group resource
```
