### PR TITLE
handle diff for duration

### DIFF
--- a/mmv1/products/pubsub/terraform.yaml
+++ b/mmv1/products/pubsub/terraform.yaml
@@ -132,8 +132,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         diff_suppress_func: 'comparePubsubSubscriptionExpirationPolicy'
       retryPolicy.minimumBackoff: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+        diff_suppress_func: 'durationDiffSuppress'
       retryPolicy.maximumBackoff: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+        diff_suppress_func: 'durationDiffSuppress'
       pushConfig.attributes: !ruby/object:Overrides::Terraform::PropertyOverride
         diff_suppress_func: 'ignoreMissingKeyInMap("x-goog-version")'
     custom_code: !ruby/object:Provider::Terraform::CustomCode

--- a/mmv1/third_party/terraform/tests/resource_pubsub_subscription_test.go
+++ b/mmv1/third_party/terraform/tests/resource_pubsub_subscription_test.go
@@ -226,6 +226,9 @@ resource "google_pubsub_subscription" "foo" {
   labels = {
     foo = "%s"
   }
+  retry_policy {
+    minimum_backoff = "60.0s"
+  }
   ack_deadline_seconds = %d
 }
 `, topic, subscription, label, deadline)

--- a/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
+++ b/mmv1/third_party/terraform/utils/common_diff_suppress.go.erb
@@ -165,3 +165,17 @@ func timestampDiffSuppress(format string) schema.SchemaDiffSuppressFunc {
 func internalIpDiffSuppress(_, old, new string, _ *schema.ResourceData) bool {
 	return (net.ParseIP(old) != nil) && (net.ParseIP(new) == nil)
 }
+
+// Suppress diffs for duration format. ex "60.0s" and "60s" same
+// https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#duration
+func durationDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	oDuration, err := time.ParseDuration(old)
+	if err != nil {
+		return false
+	}
+	nDuration, err := time.ParseDuration(new)
+	if err != nil {
+		return false
+	}
+	return oDuration == nDuration
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/9038


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
pubsub: fixed diff for `minimum_backoff & maximum_backoff` on `google_pubsub_subscription`
```
