### PR TITLE
Added resourcegroup- and cluster- to clearable test prefixes

### DIFF
--- a/mmv1/third_party/terraform/utils/gcp_sweeper_test.go
+++ b/mmv1/third_party/terraform/utils/gcp_sweeper_test.go
@@ -15,7 +15,8 @@ var testResourcePrefixes = []string{
 	"gke-us-central1-tf",  // composer-created disks which are abandoned by design (https://cloud.google.com/composer/pricing)
 	"gcs-bucket-tf-test-", // https://github.com/hashicorp/terraform-provider-google/issues/8909
 	"df-",                 // https://github.com/hashicorp/terraform-provider-google/issues/8909
-
+	"resourcegroup-",      // https://github.com/hashicorp/terraform-provider-google/issues/8924
+	"cluster-",            // https://github.com/hashicorp/terraform-provider-google/issues/8924
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Resolved https://github.com/hashicorp/terraform-provider-google/issues/8924. Added `resourcegroup-` and `cluster-` prefixes to clearable test prefixes. This is not exactly strictly correct since those could hypothetically be created outside of tests, but it's in line with the addition of [`df-`](https://github.com/GoogleCloudPlatform/magic-modules/pull/4721/files#diff-e2c913af61495b4dfc09a4d3d3232b6f05f5d3e9db1edb2a851ceb4fe52db6b9R17). However, this should be fine in the context of a test account.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
