### PR TITLE
add requireVerifiedChromeOs as optional

### DIFF
--- a/mmv1/products/accesscontextmanager/api.yaml
+++ b/mmv1/products/accesscontextmanager/api.yaml
@@ -271,6 +271,9 @@ objects:
                           The minimum allowed OS version. If not set, any version
                           of this OS satisfies the constraint.
                           Format: "major.minor.patch" such as "10.5.301", "9.2.1".
+                      - !ruby/object:Api::Type::Boolean
+                        name: 'requireVerifiedChromeOs'
+                        description: If you specify DESKTOP_CHROME_OS for osType, you can optionally include requireVerifiedChromeOs to require Chrome Verified Access.
                       - !ruby/object:Api::Type::Enum
                         name: 'osType'
                         required: true

--- a/mmv1/third_party/terraform/tests/resource_access_context_manager_access_level_condition_test.go
+++ b/mmv1/third_party/terraform/tests/resource_access_context_manager_access_level_condition_test.go
@@ -115,6 +115,7 @@ resource "google_access_context_manager_access_level" "test-access" {
         require_screen_lock = true
         os_constraints {
           os_type = "DESKTOP_CHROME_OS"
+          require_verified_chrome_os = true
         }
       }
       regions = [

--- a/mmv1/third_party/terraform/tests/resource_access_context_manager_access_level_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_access_context_manager_access_level_test.go.erb
@@ -193,6 +193,7 @@ resource "google_access_context_manager_access_level" "test-access" {
         require_corp_owned = true
         os_constraints {
           os_type = "DESKTOP_CHROME_OS"
+          require_verified_chrome_os = true
         }
       }
       regions = [


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Adds support for requireVerifiedChromeOs in basic access levels, please see https://cloud.google.com/access-context-manager/docs/access-level-attributes.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
accesscontextmanager: added support for `require_verified_chrome_os` in basic access levels.
```
