### PR TITLE
add transform error function for security policy association read error

### DIFF
--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1422,6 +1422,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     self_link: '{{policy_id}}/getAssociation?name={{name}}'
     create_url: '{{policy_id}}/addAssociation'
     delete_url: '{{policy_id}}/removeAssociation?name={{name}}'
+    read_error_transform: "transformSecurityPolicyAssociationReadError"
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "organization_security_policy_association_basic"

--- a/mmv1/third_party/terraform/utils/security_policy_association_utils.go
+++ b/mmv1/third_party/terraform/utils/security_policy_association_utils.go
@@ -1,0 +1,26 @@
+package google
+
+import (
+	"log"
+	"strings"
+
+	"github.com/hashicorp/errwrap"
+	"google.golang.org/api/googleapi"
+)
+
+func transformSecurityPolicyAssociationReadError(err error) error {
+	if gErr, ok := errwrap.GetType(err, &googleapi.Error{}).(*googleapi.Error); ok {
+		if gErr.Code == 400 && strings.Contains(gErr.Message, "An association with that name does not exist") {
+			// This error occurs when attempting a GET after deleting the security policy association. It leads to to
+			// inconsistent behavior as handleNotFoundError(...) expects an error code of 404 when a resource does not
+			// exist. To get the desired behavior from handleNotFoundError, modify the return code to 404 so that
+			// handleNotFoundError(...) will treat this as a NotFound error
+			gErr.Code = 404
+		}
+
+		log.Printf("[DEBUG] Transformed security policy association error")
+		return gErr
+	}
+
+	return err
+}

--- a/mmv1/third_party/terraform/utils/security_policy_association_utils.go.erb
+++ b/mmv1/third_party/terraform/utils/security_policy_association_utils.go.erb
@@ -1,6 +1,6 @@
 <% autogen_exception -%>
-<% unless version == 'ga' -%>
 package google
+<% unless version == 'ga' -%>
 
 import (
 	"log"

--- a/mmv1/third_party/terraform/utils/security_policy_association_utils.go.erb
+++ b/mmv1/third_party/terraform/utils/security_policy_association_utils.go.erb
@@ -1,3 +1,5 @@
+<% autogen_exception -%>
+<% unless version == 'ga' -%>
 package google
 
 import (
@@ -24,3 +26,4 @@ func transformSecurityPolicyAssociationReadError(err error) error {
 
 	return err
 }
+<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Upstream won't change not found error to 404, so will have to transform it here
Fixes https://github.com/hashicorp/terraform-provider-google/issues/7168

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed bug where, when an organization security policy association was removed outside of terraform, the next plan/apply would fail.
```
