### PR TITLE
Add support for Instance schedules to Google compute resource policy

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -12406,6 +12406,10 @@ objects:
           first character must be a lowercase letter, and all following characters
           must be a dash, lowercase letter, or digit, except the last character,
           which cannot be a dash.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          An optional description of this resource. Provide this property when you create the resource.
       - !ruby/object:Api::Type::NestedObject
         name: 'snapshotSchedulePolicy'
         conflicts:

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -12410,6 +12410,7 @@ objects:
         name: 'snapshotSchedulePolicy'
         conflicts:
           - 'group_placement_policy'
+          - 'instance_schedule_policy'
         description: |
           Policy for creating snapshots of persistent disks.
         properties:
@@ -12554,6 +12555,7 @@ objects:
       - !ruby/object:Api::Type::NestedObject
         name: 'groupPlacementPolicy'
         conflicts:
+          - 'instance_schedule_policy'
           - 'snapshot_schedule_policy'
         description: |
           Resource policy for instances used for placement configuration.
@@ -12582,6 +12584,54 @@ objects:
               attached.
             values:
               - :COLLOCATED
+      - !ruby/object:Api::Type::NestedObject
+        name: 'instanceSchedulePolicy'
+        conflicts:
+          - 'snapshot_schedule_policy'
+          - 'group_placement_policy'
+        description: |
+          Resource policy for scheduling instance operations.
+        properties:
+          - !ruby/object:Api::Type::NestedObject
+            name: 'vmStartSchedule'
+            at_least_one_of:
+              - instance_schedule_policy.0.vm_start_schedule
+              - instance_schedule_policy.0.vm_stop_schedule
+            description: |
+              Specifies the schedule for starting instances.
+            properties:
+              - !ruby/object:Api::Type::String
+                name: 'schedule'
+                description: |
+                  Specifies the frequency for the operation, using the unix-cron format.
+                required: true
+          - !ruby/object:Api::Type::NestedObject
+            name: 'vmStopSchedule'
+            at_least_one_of:
+              - instance_schedule_policy.0.vm_start_schedule
+              - instance_schedule_policy.0.vm_stop_schedule
+            description: |
+              Specifies the schedule for stopping instances.
+            properties:
+              - !ruby/object:Api::Type::String
+                name: 'schedule'
+                description: |
+                  Specifies the frequency for the operation, using the unix-cron format.
+                required: true
+          - !ruby/object:Api::Type::String
+            name: 'timeZone'
+            description: |
+              Specifies the time zone to be used in interpreting the schedule. The value of this field must be a time zone name
+              from the tz database: http://en.wikipedia.org/wiki/Tz_database.
+            required: true
+          - !ruby/object:Api::Type::String
+            name: 'startTime'
+            description: |
+              The start time of the schedule. The timestamp is an RFC3339 string.
+          - !ruby/object:Api::Type::String
+            name: 'expirationTime'
+            description: |
+              The expiration time of the schedule. The timestamp is an RFC3339 string.
   - !ruby/object:Api::Resource
     name: 'Route'
     kind: 'compute#route'

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1952,6 +1952,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "baz"
         vars:
           name: "policy"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "resource_policy_instance_schedule_policy"
+        primary_resource_id: "hourly"
+        vars:
+          name: "policy"
     properties:
       region: !ruby/object:Overrides::Terraform::PropertyOverride
         required: false

--- a/mmv1/templates/terraform/examples/resource_policy_instance_schedule_policy.tf.erb
+++ b/mmv1/templates/terraform/examples/resource_policy_instance_schedule_policy.tf.erb
@@ -1,0 +1,14 @@
+resource "google_compute_resource_policy" "hourly" {
+  name   = "<%= ctx[:vars]['name'] %>"
+  region = "us-central1"
+  description = "Start and stop instances"
+  instance_schedule_policy {
+    vm_start_schedule {
+      schedule = "0 * * * *"
+    }
+    vm_stop_schedule {
+      schedule = "15 * * * *"
+    }
+    time_zone = "US/Central"
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
This PR adds support for `instance_schedule_policy` to the `google_compute_resource_policy` resource. It also adds a missing `description` field.

Closes https://github.com/hashicorp/terraform-provider-google/issues/9001

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added "instance_schedule_policy" field to "google_compute_resource_policy" resource
```
```release-note:enhancement
compute: added "description" field to "google_compute_resource_policy" resource
```