### PR TITLE
fix TestAccComputeHaVpnGateway_haVpnGatewayGcpToGcpExample and TestAccComputeExternalVpnGateway_externalVpnGatewayExample

### DIFF
--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2669,8 +2669,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           ha_vpn_gateway1_name: "ha-vpn-1"
           network1_name: "network1"
+          router1_name: "ha-vpn-router1"
           ha_vpn_gateway2_name: "ha-vpn-2"
           network2_name: "network2"
+          router2_name: "ha-vpn-router1"
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2700,6 +2700,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           network_name: "network"
           external_gateway_name: "external-gateway"
           global_address_name: "global-address"
+          router_name: "ha-vpn-router1"
   UrlMap: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2672,7 +2672,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           router1_name: "ha-vpn-router1"
           ha_vpn_gateway2_name: "ha-vpn-2"
           network2_name: "network2"
-          router2_name: "ha-vpn-router1"
+          router2_name: "ha-vpn-router2"
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation

--- a/mmv1/templates/terraform/examples/external_vpn_gateway.tf.erb
+++ b/mmv1/templates/terraform/examples/external_vpn_gateway.tf.erb
@@ -35,7 +35,7 @@ resource "google_compute_subnetwork" "network_subnet2" {
 }
 
 resource "google_compute_router" "router1" {
-  name     = "ha-vpn-router1"
+  name     = "<%= ctx[:vars]['router_name'] %>"
   network  = google_compute_network.network.name
   bgp {
     asn = 64514

--- a/mmv1/templates/terraform/examples/ha_vpn_gateway_gcp_to_gcp.tf.erb
+++ b/mmv1/templates/terraform/examples/ha_vpn_gateway_gcp_to_gcp.tf.erb
@@ -59,7 +59,7 @@ resource "google_compute_router" "router1" {
 }
 
 resource "google_compute_router" "router2" {
-  name     = "<%= ctx[:vars]['router1_name'] %>"
+  name     = "<%= ctx[:vars]['router2_name'] %>"
   network  = google_compute_network.network2.name
   bgp {
     asn = 64515

--- a/mmv1/templates/terraform/examples/ha_vpn_gateway_gcp_to_gcp.tf.erb
+++ b/mmv1/templates/terraform/examples/ha_vpn_gateway_gcp_to_gcp.tf.erb
@@ -51,7 +51,7 @@ resource "google_compute_subnetwork" "network2_subnet2" {
 }
 
 resource "google_compute_router" "router1" {
-  name     = "ha-vpn-router1"
+  name     = "<%= ctx[:vars]['router1_name'] %>"
   network  = google_compute_network.network1.name
   bgp {
     asn = 64514
@@ -59,7 +59,7 @@ resource "google_compute_router" "router1" {
 }
 
 resource "google_compute_router" "router2" {
-  name     = "ha-vpn-router2"
+  name     = "<%= ctx[:vars]['router1_name'] %>"
   network  = google_compute_network.network2.name
   bgp {
     asn = 64515


### PR DESCRIPTION
```
=== RUN   TestAccComputeHaVpnGateway_haVpnGatewayGcpToGcpExample
=== PAUSE TestAccComputeHaVpnGateway_haVpnGatewayGcpToGcpExample
=== CONT  TestAccComputeHaVpnGateway_haVpnGatewayGcpToGcpExample
    provider_test.go:275: Step 1/2 error: Error running apply: exit status 1
        
        Error: Error creating Router: googleapi: Error 409: The resource 'projects/ci-test-project-188019/regions/us-central1/routers/ha-vpn-router1' already exists, alreadyExists
        
          on terraform_plugin_test.tf line 54, in resource "google_compute_router" "router1":
          54: resource "google_compute_router" "router1" {
        
        
--- FAIL: TestAccComputeHaVpnGateway_haVpnGatewayGcpToGcpExample (197.44s)
FAIL

```
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
