### PR TITLE
allow api gateway to change

### DIFF
--- a/mmv1/products/apigateway/api.yaml
+++ b/mmv1/products/apigateway/api.yaml
@@ -220,7 +220,8 @@ objects:
         name: 'apiConfig'
         required: true
         description: |
-          Resource name of the API Config for this Gateway. Format: projects/{project}/locations/global/apis/{api}/configs/{apiConfig}
+          Resource name of the API Config for this Gateway. Format: projects/{project}/locations/global/apis/{api}/configs/{apiConfig}.
+          When changing api configs please ensure the new config is a new resource and the lifecycle rule `create_before_destroy` is set.
       - !ruby/object:Api::Type::String
         name: 'defaultHostname'
         output: true

--- a/mmv1/products/apigateway/api.yaml
+++ b/mmv1/products/apigateway/api.yaml
@@ -152,7 +152,7 @@ objects:
             required: true
             description: |
               Google Cloud IAM service account used to sign OIDC tokens for backends that have authentication configured
-              (https://cloud.google.com/service-infrastructure/docs/service-management/reference/rest/v1/services.configs#backend). 
+              (https://cloud.google.com/service-infrastructure/docs/service-management/reference/rest/v1/services.configs#backend).
       - !ruby/object:Api::Type::Array
         name: 'openapiDocuments'
         description: |
@@ -219,7 +219,6 @@ objects:
       - !ruby/object:Api::Type::String
         name: 'apiConfig'
         required: true
-        input: true
         description: |
           Resource name of the API Config for this Gateway. Format: projects/{project}/locations/global/apis/{api}/configs/{apiConfig}
       - !ruby/object:Api::Type::String

--- a/mmv1/third_party/terraform/tests/resource_api_gateway_gateway_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_api_gateway_gateway_test.go.erb
@@ -44,6 +44,9 @@ resource "google_api_gateway_api_config" "api_gw" {
   provider = google-beta
   api = google_api_gateway_api.api_gw.api_id
   api_config_id = "tf-test-api-gw%{random_suffix}"
+	lifecycle {
+    create_before_destroy = true
+  }
 
   openapi_documents {
     document {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

closes https://github.com/hashicorp/terraform-provider-google/issues/8532


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
apigateway: allowed field `apiconfig` to change on resource `google_apigateway_gateway`
```
