### PR TITLE
align provisioned networks to have the prefix tf-test

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_compute_address_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_address_test.go
@@ -66,7 +66,7 @@ resource "google_compute_address" "internal" {
 }
 
 resource "google_compute_network" "default" {
-  name = "network-test-%s"
+  name = "tf-test-network-test-%s"
 }
 
 resource "google_compute_subnetwork" "foo" {

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
@@ -461,7 +461,7 @@ func TestAccComputeInstanceTemplate_subnet_auto(t *testing.T) {
 	t.Parallel()
 
 	var instanceTemplate compute.InstanceTemplate
-	network := "network-" + randString(t, 10)
+	network := "tf-test-network-" + randString(t, 10)
 
 	vcrTest(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -1764,7 +1764,7 @@ resource "google_compute_instance_template" "foobar" {
 func testAccComputeInstanceTemplate_subnet_custom(suffix string) string {
 	return fmt.Sprintf(`
 resource "google_compute_network" "network" {
-  name                    = "network-%s"
+  name                    = "tf-test-network-%s"
   auto_create_subnetworks = false
 }
 
@@ -1839,7 +1839,7 @@ resource "google_compute_shared_vpc_service_project" "service_project" {
 }
 
 resource "google_compute_network" "network" {
-  name                    = "network-%s"
+  name                    = "tf-test-network-%s"
   auto_create_subnetworks = false
   project                 = google_compute_shared_vpc_host_project.host_project.project
 }

--- a/mmv1/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dns_managed_zone_test.go.erb
@@ -363,7 +363,7 @@ resource "google_compute_network" "network-2" {
 }
 
 resource "google_compute_network" "network-3" {
-  name                    = "network-3-%s"
+  name                    = "tf-test-network-3-%s"
   auto_create_subnetworks = false
 }
 `, suffix, first_network, second_network, suffix, suffix, suffix)

--- a/mmv1/third_party/terraform/tests/resource_dns_policy_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dns_policy_test.go.erb
@@ -60,12 +60,12 @@ resource "google_dns_policy" "example-policy" {
 }
 
 resource "google_compute_network" "network-1" {
-  name                    = "network-1-%s"
+  name                    = "tf-test-network-1-%s"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_network" "network-2" {
-  name                    = "network-2-%s"
+  name                    = "tf-test-network-2-%s"
   auto_create_subnetworks = false
 }
 `, suffix, forwarding, first_nameserver, second_nameserver, network, suffix, suffix)


### PR DESCRIPTION
You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
