### PR TITLE
Upstream tpgb 3238: docs for cluster notification_config

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -674,7 +674,7 @@ func resourceContainerCluster() *schema.Resource {
 									"topic": {
 										Type:        schema.TypeString,
 										Optional:    true,
-										Description: `The Cloud Pub/Sub topic to send the notification to, must be in the format: projects/{project}/topics/{topic}`,
+										Description: `The pubsub topic to push upgrade notifications to. Must be in the same project as the cluster. Must be in the format: projects/{project}/topics/{topic}.`,
 									},
 								},
 							},

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -719,9 +719,9 @@ The `notification_config` block supports:
 
 The `pubsub` block supports:
 
-* `enabled` (Required) - Enable the Upgrade notifications for this cluster.
+* `enabled` (Required) - Whether or not the notification config is enabled
 
-* `topic` (Optional) - The pubsub topic to push upgrade notifications to. Must be in the same project as the cluster.
+* `topic` (Optional) - The pubsub topic to push upgrade notifications to. Must be in the same project as the cluster. Must be in the format: `projects/{project}/topics/{topic}`.
 
 ```hcl
 notification_config {

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -251,6 +251,8 @@ region are guaranteed to support the same version.
     `version_prefix` field to approximate fuzzy versions in a Terraform-compatible way.
     To update nodes in other node pools, use the `version` attribute on the node pool.
 
+* `notification_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Configuration for the [cluster upgrade notifications](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-upgrade-notifications) feature. Structure is documented below.
+
 * `pod_security_policy_config` - (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html)) Configuration for the
     [PodSecurityPolicy](https://cloud.google.com/kubernetes-engine/docs/how-to/pod-security-policies) feature.
     Structure is documented below.
@@ -708,6 +710,25 @@ The `workload_identity_config` block supports:
 ```hcl
 workload_identity_config {
   identity_namespace = "${data.google_project.project.project_id}.svc.id.goog"
+}
+```
+
+The `notification_config` block supports:
+
+* `pubsub` (Required) - The pubsub config for the cluster's upgrade notifications.
+
+The `pubsub` block supports:
+
+* `enabled` (Required) - Enable the Upgrade notifications for this cluster.
+
+* `topic` (Optional) - The pubsub topic to push upgrade notifications to. Must be in the same project as the cluster.
+
+```hcl
+notification_config {
+  pubsub {
+    enabled = true
+    topic = google_pubsub_topic.notifications.id
+  }
 }
 ```
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Upstreams https://github.com/hashicorp/terraform-provider-google-beta/pull/3238.

Third-party only, no CLA required.

Guide docs: https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-upgrade-notifications
API docs: https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.locations.clusters

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
