### PR TITLE
promote schedule-based autoscaling to ga

### DIFF
--- a/mmv1/products/compute/ansible.yaml
+++ b/mmv1/products/compute/ansible.yaml
@@ -70,6 +70,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         aliases: ['maxReplicas']
       autoscalingPolicy.coolDownPeriodSec: !ruby/object:Overrides::Ansible::PropertyOverride
         aliases: ['cooldownPeriod']
+      autoscalingPolicy.scalingSchedules: !ruby/object:Overrides::Ansible::PropertyOverride
+        exclude: true
       autoscalingPolicy.cpuUtilization.utilizationTarget: !ruby/object:Overrides::Ansible::PropertyOverride
         aliases: ['target']
       autoscalingPolicy.customMetricUtilizations: !ruby/object:Overrides::Ansible::PropertyOverride
@@ -289,6 +291,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       size: !ruby/object:Overrides::Ansible::PropertyOverride
         required: true
       initialSize: !ruby/object:Overrides::Ansible::PropertyOverride
+        exclude: true
+  RegionAutoscaler: !ruby/object:Overrides::Ansible::ResourceOverride
+    properties:
+      autoscalingPolicy.scalingSchedules: !ruby/object:Overrides::Ansible::PropertyOverride
         exclude: true
   RegionDisk: !ruby/object:Overrides::Ansible::ResourceOverride
     properties:

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -518,7 +518,6 @@ objects:
                 be a positive float value. If not defined, the default is 0.8.
           - !ruby/object:Api::Type::Map
             name: 'scalingSchedules'
-            min_version: beta
             description: |
               Scaling schedules defined for an autoscaler. Multiple schedules can be set on an autoscaler and they can overlap.
             key_name: name
@@ -9852,7 +9851,6 @@ objects:
                 be a positive float value. If not defined, the default is 0.8.
           - !ruby/object:Api::Type::Map
             name: 'scalingSchedules'
-            min_version: beta
             description: |
               Scaling schedules defined for an autoscaler. Multiple schedules can be set on an autoscaler and they can overlap.
             key_name: name

--- a/mmv1/third_party/terraform/tests/resource_compute_autoscaler_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_autoscaler_test.go.erb
@@ -97,7 +97,6 @@ func TestAccComputeAutoscaler_scaleDownControl(t *testing.T) {
 }
 <% end -%>
 
-<% unless version == 'ga' -%>
 func TestAccComputeAutoscaler_scalingSchedule(t *testing.T) {
 	t.Parallel()
 
@@ -122,7 +121,6 @@ func TestAccComputeAutoscaler_scalingSchedule(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccComputeAutoscaler_scaleInControl(t *testing.T) {
 	t.Parallel()
@@ -371,7 +369,6 @@ resource "google_compute_autoscaler" "foobar" {
 `, autoscalerName)
 }
 
-<% unless version == 'ga' -%>
 func testAccComputeAutoscaler_scalingSchedule(itName, tpName, igmName, autoscalerName string) string {
 	return testAccComputeAutoscaler_scaffolding(itName, tpName, igmName) + fmt.Sprintf(`
 resource "google_compute_autoscaler" "foobar" {
@@ -386,12 +383,14 @@ resource "google_compute_autoscaler" "foobar" {
     cpu_utilization {
       target = 0.5
     }
+<% unless version == 'ga' -%>
     scale_down_control {
       max_scaled_down_replicas {
         percent = 80
       }
       time_window_sec = 300
     }
+<% end -%>
     scaling_schedules {
       name = "every-weekday-morning"
       description = "Increase to 2 every weekday at 7AM for 6 hours."
@@ -412,4 +411,3 @@ resource "google_compute_autoscaler" "foobar" {
 }
 `, autoscalerName)
 }
-<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_compute_region_autoscaler_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_autoscaler_test.go.erb
@@ -69,7 +69,6 @@ func TestAccComputeRegionAutoscaler_scaleDownControl(t *testing.T) {
 }
 <% end -%>
 
-<% unless version == 'ga' -%>
 func TestAccComputeRegionAutoscaler_scalingSchedule(t *testing.T) {
 	t.Parallel()
 
@@ -94,7 +93,6 @@ func TestAccComputeRegionAutoscaler_scalingSchedule(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccComputeRegionAutoscaler_scaleInControl(t *testing.T) {
 	t.Parallel()
@@ -261,7 +259,6 @@ resource "google_compute_region_autoscaler" "foobar" {
 `, autoscalerName)
 }
 
-<% unless version == 'ga' -%>
 func testAccComputeRegionAutoscaler_scalingSchedule(itName, tpName, igmName, autoscalerName string) string {
 	return testAccComputeRegionAutoscaler_scaffolding(itName, tpName, igmName) + fmt.Sprintf(`
 resource "google_compute_region_autoscaler" "foobar" {
@@ -276,12 +273,14 @@ resource "google_compute_region_autoscaler" "foobar" {
     cpu_utilization {
       target = 0.5
     }
+<% unless version == 'ga' -%>
     scale_down_control {
       max_scaled_down_replicas {
         percent = 80
       }
       time_window_sec = 300
     }
+<% end -%>
     scaling_schedules {
       name = "every-weekday-morning"
       description = "Increase to 2 every weekday at 7AM for 6 hours."
@@ -302,4 +301,3 @@ resource "google_compute_region_autoscaler" "foobar" {
 }
 `, autoscalerName)
 }
-<% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


GA scaling_schedules attribute

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: promoted field `autoscaling_policy.scaling_schedules` on `google_compute_autoscaler` and `google_compute_region_autoscaler` to ga
```
