### PR TITLE
promote predictive autoscaling to ga

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -384,7 +384,6 @@ objects:
                 utilization.
             - !ruby/object:Api::Type::String
               name: 'predictiveMethod'
-              min_version: beta
               default_value: NONE
               description: |
                 Indicates whether predictive autoscaling based on CPU metric is enabled. Valid values are:
@@ -9664,7 +9663,6 @@ objects:
                 utilization.
             - !ruby/object:Api::Type::String
               name: 'predictiveMethod'
-              min_version: beta
               default_value: NONE
               description: |
                 Indicates whether predictive autoscaling based on CPU metric is enabled. Valid values are:

--- a/mmv1/third_party/terraform/tests/resource_compute_autoscaler_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_autoscaler_test.go.erb
@@ -70,7 +70,6 @@ func TestAccComputeAutoscaler_multicondition(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccComputeAutoscaler_scaleDownControl(t *testing.T) {
 	t.Parallel()
 
@@ -95,7 +94,6 @@ func TestAccComputeAutoscaler_scaleDownControl(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 <% unless version == 'ga' -%>
 func TestAccComputeAutoscaler_scalingSchedule(t *testing.T) {
@@ -293,7 +291,6 @@ resource "google_compute_autoscaler" "foobar" {
 `, autoscalerName)
 }
 
-<% unless version == 'ga' -%>
 func testAccComputeAutoscaler_scaleDownControl(itName, tpName, igmName, autoscalerName string) string {
 	return testAccComputeAutoscaler_scaffolding(itName, tpName, igmName) + fmt.Sprintf(`
 resource "google_compute_autoscaler" "foobar" {
@@ -309,17 +306,18 @@ resource "google_compute_autoscaler" "foobar" {
       target = 0.5
       predictive_method = "OPTIMIZE_AVAILABILITY"
     }
+<% unless version == 'ga' -%>
     scale_down_control {
       max_scaled_down_replicas {
         percent = 80
       }
       time_window_sec = 300
     }
+<% end -%>
   }
 }
 `, autoscalerName)
 }
-<% end -%>
 
 func testAccComputeAutoscaler_scaleInControl(itName, tpName, igmName, autoscalerName string) string {
 	return testAccComputeAutoscaler_scaffolding(itName, tpName, igmName) + fmt.Sprintf(`

--- a/mmv1/third_party/terraform/tests/resource_compute_region_autoscaler_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_autoscaler_test.go.erb
@@ -42,7 +42,6 @@ func TestAccComputeRegionAutoscaler_update(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccComputeRegionAutoscaler_scaleDownControl(t *testing.T) {
 	t.Parallel()
 
@@ -67,7 +66,6 @@ func TestAccComputeRegionAutoscaler_scaleDownControl(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 <% unless version == 'ga' -%>
 func TestAccComputeRegionAutoscaler_scalingSchedule(t *testing.T) {
@@ -208,7 +206,6 @@ resource "google_compute_region_autoscaler" "foobar" {
 `, autoscalerName)
 }
 
-<% unless version == 'ga' -%>
 func testAccComputeRegionAutoscaler_scaleDownControl(itName, tpName, igmName, autoscalerName string) string {
 	return testAccComputeRegionAutoscaler_scaffolding(itName, tpName, igmName) + fmt.Sprintf(`
 resource "google_compute_region_autoscaler" "foobar" {
@@ -224,17 +221,18 @@ resource "google_compute_region_autoscaler" "foobar" {
       target = 0.5
       predictive_method = "OPTIMIZE_AVAILABILITY"
     }
+<% unless version == 'ga' -%>
     scale_down_control {
       max_scaled_down_replicas {
         percent = 80
       }
       time_window_sec = 300
     }
+<% end -%>
   }
 }
 `, autoscalerName)
 }
-<% end -%>
 
 func testAccComputeRegionAutoscaler_scaleInControl(itName, tpName, igmName, autoscalerName string) string {
 	return testAccComputeRegionAutoscaler_scaffolding(itName, tpName, igmName) + fmt.Sprintf(`


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

GA predictive_method attribute


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
computed: promoted `autoscaling_policy.cpu_utilization.predictive_method` on `google_compute_autoscaler` and `google_compute_region_autoscaler` to ga.
```
