### PR TITLE
Update documentation for google_compute_region_per_instance_config

### DIFF
--- a/mmv1/templates/terraform/examples/stateful_rigm.tf.erb
+++ b/mmv1/templates/terraform/examples/stateful_rigm.tf.erb
@@ -47,7 +47,7 @@ resource "google_compute_disk" "default" {
 }
 
 resource "google_compute_region_per_instance_config" "with_disk" {
-  region = google_compute_instance_group_manager.igm.region
+  region = google_compute_region_instance_group_manager.igm.region
   region_instance_group_manager = google_compute_region_instance_group_manager.rigm.name
   name = "instance-1"
   preserved_state {

--- a/mmv1/templates/terraform/examples/stateful_rigm.tf.erb
+++ b/mmv1/templates/terraform/examples/stateful_rigm.tf.erb
@@ -33,6 +33,12 @@ resource "google_compute_region_instance_group_manager" "rigm" {
     instance_template = google_compute_instance_template.igm-basic.self_link
   }
 
+  update_policy {
+    type                         = "OPPORTUNISTIC"
+    instance_redistribution_type = "NONE"
+    minimal_action               = "RESTART"
+  }
+
   base_instance_name = "rigm"
   region             = "us-central1"
   target_size        = 2


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

## docs: fix region defention for region stateful mig

`google_compute_instance_group_manager` is not defined anywhere in the
example and here we are talking about region instance groups and not
zonal.

## docs: add required update_policy for stateful migs 

When you don't specify an `update_policy` and run `terraform apply` you
end up getting the following error:

```
Error waiting to create RegionPerInstanceConfig: Error waiting for Creating RegionPerInstanceConfig: CreateInstances can be used only when instance redistribution is disabled (set to NONE).
```

Also specify [`minimal_action`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_group_manager#minimal_action) and [`type`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_group_manager#type) since they are both required for `update_policy`

---
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
