### PR TITLE
Match preview versions in google_composer_environment regex

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -17,7 +17,7 @@ import (
 const (
 	composerEnvironmentEnvVariablesRegexp          = "[a-zA-Z_][a-zA-Z0-9_]*."
 	composerEnvironmentReservedAirflowEnvVarRegexp = "AIRFLOW__[A-Z0-9_]+__[A-Z0-9_]+"
-	composerEnvironmentVersionRegexp               = `composer-([0-9]+\.[0-9]+\.[0-9]+|latest)-airflow-([0-9]+\.[0-9]+(\.[0-9]+.*)?)`
+	composerEnvironmentVersionRegexp               = `composer-([0-9]+\.[0-9]+\.[0-9]+(-preview.[0-9]+)?|latest)-airflow-([0-9]+\.[0-9]+(\.[0-9]+.*)?)`
 )
 
 var composerEnvironmentReservedEnvVar = map[string]struct{}{

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -1540,7 +1540,7 @@ func composerImageVersionDiffSuppress(_, old, new string, _ *schema.ResourceData
 	versionRe := regexp.MustCompile(composerEnvironmentVersionRegexp)
 	oldVersions := versionRe.FindStringSubmatch(old)
 	newVersions := versionRe.FindStringSubmatch(new)
-	if oldVersions == nil || len(oldVersions) < 3 {
+	if oldVersions == nil || len(oldVersions) < 4 {
 		// Somehow one of the versions didn't match the regexp or didn't
 		// have values in the capturing groups. In that case, fall back to
 		// an equality check.
@@ -1557,7 +1557,7 @@ func composerImageVersionDiffSuppress(_, old, new string, _ *schema.ResourceData
 
 	// Check airflow version using the version package to account for
 	// diffs like 1.10 and 1.10.0
-	eq, err := versionsEqual(oldVersions[2], newVersions[2])
+	eq, err := versionsEqual(oldVersions[3], newVersions[3])
 	if err != nil {
 		log.Printf("[WARN] Could not parse airflow version, %s", err)
 	}

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -40,12 +40,12 @@ func TestComposerImageVersionDiffSuppress(t *testing.T) {
 		{"new latest", "composer-1.4.1-airflow-1.10.0", "composer-latest-airflow-1.10.0", true},
 		{"airflow equivalent", "composer-1.4.0-airflow-1.10.0", "composer-1.4.0-airflow-1.10", true},
 		{"airflow different", "composer-1.4.0-airflow-1.10.0", "composer-1.4-airflow-1.9.0", false},
-		{"airflow different composer latest", "composer-1.4.0-airflow-1.10.0", "composer-latest-airflow-1.9.0", false},
+		{"preview matches", "composer-1.17.0-preview.0-airflow-2.0.1", "composer-1.17.0-preview.0-airflow-2.0.1", true},
 	}
 
 	for _, tc := range cases {
 		if actual := composerImageVersionDiffSuppress("", tc.old, tc.new, nil); actual != tc.expected {
-			t.Fatalf("'%s' failed, expected %v but got %v", tc.name, tc.expected, actual)
+			t.Errorf("'%s' failed, expected %v but got %v", tc.name, tc.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Resolves a test error: `Error: "config.0.software_config.0.image_version" ("composer-1.17.0-preview.0-airflow-2.0.1") doesn't match regexp "composer-([0-9]+\\.[0-9]+\\.[0-9]+|latest)-airflow-([0-9]+\\.[0-9]+(\\.[0-9]+.*)?)"`

New string is `composer-1.17.0-preview.0-airflow-2.0.1`, we expected strings like `composer-1.4.1-airflow-1.10.0` and `composer-latest-airflow-1.10.0`.

Resolved https://github.com/hashicorp/terraform-provider-google/issues/9201

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
composer: fixed a check that did not allow for preview versions in `google_composer_environment`
```
