### PR TITLE
Fix force new on region disk for interface ENUM

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -10230,7 +10230,6 @@ objects:
         min_version: 'beta'
         description: |
           Specifies the disk interface to use for attaching this disk, which is either SCSI or NVME. The default is SCSI.
-        default_value: :SCSI
         values:
           - :SCSI
           - :NVME

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -10230,6 +10230,7 @@ objects:
         min_version: 'beta'
         description: |
           Specifies the disk interface to use for attaching this disk, which is either SCSI or NVME. The default is SCSI.
+        default_value: :SCSI
         values:
           - :SCSI
           - :NVME

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1763,6 +1763,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         default_from_api: true
       diskEncryptionKey.rawKey: !ruby/object:Overrides::Terraform::PropertyOverride
         sensitive: true
+      interface: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_delete: templates/terraform/pre_delete/detach_disk.erb
       encoder: templates/terraform/encoders/disk.erb

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1764,7 +1764,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       diskEncryptionKey.rawKey: !ruby/object:Overrides::Terraform::PropertyOverride
         sensitive: true
       interface: !ruby/object:Overrides::Terraform::PropertyOverride
-        default_from_api: true
+        custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_delete: templates/terraform/pre_delete/detach_disk.erb
       encoder: templates/terraform/encoders/disk.erb

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -589,6 +589,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           one at a time. Use
           [`google_compute_disk_resource_policy_attachment`](https://www.terraform.io/docs/providers/google/r/compute_disk_resource_policy_attachment.html)
           to allow for updating the resource policy attached to the disk.
+      interface: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       pre_delete: templates/terraform/pre_delete/detach_disk.erb
       constants: templates/terraform/constants/disk.erb


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/9194 , b/188701763
closes https://github.com/hashicorp/terraform-provider-google/issues/8457
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed issue where `google_compute_region_disk` and `google_compute_disk` would force recreation due to the addition of `interface` property
```
