### PR TITLE
send_empty_value for two fields

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -637,6 +637,7 @@ objects:
         - !ruby/object:Api::Type::Boolean
           name: 'negativeCaching'
           min_version: beta
+          send_empty_value: true
           description: |
             Negative caching allows per-status code TTLs to be set, in order to apply fine-grained caching for common errors or redirects.
         - !ruby/object:Api::Type::Array
@@ -672,6 +673,7 @@ objects:
         - !ruby/object:Api::Type::Integer
           name: 'serveWhileStale'
           min_version: beta
+          send_empty_value: true
           description: |
             Serve existing content from the cache (if available) when revalidating content with the origin, or when an error is encountered when refreshing the cache.
 
@@ -1239,6 +1241,7 @@ objects:
           - !ruby/object:Api::Type::Boolean
             name: 'negativeCaching'
             min_version: beta
+            send_empty_value: true
             description: |
               Negative caching allows per-status code TTLs to be set, in order to apply fine-grained caching for common errors or redirects.
           - !ruby/object:Api::Type::Array
@@ -1274,6 +1277,7 @@ objects:
           - !ruby/object:Api::Type::Integer
             name: 'serveWhileStale'
             min_version: beta
+            send_empty_value: true
             description: |
               Serve existing content from the cache (if available) when revalidating content with the origin, or when an error is encountered when refreshing the cache.
       - !ruby/object:Api::Type::NestedObject
@@ -2219,6 +2223,7 @@ objects:
           - !ruby/object:Api::Type::Boolean
             name: 'negativeCaching'
             min_version: beta
+            send_empty_value: true
             description: |
               Negative caching allows per-status code TTLs to be set, in order to apply fine-grained caching for common errors or redirects.
           - !ruby/object:Api::Type::Array
@@ -2254,6 +2259,7 @@ objects:
           - !ruby/object:Api::Type::Integer
             name: 'serveWhileStale'
             min_version: beta
+            send_empty_value: true
             description: |
               Serve existing content from the cache (if available) when revalidating content with the origin, or when an error is encountered when refreshing the cache.
 

--- a/mmv1/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
@@ -270,10 +270,18 @@ func TestAccComputeBackendService_withCdnPolicy(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckComputeBackendServiceDestroyProducer(t),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeBackendService_withCdnPolicy(serviceName, checkName),
 			},
-			resource.TestStep{
+			{
+				ResourceName:      "google_compute_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccComputeBackendService_withCdnPolicy2(serviceName, checkName),
+			},
+			{
 				ResourceName:      "google_compute_backend_service.foobar",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -1183,6 +1191,31 @@ resource "google_compute_backend_service" "foobar" {
   cdn_policy {
     negative_caching = false
     serve_while_stale = 0
+    cache_key_policy {
+      include_protocol       = true
+      include_host           = true
+      include_query_string   = true
+      query_string_whitelist = ["foo", "bar"]
+    }
+  }
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+`, serviceName, checkName)
+}
+
+func testAccComputeBackendService_withCdnPolicy2(serviceName, checkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name          = "%s"
+  health_checks = [google_compute_http_health_check.zero.self_link]
+
+  cdn_policy {
     cache_key_policy {
       include_protocol       = true
       include_host           = true

--- a/mmv1/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
@@ -1181,6 +1181,8 @@ resource "google_compute_backend_service" "foobar" {
   health_checks = [google_compute_http_health_check.zero.self_link]
 
   cdn_policy {
+    negative_caching = false
+    serve_while_stale = 0
     cache_key_policy {
       include_protocol       = true
       include_host           = true


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/9183


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
compute: fixed missing values for `negative_caching` and `serve_while_stale` on `google_compute_backend_service`
```
