### PR TITLE
Added go.mod as a copied file in mmv1

### DIFF
--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -88,7 +88,7 @@ fi
 
 if [ "$REPO" == "terraform" ]; then
     pushd $LOCAL_PATH
-    find . -type f -not -wholename "./.git*" -not -wholename "./.changelog*" -not -name ".travis.yml" -not -name ".golangci.yml" -not -name "CHANGELOG.md" -not -name "GNUmakefile" -not -name "docscheck.sh" -not -name "LICENSE" -not -name "README.md" -not -wholename "./examples*" -not -name "go.mod" -not -name "go.sum" -not -name "staticcheck.conf" -not -name ".go-version" -not -name ".hashibot.hcl" -not -name "tools.go"  -exec git rm {} \;
+    find . -type f -not -wholename "./.git*" -not -wholename "./.changelog*" -not -name ".travis.yml" -not -name ".golangci.yml" -not -name "CHANGELOG.md" -not -name "GNUmakefile" -not -name "docscheck.sh" -not -name "LICENSE" -not -name "README.md" -not -wholename "./examples*" -not -name "go.mod" -not -name "staticcheck.conf" -not -name ".go-version" -not -name ".hashibot.hcl" -not -name "tools.go"  -exec git rm {} \;
     go mod download
     popd
 fi

--- a/mmv1/provider/terraform/common~copy.yaml
+++ b/mmv1/provider/terraform/common~copy.yaml
@@ -59,3 +59,4 @@
 <% end -%>
 <% end -%>
 'version': 'third_party/terraform/version'
+'go.mod': 'third_party/terraform/go.mod'

--- a/mmv1/third_party/terraform/go.mod
+++ b/mmv1/third_party/terraform/go.mod
@@ -1,0 +1,36 @@
+module github.com/hashicorp/terraform-provider-google
+
+require (
+	cloud.google.com/go/bigtable v1.5.0
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v0.0.0-20210405181318-9364c5bf716b
+	github.com/apparentlymart/go-cidr v1.1.0
+	github.com/aws/aws-sdk-go v1.31.9 // indirect
+	github.com/client9/misspell v0.3.4
+	github.com/davecgh/go-spew v1.1.1
+	github.com/dnaeon/go-vcr v1.0.1
+	github.com/gammazero/deque v0.0.0-20180920172122-f6adf94963e4 // indirect
+	github.com/gammazero/workerpool v0.0.0-20181230203049-86a96b5d5d92
+	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d // indirect
+	github.com/golangci/golangci-lint v1.18.0
+	github.com/hashicorp/errwrap v1.0.0
+	github.com/hashicorp/go-cleanhttp v0.5.2
+	github.com/hashicorp/go-multierror v1.1.1
+	github.com/hashicorp/go-version v1.3.0
+	github.com/hashicorp/hcl/v2 v2.6.0 // indirect
+	github.com/hashicorp/terraform-plugin-sdk/v2 v2.5.0
+	github.com/mitchellh/go-homedir v1.1.0
+	github.com/mitchellh/hashstructure v1.1.0
+	github.com/onsi/ginkgo v1.8.0 // indirect
+	github.com/onsi/gomega v1.5.0 // indirect
+	github.com/sirupsen/logrus v1.2.0 // indirect
+	github.com/spf13/afero v1.2.2 // indirect
+	github.com/spf13/pflag v1.0.3 // indirect
+	github.com/zclconf/go-cty v1.5.1 // indirect
+	golang.org/x/net v0.0.0-20210119194325-5f4716e94777
+	golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93
+	google.golang.org/api v0.41.0
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
+)
+
+go 1.16

--- a/mmv1/third_party/terraform/go.mod
+++ b/mmv1/third_party/terraform/go.mod
@@ -1,8 +1,8 @@
 module github.com/hashicorp/terraform-provider-google
 
 require (
-	cloud.google.com/go/bigtable v1.5.0
-	github.com/GoogleCloudPlatform/declarative-resource-client-library v0.0.0-20210405181318-9364c5bf716b
+	cloud.google.com/go/bigtable v1.7.1
+	github.com/GoogleCloudPlatform/declarative-resource-client-library v0.0.0-20210519165700-76bc5cc4eeee
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/aws/aws-sdk-go v1.31.9 // indirect
 	github.com/client9/misspell v0.3.4
@@ -12,6 +12,7 @@ require (
 	github.com/gammazero/workerpool v0.0.0-20181230203049-86a96b5d5d92
 	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d // indirect
 	github.com/golangci/golangci-lint v1.18.0
+	github.com/google/btree v1.0.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
@@ -26,10 +27,10 @@ require (
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/zclconf/go-cty v1.5.1 // indirect
-	golang.org/x/net v0.0.0-20210119194325-5f4716e94777
-	golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93
-	google.golang.org/api v0.41.0
-	google.golang.org/protobuf v1.26.0 // indirect
+	golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420
+	golang.org/x/oauth2 v0.0.0-20210427180440-81ed05c6b58c
+	google.golang.org/api v0.46.0
+	google.golang.org/genproto v0.0.0-20210503173045-b96a97608f20 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )
 


### PR DESCRIPTION
Resolved https://github.com/hashicorp/terraform-provider-google/issues/8501

In addition to the reasons listed in the issue, it's been really easy to accidentally merge bad dependency upgrades because they don't automatically have their tests run.

```release-note:none

```
