### PR TITLE
fixed default for max_throughput

### DIFF
--- a/mmv1/products/vpcaccess/api.yaml
+++ b/mmv1/products/vpcaccess/api.yaml
@@ -119,9 +119,10 @@ objects:
         name: maxThroughput
         # The API documentation says this will default to 200, but when I tried that I got an error that the minimum
         # throughput must be lower than the maximum. The console defaults to 1000, so I changed it to that.
+        # API returns 300 if it is not sent
         description: |
-          Maximum throughput of the connector in Mbps, must be greater than `min_throughput`. Default is 1000.
-        default_value: 1000
+          Maximum throughput of the connector in Mbps, must be greater than `min_throughput`. Default is 300.
+        default_value: 300
       - !ruby/object:Api::Type::String
         name: 'selfLink'
         description: |

--- a/mmv1/third_party/terraform/tests/resource_vpc_access_connector_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_vpc_access_connector_test.go.erb
@@ -1,0 +1,69 @@
+<% autogen_exception -%>
+package google
+<% unless version == 'ga' -%>
+
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccVPCAccessConnector_vpcAccessConnectorThroughput(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProvidersOiCS,
+		CheckDestroy: testAccCheckVPCAccessConnectorDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccVPCAccessConnector_vpcAccessConnectorThroughput(context),
+			},
+			{
+				ResourceName:            "google_vpc_access_connector.connector",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+		},
+	})
+}
+
+func testAccVPCAccessConnector_vpcAccessConnectorThroughput(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_vpc_access_connector" "connector" {
+  provider      = google-beta
+  name          = "tf-test-vpc-con%{random_suffix}"
+  subnet {
+    name = google_compute_subnetwork.custom_test.name
+  }
+  machine_type = "e2-standard-4"
+  min_instances = 2
+  max_instances = 3
+  region        = "us-central1"
+}
+
+resource "google_compute_subnetwork" "custom_test" {
+  provider      = google-beta
+  name          = "tf-test-vpc-con%{random_suffix}"
+  ip_cidr_range = "10.2.0.0/28"
+  region        = "us-central1"
+  network       = google_compute_network.custom_test.id
+}
+
+resource "google_compute_network" "custom_test" {
+  provider                = google-beta
+  name                    = "tf-test-vpc-con%{random_suffix}"
+  auto_create_subnetworks = false
+}
+`, context)
+}
+
+<% else %>
+// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
+<% end -%>

--- a/mmv1/third_party/terraform/tests/resource_vpc_access_connector_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_vpc_access_connector_test.go.erb
@@ -2,8 +2,6 @@
 package google
 <% unless version == 'ga' -%>
 
-package google
-
 import (
 	"testing"
 
@@ -64,6 +62,4 @@ resource "google_compute_network" "custom_test" {
 `, context)
 }
 
-<% else %>
-// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
 <% end -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/9228


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
vpcaccess: fixed permadiff when `max_throughput` is not set on `google_vpc_access_connector`
```
