### PR TITLE
Add nil check to disk_autoresize_limit

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_sql_database_instance.go.erb
@@ -990,7 +990,13 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, secondGen bool)
 	if secondGen {
 		resize := _settings["disk_autoresize"].(bool)
 		settings.StorageAutoResize = &resize
-		settings.StorageAutoResizeLimit = int64(_settings["disk_autoresize_limit"].(int))
+		var resizeLimit int
+		if _settings["disk_autoresize_limit"] == nil {
+			resizeLimit = 0
+		} else {
+			resizeLimit = _settings["disk_autoresize_limit"].(int)
+		}
+		settings.StorageAutoResizeLimit = int64(resizeLimit)
 	}
 
 	return settings

--- a/mmv1/third_party/validator/sql_database_instance.go
+++ b/mmv1/third_party/validator/sql_database_instance.go
@@ -112,7 +112,13 @@ func expandSqlDatabaseInstanceSettings(configured []interface{}, secondGen bool)
 	if secondGen {
 		diskAutoresize := _settings["disk_autoresize"].(bool)
 		settings.StorageAutoResize = &diskAutoresize
-		settings.StorageAutoResizeLimit = int64(_settings["disk_autoresize_limit"].(int))
+		var resizeLimit int
+		if _settings["disk_autoresize_limit"] == nil {
+			resizeLimit = 0
+		} else {
+			resizeLimit = _settings["disk_autoresize_limit"].(int)
+		}
+		settings.StorageAutoResizeLimit = int64(resizeLimit)
 	}
 
 	return settings


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Addressing panic seen in https://github.com/GoogleCloudPlatform/terraform-validator/pull/218 tests

I'm not sure why the value isn't being set to the zero default, but I figured a nil check wouldn't hurt either way.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
