### PR TITLE
only skips tests in continuous integration

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -887,7 +887,9 @@ func TestAccContainerCluster_withVersion(t *testing.T) {
 
 func TestAccContainerCluster_updateVersion(t *testing.T) {
 	// TODO re-enable this test when GKE supports multiple versions concurrently
-	t.Skip("Only a single GKE version is supported currently by the API, this test cannot pass")
+	if v := os.Getenv("TF_ACC"); v == "" {
+		t.Skip("Only a single GKE version is supported currently by the API, this test cannot pass")
+	}
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
@@ -1177,7 +1179,9 @@ func TestAccContainerCluster_withNodePoolBasic(t *testing.T) {
 
 func TestAccContainerCluster_withNodePoolUpdateVersion(t *testing.T) {
 	// TODO re-enable this test when GKE supports multiple versions concurrently
-	t.Skip("Only a single GKE version is supported currently by the API, this test cannot pass")
+	if v := os.Getenv("TF_ACC"); v == "" {
+		t.Skip("Only a single GKE version is supported currently by the API, this test cannot pass")
+	}
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-nodepool-%s", randString(t, 10))

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -886,10 +886,6 @@ func TestAccContainerCluster_withVersion(t *testing.T) {
 }
 
 func TestAccContainerCluster_updateVersion(t *testing.T) {
-	// TODO re-enable this test when GKE supports multiple versions concurrently
-	if v := os.Getenv("TF_ACC"); v == "" {
-		t.Skip("Only a single GKE version is supported currently by the API, this test cannot pass")
-	}
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
@@ -1178,10 +1174,6 @@ func TestAccContainerCluster_withNodePoolBasic(t *testing.T) {
 }
 
 func TestAccContainerCluster_withNodePoolUpdateVersion(t *testing.T) {
-	// TODO re-enable this test when GKE supports multiple versions concurrently
-	if v := os.Getenv("TF_ACC"); v == "" {
-		t.Skip("Only a single GKE version is supported currently by the API, this test cannot pass")
-	}
 	t.Parallel()
 
 	clusterName := fmt.Sprintf("tf-test-cluster-nodepool-%s", randString(t, 10))

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -685,12 +685,6 @@ func TestAccContainerNodePool_resize(t *testing.T) {
 
 func TestAccContainerNodePool_version(t *testing.T) {
 	t.Parallel()
-
-	// Re-enable this test when there is more than one acceptable node pool version
-	// for the current master version
-	if v := os.Getenv("TF_ACC"); v == "" {
-		t.Skip()
-	}
 	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
 	np := fmt.Sprintf("tf-test-nodepool-%s", randString(t, 10))
 

--- a/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_node_pool_test.go.erb
@@ -688,8 +688,9 @@ func TestAccContainerNodePool_version(t *testing.T) {
 
 	// Re-enable this test when there is more than one acceptable node pool version
 	// for the current master version
-	t.Skip()
-
+	if v := os.Getenv("TF_ACC"); v == "" {
+		t.Skip()
+	}
 	cluster := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
 	np := fmt.Sprintf("tf-test-nodepool-%s", randString(t, 10))
 
@@ -939,7 +940,7 @@ func testAccContainerNodePool_basic(cluster, np string) string {
 	return fmt.Sprintf(`
 provider "google" {
   user_project_override = true
-}	
+}
 resource "google_container_cluster" "cluster" {
   name               = "%s"
   location           = "us-central1-a"


### PR DESCRIPTION
These were counting as early returns and thus giving unreachable code in new versions of the linter.
closes https://github.com/hashicorp/terraform-provider-google/issues/9145

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
