### PR TITLE
Made dataflow job updates fail fast if they're cancelled

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_dataflow_flex_template_job.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_dataflow_flex_template_job.go.erb
@@ -201,6 +201,10 @@ func waitForDataflowJobState(d *schema.ResourceData, config *Config, jobID, user
 			log.Printf("[DEBUG] the job with ID %q has state %q.", jobID, state)
 			return nil
 		}
+		_, terminating := dataflowTerminatingStatesMap[state]
+		if terminating && targetState == "JOB_STATE_RUNNING" {
+			return resource.NonRetryableError(fmt.Errorf("the job with ID %q is terminating with state %q and cannot reach expected state %q", jobID, state, targetState))
+		}
 		if _, terminated := dataflowTerminalStatesMap[state]; terminated {
 			return resource.NonRetryableError(fmt.Errorf("the job with ID %q has terminated with state %q instead of expected state %q", jobID, state, targetState))
 		} else {

--- a/mmv1/third_party/terraform/resources/resource_dataflow_job.go
+++ b/mmv1/third_party/terraform/resources/resource_dataflow_job.go
@@ -18,6 +18,11 @@ import (
 
 const resourceDataflowJobGoogleProvidedLabelPrefix = "labels.goog-dataflow-provided"
 
+var dataflowTerminatingStatesMap = map[string]struct{}{
+	"JOB_STATE_CANCELLING": {},
+	"JOB_STATE_DRAINING":   {},
+}
+
 var dataflowTerminalStatesMap = map[string]struct{}{
 	"JOB_STATE_DONE":      {},
 	"JOB_STATE_FAILED":    {},

--- a/mmv1/third_party/terraform/resources/resource_dataflow_job.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_dataflow_job.go.erb
@@ -1,3 +1,4 @@
+<% autogen_exception -%>
 package google
 
 import (
@@ -18,10 +19,12 @@ import (
 
 const resourceDataflowJobGoogleProvidedLabelPrefix = "labels.goog-dataflow-provided"
 
+<% unless version == "ga" -%>
 var dataflowTerminatingStatesMap = map[string]struct{}{
 	"JOB_STATE_CANCELLING": {},
 	"JOB_STATE_DRAINING":   {},
 }
+<% end -%>
 
 var dataflowTerminalStatesMap = map[string]struct{}{
 	"JOB_STATE_DONE":      {},


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Resolved https://github.com/hashicorp/terraform-provider-google/issues/9227.

Dataflow flex template jobs that are CANCELLING or DRAINING will never be able to be RUNNING. If we're expecting RUNNING but seeing CANCELLING or DRAINING, we can fail fast and let the user know (instead of making them wait for a few minutes.)

An alternative implementation would be to "update" the job by actually creating a new job (i.e. not using the update mechanism provided by dataflow flex templates.) However, that seems potentially confusing for end users. That would need some discussion as a potential enhancement, rather than a bug.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
dataflow: made `google_dataflow_flex_template_job` updates fail fast if the job is in the process of cancelling or draining (beta)
```
