### PR TITLE
Added additional filter by description to mostRecent test

### DIFF
--- a/mmv1/third_party/terraform/tests/data_source_google_compute_instance_template_test.go
+++ b/mmv1/third_party/terraform/tests/data_source_google_compute_instance_template_test.go
@@ -156,6 +156,7 @@ resource "google_compute_instance_template" "c" {
 
 data "google_compute_instance_template" "default" {
   // Hack to prevent depends_on bug triggering datasource recreate due to https://github.com/hashicorp/terraform/issues/11806
+  // This bug is fixed in 0.13+.
   project = "%{project}${replace(google_compute_instance_template.a.id, "/.*/", "")}${replace(google_compute_instance_template.b.id, "/.*/", "")}${replace(google_compute_instance_template.c.id, "/.*/", "")}"
   filter  = "name = tf-test-template-c-%{suffix}"
 }
@@ -166,7 +167,7 @@ func testAccInstanceTemplate_filter_mostRecent(project, suffix string) string {
 	return Nprintf(`
 resource "google_compute_instance_template" "a" {
   name        = "tf-test-template-%{suffix}-a"
-  description = "Example template."
+  description = "tf-test-instance-template"
 
   machine_type = "e2-small"
 
@@ -184,7 +185,7 @@ resource "google_compute_instance_template" "a" {
 }
 resource "google_compute_instance_template" "b" {
   name        = "tf-test-template-%{suffix}-b"
-  description = "Example template."
+  description = "tf-test-instance-template"
 
   machine_type = "e2-small"
 
@@ -207,7 +208,7 @@ resource "google_compute_instance_template" "b" {
 }
 resource "google_compute_instance_template" "c" {
   name        = "tf-test-template-%{suffix}-c"
-  description = "Example template."
+  description = "tf-test-instance-template"
 
   machine_type = "e2-small"
 
@@ -230,8 +231,9 @@ resource "google_compute_instance_template" "c" {
 
 data "google_compute_instance_template" "default" {
   // Hack to prevent depends_on bug triggering datasource recreate due to https://github.com/hashicorp/terraform/issues/11806
+  // This bug is fixed in 0.13+.
   project = "%{project}${replace(google_compute_instance_template.b.id, "/.*/", "")}"
-  filter      = "name != tf-test-template-%{suffix}-b"
+  filter      = "(name != tf-test-template-%{suffix}-b) (description = tf-test-instance-template)"
   most_recent = true
 }
 `, map[string]interface{}{"project": project, "suffix": suffix})


### PR DESCRIPTION
This ensures that only the relevant instances will be considered while filtering

Resolved https://github.com/hashicorp/terraform-provider-google/issues/9246

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
