### PR TITLE
Simplified ci conversion of shallow -> full clone

### DIFF
--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -5,23 +5,13 @@ steps:
       args:
           - $_PR_NUMBER
 
-    # The GCB / GH integration doesn't satisfy our use case perfectly.
-    # It doesn't check out the merge commit, and it doesn't check out the repo
-    # itself - it only gives us the actual code, not the repo. So we need
-    # to handle that access ourselves - which means deleting the code
-    # and cloning the repo to the present directory.  We need to use
-    # 'sh' to evaluate the '*' arguments, which otherwise would be
-    # passed literally to 'rm'.
-    - name: 'alpine'
-      args:
-          - sh
-          - -c
-          - rm -rf ./* ./.* || true
+    # The GCB / GH integration uses a shallow clone of the repo. We need to convert
+    # that to a full clone in order to work with it properly.
+    # https://cloud.google.com/source-repositories/docs/integrating-with-cloud-build#unshallowing_clones
     - name: 'gcr.io/cloud-builders/git'
       args:
-          - clone
-          - https://github.com/GoogleCloudPlatform/magic-modules
-          - .
+          - fetch
+          - --unshallow
     # We need to configure git since creating the merge commit is
     # technically a commit.
     - name: 'gcr.io/cloud-builders/git'


### PR DESCRIPTION
`fetch --unshallow` is the current recommended method in the docs, and should be more straightforward than the current method.

Related to https://github.com/hashicorp/terraform-provider-google/issues/9146
```release-note:none

```
