### PR TITLE
Separated out tgc test results as a different status

### DIFF
--- a/.ci/containers/terraform-google-conversion-tester/test_terraform_google_conversion.sh
+++ b/.ci/containers/terraform-google-conversion-tester/test_terraform_google_conversion.sh
@@ -2,14 +2,56 @@
 
 set -e
 
-PR_NUMBER=$1
-SCRATCH_OWNER=modular-magician
-GH_REPO=terraform-google-conversion
+pr_number=$1
+mm_commit_sha=$2
+build_id=$3
+project_id=$4
+github_username=modular-magician
+gh_repo=terraform-google-conversion
+build_step="21"
 
-SCRATCH_PATH=https://$SCRATCH_OWNER:$GITHUB_TOKEN@github.com/$SCRATCH_OWNER/$GH_REPO
-LOCAL_PATH=$GOPATH/src/github.com/GoogleCloudPlatform/$GH_REPO
-mkdir -p "$(dirname $LOCAL_PATH)"
-git clone $SCRATCH_PATH $LOCAL_PATH --single-branch --branch "auto-pr-$PR_NUMBER" --depth 1
-pushd $LOCAL_PATH
+scratch_path=https://$github_username:$GITHUB_TOKEN@github.com/$github_username/$gh_repo
+local_path=$GOPATH/src/github.com/GoogleCloudPlatform/$gh_repo
+
+post_body="{"
+post_body+='"context":"terraform-google-conversion-test",'
+post_body+='"target_url":"https://console.cloud.google.com/cloud-build/builds;region=global/'"$build_id"';step='"$build_step"'?project='"$project_id"'",'
+post_body+='"state":"success"'
+post_body+="}"
+
+curl \
+  -X POST \
+  -u "$github_username:$GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
+  -d "$post_body"
+
+mkdir -p "$(dirname $local_path)"
+git clone $scratch_path $local_path --single-branch --branch "auto-pr-$pr_number" --depth 1
+pushd $local_path
+
+set +e
 
 make test
+exit_code=$?
+
+set -e
+
+if [ $exitCode -ne 0 ]; then
+	state="failure"
+else
+	state="success"
+fi
+
+post_body="{"
+post_body+='"context":"terraform-google-conversion-test",'
+post_body+='"target_url":"https://console.cloud.google.com/cloud-build/builds;region=global/'"$build_id"';step='"$build_step"'?project='"$project_id"'",'
+post_body+='"state":"'"$state"'"'
+post_body+="}"
+
+curl \
+  -X POST \
+  -u "$github_username:$GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
+  -d "$post_body"

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -175,6 +175,9 @@ steps:
       waitFor: ["diff"]
       args:
           - $_PR_NUMBER
+          - $COMMIT_SHA
+          - $BUILD_ID
+          - $PROJECT_ID
 
     - name: 'gcr.io/graphite-docker-images/terraform-tester'
       id: tpgb-test


### PR DESCRIPTION
This uses the statuses API to split out the results for terraform-google-conversion tests from generate-diffs. Note that this means that the script should only have a nonzero exit code if the script itself fails; the tests failing will no longer cause generate_diffs to fail (which is what we want. These test failures will be tracked by this new status instead.)

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
