### PR TITLE
Separated out tgc test results as a different status

### DIFF
--- a/.ci/containers/terraform-google-conversion-tester/test_terraform_google_conversion.sh
+++ b/.ci/containers/terraform-google-conversion-tester/test_terraform_google_conversion.sh
@@ -2,14 +2,56 @@
 
 set -e
 
-PR_NUMBER=$1
-SCRATCH_OWNER=modular-magician
-GH_REPO=terraform-google-conversion
+pr_number=$1
+mm_commit_sha=$2
+build_id=$3
+project_id=$4
+github_username=modular-magician
+gh_repo=terraform-google-conversion
+build_step="21"
 
-SCRATCH_PATH=https://$SCRATCH_OWNER:$GITHUB_TOKEN@github.com/$SCRATCH_OWNER/$GH_REPO
-LOCAL_PATH=$GOPATH/src/github.com/GoogleCloudPlatform/$GH_REPO
-mkdir -p "$(dirname $LOCAL_PATH)"
-git clone $SCRATCH_PATH $LOCAL_PATH --single-branch --branch "auto-pr-$PR_NUMBER" --depth 1
-pushd $LOCAL_PATH
+scratch_path=https://$github_username:$GITHUB_TOKEN@github.com/$github_username/$gh_repo
+local_path=$GOPATH/src/github.com/GoogleCloudPlatform/$gh_repo
+
+post_body="{"
+post_body+='"context":"terraform-google-conversion-test",'
+post_body+='"target_url":"https://console.cloud.google.com/cloud-build/builds;region=global/'"$build_id"';step='"$build_step"'?project='"$project_id"'",'
+post_body+='"state":"success"'
+post_body+="}"
+
+curl \
+  -X POST \
+  -u "$github_username:$GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
+  -d "$post_body"
+
+mkdir -p "$(dirname $local_path)"
+git clone $scratch_path $local_path --single-branch --branch "auto-pr-$pr_number" --depth 1
+pushd $local_path
+
+set +e
 
 make test
+exit_code=$?
+
+set -e
+
+if [ $exitCode -ne 0 ]; then
+	state="failure"
+else
+	state="success"
+fi
+
+post_body="{"
+post_body+='"context":"terraform-google-conversion-test",'
+post_body+='"target_url":"https://console.cloud.google.com/cloud-build/builds;region=global/'"$build_id"';step='"$build_step"'?project='"$project_id"'",'
+post_body+='"state":"'"$state"'"'
+post_body+="}"
+
+curl \
+  -X POST \
+  -u "$github_username:$GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
+  -d "$post_body"

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -175,6 +175,9 @@ steps:
       waitFor: ["diff"]
       args:
           - $_PR_NUMBER
+          - $COMMIT_SHA
+          - $BUILD_ID
+          - $PROJECT_ID
 
     - name: 'gcr.io/graphite-docker-images/terraform-tester'
       id: tpgb-test


### PR DESCRIPTION
This uses the [statuses API](https://docs.github.com/en/rest/reference/repos#create-a-commit-status) to split out the results for terraform-google-conversion tests from generate-diffs. Note that this means that the script should only have a nonzero exit code if the script itself fails; the tests failing will no longer cause generate_diffs to fail (which is what we want. These test failures will be tracked by this new status instead.)

I can't test this fully because it requires rebuilding the docker containers. Doing tgc first lets us test it out with a relatively low-traffic component before doing the same conversion with e.g. tpg and tpgb.

I've tested this locally as much as I can - i.e. running the curl logic with a personal access token instead of the Magician's.

```release-note:none

```
