### PR TITLE
Promote customResponseHeaders to GA

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -677,7 +677,6 @@ objects:
 
       - !ruby/object:Api::Type::Array
         name: 'customResponseHeaders'
-        min_version: beta
         description: |
           Headers that the HTTP/S load balancer should add to proxied responses.
         item_type: Api::Type::String
@@ -1302,7 +1301,6 @@ objects:
           requests.
       - !ruby/object:Api::Type::Array
         name: 'customResponseHeaders'
-        min_version: beta
         item_type: Api::Type::String
         description: |
           Headers that the HTTP/S load balancer should add to proxied

--- a/mmv1/templates/terraform/examples/backend_bucket_full.tf.erb
+++ b/mmv1/templates/terraform/examples/backend_bucket_full.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_backend_bucket" "image_backend" {
-  provider    = google-beta
   name        = "<%= ctx[:vars]['backend_bucket_name'] %>"
   description = "Contains beautiful beta mages"
   bucket_name = google_storage_bucket.image_bucket.name
@@ -18,7 +17,6 @@ resource "google_compute_backend_bucket" "image_backend" {
 }
 
 resource "google_storage_bucket" "image_bucket" {
-  provider = google-beta
   name     = "<%= ctx[:vars]['bucket_name'] %>"
   location = "EU"
 }

--- a/mmv1/templates/terraform/examples/backend_service_network_endpoint.tf.erb
+++ b/mmv1/templates/terraform/examples/backend_service_network_endpoint.tf.erb
@@ -1,19 +1,16 @@
 resource "google_compute_global_network_endpoint_group" "external_proxy" {
-  provider=google-beta
   name                  = "<%= ctx[:vars]['neg_name'] %>"
   network_endpoint_type = "INTERNET_FQDN_PORT"
   default_port          = "443"
 }
 
 resource "google_compute_global_network_endpoint" "proxy" {
-  provider=google-beta
   global_network_endpoint_group = google_compute_global_network_endpoint_group.external_proxy.id
   fqdn                          = "test.example.com"
   port                          = google_compute_global_network_endpoint_group.external_proxy.default_port
 }
 
 resource "google_compute_backend_service" "<%= ctx[:primary_resource_id] %>" {
-  provider=google-beta
   name                            = "<%= ctx[:vars]['backend_service_name'] %>"
   enable_cdn                      = true
   timeout_sec                     = 10

--- a/mmv1/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_backend_service_test.go.erb
@@ -549,7 +549,6 @@ func TestAccComputeBackendService_withMaxConnectionsPerEndpoint(t *testing.T) {
 	})
 }
 
-<% unless version == 'ga' -%>
 func TestAccComputeBackendService_withCustomHeaders(t *testing.T) {
 	t.Parallel()
 
@@ -580,7 +579,6 @@ func TestAccComputeBackendService_withCustomHeaders(t *testing.T) {
 		},
 	})
 }
-<% end -%>
 
 func TestAccComputeBackendService_internalLoadBalancing(t *testing.T) {
 	// Instance template uses UniqueId in some cases
@@ -1535,7 +1533,6 @@ resource "google_compute_health_check" "default" {
 `, service, maxRate, instance, neg, network, network, check)
 }
 
-<% unless version == 'ga' -%>
 func testAccComputeBackendService_withCustomHeaders(serviceName, checkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
@@ -1554,7 +1551,6 @@ resource "google_compute_http_health_check" "zero" {
 }
 `, serviceName, checkName)
 }
-<% end -%>
 
 <%# This test is for import functionality. It can be removed and added to examples when this goes GA %>
 func testAccComputeBackendService_internalLoadBalancing(fr, proxy, backend, hc, urlmap string) string {


### PR DESCRIPTION
This change promotes custom_response_headers for
google_compute_backend_service and google_compute_backend_bucket
to GA.

Signed-off-by: Gorka Lerchundi Osa glertxundi@gmail.com

If this PR is for Terraform, I acknowledge that I have:
- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

```release-note:enhancement
 compute: promote `custom_response_headers` for `google_compute_backend_service` and `google_compute_backend_bucket` to GA
 ```
