### PR TITLE
Add additional loop to check changes from resp list

### DIFF
--- a/mmv1/provider/ansible/gcp_utils.py
+++ b/mmv1/provider/ansible/gcp_utils.py
@@ -382,6 +382,17 @@ class GcpRequest(object):
             if not found_item:
                 difference.append(req_item)
 
+        # We need to check list in both direction, to get changes from both sides.
+        # Or additional fields in new_resp_list get ignored
+        for resp_item in new_resp_list:
+            found_item = False
+            for req_item in new_req_list:
+                # Looking for a None value here.
+                if not self._compare_value(req_item, resp_item):
+                    found_item = True
+            if not found_item:
+                difference.append(req_item)
+
         difference2 = []
         for value in difference:
             if value:


### PR DESCRIPTION
Currently by tests, I found out that "gcp_compute_firewall" is not working like expected. 
Existing "allowed" ports, didn't get deleted and no change was detected. After some investigation, found that the comparison for "is_different" is not working correct. 

https://github.com/ansible-collections/google.cloud/blob/master/plugins/modules/gcp_compute_firewall.py#L688

More steps and I was able to reproduce the comparison and see the order of the comparison is important.
```python
>>> resp = {u'name': u'test-fw-module', u'sourceRanges': [u'127.0.0.1', u'10.10.10.10/29'], u'priority': 1000, u'targetTags': [u'monitor'], u'allowed': [{u'IPProtocol': u'tcp', u'ports': [u'1255']}, {u'IPProtocol': u'tcp', u'ports': [u'12435']}], u'network': u'https://www.googleapis.com/compute/v1/projects/kci-wordpress/global/networks/default'}
>>> req = {u'name': 'test-fw-module', u'sourceRanges': [u'127.0.0.1', u'10.10.10.10/29'], u'priority': 1000, u'targetTags': ['monitor'], u'allowed': [{u'IPProtocol': 'tcp', u'ports': ['1255']}], u'network': 'https://www.googleapis.com/compute/v1/projects/kci-wordpress/global/networks/default'}
>>> gcp_utils.GcpRequest(resp) == gcp_utils.GcpRequest(req)
False
>>> gcp_utils.GcpRequest(req) == gcp_utils.GcpRequest(resp)
True
```

I don't know if this code is the best solution, but was resolving for me the wrong behavior of this module. Related this is a basic object for the ansible google cloud module, I'm not aware if this can cause other side effects.

refs also to this issue: https://github.com/ansible-collections/google.cloud/issues/402


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
Fixed list comparison in gcp_utils.py to check both side of a GcpRequest object.
```
