### PR TITLE
make `google_iam_workload_identity_pool_provider.oidc` updatable

### DIFF
--- a/mmv1/products/iambeta/api.yaml
+++ b/mmv1/products/iambeta/api.yaml
@@ -255,7 +255,6 @@ objects:
       - !ruby/object:Api::Type::NestedObject
         name: aws
         description: An Amazon Web Services identity provider. Not compatible with the property oidc.
-        input: true
         exactly_one_of:
           - aws
           - oidc
@@ -267,7 +266,6 @@ objects:
       - !ruby/object:Api::Type::NestedObject
         name: oidc
         description: An OpenId Connect 1.0 identity provider. Not compatible with the property aws.
-        input: true
         exactly_one_of:
           - aws
           - oidc

--- a/mmv1/products/iambeta/terraform.yaml
+++ b/mmv1/products/iambeta/terraform.yaml
@@ -78,6 +78,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       workloadIdentityPoolProviderId: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateWorkloadIdentityPoolProviderId'
+      oidc: !ruby/object:Overrides::Terraform::PropertyOverride
+        update_mask_fields:
+          - "oidc.allowed_audiences"
+          - "oidc.issuer_uri"
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.

--- a/mmv1/third_party/terraform/tests/resource_iam_beta_workload_identity_pool_provider_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_iam_beta_workload_identity_pool_provider_test.go.erb
@@ -70,6 +70,14 @@ func TestAccIAMBetaWorkloadIdentityPoolProvider_oidc(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
+				Config: testAccIAMBetaWorkloadIdentityPoolProvider_oidc_update(context),
+			},
+			{
+				ResourceName:      "google_iam_workload_identity_pool_provider.my_provider",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
 				Config: testAccIAMBetaWorkloadIdentityPoolProvider_oidc_basic(context),
 			},
 			{
@@ -157,6 +165,37 @@ EOT
   oidc {
     allowed_audiences = ["https://example.com/gcp-oidc-federation", "example.com/gcp-oidc-federation"]
     issuer_uri        = "https://sts.windows.net/azure-tenant-id-full"
+  }
+}
+`, context)
+}
+
+func testAccIAMBetaWorkloadIdentityPoolProvider_oidc_update(context map[string]interface{}) string {
+	return Nprintf(`
+resource "google_iam_workload_identity_pool" "my_pool" {
+  workload_identity_pool_id = "my-pool-%{random_suffix}"
+}
+
+resource "google_iam_workload_identity_pool_provider" "my_provider" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.my_pool.workload_identity_pool_id
+  workload_identity_pool_provider_id = "my-provider-%{random_suffix}"
+  display_name                       = "Name of provider"
+  description                        = "OIDC identity pool provider for automated test"
+  disabled                           = true
+  attribute_condition                = "\"e968c2ef-047c-498d-8d79-16ca1b61e77e\" in assertion.groups"
+  attribute_mapping                  = {
+    "google.subject"                  = "\"azure::\" + assertion.tid + \"::\" + assertion.sub"
+    "attribute.tid"                   = "assertion.tid"
+    "attribute.managed_identity_name" = <<EOT
+      {
+        "8bb39bdb-1cc5-4447-b7db-a19e920eb111":"workload1",
+        "55d36609-9bcf-48e0-a366-a3cf19027d2a":"workload2"
+      }[assertion.oid]
+EOT
+  }
+  oidc {
+    allowed_audiences = ["https://example.com/gcp-oidc-federation-update", "example.com/gcp-oidc-federation-update"]
+    issuer_uri        = "https://sts.windows.net/azure-tenant-id-update"
   }
 }
 `, context)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Context: b/190760650

Currently, attempting to update fields within `oidc` gives the error:
```
googleapi: Error 400: A FieldMask with at least one path must be specified.
```

There were two problems with updating this field are:

1. `oidc` was set to `input: true` while the child fields were not. `oidc.allowed_audiences` and `oidc.issuer_uri` were not `ForceNew` but also not included in the field mask. This lead to the above error
2. `ForceNew` doesn't work for this resource unless the identity fields are changing. Deleting this resource just sets the status to inactive and when the provider goes to recreate it causes a `409 already existing`

To remedy this, I removed `input: true` on the appropriate fields and added `oidc.allowed_audiences` and `oidc.issuer_uri` to the update mask. Also added a test step to use this scenario.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
iam: fixed an issue in `google_iam_workload_identity_pool_provider` where `aws` and `oidc` were not updatable.
```
