### PR TITLE
Switched to jq for building JSON for terraform-google-conversion tests

### DIFF
--- a/.ci/containers/terraform-google-conversion-tester/Dockerfile
+++ b/.ci/containers/terraform-google-conversion-tester/Dockerfile
@@ -5,7 +5,7 @@ RUN ssh-keyscan github.com >> /known_hosts
 RUN echo "UserKnownHostsFile /known_hosts" >> /etc/ssh/ssh_config
 
 RUN apt-get update
-RUN apt-get install -y git
+RUN apt-get install -y git jq
 
 ADD test_terraform_google_conversion.sh /test_terraform_google_conversion.sh
 ENTRYPOINT ["/test_terraform_google_conversion.sh"]

--- a/.ci/containers/terraform-google-conversion-tester/test_terraform_google_conversion.sh
+++ b/.ci/containers/terraform-google-conversion-tester/test_terraform_google_conversion.sh
@@ -37,7 +37,7 @@ exit_code=$?
 
 set -e
 
-if [ $exitCode -ne 0 ]; then
+if [ $exit_code -ne 0 ]; then
 	state="failure"
 else
 	state="success"

--- a/.ci/containers/terraform-google-conversion-tester/test_terraform_google_conversion.sh
+++ b/.ci/containers/terraform-google-conversion-tester/test_terraform_google_conversion.sh
@@ -13,11 +13,11 @@ build_step="21"
 scratch_path=https://$github_username:$GITHUB_TOKEN@github.com/$github_username/$gh_repo
 local_path=$GOPATH/src/github.com/GoogleCloudPlatform/$gh_repo
 
-post_body="{"
-post_body+='"context":"terraform-google-conversion-test",'
-post_body+='"target_url":"https://console.cloud.google.com/cloud-build/builds;region=global/'"$build_id"';step='"$build_step"'?project='"$project_id"'",'
-post_body+='"state":"success"'
-post_body+="}"
+post_body=$( jq -n \
+	--arg context "terraform-google-conversion-test" \
+	--arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
+	--arg state "pending" \
+	'{context: $context, target_url: $target_url, state: $state}')
 
 curl \
   -X POST \
@@ -43,11 +43,11 @@ else
 	state="success"
 fi
 
-post_body="{"
-post_body+='"context":"terraform-google-conversion-test",'
-post_body+='"target_url":"https://console.cloud.google.com/cloud-build/builds;region=global/'"$build_id"';step='"$build_step"'?project='"$project_id"'",'
-post_body+='"state":"'"$state"'"'
-post_body+="}"
+post_body=$( jq -n \
+	--arg context "terraform-google-conversion-test" \
+	--arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
+	--arg state "${state}" \
+	'{context: $context, target_url: $target_url, state: $state}')
 
 curl \
   -X POST \


### PR DESCRIPTION
This PR is related to https://github.com/hashicorp/terraform-provider-google/issues/9146. It fixes a typo in the exit code check and also switches to jq for building the JSON strings (since that's less error-prone.)

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
