### PR TITLE
Made tgc-test only wait for the tgc diffs, not for diffs to be published on GitHub

### DIFF
--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -128,6 +128,7 @@ steps:
           - $_PR_NUMBER
 
     - name: 'gcr.io/graphite-docker-images/downstream-builder'
+      id: tgc-head
       secretEnv: ["GITHUB_TOKEN"]
       waitFor: ["merged"]
       args:
@@ -137,6 +138,7 @@ steps:
           - $_PR_NUMBER
 
     - name: 'gcr.io/graphite-docker-images/downstream-builder'
+      id: tgc-base
       secretEnv: ["GITHUB_TOKEN"]
       waitFor: ["merged"]
       args:
@@ -172,7 +174,7 @@ steps:
     - name: 'gcr.io/graphite-docker-images/terraform-google-conversion-tester'
       id: tgc-test
       secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["diff"]
+      waitFor: ["tgc-head", "tgc-base"]
       args:
           - $_PR_NUMBER
           - $COMMIT_SHA


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Related to https://github.com/hashicorp/terraform-provider-google/issues/9146.

We don't need to wait to run tests when the diff posts to GitHub, just until the diffs exist for tgc.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
