### PR TITLE
Made terraform provider linting & tests report their status via github status API

### DIFF
--- a/.ci/containers/terraform-tester/test_terraform.sh
+++ b/.ci/containers/terraform-tester/test_terraform.sh
@@ -2,28 +2,113 @@
 
 set -e
 
-REPO=$1
-REFERENCE=$2
-SCRATCH_OWNER=modular-magician
-if [ "$REPO" == "ga" ]; then
-    GH_REPO=terraform-provider-google
-elif [ "$REPO" == "beta" ]; then
-    GH_REPO=terraform-provider-google-beta
+version=$1
+pr_number=$2
+mm_commit_sha=$3
+build_id=$4
+project_id=$5
+github_username=modular-magician
+if [ "$version" == "ga" ]; then
+    gh_repo=terraform-provider-google
+    build_step="24"
+elif [ "$version" == "beta" ]; then
+    gh_repo=terraform-provider-google-beta
+    build_step="23"
 else
     echo "no repo, dying."
     exit 1
 fi
 
-SCRATCH_PATH=https://$SCRATCH_OWNER:$GITHUB_TOKEN@github.com/$SCRATCH_OWNER/$GH_REPO
-LOCAL_PATH=$GOPATH/src/github.com/terraform-providers/$GH_REPO
-mkdir -p "$(dirname $LOCAL_PATH)"
-git clone $SCRATCH_PATH $LOCAL_PATH --single-branch --branch "auto-pr-$REFERENCE" --depth 1
-pushd $LOCAL_PATH
+scratch_path=https://$github_username:$GITHUB_TOKEN@github.com/$github_username/$gh_repo
+local_path=$GOPATH/src/github.com/terraform-providers/$gh_repo
+mkdir -p "$(dirname $local_path)"
+git clone $scratch_path $local_path --single-branch --branch "auto-pr-$pr_number" --depth 1
+pushd $local_path
+
+
+post_body=$( jq -n \
+    --arg context "${gh_repo}-test" \
+    --arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
+    --arg state "pending" \
+    '{context: $context, target_url: $target_url, state: $state}')
+
+curl \
+  -X POST \
+  -u "$github_username:$GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
+  -d "$post_body"
+
+
+post_body=$( jq -n \
+    --arg context "${gh_repo}-lint" \
+    --arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
+    --arg state "pending" \
+    '{context: $context, target_url: $target_url, state: $state}')
+
+curl \
+  -X POST \
+  -u "$github_username:$GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
+  -d "$post_body"
+
+set +e
 
 make
-make tools
-make docscheck
-make test
+lint_exit_code=$?
+test_exit_code=1
 
-# make lint goes last, because it provides weird and confusing errors if the code or tests don't compile.
-make lint
+if [ $lint_exit_code -eq 0 ]; then
+    # only run lint & tests if the code compiled
+    make lint
+    lint_exit_code=$lint_exit_code || $?
+    make test
+    test_exit_code=$?
+fi
+
+make tools
+lint_exit_code=$lint_exit_code || $?
+make docscheck
+lint_exit_code=$lint_exit_code || $?
+
+set -e
+
+if [ $test_exit_code -ne 0 ]; then
+    test_state="failure"
+else
+    test_state="success"
+fi
+
+if [ $lint_exit_code -ne 0 ]; then
+    lint_state="failure"
+else
+    lint_state="success"
+fi
+
+post_body=$( jq -n \
+    --arg context "${gh_repo}-test" \
+    --arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
+    --arg state "${test_state}" \
+    '{context: $context, target_url: $target_url, state: $state}')
+
+curl \
+  -X POST \
+  -u "$github_username:$GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
+  -d "$post_body"
+
+
+post_body=$( jq -n \
+    --arg context "${gh_repo}-lint" \
+    --arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
+    --arg state "${lint_state}" \
+    '{context: $context, target_url: $target_url, state: $state}')
+
+curl \
+  -X POST \
+  -u "$github_username:$GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
+  -d "$post_body"

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -64,6 +64,7 @@ steps:
           - $_PR_NUMBER
 
     - name: 'gcr.io/graphite-docker-images/downstream-builder'
+      id: tpg-base
       secretEnv: ["GITHUB_TOKEN"]
       waitFor: ["merged"]
       args:
@@ -83,6 +84,7 @@ steps:
           - $_PR_NUMBER
 
     - name: 'gcr.io/graphite-docker-images/downstream-builder'
+      id: tpgb-base
       secretEnv: ["GITHUB_TOKEN"]
       waitFor: ["merged"]
       args:
@@ -184,18 +186,24 @@ steps:
     - name: 'gcr.io/graphite-docker-images/terraform-tester'
       id: tpgb-test
       secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["diff"]
+      waitFor: ["tpgb-head", "tpgb-base"]
       args:
           - 'beta'
           - $_PR_NUMBER
+          - $COMMIT_SHA
+          - $BUILD_ID
+          - $PROJECT_ID
 
     - name: 'gcr.io/graphite-docker-images/terraform-tester'
       id: tpg-test
       secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["diff"]
+      waitFor: ["tpg-head", "tpg-base"]
       args:
           - 'ga'
           - $_PR_NUMBER
+          - $COMMIT_SHA
+          - $BUILD_ID
+          - $PROJECT_ID
 
     - name: 'gcr.io/graphite-docker-images/terraform-vcr-tester'
       id: tpg-vcr-test


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Related to https://github.com/hashicorp/terraform-provider-google/issues/9146. Makes tpg / tpgb unit test & lint report status when they start/finish, and made them start running when the appropriate diffs are generated (not when the comment is posted)

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
