### PR TITLE
Switched to setting build steps in yaml

### DIFF
--- a/.ci/containers/terraform-google-conversion-tester/test_terraform_google_conversion.sh
+++ b/.ci/containers/terraform-google-conversion-tester/test_terraform_google_conversion.sh
@@ -6,9 +6,9 @@ pr_number=$1
 mm_commit_sha=$2
 build_id=$3
 project_id=$4
+build_step=$5
 github_username=modular-magician
 gh_repo=terraform-google-conversion
-build_step="21"
 
 scratch_path=https://$github_username:$GITHUB_TOKEN@github.com/$github_username/$gh_repo
 local_path=$GOPATH/src/github.com/GoogleCloudPlatform/$gh_repo

--- a/.ci/containers/terraform-tester/test_terraform.sh
+++ b/.ci/containers/terraform-tester/test_terraform.sh
@@ -7,13 +7,12 @@ pr_number=$2
 mm_commit_sha=$3
 build_id=$4
 project_id=$5
+build_step=$6
 github_username=modular-magician
 if [ "$version" == "ga" ]; then
     gh_repo=terraform-provider-google
-    build_step="24"
 elif [ "$version" == "beta" ]; then
     gh_repo=terraform-provider-google-beta
-    build_step="23"
 else
     echo "no repo, dying."
     exit 1

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -182,6 +182,7 @@ steps:
           - $COMMIT_SHA
           - $BUILD_ID
           - $PROJECT_ID
+          - 21  # Build step
 
     - name: 'gcr.io/graphite-docker-images/terraform-tester'
       id: tpgb-test
@@ -193,6 +194,7 @@ steps:
           - $COMMIT_SHA
           - $BUILD_ID
           - $PROJECT_ID
+          - 22  # Build step
 
     - name: 'gcr.io/graphite-docker-images/terraform-tester'
       id: tpg-test
@@ -204,6 +206,7 @@ steps:
           - $COMMIT_SHA
           - $BUILD_ID
           - $PROJECT_ID
+          - 23  # Build step
 
     - name: 'gcr.io/graphite-docker-images/terraform-vcr-tester'
       id: tpg-vcr-test


### PR DESCRIPTION
This makes it so that they're easier to compare and also doesn't require rebuilding the container to update them

Note: This updates the build steps for tpgb and tpg tests because they were previously incorrect.

```release-note:none

```
