### PR TITLE
Moved changelog check first

### DIFF
--- a/.ci/containers/changelog-checker/Dockerfile
+++ b/.ci/containers/changelog-checker/Dockerfile
@@ -3,4 +3,8 @@ FROM hashicorpdev/go-changelog
 ENV GITHUB_REPO=magic-modules
 ENV GITHUB_OWNER=GoogleCloudPlatform
 
-ENTRYPOINT ["/go-changelog/changelog-pr-body-check"]
+RUN apt-get update
+RUN apt-get install -y jq
+
+ADD check_changelog.sh /check_changelog.sh
+ENTRYPOINT ["/check_changelog.sh"]

--- a/.ci/containers/changelog-checker/check_changelog.sh
+++ b/.ci/containers/changelog-checker/check_changelog.sh
@@ -1,0 +1,49 @@
+#! /bin/bash
+
+set -e
+
+pr_number=$1
+mm_commit_sha=$2
+build_id=$3
+project_id=$4
+build_step=$5
+github_username=modular-magician
+
+post_body=$( jq -n \
+	--arg context "valid-changelog" \
+	--arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
+	--arg state "pending" \
+	'{context: $context, target_url: $target_url, state: $state}')
+
+curl \
+  -X POST \
+  -u "$github_username:$GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
+  -d "$post_body"
+
+set +e
+
+/go-changelog/changelog-pr-body-check
+exit_code=$?
+
+set -e
+
+if [ $exit_code -ne 0 ]; then
+	state="failure"
+else
+	state="success"
+fi
+
+post_body=$( jq -n \
+	--arg context "valid-changelog" \
+	--arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
+	--arg state "${state}" \
+	'{context: $context, target_url: $target_url, state: $state}')
+
+curl \
+  -X POST \
+  -u "$github_username:$GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
+  -d "$post_body"

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -1,5 +1,14 @@
 ---
 steps:
+    - name: 'gcr.io/graphite-docker-images/changelog-checker'
+      secretEnv: ["GITHUB_TOKEN"]
+      args:
+          - $_PR_NUMBER
+          - $COMMIT_SHA
+          - $BUILD_ID
+          - $PROJECT_ID
+          - 0  # Build step
+
     - name: 'gcr.io/graphite-docker-images/contributor-checker'
       secretEnv: ["GITHUB_TOKEN"]
       args:
@@ -182,7 +191,7 @@ steps:
           - $COMMIT_SHA
           - $BUILD_ID
           - $PROJECT_ID
-          - "21"  # Build step
+          - "22"  # Build step
 
     - name: 'gcr.io/graphite-docker-images/terraform-tester'
       id: tpgb-test
@@ -194,7 +203,7 @@ steps:
           - $COMMIT_SHA
           - $BUILD_ID
           - $PROJECT_ID
-          - "22"  # Build step
+          - "23"  # Build step
 
     - name: 'gcr.io/graphite-docker-images/terraform-tester'
       id: tpg-test
@@ -206,19 +215,13 @@ steps:
           - $COMMIT_SHA
           - $BUILD_ID
           - $PROJECT_ID
-          - "23"  # Build step
+          - "24"  # Build step
 
     - name: 'gcr.io/graphite-docker-images/terraform-vcr-tester'
       id: tpg-vcr-test
       secretEnv: ["TEAMCITY_TOKEN", "GITHUB_TOKEN"]
       waitFor: ["diff"]
       timeout: 12000s
-      args:
-          - $_PR_NUMBER
-
-    - name: 'gcr.io/graphite-docker-images/changelog-checker'
-      secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["tpg-test", "tpgb-test"]
       args:
           - $_PR_NUMBER
 


### PR DESCRIPTION
We're switching to a split out status check, which means we can check the changelog entry at the beginning and still run the rest of the pipeline

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```

Related to https://github.com/hashicorp/terraform-provider-google/issues/9146