### PR TITLE
Moved changelog checker to a separate build

### DIFF
--- a/.ci/containers/changelog-checker/Dockerfile
+++ b/.ci/containers/changelog-checker/Dockerfile
@@ -1,6 +1,0 @@
-FROM hashicorpdev/go-changelog
-
-ENV GITHUB_REPO=magic-modules
-ENV GITHUB_OWNER=GoogleCloudPlatform
-
-ENTRYPOINT ["/go-changelog/changelog-pr-body-check"]

--- a/.ci/gcb-changelog-checker.yml
+++ b/.ci/gcb-changelog-checker.yml
@@ -1,0 +1,17 @@
+---
+steps:
+- name: 'hashicorpdev/go-changelog'
+  id: check-changelog
+  entrypoint: /go-changelog/changelog-pr-body-check
+  secretEnv: ["GITHUB_TOKEN"]
+  dir: mmv1
+  env:
+    - GITHUB_REPO=magic-modules
+    - GITHUB_OWNER=GoogleCloudPlatform
+  args:
+    - $_PR_NUMBER
+
+secrets:
+    - kmsKeyName: projects/graphite-docker-images/locations/global/keyRings/token-keyring/cryptoKeys/github-token
+      secretEnv:
+          GITHUB_TOKEN: CiQADkR4Nt6nHLI52Kc1W55OwpLdc4vjBfVR0SGQNzm6VSVj9lUSUQBfF82vVhn43A1jNYOv8ScoWgrZONwNrUabHfGjkvl+IZxcii0JlOVUawbscs4OJga0eitNNlagAOruLs6C926X20ZZPqWtH97ui6CKNvxgkQ==

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -216,12 +216,6 @@ steps:
       args:
           - $_PR_NUMBER
 
-    - name: 'gcr.io/graphite-docker-images/changelog-checker'
-      secretEnv: ["GITHUB_TOKEN"]
-      waitFor: ["tpg-test", "tpgb-test"]
-      args:
-          - $_PR_NUMBER
-
 # Long timeout to enable waiting on VCR test
 timeout: 20000s
 options:


### PR DESCRIPTION
It is not actually reliant on anything in generate-diffs so we don't need to keep it there.

Related to https://github.com/hashicorp/terraform-provider-google/issues/9146

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
