### PR TITLE
Fixed gofmt issue

### DIFF
--- a/mmv1/third_party/terraform/utils/self_link_helpers_test.go
+++ b/mmv1/third_party/terraform/utils/self_link_helpers_test.go
@@ -125,7 +125,7 @@ func TestGetRegionFromRegionSelfLink(t *testing.T) {
 
 func TestGetRegionFromRegionalSelfLink(t *testing.T) {
 	cases := map[string]string{
-		"projects/foo/locations/europe-north1/datasets/bar/operations/foobar": "europe-north1",
+		"projects/foo/locations/europe-north1/datasets/bar/operations/foobar":        "europe-north1",
 		"projects/REDACTED/regions/europe-north1/subnetworks/tf-test-net-xbwhsmlfm8": "europe-north1",
 	}
 	for input, expected := range cases {


### PR DESCRIPTION
A small formatting issue snuck in with a PR earlier today.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
