### PR TITLE
Report VCR status updates via status API

### DIFF
--- a/.ci/containers/terraform-vcr-community/reverse_check_membership.sh
+++ b/.ci/containers/terraform-vcr-community/reverse_check_membership.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 set -e
-PR_NUMBER=$1
+pr_number=$1
+mm_commit_sha=$2
 
 USER=$(curl -H "Authorization: token ${GITHUB_TOKEN}" \
-  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}" | jq -r .user.login)
+  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${pr_number}" | jq -r .user.login)
 
 # This image runs tests for community PRs. This script reverses check_membership.sh to exit without running tests
 # for users for who tests are automatically run.
@@ -29,5 +30,5 @@ else
 	fi
 fi
 
-# Pass PR number to runner, which expects it
-sh /run_vcr_tests.sh $PR_NUMBER
+# Pass args through to runner
+sh /run_vcr_tests.sh $pr_number $mm_commit_sha

--- a/.ci/containers/terraform-vcr-tester/run_vcr_tests.sh
+++ b/.ci/containers/terraform-vcr-tester/run_vcr_tests.sh
@@ -1,17 +1,29 @@
 #!/bin/bash
 
 set -e
-PR_NUMBER=$1
+pr_number=$1
+mm_commit_sha=$2
+github_username=modular-magician
 
-sed -i 's/{{PR_NUMBER}}/'"$PR_NUMBER"'/g' /teamcityparams.xml
+sed -i 's/{{pr_number}}/'"$pr_number"'/g' /teamcityparams.xml
 curl --header "Accept: application/json" --header "Authorization: Bearer $TEAMCITY_TOKEN" https://ci-oss.hashicorp.engineering/app/rest/buildQueue --request POST --header "Content-Type:application/xml" --data-binary @/teamcityparams.xml -o build.json
 
-URL=$(cat build.json | jq .webUrl)
-comment="I have triggered VCR tests based on this PR's diffs. See the results here: $URL"
+function update_status {
+	local post_body=$( jq -n \
+		--arg context "beta-provider-vcr-test" \
+		--arg target_url "${1}" \
+		--arg state "${2}" \
+		'{context: $context, target_url: $target_url, state: $state}')
+	curl \
+	  -X POST \
+	  -u "$github_username:$GITHUB_TOKEN" \
+	  -H "Accept: application/vnd.github.v3+json" \
+	  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
+	  -d "$post_body"
+}
 
-curl -H "Authorization: token ${GITHUB_TOKEN}" \
-      -d "$(jq -r --arg comment "$comment" -n "{body: \$comment}")" \
-      "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}/comments"
+build_url=$(cat build.json | jq .webUrl)
+update_status "${build_url}" "pending"
 
 ID=$(cat build.json | jq .id -r)
 curl --header "Authorization: Bearer $TEAMCITY_TOKEN" --header "Accept: application/json" https://ci-oss.hashicorp.engineering/app/rest/builds/id:$ID --output poll.json
@@ -21,7 +33,11 @@ counter=0
 while [[ "$STATE" != "finished" ]]; do
 	if [ "$counter" -gt "500" ]; then
 		echo "Failed to wait for job to finish, exiting"
-		exit 1
+		# Call this an error because we don't know if the tests failed or not
+		update_status "${build_url}" "error"
+		# exit 0 because this script didn't have an error; the failure
+		# is reported via the Github Status API
+		exit 0
 	fi
 	sleep 30
 	curl --header "Authorization: Bearer $TEAMCITY_TOKEN" --header "Accept: application/json" https://ci-oss.hashicorp.engineering/app/rest/builds/id:$ID --output poll.json
@@ -33,6 +49,7 @@ done
 
 if [ "$STATUS" == "SUCCESS" ]; then
 	echo "Tests succeeded."
+	update_status "${build_url}" "success"
 	exit 0
 fi
 
@@ -42,19 +59,25 @@ FAILED_TESTS=$(cat failed.json | jq -r '.testOccurrence | map(.name) | join("|")
 ret=$?
 if [ $ret -ne 0 ]; then
 	echo "Job failed without failing tests"
-	exit 1
+	update_status "${build_url}" "failure"
+	# exit 0 because this script didn't have an error; the failure
+	# is reported via the Github Status API
+	exit 0
 fi
 set -e
 
-sed -i 's/{{PR_NUMBER}}/'"$PR_NUMBER"'/g' /teamcityparamsrecording.xml
+sed -i 's/{{pr_number}}/'"$pr_number"'/g' /teamcityparamsrecording.xml
 sed -i 's/{{FAILED_TESTS}}/'"$FAILED_TESTS"'/g' /teamcityparamsrecording.xml
 curl --header "Accept: application/json" --header "Authorization: Bearer $TEAMCITY_TOKEN" https://ci-oss.hashicorp.engineering/app/rest/buildQueue --request POST --header "Content-Type:application/xml" --data-binary @/teamcityparamsrecording.xml --output record.json
-URL=$(cat record.json | jq .webUrl)
-comment="I have triggered VCR tests in RECORDING mode for the following tests that failed during VCR: $FAILED_TESTS You can view the result here: $URL"
+build_url=$(cat record.json | jq .webUrl)
+comment="I have triggered VCR tests in RECORDING mode for the following tests that failed during VCR: $FAILED_TESTS You can view the result here: $build_url"
 
 curl -H "Authorization: token ${GITHUB_TOKEN}" \
       -d "$(jq -r --arg comment "$comment" -n "{body: \$comment}")" \
-      "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}/comments"
+      "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${pr_number}/comments"
+
+
+update_status "${build_url}" "pending"
 
 # Reset for checking failed tests
 rm poll.json
@@ -68,7 +91,11 @@ counter=0
 while [[ "$STATE" != "finished" ]]; do
 	if [ "$counter" -gt "500" ]; then
 		echo "Failed to wait for job to finish, exiting"
-		exit 1
+		# Call this an error because we don't know if the tests failed or not
+		update_status "${build_url}" "error"
+		# exit 0 because this script didn't have an error; the failure
+		# is reported via the Github Status API
+		exit 0
 	fi
 	sleep 30
 	curl --header "Authorization: Bearer $TEAMCITY_TOKEN" --header "Accept: application/json" https://ci-oss.hashicorp.engineering/app/rest/builds/id:$ID --output poll.json
@@ -80,6 +107,7 @@ done
 
 if [ "$STATUS" == "SUCCESS" ]; then
 	echo "Tests succeeded."
+	update_status "${build_url}" "success"
 	exit 0
 fi
 
@@ -89,7 +117,10 @@ FAILED_TESTS=$(cat failed.json | jq -r '.testOccurrence | map(.name) | join("|")
 ret=$?
 if [ $ret -ne 0 ]; then
 	echo "Job failed without failing tests"
-	exit 1
+	update_status "${build_url}" "failure"
+	# exit 0 because this script didn't have an error; the failure
+	# is reported via the Github Status API
+	exit 0
 fi
 set -e
 
@@ -97,6 +128,9 @@ comment="Tests failed during RECORDING mode: $FAILED_TESTS Please fix these to c
 
 curl -H "Authorization: token ${GITHUB_TOKEN}" \
       -d "$(jq -r --arg comment "$comment" -n "{body: \$comment}")" \
-      "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${PR_NUMBER}/comments"
-# Tests failed after recording, exit 1 to display red X on github
-exit 1
+      "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${pr_number}/comments"
+update_status "${build_url}" "failure"
+
+# exit 0 because this script didn't have an error; the failure
+# is reported via the Github Status API
+exit 0

--- a/.ci/gcb-community.yml
+++ b/.ci/gcb-community.yml
@@ -6,6 +6,7 @@ steps:
       timeout: 8000s
       args:
           - $_PR_NUMBER
+          - $COMMIT_SHA
 
 # Long timeout to enable waiting on VCR test
 timeout: 20000s

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -215,6 +215,7 @@ steps:
       timeout: 12000s
       args:
           - $_PR_NUMBER
+          - $COMMIT_SHA
 
 # Long timeout to enable waiting on VCR test
 timeout: 20000s


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Resolved https://github.com/hashicorp/terraform-provider-google/issues/9146. This separates a failure in generate-diffs from a failure in the VCR test run. 


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
