### PR TITLE
Corrected expected case of PR_NUMBER for replacement in teamcity params

### DIFF
--- a/.ci/containers/terraform-vcr-tester/run_vcr_tests.sh
+++ b/.ci/containers/terraform-vcr-tester/run_vcr_tests.sh
@@ -5,7 +5,7 @@ pr_number=$1
 mm_commit_sha=$2
 github_username=modular-magician
 
-sed -i 's/{{pr_number}}/'"$pr_number"'/g' /teamcityparams.xml
+sed -i 's/{{PR_NUMBER}}/'"$pr_number"'/g' /teamcityparams.xml
 curl --header "Accept: application/json" --header "Authorization: Bearer $TEAMCITY_TOKEN" https://ci-oss.hashicorp.engineering/app/rest/buildQueue --request POST --header "Content-Type:application/xml" --data-binary @/teamcityparams.xml -o build.json
 
 function update_status {
@@ -66,7 +66,7 @@ if [ $ret -ne 0 ]; then
 fi
 set -e
 
-sed -i 's/{{pr_number}}/'"$pr_number"'/g' /teamcityparamsrecording.xml
+sed -i 's/{{PR_NUMBER}}/'"$pr_number"'/g' /teamcityparamsrecording.xml
 sed -i 's/{{FAILED_TESTS}}/'"$FAILED_TESTS"'/g' /teamcityparamsrecording.xml
 curl --header "Accept: application/json" --header "Authorization: Bearer $TEAMCITY_TOKEN" https://ci-oss.hashicorp.engineering/app/rest/buildQueue --request POST --header "Content-Type:application/xml" --data-binary @/teamcityparamsrecording.xml --output record.json
 build_url=$(cat record.json | jq .webUrl)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Related to https://github.com/hashicorp/terraform-provider-google/issues/9146 - I was overly aggressive lowercasing script-local variable names and lowercased this as well, which broke replacement. Example broken build: https://ci-oss.hashicorp.engineering/buildConfiguration/GoogleCloudBeta_ProviderGoogleCloudBetaMmUpstreamVcr/193365


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
