### PR TITLE
Updated docs to use makefile and also provide a command to build validator

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -13,7 +13,7 @@ ifneq ($(RESOURCE),)
   mmv1_compile += -t $(RESOURCE)
   tpgtools_compile += --resource $(RESOURCE)
 endif
-build:
+terraform build:
 	make mmv1
 	make tpgtools
 
@@ -25,5 +25,10 @@ mmv1:
 tpgtools:
 	cd tpgtools;\
 		go run . --path "api" --overrides "overrides" --output $(OUTPUT_PATH) --version $(VERSION) $(tpgtools_compile)
+
+validator:
+	cd mmv1;\
+		bundle; \
+		bundle exec compiler -e terraform -f validator -o $(OUTPUT_PATH) $(mmv1_compile);
 
 .PHONY: mmv1 tpgtools

--- a/README.md
+++ b/README.md
@@ -94,46 +94,36 @@ Now, you can verify you're ready with:
 ./tools/doctor
 ```
 
-### Generating downstream tools
+### Generating the Terraform Providers
 
-Before making any changes, you can compile the "downstream" tool you're working
+Before making any changes, you can compile the Terraform provider you're working
 on by running the following command. If Magic Modules has been installed
-correctly, you'll get no errors when you run a command:
-
-```bash
-bundle exec compiler -a -v "ga" -e {{tool}} -o "{{output_folder}}"
-```
+correctly, you'll get no errors.
 
 Generally, you'll want to generate into the same output.  For terraform, that
 will be `$GOPATH/src/github.com/hashicorp/terraform-provider-google` (optionally `-beta`).
-For Ansible and Inspec, wherever you have cloned those repositories.
 
-For example, to generate Terraform:
 
 ```bash
-bundle exec compiler -e terraform -o "$GOPATH/src/github.com/hashicorp/terraform-provider-google" -v "ga" -a 
+make terraform VERSION=ga OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google"
+make terraform VERSION=beta OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google-beta"
+
+# Only generate a specific product (plus all common files)
+make terraform VERSION=ga OUTPUT_PATH="$GOPATH/src/github.com/hashicorp/terraform-provider-google" PRODUCT=dataproc
 ```
 
-It's worth noting that Magic Modules will only generate new files when ran
+It's worth noting that Magic Modules will only generate new files when run
 locally. The "Magician"- the Magic Modules CI system- handles deletion of old
 files when creating PRs.
 
-#### Compiler options
+#### Generating terraform-google-conversion
 
-`-e`, `-v`, and `-f` let you select which project should be generated.
+You can compile terraform-google-conversion by running the following command.
+If Magic Modules has been installed correctly, you'll get no errors.
 
-Target                      | compiler options
-----------------------------|-----------------
-ansible                     | `-e ansible`
-inspec                      | `-e inspec -v "beta"`
-terraform                   | `-e terraform -v "ga"`
-terraform (beta)            | `-e terraform -v "beta"`
-terraform-google-conversion | `-e terraform -f validator`
-
-Other important options are:
-
-- `-a` Generate for all products
-- `-p products/<folder_name>` Generate for a specific project, i.e. `-p products/appengine`
+```bash
+make validator OUTPUT_PATH="/path/to/your/terraform-google-conversion"
+```
 
 ### Making changes to resources
 


### PR DESCRIPTION
Since we should be moving away from inspec / ansible, it should be fine to stop documenting how to generate them; we can instead focus the docs on building for the providers & for validator, and document a `make` command that is independent of the underlying implementation(s).

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
