### PR TITLE
Add the DLP switch for replace_with_info_type_config.

### DIFF
--- a/mmv1/products/dlp/api.yaml
+++ b/mmv1/products/dlp/api.yaml
@@ -1047,7 +1047,7 @@ objects:
                                     - :SATURDAY
                                     - :SUNDAY
                         - !ruby/object:Api::Type::Boolean
-                          name: 'replaceWithInfoType'
+                          name: 'replaceWithInfoTypeConfig'
                           description: |
                             Replace each matching finding with the name of the info type.
                         - !ruby/object:Api::Type::NestedObject

--- a/mmv1/products/dlp/api.yaml
+++ b/mmv1/products/dlp/api.yaml
@@ -1046,6 +1046,10 @@ objects:
                                     - :FRIDAY
                                     - :SATURDAY
                                     - :SUNDAY
+                        - !ruby/object:Api::Type::Boolean
+                          name: 'replaceWithInfoType'
+                          description: |
+                            Replace each matching finding with the name of the info type.
                         - !ruby/object:Api::Type::NestedObject
                           name: 'characterMaskConfig'
                           description: |

--- a/mmv1/products/dlp/terraform.yaml
+++ b/mmv1/products/dlp/terraform.yaml
@@ -18,7 +18,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
-      deidentifyConfig.infoTypeTransformations.transformations.primitiveTransformation.replaceWithInfoType: !ruby/object:Overrides::Terraform::PropertyOverride
+      deidentifyConfig.infoTypeTransformations.transformations.primitiveTransformation.replaceWithInfoTypeConfig: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/object_to_bool.go.erb
         custom_expand: templates/terraform/custom_expand/bool_to_object.go.erb
     examples:

--- a/mmv1/products/dlp/terraform.yaml
+++ b/mmv1/products/dlp/terraform.yaml
@@ -18,7 +18,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
-      deidentifyConfig.infoTypeTransformations.transformations.primitiveTransformation.replaceWithInfoType:
+      deidentifyConfig.infoTypeTransformations.transformations.primitiveTransformation.replaceWithInfoType: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/object_to_bool.go.erb
         custom_expand: templates/terraform/custom_expand/bool_to_object.go.erb
     examples:

--- a/mmv1/products/dlp/terraform.yaml
+++ b/mmv1/products/dlp/terraform.yaml
@@ -18,6 +18,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
+      deidentifyConfig.infoTypeTransformations.transformations.primitiveTransformation.replaceWithInfoType:
+        custom_flatten: templates/terraform/custom_flatten/object_to_bool.go.erb
+        custom_expand: templates/terraform/custom_expand/bool_to_object.go.erb
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "dlp_deidentify_template_basic"

--- a/mmv1/templates/terraform/examples/dlp_deidentify_template_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_deidentify_template_basic.tf.erb
@@ -11,7 +11,7 @@ resource "google_data_loss_prevention_deidentify_template" "<%= ctx[:primary_res
 				}
 
 				primitive_transformation {
-					replace_with_info_type = true
+					replace_with_info_type_config = true
 				}
 			}
 

--- a/mmv1/templates/terraform/examples/dlp_deidentify_template_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_deidentify_template_basic.tf.erb
@@ -7,6 +7,15 @@ resource "google_data_loss_prevention_deidentify_template" "<%= ctx[:primary_res
 		info_type_transformations {
 			transformations {
 				info_types {
+					name = "FIRST_NAME"
+				}
+
+				primitive_transformation {
+					replace_with_info_type = true
+				}
+
+			transformations {
+				info_types {
 					name = "PHONE_NUMBER"
 				}
 				info_types {

--- a/mmv1/templates/terraform/examples/dlp_deidentify_template_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_deidentify_template_basic.tf.erb
@@ -13,6 +13,7 @@ resource "google_data_loss_prevention_deidentify_template" "<%= ctx[:primary_res
 				primitive_transformation {
 					replace_with_info_type = true
 				}
+			}
 
 			transformations {
 				info_types {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Adds `replace_with_info_type_config`, a bool (which is implemented serverside as an empty object) in the union field we already have.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/9439.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dlp: Added `replace_with_info_type_config` to `dlp_deidentify_template`.
```
