### PR TITLE
export cloud.google.com samples to terraform-docs-samples

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -43,7 +43,7 @@ Don't panic - this is all quite safe and we have fixed it before.  We store the 
 It's possible for a job to be cancelled or fail in the middle of pushing downstreams in a transient way.  The sorts of failures that happen at scale - lightning strikes a datacenter (ours or GitHub's!) or some other unlikely misfortune happens.  This has a chance to cause a hiccup in the downstream history, but isn't dangerous.  If that happens, the sync tags may need to be manually updated to sit at the same commit, just before the commit which needs to be generated, or some failed tasks might need to be run by hand.
 
 Updating the sync tags is done like this:
-First, check their state: `git fetch origin && git rev-parse origin/tpg-sync origin/tpgb-sync origin/ansible-sync origin/inspec-sync origin/tf-oics-sync origin/tf-conv-sync` will list the commits for each of the sync tags.
+First, check their state: `git fetch origin && git rev-parse origin/tpg-sync origin/tpgb-sync origin/ansible-sync origin/inspec-sync origin/tf-cloud-docs-sync origin/tf-oics-sync origin/tf-conv-sync` will list the commits for each of the sync tags.
 (If you have changed the name of the `googlecloudplatform/magic-modules` remote from `origin`, substitute that name instead)
 In normal, steady-state operation, these tags will all be identical.  When a failure occurs, some of them may be one commit ahead of the others.  It is rare for any of them to be 2 or more commits ahead of any other.  If some of them are one commit ahead of the others, and there is no pusher task currently running, this means you need to reset them by hand and rerun the failed jobs.  If they diverge by more than one commit, or a pusher task is currently running, you will need to manually run missing tasks.
 

--- a/.ci/containers/downstream-builder/generate_downstream.sh
+++ b/.ci/containers/downstream-builder/generate_downstream.sh
@@ -25,6 +25,10 @@ function clone_repo() {
         UPSTREAM_OWNER=terraform-google-modules
         GH_REPO=docs-examples
         LOCAL_PATH=$GOPATH/src/github.com/terraform-google-modules/docs-examples
+    elif [ "$REPO" == "tf-cloud-docs" ]; then
+        UPSTREAM_OWNER=terraform-google-modules
+        GH_REPO=terraform-docs-samples
+        LOCAL_PATH=$GOPATH/src/github.com/terraform-google-modules/terraform-docs-samples
     elif [ "$REPO" == "ansible" ]; then
         UPSTREAM_OWNER=ansible-collections
         GH_REPO=google.cloud
@@ -99,6 +103,9 @@ if [ "$REPO" == "tf-conversion" ]; then
 elif [ "$REPO" == "tf-oics" ]; then
     # use terraform generator with oics override
     bundle exec compiler -a -e terraform -f oics -o $LOCAL_PATH -v $VERSION
+elif [ "$REPO" == "tf-cloud-docs" ]; then
+    # use terraform generator with cloud docs override
+    bundle exec compiler -a -e terraform -f cloud_docs -o $LOCAL_PATH -v $VERSION
 else
     if [ "$REPO" == "terraform" ] && [ "$VERSION" == "ga" ]; then
         bundle exec compiler -a -e $REPO -o $LOCAL_PATH -v $VERSION --no-docs

--- a/.ci/containers/github-differ/generate_comment.sh
+++ b/.ci/containers/github-differ/generate_comment.sh
@@ -22,6 +22,8 @@ TFC_SCRATCH_PATH=https://modular-magician:$GITHUB_TOKEN@github.com/modular-magic
 TFC_LOCAL_PATH=$PWD/../tfc
 TFOICS_SCRATCH_PATH=https://modular-magician:$GITHUB_TOKEN@github.com/modular-magician/docs-examples
 TFOICS_LOCAL_PATH=$PWD/../tfoics
+TFCD_SCRATCH_PATH=https://modular-magician:$GITHUB_TOKEN@github.com/modular-magician/terraform-docs-samples
+TFCD_LOCAL_PATH=$PWD/../tfcd
 ANSIBLE_SCRATCH_PATH=https://modular-magician:$GITHUB_TOKEN@github.com/modular-magician/google.cloud
 ANSIBLE_LOCAL_PATH=$PWD/../ansible
 INSPEC_SCRATCH_PATH=https://modular-magician:$GITHUB_TOKEN@github.com/modular-magician/inspec-gcp
@@ -82,6 +84,17 @@ git fetch origin $OLD_BRANCH
 if ! git diff --exit-code --quiet origin/$OLD_BRANCH origin/$NEW_BRANCH; then
     SUMMARY="$(git diff origin/$OLD_BRANCH origin/$NEW_BRANCH --shortstat)"
     DIFFS="${DIFFS}${NEWLINE}TF OiCS: [Diff](https://github.com/modular-magician/docs-examples/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY)"
+fi
+popd
+
+# TF Cloud Docs
+mkdir -p $TFCD_LOCAL_PATH
+git clone -b $NEW_BRANCH $TFCD_SCRATCH_PATH $TFCD_LOCAL_PATH
+pushd $TFCD_LOCAL_PATH
+git fetch origin $OLD_BRANCH
+if ! git diff --exit-code --quiet origin/$OLD_BRANCH origin/$NEW_BRANCH; then
+    SUMMARY="$(git diff origin/$OLD_BRANCH origin/$NEW_BRANCH --shortstat)"
+    DIFFS="${DIFFS}${NEWLINE}TF Cloud Doc Samples: [Diff](https://github.com/modular-magician/terraform-docs-samples/compare/$OLD_BRANCH..$NEW_BRANCH) ($SUMMARY)"
 fi
 popd
 

--- a/.ci/gcb-generate-diffs.yml
+++ b/.ci/gcb-generate-diffs.yml
@@ -167,6 +167,24 @@ steps:
           - 'beta'
           - $_PR_NUMBER
 
+    - name: 'gcr.io/graphite-docker-images/downstream-builder'
+      secretEnv: ["GITHUB_TOKEN"]
+      waitFor: ["merged"]
+      args:
+          - 'head'
+          - 'tf-cloud-docs'
+          - 'beta'
+          - $_PR_NUMBER
+
+    - name: 'gcr.io/graphite-docker-images/downstream-builder'
+      secretEnv: ["GITHUB_TOKEN"]
+      waitFor: ["merged"]
+      args:
+          - 'base'
+          - 'tf-cloud-docs'
+          - 'beta'
+          - $_PR_NUMBER
+
     - name: 'gcr.io/graphite-docker-images/github-differ'
       id: diff
       secretEnv: ["GITHUB_TOKEN"]

--- a/.ci/gcb-push-downstream.yml
+++ b/.ci/gcb-push-downstream.yml
@@ -136,6 +136,34 @@ steps:
           - -c
           - git push https://modular-magician:$$GITHUB_TOKEN@github.com/GoogleCloudPlatform/magic-modules $COMMIT_SHA:tf-oics-sync
 
+    # TF-CLOUD-DOCS
+    - name: 'gcr.io/graphite-docker-images/downstream-waiter'
+      id: tf-cloud-docs-sync
+      secretEnv: ["GITHUB_TOKEN"]
+      waitFor: ["checkout"]
+      args:
+          - 'tf-cloud-docs-sync'
+          - $BRANCH_NAME
+          - $COMMIT_SHA
+
+    - name: 'gcr.io/graphite-docker-images/downstream-builder'
+      secretEnv: ["GITHUB_TOKEN"]
+      id: tf-cloud-docs-push
+      waitFor: ["tf-cloud-docs-sync"]
+      args:
+          - 'downstream'
+          - 'tf-cloud-docs'
+          - 'ga'
+          - $COMMIT_SHA
+
+    - name: 'gcr.io/cloud-builders/git'
+      waitFor: ["tf-cloud-docs-push"]
+      secretEnv: ["GITHUB_TOKEN"]
+      entrypoint: 'bash'
+      args:
+          - -c
+          - git push https://modular-magician:$$GITHUB_TOKEN@github.com/GoogleCloudPlatform/magic-modules $COMMIT_SHA:tf-cloud-docs-sync
+
     # Ansible
     - name: 'gcr.io/graphite-docker-images/downstream-waiter'
       id: ansible-sync

--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -34,6 +34,7 @@ require 'provider/ansible_devel'
 require 'provider/inspec'
 require 'provider/terraform'
 require 'provider/terraform_oics'
+require 'provider/terraform_cloud_docs'
 require 'provider/terraform_object_library'
 require 'pp' if ENV['COMPILER_DEBUG']
 
@@ -201,6 +202,7 @@ all_product_files.each do |product_name|
   else
     override_providers = {
       'oics' => Provider::TerraformOiCS,
+      'cloud_docs' => Provider::TerraformCloudDocs,
       'validator' => Provider::TerraformObjectLibrary,
       'ansible_devel' => Provider::Ansible::Devel
     }

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1514,7 +1514,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           mirroring_name: "my-mirroring"
           ilb_rule_name: "my-ilb"
           network_name: "my-network"
-
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation

--- a/mmv1/provider/terraform_cloud_docs.rb
+++ b/mmv1/provider/terraform_cloud_docs.rb
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc.
+# Copyright 2021 Google Inc.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
@@ -14,9 +14,8 @@
 require 'provider/terraform'
 
 module Provider
-  # Code generator for runnable Terraform examples that can be run via an
-  # Open in Cloud Shell link.
-  class TerraformOiCS < Provider::Terraform
+  # Code generator for Terraform samples meant to be displayed in cloud.google.com
+  class TerraformCloudDocs < Provider::Terraform
     # We don't want *any* static generation, so we override generate to only
     # generate objects.
     def generate(output_folder, types, _product_path, _dump_yaml, generate_code, generate_docs)
@@ -33,9 +32,7 @@ module Provider
       return unless generate_docs
 
       examples = data.object.examples
-                     .reject(&:skip_test)
-                     .reject { |e| !e.test_env_vars.nil? && e.test_env_vars.any? }
-                     .reject { |e| @version < @api.version_obj_or_closest(e.min_version) }
+                     .reject { |e| e.cloud_docs_region_tag.nil? || e.cloud_docs_region_tag.empty? }
 
       examples.each do |example|
         target_folder = data.output_folder
@@ -45,23 +42,8 @@ module Provider
         data.example = example
 
         data.generate(pwd,
-                      'templates/terraform/examples/base_configs/oics_example_file.tf.erb',
+                      'templates/terraform/examples/base_configs/cloud_docs_example_file.tf.erb',
                       File.join(target_folder, 'main.tf'),
-                      self)
-
-        data.generate(pwd,
-                      'templates/terraform/examples/base_configs/tutorial.md.erb',
-                      File.join(target_folder, 'tutorial.md'),
-                      self)
-
-        data.generate(pwd,
-                      'templates/terraform/examples/base_configs/example_backing_file.tf.erb',
-                      File.join(target_folder, 'backing_file.tf'),
-                      self)
-
-        data.generate(pwd,
-                      'templates/terraform/examples/static/motd',
-                      File.join(target_folder, 'motd'),
                       self)
       end
     end

--- a/mmv1/templates/terraform/examples/base_configs/cloud_docs_example_file.tf.erb
+++ b/mmv1/templates/terraform/examples/base_configs/cloud_docs_example_file.tf.erb
@@ -1,0 +1,2 @@
+<% autogen_exception -%>
+<%= example.cloud_docs_example(pwd) -%>

--- a/mmv1/templates/terraform/examples/base_configs/example_file.tf.erb
+++ b/mmv1/templates/terraform/examples/base_configs/example_file.tf.erb
@@ -1,2 +1,0 @@
-<% autogen_exception -%>
-<%= example.config_example(pwd) -%>

--- a/mmv1/templates/terraform/examples/base_configs/oics_example_file.tf.erb
+++ b/mmv1/templates/terraform/examples/base_configs/oics_example_file.tf.erb
@@ -1,0 +1,2 @@
+<% autogen_exception -%>
+<%= example.oics_example(pwd) -%>


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This PR adds a new terraform_cloud_docs provider to mmv1 which exports documentation-style samples to https://github.com/terraform-google-modules/terraform-docs-samples. 

Currently, running `bundle exec compiler -v "beta" -e terraform -f cloud_docs -o "$GOPATH/src/github.com/terraform-docs-samples" -a` does not produce any diffs since none of the examples are opted-in with a `cloud_docs_region_tag` override. I wanted to opt-in one in a separate PR to test the functionality of the CI after this has been merged.

The CI will fail in this PR because I have modified the `generate_downstream.sh` file which to my knowledge will not get uploaded until the PR has been merged. (If it doesn't automatically update the image, I'll do it manually)

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
