### PR TITLE
Added pubsubConfig and webhookConfig support to the cloud build resource.

### DIFF
--- a/mmv1/products/cloudbuild/api.yaml
+++ b/mmv1/products/cloudbuild/api.yaml
@@ -252,8 +252,10 @@ objects:
             name: 'subscription'
             description: |
               Output only. Name of the subscription.
+            output: true
           - !ruby/object:Api::Type::String
             name: 'topic'
+            required: true
             description: |
               The name of the topic from which this subscription is receiving messages.
           - !ruby/object:Api::Type::String
@@ -262,6 +264,7 @@ objects:
               Service account that will make the push request.
           - !ruby/object:Api::Type::String
             name: 'state'
+            output: true
             description: |
               Potential issues with the underlying Pub/Sub subscription configuration.
               Only populated on get requests.
@@ -278,10 +281,12 @@ objects:
         properties:
           - !ruby/object:Api::Type::String
             name: 'secret'
+            required: true
             description: |
               Resource name for the secret required as a URL parameter.
           - !ruby/object:Api::Type::String
             name: 'state'
+            output: true
             description: |
               Potential issues with the underlying Pub/Sub subscription configuration.
               Only populated on get requests.

--- a/mmv1/products/cloudbuild/api.yaml
+++ b/mmv1/products/cloudbuild/api.yaml
@@ -111,6 +111,11 @@ objects:
           Branch and tag names in trigger templates are interpreted as regular
           expressions. Any branch or tag change that matches that regular
           expression will trigger a build.
+        exactly_one_of:
+          - trigger_template
+          - github
+          - pubsub_config
+          - webhook_config
         properties:
           - !ruby/object:Api::Type::String
             name: 'projectId'
@@ -168,6 +173,8 @@ objects:
         exactly_one_of:
           - trigger_template
           - github
+          - pubsub_config
+          - webhook_config
         properties:
           - !ruby/object:Api::Type::String
             name: 'owner'
@@ -230,6 +237,54 @@ objects:
                 exactly_one_of:
                   - github.0.push.0.branch
                   - github.0.push.0.tag
+      - !ruby/object:Api::Type::NestedObject
+        name: 'pubsubConfig'
+        description: |
+          PubsubConfig describes the configuration of a trigger that creates 
+          a build whenever a Pub/Sub message is published.
+        exactly_one_of:
+          - trigger_template
+          - github
+          - pubsub_config
+          - webhook_config
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'subscription'
+            description: |
+              Output only. Name of the subscription.
+          - !ruby/object:Api::Type::String
+            name: 'topic'
+            description: |
+              The name of the topic from which this subscription is receiving messages.
+          - !ruby/object:Api::Type::String
+            name: 'service_account_email'
+            description: |
+              Service account that will make the push request.
+          - !ruby/object:Api::Type::String
+            name: 'state'
+            description: |
+              Potential issues with the underlying Pub/Sub subscription configuration.
+              Only populated on get requests.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'webhookConfig'
+        description: |
+          WebhookConfig describes the configuration of a trigger that creates 
+          a build whenever a webhook is sent to a trigger's webhook URL.
+        exactly_one_of:
+          - trigger_template
+          - github
+          - pubsub_config
+          - webhook_config
+        properties:
+          - !ruby/object:Api::Type::String
+            name: 'secret'
+            description: |
+              Resource name for the secret required as a URL parameter.
+          - !ruby/object:Api::Type::String
+            name: 'state'
+            description: |
+              Potential issues with the underlying Pub/Sub subscription configuration.
+              Only populated on get requests.
       - !ruby/object:Api::Type::NestedObject
         name: 'build'
         exactly_one_of:

--- a/mmv1/products/cloudbuild/terraform.yaml
+++ b/mmv1/products/cloudbuild/terraform.yaml
@@ -45,11 +45,19 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       triggerTemplate: !ruby/object:Overrides::Terraform::PropertyOverride
         description: |
           {{description}}
-          One of `trigger_template` or `github` must be provided.
+          One of `trigger_template`, `github`, `pubsub_config` or `webhook_config` must be provided.
       github: !ruby/object:Overrides::Terraform::PropertyOverride
         description: |
           {{description}}
-          One of `trigger_template` or `github` must be provided.
+          One of `trigger_template`, `github`, `pubsub_config` or `webhook_config` must be provided.
+      pubsubConfig: !ruby/object:Overrides::Terraform::PropertyOverride
+        description: |
+          {{description}}
+          One of `trigger_template`, `github`, `pubsub_config` or `webhook_config` must be provided.
+      webhookConfig: !ruby/object:Overrides::Terraform::PropertyOverride
+        description: |
+          {{description}}
+          One of `trigger_template`, `github`, `pubsub_config` or `webhook_config` must be provided.
       triggerTemplate.projectId: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode

--- a/mmv1/third_party/terraform/tests/resource_cloudbuild_trigger_test.go
+++ b/mmv1/third_party/terraform/tests/resource_cloudbuild_trigger_test.go
@@ -37,6 +37,64 @@ func TestAccCloudBuildTrigger_basic(t *testing.T) {
 	})
 }
 
+func TestAccCloudBuildTrigger_pubsub_config(t *testing.T) {
+	t.Parallel()
+	name := fmt.Sprintf("tf-test-%d", randInt(t))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudBuildTriggerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudBuildTrigger_pubsub_config(name),
+			},
+			{
+				ResourceName:      "google_cloudbuild_trigger.build_trigger",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCloudBuildTrigger_pubsub_config_update(name),
+			},
+			{
+				ResourceName:      "google_cloudbuild_trigger.build_trigger",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccCloudBuildTrigger_webhook_config(t *testing.T) {
+	t.Parallel()
+	name := fmt.Sprintf("tf-test-%d", randInt(t))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCloudBuildTriggerDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCloudBuildTrigger_webhook_config(name),
+			},
+			{
+				ResourceName:      "google_cloudbuild_trigger.build_trigger",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccCloudBuildTrigger_webhook_config_update(name),
+			},
+			{
+				ResourceName:      "google_cloudbuild_trigger.build_trigger",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccCloudBuildTrigger_customizeDiffTimeoutSum(t *testing.T) {
 	t.Parallel()
 
@@ -279,6 +337,192 @@ resource "google_cloudbuild_trigger" "build_trigger" {
   }
 }
   `, name)
+}
+
+func testAccCloudBuildTrigger_pubsub_config(name string) string {
+	return fmt.Sprintf(`
+resource "google_pubsub_topic" "build-trigger" {
+  name = "topic-name"
+}
+
+resource "google_cloudbuild_trigger" "build_trigger" {
+  name        = "%s"
+  description = "acceptance test build trigger"
+  pubsub_config {
+    topic = "${google_pubsub_topic.build-trigger.id}"
+  }
+  build {
+    tags   = ["team-a", "service-b"]
+    timeout = "1800s"
+    step {
+      name = "gcr.io/cloud-builders/gsutil"
+      args = ["cp", "gs://mybucket/remotefile.zip", "localfile.zip"]
+      timeout = "300s"
+    }
+  }
+  depends_on = [
+    google_pubsub_topic.build-trigger
+  ]
+}
+`, name)
+}
+
+func testAccCloudBuildTrigger_pubsub_config_update(name string) string {
+	return fmt.Sprintf(`
+resource "google_pubsub_topic" "build-trigger" {
+  name = "topic-name"
+}
+
+resource "google_cloudbuild_trigger" "build_trigger" {
+  name        = "%s"
+  description = "acceptance test build trigger updated"
+  pubsub_config {
+    topic = "${google_pubsub_topic.build-trigger.id}"
+  }
+  build {
+    tags   = ["team-a", "service-b"]
+    timeout = "1800s"
+    step {
+      name = "gcr.io/cloud-builders/gsutil"
+      args = ["cp", "gs://mybucket/remotefile.zip", "localfile.zip"]
+      timeout = "300s"
+    }
+  }
+  depends_on = [
+    google_pubsub_topic.build-trigger
+  ]
+}
+`, name)
+}
+
+func testAccCloudBuildTrigger_webhook_config(name string) string {
+	return fmt.Sprintf(`
+resource "google_secret_manager_secret" "webhook_trigger_secret_key" {
+  secret_id = "webhook_trigger-secret-key"
+
+  replication {
+    user_managed {
+      replicas {
+        location = "us-central1"
+      }
+    }
+  }
+}
+
+resource "google_secret_manager_secret_version" "webhook_trigger_secret_key_data" {
+  secret = google_secret_manager_secret.webhook_trigger_secret_key.id
+
+  secret_data = "secretkeygoeshere"
+}
+
+data "google_project" "project" {}
+
+data "google_iam_policy" "secret_accessor" {
+  binding {
+    role = "roles/secretmanager.secretAccessor"
+    members = [
+      "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudbuild.iam.gserviceaccount.com",
+    ]
+  }
+}
+
+resource "google_secret_manager_secret_iam_policy" "policy" {
+  project = google_secret_manager_secret.webhook_trigger_secret_key.project
+  secret_id = google_secret_manager_secret.webhook_trigger_secret_key.secret_id
+  policy_data = data.google_iam_policy.secret_accessor.policy_data
+}
+
+resource "google_cloudbuild_trigger" "build_trigger" {
+  name        = "%s"
+
+  webhook_config {
+    secret = "${google_secret_manager_secret_version.webhook_trigger_secret_key_data.id}"
+  }
+
+  build {
+    step {
+      name = "ubuntu"
+      args = [
+        "-c", 
+        <<EOT
+          echo data
+        EOT
+      ]
+      entrypoint = "bash"
+    }
+  }
+
+  depends_on = [
+    google_secret_manager_secret_version.webhook_trigger_secret_key_data,
+    google_secret_manager_secret_iam_policy.policy
+  ]
+}
+`, name)
+}
+
+func testAccCloudBuildTrigger_webhook_config_update(name string) string {
+	return fmt.Sprintf(`
+resource "google_secret_manager_secret" "webhook_trigger_secret_key" {
+  secret_id = "webhook_trigger-secret-key"
+
+  replication {
+    user_managed {
+      replicas {
+        location = "us-central1"
+      }
+    }
+  }
+}
+
+resource "google_secret_manager_secret_version" "webhook_trigger_secret_key_data" {
+  secret = google_secret_manager_secret.webhook_trigger_secret_key.id
+
+  secret_data = "secretkeygoeshere"
+}
+
+data "google_project" "project" {}
+
+data "google_iam_policy" "secret_accessor" {
+  binding {
+    role = "roles/secretmanager.secretAccessor"
+    members = [
+      "serviceAccount:service-${data.google_project.project.number}@gcp-sa-cloudbuild.iam.gserviceaccount.com",
+    ]
+  }
+}
+
+resource "google_secret_manager_secret_iam_policy" "policy" {
+  project = google_secret_manager_secret.webhook_trigger_secret_key.project
+  secret_id = google_secret_manager_secret.webhook_trigger_secret_key.secret_id
+  policy_data = data.google_iam_policy.secret_accessor.policy_data
+}
+
+resource "google_cloudbuild_trigger" "build_trigger" {
+  name        = "%s"
+
+  webhook_config {
+    secret = "${google_secret_manager_secret_version.webhook_trigger_secret_key_data.id}"
+  }
+
+  build {
+    step {
+      name = "ubuntu"
+      args = [
+        "-c", 
+        <<EOT
+          echo data-updated
+        EOT
+      ]
+      entrypoint = "bash"
+    }
+  }
+
+  depends_on = [
+    google_secret_manager_secret_version.webhook_trigger_secret_key_data,
+    google_secret_manager_secret_iam_policy.policy
+  ]
+}
+`, name)
 }
 
 func testAccCloudBuildTrigger_customizeDiffTimeoutSum(name string) string {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Google have [API documentation](https://cloud.google.com/build/docs/api/reference/rest/v1/projects.triggers) to create a pub/sub and webhook trigger in the cloud build resource, but, [the terraform google provider](https://github.com/hashicorp/terraform-provider-google/issues/8692) [doesn't](https://github.com/hashicorp/terraform-provider-google/issues/9189). I have updated the terraform resource to add that support.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/8692, https://github.com/hashicorp/terraform-provider-google/issues/9189

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudbuild: Added `pubsub_config` and `webhook_config` parameter to `google_cloudbuild_trigger`.
```
