### PR TITLE
Made google_billing_budget.all_updates_rule subfields get updated

### DIFF
--- a/mmv1/products/billingbudget/terraform.yaml
+++ b/mmv1/products/billingbudget/terraform.yaml
@@ -57,6 +57,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
+      allUpdatesRule: !ruby/object:Overrides::Terraform::PropertyOverride
+        update_mask_fields:
+          - "notificationsRule.pubsubTopic"
+          - "notificationsRule.schemaVersion"
+          - "notificationsRule.monitoringNotificationChannels"
+          - "notificationsRule.disableDefaultIamRecipients"
       allUpdatesRule.schemaVersion: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: templates/terraform/custom_flatten/default_if_empty.erb
       amount: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/third_party/terraform/tests/resource_billing_budget_test.go
+++ b/mmv1/third_party/terraform/tests/resource_billing_budget_test.go
@@ -92,7 +92,7 @@ func TestAccBillingBudget_billingBudgetUpdate(t *testing.T) {
 				ImportStateVerify: true,
 			},
 			{
-				Config: testAccBillingBudget_billingBudgetUpdateChangeAmount(context),
+				Config: testAccBillingBudget_billingBudgetUpdate(context),
 			},
 			{
 				ResourceName:      "google_billing_budget.budget",
@@ -105,6 +105,13 @@ func TestAccBillingBudget_billingBudgetUpdate(t *testing.T) {
 
 func testAccBillingBudget_billingBudgetUpdateStart(context map[string]interface{}) string {
 	return Nprintf(`
+resource "google_pubsub_topic" "topic1" {
+  name = "tf-test-billing-budget1-%{random_suffix}"
+}
+resource "google_pubsub_topic" "topic2" {
+  name = "tf-test-billing-budget2-%{random_suffix}"
+}
+
 data "google_billing_account" "account" {
   billing_account = "%{billing_acct}"
 }
@@ -134,12 +141,22 @@ resource "google_billing_budget" "budget" {
     threshold_percent = 0.9
     spend_basis = "FORECASTED_SPEND"
   }
+
+  all_updates_rule {
+    pubsub_topic = google_pubsub_topic.topic1.id
+  }
 }
 `, context)
 }
 
 func testAccBillingBudget_billingBudgetUpdateRemoveFilter(context map[string]interface{}) string {
 	return Nprintf(`
+resource "google_pubsub_topic" "topic1" {
+  name = "tf-test-billing-budget1-%{random_suffix}"
+}
+resource "google_pubsub_topic" "topic2" {
+  name = "tf-test-billing-budget2-%{random_suffix}"
+}
 data "google_billing_account" "account" {
   billing_account = "%{billing_acct}"
 }
@@ -169,12 +186,22 @@ resource "google_billing_budget" "budget" {
     threshold_percent = 0.9
     spend_basis = "FORECASTED_SPEND"
   }
+
+  all_updates_rule {
+    pubsub_topic = google_pubsub_topic.topic1.id
+  }
 }
 `, context)
 }
 
-func testAccBillingBudget_billingBudgetUpdateChangeAmount(context map[string]interface{}) string {
+func testAccBillingBudget_billingBudgetUpdate(context map[string]interface{}) string {
 	return Nprintf(`
+resource "google_pubsub_topic" "topic1" {
+  name = "tf-test-billing-budget1-%{random_suffix}"
+}
+resource "google_pubsub_topic" "topic2" {
+  name = "tf-test-billing-budget2-%{random_suffix}"
+}
 data "google_billing_account" "account" {
   billing_account = "%{billing_acct}"
 }
@@ -203,6 +230,10 @@ resource "google_billing_budget" "budget" {
   threshold_rules {
     threshold_percent = 0.9
     spend_basis = "FORECASTED_SPEND"
+  }
+
+  all_updates_rule {
+    pubsub_topic = google_pubsub_topic.topic2.id
   }
 }
 `, context)


### PR DESCRIPTION
This is a follow-up for https://github.com/GoogleCloudPlatform/magic-modules/pull/4929, which fixed this issue for amount and its subfields

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
billing: made `all_updates_rule.*` fields updatable on `google_billing_budget`
```
