### PR TITLE
Ignored case changes in bigquery table schema mode/type

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/resources/resource_bigquery_table.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -130,14 +131,14 @@ func bigQueryTableMapKeyOverride(key string, objectA, objectB map[string]interfa
 	valB := objectB[key]
 	switch key {
 	case "mode":
-		eq := bigQueryTableModeEq(valA, valB)
+		eq := bigQueryTableNormalizeMode(valA) == bigQueryTableNormalizeMode(valB)
 		return eq
 	case "description":
 		equivalentSet := []interface{}{nil, ""}
 		eq := valueIsInArray(valA, equivalentSet) && valueIsInArray(valB, equivalentSet)
 		return eq
 	case "type":
-		return bigQueryTableTypeEq(valA, valB)
+		return bigQueryTableTypeEq(valA.(string), valB.(string))
 	}
 
 	// otherwise rely on default behavior
@@ -167,28 +168,32 @@ func bigQueryTableSchemaDiffSuppress(name, old, new string, _ *schema.ResourceDa
 	return eq
 }
 
-func bigQueryTableTypeEq(old, new interface{}) bool {
+func bigQueryTableTypeEq(old, new string) bool {
+	// Do case-insensitive comparison. https://github.com/hashicorp/terraform-provider-google/issues/9472
+	oldUpper := strings.ToUpper(old)
+	newUpper := strings.ToUpper(new)
+
 	equivalentSet1 := []interface{}{"INTEGER", "INT64"}
 	equivalentSet2 := []interface{}{"FLOAT", "FLOAT64"}
 	equivalentSet3 := []interface{}{"BOOLEAN", "BOOL"}
-	eq0 := old == new
-	eq1 := valueIsInArray(old, equivalentSet1) && valueIsInArray(new, equivalentSet1)
-	eq2 := valueIsInArray(old, equivalentSet2) && valueIsInArray(new, equivalentSet2)
-	eq3 := valueIsInArray(old, equivalentSet3) && valueIsInArray(new, equivalentSet3)
+	eq0 := oldUpper == newUpper
+	eq1 := valueIsInArray(oldUpper, equivalentSet1) && valueIsInArray(newUpper, equivalentSet1)
+	eq2 := valueIsInArray(oldUpper, equivalentSet2) && valueIsInArray(newUpper, equivalentSet2)
+	eq3 := valueIsInArray(oldUpper, equivalentSet3) && valueIsInArray(newUpper, equivalentSet3)
 	eq := eq0 || eq1 || eq2 || eq3
 	return eq
 }
 
-func bigQueryTableModeEq(old, new interface{}) bool {
-	equivalentSet := []interface{}{nil, "NULLABLE"}
-	eq0 := old == new
-	eq1 := valueIsInArray(old, equivalentSet) && valueIsInArray(new, equivalentSet)
-	eq := eq0 || eq1
-	return eq
+func bigQueryTableNormalizeMode(mode interface{}) string {
+	if mode == nil {
+		return "NULLABLE"
+	}
+	// Upper-case to get case-insensitive comparisons. https://github.com/hashicorp/terraform-provider-google/issues/9472
+	return strings.ToUpper(mode.(string))
 }
 
-func bigQueryTableModeIsForceNew(old, new interface{}) bool {
-	eq := bigQueryTableModeEq(old, new)
+func bigQueryTableModeIsForceNew(old, new string) bool {
+	eq := old == new
 	reqToNull := old == "REQUIRED" && new == "NULLABLE"
 	return !eq && !reqToNull
 }
@@ -250,11 +255,14 @@ func resourceBigQueryTableSchemaIsChangeable(old, new interface{}) (bool, error)
 					return false, nil
 				}
 			case "type":
-				if !bigQueryTableTypeEq(valOld, valNew) {
+				if !bigQueryTableTypeEq(valOld.(string), valNew.(string)) {
 					return false, nil
 				}
 			case "mode":
-				if bigQueryTableModeIsForceNew(valOld, valNew) {
+				if bigQueryTableModeIsForceNew(
+					bigQueryTableNormalizeMode(valOld),
+					bigQueryTableNormalizeMode(valNew),
+				) {
 					return false, nil
 				}
 			case "fields":

--- a/mmv1/third_party/terraform/resources/resource_bigquery_table.go
+++ b/mmv1/third_party/terraform/resources/resource_bigquery_table.go
@@ -138,6 +138,9 @@ func bigQueryTableMapKeyOverride(key string, objectA, objectB map[string]interfa
 		eq := valueIsInArray(valA, equivalentSet) && valueIsInArray(valB, equivalentSet)
 		return eq
 	case "type":
+		if valA == nil || valB == nil {
+			return false
+		}
 		return bigQueryTableTypeEq(valA.(string), valB.(string))
 	}
 
@@ -255,6 +258,10 @@ func resourceBigQueryTableSchemaIsChangeable(old, new interface{}) (bool, error)
 					return false, nil
 				}
 			case "type":
+				if valOld == nil || valNew == nil {
+					// This is invalid, so it shouldn't require a ForceNew
+					return true, nil
+				}
 				if !bigQueryTableTypeEq(valOld.(string), valNew.(string)) {
 					return false, nil
 				}

--- a/mmv1/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -34,28 +34,28 @@ func TestBigQueryTableSchemaDiffSuppress(t *testing.T) {
 			ExpectDiffSuppress: false,
 		},
 		"no change": {
-			Old:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"finalKey\" : {} }]",
-			New:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"finalKey\" : {} }]",
+			Old:                "[{\"name\": \"someValue\", \"type\": \"INT64\", \"anotherKey\" : \"anotherValue\", \"finalKey\" : {} }]",
+			New:                "[{\"name\": \"someValue\", \"type\": \"INT64\", \"anotherKey\" : \"anotherValue\", \"finalKey\" : {} }]",
 			ExpectDiffSuppress: true,
 		},
 		"remove key": {
-			Old:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"finalKey\" : {} }]",
-			New:                "[{\"name\": \"someValue\", \"finalKey\" : {} }]",
+			Old:                "[{\"name\": \"someValue\", \"type\": \"INT64\", \"anotherKey\" : \"anotherValue\", \"finalKey\" : {} }]",
+			New:                "[{\"name\": \"someValue\", \"type\": \"INT64\", \"finalKey\" : {} }]",
 			ExpectDiffSuppress: false,
 		},
 		"empty description -> default description (empty)": {
-			Old:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"description\": \"\"  }]",
-			New:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\" }]",
+			Old:                "[{\"name\": \"someValue\", \"type\": \"INT64\", \"anotherKey\" : \"anotherValue\", \"description\": \"\"  }]",
+			New:                "[{\"name\": \"someValue\", \"type\": \"INT64\", \"anotherKey\" : \"anotherValue\" }]",
 			ExpectDiffSuppress: true,
 		},
 		"empty description -> other description": {
-			Old:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"description\": \"\"  }]",
-			New:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"description\": \"somethingRandom\"  }]",
+			Old:                "[{\"name\": \"someValue\", \"type\": \"INT64\", \"anotherKey\" : \"anotherValue\", \"description\": \"\"  }]",
+			New:                "[{\"name\": \"someValue\", \"type\": \"INT64\", \"anotherKey\" : \"anotherValue\", \"description\": \"somethingRandom\"  }]",
 			ExpectDiffSuppress: false,
 		},
 		"mode NULLABLE -> other mode": {
-			Old:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"mode\": \"NULLABLE\"  }]",
-			New:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"mode\": \"somethingRandom\"  }]",
+			Old:                "[{\"name\": \"someValue\", \"type\": \"INT64\", \"anotherKey\" : \"anotherValue\", \"mode\": \"NULLABLE\"  }]",
+			New:                "[{\"name\": \"someValue\", \"type\": \"INT64\", \"anotherKey\" : \"anotherValue\", \"mode\": \"somethingRandom\"  }]",
 			ExpectDiffSuppress: false,
 		},
 		"mode NULLABLE -> default mode (also NULLABLE)": {
@@ -70,6 +70,23 @@ func TestBigQueryTableSchemaDiffSuppress(t *testing.T) {
 				{
 					"name": "PageNo",
 					"type": "INTEGER"
+				}
+			]`,
+			ExpectDiffSuppress: true,
+		},
+		"mode & type uppercase -> lowercase": {
+			Old: `[
+				{
+					"mode": "NULLABLE",
+					"name": "PageNo",
+					"type": "INTEGER"
+				}
+			]`,
+			New: `[
+				{
+					"mode": "nullable",
+					"name": "PageNo",
+					"type": "integer"
 				}
 			]`,
 			ExpectDiffSuppress: true,
@@ -89,9 +106,9 @@ func TestBigQueryTableSchemaDiffSuppress(t *testing.T) {
 			New:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"FLOAT64\"  }]",
 			ExpectDiffSuppress: true,
 		},
-		"type FLOAT -> default": {
+		"type FLOAT -> other": {
 			Old:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"FLOAT\"  }]",
-			New:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\" }]",
+			New:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"somethingRandom\" }]",
 			ExpectDiffSuppress: false,
 		},
 		"type BOOLEAN -> BOOL": {
@@ -99,9 +116,9 @@ func TestBigQueryTableSchemaDiffSuppress(t *testing.T) {
 			New:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"BOOL\"  }]",
 			ExpectDiffSuppress: true,
 		},
-		"type BOOLEAN -> default": {
+		"type BOOLEAN -> other": {
 			Old:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"BOOLEAN\"  }]",
-			New:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\" }]",
+			New:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"somethingRandom\" }]",
 			ExpectDiffSuppress: false,
 		},
 		"reordering fields": {
@@ -1822,8 +1839,8 @@ resource "google_bigquery_table" "test" {
       {
         description = "Time snapshot was taken, in Epoch milliseconds. Same across all rows and all tables in the snapshot, and uniquely defines a particular snapshot."
         name        = "snapshot_timestamp"
-        mode        = "NULLABLE"
-        type        = "INTEGER"
+        mode        = "nullable"
+        type        = "integer"
       },
       {
         description = "Timestamp of dataset creation"

--- a/mmv1/third_party/terraform/tests/resource_bigquery_table_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_table_test.go
@@ -121,6 +121,20 @@ func TestBigQueryTableSchemaDiffSuppress(t *testing.T) {
 			New:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"somethingRandom\" }]",
 			ExpectDiffSuppress: false,
 		},
+		// this is invalid but we need to make sure we don't cause a panic
+		// if users provide an invalid schema
+		"invalid - missing type for old": {
+			Old:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\" }]",
+			New:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"BOOLEAN\" }]",
+			ExpectDiffSuppress: false,
+		},
+		// this is invalid but we need to make sure we don't cause a panic
+		// if users provide an invalid schema
+		"invalid - missing type for new": {
+			Old:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"BOOLEAN\" }]",
+			New:                "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\" }]",
+			ExpectDiffSuppress: false,
+		},
 		"reordering fields": {
 			Old: `[
 				{
@@ -358,6 +372,7 @@ func TestBigQueryTableSchemaDiffSuppress(t *testing.T) {
 	}
 
 	for tn, tc := range cases {
+		tn := tn
 		tc := tc
 		t.Run(tn, func(t *testing.T) {
 			t.Parallel()
@@ -1054,6 +1069,22 @@ var testUnitBigQueryDataTableIsChangableTestCases = []testUnitBigQueryDataTableJ
 		jsonNew:    "[{\"name\": \"someValue\", \"type\" : \"DATETIME\", \"mode\" : \"NULLABLE\", \"description\" : \"some new value\" }]",
 		changeable: false,
 	},
+	// this is invalid but we need to make sure we don't cause a panic
+	// if users provide an invalid schema
+	{
+		name:       "typeChangeIgnoreNewMissingType",
+		jsonOld:    "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\" }]",
+		jsonNew:    "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"BOOLEAN\" }]",
+		changeable: true,
+	},
+	// this is invalid but we need to make sure we don't cause a panic
+	// if users provide an invalid schema
+	{
+		name:       "typeChangeIgnoreOldMissingType",
+		jsonOld:    "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\" }]",
+		jsonNew:    "[{\"name\": \"someValue\", \"anotherKey\" : \"anotherValue\", \"type\": \"BOOLEAN\" }]",
+		changeable: true,
+	},
 	{
 		name:       "typeModeReqToNull",
 		jsonOld:    "[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"mode\" : \"REQUIRED\", \"description\" : \"someVal\" }]",
@@ -1067,10 +1098,10 @@ var testUnitBigQueryDataTableIsChangableTestCases = []testUnitBigQueryDataTableJ
 		changeable: false,
 	},
 	{
-		name:       "typeModeOmission",
+		name:       "modeToDefaultNullable",
 		jsonOld:    "[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"mode\" : \"REQUIRED\", \"description\" : \"someVal\" }]",
 		jsonNew:    "[{\"name\": \"someValue\", \"type\" : \"BOOLEAN\", \"description\" : \"some new value\" }]",
-		changeable: false,
+		changeable: true,
 	},
 	{
 		name:       "orderOfArrayChangesAndDescriptionChanges",


### PR DESCRIPTION
BigQuery table schema normalizes the mode and type to uppercase, which causes a permadiff for the end user if they set it in lowercase.

Also removed tests for setting type to nil, because a field type being nil is invalid.

Resolved https://github.com/hashicorp/terraform-provider-google/issues/9472

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
bigquery: Fixed permadiff due to lowercase mode/type in `google_bigquery_table.schema`
```
