### PR TITLE
New Resource : `google_dialogflow_cx_intent`

### DIFF
--- a/mmv1/products/dialogflowcx/api.yaml
+++ b/mmv1/products/dialogflowcx/api.yaml
@@ -138,7 +138,6 @@ objects:
           Intent.training_phrases.parts.text
           If not specified, the agent's default language is used. Many languages are supported. Note: languages must be enabled in the agent before they can be used.
         input: true
-        url_param_only: true
     properties:
       - !ruby/object:Api::Type::String
         name: 'name'

--- a/mmv1/products/dialogflowcx/api.yaml
+++ b/mmv1/products/dialogflowcx/api.yaml
@@ -111,3 +111,135 @@ objects:
         name: 'enableSpellCorrection'
         description: |
          Indicates if automatic spell correction is enabled in detect intent requests.
+  - !ruby/object:Api::Resource
+    name: 'Intent'
+    base_url: "{{parent}}/intents/"
+    self_link: "{{name}}"
+    update_verb: :PATCH
+    update_mask: true
+    description: |
+      An intent represents a user's intent to interact with a conversational agent.
+    references: !ruby/object:Api::Resource::ReferenceLinks
+      guides:
+        'Official Documentation':
+          'https://cloud.google.com/dialogflow/cx/docs'
+      api: 'https://cloud.google.com/dialogflow/cx/docs/reference/rest/v3/projects.locations.agents.intents'
+    parameters:
+      - !ruby/object:Api::Type::String
+        name: parent
+        url_param_only: true
+        input: true
+        description: |
+          The agent to create an intent for.
+          Format: projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>.
+      - !ruby/object:Api::Type::String
+        name: 'location'
+        description: |
+          The name of the location this intent is located in.
+        required: true
+        input: true
+        url_param_only: true
+      - !ruby/object:Api::Type::String
+        name: 'languageCode'
+        description: |
+          The language of the following fields in intent:
+          Intent.training_phrases.parts.text
+          If not specified, the agent's default language is used. Many languages are supported. Note: languages must be enabled in the agent before they can be used.
+        input: true
+        url_param_only: true
+    properties:
+      - !ruby/object:Api::Type::String
+        name: 'name'
+        output: true
+        description: |
+          The unique identifier of the intent.  
+          Format: projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/intents/<Intent ID>.
+      - !ruby/object:Api::Type::String
+        name: 'displayName'
+        required: true
+        description: |
+          The human-readable name of the intent, unique within the agent.
+      - !ruby/object:Api::Type::Array
+        name: 'trainingPhrases'
+        description: |
+          The collection of training phrases the agent is trained on to identify the intent.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'id'
+              output: true
+              description: |
+                The unique identifier of the training phrase.
+            - !ruby/object:Api::Type::Array
+             name: 'parts'
+             required: true
+             description: |
+               The ordered list of training phrase parts. The parts are concatenated in order to form the training phrase.
+               Note: The API does not automatically annotate training phrases like the Dialogflow Console does.
+               Note: Do not forget to include whitespace at part boundaries, so the training phrase is well formatted when the parts are concatenated.
+               If the training phrase does not need to be annotated with parameters, you just need a single part with only the Part.text field set.
+               If you want to annotate the training phrase, you must create multiple parts, where the fields of each part are populated in one of two ways:
+               Part.text is set to a part of the phrase that has no parameters.
+               Part.text is set to a part of the phrase that you want to annotate, and the parameterId field is set.
+             item_type: !ruby/object:Api::Type::NestedObject
+               properties:
+                 - !ruby/object:Api::Type::String
+                   name: 'text'
+                   required: true
+                   description: |
+                     The text for this part.
+                 - !ruby/object:Api::Type::String
+                   name: 'parameterId'
+                   description: |
+                     The parameter used to annotate this part of the training phrase. This field is required for annotated parts of the training phrase.
+            - !ruby/object:Api::Type::Integer
+             name: 'repeatCount'
+             description: |
+               Indicates how many times this example was added to the intent.
+      - !ruby/object:Api::Type::Array
+        name: 'parameters'
+        description: |
+          The collection of parameters associated with the intent.
+        item_type: !ruby/object:Api::Type::NestedObject
+          properties:
+            - !ruby/object:Api::Type::String
+              name: 'id'
+              required: true
+              description: |
+                The unique identifier of the parameter. This field is used by training phrases to annotate their parts.
+            - !ruby/object:Api::Type::String
+              name: 'entityType'
+              required: true
+              description: |
+                The entity type of the parameter. 
+                Format: projects/-/locations/-/agents/-/entityTypes/<System Entity Type ID> for system entity types (for example, projects/-/locations/-/agents/-/entityTypes/sys.date), or projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>/entityTypes/<Entity Type ID> for developer entity types.
+            - !ruby/object:Api::Type::Boolean
+              name: 'isList'
+              description: |
+                Indicates whether the parameter represents a list of values.
+            - !ruby/object:Api::Type::Boolean
+              name: 'redact'
+              description: |
+                Indicates whether the parameter content should be redacted in log. If redaction is enabled, the parameter content will be replaced by parameter name during logging. 
+                Note: the parameter content is subject to redaction if either parameter level redaction or entity type level redaction is enabled.
+      - !ruby/object:Api::Type::Integer
+        name: 'priority'
+        description: |
+          The priority of this intent. Higher numbers represent higher priorities.
+          If the supplied value is unspecified or 0, the service translates the value to 500,000, which corresponds to the Normal priority in the console.
+          If the supplied value is negative, the intent is ignored in runtime detect intent requests.
+      - !ruby/object:Api::Type::Boolean
+        name: 'isFallback'
+        description: |
+          Indicates whether this is a fallback intent. Currently only default fallback intent is allowed in the agent, which is added upon agent creation. 
+          Adding training phrases to fallback intent is useful in the case of requests that are mistakenly matched, since training phrases assigned to fallback intents act as negative examples that triggers no-match event.
+      - !ruby/object:Api::Type::KeyValuePairs
+        name: 'labels'
+        description: |
+          The key/value metadata to label an intent. Labels can contain lowercase letters, digits and the symbols '-' and '_'. International characters are allowed, including letters from unicase alphabets. Keys must start with a letter. Keys and values can be no longer than 63 characters and no more than 128 bytes.
+          Prefix "sys-" is reserved for Dialogflow defined labels. Currently allowed Dialogflow defined labels include: * sys-head * sys-contextual The above labels do not require value. "sys-head" means the intent is a head intent. "sys.contextual" means the intent is a contextual intent.
+          An object containing a list of "key": value pairs. Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.
+      - !ruby/object:Api::Type::String
+        name: 'description'
+        description: |
+          Human readable description for better understanding an intent like its scope, content, result etc. Maximum character limit: 140 characters.

--- a/mmv1/products/dialogflowcx/api.yaml
+++ b/mmv1/products/dialogflowcx/api.yaml
@@ -17,7 +17,7 @@ display_name: Dialogflow CX
 versions:
   - !ruby/object:Api::Product::Version
     name: ga
-    base_url: https://{{location}}-dialogflow.googleapis.com/v3/
+    base_url: https://dialogflow.googleapis.com/v3/
 scopes:
   - https://www.googleapis.com/auth/cloud-platform
 apis_required:
@@ -113,8 +113,7 @@ objects:
          Indicates if automatic spell correction is enabled in detect intent requests.
   - !ruby/object:Api::Resource
     name: 'Intent'
-    base_url: "{{parent}}/intents/"
-    self_link: "{{name}}"
+    base_url: "{{parent}}/intents"
     update_verb: :PATCH
     update_mask: true
     description: |
@@ -132,13 +131,6 @@ objects:
         description: |
           The agent to create an intent for.
           Format: projects/<Project ID>/locations/<Location ID>/agents/<Agent ID>.
-      - !ruby/object:Api::Type::String
-        name: 'location'
-        description: |
-          The name of the location this intent is located in.
-        required: true
-        input: true
-        url_param_only: true
       - !ruby/object:Api::Type::String
         name: 'languageCode'
         description: |

--- a/mmv1/products/dialogflowcx/terraform.yaml
+++ b/mmv1/products/dialogflowcx/terraform.yaml
@@ -33,6 +33,28 @@ overrides: !ruby/object:Overrides::ResourceOverrides
       description: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validation.StringLenBetween(0, 500)'
+  Intent: !ruby/object:Overrides::Terraform::ResourceOverride
+    timeouts: !ruby/object:Api::Timeouts
+      insert_minutes: 40
+      update_minutes: 40
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      custom_import: templates/terraform/custom_import/self_link_as_name_set_location.go.erb   
+    examples:
+      - !ruby/object:Provider::Terraform::Examples
+        name: "dialogflowcx_intent_full"
+        primary_resource_id: "basic_intent"
+        vars:
+          agent_name: "dialogflowcx-agent"
+    skip_sweeper: true
+    id_format: "{{name}}"
+    import_format: ["{{name}}"]
+    properties:
+      displayName: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.StringLenBetween(0, 64)'
+      description: !ruby/object:Overrides::Terraform::PropertyOverride
+        validation: !ruby/object:Provider::Terraform::Validation
+          function: 'validation.StringLenBetween(0, 140)'
 # This is for copying files over
 files: !ruby/object:Provider::Config::Files
   # These files have templating (ERB) code that will be run.

--- a/mmv1/products/dialogflowcx/terraform.yaml
+++ b/mmv1/products/dialogflowcx/terraform.yaml
@@ -36,9 +36,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   Intent: !ruby/object:Overrides::Terraform::ResourceOverride
     timeouts: !ruby/object:Api::Timeouts
       insert_minutes: 40
-      update_minutes: 40
-    custom_code: !ruby/object:Provider::Terraform::CustomCode
-      custom_import: templates/terraform/custom_import/self_link_as_name_set_location.go.erb   
+      update_minutes: 40  
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "dialogflowcx_intent_full"
@@ -46,9 +44,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           agent_name: "dialogflowcx-agent"
     skip_sweeper: true
-    id_format: "{{name}}"
-    import_format: ["{{name}}"]
+    id_format: "{{parent}}/intents/{{name}}"
+    import_format: ["{{parent}}/intents/{{name}}"]
     properties:
+      name: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
       displayName: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validation.StringLenBetween(0, 64)'

--- a/mmv1/products/dialogflowcx/terraform.yaml
+++ b/mmv1/products/dialogflowcx/terraform.yaml
@@ -37,6 +37,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     timeouts: !ruby/object:Api::Timeouts
       insert_minutes: 40
       update_minutes: 40  
+    custom_code: !ruby/object:Provider::Terraform::CustomCode
+      custom_import: templates/terraform/custom_import/dialogflowcx_intent.go.erb   
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "dialogflowcx_intent_full"

--- a/mmv1/templates/terraform/custom_import/dialogflowcx_intent.go.erb
+++ b/mmv1/templates/terraform/custom_import/dialogflowcx_intent.go.erb
@@ -1,0 +1,18 @@
+    config := meta.(*Config)
+
+	// current import_formats can't import fields with forward slashes in their value and parent contains slashes
+	if err := parseImportId([]string{
+		"(?P<parent>.+)/intents/(?P<name>[^/]+)",
+		"(?P<parent>.+)/(?P<name>[^/]+)",
+	}, d, config); err != nil {
+		return nil, err
+	}
+
+	// Replace import id for the resource id
+	id, err := replaceVars(d, config, "{{parent}}/intents/{{name}}")
+	if err != nil {
+		return nil, fmt.Errorf("Error constructing id: %s", err)
+	}
+	d.SetId(id)
+
+	return []*schema.ResourceData{d}, nil

--- a/mmv1/templates/terraform/examples/dialogflowcx_intent_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_intent_full.tf.erb
@@ -16,7 +16,6 @@ resource "google_dialogflow_cx_agent" "agent" {
 
 resource "google_dialogflow_cx_intent" "<%= ctx[:primary_resource_id] %>" {
   parent       = google_dialogflow_cx_agent.agent.id
-  location     = google_dialogflow_cx_agent.agent.location
   display_name = "Example"
   priority     = 1
   description  = "Intent example"
@@ -32,11 +31,13 @@ resource "google_dialogflow_cx_intent" "<%= ctx[:primary_resource_id] %>" {
      parts {
          text = "example"
      }
+
+     repeat_count = 1
   }
 
   parameters {
-    id          = 1
-    entity_type = "${google_dialogflow_cx_agent.agent.id}/entityTypes/sys.date"
+    id          = "param1"
+    entity_type = "projects/-/locations/-/agents/-/entityTypes/sys.date"
   }
 
   labels  = {

--- a/mmv1/templates/terraform/examples/dialogflowcx_intent_full.tf.erb
+++ b/mmv1/templates/terraform/examples/dialogflowcx_intent_full.tf.erb
@@ -1,0 +1,46 @@
+resource "google_dialogflow_cx_agent" "agent" {
+  display_name = "<%= ctx[:vars]["agent_name"] %>"
+  location = "global"
+  default_language_code = "en"
+  supported_language_codes = ["fr","de","es"]
+  time_zone = "America/New_York"
+  description = "Example description."
+  avatar_uri = "https://cloud.google.com/_static/images/cloud/icons/favicons/onecloud/super_cloud.png"
+  enable_stackdriver_logging = true
+  enable_spell_correction    = true
+	speech_to_text_settings {
+		enable_speech_adaptation = true
+	}
+}
+
+
+resource "google_dialogflow_cx_intent" "<%= ctx[:primary_resource_id] %>" {
+  parent       = google_dialogflow_cx_agent.agent.id
+  location     = google_dialogflow_cx_agent.agent.location
+  display_name = "Example"
+  priority     = 1
+  description  = "Intent example"
+  training_phrases {
+     parts {
+         text = "training"
+     }
+
+     parts {
+         text = "phrase"
+     }
+
+     parts {
+         text = "example"
+     }
+  }
+
+  parameters {
+    id          = 1
+    entity_type = "${google_dialogflow_cx_agent.agent.id}/entityTypes/sys.date"
+  }
+
+  labels  = {
+      label1 = "value1",
+      label2 = "value2"
+   } 
+} 

--- a/mmv1/third_party/terraform/tests/resource_dialogflowcx_intent_test.go
+++ b/mmv1/third_party/terraform/tests/resource_dialogflowcx_intent_test.go
@@ -1,4 +1,3 @@
-<% autogen_exception -%>
 package google
 
 import (
@@ -24,17 +23,17 @@ func TestAccDialogflowCXIntent_update(t *testing.T) {
 				Config: testAccDialogflowCXIntent_basic(context),
 			},
 			{
-				ResourceName:            "google_dialogflow_cx_intent.my_intent",
-				ImportState:             true,
-				ImportStateVerify:       true,
+				ResourceName:      "google_dialogflow_cx_intent.my_intent",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 			{
 				Config: testAccDialogflowCXIntent_full(context),
 			},
 			{
-				ResourceName:            "google_dialogflow_cx_intent.my_intent",
-				ImportState:             true,
-				ImportStateVerify:       true,
+				ResourceName:      "google_dialogflow_cx_intent.my_intent",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/tests/resource_dialogflowcx_intent_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dialogflowcx_intent_test.go.erb
@@ -51,7 +51,7 @@ func testAccDialogflowCXIntent_basic(context map[string]interface{}) string {
 		member  = "serviceAccount:${google_service_account.dialogflowcx_service_account.email}"
 	}
 
-	resource "google_dialogflow_cx_agent" "agent_entity" {
+	resource "google_dialogflow_cx_agent" "agent_intent" {
 		display_name = "tf-test-%{random_suffix}"
 		location = "global"
 		default_language_code = "en"
@@ -64,7 +64,6 @@ func testAccDialogflowCXIntent_basic(context map[string]interface{}) string {
     
 	resource "google_dialogflow_cx_intent" "my_intent" {
         parent       = google_dialogflow_cx_agent.agent_intent.id
-        location     = google_dialogflow_cx_agent.agent_intent.location
         display_name = "Example"
         priority     = 1
         description  = "Intent example"
@@ -80,11 +79,13 @@ func testAccDialogflowCXIntent_basic(context map[string]interface{}) string {
             parts {
                 text = "example"
             }
+
+			repeat_count = 1
         }
 
         parameters {
-            id          = 1
-            entity_type = "${google_dialogflow_cx_agent.agent_intent.id}/entityTypes/sys.date"
+            id          = "param1"
+            entity_type = "projects/-/locations/-/agents/-/entityTypes/sys.date"
         }
 
         labels  = {
@@ -124,7 +125,6 @@ func testAccDialogflowCXIntent_full(context map[string]interface{}) string {
     
 	resource "google_dialogflow_cx_intent" "my_intent" {
         parent       = google_dialogflow_cx_agent.agent_intent.id
-        location     = google_dialogflow_cx_agent.agent_intent.location
         display_name = "Example"
         priority     = 1
         description  = "Intent example"
@@ -140,11 +140,13 @@ func testAccDialogflowCXIntent_full(context map[string]interface{}) string {
             parts {
                 text = "example"
             }
+
+			repeat_count = 1
         }
 
         parameters {
-            id          = 1
-            entity_type = "${google_dialogflow_cx_agent.agent_intent.id}/entityTypes/sys.date"
+            id          = "param1"
+            entity_type = "projects/-/locations/-/agents/-/entityTypes/sys.date"
         }
 
         labels  = {

--- a/mmv1/third_party/terraform/tests/resource_dialogflowcx_intent_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_dialogflowcx_intent_test.go.erb
@@ -1,0 +1,156 @@
+<% autogen_exception -%>
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDialogflowCXIntent_update(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"org_id":          getTestOrgFromEnv(t),
+		"billing_account": getTestBillingAccountFromEnv(t),
+		"random_suffix":   randString(t, 10),
+	}
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDialogflowCXIntent_basic(context),
+			},
+			{
+				ResourceName:            "google_dialogflow_cx_intent.my_intent",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+			{
+				Config: testAccDialogflowCXIntent_full(context),
+			},
+			{
+				ResourceName:            "google_dialogflow_cx_intent.my_intent",
+				ImportState:             true,
+				ImportStateVerify:       true,
+			},
+		},
+	})
+}
+
+func testAccDialogflowCXIntent_basic(context map[string]interface{}) string {
+	return Nprintf(`
+	resource "google_service_account" "dialogflowcx_service_account" {
+		account_id = "tf-test-dialogflow-%{random_suffix}"
+	}
+	  
+	resource "google_project_iam_member" "agent_create" {
+		role    = "roles/dialogflow.admin"
+		member  = "serviceAccount:${google_service_account.dialogflowcx_service_account.email}"
+	}
+
+	resource "google_dialogflow_cx_agent" "agent_entity" {
+		display_name = "tf-test-%{random_suffix}"
+		location = "global"
+		default_language_code = "en"
+		supported_language_codes = ["fr","de","es"]
+		time_zone = "America/New_York"
+		description = "Description 1."
+		avatar_uri = "https://storage.cloud.google.com/dialogflow-test-host-image/cloud-logo.png"
+		depends_on = [google_project_iam_member.agent_create]
+	}
+    
+	resource "google_dialogflow_cx_intent" "my_intent" {
+        parent       = google_dialogflow_cx_agent.agent_intent.id
+        location     = google_dialogflow_cx_agent.agent_intent.location
+        display_name = "Example"
+        priority     = 1
+        description  = "Intent example"
+        training_phrases {
+            parts {
+                text = "training"
+            }
+
+            parts {
+                text = "phrase"
+            }
+
+            parts {
+                text = "example"
+            }
+        }
+
+        parameters {
+            id          = 1
+            entity_type = "${google_dialogflow_cx_agent.agent_intent.id}/entityTypes/sys.date"
+        }
+
+        labels  = {
+            label1 = "value1",
+            label2 = "value2"
+        } 
+    } 
+    `, context)
+}
+
+func testAccDialogflowCXIntent_full(context map[string]interface{}) string {
+	return Nprintf(`
+    resource "google_service_account" "dialogflowcx_service_account" {
+		account_id = "tf-test-dialogflow-%{random_suffix}"
+	}
+	  
+	resource "google_project_iam_member" "agent_create" {
+		role    = "roles/dialogflow.admin"
+		member  = "serviceAccount:${google_service_account.dialogflowcx_service_account.email}"
+	}
+
+	resource "google_dialogflow_cx_agent" "agent_intent" {
+		display_name = "tf-test-%{random_suffix}update"
+		location = "global"
+		default_language_code = "en"
+		supported_language_codes = ["no"]
+		time_zone = "Europe/London"
+		description = "Description 2!"
+		avatar_uri = "https://storage.cloud.google.com/dialogflow-test-host-image/cloud-logo-2.png"
+		enable_stackdriver_logging = true
+        enable_spell_correction    = true
+		speech_to_text_settings {
+			enable_speech_adaptation = true
+		}
+		depends_on = [google_project_iam_member.agent_create]
+	}
+    
+	resource "google_dialogflow_cx_intent" "my_intent" {
+        parent       = google_dialogflow_cx_agent.agent_intent.id
+        location     = google_dialogflow_cx_agent.agent_intent.location
+        display_name = "Example"
+        priority     = 1
+        description  = "Intent example"
+        training_phrases {
+            parts {
+                text = "training"
+            }
+
+            parts {
+                text = "phrase"
+            }
+
+            parts {
+                text = "example"
+            }
+        }
+
+        parameters {
+            id          = 1
+            entity_type = "${google_dialogflow_cx_agent.agent_intent.id}/entityTypes/sys.date"
+        }
+
+        labels  = {
+            label1 = "value1",
+            label2 = "value2"
+        } 
+    } 
+	  `, context)
+}


### PR DESCRIPTION
Fixes hashicorp/terraform-provider-google#9498


Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:new-resource
`google_dialogflow_cx_intent`
```
