### PR TITLE
Add support for Composer maintenance window configuration

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -52,11 +52,10 @@ var (
 		"config.0.private_environment_config",
 <% unless version == "ga" -%>
 		"config.0.web_server_network_access_control",
-<% end -%>
-<% unless version == "ga" -%>
 		"config.0.database_config",
 		"config.0.web_server_config",
-    "config.0.encryption_config",
+	    "config.0.encryption_config",
+		"config.0.maintenance_window",
 <% end -%>
 	}
 
@@ -461,6 +460,36 @@ func resourceComposerEnvironment() *schema.Resource {
 								},
 							},
 						},
+						"maintenance_window": {
+							Type:         schema.TypeList,
+							Optional:     true,
+							Computed:     false,
+							AtLeastOneOf: composerConfigKeys,
+							MaxItems:     1,
+							Description:  `The configuration for Cloud Composer maintenance window.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"start_time": {
+										Type:        schema.TypeString,
+										Required:    true,
+										ForceNew:    false,
+										Description: `Start time of the first recurrence of the maintenance window.`,
+									},
+									"end_time": {
+										Type:        schema.TypeString,
+										Required:    true,
+										ForceNew:    false,
+										Description: `Maintenance window end time. It is used only to calculate the duration of the maintenance window. The value for end-time must be in the future, relative to 'start_time'.`,
+									},
+									"recurrence": {
+										Type:        schema.TypeString,
+										Required:    true,
+										ForceNew:    false,
+										Description: `Maintenance window recurrence. Format is a subset of RFC-5545 (https://tools.ietf.org/html/rfc5545) 'RRULE'. The only allowed values for 'FREQ' field are 'FREQ=DAILY' and 'FREQ=WEEKLY;BYDAY=...'. Example values: 'FREQ=WEEKLY;BYDAY=TU,WE', 'FREQ=DAILY'.`,
+									},
+								},
+							},
+						},
 <% end -%>
 						"airflow_uri": {
 							Type:        schema.TypeString,
@@ -729,6 +758,17 @@ func resourceComposerEnvironmentUpdate(d *schema.ResourceData, meta interface{})
 				return err
 			}
 		}
+
+		if d.HasChange("config.0.maintenance_window") {
+			patchObj := &composer.Environment{Config: &composer.EnvironmentConfig{}}
+			if config != nil {
+				patchObj.Config.MaintenanceWindow = config.MaintenanceWindow
+			}
+			err = resourceComposerEnvironmentPatchField("config.maintenanceWindow", userAgent, patchObj, d, tfConfig)
+			if err != nil {
+				return err
+			}
+		}
 <% end -%>
 	}
 
@@ -850,11 +890,10 @@ func flattenComposerEnvironmentConfig(envCfg *composer.EnvironmentConfig) interf
 	transformed["private_environment_config"] = flattenComposerEnvironmentConfigPrivateEnvironmentConfig(envCfg.PrivateEnvironmentConfig)
 <% unless version == "ga" -%>
 	transformed["web_server_network_access_control"] = flattenComposerEnvironmentConfigWebServerNetworkAccessControl(envCfg.WebServerNetworkAccessControl)
-<% end -%>
-<% unless version == "ga" -%>
 	transformed["database_config"] = flattenComposerEnvironmentConfigDatabaseConfig(envCfg.DatabaseConfig)
 	transformed["web_server_config"] = flattenComposerEnvironmentConfigWebServerConfig(envCfg.WebServerConfig)
 	transformed["encryption_config"] = flattenComposerEnvironmentConfigEncryptionConfig(envCfg.EncryptionConfig)
+	transformed["maintenance_window"] = flattenComposerEnvironmentConfigMaintenanceWindow(envCfg.MaintenanceWindow)
 <% end -%>
 
 	return []interface{}{transformed}
@@ -913,6 +952,19 @@ func flattenComposerEnvironmentConfigEncryptionConfig(encryptionCfg *composer.En
 
 	transformed := make(map[string]interface{})
 	transformed["kms_key_name"] = encryptionCfg.KmsKeyName
+
+	return []interface{}{transformed}
+}
+
+func flattenComposerEnvironmentConfigMaintenanceWindow(maintenanceWindow *composer.MaintenanceWindow) interface{} {
+	if maintenanceWindow == nil {
+		return nil
+	}
+
+	transformed := make(map[string]interface{})
+	transformed["start_time"] = maintenanceWindow.StartTime
+	transformed["end_time"] = maintenanceWindow.EndTime
+	transformed["recurrence"] = maintenanceWindow.Recurrence
 
 	return []interface{}{transformed}
 }
@@ -1055,6 +1107,13 @@ func expandComposerEnvironmentConfig(v interface{}, d *schema.ResourceData, conf
 	}
 	transformed.EncryptionConfig = transformedEncryptionConfig
 
+	log.Printf("tst tst tst")
+
+	transformedMaintenanceWindow, err := expandComposerEnvironmentConfigMaintenanceWindow(original["maintenance_window"], d, config)
+	if err != nil {
+		return nil, err
+	}
+	transformed.MaintenanceWindow = transformedMaintenanceWindow
 <% end -%>
 	return transformed, nil
 }
@@ -1144,6 +1203,29 @@ func expandComposerEnvironmentConfigEncryptionConfig(v interface{}, d *schema.Re
 	return transformed, nil
 }
 
+func expandComposerEnvironmentConfigMaintenanceWindow(v interface{}, d *schema.ResourceData, config *Config) (*composer.MaintenanceWindow, error) {
+	l := v.([]interface{})
+	if len(l) == 0 {
+		return nil, nil
+	}
+	raw := l[0]
+	original := raw.(map[string]interface{})
+	transformed := &composer.MaintenanceWindow{}
+
+	if v, ok := original["start_time"]; ok {
+		transformed.StartTime = v.(string)
+	}
+
+	if v, ok := original["end_time"]; ok {
+		transformed.EndTime = v.(string)
+	}
+
+	if v, ok := original["recurrence"]; ok {
+		transformed.Recurrence = v.(string)
+	}
+
+	return transformed, nil
+}
 <% end -%>
 
 func expandComposerEnvironmentConfigPrivateEnvironmentConfig(v interface{}, d *schema.ResourceData, config *Config) (*composer.PrivateEnvironmentConfig, error) {

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -54,7 +54,7 @@ var (
 		"config.0.web_server_network_access_control",
 		"config.0.database_config",
 		"config.0.web_server_config",
-	    "config.0.encryption_config",
+		"config.0.encryption_config",
 		"config.0.maintenance_window",
 <% end -%>
 	}
@@ -463,7 +463,7 @@ func resourceComposerEnvironment() *schema.Resource {
 						"maintenance_window": {
 							Type:         schema.TypeList,
 							Optional:     true,
-							Computed:     false,
+							Computed:     true,
 							AtLeastOneOf: composerConfigKeys,
 							MaxItems:     1,
 							Description:  `The configuration for Cloud Composer maintenance window.`,
@@ -1106,8 +1106,6 @@ func expandComposerEnvironmentConfig(v interface{}, d *schema.ResourceData, conf
 		return nil, err
 	}
 	transformed.EncryptionConfig = transformedEncryptionConfig
-
-	log.Printf("tst tst tst")
 
 	transformedMaintenanceWindow, err := expandComposerEnvironmentConfigMaintenanceWindow(original["maintenance_window"], d, config)
 	if err != nil {

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -329,6 +329,40 @@ func TestAccComposerEnvironment_withEncryptionConfig(t *testing.T) {
     },
   })
 }
+
+func TestAccComposerEnvironment_withMaintenanceWindow(t *testing.T) {
+  t.Parallel()
+
+  pid := getTestProjectFromEnv()
+  envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
+  network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
+  subnetwork := network + "-1"
+
+  vcrTest(t, resource.TestCase{
+    PreCheck:     func() { testAccPreCheck(t) },
+    Providers:    testAccProviders,
+    CheckDestroy: testAccComposerEnvironmentDestroyProducer(t),
+    Steps: []resource.TestStep{
+      {
+        Config: testAccComposerEnvironment_maintenanceWindow(pid, envName, network, subnetwork),
+      },
+      {
+        ResourceName:      "google_composer_environment.test",
+        ImportState:       true,
+        ImportStateVerify: true,
+      },
+      // This is a terrible clean-up step in order to get destroy to succeed,
+      // due to dangling firewall rules left by the Composer Environment blocking network deletion.
+      // TODO(dzarmola): Remove this check if firewall rules bug gets fixed by Composer.
+      {
+        PlanOnly:           true,
+        ExpectNonEmptyPlan: false,
+        Config:             testAccComposerEnvironment_maintenanceWindow(pid, envName, network, subnetwork),
+        Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
+      },
+    },
+  })
+}
 <% end -%>
 // Checks behavior of node config, including dependencies on Compute resources.
 func TestAccComposerEnvironment_withNodeConfig(t *testing.T) {
@@ -836,6 +870,35 @@ resource "google_compute_subnetwork" "test" {
 }
 `, pid, kmsKey, name, kmsKey, network, subnetwork)
 }
+
+func testAccComposerEnvironment_maintenanceWindow(pid, envName, network, subnetwork string) string {
+	return fmt.Sprintf(`
+resource "google_composer_environment" "test" {
+	name   = "%s"
+	region = "us-central1"
+	config {
+		maintenance_window {
+			start_time = "2019-08-01T01:00:00Z"
+			end_time = "2019-08-01T07:00:00Z"
+			recurrence = "FREQ=WEEKLY;BYDAY=TU,WE"
+		}
+	}
+}
+
+resource "google_compute_network" "test" {
+	name                    = "%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+	name          = "%s"
+	ip_cidr_range = "10.2.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.test.self_link
+}
+
+`, envName, network, subnetwork)
+}
 <% end -%>
 func testAccComposerEnvironment_update(name, network, subnetwork string) string {
 	return fmt.Sprintf(`
@@ -923,7 +986,6 @@ resource "google_composer_environment" "test" {
 			}
 		}
 	}
-
 	depends_on = [google_project_iam_member.composer-worker]
 }
 

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -182,6 +182,10 @@ The `config` block supports:
 * `encryption_config` -
   (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
   The encryption options for the Cloud Composer environment and its dependencies.
+  
+* `maintenance_window` -
+  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  The configuration settings for Cloud Composer maintenance window.
 
 The `node_config` block supports:
 
@@ -410,6 +414,22 @@ The `encryption_config` block supports:
   be the fully qualified resource name, 
   i.e. projects/project-id/locations/location/keyRings/keyring/cryptoKeys/key. Cannot be updated.
 
+The `maintenance_window` block supports:
+
+* `start_time` -
+  (Required)
+  Start time of the first recurrence of the maintenance window.
+
+* `end_time` -
+  (Required)
+  Maintenance window end time. It is used only to calculate the duration of the maintenance window.
+  The value for end-time must be in the future, relative to 'start_time'.
+
+* `recurrence` -
+  (Required)
+  Maintenance window recurrence. Format is a subset of RFC-5545 (https://tools.ietf.org/html/rfc5545) 'RRULE'.
+  The only allowed values for 'FREQ' field are 'FREQ=DAILY' and 'FREQ=WEEKLY;BYDAY=...'.
+  Example values: 'FREQ=WEEKLY;BYDAY=TU,WE', 'FREQ=DAILY'.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add maintenance_window to google_composer_environment (beta)

fixes hashicorp/terraform-provider-google#9423

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
composer: added field `maintenance_window` to resource `google_composer_environment` (beta)
```
