### PR TITLE
Add cryptography fields to dlp deidentify template

### DIFF
--- a/mmv1/products/dlp/api.yaml
+++ b/mmv1/products/dlp/api.yaml
@@ -1091,3 +1091,202 @@ objects:
                                       - :ALPHA_LOWER_CASE
                                       - :PUNCTUATION
                                       - :WHITESPACE
+                        - !ruby/object:Api::Type::NestedObject
+                          name: 'cryptoDeterministicConfig'
+                          description: |
+                            Pseudonymization method that generates deterministic encryption for the given input. Outputs a base64 encoded representation of the encrypted output. Uses AES-SIV based on the RFC [https://tools.ietf.org/html/rfc5297](https://tools.ietf.org/html/rfc5297).
+                          properties:
+                            - !ruby/object:Api::Type::NestedObject
+                              name: 'cryptoKey'
+                              description: |
+                                The key used by the encryption function.
+                              properties:
+                                - !ruby/object:Api::Type::NestedObject
+                                  name: 'transient'
+                                  description: |
+                                    Transient crypto key
+                                  properties:
+                                    - !ruby/object:Api::Type::String
+                                      name: 'name'
+                                      required: true
+                                      description: |
+                                        Name of the key. This is an arbitrary string used to differentiate different keys. A unique key is generated per name: two separate `TransientCryptoKey` protos share the same generated key if their names are the same. When the data crypto key is generated, this name is not used in any way (repeating the api call will result in a different key being generated).
+                                - !ruby/object:Api::Type::NestedObject
+                                  name: 'unwrapped'
+                                  description: |
+                                    Unwrapped crypto key
+                                  properties:
+                                    - !ruby/object:Api::Type::String
+                                      name: 'key'
+                                      required: true
+                                      description: |
+                                        A 128/192/256 bit key.
+
+                                        A base64-encoded string.
+                                - !ruby/object:Api::Type::NestedObject
+                                  name: 'kmsWrapped'
+                                  description: |
+                                    Kms wrapped key
+                                  properties:
+                                    - !ruby/object:Api::Type::String
+                                      name: 'wrappedKey'
+                                      required: true
+                                      description: |
+                                        The wrapped data crypto key.
+
+                                        A base64-encoded string.
+                                    - !ruby/object:Api::Type::String
+                                      name: 'cryptoKeyName'
+                                      required: true
+                                      description: |
+                                        The resource name of the KMS CryptoKey to use for unwrapping.
+                            - !ruby/object:Api::Type::NestedObject
+                              name: 'surrogateInfoType'
+                              description: |
+                                The custom info type to annotate the surrogate with. This annotation will be applied to the surrogate by prefixing it with the name of the custom info type followed by the number of characters comprising the surrogate. The following scheme defines the format: {info type name}({surrogate character count}):{surrogate}
+
+                                For example, if the name of custom info type is 'MY\_TOKEN\_INFO\_TYPE' and the surrogate is 'abc', the full replacement value will be: 'MY\_TOKEN\_INFO\_TYPE(3):abc'
+
+                                This annotation identifies the surrogate when inspecting content using the custom info type 'Surrogate'. This facilitates reversal of the surrogate when it occurs in free text.
+
+                                Note: For record transformations where the entire cell in a table is being transformed, surrogates are not mandatory. Surrogates are used to denote the location of the token and are necessary for re-identification in free form text.
+
+                                In order for inspection to work properly, the name of this info type must not occur naturally anywhere in your data; otherwise, inspection may either
+
+                                *   reverse a surrogate that does not correspond to an actual identifier
+                                *   be unable to parse the surrogate and result in an error
+
+                                Therefore, choose your custom info type name carefully after considering what your data looks like. One way to select a name that has a high chance of yielding reliable detection is to include one or more unicode characters that are highly improbable to exist in your data. For example, assuming your data is entered from a regular ASCII keyboard, the symbol with the hex code point 29DD might be used like so: ⧝MY\_TOKEN\_TYPE.
+                              properties:
+                                - !ruby/object:Api::Type::String
+                                  name: 'name'
+                                  description: |
+                                    Name of the information type. Either a name of your choosing when creating a CustomInfoType, or one of the names listed at [https://cloud.google.com/dlp/docs/infotypes-reference](https://cloud.google.com/dlp/docs/infotypes-reference) when specifying a built-in type. When sending Cloud DLP results to Data Catalog, infoType names should conform to the pattern `[A-Za-z0-9$-_]{1,64}`.
+                            - !ruby/object:Api::Type::NestedObject
+                              name: 'context'
+                              description: |
+                                A context may be used for higher security and maintaining referential integrity such that the same identifier in two different contexts will be given a distinct surrogate. The context is appended to plaintext value being encrypted. On decryption the provided context is validated against the value used during encryption. If a context was provided during encryption, same context must be provided during decryption as well.
+
+                                If the context is not set, plaintext would be used as is for encryption. If the context is set but:
+
+                                1.  there is no record present when transforming a given value or
+                                2.  the field is not present when transforming a given value,
+
+                                plaintext would be used as is for encryption.
+
+                                Note that case (1) is expected when an `InfoTypeTransformation` is applied to both structured and non-structured `ContentItem`s.
+                              properties:
+                                - !ruby/object:Api::Type::String
+                                  name: 'name'
+                                  description: |
+                                    Name describing the field.
+                        - !ruby/object:Api::Type::NestedObject
+                          name: 'cryptoReplaceFfxFpeConfig'
+                          description: |
+                            Replaces an identifier with a surrogate using Format Preserving Encryption (FPE) with the FFX mode of operation; however when used in the `content.reidentify` API method, it serves the opposite function by reversing the surrogate back into the original identifier. The identifier must be encoded as ASCII. For a given crypto key and context, the same identifier will be replaced with the same surrogate. Identifiers must be at least two characters long. In the case that the identifier is the empty string, it will be skipped. See [https://cloud.google.com/dlp/docs/pseudonymization](https://cloud.google.com/dlp/docs/pseudonymization) to learn more.
+
+                            Note: We recommend using CryptoDeterministicConfig for all use cases which do not require preserving the input alphabet space and size, plus warrant referential integrity.
+                          properties:
+                            - !ruby/object:Api::Type::NestedObject
+                              name: 'cryptoKey'
+                              description: |
+                                The key used by the encryption algorithm.
+                              properties:
+                                - !ruby/object:Api::Type::NestedObject
+                                  name: 'transient'
+                                  description: |
+                                    Transient crypto key
+                                  properties:
+                                    - !ruby/object:Api::Type::String
+                                      name: 'name'
+                                      required: true
+                                      description: |
+                                        Name of the key. This is an arbitrary string used to differentiate different keys. A unique key is generated per name: two separate `TransientCryptoKey` protos share the same generated key if their names are the same. When the data crypto key is generated, this name is not used in any way (repeating the api call will result in a different key being generated).
+                                - !ruby/object:Api::Type::NestedObject
+                                  name: 'unwrapped'
+                                  description: |
+                                    Unwrapped crypto key
+                                  properties:
+                                    - !ruby/object:Api::Type::String
+                                      name: 'key'
+                                      required: true
+                                      description: |
+                                        A 128/192/256 bit key.
+
+                                        A base64-encoded string.
+                                - !ruby/object:Api::Type::NestedObject
+                                  name: 'kmsWrapped'
+                                  description: |
+                                    Kms wrapped key
+                                  properties:
+                                    - !ruby/object:Api::Type::String
+                                      name: 'wrappedKey'
+                                      required: true
+                                      description: |
+                                        The wrapped data crypto key.
+
+                                        A base64-encoded string.
+                                    - !ruby/object:Api::Type::String
+                                      name: 'cryptoKeyName'
+                                      required: true
+                                      description: |
+                                        The resource name of the KMS CryptoKey to use for unwrapping.
+                            - !ruby/object:Api::Type::NestedObject
+                              name: 'context'
+                              description: |
+                                The 'tweak', a context may be used for higher security since the same identifier in two different contexts won't be given the same surrogate. If the context is not set, a default tweak will be used.
+
+                                If the context is set but:
+
+                                1.  there is no record present when transforming a given value or
+                                2.  the field is not present when transforming a given value,
+
+                                a default tweak will be used.
+
+                                Note that case (1) is expected when an `InfoTypeTransformation` is applied to both structured and non-structured `ContentItem`s. Currently, the referenced field may be of value type integer or string.
+
+                                The tweak is constructed as a sequence of bytes in big endian byte order such that:
+
+                                *   a 64 bit integer is encoded followed by a single byte of value 1
+                                *   a string is encoded in UTF-8 format followed by a single byte of value 2
+                              properties:
+                                - !ruby/object:Api::Type::String
+                                  name: 'name'
+                                  description: |
+                                    Name describing the field.
+                            - !ruby/object:Api::Type::NestedObject
+                              name: 'surrogateInfoType'
+                              description: |
+                                The custom infoType to annotate the surrogate with. This annotation will be applied to the surrogate by prefixing it with the name of the custom infoType followed by the number of characters comprising the surrogate. The following scheme defines the format: info\_type\_name(surrogate\_character\_count):surrogate
+
+                                For example, if the name of custom infoType is 'MY\_TOKEN\_INFO\_TYPE' and the surrogate is 'abc', the full replacement value will be: 'MY\_TOKEN\_INFO\_TYPE(3):abc'
+
+                                This annotation identifies the surrogate when inspecting content using the custom infoType [`SurrogateType`](https://cloud.google.com/dlp/docs/reference/rest/v2/InspectConfig#surrogatetype). This facilitates reversal of the surrogate when it occurs in free text.
+
+                                In order for inspection to work properly, the name of this infoType must not occur naturally anywhere in your data; otherwise, inspection may find a surrogate that does not correspond to an actual identifier. Therefore, choose your custom infoType name carefully after considering what your data looks like. One way to select a name that has a high chance of yielding reliable detection is to include one or more unicode characters that are highly improbable to exist in your data. For example, assuming your data is entered from a regular ASCII keyboard, the symbol with the hex code point 29DD might be used like so: ⧝MY\_TOKEN\_TYPE
+                              properties:
+                                - !ruby/object:Api::Type::String
+                                  name: 'name'
+                                  description: |
+                                    Name of the information type. Either a name of your choosing when creating a CustomInfoType, or one of the names listed at [https://cloud.google.com/dlp/docs/infotypes-reference](https://cloud.google.com/dlp/docs/infotypes-reference) when specifying a built-in type. When sending Cloud DLP results to Data Catalog, infoType names should conform to the pattern `[A-Za-z0-9$-_]{1,64}`.
+                            - !ruby/object:Api::Type::Enum
+                              name: 'commonAlphabet'
+                              description: |
+                                Common alphabets.
+                              values:
+                                - :FFX_COMMON_NATIVE_ALPHABET_UNSPECIFIED  #Unused.
+                                - :NUMERIC  #[0-9] (radix of 10)
+                                - :HEXADECIMAL  #[0-9A-F] (radix of 16)
+                                - :UPPER_CASE_ALPHA_NUMERIC  #[0-9A-Z] (radix of 36)
+                                - :ALPHA_NUMERIC  #[0-9A-Za-z] (radix of 62)
+                            - !ruby/object:Api::Type::String
+                              name: 'customAlphabet'
+                              description: |
+                                This is supported by mapping these to the alphanumeric characters that the FFX mode natively supports. This happens before/after encryption/decryption. Each character listed must appear only once. Number of characters must be in the range \[2, 95\]. This must be encoded as ASCII. The order of characters does not matter. The full list of allowed characters is:
+
+                                ``0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz ~`!@#$%^&*()_-+={[}]|:;"'<,>.?/``
+                            - !ruby/object:Api::Type::Integer
+                              name: 'radix'
+                              description: |
+                                The native way to select the alphabet. Must be in the range \[2, 95\].
+

--- a/mmv1/templates/terraform/examples/dlp_deidentify_template_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/dlp_deidentify_template_basic.tf.erb
@@ -69,6 +69,28 @@ resource "google_data_loss_prevention_deidentify_template" "<%= ctx[:primary_res
 					}
 				}
 			}
+
+      transformations {
+        info_types {
+          name = "CREDIT_CARD_NUMBER"
+        }
+
+        primitive_transformation {
+          crypto_deterministic_config {
+            context {
+              name = "sometweak"
+            }
+            crypto_key {
+              transient {
+                name = "beep"
+              }
+            }
+            surrogate_info_type {
+              name = "abc"
+            }
+          }
+        }
+      }
 		}
 	}
 }

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_deidentify_template_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_deidentify_template_test.go
@@ -102,8 +102,103 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
 					}
 				}
 			}
+
+      transformations {
+        info_types {
+          name = "CREDIT_CARD_NUMBER2322"
+        }
+
+        primitive_transformation {
+          crypto_deterministic_config {
+            context {
+              name = "sometweak"
+            }
+            crypto_key {
+              kms_wrapped {
+                wrapped_key     = "B64/WRAPPED/TOKENIZATION/KEY"
+                crypto_key_name = google_kms_crypto_key.my_key.id
+              }
+            }
+            surrogate_info_type {
+              name = "abc"
+            }
+          }
+        }
+      }
+      transformations {
+        info_types {
+          name = "CUSTOM_INFO_TYPE"
+        }
+
+        primitive_transformation {
+          crypto_deterministic_config {
+            crypto_key {
+              transient {
+                name = "beep"
+              }
+            }
+            surrogate_info_type {
+              name = "CUSTOM_INFO_TYPE"
+            }
+          }
+        }
+      }
+      transformations {
+        info_types {
+          name = "PHONE_NUMBER2"
+        }
+        primitive_transformation {
+          crypto_replace_ffx_fpe_config {
+            context {
+              name = "someTweak"
+            }
+            crypto_key {
+              kms_wrapped {
+                wrapped_key     = "B64/WRAPPED/TOKENIZATION/KEY"
+                crypto_key_name = google_kms_crypto_key.my_key.id
+              }
+            }
+            radix = 10
+            surrogate_info_type {
+              name = "CUSTOM_INFO_TYPE"
+            }
+          }
+        }
+      }
+
+      transformations {
+        info_types {
+          name = "SSN"
+        }
+        primitive_transformation {
+          crypto_replace_ffx_fpe_config {
+            common_alphabet = "UPPER_CASE_ALPHA_NUMERIC"
+            context {
+              name = "someTweak"
+            }
+            crypto_key {
+              transient {
+                name = "beep"
+              }
+            }
+            surrogate_info_type {
+              name = "CUSTOM_INFO_TYPE"
+            }
+          }
+        }
+      }
 		}
 	}
+}
+
+resource "google_kms_crypto_key" "my_key" {
+  name     = "tf-test-example-k%{random_suffix}"
+  key_ring = google_kms_key_ring.key_ring.id
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  name     = "tf-test-example-keyr%{random_suffix}"
+  location = "global"
 }
 `, context)
 }
@@ -164,8 +259,103 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
 					}
 				}
 			}
+
+			transformations {
+        info_types {
+          name = "CREDIT_CARD_NUMBERR"
+        }
+
+        primitive_transformation {
+          crypto_deterministic_config {
+            context {
+              name = "sometweakd"
+            }
+            crypto_key {
+              kms_wrapped {
+                wrapped_key     = "B64/WRAPPED/TOKENIZATION/KEY"
+                crypto_key_name = google_kms_crypto_key.my_key.id
+              }
+            }
+            surrogate_info_type {
+              name = "abcd"
+            }
+          }
+        }
+      }
+      transformations {
+        info_types {
+          name = "CUSTOM_INFO_TYPE"
+        }
+
+        primitive_transformation {
+          crypto_deterministic_config {
+            crypto_key {
+              transient {
+                name = "beeper"
+              }
+            }
+            surrogate_info_type {
+              name = "CUSTOM_INFO_TYPEf"
+            }
+          }
+        }
+      }
+      transformations {
+        info_types {
+          name = "PHONE_NUMBER2"
+        }
+        primitive_transformation {
+          crypto_replace_ffx_fpe_config {
+            context {
+              name = "someTweaker"
+            }
+            crypto_key {
+              kms_wrapped {
+                wrapped_key     = "B64/WRAPPED/TOKENIZATION/KEY"
+                crypto_key_name = google_kms_crypto_key.my_key.id
+              }
+            }
+            radix = 10
+            surrogate_info_type {
+              name = "CUSTOM_INFO_TYPEF"
+            }
+          }
+        }
+      }
+
+      transformations {
+        info_types {
+          name = "SSN"
+        }
+        primitive_transformation {
+          crypto_replace_ffx_fpe_config {
+            common_alphabet = "UPPER_CASE_ALPHA_NUMERIC"
+            context {
+              name = "someTweak2"
+            }
+            crypto_key {
+              transient {
+                name = "beepf"
+              }
+            }
+            surrogate_info_type {
+              name = "CUSTOM_INFO_TYPE"
+            }
+          }
+        }
+      }
 		}
 	}
+}
+
+resource "google_kms_crypto_key" "my_key" {
+  name     = "tf-test-example-k%{random_suffix}"
+  key_ring = google_kms_key_ring.key_ring.id
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  name     = "tf-test-example-keyr%{random_suffix}"
+  location = "global"
 }
 `, context)
 }

--- a/mmv1/third_party/terraform/tests/resource_data_loss_prevention_deidentify_template_test.go
+++ b/mmv1/third_party/terraform/tests/resource_data_loss_prevention_deidentify_template_test.go
@@ -42,66 +42,66 @@ func TestAccDataLossPreventionDeidentifyTemplate_dlpDeidentifyTemplateUpdate(t *
 func testAccDataLossPreventionDeidentifyTemplate_dlpDeidentifyTemplateStart(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_data_loss_prevention_deidentify_template" "basic" {
-	parent = "organizations/%{organization}"
-	description = "Description"
-	display_name = "Displayname"
+  parent = "organizations/%{organization}"
+  description = "Description"
+  display_name = "Displayname"
 
-	deidentify_config {
-		info_type_transformations {
-			transformations {
-				info_types {
-					name = "PHONE_NUMBER"
-				}
-				info_types {
-					name = "CREDIT_CARD_NUMBER"
-				}
+  deidentify_config {
+    info_type_transformations {
+      transformations {
+        info_types {
+          name = "PHONE_NUMBER"
+        }
+        info_types {
+          name = "CREDIT_CARD_NUMBER"
+        }
 
-				primitive_transformation {
-					replace_config {
-						new_value {
-							integer_value = 9
-						}
-					}
-				}
-			}
+        primitive_transformation {
+          replace_config {
+            new_value {
+              integer_value = 9
+            }
+          }
+        }
+      }
 
-			transformations {
-				info_types {
-					name = "EMAIL_ADDRESS"
-				}
-				info_types {
-					name = "LAST_NAME"
-				}
+      transformations {
+        info_types {
+          name = "EMAIL_ADDRESS"
+        }
+        info_types {
+          name = "LAST_NAME"
+        }
 
-				primitive_transformation {
-					character_mask_config {
-						masking_character = "X"
-						number_to_mask = 4
-						reverse_order = true
-						characters_to_ignore {
-							common_characters_to_ignore = "PUNCTUATION"
-						}
-					}
-				}
-			}
+        primitive_transformation {
+          character_mask_config {
+            masking_character = "X"
+            number_to_mask = 4
+            reverse_order = true
+            characters_to_ignore {
+              common_characters_to_ignore = "PUNCTUATION"
+            }
+          }
+        }
+      }
 
-			transformations {
-				info_types {
-					name = "DATE_OF_BIRTH"
-				}
+      transformations {
+        info_types {
+          name = "DATE_OF_BIRTH"
+        }
 
-				primitive_transformation {
-					replace_config {
-						new_value {
-							date_value {
-								year  = 2020
-								month = 1
-								day   = 1
-							}
-						}
-					}
-				}
-			}
+        primitive_transformation {
+          replace_config {
+            new_value {
+              date_value {
+                year  = 2020
+                month = 1
+                day   = 1
+              }
+            }
+          }
+        }
+      }
 
       transformations {
         info_types {
@@ -125,6 +125,29 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
           }
         }
       }
+
+      transformations {
+        info_types {
+          name = "CREDIT_CARD_NUMBER23224"
+        }
+
+        primitive_transformation {
+          crypto_deterministic_config {
+            context {
+              name = "sometweak"
+            }
+            crypto_key {
+              unwrapped {
+                key     = "VVdWVWFGZHRXbkUwZERkM0lYb2xRdz09"
+              }
+            }
+            surrogate_info_type {
+              name = "abc"
+            }
+          }
+        }
+      }
+
       transformations {
         info_types {
           name = "CUSTOM_INFO_TYPE"
@@ -187,8 +210,27 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
           }
         }
       }
-		}
-	}
+
+      transformations {
+        info_types {
+          name = "SSN33"
+        }
+        primitive_transformation {
+          crypto_replace_ffx_fpe_config {
+            common_alphabet = "UPPER_CASE_ALPHA_NUMERIC"
+            crypto_key {
+              unwrapped {
+                key = "VVdWVWFGZHRXbkUwZERkM0lYb2xRdz09"
+              }
+            }
+            surrogate_info_type {
+              name = "CUSTOM_INFO_TYPE"
+            }
+          }
+        }
+      }
+    }
+  }
 }
 
 resource "google_kms_crypto_key" "my_key" {
@@ -206,61 +248,61 @@ resource "google_kms_key_ring" "key_ring" {
 func testAccDataLossPreventionDeidentifyTemplate_dlpDeidentifyTemplateUpdate(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_data_loss_prevention_deidentify_template" "basic" {
-	parent = "organizations/%{organization}"
-	description = "Description"
-	display_name = "Displayname"
+  parent = "organizations/%{organization}"
+  description = "Description"
+  display_name = "Displayname"
 
-	deidentify_config {
-		info_type_transformations {
-			transformations {
-				info_types {
-					name = "CREDIT_CARD_NUMBER"
-				}
+  deidentify_config {
+    info_type_transformations {
+      transformations {
+        info_types {
+          name = "CREDIT_CARD_NUMBER"
+        }
 
-				primitive_transformation {
-					replace_config {
-						new_value {
-							integer_value = 9
-						}
-					}
-				}
-			}
+        primitive_transformation {
+          replace_config {
+            new_value {
+              integer_value = 9
+            }
+          }
+        }
+      }
 
-			transformations {
-				info_types {
-					name = "EMAIL_ADDRESS"
-				}
-				info_types {
-					name = "LAST_NAME"
-				}
+      transformations {
+        info_types {
+          name = "EMAIL_ADDRESS"
+        }
+        info_types {
+          name = "LAST_NAME"
+        }
 
-				primitive_transformation {
-					character_mask_config {
-						number_to_mask = 3
-						reverse_order = true
-					}
-				}
-			}
+        primitive_transformation {
+          character_mask_config {
+            number_to_mask = 3
+            reverse_order = true
+          }
+        }
+      }
 
-			transformations {
-				info_types {
-					name = "DATE_OF_BIRTH"
-				}
+      transformations {
+        info_types {
+          name = "DATE_OF_BIRTH"
+        }
 
-				primitive_transformation {
-					replace_config {
-						new_value {
-							date_value {
-								year  = 2020
-								month = 1
-								day   = 1
-							}
-						}
-					}
-				}
-			}
+        primitive_transformation {
+          replace_config {
+            new_value {
+              date_value {
+                year  = 2020
+                month = 1
+                day   = 1
+              }
+            }
+          }
+        }
+      }
 
-			transformations {
+      transformations {
         info_types {
           name = "CREDIT_CARD_NUMBERR"
         }
@@ -344,8 +386,8 @@ resource "google_data_loss_prevention_deidentify_template" "basic" {
           }
         }
       }
-		}
-	}
+    }
+  }
 }
 
 resource "google_kms_crypto_key" "my_key" {


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/9108

**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
dlp: added `crypto_replace_ffx_fpe_config` and `crypto_replace_ffx_fpe_config` as primitive transformation types to `google_data_loss_prevention_deidentify_template`
```
