### PR TITLE
add support for available_secrets to google_cloudbuild_trigger

### DIFF
--- a/mmv1/products/cloudbuild/api.yaml
+++ b/mmv1/products/cloudbuild/api.yaml
@@ -447,6 +447,30 @@ objects:
                     Secret environment variables must be unique across all of a build's secrets, 
                     and must be used by at least one build step. Values can be at most 64 KB in size. 
                     There can be at most 100 secret values across all of a build's secrets.
+          - !ruby/object:Api::Type::NestedObject
+            name: 'availableSecrets'
+            description: |
+              Secrets and secret environment variables.
+            properties:
+              - !ruby/object:Api::Type::Array
+                name: 'secretManager'
+                required: true
+                description: |
+                  Pairs a secret environment variable with a SecretVersion in Secret Manager.
+                item_type: !ruby/object:Api::Type::NestedObject
+                  properties:
+                    - !ruby/object:Api::Type::String
+                      name: 'versionName'
+                      required: true
+                      description: |
+                        Resource name of the SecretVersion. In format: projects/*/secrets/*/versions/*
+                    - !ruby/object:Api::Type::String
+                      name: 'env'
+                      required: true
+                      description: |
+                        Environment variable name to associate with the secret. Secret environment
+                        variables must be unique across all of a build's secrets, and must be used
+                        by at least one build step.
           - !ruby/object:Api::Type::Array
             name: 'steps'
             required: true

--- a/mmv1/templates/terraform/examples/cloudbuild_trigger_build.tf.erb
+++ b/mmv1/templates/terraform/examples/cloudbuild_trigger_build.tf.erb
@@ -3,12 +3,13 @@ resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
     branch_name = "master"
     repo_name   = "my-repo"
   }
-  
+
   build {
     step {
       name = "gcr.io/cloud-builders/gsutil"
       args = ["cp", "gs://mybucket/remotefile.zip", "localfile.zip"]
       timeout = "120s"
+      secret_env = ["MY_SECRET"]
     }
 
     source {
@@ -28,6 +29,12 @@ resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
       kms_key_name = "projects/myProject/locations/global/keyRings/keyring-name/cryptoKeys/key-name"
       secret_env = {
         PASSWORD = "ZW5jcnlwdGVkLXBhc3N3b3JkCg=="
+      }
+    }
+    available_secrets {
+      secret_manager {
+        env          = "MY_SECRET"
+        version_name = "projects/myProject/secrets/mySecret/versions/latest"
       }
     }
     artifacts {
@@ -54,5 +61,5 @@ resource "google_cloudbuild_trigger" "<%= ctx[:primary_resource_id] %>" {
         path = "v1"
       }
     }
-  }  
+  }
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
add support for available_secrets to google_cloudbuild_trigger.
https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds#secrets

fixes https://github.com/hashicorp/terraform-provider-google/issues/8808

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudbuild: added support for available_secrets to google_cloudbuild_trigger
```