### PR TITLE
GA ipsec interconnect tests

### DIFF
--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -1118,7 +1118,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           address_name: "test-address"
           router_name: "test-router"
           network_name: "test-network"
-        min_version: beta
     properties:
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
@@ -2102,7 +2101,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           router_name: "test-router"
           network_name: "test-network"
-        min_version: beta
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/router.go.erb
       resource_definition: templates/terraform/resource_definition/router.go.erb
@@ -2801,7 +2799,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           address2_name: "test-address2"
           router_name: "test-router"
           network_name: "test-network"
-        min_version: beta
     properties:
       name: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation

--- a/mmv1/templates/terraform/examples/compute_ha_vpn_gateway_encrypted_interconnect.tf.erb
+++ b/mmv1/templates/terraform/examples/compute_ha_vpn_gateway_encrypted_interconnect.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_ha_vpn_gateway" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   name           = "<%= ctx[:vars]['ha_vpn_gateway_name'] %>"
   network        = google_compute_network.network.id
   vpn_interfaces {
@@ -13,7 +12,6 @@ resource "google_compute_ha_vpn_gateway" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_compute_interconnect_attachment" "attachment1" {
-  provider = google-beta
   name                     = "<%= ctx[:vars]['interconnect_attachment1_name'] %>"
   edge_availability_domain = "AVAILABILITY_DOMAIN_1"
   type                     = "PARTNER"
@@ -25,7 +23,6 @@ resource "google_compute_interconnect_attachment" "attachment1" {
 }
 
 resource "google_compute_interconnect_attachment" "attachment2" {
-  provider = google-beta
   name                     = "<%= ctx[:vars]['interconnect_attachment2_name'] %>"
   edge_availability_domain = "AVAILABILITY_DOMAIN_2"
   type                     = "PARTNER"
@@ -37,7 +34,6 @@ resource "google_compute_interconnect_attachment" "attachment2" {
 }
 
 resource "google_compute_address" "address1" {
-  provider = google-beta
   name          = "<%= ctx[:vars]['address1_name'] %>"
   address_type  = "INTERNAL"
   purpose       = "IPSEC_INTERCONNECT"
@@ -47,7 +43,6 @@ resource "google_compute_address" "address1" {
 }
 
 resource "google_compute_address" "address2" {
-  provider = google-beta
   name          = "<%= ctx[:vars]['address2_name'] %>"
   address_type  = "INTERNAL"
   purpose       = "IPSEC_INTERCONNECT"
@@ -57,7 +52,6 @@ resource "google_compute_address" "address2" {
 }
 
 resource "google_compute_router" "router" {
-  provider = google-beta
   name                          = "<%= ctx[:vars]['router_name'] %>"
   network                       = google_compute_network.network.name
   encrypted_interconnect_router = true
@@ -67,7 +61,6 @@ resource "google_compute_router" "router" {
 }
 
 resource "google_compute_network" "network" {
-  provider = google-beta
   name                    = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks = false
 }

--- a/mmv1/templates/terraform/examples/compute_interconnect_attachment_ipsec_encryption.tf.erb
+++ b/mmv1/templates/terraform/examples/compute_interconnect_attachment_ipsec_encryption.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_interconnect_attachment" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   name                     = "<%= ctx[:vars]['interconnect_attachment_name'] %>"
   edge_availability_domain = "AVAILABILITY_DOMAIN_1"
   type                     = "PARTNER"
@@ -11,7 +10,6 @@ resource "google_compute_interconnect_attachment" "<%= ctx[:primary_resource_id]
 }
 
 resource "google_compute_address" "address" {
-  provider = google-beta
   name          = "<%= ctx[:vars]['address_name'] %>"
   address_type  = "INTERNAL"
   purpose       = "IPSEC_INTERCONNECT"
@@ -21,7 +19,6 @@ resource "google_compute_address" "address" {
 }
 
 resource "google_compute_router" "router" {
-  provider = google-beta
   name                          = "<%= ctx[:vars]['router_name'] %>"
   network                       = google_compute_network.network.name
   encrypted_interconnect_router = true
@@ -31,7 +28,6 @@ resource "google_compute_router" "router" {
 }
 
 resource "google_compute_network" "network" {
-  provider = google-beta
   name                    = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks = false
 }

--- a/mmv1/templates/terraform/examples/compute_router_encrypted_interconnect.tf.erb
+++ b/mmv1/templates/terraform/examples/compute_router_encrypted_interconnect.tf.erb
@@ -1,5 +1,4 @@
 resource "google_compute_router" "<%= ctx[:primary_resource_id] %>" {
-  provider = google-beta
   name                          = "<%= ctx[:vars]['router_name'] %>"
   network                       = google_compute_network.network.name
   encrypted_interconnect_router = true
@@ -9,7 +8,6 @@ resource "google_compute_router" "<%= ctx[:primary_resource_id] %>" {
 }
 
 resource "google_compute_network" "network" {
-  provider = google-beta
   name                    = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks = false
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Updates docs, tests to use GA provider

The actual updates to resources went out in https://github.com/hashicorp/terraform-provider-google/blob/master/CHANGELOG.md#3720-june-14-2021



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
