### PR TITLE
account for sql user names that are different for iam users

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_sql_user.go
+++ b/mmv1/third_party/terraform/resources/resource_sql_user.go
@@ -34,6 +34,7 @@ func resourceSqlUser() *schema.Resource {
 			"host": {
 				Type:        schema.TypeString,
 				Optional:    true,
+				Computed:    true,
 				ForceNew:    true,
 				Description: `The host the user can connect from. This is only supported for MySQL instances. Don't set this field for PostgreSQL instances. Can be an IP address. Changing this forces a new resource to be created.`,
 			},
@@ -173,10 +174,13 @@ func resourceSqlUserRead(d *schema.ResourceData, meta interface{}) error {
 
 	var user *sqladmin.User
 	for _, currentUser := range users.Items {
+
+		name = strings.Split(name, "@")[0]
+
 		if currentUser.Name == name {
 			// Host can only be empty for postgres instances,
 			// so don't compare the host if the API host is empty.
-			if currentUser.Host == "" || currentUser.Host == host {
+			if host == "" || currentUser.Host == host {
 				user = currentUser
 				break
 			}

--- a/mmv1/third_party/terraform/resources/resource_sql_user.go
+++ b/mmv1/third_party/terraform/resources/resource_sql_user.go
@@ -11,6 +11,18 @@ import (
 	sqladmin "google.golang.org/api/sqladmin/v1beta4"
 )
 
+func diffSuppressIamUserName(_, old, new string, d *schema.ResourceData) bool {
+	strippedName := strings.Split(new, "@")[0]
+
+	userType := d.Get("type").(string)
+
+	if old == strippedName && strings.Contains(userType, "IAM") {
+		return true
+	}
+
+	return false
+}
+
 func resourceSqlUser() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceSqlUserCreate,
@@ -47,10 +59,11 @@ func resourceSqlUser() *schema.Resource {
 			},
 
 			"name": {
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
-				Description: `The name of the user. Changing this forces a new resource to be created.`,
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: diffSuppressIamUserName,
+				Description:      `The name of the user. Changing this forces a new resource to be created.`,
 			},
 
 			"password": {


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fxies https://github.com/hashicorp/terraform-provider-google/issues/9553

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
sql: fixed bug that wouldn't insert the `google_sql_user` in state for iam users.
```
