### PR TITLE
Made resource_bigquery_reservation_test be included in GA

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_bigquery_reservation_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_reservation_test.go
@@ -1,12 +1,9 @@
 package google
 
 import (
-	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccBigqueryReservationReservation_bigqueryReservation(t *testing.T) {

--- a/mmv1/third_party/terraform/tests/resource_bigquery_reservation_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_reservation_test.go
@@ -1,4 +1,3 @@
-<% autogen_exception -%>
 package google
 
 import (
@@ -39,7 +38,7 @@ func TestAccBigqueryReservationReservation_bigqueryReservation(t *testing.T) {
 func testAccBigqueryReservationReservation_bigqueryReservationBasic(context map[string]interface{}) string {
 	return Nprintf(`
 resource "google_bigquery_reservation" "reservation" {
-	name           = "reservation%{random_suffix}"
+	name           = "tf-test-reservation%{random_suffix}"
 	location       = "%{location}"
 	// Set to 0 for testing purposes
 	// In reality this would be larger than zero

--- a/mmv1/third_party/terraform/tests/resource_bigquery_reservation_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_bigquery_reservation_test.go.erb
@@ -1,6 +1,5 @@
 <% autogen_exception -%>
 package google
-<% unless version == 'ga' -%>
 
 import (
 	"fmt"
@@ -49,6 +48,3 @@ resource "google_bigquery_reservation" "reservation" {
 }
 `, context)
 }
-<% else %>
-// Magic Modules doesn't let us remove files - blank out beta-only common-compile files for now.
-<% end -%>


### PR DESCRIPTION
This resource was moved to GA in https://github.com/GoogleCloudPlatform/magic-modules/pull/4342

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
