### PR TITLE
Confusing environment variable with secrets in `google_cloud_run_service` documentation.

### DIFF
--- a/mmv1/products/cloudrun/api.yaml
+++ b/mmv1/products/cloudrun/api.yaml
@@ -544,8 +544,10 @@ objects:
                             is assumed to be in the same project.
                             If the secret is in another project, you must define an alias.
                             You set the <alias> in this field, and create an annotation with the
-                            following structure "run.googleapis.com/secrets" = "<alias>:projects/<project-id|project-number>/secrets/<secret-name>".
-                            If multiple alias definitions are needed, they must be separated by commas in the annotation field.
+                            following structure 
+                            "run.googleapis.com/secrets" = "<alias>:projects/<project-id|project-number>/secrets/<secret-name>".
+                            If multiple alias definitions are needed, they must be separated by 
+                            commas in the annotation field.
             - !ruby/object:Api::Type::Array
               name: ports
               description: |-

--- a/mmv1/products/cloudrun/api.yaml
+++ b/mmv1/products/cloudrun/api.yaml
@@ -543,12 +543,9 @@ objects:
                             The name of the secret in Cloud Secret Manager. By default, the secret
                             is assumed to be in the same project.
                             If the secret is in another project, you must define an alias.
-                            An alias definition has the form:
-                            <alias>:projects/<project-id|project-number>/secrets/<secret-name>.
-                            If multiple alias definitions are needed, they must be separated by
-                            commas.
-                            The alias definitions must be set on the run.googleapis.com/secrets
-                            annotation.
+                            You set the <alias> in this field, and create an annotation with the
+                            following structure "run.googleapis.com/secrets" = "<alias>:projects/<project-id|project-number>/secrets/<secret-name>".
+                            If multiple alias definitions are needed, they must be separated by commas in the annotation field.
             - !ruby/object:Api::Type::Array
               name: ports
               description: |-


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/9575

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
