### PR TITLE
Add support for `processing_units` to `google_spanner_instance`

### DIFF
--- a/mmv1/products/spanner/api.yaml
+++ b/mmv1/products/spanner/api.yaml
@@ -105,7 +105,7 @@ objects:
         description: |
           The number of nodes allocated to this instance. At most one of either node_count or processing_units can be present in terraforn. 
         exactly_one_of:
-          - num_names
+          - num_nodes
           - processing_units
       - !ruby/object:Api::Type::Integer
         name: 'processingUnits'
@@ -113,7 +113,7 @@ objects:
           The number of processing units allocated to this instance. At most one of processing_units 
           or node_count can be present in terraform. 
         exactly_one_of:
-          - num_modes
+          - num_nodes
           - processing_units
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'

--- a/mmv1/products/spanner/api.yaml
+++ b/mmv1/products/spanner/api.yaml
@@ -104,17 +104,11 @@ objects:
         name: 'nodeCount'
         description: |
           The number of nodes allocated to this instance. At most one of either node_count or processing_units can be present in terraforn. 
-        exactly_one_of:
-          - num_nodes
-          - processing_units
       - !ruby/object:Api::Type::Integer
         name: 'processingUnits'
         description: |
           The number of processing units allocated to this instance. At most one of processing_units 
           or node_count can be present in terraform. 
-        exactly_one_of:
-          - num_nodes
-          - processing_units
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: |

--- a/mmv1/products/spanner/api.yaml
+++ b/mmv1/products/spanner/api.yaml
@@ -103,7 +103,8 @@ objects:
       - !ruby/object:Api::Type::Integer
         name: 'nodeCount'
         description: |
-          The number of nodes allocated to this instance. At most one of either node_count or processing_units can be present in terraforn. 
+          The number of nodes allocated to this instance. At most one of either node_count or processing_units
+          can be present in terraform. 
       - !ruby/object:Api::Type::Integer
         name: 'processingUnits'
         description: |
@@ -202,4 +203,3 @@ objects:
             description: |
               Fully qualified name of the KMS key to use to encrypt this database. This key must exist
               in the same location as the Spanner Database.
-

--- a/mmv1/products/spanner/api.yaml
+++ b/mmv1/products/spanner/api.yaml
@@ -102,8 +102,19 @@ objects:
         required: true
       - !ruby/object:Api::Type::Integer
         name: 'nodeCount'
-        description: 'The number of nodes allocated to this instance.'
-        default_value: 1
+        description: |
+          The number of nodes allocated to this instance. At most one of either node_count or processing_units can be present in terraforn. 
+        exactly_one_of:
+          - num_names
+          - processing_units
+      - !ruby/object:Api::Type::Integer
+        name: 'processingUnits'
+        description: |
+          The number of processing units allocated to this instance. At most one of processing_units 
+          or node_count can be present in terraform. 
+        exactly_one_of:
+          - num_modes
+          - processing_units
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: |

--- a/mmv1/products/spanner/terraform.yaml
+++ b/mmv1/products/spanner/terraform.yaml
@@ -113,6 +113,9 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_flatten: 'templates/terraform/custom_flatten/name_from_self_link.erb'
       nodeCount: !ruby/object:Overrides::Terraform::PropertyOverride
         name: num_nodes
+        default_from_api: true
+      processingUnits: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       config: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_expand: templates/terraform/custom_expand/spanner_instance_config.go.erb
       state: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/products/spanner/terraform.yaml
+++ b/mmv1/products/spanner/terraform.yaml
@@ -82,6 +82,11 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         # Randomness
         skip_vcr: true
       - !ruby/object:Provider::Terraform::Examples
+        name: "spanner_instance_processing_units"
+        primary_resource_id: "example"
+        # Randomness
+        skip_vcr: true
+      - !ruby/object:Provider::Terraform::Examples
         name: "spanner_instance_multi_regional"
         primary_resource_id: "example"
         # Randomness

--- a/mmv1/templates/terraform/encoders/spanner_instance.go.erb
+++ b/mmv1/templates/terraform/encoders/spanner_instance.go.erb
@@ -1,3 +1,7 @@
+// Temp Logic to accomodate processing_units and num_nodes
+if obj["processingUnits"] == nil && obj["nodeCount"] == nil {
+	obj["nodeCount"] = 1
+}
 newObj := make(map[string]interface{})
 newObj["instance"] = obj
 if obj["name"] == nil {

--- a/mmv1/templates/terraform/examples/spanner_instance_processing_units.tf.erb
+++ b/mmv1/templates/terraform/examples/spanner_instance_processing_units.tf.erb
@@ -1,0 +1,8 @@
+resource "google_spanner_instance" "example" {
+  config       = "regional-us-central1"
+  display_name = "Test Spanner Instance"
+  processing_units    = 200
+  labels = {
+    "foo" = "bar"
+  }
+}

--- a/mmv1/third_party/terraform/tests/resource_spanner_instance_test.go
+++ b/mmv1/third_party/terraform/tests/resource_spanner_instance_test.go
@@ -71,6 +71,30 @@ func TestAccSpannerInstance_basic(t *testing.T) {
 	})
 }
 
+func TestAccSpannerInstance_noNodeCountSpecified(t *testing.T) {
+	t.Parallel()
+
+	idName := fmt.Sprintf("spanner-test-%s", randString(t, 10))
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckSpannerInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccSpannerInstance_noNodeCountSpecified(idName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("google_spanner_instance.basic", "state"),
+				),
+			},
+			{
+				ResourceName:      "google_spanner_instance.basic",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccSpannerInstance_basicWithAutogenName(t *testing.T) {
 	// Randomness
 	skipIfVcr(t)
@@ -136,6 +160,16 @@ resource "google_spanner_instance" "basic" {
   config       = "regional-us-central1"
   display_name = "%s-dname"
   num_nodes    = 1
+}
+`, name, name)
+}
+
+func testAccSpannerInstance_noNodeCountSpecified(name string) string {
+	return fmt.Sprintf(`
+resource "google_spanner_instance" "basic" {
+  name         = "%s"
+  config       = "regional-us-central1"
+  display_name = "%s-dname"
 }
 `, name, name)
 }


### PR DESCRIPTION
Fixes:  https://github.com/hashicorp/terraform-provider-google/issues/9599

This will be a breaking change as the new field is mutually exclusive with `num_nodes`.

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:note
spanner: `num_nodes` will become a required field in the next major release and a value has to be set on `google_spanner_instance`. It will also conflict with the new field `processing_units`.
```
```release-note:enhancement
spanner: added `processing_units` to `google_spanner_instance`.     
```
