### PR TITLE
Backfill support for `user_project_override` and `billing_project` for `google_service_networking_connection`

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_service_networking_connection.go
+++ b/mmv1/third_party/terraform/resources/resource_service_networking_connection.go
@@ -83,6 +83,12 @@ func resourceServiceNetworkingConnectionCreate(d *schema.ResourceData, meta inte
 		ReservedPeeringRanges: convertStringArr(d.Get("reserved_peering_ranges").([]interface{})),
 	}
 
+	networkFieldValue, err := ParseNetworkFieldValue(network, d, config)
+	if err != nil {
+		return errwrap.Wrapf("Failed to retrieve network field value, err: {{err}}", err)
+	}
+	project := networkFieldValue.Project
+
 	parentService := formatParentService(d.Get("service").(string))
 	// We use Patch instead of Create, because we're getting
 	//  "Error waiting for Create Service Networking Connection:
@@ -98,12 +104,16 @@ func resourceServiceNetworkingConnectionCreate(d *schema.ResourceData, meta inte
 	// The API docs don't specify that you can do connections/-,
 	// but that's what gcloud does, and it's easier than grabbing
 	// the connection name.
-	op, err := config.NewServiceNetworkingClient(userAgent).Services.Connections.Patch(parentService+"/connections/-", connection).UpdateMask("reservedPeeringRanges").Force(true).Do()
+	createCall := config.NewServiceNetworkingClient(userAgent).Services.Connections.Patch(parentService+"/connections/-", connection).UpdateMask("reservedPeeringRanges").Force(true)
+	if config.UserProjectOverride {
+		createCall.Header().Add("X-Goog-User-Project", project)
+	}
+	op, err := createCall.Do()
 	if err != nil {
 		return err
 	}
 
-	if err := serviceNetworkingOperationWaitTime(config, op, "Create Service Networking Connection", userAgent, d.Timeout(schema.TimeoutCreate)); err != nil {
+	if err := serviceNetworkingOperationWaitTime(config, op, "Create Service Networking Connection", userAgent, project, d.Timeout(schema.TimeoutCreate)); err != nil {
 		return err
 	}
 
@@ -133,9 +143,19 @@ func resourceServiceNetworkingConnectionRead(d *schema.ResourceData, meta interf
 		return errwrap.Wrapf("Failed to find Service Networking Connection, err: {{err}}", err)
 	}
 
+	network := d.Get("network").(string)
+	networkFieldValue, err := ParseNetworkFieldValue(network, d, config)
+	if err != nil {
+		return errwrap.Wrapf("Failed to retrieve network field value, err: {{err}}", err)
+	}
+	project := networkFieldValue.Project
+
 	parentService := formatParentService(connectionId.Service)
-	response, err := config.NewServiceNetworkingClient(userAgent).Services.Connections.List(parentService).
-		Network(serviceNetworkingNetworkName).Do()
+	readCall := config.NewServiceNetworkingClient(userAgent).Services.Connections.List(parentService).Network(serviceNetworkingNetworkName)
+	if config.UserProjectOverride {
+		readCall.Header().Add("X-Goog-User-Project", project)
+	}
+	response, err := readCall.Do()
 	if err != nil {
 		return err
 	}
@@ -195,13 +215,23 @@ func resourceServiceNetworkingConnectionUpdate(d *schema.ResourceData, meta inte
 			ReservedPeeringRanges: convertStringArr(d.Get("reserved_peering_ranges").([]interface{})),
 		}
 
+		networkFieldValue, err := ParseNetworkFieldValue(network, d, config)
+		if err != nil {
+			return errwrap.Wrapf("Failed to retrieve network field value, err: {{err}}", err)
+		}
+		project := networkFieldValue.Project
+
 		// The API docs don't specify that you can do connections/-, but that's what gcloud does,
 		// and it's easier than grabbing the connection name.
-		op, err := config.NewServiceNetworkingClient(userAgent).Services.Connections.Patch(parentService+"/connections/-", connection).UpdateMask("reservedPeeringRanges").Force(true).Do()
+		patchCall := config.NewServiceNetworkingClient(userAgent).Services.Connections.Patch(parentService+"/connections/-", connection).UpdateMask("reservedPeeringRanges").Force(true)
+		if config.UserProjectOverride {
+			patchCall.Header().Add("X-Goog-User-Project", project)
+		}
+		op, err := patchCall.Do()
 		if err != nil {
 			return err
 		}
-		if err := serviceNetworkingOperationWaitTime(config, op, "Update Service Networking Connection", userAgent, d.Timeout(schema.TimeoutUpdate)); err != nil {
+		if err := serviceNetworkingOperationWaitTime(config, op, "Update Service Networking Connection", userAgent, project, d.Timeout(schema.TimeoutUpdate)); err != nil {
 			return err
 		}
 	}
@@ -322,7 +352,11 @@ func retrieveServiceNetworkingNetworkName(d *schema.ResourceData, config *Config
 		return "", fmt.Errorf("Could not determine project")
 	}
 	log.Printf("[DEBUG] Retrieving project number by doing a GET with the project id, as required by service networking")
-	project, err := config.NewResourceManagerClient(userAgent).Projects.Get(pid).Do()
+	getProjectCall := config.NewResourceManagerClient(userAgent).Projects.Get(pid)
+	if config.UserProjectOverride {
+		getProjectCall.Header().Add("X-Goog-User-Project", pid)
+	}
+	project, err := getProjectCall.Do()
 	if err != nil {
 		// note: returning a wrapped error is part of this method's contract!
 		// https://blog.golang.org/go1.13-errors

--- a/mmv1/third_party/terraform/tests/resource_service_networking_connection_test.go
+++ b/mmv1/third_party/terraform/tests/resource_service_networking_connection_test.go
@@ -71,9 +71,11 @@ func testServiceNetworkingConnectionDestroy(t *testing.T, parent, network string
 		config := googleProviderConfig(t)
 		parentService := "services/" + parent
 		networkName := fmt.Sprintf("projects/%s/global/networks/%s", getTestProjectFromEnv(), network)
-
-		response, err := config.NewServiceNetworkingClient(config.userAgent).Services.Connections.List(parentService).
-			Network(networkName).Do()
+		listCall := config.NewServiceNetworkingClient(config.userAgent).Services.Connections.List(parentService).Network(networkName)
+		if config.UserProjectOverride {
+			listCall.Header().Add("X-Goog-User-Project", getTestProjectFromEnv())
+		}
+		response, err := listCall.Do()
 		if err != nil {
 			return err
 		}

--- a/mmv1/third_party/terraform/utils/service_networking_operation.go
+++ b/mmv1/third_party/terraform/utils/service_networking_operation.go
@@ -7,17 +7,25 @@ import (
 )
 
 type ServiceNetworkingOperationWaiter struct {
-	Service *servicenetworking.APIService
+	Service             *servicenetworking.APIService
+	Project             string
+	UserProjectOverride bool
 	CommonOperationWaiter
 }
 
 func (w *ServiceNetworkingOperationWaiter) QueryOp() (interface{}, error) {
-	return w.Service.Operations.Get(w.Op.Name).Do()
+	opGetCall := w.Service.Operations.Get(w.Op.Name)
+	if w.UserProjectOverride {
+		opGetCall.Header().Add("X-Goog-User-Project", w.Project)
+	}
+	return opGetCall.Do()
 }
 
-func serviceNetworkingOperationWaitTime(config *Config, op *servicenetworking.Operation, activity, userAgent string, timeout time.Duration) error {
+func serviceNetworkingOperationWaitTime(config *Config, op *servicenetworking.Operation, activity, userAgent, project string, timeout time.Duration) error {
 	w := &ServiceNetworkingOperationWaiter{
-		Service: config.NewServiceNetworkingClient(userAgent),
+		Service:             config.NewServiceNetworkingClient(userAgent),
+		Project:             project,
+		UserProjectOverride: config.UserProjectOverride,
 	}
 
 	if err := w.SetOp(op); err != nil {

--- a/mmv1/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/service_networking_connection.html.markdown
@@ -56,3 +56,8 @@ ServiceNetworkingConnection can be imported using any of these accepted formats
 * terraform import google_service_networking_connection.peering_connection {{peering-network}}:{{service}}
 
 * terraform import google_service_networking_connection.peering_connection /projects/{{project}}/global/networks/{{peering-network}}:{{service}}
+
+
+## User Project Overrides
+
+This resource supports [User Project Overrides](https://www.terraform.io/docs/providers/google/guides/provider_reference.html#user_project_override).


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/9466

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
servicenetworking: added support for `user_project_override` and `billing_project ` to `google_service_networking_connection`
```
