### PR TITLE
Fix internal section header reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,9 +182,10 @@ wrapping those lines of code in version guards;
 ### Testing your changes
 
 Once you've made changes to resource definition, you can run Magic Modules
-to generate changes to your tool; see "Generating downstream tools" above if
-you need a refresher. Once it's generated, you should run the tool-specific
-tests as if you were submitting a PR against that tool.
+to generate changes to your tool; see
+["Generating the Terraform Providers"](#generating-the-terraform-providers)
+above if you need a refresher. Once it's generated, you should run the
+tool-specific tests as if you were submitting a PR against that tool.
 
 You can run tests in the `{{output_folder}}` you generated the tool in.
 See the following tool-specific documentation for more details on testing that


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

The README file had an outdated reference to "Generating downstream tools" which was renamed to "Generating the Terraform Providers". Fixed the ref and also made it a link.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have: (not applicable)


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
