### PR TITLE
Add securitySettings to the backendService

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -1683,12 +1683,14 @@ objects:
           # TODO: make a ResourceRef to ClientTlsPolicy
           - !ruby/object:Api::Type::String
             name: 'clientTlsPolicy'
+            min_version: beta
             description: |
               ClientTlsPolicy is a resource that specifies how a client should authenticate
               connections to backends of a service. This resource itself does not affect
               configuration unless it is attached to a backend service resource.
           - !ruby/object:Api::Type::Array
             name: 'subjectAltNames'
+            min_version: beta
             description: |
               A list of alternate names to verify the subject identity in the certificate.
               If specified, the client will verify that the server certificate's subject

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -1680,9 +1680,11 @@ objects:
           load_balancing_scheme set to INTERNAL_MANAGED; or a global backend service with the
           load_balancing_scheme set to INTERNAL_SELF_MANAGED.
         properties:
-          # TODO: make a ResourceRef to ClientTlsPolicy
-          - !ruby/object:Api::Type::String
+          # TODO: 'Region' resource type is incorrect and should be ClientTLSPolicy
+          - !ruby/object:Api::Type::ResourceRef
             name: 'clientTlsPolicy'
+            resource: 'Region'
+            imports: 'name'
             min_version: beta
             description: |
               ClientTlsPolicy is a resource that specifies how a client should authenticate

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -1674,22 +1674,23 @@ objects:
           The security policy associated with this backend service.
       - !ruby/object:Api::Type::NestedObject
         name: 'securitySettings'
+        min_version: beta
         description: |
           The security settings that apply to this backend service. This field is applicable to either
           a regional backend service with the service_protocol set to HTTP, HTTPS, or HTTP2, and
           load_balancing_scheme set to INTERNAL_MANAGED; or a global backend service with the
           load_balancing_scheme set to INTERNAL_SELF_MANAGED.
         properties:
-          # TODO: 'Region' resource type is incorrect and should be ClientTLSPolicy
           - !ruby/object:Api::Type::ResourceRef
             name: 'clientTlsPolicy'
-            resource: 'Region'
+            resource: 'Region' # TODO: 'Region' is incorrect and should be 'ClientTlsPolicy'
             imports: 'name'
             min_version: beta
             description: |
               ClientTlsPolicy is a resource that specifies how a client should authenticate
               connections to backends of a service. This resource itself does not affect
               configuration unless it is attached to a backend service resource.
+            required: true
           - !ruby/object:Api::Type::Array
             name: 'subjectAltNames'
             min_version: beta
@@ -1697,6 +1698,7 @@ objects:
               A list of alternate names to verify the subject identity in the certificate.
               If specified, the client will verify that the server certificate's subject
               alt name matches one of the specified values.
+            required: true
             item_type: Api::Type::String
       - !ruby/object:Api::Type::Enum
         name: 'sessionAffinity'

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -1672,6 +1672,28 @@ objects:
         name: 'securityPolicy'
         description: |
           The security policy associated with this backend service.
+      - !ruby/object:Api::Type::NestedObject
+        name: 'securitySettings'
+        description: |
+          The security settings that apply to this backend service. This field is applicable to either
+          a regional backend service with the service_protocol set to HTTP, HTTPS, or HTTP2, and
+          load_balancing_scheme set to INTERNAL_MANAGED; or a global backend service with the
+          load_balancing_scheme set to INTERNAL_SELF_MANAGED.
+        properties:
+          # TODO: make a ResourceRef to ClientTlsPolicy
+          - !ruby/object:Api::Type::String
+            name: 'clientTlsPolicy'
+            description: |
+              ClientTlsPolicy is a resource that specifies how a client should authenticate
+              connections to backends of a service. This resource itself does not affect
+              configuration unless it is attached to a backend service resource.
+          - !ruby/object:Api::Type::Array
+            name: 'subjectAltNames'
+            description: |
+              A list of alternate names to verify the subject identity in the certificate.
+              If specified, the client will verify that the server certificate's subject
+              alt name matches one of the specified values.
+            item_type: Api::Type::String
       - !ruby/object:Api::Type::Enum
         name: 'sessionAffinity'
         description: |


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/9545

Need the new securitySettings field in backendService in Compute.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have: (not applicable for draft PR)


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added support for `security_settings` to `google_compute_backend_service`
```
