### PR TITLE
add public_ptr_domain_name to google_compute_instance_template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ your code to be reviewed.
 If this PR is for Terraform, I acknowledge that I have:
 
 - [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
-- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
+- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-the-terraform-providers), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
 - [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
 - [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
 - [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -375,11 +375,12 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 										Description:  `The networking tier used for configuring this instance template. This field can take the following values: PREMIUM or STANDARD. If this field is not specified, it is assumed to be PREMIUM.`,
 										ValidateFunc: validation.StringInSlice([]string{"PREMIUM", "STANDARD"}, false),
 									},
-									// Possibly configurable- this was added so we don't break if it's inadvertently set
 									"public_ptr_domain_name": {
 										Type:        schema.TypeString,
+										Optional:    true,
 										Computed:    true,
-										Description: `The DNS domain name for the public PTR record.The DNS domain name for the public PTR record.`,
+										ForceNew:    true,
+										Description: `The DNS domain name for the public PTR record.`,
 									},
 								},
 							},

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
@@ -401,6 +401,34 @@ func TestAccComputeInstanceTemplate_networkIPAddress(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstanceTemplate_PTRRecord(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+	var ptrName = fmt.Sprintf("tf-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceTemplate_PTR(ptrName, randString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(
+						t, "google_compute_instance_template.foobar", &instanceTemplate),
+					testAccCheckComputeInstanceTemplateAccessConfigHasPTR(&instanceTemplate),
+				),
+			},
+			{
+				ResourceName:      "google_compute_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeInstanceTemplate_disks(t *testing.T) {
 	t.Parallel()
 
@@ -1162,6 +1190,20 @@ func testAccCheckComputeInstanceTemplateNetwork(instanceTemplate *compute.Instan
 	}
 }
 
+func testAccCheckComputeInstanceTemplateAccessConfigHasPTR(instanceTemplate *compute.InstanceTemplate) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, i := range instanceTemplate.Properties.NetworkInterfaces {
+			for _, c := range i.AccessConfigs {
+				if c.PublicPtrDomainName == "" {
+					return fmt.Errorf("no PTR Record")
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckComputeInstanceTemplateNetworkName(instanceTemplate *compute.InstanceTemplate, network string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		for _, i := range instanceTemplate.Properties.NetworkInterfaces {
@@ -1584,6 +1626,36 @@ resource "google_compute_instance_template" "foobar" {
   }
 }
 `, suffix, suffix)
+}
+
+func testAccComputeInstanceTemplate_PTR(record, suffix string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-medium"
+  tags         = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+  }
+
+  network_interface {
+    network = "default"
+    access_config {
+      public_ptr_domain_name = "%s.gcp.tfacc.hashicorptest.com."
+    }
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+}
+`, suffix, record)
 }
 
 func testAccComputeInstanceTemplate_networkTier(suffix string) string {

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -386,6 +386,11 @@ The `access_config` block supports:
     this instance template. This field can take the following values: PREMIUM or
     STANDARD. If this field is not specified, it is assumed to be PREMIUM.
 
+* `public_ptr_domain_name` - (Optional) The DNS domain name for the public PTR record.
+    To set this field on an instance template, you must be verified as the owner of the domain.
+    See [the docs](https://cloud.google.com/compute/docs/instances/create-ptr-record) for how
+    to become verified as a domain owner.
+
 The `alias_ip_range` block supports:
 
 * `ip_cidr_range` - The IP CIDR range represented by this alias IP range. This IP CIDR range


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
## description

Fixes https://github.com/hashicorp/terraform-provider-google/issues/9664

`public_ptr_domain_name` was added to `compute_instance_template`'s `access_config` schema in this PR:

https://github.com/GoogleCloudPlatform/magic-modules/pull/3197/files

However, it was marked as a computed attribute only, meaning it could not be set by terraform, so its use was to prevent terraform from breaking if the attribute was in an instance template response from GCE's API. This PR updates it so that this attribute is configurable.

## terraform provider checklist
<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


#### note

I have not run the acceptance tests because I do not own the domain used in the test (`hashicorptest.com`)
<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added field `public_ptr_domain_name` to `google_compute_instance_template` resource
```
