### PR TITLE
Renamed terraform validator provider to terraform_validator

### DIFF
--- a/mmv1/compiler.rb
+++ b/mmv1/compiler.rb
@@ -35,7 +35,7 @@ require 'provider/inspec'
 require 'provider/terraform'
 require 'provider/terraform_oics'
 require 'provider/terraform_cloud_docs'
-require 'provider/terraform_object_library'
+require 'provider/terraform_validator'
 require 'pp' if ENV['COMPILER_DEBUG']
 
 products_to_generate = nil
@@ -203,7 +203,7 @@ all_product_files.each do |product_name|
     override_providers = {
       'oics' => Provider::TerraformOiCS,
       'cloud_docs' => Provider::TerraformCloudDocs,
-      'validator' => Provider::TerraformObjectLibrary,
+      'validator' => Provider::TerraformValidator,
       'ansible_devel' => Provider::Ansible::Devel
     }
 

--- a/mmv1/provider/terraform_validator.rb
+++ b/mmv1/provider/terraform_validator.rb
@@ -15,7 +15,7 @@ require 'provider/terraform_oics'
 
 module Provider
   # Code generator for a library converting terraform state to gcp objects.
-  class TerraformObjectLibrary < Provider::Terraform
+  class TerraformValidator < Provider::Terraform
     def generate(output_folder, types, _product_path, _dump_yaml, generate_code, generate_docs)
       @base_url = @version.base_url
       generate_objects(

--- a/mmv1/templates/terraform/constants/interconnect_attachment.go.erb
+++ b/mmv1/templates/terraform/constants/interconnect_attachment.go.erb
@@ -1,4 +1,4 @@
-<% unless compiler == "terraformobjectlibrary-codegen" -%>
+<% unless compiler == "terraformvalidator-codegen" -%>
 // waitForAttachmentToBeProvisioned waits for an attachment to leave the
 // "UNPROVISIONED" state, to indicate that it's either ready or awaiting partner
 // activity.

--- a/mmv1/templates/terraform/constants/secret_version.go.erb
+++ b/mmv1/templates/terraform/constants/secret_version.go.erb
@@ -1,4 +1,4 @@
-<% unless compiler == "terraformobjectlibrary-codegen" -%>
+<% unless compiler == "terraformvalidator-codegen" -%>
 func resourceSecretManagerSecretVersionUpdate(d *schema.ResourceData, meta interface{}) error {
     config := meta.(*Config)
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Related to https://github.com/GoogleCloudPlatform/terraform-validator/issues/237


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
