### PR TITLE
Ignore diff after apply errors

### DIFF
--- a/tpgtools/templates/resource.go.tmpl
+++ b/tpgtools/templates/resource.go.tmpl
@@ -256,9 +256,13 @@ func resource{{$.PathType}}Create(d *schema.ResourceData, meta interface{}) erro
 	client := NewDCL{{$.ProductType}}Client(config, userAgent, billingProject)
 	res, err := client.Apply{{$.Type}}(context.Background(), obj, createDirective...)
 	if err != nil {
-		// The resource didn't actually create
-		d.SetId("")
-		return fmt.Errorf("Error creating {{$.Type}}: %s", err)
+		if _, ok := err.(dcl.DiffAfterApplyError); ok {
+			log.Printf("[DEBUG] Diff after apply returned from the DCL: %s", err)
+		} else {
+			// The resource didn't actually create
+			d.SetId("")
+			return fmt.Errorf("Error creating {{$.Type}}: %s", err)
+		}
 	}
 
 	log.Printf("[DEBUG] Finished creating {{$.Type}} %q: %#v", d.Id(), res)
@@ -401,7 +405,13 @@ func resource{{$.PathType}}Update(d *schema.ResourceData, meta interface{}) erro
 	client := NewDCL{{$.ProductType}}Client(config, userAgent, billingProject)
 	res, err := client.Apply{{$.Type}}(context.Background(), obj, directive...)
 	if err != nil {
-		return fmt.Errorf("Error updating {{$.Type}}: %s", err)
+		if _, ok := err.(dcl.DiffAfterApplyError); ok {
+			log.Printf("[DEBUG] Diff after apply returned from the DCL: %s", err)
+		} else {
+			// The resource didn't actually create
+			d.SetId("")
+			return fmt.Errorf("Error updating {{$.Type}}: %s", err)
+		}
 	}
 
 	log.Printf("[DEBUG] Finished creating {{$.Type}} %q: %#v", d.Id(), res)


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Diff after apply errors mean an apply was not fully successful, but the resource does exist. We should ignore these errors and let them show up as perma-diffs which are more recognizable by users as well as fixable within a user config (via ignore_diffs, etc)

Diff after apply errors are difficult to understand, and not actionable for users of Terraform

Fixes: https://github.com/hashicorp/terraform-provider-google/issues/9501


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
all (DCL resources only): ignore diff after apply errors coming from the DCL
```
