### PR TITLE
Skip terraform tests if no go files were changed in the downstream

### DIFF
--- a/.ci/containers/terraform-tester/test_terraform.sh
+++ b/.ci/containers/terraform-tester/test_terraform.sh
@@ -18,10 +18,43 @@ else
     exit 1
 fi
 
-scratch_path=https://$github_username:$GITHUB_TOKEN@github.com/$github_username/$gh_repo
-local_path=$GOPATH/src/github.com/terraform-providers/$gh_repo
+
+new_branch="auto-pr-$pr_number"
+old_branch="auto-pr-$pr_number-old"
+
+# https://docs.github.com/en/rest/reference/repos#compare-two-commits
+echo "Fetching diff from Github"
+http_response=$(curl \
+  -X GET \
+  -u "$github_username:$GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  -o response.txt \
+  -w "%{http_code}" \
+  "https://api.github.com/repos/$github_username/$gh_repo/compare/$old_branch...$new_branch")
+
+# Only skip tests if we can tell for sure that no go files were changed
+if [ $http_response != "200" ]; then
+    echo "Running tests: Could not determine whether diff contains go files due to non-200 response"
+    echo "Github response content:"
+    cat response.txt
+else
+    echo "Successfully requested diff from Github; checking for go files"
+    # Read the response, parse out the filenames, and look for go files
+    # (ignoring "no matches found" errors from grep)
+    gofiles=$(cat response.txt | jq -r ".files[].filename" | { grep "\.go$" || test $? = 1; })
+    if [[ -z $gofiles ]]; then
+        echo "Skipping tests: No go files changed"
+        exit 0
+    else
+        echo "Running tests: Go files changed"
+    fi
+fi
+
+
+git_remote=https://$github_username:$GITHUB_TOKEN@github.com/$github_username/$gh_repo
+local_path=$GOPATH/src/github.com/hashicorp/$gh_repo
 mkdir -p "$(dirname $local_path)"
-git clone $scratch_path $local_path --single-branch --branch "auto-pr-$pr_number" --depth 1
+git clone $git_remote $local_path --single-branch --branch $new_branch --depth 1
 pushd $local_path
 
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Uses https://docs.github.com/en/rest/reference/repos#compare-two-commits to check whether there were any go files changed, then skips everything else if so. This only impacts the terraform tester, as a first step.

Related to https://github.com/hashicorp/terraform-provider-google/issues/9147

This can be tested locally by altering the git_remote and local_path variables and running the script directly against a given version & PR number - i.e.:

```
# new git_remote and local_path
git_remote=https://github.com/$github_username/$gh_repo
local_path=./tmp

# Run script for https://github.com/GoogleCloudPlatform/magic-modules/pull/5022 (changes go files)
./magic-modules/.ci/containers/terraform-tester/test_terraform.sh ga 5022
# Run script for https://github.com/GoogleCloudPlatform/magic-modules/pull/5021 (doesn't change go files)
./magic-modules/.ci/containers/terraform-tester/test_terraform.sh ga 5021
```

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
