### PR TITLE
Promote `google_compute_service_attachment` to GA

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -14091,7 +14091,6 @@ objects:
     base_url: projects/{{project}}/regions/{{region}}/serviceAttachments
     has_self_link: true
     input: true
-    min_version: beta
     description: |
       Represents a ServiceAttachment resource.
     references: !ruby/object:Api::Resource::ReferenceLinks
@@ -14434,7 +14433,6 @@ objects:
         required: true
       - !ruby/object:Api::Type::String
         name: 'purpose'
-        min_version: beta
         input: true
         description: |
           The purpose of the resource. This field can be either PRIVATE
@@ -14446,7 +14444,6 @@ objects:
           If set to INTERNAL_HTTPS_LOAD_BALANCER you must also set `role`.
       - !ruby/object:Api::Type::Enum
         name: 'role'
-        min_version: beta
         update_verb: :PATCH
         update_url: projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
         update_id: 'role'

--- a/mmv1/templates/terraform/examples/service_attachment_basic.tf.erb
+++ b/mmv1/templates/terraform/examples/service_attachment_basic.tf.erb
@@ -1,6 +1,4 @@
 resource "google_compute_service_attachment" "<%= ctx[:primary_resource_id] %>" {
-  provider = "google-beta"
-
   name        = "<%= ctx[:vars]['service_attachment_name'] %>"
   region      = "us-west2"
   description = "A service attachment configured with Terraform"
@@ -12,8 +10,6 @@ resource "google_compute_service_attachment" "<%= ctx[:primary_resource_id] %>" 
 }
 
 resource "google_compute_address" "psc_ilb_consumer_address" {
-  provider = "google-beta"
-
   name   = "<%= ctx[:vars]['consumer_address_name'] %>"
   region = "us-west2"
 
@@ -23,8 +19,6 @@ resource "google_compute_address" "psc_ilb_consumer_address" {
 }
 
 resource "google_compute_forwarding_rule" "psc_ilb_consumer" {
-  provider = "google-beta"
-
   name   = "<%= ctx[:vars]['consumer_forwarding_rule_name'] %>"
   region = "us-west2"
 
@@ -35,8 +29,6 @@ resource "google_compute_forwarding_rule" "psc_ilb_consumer" {
 }
 
 resource "google_compute_forwarding_rule" "psc_ilb_target_service" {
-  provider = "google-beta"
-
   name   = "<%= ctx[:vars]['producer_forwarding_rule_name'] %>"
   region = "us-west2"
 
@@ -48,8 +40,6 @@ resource "google_compute_forwarding_rule" "psc_ilb_target_service" {
 }
 
 resource "google_compute_region_backend_service" "producer_service_backend" {
-  provider = "google-beta"
-
   name   = "<%= ctx[:vars]['producer_service_name'] %>"
   region = "us-west2"
 
@@ -57,8 +47,6 @@ resource "google_compute_region_backend_service" "producer_service_backend" {
 }
 
 resource "google_compute_health_check" "producer_service_health_check" {
-  provider = "google-beta"
-
   name = "<%= ctx[:vars]['producer_health_check_name'] %>"
 
   check_interval_sec = 1
@@ -69,15 +57,11 @@ resource "google_compute_health_check" "producer_service_health_check" {
 }
 
 resource "google_compute_network" "psc_ilb_network" {
-  provider = "google-beta"
-
   name = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "psc_ilb_producer_subnetwork" {
-  provider = "google-beta"
-
   name   = "<%= ctx[:vars]['producer_subnetwork_name'] %>"
   region = "us-west2"
 
@@ -86,8 +70,6 @@ resource "google_compute_subnetwork" "psc_ilb_producer_subnetwork" {
 }
 
 resource "google_compute_subnetwork" "psc_ilb_nat" {
-  provider = "google-beta"
-
   name   = "<%= ctx[:vars]['nat_subnetwork_name'] %>"
   region = "us-west2"
 

--- a/mmv1/templates/terraform/examples/service_attachment_explicit_projects.tf.erb
+++ b/mmv1/templates/terraform/examples/service_attachment_explicit_projects.tf.erb
@@ -1,6 +1,4 @@
 resource "google_compute_service_attachment" "<%= ctx[:primary_resource_id] %>" {
-  provider = "google-beta"
-
   name        = "<%= ctx[:vars]['service_attachment_name'] %>"
   region      = "us-west2"
   description = "A service attachment configured with Terraform"
@@ -19,8 +17,6 @@ resource "google_compute_service_attachment" "<%= ctx[:primary_resource_id] %>" 
 }
 
 resource "google_compute_address" "psc_ilb_consumer_address" {
-  provider = "google-beta"
-
   name   = "<%= ctx[:vars]['consumer_address_name'] %>"
   region = "us-west2"
 
@@ -30,8 +26,6 @@ resource "google_compute_address" "psc_ilb_consumer_address" {
 }
 
 resource "google_compute_forwarding_rule" "psc_ilb_consumer" {
-  provider = "google-beta"
-
   name   = "<%= ctx[:vars]['consumer_forwarding_rule_name'] %>"
   region = "us-west2"
 
@@ -42,8 +36,6 @@ resource "google_compute_forwarding_rule" "psc_ilb_consumer" {
 }
 
 resource "google_compute_forwarding_rule" "psc_ilb_target_service" {
-  provider = "google-beta"
-
   name   = "<%= ctx[:vars]['producer_forwarding_rule_name'] %>"
   region = "us-west2"
 
@@ -55,8 +47,6 @@ resource "google_compute_forwarding_rule" "psc_ilb_target_service" {
 }
 
 resource "google_compute_region_backend_service" "producer_service_backend" {
-  provider = "google-beta"
-
   name   = "<%= ctx[:vars]['producer_service_name'] %>"
   region = "us-west2"
 
@@ -64,8 +54,6 @@ resource "google_compute_region_backend_service" "producer_service_backend" {
 }
 
 resource "google_compute_health_check" "producer_service_health_check" {
-  provider = "google-beta"
-
   name = "<%= ctx[:vars]['producer_health_check_name'] %>"
 
   check_interval_sec = 1
@@ -76,15 +64,11 @@ resource "google_compute_health_check" "producer_service_health_check" {
 }
 
 resource "google_compute_network" "psc_ilb_network" {
-  provider = "google-beta"
-
   name = "<%= ctx[:vars]['network_name'] %>"
   auto_create_subnetworks = false
 }
 
 resource "google_compute_subnetwork" "psc_ilb_producer_subnetwork" {
-  provider = "google-beta"
-
   name   = "<%= ctx[:vars]['producer_subnetwork_name'] %>"
   region = "us-west2"
 
@@ -93,8 +77,6 @@ resource "google_compute_subnetwork" "psc_ilb_producer_subnetwork" {
 }
 
 resource "google_compute_subnetwork" "psc_ilb_nat" {
-  provider = "google-beta"
-
   name   = "<%= ctx[:vars]['nat_subnetwork_name'] %>"
   region = "us-west2"
 


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/9647

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: promoted `google_compute_service_attachment` to ga
```
```release-note:enhancement
compute: promoted `role` and `purpose` fields in `google_compute_subnetwork` to ga
```
