### PR TITLE
Skip terraform-google-conversion tests if no go files were modified

### DIFF
--- a/.ci/containers/terraform-google-conversion-tester/test_terraform_google_conversion.sh
+++ b/.ci/containers/terraform-google-conversion-tester/test_terraform_google_conversion.sh
@@ -10,8 +10,24 @@ build_step=$5
 github_username=modular-magician
 gh_repo=terraform-google-conversion
 
-scratch_path=https://$github_username:$GITHUB_TOKEN@github.com/$github_username/$gh_repo
+new_branch="auto-pr-$pr_number"
+git_remote=https://$github_username:$GITHUB_TOKEN@github.com/$github_username/$gh_repo
 local_path=$GOPATH/src/github.com/GoogleCloudPlatform/$gh_repo
+mkdir -p "$(dirname $local_path)"
+git clone $git_remote $local_path --branch $new_branch --depth 2
+pushd $local_path
+
+# Only skip tests if we can tell for sure that no go files were changed
+echo "Checking for modified go files"
+# get the names of changed files and look for go files
+# (ignoring "no matches found" errors from grep)
+gofiles=$(git diff --name-only HEAD~1 | { grep "\.go$" || test $? = 1; })
+if [[ -z $gofiles ]]; then
+    echo "Skipping tests: No go files changed"
+    exit 0
+else
+    echo "Running tests: Go files changed"
+fi
 
 post_body=$( jq -n \
 	--arg context "terraform-google-conversion-test" \
@@ -25,10 +41,6 @@ curl \
   -H "Accept: application/vnd.github.v3+json" \
   "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
   -d "$post_body"
-
-mkdir -p "$(dirname $local_path)"
-git clone $scratch_path $local_path --single-branch --branch "auto-pr-$pr_number" --depth 1
-pushd $local_path
 
 set +e
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Resolved https://github.com/hashicorp/terraform-provider-google/issues/9147. 

Technically this was already resolved by https://github.com/GoogleCloudPlatform/magic-modules/pull/5030 and https://github.com/GoogleCloudPlatform/magic-modules/pull/5026 but I thought the ticket included terraform-google-conversion tests as well.

Anyway though it's easy to add support for skipping tgc tests as well. It'll have more of an impact after tgc & validator are merged.

```release-note:none

```
