### PR TITLE
Shared scripts & base image for testing

### DIFF
--- a/.ci/containers/magic-modules-base/Dockerfile
+++ b/.ci/containers/magic-modules-base/Dockerfile
@@ -1,0 +1,10 @@
+from golang:1.16-stretch as resource
+SHELL ["/bin/bash", "-c"]
+# Set up Github SSH cloning.
+RUN ssh-keyscan github.com >> /known_hosts
+RUN echo "UserKnownHostsFile /known_hosts" >> /etc/ssh/ssh_config
+
+RUN apt-get update
+RUN apt-get install -y git jq
+
+ADD utils.sh /utils.sh

--- a/.ci/containers/magic-modules-base/utils.sh
+++ b/.ci/containers/magic-modules-base/utils.sh
@@ -1,3 +1,16 @@
+# Usage: grep_files_modified grep_pattern
+# Must be called while inside a downstream git repository.
+# Requires 2 commits of depth.
+# Returns 0 if there are matches and 1 otherwise.
+function grep_files_modified {
+	matching_files=$(git diff --name-only HEAD~1 | { grep "${1}" || test $? = 1; })
+	if [[ -z $matching_files ]]; then
+		return 1
+	else
+		return 0
+	fi
+}
+
 # Usage: update_status context state target_url
 # Expected env: GITHUB_TOKEN
 function update_status {

--- a/.ci/containers/magic-modules-base/utils.sh
+++ b/.ci/containers/magic-modules-base/utils.sh
@@ -1,0 +1,16 @@
+# Usage: update_status context state target_url
+# Expected env: GITHUB_TOKEN
+function update_status {
+	local post_body=$( jq -n \
+		--arg context "${1}" \
+		--arg state "${2}" \
+		--arg target_url "${3}" \
+		'{context: $context, target_url: $target_url, state: $state}')
+	echo "Updating status ${1} to ${2} with target_url ${3} for sha ${mm_commit_sha}"
+	curl \
+	  -X POST \
+	  -u "modular-magician:$GITHUB_TOKEN" \
+	  -H "Accept: application/vnd.github.v3+json" \
+	  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/${mm_commit_sha}" \
+	  -d "$post_body"
+}

--- a/.ci/containers/terraform-google-conversion-tester/Dockerfile
+++ b/.ci/containers/terraform-google-conversion-tester/Dockerfile
@@ -1,11 +1,4 @@
-from golang:1.16-stretch as resource
-SHELL ["/bin/bash", "-c"]
-# Set up Github SSH cloning.
-RUN ssh-keyscan github.com >> /known_hosts
-RUN echo "UserKnownHostsFile /known_hosts" >> /etc/ssh/ssh_config
-
-RUN apt-get update
-RUN apt-get install -y git jq
+FROM gcr.io/graphite-docker-images/magic-modules-base:latest
 
 ADD test_terraform_google_conversion.sh /test_terraform_google_conversion.sh
 ENTRYPOINT ["/test_terraform_google_conversion.sh"]

--- a/.ci/containers/terraform-google-conversion-tester/test_terraform_google_conversion.sh
+++ b/.ci/containers/terraform-google-conversion-tester/test_terraform_google_conversion.sh
@@ -17,16 +17,13 @@ mkdir -p "$(dirname $local_path)"
 git clone $git_remote $local_path --branch $new_branch --depth 2
 pushd $local_path
 
-# Only skip tests if we can tell for sure that no go files were changed
+# Only skip tests if no go files were changed
 echo "Checking for modified go files"
-# get the names of changed files and look for go files
-# (ignoring "no matches found" errors from grep)
-gofiles=$(git diff --name-only HEAD~1 | { grep "\.go$" || test $? = 1; })
-if [[ -z $gofiles ]]; then
+if grep_files_modified "\.go$"; then
+    echo "Running tests: Go files changed"
+else
     echo "Skipping tests: No go files changed"
     exit 0
-else
-    echo "Running tests: Go files changed"
 fi
 
 update_status "terraform-google-conversion-test" "pending" "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}"

--- a/.ci/containers/terraform-google-conversion-tester/test_terraform_google_conversion.sh
+++ b/.ci/containers/terraform-google-conversion-tester/test_terraform_google_conversion.sh
@@ -29,18 +29,7 @@ else
     echo "Running tests: Go files changed"
 fi
 
-post_body=$( jq -n \
-	--arg context "terraform-google-conversion-test" \
-	--arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
-	--arg state "pending" \
-	'{context: $context, target_url: $target_url, state: $state}')
-
-curl \
-  -X POST \
-  -u "$github_username:$GITHUB_TOKEN" \
-  -H "Accept: application/vnd.github.v3+json" \
-  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
-  -d "$post_body"
+update_status "terraform-google-conversion-test" "pending" "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}"
 
 set +e
 
@@ -55,15 +44,4 @@ else
 	state="success"
 fi
 
-post_body=$( jq -n \
-	--arg context "terraform-google-conversion-test" \
-	--arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
-	--arg state "${state}" \
-	'{context: $context, target_url: $target_url, state: $state}')
-
-curl \
-  -X POST \
-  -u "$github_username:$GITHUB_TOKEN" \
-  -H "Accept: application/vnd.github.v3+json" \
-  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
-  -d "$post_body"
+update_status "terraform-google-conversion-test" "${state}" "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}"

--- a/.ci/containers/terraform-tester/test_terraform.sh
+++ b/.ci/containers/terraform-tester/test_terraform.sh
@@ -27,16 +27,13 @@ mkdir -p "$(dirname $local_path)"
 git clone $git_remote $local_path --branch $new_branch --depth 2
 pushd $local_path
 
-# Only skip tests if we can tell for sure that no go files were changed
+# Only skip tests if no go files were changed
 echo "Checking for modified go files"
-# get the names of changed files and look for go files
-# (ignoring "no matches found" errors from grep)
-gofiles=$(git diff --name-only HEAD~1 | { grep "\.go$" || test $? = 1; })
-if [[ -z $gofiles ]]; then
+if grep_files_modified "\.go$"; then
+    echo "Running tests: Go files changed"
+else
     echo "Skipping tests: No go files changed"
     exit 0
-else
-    echo "Running tests: Go files changed"
 fi
 
 update_status "${gh_repo}-test" "pending" "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}"

--- a/.ci/containers/terraform-tester/test_terraform.sh
+++ b/.ci/containers/terraform-tester/test_terraform.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /utils.sh
+
 set -e
 
 version=$1
@@ -37,32 +39,8 @@ else
     echo "Running tests: Go files changed"
 fi
 
-post_body=$( jq -n \
-    --arg context "${gh_repo}-test" \
-    --arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
-    --arg state "pending" \
-    '{context: $context, target_url: $target_url, state: $state}')
-
-curl \
-  -X POST \
-  -u "$github_username:$GITHUB_TOKEN" \
-  -H "Accept: application/vnd.github.v3+json" \
-  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
-  -d "$post_body"
-
-
-post_body=$( jq -n \
-    --arg context "${gh_repo}-lint" \
-    --arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
-    --arg state "pending" \
-    '{context: $context, target_url: $target_url, state: $state}')
-
-curl \
-  -X POST \
-  -u "$github_username:$GITHUB_TOKEN" \
-  -H "Accept: application/vnd.github.v3+json" \
-  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
-  -d "$post_body"
+update_status "${gh_repo}-test" "pending" "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}"
+update_status "${gh_repo}-lint" "pending" "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}"
 
 set +e
 
@@ -97,29 +75,5 @@ else
     lint_state="success"
 fi
 
-post_body=$( jq -n \
-    --arg context "${gh_repo}-test" \
-    --arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
-    --arg state "${test_state}" \
-    '{context: $context, target_url: $target_url, state: $state}')
-
-curl \
-  -X POST \
-  -u "$github_username:$GITHUB_TOKEN" \
-  -H "Accept: application/vnd.github.v3+json" \
-  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
-  -d "$post_body"
-
-
-post_body=$( jq -n \
-    --arg context "${gh_repo}-lint" \
-    --arg target_url "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}" \
-    --arg state "${lint_state}" \
-    '{context: $context, target_url: $target_url, state: $state}')
-
-curl \
-  -X POST \
-  -u "$github_username:$GITHUB_TOKEN" \
-  -H "Accept: application/vnd.github.v3+json" \
-  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/$mm_commit_sha" \
-  -d "$post_body"
+update_status "${gh_repo}-test" "${test_state}" "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}"
+update_status "${gh_repo}-lint" "${lint_state}" "https://console.cloud.google.com/cloud-build/builds;region=global/${build_id};step=${build_step}?project=${project_id}"

--- a/.ci/containers/terraform-vcr-tester/Dockerfile
+++ b/.ci/containers/terraform-vcr-tester/Dockerfile
@@ -1,8 +1,4 @@
-FROM alpine
-
-RUN apk add --no-cache bash
-RUN apk add --no-cache curl
-RUN apk add --no-cache jq
+FROM gcr.io/graphite-docker-images/magic-modules-base:latest
 
 ADD teamcityparams.xml /teamcityparams.xml
 ADD run_vcr_tests.sh /run_vcr_tests.sh

--- a/.ci/containers/terraform-vcr-tester/run_vcr_tests.sh
+++ b/.ci/containers/terraform-vcr-tester/run_vcr_tests.sh
@@ -17,16 +17,13 @@ mkdir -p "$(dirname $local_path)"
 git clone $git_remote $local_path --branch $new_branch --depth 2
 pushd $local_path
 
-# Only skip tests if we can tell for sure that no go files were changed
+# Only skip tests if no go files were changed
 echo "Checking for modified go files"
-# get the names of changed files and look for go files
-# (ignoring "no matches found" errors from grep)
-gofiles=$(git diff --name-only HEAD~1 | { grep "\.go$" || test $? = 1; })
-if [[ -z $gofiles ]]; then
+if grep_files_modified "\.go$"; then
+    echo "Running tests: Go files changed"
+else
     echo "Skipping tests: No go files changed"
     exit 0
-else
-    echo "Running tests: Go files changed"
 fi
 
 sed -i 's/{{PR_NUMBER}}/'"$pr_number"'/g' /teamcityparams.xml

--- a/.ci/containers/terraform-vcr-tester/run_vcr_tests.sh
+++ b/.ci/containers/terraform-vcr-tester/run_vcr_tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /utils.sh
+
 set -e
 pr_number=$1
 mm_commit_sha=$2
@@ -30,24 +32,8 @@ fi
 sed -i 's/{{PR_NUMBER}}/'"$pr_number"'/g' /teamcityparams.xml
 curl --header "Accept: application/json" --header "Authorization: Bearer $TEAMCITY_TOKEN" https://ci-oss.hashicorp.engineering/app/rest/buildQueue --request POST --header "Content-Type:application/xml" --data-binary @/teamcityparams.xml -o build.json
 
-function update_status {
-	local context="beta-provider-vcr-test"
-	local post_body=$( jq -n \
-		--arg context "${context}" \
-		--arg target_url "${1}" \
-		--arg state "${2}" \
-		'{context: $context, target_url: $target_url, state: $state}')
-	echo "Updating status ${context} to ${2} with target_url ${1} for sha ${mm_commit_sha}"
-	curl \
-	  -X POST \
-	  -u "$github_username:$GITHUB_TOKEN" \
-	  -H "Accept: application/vnd.github.v3+json" \
-	  "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/statuses/${mm_commit_sha}" \
-	  -d "$post_body"
-}
-
 build_url=$(cat build.json | jq -r .webUrl)
-update_status "${build_url}" "pending"
+update_status "beta-provider-vcr-test" "pending" "${build_url}"
 
 ID=$(cat build.json | jq .id -r)
 curl --header "Authorization: Bearer $TEAMCITY_TOKEN" --header "Accept: application/json" https://ci-oss.hashicorp.engineering/app/rest/builds/id:$ID --output poll.json
@@ -58,7 +44,7 @@ while [[ "$STATE" != "finished" ]]; do
 	if [ "$counter" -gt "500" ]; then
 		echo "Failed to wait for job to finish, exiting"
 		# Call this an error because we don't know if the tests failed or not
-		update_status "${build_url}" "error"
+		update_status "beta-provider-vcr-test" "error" "${build_url}"
 		# exit 0 because this script didn't have an error; the failure
 		# is reported via the Github Status API
 		exit 0
@@ -73,7 +59,7 @@ done
 
 if [ "$STATUS" == "SUCCESS" ]; then
 	echo "Tests succeeded."
-	update_status "${build_url}" "success"
+	update_status "beta-provider-vcr-test" "success" "${build_url}"
 	exit 0
 fi
 
@@ -83,7 +69,7 @@ FAILED_TESTS=$(cat failed.json | jq -r '.testOccurrence | map(.name) | join("|")
 ret=$?
 if [ $ret -ne 0 ]; then
 	echo "Job failed without failing tests"
-	update_status "${build_url}" "failure"
+	update_status "beta-provider-vcr-test" "failure" "${build_url}"
 	# exit 0 because this script didn't have an error; the failure
 	# is reported via the Github Status API
 	exit 0
@@ -101,7 +87,7 @@ curl -H "Authorization: token ${GITHUB_TOKEN}" \
       "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${pr_number}/comments"
 
 
-update_status "${build_url}" "pending"
+update_status "beta-provider-vcr-test" "pending" "${build_url}"
 
 # Reset for checking failed tests
 rm poll.json
@@ -116,7 +102,7 @@ while [[ "$STATE" != "finished" ]]; do
 	if [ "$counter" -gt "500" ]; then
 		echo "Failed to wait for job to finish, exiting"
 		# Call this an error because we don't know if the tests failed or not
-		update_status "${build_url}" "error"
+		update_status "beta-provider-vcr-test" "error" "${build_url}"
 		# exit 0 because this script didn't have an error; the failure
 		# is reported via the Github Status API
 		exit 0
@@ -131,7 +117,7 @@ done
 
 if [ "$STATUS" == "SUCCESS" ]; then
 	echo "Tests succeeded."
-	update_status "${build_url}" "success"
+	update_status "beta-provider-vcr-test" "success" "${build_url}"
 	exit 0
 fi
 
@@ -141,7 +127,7 @@ FAILED_TESTS=$(cat failed.json | jq -r '.testOccurrence | map(.name) | join("|")
 ret=$?
 if [ $ret -ne 0 ]; then
 	echo "Job failed without failing tests"
-	update_status "${build_url}" "failure"
+	update_status "beta-provider-vcr-test" "failure" "${build_url}"
 	# exit 0 because this script didn't have an error; the failure
 	# is reported via the Github Status API
 	exit 0
@@ -153,7 +139,7 @@ comment="Tests failed during RECORDING mode: $FAILED_TESTS Please fix these to c
 curl -H "Authorization: token ${GITHUB_TOKEN}" \
       -d "$(jq -r --arg comment "$comment" -n "{body: \$comment}")" \
       "https://api.github.com/repos/GoogleCloudPlatform/magic-modules/issues/${pr_number}/comments"
-update_status "${build_url}" "failure"
+update_status "beta-provider-vcr-test" "failure" "${build_url}"
 
 # exit 0 because this script didn't have an error; the failure
 # is reported via the Github Status API


### PR DESCRIPTION
There are now a couple of bash functions that we might want to share between our tester images: updating github statuses and grepping for modified files.

There's also a good chance we'll want to add more (especially around interactions with Github, for example) going forward. This PR tries to address that by adding a base image that supplies a utils.sh file, which inheritors can source to get access to shared functions.

Cons: Updating the shared image will require remembering to update all the child images as well
Pros: Shared code in one place means we won't have to remember all the places it's used and update them as well.

Other notes: This was originally spawned due to a comment on https://github.com/GoogleCloudPlatform/magic-modules/pull/5032 - but I was not able to reduce that particular code as much as I expected, because the setup of the repository & the files we check for are too varied; I'm not sure that making this more DRY would make it easier to maintain. (In particular, right now we're checking for go files in all locations - but in the long run, the terraform providers are going to have different files they check for than e.g. terraform validator will.

I need to do more testing to make sure this works as expected, but I wanted to run the PR by folks first to make sure we agree on the general approach. (Please also feel free to request changes though!)

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
