### PR TITLE
Made terraform-vcr-tester use same golang image setup as other tester images

### DIFF
--- a/.ci/containers/terraform-vcr-tester/Dockerfile
+++ b/.ci/containers/terraform-vcr-tester/Dockerfile
@@ -1,9 +1,11 @@
-FROM alpine
+from golang:1.16-stretch as resource
+SHELL ["/bin/bash", "-c"]
+# Set up Github SSH cloning.
+RUN ssh-keyscan github.com >> /known_hosts
+RUN echo "UserKnownHostsFile /known_hosts" >> /etc/ssh/ssh_config
 
-RUN apk add --no-cache bash
-RUN apk add --no-cache curl
-RUN apk add --no-cache git
-RUN apk add --no-cache jq
+RUN apt-get update
+RUN apt-get install -y git jq
 
 ADD teamcityparams.xml /teamcityparams.xml
 ADD run_vcr_tests.sh /run_vcr_tests.sh


### PR DESCRIPTION
This image is having trouble doing the same things that are done in other tester images. It's possible that we could just install one more thing - but I'd rather just switch to using the same base image & setup, especially since we are probably going to switch to a single base image overall

```release-note:none

```
