### PR TITLE
Run vcr test script with bash

### DIFF
--- a/.ci/containers/terraform-vcr-tester/check_membership.sh
+++ b/.ci/containers/terraform-vcr-tester/check_membership.sh
@@ -28,4 +28,4 @@ else
 fi
 
 # Pass args through to runner
-sh /run_vcr_tests.sh $pr_number $mm_commit_sha
+bash /run_vcr_tests.sh $pr_number $mm_commit_sha


### PR DESCRIPTION
pushd is not available in sh

```release-note:none

```
