### PR TITLE
Testing fix for tpg 9586

### DIFF
--- a/mmv1/third_party/terraform/resources/common_operation_test.go
+++ b/mmv1/third_party/terraform/resources/common_operation_test.go
@@ -51,7 +51,7 @@ func (TestWaiter) TargetStates() []string {
 	return []string{"DONE"}
 }
 
-func TestOperationWait_TimeoutsShouldRetry(t *testing.T) {
+func TestOperationWait_TimeoutsShouldRetryNew(t *testing.T) {
 	testWaiter := TestWaiter{
 		runCount: 0,
 	}

--- a/mmv1/third_party/terraform/tests/resource_bigtable_table_test.go
+++ b/mmv1/third_party/terraform/tests/resource_bigtable_table_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccBigtableTable_basic(t *testing.T) {
+func TestAccBigtableTable_basicNew(t *testing.T) {
 	// bigtable instance does not use the shared HTTP client, this test creates an instance
 	skipIfVcr(t)
 	t.Parallel()

--- a/mmv1/third_party/terraform/tests/resource_compute_target_ssl_proxy_test.go
+++ b/mmv1/third_party/terraform/tests/resource_compute_target_ssl_proxy_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccComputeTargetSslProxy_update(t *testing.T) {
+func TestAccComputeTargetSslProxy_updateNew(t *testing.T) {
 	target := fmt.Sprintf("tssl-test-%s", randString(t, 10))
 	sslPolicy := fmt.Sprintf("tssl-test-%s", randString(t, 10))
 	cert1 := fmt.Sprintf("tssl-test-%s", randString(t, 10))


### PR DESCRIPTION
Renamed several tests to exercise the detection code

```release-note:none

```
