### PR TITLE
L3 default support for Network Load Balancer

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -3772,15 +3772,18 @@ objects:
         name: 'ports'
         max_size: 5
         description: |
-          This field is used along with the backend_service field for internal
-          load balancing.
+          This field is used along with internal load balancing and network
+          load balancer when the forwarding rule references a backend service
+          and when protocol is not L3_DEFAULT.
 
-          When the load balancing scheme is INTERNAL, a single port or a comma
-          separated list of ports can be configured. Only packets addressed to
-          these ports will be forwarded to the backends configured with this
-          forwarding rule.
+          A single port or a comma separated list of ports can be configured.
+          Only packets addressed to these ports will be forwarded to the backends
+          configured with this forwarding rule.
 
-          You may specify a maximum of up to 5 ports.
+          You can only use one of ports and portRange, or allPorts.
+          The three are mutually exclusive.
+
+          You may specify a maximum of up to 5 ports, which can be non-contiguous.
         item_type: Api::Type::String
       - !ruby/object:Api::Type::ResourceRef
         name: 'subnetwork'
@@ -3834,11 +3837,13 @@ objects:
       - !ruby/object:Api::Type::Boolean
         name: 'allPorts'
         description: |
-          For internal TCP/UDP load balancing (i.e. load balancing scheme is
-          INTERNAL and protocol is TCP/UDP), set this to true to allow packets
-          addressed to any ports to be forwarded to the backends configured
-          with this forwarding rule. Used with backend service. Cannot be set
-          if port or portRange are set.
+          This field can be used with internal load balancer or network load balancer
+          when the forwarding rule references a backend service, or with the target
+          field when it references a TargetInstance. Set this to true to
+          allow packets addressed to any ports to be forwarded to the backends configured
+          with this forwarding rule. This can be used when the protocol is TCP/UDP, and it
+          must be set to true when the protocol is set to L3_DEFAULT.
+          Cannot be set if port or portRange are set.
       - !ruby/object:Api::Type::Enum
         name: 'networkTier'
         description: |

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -2654,6 +2654,7 @@ objects:
           - :TCP
           - :UDP
           - :GRPC
+          - :UNSPECIFIED
       - !ruby/object:Api::Type::Enum
         name: 'sessionAffinity'
         description: |
@@ -3697,6 +3698,7 @@ objects:
           - :AH
           - :SCTP
           - :ICMP
+          - :L3_DEFAULT
       # This is a multi-resource resource reference (BackendService (global), RegionBackendService)
       # We have custom expands that manage this.
       - !ruby/object:Api::Type::ResourceRef

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -724,6 +724,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           forwarding_rule_name: "website-forwarding-rule"
           target_pool_name: "website-target-pool"
       - !ruby/object:Provider::Terraform::Examples
+        name: "forwarding_rule_l3_default"
+        primary_resource_id: "fwd_rule"
+        vars:
+          forwarding_rule_name: "l3-forwarding-rule"
+          service_name: "service"
+          health_check_name: "health-check"
+        min_version: beta
+      - !ruby/object:Provider::Terraform::Examples
         name: "forwarding_rule_internallb"
         primary_resource_id: "default"
         vars:

--- a/mmv1/templates/terraform/examples/forwarding_rule_l3_default.tf.erb
+++ b/mmv1/templates/terraform/examples/forwarding_rule_l3_default.tf.erb
@@ -1,0 +1,26 @@
+resource "google_compute_forwarding_rule" "<%= ctx[:primary_resource_id] %>" {
+  provider        = google-beta
+  name            = "<%= ctx[:vars]['forwarding_rule_name'] %>"
+  backend_service = google_compute_region_backend_service.service.id
+  ip_protocol     = "L3_DEFAULT"
+  all_ports       = true
+}
+
+resource "google_compute_region_backend_service" "service" {
+  provider              = google-beta
+  region                = "us-central1"
+  name                  = "<%= ctx[:vars]['service_name'] %>"
+  health_checks         = [google_compute_region_health_check.health_check.id]
+  protocol              = "UNSPECIFIED"
+  load_balancing_scheme = "EXTERNAL"
+}
+
+resource "google_compute_region_health_check" "health_check" {
+  provider           = google-beta
+  name               = "<%= ctx[:vars]['health_check_name'] %>"
+  region             = "us-central1"
+
+  tcp_health_check {
+    port = 80
+  }
+}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added support for `L3_DEFAULT` as `ip_protocol` for `google_compute_forwarding_rule` and `UNSPECIFIED` as `protocol` for `google_compute_region_backend_service` to support network load balancers that forward all protocols and ports.
```
