### PR TITLE
Avoid printing confusing log entry when image version doesn't exist

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -1643,14 +1643,18 @@ func composerImageVersionDiffSuppress(_, old, new string, _ *schema.ResourceData
 		// Somehow one of the versions didn't match the regexp or didn't
 		// have values in the capturing groups. In that case, fall back to
 		// an equality check.
-		log.Printf("[WARN] Composer version didn't match regexp: %s", old)
+		if old != "" {
+			log.Printf("[WARN] Composer version didn't match regexp: %s", old)
+		}
 		return old == new
 	}
 	if newVersions == nil || len(newVersions) < 3 {
 		// Somehow one of the versions didn't match the regexp or didn't
 		// have values in the capturing groups. In that case, fall back to
 		// an equality check.
-		log.Printf("[WARN] Composer version didn't match regexp: %s", new)
+		if new != "" {
+			log.Printf("[WARN] Composer version didn't match regexp: %s", new)
+		}
 		return old == new
 	}
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

When image version is empty, for example when creating a new environment (old image version is empty), following log entries are printed:

```
2021/08/09 10:03:16 [WARN] Composer version didn't match regexp: 
2021/08/09 10:03:16 [WARN] Composer version didn't match regexp: 
```

These warnings seem a bit misleading - suggesting something is wrong while this can be a valid situation. This log seems more appropriate when version exists but it doesn't match the regexp, so I suggest avoid printing it if version is empty.

part of {https://github.com/hashicorp/terraform-provider-google/issues/9611}


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
Avoid printing confusing (Compsoer version didn't match regexp) log entry when version is empty.
```
