### PR TITLE
enable/disable for BgpPeer

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -13379,6 +13379,14 @@ objects:
           PARTNER InterconnectAttachment is created, updated,
           or deleted.
         output: true
+      - !ruby/object:Api::Type::Boolean
+         name: 'enable'
+         description: |
+           The status of the BGP peer connection. If set to false, any active session
+           with the peer is terminated and all associated routing information is removed.
+           If set to true, the peer connection can be established with routing information.
+           The default is true.
+         default_value: true
   - !ruby/object:Api::Resource
     name: 'SecurityPolicy'
     kind: 'compute#securityPolicy'

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2199,6 +2199,13 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           router_name: "my-router"
           peer_name: "my-router-peer"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "router_peer_disabled"
+        primary_resource_id: "peer"
+        skip_test: true
+        vars:
+          router_name: "my-router"
+          peer_name: "my-router-peer"
     properties:
       advertiseMode: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
@@ -2214,6 +2221,10 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         description: |
           {{description}}
           If it is not provided, the provider region is used.
+      enable: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_expand: 'templates/terraform/custom_expand/bool_to_upper_string.erb'
+        custom_flatten: 'templates/terraform/custom_flatten/string_to_bool.erb'
+        send_empty_value: true
   SecurityPolicy: !ruby/object:Overrides::Terraform::ResourceOverride
     exclude: true
   ServiceAttachment: !ruby/object:Overrides::Terraform::ResourceOverride

--- a/mmv1/templates/terraform/custom_expand/bool_to_upper_string.erb
+++ b/mmv1/templates/terraform/custom_expand/bool_to_upper_string.erb
@@ -1,0 +1,21 @@
+<%- # the license inside this block applies to this file
+	# Copyright 2021 Google Inc.
+	# Licensed under the Apache License, Version 2.0 (the "License");
+	# you may not use this file except in compliance with the License.
+	# You may obtain a copy of the License at
+	#
+	#     http://www.apache.org/licenses/LICENSE-2.0
+	#
+	# Unless required by applicable law or agreed to in writing, software
+	# distributed under the License is distributed on an "AS IS" BASIS,
+	# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	# See the License for the specific language governing permissions and
+	# limitations under the License.
+-%>
+func expand<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d TerraformResourceData, config *Config) (interface{}, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	return strings.ToUpper(strconv.FormatBool(v.(bool))), nil
+}

--- a/mmv1/templates/terraform/custom_flatten/string_to_bool.erb
+++ b/mmv1/templates/terraform/custom_flatten/string_to_bool.erb
@@ -1,0 +1,8 @@
+func flatten<%= prefix -%><%= titlelize_property(property) -%>(v interface{}, d *schema.ResourceData, config *Config) interface{} {
+     b, err := strconv.ParseBool(v.(string))
+     if err != nil {
+         // If we can't convert it into a bool return value as is and let caller handle it
+         return v
+     }
+     return b
+ }

--- a/mmv1/templates/terraform/examples/router_peer_disabled.tf.erb
+++ b/mmv1/templates/terraform/examples/router_peer_disabled.tf.erb
@@ -1,0 +1,10 @@
+resource "google_compute_router_peer" "<%= ctx[:primary_resource_id] %>" {
+   name                      = "<%= ctx[:vars]['peer_name'] %>"
+   router                    = "<%= ctx[:vars]['router_name'] %>"
+   region                    = "us-central1"
+   peer_ip_address           = "169.254.1.2"
+   peer_asn                  = 65513
+   advertised_route_priority = 100
+   interface                 = "interface-1"
+   enable                    = false
+ }


### PR DESCRIPTION
Partially supersedes GoogleCloudPlatform/magic-modules#3258

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Added `enable` attribute to `google_compute_router_peer`
```
