### PR TITLE
Recreate patch to add trigger_http to cloud function

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -26,6 +26,11 @@ var allowedVpcConnectorEgressSettings = []string{
 	"PRIVATE_RANGES_ONLY",
 }
 
+var allowedSecurityLevelSettings = []string{
+	"SECURE_ALWAYS",
+	"SECURE_OPTIONAL",
+}
+
 type cloudFunctionId struct {
 	Project string
 	Region  string
@@ -231,17 +236,25 @@ func resourceCloudFunctionsFunction() *schema.Resource {
 			},
 
 			"trigger_http": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				ForceNew:    true,
-				Description: `Boolean variable. Any HTTP request (of a supported type) to the endpoint will trigger function execution. Supported HTTP request types are: POST, PUT, GET, DELETE, and OPTIONS. Endpoint is returned as https_trigger_url. Cannot be used with trigger_bucket and trigger_topic.`,
+				Type:         schema.TypeBool,
+				Optional:     true,
+				ForceNew:     true,
+				RequiredWith: []string{"security_level"},
+				Description:  `Boolean variable. Any HTTP request (of a supported type) to the endpoint will trigger function execution. Supported HTTP request types are: POST, PUT, GET, DELETE, and OPTIONS. Endpoint is returned as https_trigger_url. Cannot be used with trigger_bucket and trigger_topic.`,
+			},
+
+			"security_level": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice(allowedSecurityLevelSettings, true),
+				Description:  `String value that controls whether HTTP and HTTPS trafic is allowed or just HTTP. Allowed values are SECURE_OPTIONAL and SECURE_ALWAYS. Only can be used when trigger_http is set.`,
 			},
 
 			"event_trigger": {
 				Type:          schema.TypeList,
 				Optional:      true,
 				Computed:      true,
-				ConflictsWith: []string{"trigger_http"},
+				ConflictsWith: []string{"trigger_http", "security_level"},
 				MaxItems:      1,
 				Description:   `A source that fires events in response to a condition in another service. Cannot be used with trigger_http.`,
 				Elem: &schema.Resource{
@@ -381,6 +394,13 @@ func resourceCloudFunctionsCreate(d *schema.ResourceData, meta interface{}) erro
 			"You must specify a trigger when deploying a new function.")
 	}
 
+	if v, ok := d.GetOk("security_level"); ok {
+		if function.HttpsTrigger == nil {
+			return fmt.Errorf("`security_level` requires `trigger_http` to be enabled")
+		}
+		function.HttpsTrigger.SecurityLevel = v.(string)
+	}
+
 	if v, ok := d.GetOk("ingress_settings"); ok {
 		function.IngressSettings = v.(string)
 	}
@@ -516,6 +536,9 @@ func resourceCloudFunctionsRead(d *schema.ResourceData, meta interface{}) error 
 		if err := d.Set("trigger_http", true); err != nil {
 			return fmt.Errorf("Error setting trigger_http: %s", err)
 		}
+		if err := d.Set("security_level", function.HttpsTrigger.SecurityLevel); err != nil {
+			return fmt.Errorf("Error setting security_level: %s", err)
+		}
 		if err := d.Set("https_trigger_url", function.HttpsTrigger.Url); err != nil {
 			return fmt.Errorf("Error setting https_trigger_url: %s", err)
 		}
@@ -634,6 +657,14 @@ func resourceCloudFunctionsUpdate(d *schema.ResourceData, meta interface{}) erro
 	if d.HasChange("event_trigger") {
 		function.EventTrigger = expandEventTrigger(d.Get("event_trigger").([]interface{}), project)
 		updateMaskArr = append(updateMaskArr, "eventTrigger", "eventTrigger.failurePolicy.retry")
+	}
+
+	if d.HasChange("security_level") {
+		if function.HttpsTrigger == nil {
+			return fmt.Errorf("cannot update `security_level` as `trigger_http` is not enabled")
+		}
+		function.HttpsTrigger.SecurityLevel = d.Get("security_level").(string)
+		updateMaskArr = append(updateMaskArr, "httpsTrigger.securityLevel")
 	}
 
 	if d.HasChange("max_instances") {

--- a/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
+++ b/mmv1/third_party/terraform/resources/resource_cloudfunctions_function.go
@@ -247,7 +247,7 @@ func resourceCloudFunctionsFunction() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validation.StringInSlice(allowedSecurityLevelSettings, true),
-				Description:  `String value that controls whether HTTP and HTTPS trafic is allowed or just HTTP. Allowed values are SECURE_OPTIONAL and SECURE_ALWAYS. Only can be used when trigger_http is set.`,
+				Description:  `String value that controls whether HTTP and HTTPS trafic is allowed or just HTTPS. Allowed values are SECURE_OPTIONAL and SECURE_ALWAYS. Only can be used when trigger_http is set.`,
 			},
 
 			"event_trigger": {

--- a/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_cloudfunctions_function_test.go.erb
@@ -154,6 +154,8 @@ func TestAccCloudFunctionsFunction_basic(t *testing.T) {
 						"entry_point", "helloGET"),
 					resource.TestCheckResourceAttr(funcResourceName,
 						"trigger_http", "true"),
+					resource.TestCheckResourceAttr(funcResourceName,
+						"security_level", "SECURE_ALWAYS"),
 					testAccCloudFunctionsFunctionHasLabel("my-label", "my-label-value", &function),
 					testAccCloudFunctionsFunctionHasEnvironmentVariable("TEST_ENV_VARIABLE",
 						"test-env-variable-value", &function),
@@ -216,6 +218,8 @@ func TestAccCloudFunctionsFunction_update(t *testing.T) {
 						"max_instances", "15"),
 					resource.TestCheckResourceAttr(funcResourceName,
 						"ingress_settings", "ALLOW_ALL"),
+					resource.TestCheckResourceAttr(funcResourceName,
+						"security_level", "SECURE_OPTIONAL"),
 					testAccCloudFunctionsFunctionHasLabel("my-label", "my-updated-label-value", &function),
 					testAccCloudFunctionsFunctionHasLabel("a-new-label", "a-new-label-value", &function),
 					testAccCloudFunctionsFunctionHasEnvironmentVariable("TEST_ENV_VARIABLE",
@@ -608,6 +612,7 @@ resource "google_cloudfunctions_function" "function" {
   source_archive_bucket = google_storage_bucket.bucket.name
   source_archive_object = google_storage_bucket_object.archive.name
   trigger_http          = true
+  security_level        = "SECURE_ALWAYS"
   timeout               = 61
   entry_point           = "helloGET"
   ingress_settings      = "ALLOW_INTERNAL_ONLY"
@@ -644,6 +649,7 @@ resource "google_cloudfunctions_function" "function" {
   source_archive_bucket = google_storage_bucket.bucket.name
   source_archive_object = google_storage_bucket_object.archive.name
   trigger_http          = true
+  security_level        = "SECURE_OPTIONAL"
   runtime               = "nodejs10"
   timeout               = 91
   entry_point           = "helloGET"
@@ -808,8 +814,9 @@ resource "google_cloudfunctions_function" "function" {
     url = "https://source.developers.google.com/projects/%s/repos/cloudfunctions-test-do-not-delete/moveable-aliases/master/paths/"
   }
 
-  trigger_http = true
-  entry_point  = "helloGET"
+  trigger_http   = true
+  security_level = "SECURE_OPTIONAL"
+  entry_point    = "helloGET"
 }
 `, functionName, project)
 }
@@ -838,8 +845,9 @@ resource "google_cloudfunctions_function" "function" {
 
   service_account_email = data.google_compute_default_service_account.default.email
 
-  trigger_http = true
-  entry_point  = "helloGET"
+  trigger_http   = true
+  security_level = "SECURE_OPTIONAL"
+  entry_point    = "helloGET"
 }
 `, bucketName, zipFilePath, functionName)
 }

--- a/mmv1/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/cloudfunctions_function.html.markdown
@@ -125,6 +125,8 @@ Eg. `"nodejs10"`, `"nodejs12"`, `"nodejs14"`, `"python37"`, `"python38"`, `"pyth
 
 * `trigger_http` - (Optional) Boolean variable. Any HTTP request (of a supported type) to the endpoint will trigger function execution. Supported HTTP request types are: POST, PUT, GET, DELETE, and OPTIONS. Endpoint is returned as `https_trigger_url`. Cannot be used with `event_trigger`.
 
+* `security_level` - (Optional) String value that controls whether HTTP and HTTPS traffic is allowed or just HTTPS. Allowed values are `SECURE_OPTIONAL` and `SECURE_ALWAYS`. Only can be used when `trigger_http` is set.
+
 * `ingress_settings` - (Optional) String value that controls what traffic can reach the function. Allowed values are `ALLOW_ALL`, `ALLOW_INTERNAL_AND_GCLB` and `ALLOW_INTERNAL_ONLY`. Check [ingress documentation](https://cloud.google.com/functions/docs/networking/network-settings#ingress_settings) to see the impact of each settings value. Changes to this field will recreate the cloud function.
 
 * `labels` - (Optional) A set of key/value label pairs to assign to the function. Label keys must follow the requirements at https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements.


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Upstreams: https://github.com/hashicorp/terraform-provider-google/pull/9583

Upstreaming script didn't work as this refers to some .go.erb files

Need markdown docs on this, will ask contributor for them



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
cloudfunctions: added support for `security_level` for HTTP triggers on `google_cloudfunctions_function`
```
