### PR TITLE
Fixed alerting for tests that were not run on teamcity

### DIFF
--- a/.ci/containers/terraform-vcr-tester/run_vcr_tests.sh
+++ b/.ci/containers/terraform-vcr-tester/run_vcr_tests.sh
@@ -123,7 +123,7 @@ if [[ -n $MISSING_TESTS ]]; then
 	add_comment "${comment}" "${pr_number}"
 fi
 
-FAILED_TESTS=$(cat tests.json | jq -r '.testOccurrence | select(.status == "FAILURE") | map(.name) | join("|")')
+FAILED_TESTS=$(cat tests.json | jq -r '.testOccurrence | map(select(.status == "FAILURE")) | map(.name) | join("|")')
 ret=$?
 if [ $ret -ne 0 ]; then
 	echo "Job failed without failing tests"

--- a/.ci/containers/terraform-vcr-tester/run_vcr_tests.sh
+++ b/.ci/containers/terraform-vcr-tester/run_vcr_tests.sh
@@ -127,6 +127,7 @@ FAILED_TESTS=$(cat tests.json | jq -r '.testOccurrence | select(.status == "FAIL
 ret=$?
 if [ $ret -ne 0 ]; then
 	echo "Job failed without failing tests"
+	cat tests.json
 	update_status "${build_url}" "failure"
 	# exit 0 because this script didn't have an error; the failure
 	# is reported via the Github Status API


### PR DESCRIPTION
Resolved https://github.com/hashicorp/terraform-provider-google/issues/9586

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Corrected detection of unrun tests
    
- Added pagination support
- ignored skipped tests in the 'run' list
- fixed jq parsing
- detected non-test failures by checking test count instead of detecting failure to parse out test occurrences

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
