### PR TITLE
fix bug with sample generation

### DIFF
--- a/tpgtools/sample.go
+++ b/tpgtools/sample.go
@@ -247,7 +247,7 @@ func (s *Sample) EnumerateWithUpdateSamples() []Sample {
 		newSample.PrimaryResource = &primaryResource
 		if !newSample.isNativeHCL() {
 			var newDeps []Dependency
-			copy(newDeps, newSample.DependencyList)
+			newDeps = append(newDeps, newSample.DependencyList...)
 			newDeps[0] = newSample.generateSampleDependencyWithName(*newSample.PrimaryResource, "primary")
 			newSample.DependencyList = newDeps
 		}

--- a/tpgtools/sample.go
+++ b/tpgtools/sample.go
@@ -243,7 +243,8 @@ func (s *Sample) EnumerateWithUpdateSamples() []Sample {
 	out := []Sample{*s}
 	for i, update := range s.Updates {
 		newSample := *s
-		*newSample.PrimaryResource = update["resource"]
+		primaryResource := update["resource"]
+		newSample.PrimaryResource = &primaryResource
 		if !newSample.isNativeHCL() {
 			newSample.DependencyList[0] = newSample.generateSampleDependencyWithName(*newSample.PrimaryResource, "primary")
 		}

--- a/tpgtools/sample.go
+++ b/tpgtools/sample.go
@@ -246,7 +246,10 @@ func (s *Sample) EnumerateWithUpdateSamples() []Sample {
 		primaryResource := update["resource"]
 		newSample.PrimaryResource = &primaryResource
 		if !newSample.isNativeHCL() {
-			newSample.DependencyList[0] = newSample.generateSampleDependencyWithName(*newSample.PrimaryResource, "primary")
+			var newDeps []Dependency
+			copy(newDeps, newSample.DependencyList)
+			newDeps[0] = newSample.generateSampleDependencyWithName(*newSample.PrimaryResource, "primary")
+			newSample.DependencyList = newDeps
 		}
 		newSample.TestSlug = fmt.Sprintf("%sUpdate%v", newSample.TestSlug, i)
 		newSample.Updates = nil


### PR DESCRIPTION
Sample updates were improperly enumerating with the wrong values. This was because the previous samples pointer was being overwritten instead of initializing a new value. 

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
