### PR TITLE
change terminology up upstream-diff-to-release

### DIFF
--- a/mmv1/third_party/terraform/utils/provider_test.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test.go.erb
@@ -281,8 +281,8 @@ func vcrTest(t *testing.T, c resource.TestCase) {
 		providers := getTestAccProviders(t.Name())
 		c.Providers = providers
 		defer closeRecorder(t)
-	} else if isUpstreamDiffEnabled() {
-		c = initializeUpstreamDiffTest(c)
+	} else if isDownstreamDiffEnabled() {
+		c = initializeDownstreamDiffTest(c)
 	}
 	resource.Test(t, c)
 }
@@ -957,25 +957,25 @@ func sleepInSecondsForTest(t int) resource.TestCheckFunc {
 	}
 }
 
-func isUpstreamDiffEnabled() bool {
-	upstreamDiff := os.Getenv("UPSTREAM_DIFF")
-	return upstreamDiff != ""
+func isDownstreamDiffEnabled() bool {
+	downstreamDiff := os.Getenv("DOWNSTREAM_DIFF")
+	return downstreamDiff != ""
 }
 
-func initializeUpstreamDiffTest(c resource.TestCase) resource.TestCase {
-	var upstreamProvider string
+func initializeDownstreamDiffTest(c resource.TestCase) resource.TestCase {
+	var downstreamProvider string
 	packagePath := fmt.Sprint(reflect.TypeOf(Config{}).PkgPath())
 	if strings.Contains(packagePath, "google-beta") {
-		upstreamProvider = "google-beta"
+		downstreamProvider = "google-beta"
 	} else {
-		upstreamProvider = "google"
+		downstreamProvider = "google"
 	}
 
 	if c.ExternalProviders != nil {
-		c.ExternalProviders[upstreamProvider] = resource.ExternalProvider{}
+		c.ExternalProviders[downstreamProvider] = resource.ExternalProvider{}
 	} else {
 		c.ExternalProviders = map[string]resource.ExternalProvider{
-			upstreamProvider: {},
+			downstreamProvider: {},
 		}
 	}
 
@@ -993,7 +993,7 @@ func initializeUpstreamDiffTest(c resource.TestCase) resource.TestCase {
 			replacementSteps = append(replacementSteps, teststep)
 			if teststep.ExpectError == nil && teststep.PlanOnly == false {
 				newStep := resource.TestStep{
-					Config:   reformConfigWithProvider(ogConfig, upstreamProvider),
+					Config:   reformConfigWithProvider(ogConfig, downstreamProvider),
 					PlanOnly: true,
 				}
 				replacementSteps = append(replacementSteps, newStep)

--- a/mmv1/third_party/terraform/utils/provider_test.go.erb
+++ b/mmv1/third_party/terraform/utils/provider_test.go.erb
@@ -281,8 +281,8 @@ func vcrTest(t *testing.T, c resource.TestCase) {
 		providers := getTestAccProviders(t.Name())
 		c.Providers = providers
 		defer closeRecorder(t)
-	} else if isDownstreamDiffEnabled() {
-		c = initializeDownstreamDiffTest(c)
+	} else if isReleaseDiffEnabled() {
+		c = initializeReleaseDiffTest(c)
 	}
 	resource.Test(t, c)
 }
@@ -957,25 +957,25 @@ func sleepInSecondsForTest(t int) resource.TestCheckFunc {
 	}
 }
 
-func isDownstreamDiffEnabled() bool {
-	downstreamDiff := os.Getenv("DOWNSTREAM_DIFF")
-	return downstreamDiff != ""
+func isReleaseDiffEnabled() bool {
+	releaseDiff := os.Getenv("RELEASE_DIFF")
+	return releaseDiff != ""
 }
 
-func initializeDownstreamDiffTest(c resource.TestCase) resource.TestCase {
-	var downstreamProvider string
+func initializeReleaseDiffTest(c resource.TestCase) resource.TestCase {
+	var releaseProvider string
 	packagePath := fmt.Sprint(reflect.TypeOf(Config{}).PkgPath())
 	if strings.Contains(packagePath, "google-beta") {
-		downstreamProvider = "google-beta"
+		releaseProvider = "google-beta"
 	} else {
-		downstreamProvider = "google"
+		releaseProvider = "google"
 	}
 
 	if c.ExternalProviders != nil {
-		c.ExternalProviders[downstreamProvider] = resource.ExternalProvider{}
+		c.ExternalProviders[releaseProvider] = resource.ExternalProvider{}
 	} else {
 		c.ExternalProviders = map[string]resource.ExternalProvider{
-			downstreamProvider: {},
+			releaseProvider: {},
 		}
 	}
 
@@ -993,7 +993,7 @@ func initializeDownstreamDiffTest(c resource.TestCase) resource.TestCase {
 			replacementSteps = append(replacementSteps, teststep)
 			if teststep.ExpectError == nil && teststep.PlanOnly == false {
 				newStep := resource.TestStep{
-					Config:   reformConfigWithProvider(ogConfig, downstreamProvider),
+					Config:   reformConfigWithProvider(ogConfig, releaseProvider),
 					PlanOnly: true,
 				}
 				replacementSteps = append(replacementSteps, newStep)


### PR DESCRIPTION
upstream diff makes less sense in light of the functionality. Changing this in accordance with 
https://github.com/hashicorp/terraform-provider-google/pull/9798


**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
