### PR TITLE
Send billing_project for every request when set

### DIFF
--- a/mmv1/third_party/terraform/utils/config.go.erb
+++ b/mmv1/third_party/terraform/utils/config.go.erb
@@ -210,6 +210,7 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
 	// Userinfo is fetched before request logging is enabled to reduce additional noise.
 	err = c.logGoogleIdentities()
 	if err != nil {
@@ -230,6 +231,12 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 	headerTransport := newTransportWithHeaders(retryTransport)
 	if c.RequestReason != "" {
 		headerTransport.Set("X-Goog-Request-Reason", c.RequestReason)
+	}
+
+	// Ensure $userProject is set for all HTTP requests using the client if specified by the provider config
+	// See https://cloud.google.com/apis/docs/system-parameters
+	if c.UserProjectOverride && c.BillingProject != "" {
+		headers.Set("X-Goog-User-Project", c.BillingProject)
 	}
 
 	// Set final transport value.

--- a/mmv1/third_party/terraform/utils/config.go.erb
+++ b/mmv1/third_party/terraform/utils/config.go.erb
@@ -36,7 +36,6 @@ import (
 	"google.golang.org/api/cloudresourcemanager/v1"
 	resourceManagerV2 "google.golang.org/api/cloudresourcemanager/v2"
 	composer "google.golang.org/api/composer/v1beta1"
-	"google.golang.org/api/composer/v1beta1"
 	computeBeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/container/v1"

--- a/mmv1/third_party/terraform/utils/config.go.erb
+++ b/mmv1/third_party/terraform/utils/config.go.erb
@@ -235,7 +235,7 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 	// Ensure $userProject is set for all HTTP requests using the client if specified by the provider config
 	// See https://cloud.google.com/apis/docs/system-parameters
 	if c.UserProjectOverride && c.BillingProject != "" {
-		headers.Set("X-Goog-User-Project", c.BillingProject)
+		headerTransport.Set("X-Goog-User-Project", c.BillingProject)
 	}
 
 	// Set final transport value.

--- a/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
@@ -121,15 +121,18 @@ authenticate HTTP requests to GCP APIs. This is an alternative to `credentials`,
 and ignores the `scopes` field. If both are specified, `access_token` will be
 used over the `credentials` field.
 
-* `user_project_override` - (Optional) Defaults to false. If true, uses the
-resource project for preconditions, quota, and billing, instead of the project
-the credentials belong to. Not all resources support this- see the
-documentation for each resource to learn whether it does.
+* `user_project_override` - (Optional) Defaults to `false`. Controls the quota
+project used in requests to GCP APIs for the purpose of preconditions, quota,
+and billing. If `false`, the quota project is determined by the API and may be
+the project associated with your credentials, or the resource project. If `true`,
+most resources in the provider will explicitly supply their resource project, as
+described in their documentation. Otherwise, a `billing_project` value must be
+supplied.
 
-* `billing_project` - (Optional) This fields specifies a project that's used for
-preconditions, quota, and billing for requests. All resources that support user project
-overrides will use this project instead of the resource's project (if available). This
-field is ignored if `user_project_override` is set to false or unset.
+* `billing_project` - (Optional) A quota project to send in `user_project_override`,
+used for all requests sent from the provider. If set on a resource that supports
+sending the resource project, this value will supersede the resource project.
+This field is ignored if `user_project_override` is set to false or unset.
 
 * `{{service}}_custom_endpoint` - (Optional) The endpoint for a service's APIs,
 such as `compute_custom_endpoint`. Defaults to the production GCP endpoint for
@@ -209,13 +212,6 @@ following ordered by precedence.
     * GOOGLE_CLOUD_PROJECT
     * GCLOUD_PROJECT
     * CLOUDSDK_CORE_PROJECT
-
----
-
-* `billing_project` - (Optional) This fields allows Terraform to set X-Goog-User-Project
-for APIs that require a billing project to be specified like Access Context Manager APIs if
-User ADCs are being used. This can also be
-specified using the `GOOGLE_BILLING_PROJECT` environment variable.
 
 ---
 
@@ -450,18 +446,30 @@ to create the resource.  This may help in those cases.
 
 ---
 
-* `user_project_override` - (Optional) Defaults to false. If true, uses the
-resource project for preconditions, quota, and billing, instead of the project
-the credentials belong to. Not all resources support this- see the
-documentation for each resource to learn whether it does. Alternatively, this can
-be specified using the `USER_PROJECT_OVERRIDE` environment variable.
+* `user_project_override` - (Optional) Defaults to `false`. Controls the quota
+project used in requests to GCP APIs for the purpose of preconditions, quota,
+and billing. If `false`, the quota project is determined by the API and may be
+the project associated with your credentials, or the resource project. If `true`,
+most resources in the provider will explicitly supply their resource project, as
+described in their documentation. Otherwise, a `billing_project` value must be
+supplied. Alternatively, this can be specified using the `USER_PROJECT_OVERRIDE`
+environment variable.
 
-When set to false, the project the credentials belong to will be billed for the
-request, and quota / API enablement checks will be done against that project.
-For service account credentials, this is the project the service account was
-created in. For credentials that come from the gcloud tool, this is a project
-owned by Google. In order to properly use credentials that come from gcloud
-with Terraform, it is recommended to set this property to true.
+Service account credentials are associated with the project the service account
+was created in. Credentials that come from the gcloud tool are associated with a
+project owned by Google. In order to properly use credentials that come from
+gcloud with Terraform, it is recommended to set this property to true.
 
-When set to true, the caller must have `serviceusage.services.use` permission
-on the resource project.
+`user_project_override` uses the `X-Goog-User-Project`
+[system parameter](https://cloud.google.com/apis/docs/system-parameters). When
+set to true, the caller must have `serviceusage.services.use` permission on the
+resource project.
+
+---
+
+* `billing_project` - (Optional) A quota project to send in `user_project_override`,
+used for all requests sent from the provider. If set on a resource that supports
+sending the resource project, this value will supersede the resource project.
+This field is ignored if `user_project_override` is set to false or unset.
+Alternatively, this can be specified using the `GOOGLE_BILLING_PROJECT`
+environment variable.

--- a/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/provider_reference.html.markdown
@@ -463,7 +463,7 @@ gcloud with Terraform, it is recommended to set this property to true.
 `user_project_override` uses the `X-Goog-User-Project`
 [system parameter](https://cloud.google.com/apis/docs/system-parameters). When
 set to true, the caller must have `serviceusage.services.use` permission on the
-resource project.
+quota project.
 
 ---
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Upstream of https://github.com/hashicorp/terraform-provider-google/pull/9636, making up for some churn in headers since then and fixing up some documentation that's become fairly stale

This means that more resources will send the project override header, requiring additional permissions on the quota project. I believe that's fine, and safe- the only way a user could run into issues is if they've enabled `user_project_override`, defined a `billing_project`, are using no resources that already supported a billing project (all MMv1 resources, 70%+ of total), and have not granted the appropriate permission to their credentials.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
provider: added support for `billing_project` across all resources. If `user_project_override` is set to `true` and a `billing_project` is set, the `X-Goog-User-Project` header will be sent for all resources.
```
