### PR TITLE
Add terraform verb to request header

### DIFF
--- a/mmv1/third_party/terraform/utils/config.go.erb
+++ b/mmv1/third_party/terraform/utils/config.go.erb
@@ -17,7 +17,8 @@ import (
 	"golang.org/x/oauth2"
 	googleoauth "golang.org/x/oauth2/google"
 	"golang.org/x/oauth2/jwt"
-	appengine "google.golang.org/api/appengine/v1"
+        appengine "google.golang.org/api/appengine/v1"
+        gops "github.com/shirou/gopsutil/process"
 <% unless version == 'ga' -%>
 	"google.golang.org/api/accesscontextmanager/v1beta"
 <% end -%>
@@ -228,8 +229,40 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 	// 4. Header Transport - outer wrapper to inject additional headers we want to apply
 	// before making requests
 	headerTransport := newTransportWithHeaders(retryTransport)
-	if c.RequestReason != "" {
-		headerTransport.Set("X-Goog-Request-Reason", c.RequestReason)
+        
+        // Retrieve the verb being used by terraform core (apply/plan/destroy/refresh)
+	// by fetching all processes on the OS and retrieving the process named "terraform".
+	// The verb is appended to the X-Goog-Request-Reason by default as long as a matching process
+	// is retrieved.
+	var verb string
+	processes, err := gops.Processes()
+	if err != nil {
+	  return err
+	}
+	for _, p := range processes {
+	  processName, err := p.Name()
+	  if err != nil {
+	    return err
+	  }
+	  if processName == "terraform" {
+	    log.Printf("[INFO] found terraform process")
+	    cmdLine, err := p.Cmdline()
+	    if err != nil {
+	      return err
+	    }
+	    cmdLineArr := strings.Split(cmdLine, " ")
+	    verb = cmdLineArr[len(cmdLineArr)-1]
+	    log.Printf("[INFO] verb: %v", verb)
+	    log.Printf("[INFO] process name: %v", processName)
+	  }
+        }
+
+        if c.RequestReason != "" {
+	  requestReason := fmt.Sprintf("%s - %s", verb, c.RequestReason)
+	  headerTransport.Set("X-Goog-Request-Reason", requestReason)
+	} else if verb != "" {
+	  requestReason := fmt.Sprintf("%s - %s", verb, "_")
+	  headerTransport.Set("X-Goog-Request-Reason", requestReason)
 	}
 
 	// Set final transport value.

--- a/mmv1/third_party/terraform/utils/config.go.erb
+++ b/mmv1/third_party/terraform/utils/config.go.erb
@@ -250,20 +250,18 @@ func (c *Config) LoadAndValidate(ctx context.Context) error {
 	    if err != nil {
 	      return err
 	    }
-	    cmdLineArr := strings.Split(cmdLine, " ")
-	    verb = cmdLineArr[len(cmdLineArr)-1]
-	    log.Printf("[INFO] verb: %v", verb)
-	    log.Printf("[INFO] process name: %v", processName)
+            
+            re := regexp.MustCompile(" plan| apply| refresh| import")
+            verb = re.FindString(cmdLine)
+            log.Printf("[DEBUG] cmdLine %v", cmdLine)
+            log.Printf("[DEBUG] verb: %v", verb)
+            log.Printf("[DEBUG] process name: %v", processName)
 	  }
         }
 
-        if c.RequestReason != "" {
-	  requestReason := fmt.Sprintf("%s - %s", verb, c.RequestReason)
-	  headerTransport.Set("X-Goog-Request-Reason", requestReason)
-	} else if verb != "" {
-	  requestReason := fmt.Sprintf("%s - %s", verb, "_")
-	  headerTransport.Set("X-Goog-Request-Reason", requestReason)
-	}
+        // Append verb to user agent
+        ua := c.userAgent
+        c.userAgent = fmt.Sprintf("%v - %v", ua, verb)
 
 	// Set final transport value.
 	client.Transport = headerTransport


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Context: b/182309601

This PR is to add verbs to X-Goog-Request-Reason header

Example output in TF logs

With request_reason set to "foo2"
```
---[ REQUEST ]---------------------------------------
GET /v1/projects/<project-id>/topics/my-topic2?alt=json HTTP/1.1
Host: pubsub.googleapis.com
User-Agent: Terraform/1.0.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.5.0 terraform-provider-google/dev
Content-Type: application/json
X-Goog-Request-Reason: apply - foo2
Accept-Encoding: gzip
```

With request_reason not set
```
---[ REQUEST ]---------------------------------------
GET /v1/projects/<project-id>/topics/my-topic2?alt=json HTTP/1.1
Host: pubsub.googleapis.com
User-Agent: Terraform/1.0.4 (+https://www.terraform.io) Terraform-Plugin-SDK/2.5.0 terraform-provider-google/dev
Content-Type: application/json
X-Goog-Request-Reason: apply - _
Accept-Encoding: gzip
```

Haven't gone through all the [X] will update this comment as I go through them



<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:REPLACEME

```
