### PR TITLE
Adding end-to-end example for L4 ILB

### DIFF
--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -740,11 +740,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           mig_template_name: "l4-ilb-mig-template"
           hc_name: "l4-ilb-hc"
           mig_name: "l4-ilb-mig1"
-<<<<<<< HEAD
           fw_allow_hc_name: "l4-ilb-fw-allow-hc"
-=======
-          fw_allow_iap_hc_name: "l4-ilb-fw-allow-hc"
->>>>>>> 8772b2f2bbff65581db9d192485a4c853cb3b9dd
           fw_allow_ilb_to_backends_name: "l4-ilb-fw-allow-ilb-to-backends"
           fw_allow_ilb_ssh_name: "l4-ilb-fw-ssh"
           vm_test_name: "l4-ilb-test-vm"

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -725,9 +725,29 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           mig_template_name: "l7-ilb-mig-template"
           hc_name: "l7-ilb-hc"
           mig_name: "l7-ilb-mig1"
-          fw-allow_iap_hc_name: "l7-ilb-fw-allow-iap-hc"
+          fw_allow_iap_hc_name: "l7-ilb-fw-allow-iap-hc"
           fw_allow_ilb_to_backends_name: "l7-ilb-fw-allow-ilb-to-backends"
           vm_test_name: "l7-ilb-test-vm"
+        min_version: beta
+      - !ruby/object:Provider::Terraform::Examples
+        name: "internal_tcp_udp_lb_with_mig_backend"
+        primary_resource_id: "google_compute_forwarding_rule"
+        vars:
+          ilb_network_name: "l4-ilb-network"
+          backend_subnet_name: "l4-ilb-subnet"
+          forwarding_rule_name: "l4-ilb-forwarding-rule"
+          backend_service_name: "l4-ilb-backend-subnet"
+          mig_template_name: "l4-ilb-mig-template"
+          hc_name: "l4-ilb-hc"
+          mig_name: "l4-ilb-mig1"
+<<<<<<< HEAD
+          fw_allow_hc_name: "l4-ilb-fw-allow-hc"
+=======
+          fw_allow_iap_hc_name: "l4-ilb-fw-allow-hc"
+>>>>>>> 8772b2f2bbff65581db9d192485a4c853cb3b9dd
+          fw_allow_ilb_to_backends_name: "l4-ilb-fw-allow-ilb-to-backends"
+          fw_allow_ilb_ssh_name: "l4-ilb-fw-ssh"
+          vm_test_name: "l4-ilb-test-vm"
         min_version: beta
       - !ruby/object:Provider::Terraform::Examples
         name: "forwarding_rule_externallb"

--- a/mmv1/templates/terraform/examples/internal_http_lb_with_mig_backend.tf.erb
+++ b/mmv1/templates/terraform/examples/internal_http_lb_with_mig_backend.tf.erb
@@ -148,7 +148,7 @@ resource "google_compute_region_instance_group_manager" "mig" {
 
 # allow all access from IAP and health check ranges
 resource "google_compute_firewall" "fw-iap" {
-  name          = "<%= ctx[:vars]['fw-allow_iap_hc_name'] %>"
+  name          = "<%= ctx[:vars]['fw_allow_iap_hc_name'] %>"
   provider      = google-beta
   direction     = "INGRESS"
   network       = google_compute_network.ilb_network.id

--- a/mmv1/templates/terraform/examples/internal_tcp_udp_lb_with_mig_backend.tf.erb
+++ b/mmv1/templates/terraform/examples/internal_tcp_udp_lb_with_mig_backend.tf.erb
@@ -118,11 +118,7 @@ resource "google_compute_region_instance_group_manager" "mig" {
 
 # allow all access from health check ranges
 resource "google_compute_firewall" "fw_hc" {
-<<<<<<< HEAD
   name          = "<%= ctx[:vars]['fw_allow_hc_name'] %>"
-=======
-  name          = "<%= ctx[:vars]['fw_allow_iap_hc_name'] %>"
->>>>>>> 8772b2f2bbff65581db9d192485a4c853cb3b9dd
   provider      = google-beta
   direction     = "INGRESS"
   network       = google_compute_network.ilb_network.id

--- a/mmv1/templates/terraform/examples/internal_tcp_udp_lb_with_mig_backend.tf.erb
+++ b/mmv1/templates/terraform/examples/internal_tcp_udp_lb_with_mig_backend.tf.erb
@@ -1,0 +1,183 @@
+# Internal TCP/UDP load balancer with a managed instance group backend
+
+# [START cloudloadbalancing_int_tcp_udp_gce]
+# VPC
+resource "google_compute_network" "ilb_network" {
+  name                    = "<%= ctx[:vars]['ilb_network_name'] %>"
+  provider                = google-beta
+  auto_create_subnetworks = false
+}
+
+# backed subnet
+resource "google_compute_subnetwork" "ilb_subnet" {
+  name          = "<%= ctx[:vars]['backend_subnet_name'] %>"
+  provider      = google-beta
+  ip_cidr_range = "10.0.1.0/24"
+  region        = "europe-west1"
+  network       = google_compute_network.ilb_network.id
+}
+
+# forwarding rule
+resource "google_compute_forwarding_rule" "<%= ctx[:primary_resource_id] %>" {
+  name                  = "<%= ctx[:vars]['forwarding_rule_name'] %>"
+  backend_service       = google_compute_region_backend_service.default.id
+  provider              = google-beta
+  region                = "europe-west1"
+  ip_protocol           = "TCP"
+  load_balancing_scheme = "INTERNAL"
+  all_ports             = true
+  allow_global_access   = true
+  network               = google_compute_network.ilb_network.id
+  subnetwork            = google_compute_subnetwork.ilb_subnet.id
+}
+
+# backend service
+resource "google_compute_region_backend_service" "default" {
+  name                  = "<%= ctx[:vars]['backend_service_name'] %>"
+  provider              = google-beta
+  region                = "europe-west1"
+  protocol              = "TCP"
+  load_balancing_scheme = "INTERNAL"
+  health_checks         = [google_compute_region_health_check.default.id]
+  backend {
+    group           = google_compute_region_instance_group_manager.mig.instance_group
+    balancing_mode  = "CONNECTION"
+  }
+}
+
+# instance template
+resource "google_compute_instance_template" "instance_template" {
+  name         = "<%= ctx[:vars]['mig_template_name'] %>"
+  provider     = google-beta
+  machine_type = "e2-small"
+  tags         = ["allow-ssh","allow-health-check"]
+
+  network_interface {
+    network    = google_compute_network.ilb_network.id
+    subnetwork = google_compute_subnetwork.ilb_subnet.id
+    access_config {
+      # add external ip to fetch packages
+    }
+  }
+  disk {
+    source_image = "debian-cloud/debian-10"
+    auto_delete  = true
+    boot         = true
+  }
+
+  # install nginx and serve a simple web page
+  metadata = {
+    startup-script = <<-EOF1
+      #! /bin/bash
+      set -euo pipefail
+
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update
+      apt-get install -y nginx-light jq
+
+      NAME=$(curl -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/hostname")
+      IP=$(curl -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip")
+      METADATA=$(curl -f -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/?recursive=True" | jq 'del(.["startup-script"])')
+
+      cat <<EOF > /var/www/html/index.html
+      <pre>
+      Name: $NAME
+      IP: $IP
+      Metadata: $METADATA
+      </pre>
+      EOF
+    EOF1
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# health check
+resource "google_compute_region_health_check" "default" {
+  name     = "<%= ctx[:vars]['hc_name'] %>"
+  provider = google-beta
+  region   = "europe-west1"
+  http_health_check {
+    port = "80"
+  }
+}
+
+# MIG
+resource "google_compute_region_instance_group_manager" "mig" {
+  name     = "<%= ctx[:vars]['mig_name'] %>"
+  provider = google-beta
+  region   = "europe-west1"
+  version {
+    instance_template = google_compute_instance_template.instance_template.id
+    name              = "primary"
+  }
+  base_instance_name = "vm"
+  target_size        = 2
+}
+
+# allow all access from health check ranges
+resource "google_compute_firewall" "fw_hc" {
+<<<<<<< HEAD
+  name          = "<%= ctx[:vars]['fw_allow_hc_name'] %>"
+=======
+  name          = "<%= ctx[:vars]['fw_allow_iap_hc_name'] %>"
+>>>>>>> 8772b2f2bbff65581db9d192485a4c853cb3b9dd
+  provider      = google-beta
+  direction     = "INGRESS"
+  network       = google_compute_network.ilb_network.id
+  source_ranges = ["130.211.0.0/22", "35.191.0.0/16", "35.235.240.0/20"]
+  allow {
+    protocol = "tcp"
+  }
+  source_tags = ["allow-health-check"]
+}
+
+# allow communication within the subnet 
+resource "google_compute_firewall" "fw_ilb_to_backends" {
+  name          = "<%= ctx[:vars]['fw_allow_ilb_to_backends_name'] %>"
+  provider      = google-beta
+  direction     = "INGRESS"
+  network       = google_compute_network.ilb_network.id
+  source_ranges = ["10.0.1.0/24"]
+  allow {
+    protocol = "tcp"
+  }
+  allow {
+    protocol = "udp"
+  }
+  allow {
+    protocol = "icmp"
+  }
+}
+
+# allow SSH
+resource "google_compute_firewall" "fw_ilb_ssh" {
+  name          = "<%= ctx[:vars]['fw_allow_ilb_ssh_name'] %>"
+  provider      = google-beta
+  direction     = "INGRESS"
+  network       = google_compute_network.ilb_network.id
+  allow {
+    protocol = "tcp"
+    ports = ["22"]
+  }
+  source_tags = ["allow-ssh"]
+}
+
+# test instance
+resource "google_compute_instance" "vm_test" {
+  name         = "<%= ctx[:vars]['vm_test_name'] %>"
+  provider     = google-beta
+  zone         = "europe-west1-b"
+  machine_type = "e2-small"
+  network_interface {
+    network    = google_compute_network.ilb_network.id
+    subnetwork = google_compute_subnetwork.ilb_subnet.id
+  }
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-10"
+    }
+  }
+}
+# [END cloudloadbalancing_int_tcp_udp_gce]


### PR DESCRIPTION
This example creates an internal TCP/UDP load balancer with a Compute Engine backend. The backend is created via managed instance group. 

The intention is to publish this example on this page:

https://cloud.devsite.corp.google.com/load-balancing/docs/internal/int-tcp-udp-lb-tf-module-examples

```release-note:none
```

