### PR TITLE
Added primary resource ID to VPN example

### DIFF
--- a/mmv1/templates/terraform/examples/ha_vpn_gateway_gcp_to_gcp.tf.erb
+++ b/mmv1/templates/terraform/examples/ha_vpn_gateway_gcp_to_gcp.tf.erb
@@ -1,4 +1,4 @@
-resource "google_compute_ha_vpn_gateway" "ha_gateway1" {
+resource "google_compute_ha_vpn_gateway" "<%= ctx[:primary_resource_id] %>" {
   region   = "us-central1"
   name     = "<%= ctx[:vars]['ha_vpn_gateway1_name'] %>"
   network  = google_compute_network.network1.id


### PR DESCRIPTION
The intention is to publish this example on a new standaone page in the [VPNs](https://cloud.google.com/network-connectivity/docs/vpn/how-to/creating-ha-vpn2) guide.

The new page will be similar to this page:

https://cloud.google.com/load-balancing/docs/internal/int-tcp-udp-lb-tf-module-examples

```release-note:none
```

