### PR TITLE
Add IAP support to `compute_region_backend_service`

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -2320,6 +2320,28 @@ objects:
         name: 'id'
         description: 'The unique identifier for the resource.'
         output: true
+      - !ruby/object:Api::Type::NestedObject
+        name: 'iap'
+        description: Settings for enabling Cloud Identity Aware Proxy
+        properties:
+          - !ruby/object:Api::Type::Boolean
+            name: 'enabled'
+            description: Enables IAP.
+          - !ruby/object:Api::Type::String
+            name: 'oauth2ClientId'
+            required: true
+            description: |
+              OAuth2 Client ID for IAP
+          - !ruby/object:Api::Type::String
+            name: 'oauth2ClientSecret'
+            required: true
+            description: |
+              OAuth2 Client Secret for IAP
+          - !ruby/object:Api::Type::String
+            name: 'oauth2ClientSecretSha256'
+            output: true
+            description: |
+              OAuth2 Client Secret SHA-256 for IAP
       - !ruby/object:Api::Type::Enum
         name: 'loadBalancingScheme'
         input: true

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -425,6 +425,18 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         custom_flatten: templates/terraform/custom_flatten/guard_self_link_array.go.erb
       id: !ruby/object:Overrides::Terraform::PropertyOverride
         exclude: true
+      iap: !ruby/object:Overrides::Terraform::PropertyOverride
+        send_empty_value: true
+      iap.enabled: !ruby/object:Overrides::Terraform::PropertyOverride
+        exclude: true
+      iap.oauth2ClientSecret: !ruby/object:Overrides::Terraform::PropertyOverride
+        send_empty_value: true
+        # We don't support ignore_read on nested fields
+        ignore_read: true
+        sensitive: true
+        custom_flatten: templates/terraform/custom_flatten/compute_backend_service_iap_oauth2_client_secret.go.erb
+      iap.oauth2ClientSecretSha256: !ruby/object:Overrides::Terraform::PropertyOverride
+        sensitive: true
       protocol: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
       portName: !ruby/object:Overrides::Terraform::PropertyOverride

--- a/mmv1/templates/terraform/decoders/region_backend_service.go.erb
+++ b/mmv1/templates/terraform/decoders/region_backend_service.go.erb
@@ -12,6 +12,18 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
+// We need to pretend IAP isn't there if it's disabled for Terraform to maintain
+// BC behaviour with the handwritten resource.
+v, ok :=  res["iap"]
+if !ok || v == nil {
+	delete(res, "iap")
+	return res, nil
+}
+m := v.(map[string]interface{})
+if ok && m["enabled"] == false {
+	delete(res, "iap")
+}
+
 // Requests with consistentHash will error for specific values of
 // localityLbPolicy. However, the API will not remove it if the backend
 // service is updated to from supporting to non-supporting localityLbPolicy

--- a/mmv1/templates/terraform/encoders/region_backend_service.go.erb
+++ b/mmv1/templates/terraform/encoders/region_backend_service.go.erb
@@ -12,6 +12,26 @@
 	# See the License for the specific language governing permissions and
 	# limitations under the License.
 -%>
+// The RegionBackendService API's Update / PUT API is badly formed and behaves like
+// a PATCH field for at least IAP. When sent a `null` `iap` field, the API
+// doesn't disable an existing field. To work around this, we need to emulate
+// the old Terraform behaviour of always sending the block (at both update and
+// create), and force sending each subfield as empty when the block isn't
+// present in config.
+
+iapVal := obj["iap"]
+if iapVal == nil {
+	data := map[string]interface{}{}
+	data["enabled"] = false
+	data["oauth2ClientId"] = ""
+	data["oauth2ClientSecret"] = ""
+	obj["iap"] = data
+} else {
+	iap := iapVal.(map[string]interface{})
+	iap["enabled"] = true
+	obj["iap"] = iap
+}
+
 if d.Get("load_balancing_scheme").(string) == "INTERNAL_MANAGED" {
 	return obj, nil
 }

--- a/mmv1/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_region_backend_service_test.go.erb
@@ -239,6 +239,36 @@ func TestAccComputeRegionBackendService_ilbUpdateFull(t *testing.T) {
 }
 <% end -%>
 
+func TestAccComputeRegionBackendService_withBackendAndIAP(t *testing.T) {
+	backendName := fmt.Sprintf("foo-%s", randString(t, 10))
+	checkName := fmt.Sprintf("bar-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeRegionBackendServiceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeRegionBackendService_ilbBasicwithIAP(backendName, checkName),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+        ImportStateVerifyIgnore: []string{"iap.0.oauth2_client_secret"},
+			},
+			{
+				Config: testAccComputeRegionBackendService_ilbBasic(backendName, checkName),
+			},
+			{
+				ResourceName:      "google_compute_region_backend_service.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccComputeRegionBackendService_ilbBasic(serviceName, checkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_region_backend_service" "foobar" {
@@ -964,4 +994,44 @@ resource "google_compute_health_check" "zero" {
   }
 }
 `, serviceName, drainingTimeout, checkName)
+}
+
+func testAccComputeRegionBackendService_ilbBasicwithIAP(serviceName, checkName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_region_backend_service" "foobar" {
+  name                  = "%s"
+  health_checks         = [google_compute_health_check.health_check.self_link]
+  port_name             = "http"
+  protocol              = "HTTP"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  locality_lb_policy    = "RING_HASH"
+  circuit_breakers {
+    max_connections = 10
+  }
+  consistent_hash {
+    http_cookie {
+      ttl {
+        seconds = 11
+        nanos   = 1234
+      }
+      name = "mycookie"
+    }
+  }
+  outlier_detection {
+    consecutive_errors = 2
+  }
+
+  iap {
+    oauth2_client_id     = "test"
+    oauth2_client_secret = "test"
+  }
+}
+
+resource "google_compute_health_check" "health_check" {
+  name     = "%s"
+  http_health_check {
+    port = 80
+  }
+}
+`, serviceName, checkName)
 }


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform-provider-google/issues/9279

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `iap` fields to `google_compute_region_backend_service`
```
