### PR TITLE
Add certificate template field to privateca Certificate

### DIFF
--- a/mmv1/products/privateca/api.yaml
+++ b/mmv1/products/privateca/api.yaml
@@ -891,6 +891,17 @@ objects:
           Output only. The time at which this CertificateAuthority was updated.
           This is in RFC3339 text format.
         output: true
+        # Note: would be a resourceref, except that CertificateTemplate is in the DCL
+        # and we don't have references across mmv1-dcl bridge yet.
+      - !ruby/object:Api::Type::String
+        name: 'certificateTemplate'
+        input: true
+        description: |
+          The resource name for a CertificateTemplate used to issue this certificate,
+          in the format `projects/*/locations/*/certificateTemplates/*`. If this is specified,
+          the caller must have the necessary permission to use this template. If this is
+          omitted, no template will be used. This template must be in the same location
+          as the Certificate.
       - !ruby/object:Api::Type::KeyValuePairs
         name: 'labels'
         description: |

--- a/mmv1/products/privateca/terraform.yaml
+++ b/mmv1/products/privateca/terraform.yaml
@@ -81,6 +81,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
     properties:
       config.x509Config: !ruby/object:Overrides::Terraform::PropertyOverride
         custom_flatten: 'templates/terraform/custom_flatten/privateca_certificate_509_config.go.erb'
+      certificateTemplate: !ruby/object:Overrides::Terraform::PropertyOverride
+        diff_suppress_func: 'compareSelfLinkOrResourceName'
     examples:
       - !ruby/object:Provider::Terraform::Examples
         name: "privateca_certificate_config"
@@ -88,6 +90,17 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           certificate_authority_id: "my-certificate-authority" 
           certificate_name: "my-certificate"
+        test_env_vars:
+          project: :PROJECT_NAME
+        test_vars_overrides:
+          pool: "\"static-ca-pool\""
+      - !ruby/object:Provider::Terraform::Examples
+        name: "privateca_certificate_with_template"
+        primary_resource_id: "default"
+        vars:
+          certificate_name: "my-certificate"
+          certificate_authority_id: "my-certificate-authority"
+          certificate_template_name: "my-certificate-template"
         test_env_vars:
           project: :PROJECT_NAME
         test_vars_overrides:

--- a/mmv1/templates/terraform/examples/privateca_certificate_with_template.tf.erb
+++ b/mmv1/templates/terraform/examples/privateca_certificate_with_template.tf.erb
@@ -1,0 +1,121 @@
+resource "google_privateca_certificate_template" "template" {
+  location    = "us-central1"
+  name = "<%= ctx[:vars]["certificate_template_name"] %>"
+  description = "An updated sample certificate template"
+
+  identity_constraints {
+    allow_subject_alt_names_passthrough = true
+    allow_subject_passthrough           = true
+
+    cel_expression {
+      description = "Always true"
+      expression  = "true"
+      location    = "any.file.anywhere"
+      title       = "Sample expression"
+    }
+  }
+
+  passthrough_extensions {
+    additional_extensions {
+      object_id_path = [1, 6]
+    }
+
+    known_extensions = ["EXTENDED_KEY_USAGE"]
+  }
+
+  predefined_values {
+    additional_extensions {
+      object_id {
+        object_id_path = [1, 6]
+      }
+
+      value    = "c3RyaW5nCg=="
+      critical = true
+    }
+
+    aia_ocsp_servers = ["string"]
+
+    ca_options {
+      is_ca                  = false
+      max_issuer_path_length = 6
+    }
+
+    key_usage {
+      base_key_usage {
+        cert_sign          = false
+        content_commitment = true
+        crl_sign           = false
+        data_encipherment  = true
+        decipher_only      = true
+        digital_signature  = true
+        encipher_only      = true
+        key_agreement      = true
+        key_encipherment   = true
+      }
+
+      extended_key_usage {
+        client_auth      = true
+        code_signing     = true
+        email_protection = true
+        ocsp_signing     = true
+        server_auth      = true
+        time_stamping    = true
+      }
+
+      unknown_extended_key_usages {
+        object_id_path = [1, 6]
+      }
+    }
+
+    policy_ids {
+      object_id_path = [1, 6]
+    }
+  }
+}
+
+resource "google_privateca_certificate_authority" "test-ca" {
+  pool = "<%= ctx[:vars]["pool"] %>"
+  certificate_authority_id = "<%= ctx[:vars]["certificate_authority_id"] %>"
+  location = "us-central1"
+  config {
+    subject_config {
+      subject {
+        organization = "HashiCorp"
+        common_name = "my-certificate-authority"
+      }
+      subject_alt_name {
+        dns_names = ["hashicorp.com"]
+      }
+    }
+    x509_config {
+      ca_options {
+        # is_ca *MUST* be true for certificate authorities
+        is_ca = true
+      }
+      key_usage {
+        base_key_usage {
+          # cert_sign and crl_sign *MUST* be true for certificate authorities
+          cert_sign = true
+          crl_sign = true
+        }
+        extended_key_usage {
+          server_auth = false
+        }
+      }
+    }
+  }
+  key_spec {
+    algorithm = "RSA_PKCS1_4096_SHA256"
+  }
+}
+
+
+resource "google_privateca_certificate" "<%= ctx[:primary_resource_id] %>" {
+  pool = "<%= ctx[:vars]["pool"] %>"
+  location = "us-central1"
+  certificate_authority = google_privateca_certificate_authority.test-ca.certificate_authority_id
+  lifetime = "860s"
+  name = "<%= ctx[:vars]["certificate_name"] %>"
+  pem_csr = file("test-fixtures/rsa_csr.pem")
+  certificate_template = google_privateca_certificate_template.template.id
+}


### PR DESCRIPTION
Now that privateca certificate template is present in TF.

Also adds test - which will only successfully run in CI since it depends on a static CA pool.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


(note that tests will have to run on this PR overnight, since the privateca resources are hard to test and depend on a certificate pool that's set up statically).

Fixes https://github.com/hashicorp/terraform-provider-google/issues/9792.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
`privateca`: Added `certificate_template` to `google_privateca_certificate`.
```
