### PR TITLE
[DO NOT MERGE] Composer PUPI flag support (beta) (#9697)

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -393,6 +393,15 @@ func resourceComposerEnvironment() *schema.Resource {
 										ForceNew:    true,
 										Description: `The CIDR block from which IP range in tenant project will be reserved for Cloud SQL. Needs to be disjoint from web_server_ipv4_cidr_block.`,
 									},
+<% unless version == "ga" -%>
+									"enable_privately_used_public_ips": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Computed: true,
+										ForceNew: true,
+										Description: `When enabled, IPs from public (non-RFC1918) ranges can be used for ip_allocation_policy.cluster_ipv4_cidr_block and ip_allocation_policy.service_ipv4_cidr_block.`,
+									},
+<% end -%>
 								},
 							},
 						},
@@ -989,6 +998,9 @@ func flattenComposerEnvironmentConfigPrivateEnvironmentConfig(envCfg *composer.P
 	transformed["master_ipv4_cidr_block"] = envCfg.PrivateClusterConfig.MasterIpv4CidrBlock
 	transformed["cloud_sql_ipv4_cidr_block"] = envCfg.CloudSqlIpv4CidrBlock
 	transformed["web_server_ipv4_cidr_block"] = envCfg.WebServerIpv4CidrBlock
+<% unless version == "ga" -%>
+	transformed["enable_privately_used_public_ips"] = envCfg.EnablePrivatelyUsedPublicIps
+<% end -%>
 
 	return []interface{}{transformed}
 }
@@ -1005,7 +1017,7 @@ func flattenComposerEnvironmentConfigNodeConfig(nodeCfg *composer.NodeConfig) in
 	transformed["disk_size_gb"] = nodeCfg.DiskSizeGb
 	transformed["service_account"] = nodeCfg.ServiceAccount
 	transformed["oauth_scopes"] = flattenComposerEnvironmentConfigNodeConfigOauthScopes(nodeCfg.OauthScopes)
-<% unless version == "ga" -%>	
+<% unless version == "ga" -%>
 	transformed["max_pods_per_node"] = nodeCfg.MaxPodsPerNode
 <% end -%>
 	transformed["tags"] = flattenComposerEnvironmentConfigNodeConfigTags(nodeCfg.Tags)
@@ -1265,6 +1277,12 @@ func expandComposerEnvironmentConfigPrivateEnvironmentConfig(v interface{}, d *s
 		transformed.WebServerIpv4CidrBlock = v.(string)
 	}
 
+<% unless version == "ga" -%>
+	if v, ok := original["enable_privately_used_public_ips"]; ok {
+		transformed.EnablePrivatelyUsedPublicIps = v.(bool)
+	}
+<% end -%>
+
 	transformed.PrivateClusterConfig = subBlock
 
 	return transformed, nil
@@ -1291,7 +1309,7 @@ func expandComposerEnvironmentConfigNodeConfig(v interface{}, d *schema.Resource
 		transformed.ServiceAccount = transformedServiceAccount
 	}
 
-<% unless version == "ga" -%>	
+<% unless version == "ga" -%>
 	if transformedMaxPodsPerNode, ok := original["max_pods_per_node"]; ok {
 		transformed.MaxPodsPerNode = int64(transformedMaxPodsPerNode.(int))
 	}

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -133,7 +133,7 @@ func TestAccComposerEnvironment_update(t *testing.T) {
 	})
 }
 
-// Checks environment creation with minimum required information.
+// Checks private environment creation.
 func TestAccComposerEnvironment_private(t *testing.T) {
 	t.Parallel()
 
@@ -575,7 +575,10 @@ resource "google_composer_environment" "test" {
 		}
 		private_environment_config {
 			enable_private_endpoint = true
-		}
+<% unless version == "ga" -%>
+			enable_privately_used_public_ips = true
+<% end -%>
+	}
 	}
 }
 

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -338,6 +338,11 @@ See [documentation](https://cloud.google.com/composer/docs/how-to/managing/confi
   (Optional)
   The CIDR block from which IP range for web server will be reserved. Needs to be disjoint from `master_ipv4_cidr_block` and `cloud_sql_ipv4_cidr_block`.
 
+* `enable_privately_used_public_ips` -
+  (Optional, [Beta](https://terraform.io/docs/providers/google/guides/provider_versions.html))
+  When enabled, IPs from public (non-RFC1918) ranges can be used for 
+  `IPAllocationPolicy.cluster_ipv4_cidr_block` and `IPAllocationPolicy.service_ipv4_cidr_block`.
+
 The `web_server_network_access_control` supports:
 
 * `allowed_ip_range` -


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add enable_privately_used_public_ips to google_composer_environment (beta)

fixes hashicorp/terraform-provider-google#9697

Do not merge until Composer experiment is fully ramped up.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
composer: added field `enable_privately_used_public_ips` to resource `google_composer_environment` (beta)
```
