### PR TITLE
Add import-only to KMS key

### DIFF
--- a/mmv1/products/kms/api.yaml
+++ b/mmv1/products/kms/api.yaml
@@ -154,6 +154,11 @@ objects:
         description: |
           The period of time that versions of this key spend in the DESTROY_SCHEDULED state before transitioning to DESTROYED.
           If not specified at creation time, the default duration is 24 hours.
+      - !ruby/object:Api::Type::Boolean
+        name: 'importOnly'
+        input: true
+        description: |
+          Whether this key may contain imported versions only.
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Creating a key':

--- a/mmv1/products/kms/terraform.yaml
+++ b/mmv1/products/kms/terraform.yaml
@@ -97,6 +97,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         exclude: true
       destroyScheduledDuration: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      importOnly: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       custom_delete: templates/terraform/custom_delete/kms_crypto_key.erb
       custom_import: templates/terraform/custom_import/kms_crypto_key.go.erb

--- a/mmv1/third_party/terraform/tests/resource_kms_crypto_key_test.go
+++ b/mmv1/third_party/terraform/tests/resource_kms_crypto_key_test.go
@@ -630,6 +630,7 @@ resource "google_kms_crypto_key" "crypto_key" {
   labels = {
     key = "value"
   }
+  skip_initial_version_creation = true
   import_only = true
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)

--- a/mmv1/third_party/terraform/tests/resource_kms_crypto_key_test.go
+++ b/mmv1/third_party/terraform/tests/resource_kms_crypto_key_test.go
@@ -353,9 +353,10 @@ func TestAccKmsCryptoKey_importOnly(t *testing.T) {
 				Config: testGoogleKmsCryptoKey_importOnly(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
 			},
 			{
-				ResourceName:      "google_kms_crypto_key.crypto_key",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_kms_crypto_key.crypto_key",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"skip_initial_version_creation"},
 			},
 			// Use a separate TestStep rather than a CheckDestroy because we need the project to still exist.
 			{

--- a/mmv1/third_party/terraform/tests/resource_kms_crypto_key_test.go
+++ b/mmv1/third_party/terraform/tests/resource_kms_crypto_key_test.go
@@ -335,6 +335,41 @@ func TestAccKmsCryptoKey_destroyDuration(t *testing.T) {
 	})
 }
 
+func TestAccKmsCryptoKey_importOnly(t *testing.T) {
+	t.Parallel()
+
+	projectId := fmt.Sprintf("tf-test-%d", randInt(t))
+	projectOrg := getTestOrgFromEnv(t)
+	location := getTestRegionFromEnv()
+	projectBillingAccount := getTestBillingAccountFromEnv(t)
+	keyRingName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+	cryptoKeyName := fmt.Sprintf("tf-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testGoogleKmsCryptoKey_importOnly(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName),
+			},
+			{
+				ResourceName:      "google_kms_crypto_key.crypto_key",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Use a separate TestStep rather than a CheckDestroy because we need the project to still exist.
+			{
+				Config: testGoogleKmsCryptoKey_removed(projectId, projectOrg, projectBillingAccount, keyRingName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleKmsCryptoKeyWasRemovedFromState("google_kms_crypto_key.crypto_key"),
+					testAccCheckGoogleKmsCryptoKeyVersionsDestroyed(t, projectId, location, keyRingName, cryptoKeyName),
+					testAccCheckGoogleKmsCryptoKeyRotationDisabled(t, projectId, location, keyRingName, cryptoKeyName),
+				),
+			},
+		},
+	})
+}
+
 // KMS KeyRings cannot be deleted. This ensures that the CryptoKey resource was removed from state,
 // even though the server-side resource was not removed.
 func testAccCheckGoogleKmsCryptoKeyWasRemovedFromState(resourceName string) resource.TestCheckFunc {
@@ -565,6 +600,37 @@ resource "google_kms_crypto_key" "crypto_key" {
     key = "value"
   }
   destroy_scheduled_duration = "129600s"
+}
+`, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
+}
+
+func testGoogleKmsCryptoKey_importOnly(projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+  name            = "%s"
+  project_id      = "%s"
+  org_id          = "%s"
+  billing_account = "%s"
+}
+
+resource "google_project_service" "acceptance" {
+  project = google_project.acceptance.project_id
+  service = "cloudkms.googleapis.com"
+}
+
+resource "google_kms_key_ring" "key_ring" {
+  project  = google_project_service.acceptance.project
+  name     = "%s"
+  location = "us-central1"
+}
+
+resource "google_kms_crypto_key" "crypto_key" {
+  name     = "%s"
+  key_ring = google_kms_key_ring.key_ring.self_link
+  labels = {
+    key = "value"
+  }
+  import_only = true
 }
 `, projectId, projectId, projectOrg, projectBillingAccount, keyRingName, cryptoKeyName)
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->
Similar to #5131, and probably also required for the same customer.
Apologies for the oversight.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
kms: added support for `import_only` to `google_kms_crypto_key`
```
