### PR TITLE
Add partition in `provider.go` resource declarations for tpgtool generated resources

### DIFF
--- a/mmv1/third_party/terraform/utils/provider.go.erb
+++ b/mmv1/third_party/terraform/utils/provider.go.erb
@@ -358,22 +358,15 @@ end     # products.each do
 -%>
 			},
 			map[string]*schema.Resource{
-				"google_assured_workloads_workload":            resourceAssuredWorkloadsWorkload(),
 				"google_app_engine_application":                resourceAppEngineApplication(),
 				"google_bigquery_table":                        resourceBigQueryTable(),
 				"google_bigtable_gc_policy":                    resourceBigtableGCPolicy(),
 				"google_bigtable_instance":                     resourceBigtableInstance(),
 				"google_bigtable_table":                        resourceBigtableTable(),
 				"google_billing_subaccount":                    resourceBillingSubaccount(),
-				<% unless version == 'ga' -%>
-				"google_cloudbuild_worker_pool":                resourceCloudbuildWorkerPool(),
-				<% end -%>
 				"google_cloudfunctions_function":               resourceCloudFunctionsFunction(),
 				"google_composer_environment":                  resourceComposerEnvironment(),
 				"google_compute_attached_disk":                 resourceComputeAttachedDisk(),
-				"google_compute_firewall_policy_association":   resourceComputeFirewallPolicyAssociation(),
-				"google_compute_firewall_policy":               resourceComputeFirewallPolicy(),
-				"google_compute_firewall_policy_rule":          resourceComputeFirewallPolicyRule(),
 				"google_compute_instance":                      resourceComputeInstance(),
 				<% unless version == 'ga' -%>
 				"google_compute_instance_from_machine_image":   resourceComputeInstanceFromMachineImage(),
@@ -401,16 +394,9 @@ end     # products.each do
 				<% end -%>
 				"google_dataproc_cluster":                      resourceDataprocCluster(),
 				"google_dataproc_job":                          resourceDataprocJob(),
-				"google_dataproc_workflow_template":            resourceDataprocWorkflowTemplate(),
 				"google_endpoints_service":                     resourceEndpointsService(),
-				"google_eventarc_trigger":                      resourceEventarcTrigger(),
 				"google_folder":                                resourceGoogleFolder(),
 				"google_folder_organization_policy":            resourceGoogleFolderOrganizationPolicy(),
-				"google_privateca_certificate_template":                        resourcePrivatecaCertificateTemplate(),
-				<% unless version == 'ga' -%>
-				"google_gke_hub_feature":                        resourceGkeHubFeature(),
-				"google_gke_hub_feature_membership":             resourceGkeHubFeatureMembership(),
-				<% end -%>
 				"google_logging_billing_account_sink":          resourceLoggingBillingAccountSink(),
 				"google_logging_billing_account_exclusion":     ResourceLoggingExclusion(BillingAccountLoggingExclusionSchema, NewBillingAccountLoggingExclusionUpdater, billingAccountLoggingExclusionIdParseFunc),
 				"google_logging_billing_account_bucket_config": ResourceLoggingBillingAccountBucketConfig(),
@@ -451,6 +437,24 @@ end     # products.each do
 				"google_storage_notification":                  resourceStorageNotification(),
 				"google_storage_transfer_job":                  resourceStorageTransferJob(),
 			},
+			// resources implemented within tpgtools
+			map[string]*schema.Resource{
+				"google_assured_workloads_workload":            resourceAssuredWorkloadsWorkload(),
+				<% unless version == 'ga' -%>
+				"google_cloudbuild_worker_pool":                resourceCloudbuildWorkerPool(),
+				<% end -%>
+				"google_compute_firewall_policy_association":   resourceComputeFirewallPolicyAssociation(),
+				"google_compute_firewall_policy":               resourceComputeFirewallPolicy(),
+				"google_compute_firewall_policy_rule":          resourceComputeFirewallPolicyRule(),
+				"google_dataproc_workflow_template":            resourceDataprocWorkflowTemplate(),
+				"google_eventarc_trigger":                      resourceEventarcTrigger(),
+				<% unless version == 'ga' -%>
+				"google_gke_hub_feature":                       resourceGkeHubFeature(),
+				"google_gke_hub_feature_membership":            resourceGkeHubFeatureMembership(),
+				<% end -%>
+				"google_privateca_certificate_template":        resourcePrivatecaCertificateTemplate(),
+			},
+			// ------------------------------------
 			map[string]*schema.Resource{
 				"google_bigtable_instance_iam_binding":         ResourceIamBinding(IamBigtableInstanceSchema, NewBigtableInstanceUpdater, BigtableInstanceIdParseFunc),
 				"google_bigtable_instance_iam_member":          ResourceIamMember(IamBigtableInstanceSchema, NewBigtableInstanceUpdater, BigtableInstanceIdParseFunc),
@@ -546,7 +550,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, p *schema.Pr
 
 	if v, ok := d.GetOk("request_reason"); ok {
 		config.RequestReason = v.(string)
-	}	
+	}
 
 	// Search for default credentials
 	config.Credentials = multiEnvSearch([]string{


### PR DESCRIPTION
To separate handwritten resources from tpgtool resources I've moved them to their own partition in the resource declartion. 

```release-note:none

```
