### PR TITLE
Preparing external_vpn_gateway example for inclusion on c.g.c.

### DIFF
--- a/mmv1/templates/terraform/examples/external_vpn_gateway.tf.erb
+++ b/mmv1/templates/terraform/examples/external_vpn_gateway.tf.erb
@@ -1,10 +1,11 @@
+# [START cloudvpn_ha_external]
 resource "google_compute_ha_vpn_gateway" "ha_gateway" {
   region   = "us-central1"
   name     = "<%= ctx[:vars]['ha_vpn_gateway_name'] %>"
   network  = google_compute_network.network.id
 }
 
-resource "google_compute_external_vpn_gateway" "external_gateway" {
+resource "google_compute_external_vpn_gateway" "<%= ctx[:primary_resource_id] %>" {
   name            = "<%= ctx[:vars]['external_gateway_name'] %>"
   redundancy_type = "SINGLE_IP_INTERNALLY_REDUNDANT"
   description     = "An externally managed VPN gateway"
@@ -99,3 +100,4 @@ resource "google_compute_router_peer" "router1_peer2" {
   advertised_route_priority = 100
   interface                 = google_compute_router_interface.router1_interface2.name
 }
+# [START cloudvpn_ha_external]

--- a/mmv1/templates/terraform/examples/external_vpn_gateway.tf.erb
+++ b/mmv1/templates/terraform/examples/external_vpn_gateway.tf.erb
@@ -100,4 +100,4 @@ resource "google_compute_router_peer" "router1_peer2" {
   advertised_route_priority = 100
   interface                 = google_compute_router_interface.router1_interface2.name
 }
-# [START cloudvpn_ha_external]
+# [END cloudvpn_ha_external]


### PR DESCRIPTION
The intention is to add this example to https://cloud.devsite.corp.google.com/network-connectivity/docs/vpn/how-to/automate-vpn-setup-with-terraform.


```release-note:none
```
