### PR TITLE
Fix #9951 missing connectMode on filestore_inst

### DIFF
--- a/mmv1/products/filestore/api.yaml
+++ b/mmv1/products/filestore/api.yaml
@@ -233,6 +233,7 @@ objects:
                 DIRECT_PEERING.
               input: true
               min_version: beta
+              default_value: :DIRECT_PEERING
               values:
                 - :DIRECT_PEERING
                 - :PRIVATE_SERVICE_ACCESS

--- a/mmv1/products/filestore/api.yaml
+++ b/mmv1/products/filestore/api.yaml
@@ -225,6 +225,17 @@ objects:
                 A list of IPv4 or IPv6 addresses.
               output: true
               item_type: Api::Type::String
+            - !ruby/object:Api::Type::Enum
+              name: 'connectMode'
+              description: |
+                The network connect mode of the Filestore instance.
+                If not provided, the connect mode defaults to
+                DIRECT_PEERING.
+              input: true
+              min_version: beta
+              values:
+                - :DIRECT_PEERING
+                - :PRIVATE_SERVICE_ACCESS
       - !ruby/object:Api::Type::String
         name: 'etag'
         description: |

--- a/mmv1/products/filestore/examples/ansible/instance.yaml
+++ b/mmv1/products/filestore/examples/ansible/instance.yaml
@@ -24,6 +24,7 @@ task: !ruby/object:Provider::Ansible::Task
       - network: default
         modes:
           - MODE_IPV4
+        connect_mode: DIRECT_PEERING
     project: <%= ctx[:project] %>
     auth_kind: <%= ctx[:auth_kind] %>
     service_account_file: <%= ctx[:service_account_file] %>

--- a/mmv1/products/filestore/terraform.yaml
+++ b/mmv1/products/filestore/terraform.yaml
@@ -40,6 +40,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         ignore_read: true
       networks.reservedIpRange: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true
+      networks.connectMode: !ruby/object:Overrides::Terraform::PropertyOverride
+        custom_flatten: 'templates/terraform/custom_flatten/default_if_empty.erb'
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/filestore.erb
 

--- a/mmv1/templates/terraform/examples/filestore_instance_full.tf.erb
+++ b/mmv1/templates/terraform/examples/filestore_instance_full.tf.erb
@@ -26,5 +26,6 @@ resource "google_filestore_instance" "<%= ctx[:primary_resource_id] %>" {
   networks {
     network = "default"
     modes   = ["MODE_IPV4"]
+    connect_mode = "DIRECT_PEERING"
   }
 }


### PR DESCRIPTION
The missing object is documented here:
https://cloud.google.com/filestore/docs/reference/rest/v1beta1/projects.locations.instances#ConnectMode

Fixes https://github.com/hashicorp/terraform-provider-google/issues/9951
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->




<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
filestore: added `connect_mode` to `networks` field in `google_filestore_instance` (beta)
```
