### PR TITLE
Compute instance reservation affinity

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -5688,6 +5688,37 @@ objects:
                     should be specified.
                 # networkInterfaces.kind is not necessary for convergence.
           - !ruby/object:Api::Type::NestedObject
+            name: 'reservationAffinity'
+            description: |
+              Specifies the reservations that this instance can consume from.
+            properties:
+              - !ruby/object:Api::Type::Enum
+                name: 'consumeReservationType'
+                description: |
+                  Specifies the type of reservation from which this instance 
+                  can consume resources: ANY_RESERVATION (default), 
+                  SPECIFIC_RESERVATION, or NO_RESERVATION.
+                values:
+                   - :ANY_RESERVATION
+                   - :SPECIFIC_RESERVATION
+                   - :NO_RESERVATION
+              - !ruby/object:Api::Type::String
+                name: 'key'
+                description: |
+                  Corresponds to the label key of a reservation resource. 
+                  To target a SPECIFIC_RESERVATION by name, specify 
+                  googleapis.com/reservation-name as the key and specify 
+                  the name of your reservation as its value.
+              - !ruby/object:Api::Type::Array
+                name: 'values'
+                description: |
+                  Corresponds to the label values of a reservation resource. 
+                  This can be either a name to a reservation in the same project 
+                  or "projects/different-project/reservations/some-reservation-name" 
+                  to target a shared reservation in the same zone but in 
+                  a different project.
+                item_type: Api::Type::String
+          - !ruby/object:Api::Type::NestedObject
             name: 'scheduling'
             description: Sets the scheduling options for this instance.
             properties:

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -6591,6 +6591,37 @@ objects:
                 should be specified.
             # networkInterfaces.kind is not necessary for convergence.
       - !ruby/object:Api::Type::NestedObject
+        name: 'reservationAffinity'
+        description: |
+          Specifies the reservations that this instance can consume from.
+        properties:
+          - !ruby/object:Api::Type::Enum
+            name: 'consumeReservationType'
+            description: |
+              Specifies the type of reservation from which this instance 
+              can consume resources: ANY_RESERVATION (default), 
+              SPECIFIC_RESERVATION, or NO_RESERVATION.
+            values:
+               - :ANY_RESERVATION
+               - :SPECIFIC_RESERVATION
+               - :NO_RESERVATION
+          - !ruby/object:Api::Type::String
+            name: 'key'
+            description: |
+              Corresponds to the label key of a reservation resource. 
+              To target a SPECIFIC_RESERVATION by name, specify 
+              googleapis.com/reservation-name as the key and specify 
+              the name of your reservation as its value.
+          - !ruby/object:Api::Type::Array
+            name: 'values'
+            description: |
+              Corresponds to the label values of a reservation resource. 
+              This can be either a name to a reservation in the same project 
+              or "projects/different-project/reservations/some-reservation-name" 
+              to target a shared reservation in the same zone but in 
+              a different project.
+            item_type: Api::Type::String
+      - !ruby/object:Api::Type::NestedObject
         name: 'scheduling'
         description: Sets the scheduling options for this instance.
         properties:


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add `reservationAffinity` field into [Instances](https://cloud.google.com/compute/docs/reference/rest/v1/instances) and [InstanceTemplates](https://cloud.google.com/compute/docs/reference/rest/v1/instanceTemplates).


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added `reservation_affinity` field to `google_compute_instance` resource
compute: added `reservation_affinity` field to `google_compute_instance_template` resource
```
