### PR TITLE
Made fetching IAM policies return a special error if it fails due to missing permissions

### DIFF
--- a/mmv1/templates/validator/mappers/mappers.go.erb
+++ b/mmv1/templates/validator/mappers/mappers.go.erb
@@ -191,50 +191,6 @@ func Mappers() map[string][]Mapper {
 				Fetch:             FetchProjectIamPolicy,
 			},
 		},
-		"google_kms_key_ring_iam_policy": {
-			{
-				Convert:           GetKmsKeyRingIamPolicyCaiObject,
-				MergeCreateUpdate: MergeKmsKeyRingIamPolicy,
-			},
-		},
-		"google_kms_key_ring_iam_binding": {
-			{
-				Convert:           GetKmsKeyRingIamBindingCaiObject,
-				MergeCreateUpdate: MergeKmsKeyRingIamBinding,
-				MergeDelete:       MergeKmsKeyRingIamBindingDelete,
-				Fetch:             FetchKmsKeyRingIamPolicy,
-			},
-		},
-		"google_kms_key_ring_iam_member": {
-			{
-				Convert:           GetKmsKeyRingIamMemberCaiObject,
-				MergeCreateUpdate: MergeKmsKeyRingIamMember,
-				MergeDelete:       MergeKmsKeyRingIamMemberDelete,
-				Fetch:             FetchKmsKeyRingIamPolicy,
-			},
-		},
-		"google_kms_crypto_key_iam_policy": {
-			{
-				Convert:           GetKmsCryptoKeyIamPolicyCaiObject,
-				MergeCreateUpdate: MergeKmsCryptoKeyIamPolicy,
-			},
-		},
-		"google_kms_crypto_key_iam_binding": {
-			{
-				Convert:           GetKmsCryptoKeyIamBindingCaiObject,
-				MergeCreateUpdate: MergeKmsCryptoKeyIamBinding,
-				MergeDelete:       MergeKmsCryptoKeyIamBindingDelete,
-				Fetch:             FetchKmsCryptoKeyIamPolicy,
-			},
-		},
-		"google_kms_crypto_key_iam_member": {
-			{
-				Convert:           GetKmsCryptoKeyIamMemberCaiObject,
-				MergeCreateUpdate: MergeKmsCryptoKeyIamMember,
-				MergeDelete:       MergeKmsCryptoKeyIamMemberDelete,
-				Fetch:             FetchKmsCryptoKeyIamPolicy,
-			},
-		},
 	}
 }
 

--- a/mmv1/third_party/validator/constants.go
+++ b/mmv1/third_party/validator/constants.go
@@ -14,5 +14,9 @@ var ErrNoConversion = errors.New("no conversion")
 // due to the identity field of that resource returning empty.
 var ErrEmptyIdentityField = errors.New("empty identity field")
 
+// ErrLackingReadPermissions can be returned when fetching a resource is not possible
+// due to the user not having read permissions.
+var ErrLackingReadPermission = errors.New("lacking read permissions")
+
 // Global MutexKV
 var mutexKV = NewMutexKV()

--- a/mmv1/third_party/validator/iam_helpers.go
+++ b/mmv1/third_party/validator/iam_helpers.go
@@ -202,6 +202,11 @@ func fetchIamPolicy(
 	}
 
 	iamPolicy, err := updater.GetResourceIamPolicy()
+	if isGoogleApiErrorWithCode(err, 403) {
+		return Asset{}, ErrLackingReadPermission
+	}
+
+	iamPolicy, err := updater.GetResourceIamPolicy()
 	if err != nil {
 		return Asset{}, err
 	}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

This is related to https://github.com/GoogleCloudPlatform/terraform-validator/issues/290. It makes Terraform Google Conversion return a special error if fetching an IAM policy fails due to missing permissions; then Terraform Validator can detect that error and warn the user rather than erroring out.

Note: I also had to remove a few IAM resources from the mappers since they don't yet have tests added - see https://github.com/GoogleCloudPlatform/terraform-validator/pull/277.

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
