### PR TITLE
Make tpgtools spit out working documentation.

### DIFF
--- a/tpgtools/api/gkehub/beta/feature_membership.yaml
+++ b/tpgtools/api/gkehub/beta/feature_membership.yaml
@@ -84,7 +84,7 @@ components:
               type: object
               x-dcl-go-name: Binauthz
               x-dcl-go-type: FeatureMembershipConfigmanagementBinauthz
-              description: Binauthz conifguration for the cluster.
+              description: Binauthz configuration for the cluster.
               properties:
                 enabled:
                   type: boolean

--- a/tpgtools/main.go
+++ b/tpgtools/main.go
@@ -496,10 +496,11 @@ func generateProductsFile(fileName string, products []*ProductMetadata) {
 }
 
 var TemplateFunctions = template.FuncMap{
-	"title":          strings.Title,
-	"patternToRegex": PatternToRegex,
-	"replace":        strings.Replace,
-	"isLastIndex":    isLastIndex,
+	"title":             strings.Title,
+	"patternToRegex":    PatternToRegex,
+	"replace":           strings.Replace,
+	"isLastIndex":       isLastIndex,
+	"escapeDescription": escapeDescription,
 }
 
 // TypeFetcher fetches reused types, as marked by the $ref field being marked on an OpenAPI schema.

--- a/tpgtools/main_helpers.go
+++ b/tpgtools/main_helpers.go
@@ -46,6 +46,10 @@ func formatComparator(formats []string) func(i, j int) bool {
 	}
 }
 
+func escapeDescription(in string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(strings.ReplaceAll(in, `\`, `\\`), `"`, `\"`), "\n", `\n`)
+}
+
 func stringInSlice(a string, list []string) bool {
 	for _, b := range list {
 		if b == a {

--- a/tpgtools/templates/resource.go.tmpl
+++ b/tpgtools/templates/resource.go.tmpl
@@ -98,7 +98,7 @@ func resource{{$.PathType}}() *schema.Resource {
 	{{- if $p.DiffSuppressFunc }}
 				DiffSuppressFunc: {{$p.DiffSuppressFunc}},
 	{{- end }}
-				Description: `{{/* TODO fix formatting for $p.Description - see https://github.com/hashicorp/terraform-provider-google/issues/9197 */}}`,
+				Description: "{{escapeDescription $p.Description}}",
 	{{- if $p.MaxItems }}
 				MaxItems: {{$p.MaxItems}},
 	{{- end }}
@@ -158,7 +158,7 @@ func {{$.PathType}}{{$v.PackagePath}}Schema() *schema.Resource {
 		{{- if $p.DiffSuppressFunc }}
 					DiffSuppressFunc: {{$p.DiffSuppressFunc}},
 		{{- end }}
-					Description: `{{/* TODO fix formatting for $p.Description */}}`,
+					Description: "{{escapeDescription $p.Description}}",
 		{{- if $p.MaxItems }}
 					MaxItems: {{$p.MaxItems}},
 		{{- end }}


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

In order for KCC to depend on a tpgtools resource, tpgtools needs to fix the longstanding-but-low-priority bug with documentation escaping.  It turns out not to be too hard since go doesn't have a whole lot of necessary escape sequences - just `"`, `\`, and newlines.  Made it a function that's easy to work with if we find more that we need to add, although I was going based on https://golang.org/ref/spec#String_literals so it should be pretty correct.

Fixes https://github.com/hashicorp/terraform-provider-google/issues/9197.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
