### PR TITLE
Handle scenarios where the dcl resource can't be found on READ

### DIFF
--- a/tpgtools/handwritten/tpgtools_utils.go
+++ b/tpgtools/handwritten/tpgtools_utils.go
@@ -1,5 +1,26 @@
 package google
 
+import (
+	"fmt"
+	"log"
+
+	dcl "github.com/GoogleCloudPlatform/declarative-resource-client-library/dcl"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
 func oldValue(old, new interface{}) interface{} {
 	return old
+}
+
+func handleNotFoundDCLError(err error, d *schema.ResourceData, resourceName string) error {
+	if dcl.IsNotFound(err) {
+		log.Printf("[WARN] Removing %s because it's gone", resourceName)
+		// The resource doesn't exist anymore
+		d.SetId("")
+		return nil
+	}
+
+	return errwrap.Wrapf(
+		fmt.Sprintf("Error when reading or editing %s: {{err}}", resourceName), err)
 }

--- a/tpgtools/templates/resource.go.tmpl
+++ b/tpgtools/templates/resource.go.tmpl
@@ -327,9 +327,8 @@ func resource{{$.PathType}}Read(d *schema.ResourceData, meta interface{}) error 
 	client := NewDCL{{$.ProductType}}Client(config, userAgent, billingProject)
 	res, err := client.Get{{$.Type}}(context.Background(), obj)
 	if err != nil {
-		// Resource not found
-		d.SetId("")
-		return err
+		resourceName := fmt.Sprintf("{{$.PathType}} %q", d.Id())
+		return handleNotFoundDCLError(err, d, resourceName)
 	}
 
 {{ range $v := .Properties -}}


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/9904

**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
eventarc: fixed bug where resources could not be deleted out of bounds
```
