### PR TITLE
Example of deploying Cloud Run to use a VPC connector

### DIFF
--- a/mmv1/products/cloudrun/terraform.yaml
+++ b/mmv1/products/cloudrun/terraform.yaml
@@ -87,6 +87,14 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         test_env_vars:
           project: :PROJECT_NAME
       - !ruby/object:Provider::Terraform::Examples
+        name: "cloud_run_service_vpc_connector"
+        primary_resource_id: "default"
+        primary_resource_name: "fmt.Sprintf(\"tf-test-cloudrun-srv%s\", context[\"random$
+        vars:
+          cloud_run_service_name: "cloudrun-srv"
+        test_env_vars:
+          project: :PROJECT_NAME
+      - !ruby/object:Provider::Terraform::Examples
         name: "cloud_run_service_sql"
         primary_resource_id: "default"
         primary_resource_name: "fmt.Sprintf(\"tf-test-cloudrun-srv%s\", context[\"random_suffix\"])"

--- a/mmv1/templates/terraform/examples/cloud_run_service_vpc_connector.tf.erb
+++ b/mmv1/templates/terraform/examples/cloud_run_service_vpc_connector.tf.erb
@@ -1,0 +1,31 @@
+resource "google_cloud_run_service" "<%= ctx[:primary_resource_id] %>" {
+  name     = "<%= ctx[:vars]['cloud_run_service_name'] %>"
+  location = "us-central1"
+
+  template {
+    spec {
+      containers {
+        image = "gcr.io/cloudrun/hello"
+      }
+    }
+    metadata {
+      annotations = {
+        # limit scale up to prevent any cost blow outs!
+        "autoscaling.knative.dev/maxScale" = "5"
+        # Set minimum if do not require scale to zero
+        # "autoscaling.knative.dev/minScale" = "1"
+        # use the VPC Connector above
+        "run.googleapis.com/vpc-access-connector" = "central-serverless"
+        # all egress from the service should go through the VPC Connector
+        "run.googleapis.com/vpc-access-egress" = "all"
+      }
+    }
+  }
+}
+
+resource "google_cloud_run_service_iam_member" "public-access" {
+  location = google_cloud_run_service.default.location
+  service  = google_cloud_run_service.default.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}


### PR DESCRIPTION
Intending to add example to 

* https://cloud.google.com/run/docs/configuring/connecting-vpc
* https://cloud.google.com/vpc/docs/configure-serverless-vpc-access


```release-note:none
```
