### PR TITLE
Support for Composer scheduler count flag (beta) (#10026)

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -1055,6 +1055,9 @@ func flattenComposerEnvironmentConfigSoftwareConfig(softwareCfg *composer.Softwa
 	transformed["airflow_config_overrides"] = softwareCfg.AirflowConfigOverrides
 	transformed["pypi_packages"] = softwareCfg.PypiPackages
 	transformed["env_variables"] = softwareCfg.EnvVariables
+<% unless version == "ga" -%>
+	transformed["scheduler_count"] = softwareCfg.SchedulerCount
+<% end -%>
 	return []interface{}{transformed}
 }
 
@@ -1480,6 +1483,9 @@ func expandComposerEnvironmentConfigSoftwareConfig(v interface{}, d *schema.Reso
 	transformed.AirflowConfigOverrides = expandComposerEnvironmentConfigSoftwareConfigStringMap(original, "airflow_config_overrides")
 	transformed.PypiPackages = expandComposerEnvironmentConfigSoftwareConfigStringMap(original, "pypi_packages")
 	transformed.EnvVariables = expandComposerEnvironmentConfigSoftwareConfigStringMap(original, "env_variables")
+<% unless version == "ga" -%>
+	transformed.SchedulerCount = int64(original["scheduler_count"].(int))
+<% end -%>
 	return transformed, nil
 }
 

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -43,6 +43,9 @@ var (
 		"config.0.software_config.0.env_variables",
 		"config.0.software_config.0.image_version",
 		"config.0.software_config.0.python_version",
+<% unless version == "ga" -%>
+		"config.0.software_config.0.scheduler_count",
+<% end -%>
 	}
 
 	composerConfigKeys = []string{
@@ -320,6 +323,15 @@ func resourceComposerEnvironment() *schema.Resource {
 										ForceNew:     true,
 										Description:  `The major version of Python used to run the Apache Airflow scheduler, worker, and webserver processes. Can be set to '2' or '3'. If not specified, the default is '2'. Cannot be updated.`,
 									},
+<% unless version == "ga" -%>
+									"scheduler_count": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										AtLeastOneOf: composerSoftwareConfigKeys,
+										Computed:     true,
+										Description:  'The number of schedulers for Airflow. This field is supported for Cloud Composer environments in versions composer-1.*.*-airflow-2.*.*.',
+									},
+<% end -%>
 								},
 							},
 						},

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -329,7 +329,7 @@ func resourceComposerEnvironment() *schema.Resource {
 										Optional:     true,
 										AtLeastOneOf: composerSoftwareConfigKeys,
 										Computed:     true,
-										Description:  'The number of schedulers for Airflow. This field is supported for Cloud Composer environments in versions composer-1.*.*-airflow-2.*.*.',
+										Description:  `The number of schedulers for Airflow. This field is supported for Cloud Composer environments in versions composer-1.*.*-airflow-2.*.*.`,
 									},
 <% end -%>
 								},

--- a/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_composer_environment.go.erb
@@ -43,9 +43,7 @@ var (
 		"config.0.software_config.0.env_variables",
 		"config.0.software_config.0.image_version",
 		"config.0.software_config.0.python_version",
-<% unless version == "ga" -%>
 		"config.0.software_config.0.scheduler_count",
-<% end -%>
 	}
 
 	composerConfigKeys = []string{
@@ -323,7 +321,6 @@ func resourceComposerEnvironment() *schema.Resource {
 										ForceNew:     true,
 										Description:  `The major version of Python used to run the Apache Airflow scheduler, worker, and webserver processes. Can be set to '2' or '3'. If not specified, the default is '2'. Cannot be updated.`,
 									},
-<% unless version == "ga" -%>
 									"scheduler_count": {
 										Type:         schema.TypeInt,
 										Optional:     true,
@@ -331,7 +328,6 @@ func resourceComposerEnvironment() *schema.Resource {
 										Computed:     true,
 										Description:  `The number of schedulers for Airflow. This field is supported for Cloud Composer environments in versions composer-1.*.*-airflow-2.*.*.`,
 									},
-<% end -%>
 								},
 							},
 						},
@@ -1055,9 +1051,7 @@ func flattenComposerEnvironmentConfigSoftwareConfig(softwareCfg *composer.Softwa
 	transformed["airflow_config_overrides"] = softwareCfg.AirflowConfigOverrides
 	transformed["pypi_packages"] = softwareCfg.PypiPackages
 	transformed["env_variables"] = softwareCfg.EnvVariables
-<% unless version == "ga" -%>
 	transformed["scheduler_count"] = softwareCfg.SchedulerCount
-<% end -%>
 	return []interface{}{transformed}
 }
 
@@ -1483,9 +1477,7 @@ func expandComposerEnvironmentConfigSoftwareConfig(v interface{}, d *schema.Reso
 	transformed.AirflowConfigOverrides = expandComposerEnvironmentConfigSoftwareConfigStringMap(original, "airflow_config_overrides")
 	transformed.PypiPackages = expandComposerEnvironmentConfigSoftwareConfigStringMap(original, "pypi_packages")
 	transformed.EnvVariables = expandComposerEnvironmentConfigSoftwareConfigStringMap(original, "env_variables")
-<% unless version == "ga" -%>
 	transformed.SchedulerCount = int64(original["scheduler_count"].(int))
-<% end -%>
 	return transformed, nil
 }
 

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -1136,6 +1136,14 @@ func testAccComposerEnvironment_airflow2SoftwareCfg(name, network, subnetwork st
 data "google_composer_image_versions" "all" {
 }
 
+locals {
+	composer_version = "1"  # both composer_version and airflow_version are parts of regex, so if either 1 or 2 version is ok "[12]" should be used,  
+	airflow_version = "2"   # if subversion is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2" 
+	reg_ex = join("", ["composer-", local.composer_version, "\\.[\\d+\\.]*\\d+.*-airflow-", local.airflow_version, "\\.[\\d+\\.]*\\d+"])
+	matching_images = [for v in data.google_composer_image_versions.all.image_versions[*].image_version_id: v if length(regexall(local.reg_ex, v)) > 0]
+}
+
+
 resource "google_composer_environment" "test" {
 	name   = "%s"
 	region = "us-central1"
@@ -1146,7 +1154,7 @@ resource "google_composer_environment" "test" {
 			zone       = "us-central1-a"
 		}
 		software_config {
-			image_version  = "composer-1.17.0-preview.10-airflow-2.0.2"
+			image_version  = local.matching_images[0]
 			scheduler_count = 2
 		}
 	}

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -934,6 +934,16 @@ resource "google_compute_subnetwork" "test" {
 <% end -%>
 func testAccComposerEnvironment_update(name, network, subnetwork string) string {
 	return fmt.Sprintf(`
+data "google_composer_image_versions" "all" {
+}
+
+locals {
+	composer_version = "1"  # both composer_version and airflow_version are parts of regex, so if either 1 or 2 version is ok "[12]" should be used,  
+	airflow_version = "1"   # if subversion is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2" 
+	reg_ex = join("", ["composer-", local.composer_version, "\\.[\\d+\\.]*\\d+.*-airflow-", local.airflow_version, "\\.[\\d+\\.]*\\d+"])
+	matching_images = [for v in data.google_composer_image_versions.all.image_versions[*].image_version_id: v if length(regexall(local.reg_ex, v)) > 0]
+}
+
 resource "google_composer_environment" "test" {
 	name   = "%s"
 	region = "us-central1"
@@ -947,7 +957,7 @@ resource "google_composer_environment" "test" {
 		}
 
 		software_config {
-			image_version = "composer-1.16.14-airflow-1.10.15"
+			image_version = local.matching_images[0]
 
 			airflow_config_overrides = {
 				core-load_example = "True"
@@ -1044,6 +1054,16 @@ resource "google_project_iam_member" "composer-worker" {
 
 func testAccComposerEnvironment_softwareCfg(name, network, subnetwork string) string {	
 	return fmt.Sprintf(`
+data "google_composer_image_versions" "all" {
+}
+
+locals {
+	composer_version = "1"  # both composer_version and airflow_version are parts of regex, so if either 1 or 2 version is ok "[12]" should be used,  
+	airflow_version = "1"   # if subversion is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2" 
+	reg_ex = join("", ["composer-", local.composer_version, "\\.[\\d+\\.]*\\d+.*-airflow-", local.airflow_version, "\\.[\\d+\\.]*\\d+"])
+	matching_images = [for v in data.google_composer_image_versions.all.image_versions[*].image_version_id: v if length(regexall(local.reg_ex, v)) > 0]
+}
+
 resource "google_composer_environment" "test" {
 	name   = "%s"
 	region = "us-central1"
@@ -1054,7 +1074,7 @@ resource "google_composer_environment" "test" {
 			zone       = "us-central1-a"
 		}
 		software_config {
-			image_version  = "composer-1.16.14-airflow-1.10.15"
+			image_version  = local.matching_images[0]
 			python_version = "3"
 		}
 	}

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -431,6 +431,38 @@ func TestAccComposerEnvironment_withSoftwareConfig(t *testing.T) {
 	})
 }
 
+func TestAccComposerEnvironmentAirflow2_withSoftwareConfig(t *testing.T) {
+	t.Parallel()
+	envName := fmt.Sprintf("%s-%d", testComposerEnvironmentPrefix, randInt(t))
+	network := fmt.Sprintf("%s-%d", testComposerNetworkPrefix, randInt(t))
+	subnetwork := network + "-1"
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccComposerEnvironmentDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComposerEnvironment_airflow2SoftwareCfg(envName, network, subnetwork),
+			},
+			{
+				ResourceName:      "google_composer_environment.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// This is a terrible clean-up step in order to get destroy to succeed,
+			// due to dangling firewall rules left by the Composer Environment blocking network deletion.
+			// TODO(emilyye): Remove this check if firewall rules bug gets fixed by Composer.
+			{
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+				Config:             testAccComposerEnvironment_airflow2SoftwareCfg(envName, network, subnetwork),
+				Check:              testAccCheckClearComposerEnvironmentFirewalls(t, network),
+			},
+		},
+	})
+}
+
 // Checks behavior of config for creation for attributes that must
 // be updated during create.
 func TestAccComposerEnvironment_withUpdateOnCreate(t *testing.T) {
@@ -1059,6 +1091,43 @@ resource "google_composer_environment" "test" {
 			pypi_packages = {
 				numpy = ""
 			}
+		}
+	}
+}
+
+// use a separate network to avoid conflicts with other tests running in parallel
+// that use the default network/subnet
+resource "google_compute_network" "test" {
+	name                    = "%s"
+	auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "test" {
+	name          = "%s"
+	ip_cidr_range = "10.2.0.0/16"
+	region        = "us-central1"
+	network       = google_compute_network.test.self_link
+}
+`, name, network, subnetwork)
+}
+
+func testAccComposerEnvironment_airflow2SoftwareCfg(name, network, subnetwork string) string {
+	return fmt.Sprintf(`
+data "google_composer_image_versions" "all" {
+}
+
+resource "google_composer_environment" "test" {
+	name   = "%s"
+	region = "us-central1"
+	config {
+		node_config {
+			network    = google_compute_network.test.self_link
+			subnetwork = google_compute_subnetwork.test.self_link
+			zone       = "us-central1-a"
+		}
+		software_config {
+			image_version  = "composer-1.17.0-preview.10-airflow-2.0.2"
+			scheduler_count = 2
 		}
 	}
 }

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -1042,7 +1042,7 @@ resource "google_project_iam_member" "composer-worker" {
 `, environment, network, subnetwork, serviceAccount)
 }
 
-func testAccComposerEnvironment_softwareCfg(name, network, subnetwork string) string {
+func testAccComposerEnvironment_softwareCfg(name, network, subnetwork string) string {	
 	return fmt.Sprintf(`
 resource "google_composer_environment" "test" {
 	name   = "%s"

--- a/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_composer_environment_test.go.erb
@@ -939,7 +939,7 @@ data "google_composer_image_versions" "all" {
 
 locals {
 	composer_version = "1"  # both composer_version and airflow_version are parts of regex, so if either 1 or 2 version is ok "[12]" should be used,  
-	airflow_version = "1"   # if subversion is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2" 
+	airflow_version = "1"   # if sub-version is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2"
 	reg_ex = join("", ["composer-", local.composer_version, "\\.[\\d+\\.]*\\d+.*-airflow-", local.airflow_version, "\\.[\\d+\\.]*\\d+"])
 	matching_images = [for v in data.google_composer_image_versions.all.image_versions[*].image_version_id: v if length(regexall(local.reg_ex, v)) > 0]
 }
@@ -1059,7 +1059,7 @@ data "google_composer_image_versions" "all" {
 
 locals {
 	composer_version = "1"  # both composer_version and airflow_version are parts of regex, so if either 1 or 2 version is ok "[12]" should be used,  
-	airflow_version = "1"   # if subversion is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2" 
+	airflow_version = "1"   # if sub-version is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2"
 	reg_ex = join("", ["composer-", local.composer_version, "\\.[\\d+\\.]*\\d+.*-airflow-", local.airflow_version, "\\.[\\d+\\.]*\\d+"])
 	matching_images = [for v in data.google_composer_image_versions.all.image_versions[*].image_version_id: v if length(regexall(local.reg_ex, v)) > 0]
 }
@@ -1138,7 +1138,7 @@ data "google_composer_image_versions" "all" {
 
 locals {
 	composer_version = "1"  # both composer_version and airflow_version are parts of regex, so if either 1 or 2 version is ok "[12]" should be used,  
-	airflow_version = "2"   # if subversion is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2" 
+	airflow_version = "2"   # if sub-version is needed remember to escape "." with "\\." for example 1.2 should be written as "1\\.2"
 	reg_ex = join("", ["composer-", local.composer_version, "\\.[\\d+\\.]*\\d+.*-airflow-", local.airflow_version, "\\.[\\d+\\.]*\\d+"])
 	matching_images = [for v in data.google_composer_image_versions.all.image_versions[*].image_version_id: v if length(regexall(local.reg_ex, v)) > 0]
 }

--- a/mmv1/third_party/terraform/website/docs/guides/version_3_upgrade.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/guides/version_3_upgrade.html.markdown
@@ -460,10 +460,10 @@ In an attempt to avoid allowing empty blocks in config files, at least one of `s
 
 ## Resource: `google_composer_environment`
 
-### At least one of `airflow_config_overrides`, `pypi_packages`, `env_variables`, `image_version`, or `python_version` is now required on `google_composer_environment.config.software_config`
+### At least one of `airflow_config_overrides`, `pypi_packages`, `env_variables`, `image_version`, `python_version` or `scheduler_count` is now required on `google_composer_environment.config.software_config`
 
 In an attempt to avoid allowing empty blocks in config files, at least one of `airflow_config_overrides`,
-`pypi_packages`, `env_variables`, `image_version`, or `python_version` is now required on the
+`pypi_packages`, `env_variables`, `image_version`, `python_version` or `scheduler_count` is now required on the
 `config.software_config` block.
 
 ### `use_ip_aliases` is now required on block `google_composer_environment.ip_allocation_policy`

--- a/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/composer_environment.html.markdown
@@ -314,6 +314,9 @@ The `software_config` block supports:
   The major version of Python used to run the Apache Airflow scheduler, worker, and webserver processes.
   Can be set to '2' or '3'. If not specified, the default is '2'. Cannot be updated.
 
+* `scheduler_count` (Optional) -
+  The number of schedulers for Airflow. This field is supported for Cloud Composer environments in versions composer-1.*.*-airflow-2.*.*.`
+
 See [documentation](https://cloud.google.com/composer/docs/how-to/managing/configuring-private-ip) for setting up private environments. The `private_environment_config` block supports:
 
 * `enable_private_endpoint` -


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Add scheduler_count to google_composer_environment (beta)

fixes [hashicorp/terraform-provider-google/issues/10026](https://github.com/hashicorp/terraform-provider-google/issues/10026)


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
composer: added field `scheduler_count` to `google_composer_environment`
```
