### PR TITLE
Remove `google_project_service` from state if not found

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_google_project_service.go
+++ b/mmv1/third_party/terraform/resources/resource_google_project_service.go
@@ -219,15 +219,8 @@ func resourceGoogleProjectServiceRead(d *schema.ResourceData, meta interface{}) 
 		return nil
 	}
 
-	// If we get here due to eventual consistency, the next apply will fix things
-	// instead of re-creating the resource and if we didn't get here by error,
-	// the next apply will (correctly) remove it from state, anyways. Seeing as
-	// no downstreams can possibly get the result, as we're halting execution,
-	// it's safe to rely on refresh for putting the state back in order.
-	if !d.IsNewResource() {
-		// The service is was not found in enabled services - return an error
-		return fmt.Errorf("service %s not in enabled services for project %s", srv, project)
-	}
+	log.Printf("[DEBUG] service %s not in enabled services for project %s, removing from state", srv, project)
+	d.SetId("")
 	return nil
 }
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/9841

This PR reverses the change introduced in the sdkv2 upgrade: https://github.com/hashicorp/terraform-provider-google/blame/d1014fe3b47d377db9a6eee9cfa9cbb0412c18e2/google/resource_google_project_service.go#L190

If a service was disabled outside of TF, the previous change showed a permanent error and would not let users re-enable the service until it was removed from state and added back to the config.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
serviceusage: fixed an issue in `google_project_service` where users could not reenable services that were disabled outside of Terraform.
```
