### PR TITLE
configure the sweeper to clean up firewall rules that are leftover 

### DIFF
--- a/mmv1/third_party/terraform/tests/resource_google_project_test.go
+++ b/mmv1/third_party/terraform/tests/resource_google_project_test.go
@@ -432,7 +432,7 @@ func skipIfEnvNotSet(t *testing.T, envs ...string) {
 
 	for _, k := range envs {
 		if os.Getenv(k) == "" {
-			log.Printf("[DEBUG] Environment variable %s is not set - skipping test", k)
+			log.Printf("[DEBUG] Warning - environment variable %s is not set - skipping test %s", k, t.Name())
 			t.Skipf("Environment variable %s is not set", k)
 		}
 	}

--- a/mmv1/third_party/terraform/tests/resource_google_project_test.go
+++ b/mmv1/third_party/terraform/tests/resource_google_project_test.go
@@ -432,6 +432,7 @@ func skipIfEnvNotSet(t *testing.T, envs ...string) {
 
 	for _, k := range envs {
 		if os.Getenv(k) == "" {
+			log.Printf("[DEBUG] Environment variable %s is not set - skipping test", k)
 			t.Skipf("Environment variable %s is not set", k)
 		}
 	}

--- a/mmv1/third_party/terraform/utils/gcp_sweeper_test.go
+++ b/mmv1/third_party/terraform/utils/gcp_sweeper_test.go
@@ -17,6 +17,7 @@ var testResourcePrefixes = []string{
 	"df-",                 // https://github.com/hashicorp/terraform-provider-google/issues/8909
 	"resourcegroup-",      // https://github.com/hashicorp/terraform-provider-google/issues/8924
 	"cluster-",            // https://github.com/hashicorp/terraform-provider-google/issues/8924
+	"k8s-fw-",
 }
 
 func TestMain(m *testing.M) {

--- a/mmv1/third_party/terraform/utils/gcp_sweeper_test.go
+++ b/mmv1/third_party/terraform/utils/gcp_sweeper_test.go
@@ -17,7 +17,7 @@ var testResourcePrefixes = []string{
 	"df-",                 // https://github.com/hashicorp/terraform-provider-google/issues/8909
 	"resourcegroup-",      // https://github.com/hashicorp/terraform-provider-google/issues/8924
 	"cluster-",            // https://github.com/hashicorp/terraform-provider-google/issues/8924
-	"k8s-fw-",
+	"k8s-fw-",             // firewall rules are getting created and not cleaned up by k8 resources using this prefix
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
from k8 stuff

**Release Note Template for Downstream PRs (will be copied)**

```release-note:none

```
