### PR TITLE
docs: use urlencode function

### DIFF
--- a/mmv1/templates/terraform/examples/consumer_quota_override.tf.erb
+++ b/mmv1/templates/terraform/examples/consumer_quota_override.tf.erb
@@ -9,8 +9,8 @@ resource "google_service_usage_consumer_quota_override" "override" {
   provider       = google-beta
   project        = google_project.my_project.project_id
   service        = "servicemanagement.googleapis.com"
-  metric         = "servicemanagement.googleapis.com%2Fdefault_requests"
-  limit          = "%2Fmin%2Fproject"
+  metric         = urlencode("servicemanagement.googleapis.com/default_requests")
+  limit          = urlencode("/min/project")
   override_value = "95"
   force          = true
 }

--- a/mmv1/templates/terraform/examples/consumer_quota_override_zero_value.tf.erb
+++ b/mmv1/templates/terraform/examples/consumer_quota_override_zero_value.tf.erb
@@ -9,8 +9,8 @@ resource "google_service_usage_consumer_quota_override" "override" {
   provider       = google-beta
   project        = google_project.my_project.project_id
   service        = "servicemanagement.googleapis.com"
-  metric         = "servicemanagement.googleapis.com%2Fdefault_requests"
-  limit          = "%2Fmin%2Fproject"
+  metric         = urlencode("servicemanagement.googleapis.com/default_requests")
+  limit          = urlencode("/min/project")
   override_value = "0"
   force          = true
 }

--- a/mmv1/templates/terraform/examples/region_consumer_quota_override.tf.erb
+++ b/mmv1/templates/terraform/examples/region_consumer_quota_override.tf.erb
@@ -12,8 +12,8 @@ resource "google_service_usage_consumer_quota_override" "override" {
   }
   project        = google_project.my_project.project_id
   service        = "compute.googleapis.com"
-  metric         = "compute.googleapis.com%2Fn2_cpus"
-  limit          = "%2Fproject%2Fregion"
+  metric         = urlencode("compute.googleapis.com/n2_cpus")
+  limit          = urlencode("/project/region")
   override_value = "8"
   force          = true
 }


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

In the `google_service_usage_consumer_quota_override` example,
I changed the description to use the urlencode function instead of directly using the decoded value to make it easier to understand the meaning of the set value.


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:


```release-note:none
```
    
