### PR TITLE
Don't recreate GCE instances when updating resource_policies property

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -777,7 +777,7 @@ func resourceComputeInstance() *schema.Resource {
 				Optional:         true,
 				ForceNew:         true,
 				MaxItems:         1,
-				Description:      `A list of short names or self_links of resource policies to attach to the instance. Modifying this list will cause the instance to recreate. Currently a max of 1 resource policy is supported.`,
+				Description:      `A list of short names or self_links of resource policies to attach to the instance. Currently a max of 1 resource policy is supported.`,
 			},
 
 			"reservation_affinity": {
@@ -1454,6 +1454,37 @@ func resourceComputeInstanceUpdate(d *schema.ResourceData, meta interface{}) err
 		opErr := computeOperationWaitTime(config, op, project, "labels to update", userAgent, d.Timeout(schema.TimeoutUpdate))
 		if opErr != nil {
 			return opErr
+		}
+	}
+
+	if d.HasChange("resource_policies") {
+		if len(instance.ResourcePolicies) > 0 {
+			req := compute.InstancesRemoveResourcePoliciesRequest{ResourcePolicies: instance.ResourcePolicies}
+
+			op, err := config.NewComputeClient(userAgent).Instances.RemoveResourcePolicies(project, zone, instance.Name, &req).Do()
+			if err != nil {
+				return fmt.Errorf("Error removing existing resource policies: %s", err)
+			}
+
+			opErr := computeOperationWaitTime(config, op, project, "resource policies to remove", userAgent, d.Timeout(schema.TimeoutUpdate))
+			if opErr != nil {
+				return opErr
+			}
+		}
+
+		resourcePolicies := convertStringArr(d.Get("resource_policies").([]interface{}))
+		if len(resourcePolicies) > 0 {
+			req := compute.InstancesAddResourcePoliciesRequest{ResourcePolicies: resourcePolicies}
+
+			op, err := config.NewComputeClient(userAgent).Instances.AddResourcePolicies(project, zone, instance.Name, &req).Do()
+			if err != nil {
+				return fmt.Errorf("Error adding resource policies: %s", err)
+			}
+
+			opErr := computeOperationWaitTime(config, op, project, "resource policies to add", userAgent, d.Timeout(schema.TimeoutUpdate))
+			if opErr != nil {
+				return opErr
+			}
 		}
 	}
 

--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -775,7 +775,6 @@ func resourceComputeInstance() *schema.Resource {
 				Elem:             &schema.Schema{Type: schema.TypeString},
 				DiffSuppressFunc: compareSelfLinkRelativePaths,
 				Optional:         true,
-				ForceNew:         true,
 				MaxItems:         1,
 				Description:      `A list of short names or self_links of resource policies to attach to the instance. Currently a max of 1 resource policy is supported.`,
 			},

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -420,6 +420,58 @@ func TestAccComputeInstance_kmsDiskEncryption(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_resourcePolicyUpdate(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	var instanceName = fmt.Sprintf("tf-test-%s", randString(t, 10))
+	var scheduleName1 = fmt.Sprintf("tf-tests-%s", randString(t, 10))
+	var scheduleName2 = fmt.Sprintf("tf-tests-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_instanceSchedule(instanceName, scheduleName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeResourcePolicy(&instance, "", 0),
+				),
+			},
+			// check adding
+			{
+				Config: testAccComputeInstance_addResourcePolicy(instanceName, scheduleName1),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeResourcePolicy(&instance, scheduleName1, 1),
+				),
+			},
+			// check updating
+			{
+				Config: testAccComputeInstance_updateResourcePolicy(instanceName, scheduleName1, scheduleName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeResourcePolicy(&instance, scheduleName2, 1),
+				),
+			},
+			// check removing
+			{
+				Config: testAccComputeInstance_removeResourcePolicy(instanceName, scheduleName1, scheduleName2),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+					testAccCheckComputeResourcePolicy(&instance, "", 0),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeInstance_attachedDisk(t *testing.T) {
 	t.Parallel()
 
@@ -2440,6 +2492,21 @@ func testAccCheckComputeInstanceAccessConfigHasPTR(instance *compute.Instance) r
 	}
 }
 
+func testAccCheckComputeResourcePolicy(instance *compute.Instance, scheduleName string, resourcePolicyCountWant int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resourcePoliciesCountHave := len(instance.ResourcePolicies)
+		if resourcePoliciesCountHave != resourcePolicyCountWant {
+			return fmt.Errorf("number of resource polices does not match: have: %d; want: %d", resourcePoliciesCountHave, resourcePolicyCountWant)
+		}
+
+		if resourcePoliciesCountHave == 1 && !strings.Contains(instance.ResourcePolicies[0], scheduleName) {
+			return fmt.Errorf("got the wrong schedule: have: %s; want: %s", instance.ResourcePolicies[0], scheduleName)
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckComputeInstanceDisk(instance *compute.Instance, source string, delete bool, boot bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if instance.Disks == nil {
@@ -3643,6 +3710,196 @@ resource "google_compute_instance" "foobar" {
 		"tf-testd-"+suffix,
 		instance, bootEncryptionKey,
 		diskNameToEncryptionKey[diskNames[0]].KmsKeyName, diskNameToEncryptionKey[diskNames[1]].KmsKeyName)
+}
+
+func testAccComputeInstance_instanceSchedule(instance, schedule string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+}
+
+resource "google_compute_resource_policy" "instance_schedule" {
+  name        = "%s"
+  region      = "us-central1"
+  instance_schedule_policy {
+    vm_start_schedule {
+      schedule = "1 1 1 1 1"
+    }
+    vm_stop_schedule {
+      schedule = "2 2 2 2 2"
+    }
+    time_zone = "UTC"
+  }
+}
+`, instance, schedule)
+}
+
+func testAccComputeInstance_addResourcePolicy(instance, schedule string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  resource_policies = [google_compute_resource_policy.instance_schedule.self_link]
+}
+
+resource "google_compute_resource_policy" "instance_schedule" {
+  name        = "%s"
+  region      = "us-central1"
+  instance_schedule_policy {
+    vm_start_schedule {
+      schedule = "1 1 1 1 1"
+    }
+    vm_stop_schedule {
+      schedule = "2 2 2 2 2"
+    }
+    time_zone = "UTC"
+  }
+}
+`, instance, schedule)
+}
+
+func testAccComputeInstance_updateResourcePolicy(instance, schedule1, schedule2 string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  resource_policies = [google_compute_resource_policy.instance_schedule2.self_link]
+}
+
+resource "google_compute_resource_policy" "instance_schedule" {
+  name        = "%s"
+  region      = "us-central1"
+  instance_schedule_policy {
+    vm_start_schedule {
+      schedule = "1 1 1 1 1"
+    }
+    vm_stop_schedule {
+      schedule = "2 2 2 2 2"
+    }
+    time_zone = "UTC"
+  }
+}
+
+resource "google_compute_resource_policy" "instance_schedule2" {
+  name        = "%s"
+  region      = "us-central1"
+  instance_schedule_policy {
+    vm_start_schedule {
+      schedule = "2 2 2 2 2"
+    }
+    vm_stop_schedule {
+      schedule = "3 3 3 3 3"
+    }
+    time_zone = "UTC"
+  }
+}
+`, instance, schedule1, schedule2)
+}
+
+func testAccComputeInstance_removeResourcePolicy(instance, schedule1, schedule2 string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    network = "default"
+  }
+
+  resource_policies = null
+}
+
+resource "google_compute_resource_policy" "instance_schedule" {
+  name        = "%s"
+  region      = "us-central1"
+  instance_schedule_policy {
+    vm_start_schedule {
+      schedule = "1 1 1 1 1"
+    }
+    vm_stop_schedule {
+      schedule = "2 2 2 2 2"
+    }
+    time_zone = "UTC"
+  }
+}
+
+resource "google_compute_resource_policy" "instance_schedule2" {
+  name        = "%s"
+  region      = "us-central1"
+  instance_schedule_policy {
+    vm_start_schedule {
+      schedule = "2 2 2 2 2"
+    }
+    vm_stop_schedule {
+      schedule = "3 3 3 3 3"
+    }
+    time_zone = "UTC"
+  }
+}
+`, instance, schedule1, schedule2)
 }
 
 func testAccComputeInstance_attachedDisk(disk, instance string) string {


### PR DESCRIPTION
This fixes the behaviour described in https://github.com/hashicorp/terraform-provider-google/issues/9981.
Basically, the change removes the ForceNew attribute from the resource_policies property of google_compute_instance and adds code to check for changes of the property. If the property changed, all old values get removed and all new values (if there are any) get added.
The change was previously submitted in https://github.com/hashicorp/terraform-provider-google/pull/10029

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: Fixed recreation of GCE instances when updating `resource_policies` property
```

Regarding tests: There doesn't seem to be a test specific for this behaviour. Do you need me to create one?