### PR TITLE
Add`logging_config` and `monitoring_config` to container cluster

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_cluster.go.erb
@@ -549,6 +549,27 @@ func resourceContainerCluster() *schema.Resource {
 				Description: `The number of nodes to create in this cluster's default node pool. In regional or multi-zonal clusters, this is the number of nodes per zone. Must be set if node_pool is not set. If you're using google_container_node_pool objects with no default node pool, you'll need to set this to a value of at least 1, alongside setting remove_default_node_pool to true.`,
 			},
 
+			"logging_config": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				MaxItems:    1,
+				Description: `Logging configuration for the cluster.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enable_components": {
+							Type:        schema.TypeList,
+							Required:    true,
+							Description: `GKE components exposing logs. Valid values include SYSTEM_COMPONENTS and WORKLOADS.`,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{"SYSTEM_COMPONENTS", "WORKLOADS"}, false),
+							},
+						},
+					},
+				},
+			},
+
 			"logging_service": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -642,6 +663,27 @@ func resourceContainerCluster() *schema.Resource {
 										ValidateFunc: validateRFC3339Date,
 									},
 								},
+							},
+						},
+					},
+				},
+			},
+
+			"monitoring_config": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				MaxItems:    1,
+				Description: `Monitoring configuration for the cluster.`,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enable_components": {
+							Type:        schema.TypeList,
+							Required:    true,
+							Description: `GKE components exposing metrics. Valid values include SYSTEM_COMPONENTS.`,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{"SYSTEM_COMPONENTS"}, false),
 							},
 						},
 					},
@@ -1542,6 +1584,14 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		cluster.ResourceUsageExportConfig = expandResourceUsageExportConfig(v)
 	}
 
+	if v, ok := d.GetOk("logging_config"); ok {
+		cluster.LoggingConfig = expandContainerClusterLoggingConfig(v)
+	}
+
+	if v, ok := d.GetOk("monitoring_config"); ok {
+		cluster.MonitoringConfig = expandMonitoringConfig(v)
+	}
+
 	req := &containerBeta.CreateClusterRequest{
 		Cluster: cluster,
 	}
@@ -1884,6 +1934,14 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 <% end -%>
+
+	if err := d.Set("logging_config", flattenContainerClusterLoggingConfig(cluster.LoggingConfig)); err != nil {
+		return err
+	}
+
+	if err := d.Set("monitoring_config", flattenMonitoringConfig(cluster.MonitoringConfig)); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -2649,6 +2707,36 @@ func resourceContainerClusterUpdate(d *schema.ResourceData, meta interface{}) er
 		}
 
 		log.Printf("[INFO] GKE cluster %s workload identity config has been updated", d.Id())
+	}
+
+	if d.HasChange("logging_config") {
+		req := &containerBeta.UpdateClusterRequest{
+			Update: &containerBeta.ClusterUpdate{
+				DesiredLoggingConfig: expandContainerClusterLoggingConfig(d.Get("logging_config")),
+			},
+		}
+		updateF := updateFunc(req, "updating GKE cluster logging config")
+		// Call update serially.
+		if err := lockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s logging config has been updated", d.Id())
+	}
+
+	if d.HasChange("monitoring_config") {
+		req := &containerBeta.UpdateClusterRequest{
+			Update: &containerBeta.ClusterUpdate{
+				DesiredMonitoringConfig: expandMonitoringConfig(d.Get("monitoring_config")),
+			},
+		}
+		updateF := updateFunc(req, "updating GKE cluster monitoring config")
+		// Call update serially.
+		if err := lockedCall(lockKey, updateF); err != nil {
+			return err
+		}
+
+		log.Printf("[INFO] GKE cluster %s monitoring config has been updated", d.Id())
 	}
 
 	if d.HasChange("resource_labels") {
@@ -3519,6 +3607,34 @@ func expandDnsConfig(configured interface{}) *containerBeta.DNSConfig {
 }
 <% end -%>
 
+func expandContainerClusterLoggingConfig(configured interface{}) *containerBeta.LoggingConfig {
+	l := configured.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	config := l[0].(map[string]interface{})
+	return &containerBeta.LoggingConfig{
+		ComponentConfig: &containerBeta.LoggingComponentConfig{
+			EnableComponents: convertStringArr(config["enable_components"].([]interface{})),
+		},
+	}
+}
+
+func expandMonitoringConfig(configured interface{}) *containerBeta.MonitoringConfig {
+	l := configured.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	config := l[0].(map[string]interface{})
+	return &containerBeta.MonitoringConfig{
+		ComponentConfig: &containerBeta.MonitoringComponentConfig{
+			EnableComponents: config["enable_components"].([]string),
+		},
+	}
+}
+
 <% unless version == 'ga' -%>
 func flattenNotificationConfig(c *containerBeta.NotificationConfig) []map[string]interface{} {
 	if c == nil {
@@ -3983,6 +4099,30 @@ func flattenDnsConfig(c *containerBeta.DNSConfig) []map[string]interface{} {
 	}
 }
 <% end -%>
+
+func flattenContainerClusterLoggingConfig(c *containerBeta.LoggingConfig) []map[string]interface{} {
+	if c == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"enable_components":        c.ComponentConfig.EnableComponents,
+		},
+	}
+}
+
+func flattenMonitoringConfig(c *containerBeta.MonitoringConfig) []map[string]interface{} {
+	if c == nil {
+		return nil
+	}
+
+	return []map[string]interface{}{
+		{
+			"enable_components":        c.ComponentConfig.EnableComponents,
+		},
+	}
+}
 
 func resourceContainerClusterStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	config := meta.(*Config)

--- a/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_container_cluster_test.go.erb
@@ -1709,7 +1709,52 @@ func TestAccContainerCluster_withWorkloadIdentityConfig(t *testing.T) {
 			},
 		},
 	})
+}
 
+
+func TestAccContainerCluster_withLoggingConfig(t *testing.T) {
+	t.Parallel()
+
+	clusterName := fmt.Sprintf("tf-test-cluster-%s", randString(t, 10))
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccContainerCluster_basic(clusterName),
+			},
+			{
+				ResourceName:        "google_container_cluster.primary",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+			{
+				Config: testAccContainerCluster_withLoggingConfigEnabled(clusterName),
+			},
+			{
+				ResourceName:        "google_container_cluster.primary",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+			{
+				Config: testAccContainerCluster_withLoggingConfigUpdated(clusterName),
+			},
+			{
+				ResourceName:        "google_container_cluster.primary",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+			{
+				Config: testAccContainerCluster_basic(clusterName),
+			},
+			{
+				ResourceName:        "google_container_cluster.primary",
+				ImportState:         true,
+				ImportStateVerify:   true,
+			},
+		},
+	})
 }
 
 <% unless version == 'ga' -%>
@@ -4609,3 +4654,35 @@ resource "google_container_cluster" "with_dns_config" {
 `, clusterName, clusterDns, clusterDnsDomain, clusterDnsScope)
 }
 <% end -%>
+
+func testAccContainerCluster_withLoggingConfigEnabled(name string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  logging_config {
+	  enable_components = [ "SYSTEM_COMPONENTS" ]
+  }
+  monitoring_config {
+      enable_components = [ "SYSTEM_COMPONENTS" ]
+  }
+}
+`, name)
+}
+
+func testAccContainerCluster_withLoggingConfigUpdated(name string) string {
+	return fmt.Sprintf(`
+resource "google_container_cluster" "primary" {
+  name               = "%s"
+  location           = "us-central1-a"
+  initial_node_count = 1
+  logging_config {
+	  enable_components = [ "SYSTEM_COMPONENTS", "WORKLOADS" ]
+  }
+  monitoring_config {
+	  enable_components = [ "SYSTEM_COMPONENTS" ]
+  }
+}
+`, name)
+}

--- a/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_cluster.html.markdown
@@ -180,6 +180,9 @@ below.
 Options are `VPC_NATIVE` or `ROUTES`. `VPC_NATIVE` enables [IP aliasing](https://cloud.google.com/kubernetes-engine/docs/how-to/ip-aliases),
 and requires the `ip_allocation_policy` block to be defined. By default when this field is unspecified, GKE will create a `ROUTES`-based cluster.
 
+* `logging_config` - (Optional) Logging configuration for the cluster.
+    Structure is documented below.
+
 * `logging_service` - (Optional) The logging service that the cluster should
     write logs to. Available options include `logging.googleapis.com`(Legacy Stackdriver),
     `logging.googleapis.com/kubernetes`(Stackdriver Kubernetes Engine Logging), and `none`. Defaults to `logging.googleapis.com/kubernetes`
@@ -212,6 +215,9 @@ Structure is documented below. This has been deprecated as of GKE 1.19.
 -> If you are using the `google_container_engine_versions` datasource with a regional cluster, ensure that you have provided a `location`
 to the datasource. A region can have a different set of supported versions than its corresponding zones, and not all zones in a
 region are guaranteed to support the same version.
+
+* `monitoring_config` - (Optional) Monitoring configuration for the cluster.
+    Structure is documented below.
 
 * `monitoring_service` - (Optional) The monitoring service that the cluster
     should write metrics to.
@@ -452,6 +458,16 @@ as "Intel Haswell" or "Intel Sandy Bridge".
 The `authenticator_groups_config` block supports:
 
 * `security_group` - (Required) The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format `gke-security-groups@yourdomain.com`.
+
+The `logging_config` block supports:
+
+*  `enable_components` - (Required) The GKE components exposing logs. Supported values include:
+`SYSTEM_COMPONENTS` and `WORKLOADS`.
+
+The `monitoring_config` block supports:
+
+*  `enable_components` - (Required) The GKE components exposing logs. Only `SYSTEM_COMPONENTS`
+is supported.
 
 The `maintenance_policy` block supports:
 * `daily_maintenance_window` - (Optional) structure documented below.

--- a/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/container_node_pool.html.markdown
@@ -147,7 +147,7 @@ cluster.
 * `name_prefix` - (Optional) Creates a unique name for the node pool beginning
     with the specified prefix. Conflicts with `name`.
 
-* `node_config` - (Optional) The network configuration of the pool. See
+* `node_config` - (Optional) Parameters used in creating the default node pool. See
     [google_container_cluster](container_cluster.html) for schema.
 
 * `network_config` - (Optional) The network configuration of the pool. See


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform-provider-google/issues/6583
Fixes https://github.com/hashicorp/terraform-provider-google/issues/9901

<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
container: added support for `logging_config` and `monitoring_config` to google_container_cluster
```
