### PR TITLE
Check if nodepool created before returning error

### DIFF
--- a/mmv1/third_party/terraform/resources/resource_container_node_pool.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_container_node_pool.go.erb
@@ -397,9 +397,14 @@ func resourceContainerNodePoolCreate(d *schema.ResourceData, meta interface{}) e
 		default:
 			// leaving default case to ensure this is non blocking
 		}
-		// The resource didn't actually create
-		d.SetId("")
-		return waitErr
+		// Check if resource was created but apply timed out.
+		// Common cause for that is GCE_STOCKOUT which will wait for resources and return error after timeout,
+		// but in fact nodepool will be created so we have to capture that in state.
+		_, err = clusterNodePoolsGetCall.Do()
+		if err != nil {
+			d.SetId("")
+			return waitErr
+		}
 	}
 
 	log.Printf("[INFO] GKE NodePool %s has been created", nodePool.Name)


### PR DESCRIPTION
Current implementation of GKE_STOCKOUT not being captured in state issue from #6287 doesn't seems to work.
Error during apply is as follows:
`Error: Error waiting for creating GKE NodePool: Google Compute Engine: Not all instances running in IGM after 1m6.219216581s. Expected 40, running 1, transitioning 39. Current errors: [GCE_STOCKOUT]: Instance 'instance' creation failed: The zone 'projects/redacted/zones/us-west1-b' does not have enough resources available to fulfill the request. '(resource type:compute)'.; (truncated).`

GCP behavior is to create a node pool in error state and keep waiting for resources to show up. This cause the node pool to be created but this fact is not captured in the state since error is returned.

In order to fix this bug I'm proposing to re-check if node pool exist instead of simply assuming that it doesn't. This approach will prevent any type of situation like that, since the whole flow will be as follow:

- ensure node pool doesn't exist
- create the node pool
- if error, check if exist
- if exist - capture that in state
- if doesn't - return error


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [X] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [X] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [X] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [X] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [X] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:bug
container: fixed an issue where a node pool created with error (eg. GKE_STOCKOUT) would not be captured in state
```
