### PR TITLE
Automatically determine whether we can add sweepers or not

### DIFF
--- a/tpgtools/overrides/assuredworkloads/beta/workload.yaml
+++ b/tpgtools/overrides/assuredworkloads/beta/workload.yaml
@@ -1,1 +1,0 @@
-- type: NO_SWEEPER

--- a/tpgtools/overrides/assuredworkloads/workload.yaml
+++ b/tpgtools/overrides/assuredworkloads/workload.yaml
@@ -1,1 +1,0 @@
-- type: NO_SWEEPER

--- a/tpgtools/overrides/compute/beta/firewall_policy.yaml
+++ b/tpgtools/overrides/compute/beta/firewall_policy.yaml
@@ -1,2 +1,0 @@
-# Sweeper depends on parent we can't generate due to multi-parent possibilities
-- type: NO_SWEEPER

--- a/tpgtools/overrides/compute/beta/firewall_policy_association.yaml
+++ b/tpgtools/overrides/compute/beta/firewall_policy_association.yaml
@@ -1,2 +1,0 @@
-# Fine-grained resource, no sweeper
-- type: NO_SWEEPER

--- a/tpgtools/overrides/compute/beta/firewall_policy_rule.yaml
+++ b/tpgtools/overrides/compute/beta/firewall_policy_rule.yaml
@@ -1,5 +1,3 @@
-# Fine-grained resource, no sweeper
-- type: NO_SWEEPER
 - type: DIFF_SUPPRESS_FUNC
   field: target_resources
   details:

--- a/tpgtools/overrides/compute/firewall_policy.yaml
+++ b/tpgtools/overrides/compute/firewall_policy.yaml
@@ -1,2 +1,0 @@
-# Sweeper depends on parent we can't generate due to multi-parent possibilities
-- type: NO_SWEEPER

--- a/tpgtools/overrides/compute/firewall_policy_association.yaml
+++ b/tpgtools/overrides/compute/firewall_policy_association.yaml
@@ -1,2 +1,0 @@
-# Fine-grained resource, no sweeper
-- type: NO_SWEEPER

--- a/tpgtools/overrides/compute/firewall_policy_rule.yaml
+++ b/tpgtools/overrides/compute/firewall_policy_rule.yaml
@@ -1,5 +1,3 @@
-# Fine-grained resource, no sweeper
-- type: NO_SWEEPER
 - type: DIFF_SUPPRESS_FUNC
   field: target_resources
   details:

--- a/tpgtools/overrides/gkehub/beta/feature_membership.yaml
+++ b/tpgtools/overrides/gkehub/beta/feature_membership.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-- type: NO_SWEEPER
 - type: CUSTOM_ID
   details:
     id: 'projects/{{project}}/locations/{{location}}/features/{{feature}}/membershipId/{{membership}}'

--- a/tpgtools/overrides/orgpolicy/beta/policy.yaml
+++ b/tpgtools/overrides/orgpolicy/beta/policy.yaml
@@ -1,7 +1,6 @@
 - type: CUSTOM_IMPORT_FUNCTION
   details:
     function: resourceOrgPolicyPolicyCustomImport
-- type: NO_SWEEPER
 - type: USE_DCL_ID
 - type: ENUM_BOOL
   field: spec.rules.allow_all


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Obseletes changes like https://github.com/GoogleCloudPlatform/magic-modules/pull/5224 (which we actually should have made, prior to this change, as the sweeper wasn't provided the correct values to be able to succeed. DCL doesn't run it, either.)


<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [ ] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [ ] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [ ] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [ ] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [ ] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:none
```
