### PR TITLE
serviceusage: retry on 403's for operation calls

### DIFF
--- a/mmv1/api/product.rb
+++ b/mmv1/api/product.rb
@@ -49,7 +49,7 @@ module Api
     # A function reference designed for the rare case where you
     # need to use retries in operation calls. Used for the service api
     # as it enables itself (self referential) and can result in occasional
-    # failures on operation_get. see
+    # failures on operation_get. see https://git.io/Jzu04
     attr_reader :operation_retry
 
     # The APIs required to be enabled for this product.

--- a/mmv1/api/product.rb
+++ b/mmv1/api/product.rb
@@ -49,7 +49,7 @@ module Api
     # A function reference designed for the rare case where you
     # need to use retries in operation calls. Used for the service api
     # as it enables itself (self referential) and can result in occasional
-    # failures on operation_get. see https://git.io/Jzu04
+    # failures on operation_get. see github.com/hashicorp/terraform-provider-google/issues/9489
     attr_reader :operation_retry
 
     # The APIs required to be enabled for this product.

--- a/mmv1/api/product.rb
+++ b/mmv1/api/product.rb
@@ -46,6 +46,12 @@ module Api
     # For example: `https://www.googleapis.com/compute/v1/`
     attr_reader :base_url
 
+    # A function reference designed for the rare case where you
+    # need to use retries in operation calls. Used for the service api
+    # as it enables itself (self referential) and can result in occasional
+    # failures on operation_get. see
+    attr_reader :operation_retry
+
     # The APIs required to be enabled for this product.
     # Usually just the product's API
     attr_reader :apis_required
@@ -59,6 +65,7 @@ module Api
       check :objects, type: Array, item_type: Api::Resource, required: true
       check :scopes, type: Array, item_type: String, required: true
       check :apis_required, type: Array, item_type: Api::Product::ApiReference
+      check :operation_retry, type: String
 
       check :async, type: Api::Async
 

--- a/mmv1/products/serviceusage/api.yaml
+++ b/mmv1/products/serviceusage/api.yaml
@@ -13,6 +13,7 @@
 --- !ruby/object:Api::Product
 name: ServiceUsage
 display_name: Service Usage
+operation_retry: templates/terraform/operation_retry/service_usage.go
 versions:
   - !ruby/object:Api::Product::Version
     name: ga

--- a/mmv1/templates/terraform/operation.go.erb
+++ b/mmv1/templates/terraform/operation.go.erb
@@ -15,6 +15,9 @@ type <%= product_name -%>OperationWaiter struct {
 <% if has_project -%>
   Project string
 <% end -%>
+<%  if object.__product.operation_retry -%>
+	retryCount int
+<% end -%>
   CommonOperationWaiter
 }
 
@@ -27,6 +30,13 @@ func (w *<%= product_name -%>OperationWaiter) QueryOp() (interface{}, error) {
 
   return sendRequest(w.Config, "GET", <% if has_project %>w.Project<% else %>""<% end %>, url, w.UserAgent, nil<%= object.error_retry_predicates ? ", " + object.error_retry_predicates.join(',') : "" -%>)
 }
+
+<%  if object.__product.operation_retry -%>
+func (w *<%= product_name -%>OperationWaiter) IsRetryable(err error) bool {
+	<%= lines(compile(pwd + '/' + object.__product.operation_retry)) -%>
+}
+<% end -%>
+
 
 func create<%= product_name %>Waiter(config *Config, op map[string]interface{}, <% if has_project -%> project, <% end -%> activity, userAgent string) (*<%=product_name%>OperationWaiter, error) {
   w := &<%= product_name -%>OperationWaiter{

--- a/mmv1/templates/terraform/operation_retry/service_usage.go
+++ b/mmv1/templates/terraform/operation_retry/service_usage.go
@@ -1,0 +1,11 @@
+// Retries errors on 403 3 times if the error message
+// returned contains `has not been used in project`
+maxRetries := 3
+if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 403 {
+	if w.retryCount < maxRetries && strings.Contains(gerr.Body, "has not been used in project") {
+		w.retryCount += 1
+		log.Printf("[DEBUG] retrying on 403 %v more times", w.retryCount-maxRetries-1)
+		return true
+	}
+}
+return false


### PR DESCRIPTION
closes https://github.com/hashicorp/terraform-provider-google/issues/9489

**Release Note Template for Downstream PRs (will be copied)**
```release-note:bug
serviceusage: enabled the service api to retry on failed operation calls in anticipation of transient errors that occur when first enabling the service.
```
