### PR TITLE
add external ipv6 support

### DIFF
--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -14674,6 +14674,36 @@ objects:
               https://cloud.google.com/vpc/docs/flow-logs#filtering for details on how to format this field.
               The default value is 'true', which evaluates to include everything.
             default_value: "true"
+      - !ruby/object:Api::Type::Enum
+        name: 'stackType'
+        update_verb: :PATCH
+        update_url: projects/{{project}}/regions/{{region}}/subnetworks/{{name}}
+        fingerprint_name: 'fingerprint'
+        values:
+          - :IPV4_ONLY
+          - :IPV4_IPV6
+        default_value: :IPV4_ONLY
+        description: |
+          The stack type for this subnet to identify whether the IPv6 feature is enabled or not.
+          If not specified IPV4_ONLY will be used.
+      - !ruby/object:Api::Type::Enum
+        name: 'ipv6AccessType'
+        values:
+          - :EXTERNAL
+        description: |
+          The access type of IPv6 address this subnet holds. It's immutable and can only be specified during creation
+          or the first time the subnet is updated into IPV4_IPV6 dual stack. If the ipv6_type is EXTERNAL then this subnet
+          cannot enable direct path.
+      - !ruby/object:Api::Type::String
+        name: 'ipv6CidrRange'
+        output: true
+        description: |
+          The range of internal IPv6 addresses that are owned by this subnetwork.
+      - !ruby/object:Api::Type::String
+        name: 'externalIpv6Prefix'
+        output: true
+        description: |
+          The range of external IPv6 addresses that are owned by this subnetwork.
     references: !ruby/object:Api::Resource::ReferenceLinks
       guides:
         'Private Google Access':

--- a/mmv1/products/compute/api.yaml
+++ b/mmv1/products/compute/api.yaml
@@ -14682,7 +14682,6 @@ objects:
         values:
           - :IPV4_ONLY
           - :IPV4_IPV6
-        default_value: :IPV4_ONLY
         description: |
           The stack type for this subnet to identify whether the IPv6 feature is enabled or not.
           If not specified IPV4_ONLY will be used.

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2711,6 +2711,12 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           subnetwork_name: "l7lb-test-subnetwork"
           network_name: "l7lb-test-network"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "subnetwork_ipv6"
+        primary_resource_id: "subnetwork-ipv6"
+        vars:
+          subnetwork_name: "ipv6-test-subnetwork"
+          network_name: "ipv6-test-network"
   TargetHttpProxy: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2675,6 +2675,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         exclude: true
       logConfig.metadataFields: !ruby/object:Overrides::Terraform::PropertyOverride
         is_set: true
+      stackType: !ruby/object:Overrides::Terraform::PropertyOverride
+        default_from_api: true
       ipCidrRange: !ruby/object:Overrides::Terraform::PropertyOverride
         validation: !ruby/object:Provider::Terraform::Validation
           function: 'validateIpCidrRange'

--- a/mmv1/templates/terraform/examples/subnetwork_ipv6.tf.erb
+++ b/mmv1/templates/terraform/examples/subnetwork_ipv6.tf.erb
@@ -1,0 +1,16 @@
+resource "google_compute_subnetwork" "subnetwork-ipv6" {
+  name          = "<%= ctx[:vars]['subnetwork_name'] %>"
+  
+  ip_cidr_range = "10.0.0.0/22"
+  region        = "us-west2"
+  
+  stack_type       = "IPV4_IPV6"
+  ipv6_access_type = "EXTERNAL"
+
+  network       = google_compute_network.custom-test.id
+}
+
+resource "google_compute_network" "custom-test" {
+  name                    = "<%= ctx[:vars]['network_name'] %>"
+  auto_create_subnetworks = false
+}

--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -357,7 +357,6 @@ func resourceComputeInstance() *schema.Resource {
 							Optional:     true,
 							ValidateFunc: validation.StringInSlice([]string{"IPV4_ONLY", "IPV4_IPV6", ""}, false),
 							Description: `The stack type for this network interface to identify whether the IPv6 feature is enabled or not. If not specified, IPV4_ONLY will be used.`,
-							Default:      "IPV4_ONLY",
 						},
 
 						"ipv6_access_type": {
@@ -392,7 +391,7 @@ func resourceComputeInstance() *schema.Resource {
 
 									"network_tier": {
 										Type:         schema.TypeString,
-										Optional:     true,
+										Required:     true,
 										ValidateFunc: validation.StringInSlice([]string{"PREMIUM"}, false),
 										Description:  `The service-level to be provided for IPv6 traffic when the subnet has an external subnet. Only PREMIUM tier is valid for IPv6`,
 									},

--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -372,29 +372,26 @@ func resourceComputeInstance() *schema.Resource {
 							Description: `An array of IPv6 access configurations for this interface. Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig specified, then this instance will have no external IPv6 Internet access.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"external_ipv6": {
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: `The first IPv6 address of the external IPv6 range associated with this instance, prefix length is stored in externalIpv6PrefixLength in ipv6AccessConfig. The field is output only, an IPv6 address from a subnetwork associated with the instance will be allocated dynamically.`,
-									},
-
-									"external_ipv6_prefix_length": {
-										Type:         schema.TypeString,
-										Computed:     true,
-										Description:  `The prefix length of the external IPv6 range.`,
-									},
-
-									"public_ptr_domain_name": {
-										Type:        schema.TypeString,
-										Optional:    true,
-										Description: `The domain name to be used when creating DNSv6 records for the external IPv6 ranges.`,
-									},
-
 									"network_tier": {
 										Type:         schema.TypeString,
 										Required:     true,
 										ValidateFunc: validation.StringInSlice([]string{"PREMIUM"}, false),
 										Description:  `The service-level to be provided for IPv6 traffic when the subnet has an external subnet. Only PREMIUM tier is valid for IPv6`,
+									},
+									"public_ptr_domain_name": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: `The domain name to be used when creating DNSv6 records for the external IPv6 ranges.`,
+									},
+									"external_ipv6": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The first IPv6 address of the external IPv6 range associated with this instance, prefix length is stored in externalIpv6PrefixLength in ipv6AccessConfig. The field is output only, an IPv6 address from a subnetwork associated with the instance will be allocated dynamically.`,
+									},
+									"external_ipv6_prefix_length": {
+										Type:         schema.TypeString,
+										Computed:     true,
+										Description:  `The prefix length of the external IPv6 range.`,
 									},
 								},
 							},

--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -366,7 +366,7 @@ func resourceComputeInstance() *schema.Resource {
 							Description: `One of EXTERNAL, INTERNAL to indicate whether the IP can be accessed from the Internet. This field is always inherited from its subnetwork.`,
 						},
 
-						"ipv6_access_configs": {
+						"ipv6_access_config": {
 							Type:        schema.TypeList,
 							Optional:    true,
 							Description: `An array of IPv6 access configurations for this interface. Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig specified, then this instance will have no external IPv6 Internet access.`,

--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -351,6 +351,54 @@ func resourceComputeInstance() *schema.Resource {
 								},
 							},
 						},
+
+						"stack_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"IPV4_ONLY", "IPV4_IPV6", ""}, false),
+							Description: `The stack type for this network interface to identify whether the IPv6 feature is enabled or not. If not specified, IPV4_ONLY will be used.`,
+							Default:      "IPV4_ONLY",
+						},
+
+						"ipv6_access_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `One of EXTERNAL, INTERNAL to indicate whether the IP can be accessed from the Internet. This field is always inherited from its subnetwork.`,
+						},
+
+						"ipv6_access_configs": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: `An array of IPv6 access configurations for this interface. Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig specified, then this instance will have no external IPv6 Internet access.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"external_ipv6": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The first IPv6 address of the external IPv6 range associated with this instance, prefix length is stored in externalIpv6PrefixLength in ipv6AccessConfig. The field is output only, an IPv6 address from a subnetwork associated with the instance will be allocated dynamically.`,
+									},
+
+									"external_ipv6_prefix_length": {
+										Type:         schema.TypeString,
+										Computed:     true,
+										Description:  `The prefix length of the external IPv6 range.`,
+									},
+
+									"public_ptr_domain_name": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: `The domain name to be used when creating DNSv6 records for the external IPv6 ranges.`,
+									},
+
+									"network_tier": {
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validation.StringInSlice([]string{"PREMIUM"}, false),
+										Description:  `The service-level to be provided for IPv6 traffic when the subnet has an external subnet. Only PREMIUM tier is valid for IPv6`,
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance.go.erb
@@ -355,6 +355,7 @@ func resourceComputeInstance() *schema.Resource {
 						"stack_type": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							Computed:     true,
 							ValidateFunc: validation.StringInSlice([]string{"IPV4_ONLY", "IPV4_IPV6", ""}, false),
 							Description: `The stack type for this network interface to identify whether the IPv6 feature is enabled or not. If not specified, IPV4_ONLY will be used.`,
 						},

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -412,6 +412,7 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 						"stack_type": {
 							Type:         schema.TypeString,
 							Optional:     true,
+							Computed:     true,
 							ValidateFunc: validation.StringInSlice([]string{"IPV4_ONLY", "IPV4_IPV6", ""}, false),
 							Description: `The stack type for this network interface to identify whether the IPv6 feature is enabled or not. If not specified, IPV4_ONLY will be used.`,
 						},

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -408,6 +408,53 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 								},
 							},
 						},
+
+						"stack_type": {
+							Type:         schema.TypeString,
+							Optional:     true,
+							ValidateFunc: validation.StringInSlice([]string{"IPV4_ONLY", "IPV4_IPV6", ""}, false),
+							Description: `The stack type for this network interface to identify whether the IPv6 feature is enabled or not. If not specified, IPV4_ONLY will be used.`,
+						},
+
+						"ipv6_access_type": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: `One of EXTERNAL, INTERNAL to indicate whether the IP can be accessed from the Internet. This field is always inherited from its subnetwork.`,
+						},
+
+						"ipv6_access_config": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: `An array of IPv6 access configurations for this interface. Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig specified, then this instance will have no external IPv6 Internet access.`,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"external_ipv6": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The first IPv6 address of the external IPv6 range associated with this instance, prefix length is stored in externalIpv6PrefixLength in ipv6AccessConfig. The field is output only, an IPv6 address from a subnetwork associated with the instance will be allocated dynamically.`,
+									},
+
+									"external_ipv6_prefix_length": {
+										Type:         schema.TypeString,
+										Computed:     true,
+										Description:  `The prefix length of the external IPv6 range.`,
+									},
+
+									"public_ptr_domain_name": {
+										Type:        schema.TypeString,
+										Optional:    true,
+										Description: `The domain name to be used when creating DNSv6 records for the external IPv6 ranges.`,
+									},
+
+									"network_tier": {
+										Type:         schema.TypeString,
+										Required:     true,
+										ValidateFunc: validation.StringInSlice([]string{"PREMIUM"}, false),
+										Description:  `The service-level to be provided for IPv6 traffic when the subnet has an external subnet. Only PREMIUM tier is valid for IPv6`,
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
+++ b/mmv1/third_party/terraform/resources/resource_compute_instance_template.go.erb
@@ -429,29 +429,28 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 							Description: `An array of IPv6 access configurations for this interface. Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig specified, then this instance will have no external IPv6 Internet access.`,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"external_ipv6": {
-										Type:        schema.TypeString,
-										Computed:    true,
-										Description: `The first IPv6 address of the external IPv6 range associated with this instance, prefix length is stored in externalIpv6PrefixLength in ipv6AccessConfig. The field is output only, an IPv6 address from a subnetwork associated with the instance will be allocated dynamically.`,
-									},
-
-									"external_ipv6_prefix_length": {
-										Type:         schema.TypeString,
-										Computed:     true,
-										Description:  `The prefix length of the external IPv6 range.`,
-									},
-
-									"public_ptr_domain_name": {
-										Type:        schema.TypeString,
-										Optional:    true,
-										Description: `The domain name to be used when creating DNSv6 records for the external IPv6 ranges.`,
-									},
-
 									"network_tier": {
 										Type:         schema.TypeString,
 										Required:     true,
 										ValidateFunc: validation.StringInSlice([]string{"PREMIUM"}, false),
 										Description:  `The service-level to be provided for IPv6 traffic when the subnet has an external subnet. Only PREMIUM tier is valid for IPv6`,
+									},
+									// Possibly configurable- this was added so we don't break if it's inadvertently set
+									// (assuming the same ass access config)
+									"public_ptr_domain_name": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The domain name to be used when creating DNSv6 records for the external IPv6 ranges.`,
+									},
+									"external_ipv6": {
+										Type:        schema.TypeString,
+										Computed:    true,
+										Description: `The first IPv6 address of the external IPv6 range associated with this instance, prefix length is stored in externalIpv6PrefixLength in ipv6AccessConfig. The field is output only, an IPv6 address from a subnetwork associated with the instance will be allocated dynamically.`,
+									},
+									"external_ipv6_prefix_length": {
+										Type:         schema.TypeString,
+										Computed:     true,
+										Description:  `The prefix length of the external IPv6 range.`,
 									},
 								},
 							},

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_template_test.go.erb
@@ -321,6 +321,32 @@ func TestAccComputeInstanceTemplate_IP(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstanceTemplate_IPv6(t *testing.T) {
+	t.Parallel()
+
+	var instanceTemplate compute.InstanceTemplate
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceTemplateDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstanceTemplate_ipv6(randString(t, 10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceTemplateExists(
+						t, "google_compute_instance_template.foobar", &instanceTemplate),
+				),
+			},
+			{
+				ResourceName:      "google_compute_instance_template.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccComputeInstanceTemplate_networkTier(t *testing.T) {
 	t.Parallel()
 
@@ -1584,6 +1610,59 @@ resource "google_compute_instance_template" "foobar" {
   }
 }
 `, suffix, suffix)
+}
+
+func testAccComputeInstanceTemplate_ipv6(suffix string) string {
+	return fmt.Sprintf(`
+resource "google_compute_address" "foo" {
+  name = "tf-test-instance-template-%s"
+}
+
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_network" "foo" {
+  name                    = "tf-test-network-%s"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork-ipv6" {
+  name          = "tf-test-subnetwork-%s"
+
+  ip_cidr_range = "10.0.0.0/22"
+  region        = "us-west2"
+
+  stack_type       = "IPV4_IPV6"
+  ipv6_access_type = "EXTERNAL"
+
+  network       = google_compute_network.foo.id
+}
+
+resource "google_compute_instance_template" "foobar" {
+  name         = "tf-test-instance-template-%s"
+  machine_type = "e2-medium"
+  region       = "us-west2"
+  tags         = ["foo", "bar"]
+
+  disk {
+    source_image = data.google_compute_image.my_image.self_link
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.subnetwork-ipv6.name
+    stack_type = "IPV4_IPV6"
+    ipv6_access_config {
+      network_tier = "PREMIUM"
+    }
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+}
+`, suffix, suffix, suffix, suffix)
 }
 
 func testAccComputeInstanceTemplate_networkTier(suffix string) string {

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -247,6 +247,30 @@ func TestAccComputeInstance_IP(t *testing.T) {
 	})
 }
 
+func TestAccComputeInstance_IPv6(t *testing.T) {
+	t.Parallel()
+
+	var instance compute.Instance
+	var ipName = fmt.Sprintf("tf-test-%s", randString(t, 10))
+	var instanceName = fmt.Sprintf("tf-test-%s", randString(t, 10))
+	var ptrName = fmt.Sprintf("tf-test-%s", randString(t, 10))
+
+	vcrTest(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeInstanceDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeInstance_ipv6(ipName, instanceName, ptrName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeInstanceExists(
+						t, "google_compute_instance.foobar", &instance),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeInstance_PTRRecord(t *testing.T) {
 	t.Parallel()
 
@@ -3257,6 +3281,63 @@ resource "google_compute_instance" "foobar" {
   }
 }
 `, ip, instance)
+}
+
+func testAccComputeInstance_ipv6(ip, instance, record string) string {
+	return fmt.Sprintf(`
+data "google_compute_image" "my_image" {
+  family  = "debian-9"
+  project = "debian-cloud"
+}
+
+resource "google_compute_subnetwork" "subnetwork-ipv6" {
+  name          = "%s-subnetwork"
+
+  ip_cidr_range = "10.0.0.0/22"
+  region        = "us-west2"
+
+  stack_type       = "IPV4_IPV6"
+  ipv6_access_type = "EXTERNAL"
+
+  network       = google_compute_network.custom-test.id
+}
+
+resource "google_compute_network" "custom-test" {
+  name                    = "%s-network"
+  auto_create_subnetworks = false
+}
+
+
+resource "google_compute_address" "foo" {
+  name = "%s"
+}
+
+resource "google_compute_instance" "foobar" {
+  name         = "%s"
+  machine_type = "e2-medium"
+  zone         = "us-west2-a"
+  tags         = ["foo", "bar"]
+
+  boot_disk {
+    initialize_params {
+      image = data.google_compute_image.my_image.self_link
+    }
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.subnetwork-ipv6.name
+    stack_type = "IPV4_IPV6"
+    ipv6_access_configs {
+      network_tier = "PREMIUM"
+      public_ptr_domain_name = "%s.gcp.tfacc.hashicorptest.com."
+    }
+  }
+
+  metadata = {
+    foo = "bar"
+  }
+}
+`, instance, instance, ip, instance, record)
 }
 
 func testAccComputeInstance_PTRRecord(record, instance string) string {

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -3327,7 +3327,7 @@ resource "google_compute_instance" "foobar" {
   network_interface {
     subnetwork = google_compute_subnetwork.subnetwork-ipv6.name
     stack_type = "IPV4_IPV6"
-    ipv6_access_configs {
+    ipv6_access_config {
       network_tier = "PREMIUM"
       public_ptr_domain_name = "%s.gcp.tfacc.hashicorptest.com."
     }

--- a/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
+++ b/mmv1/third_party/terraform/tests/resource_compute_instance_test.go.erb
@@ -267,6 +267,11 @@ func TestAccComputeInstance_IPv6(t *testing.T) {
 						t, "google_compute_instance.foobar", &instance),
 				),
 			},
+			{
+				ResourceName:      "google_compute_instance.foobar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }
@@ -3306,7 +3311,6 @@ resource "google_compute_network" "custom-test" {
   name                    = "%s-network"
   auto_create_subnetworks = false
 }
-
 
 resource "google_compute_address" "foo" {
   name = "%s"

--- a/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
@@ -164,6 +164,17 @@ func flattenAccessConfigs(accessConfigs []*computeBeta.AccessConfig) ([]map[stri
 	return flattened, natIP
 }
 
+func flattenIpv6AccessConfigs(ipv6AccessConfigs []*computeBeta.AccessConfig) []map[string]interface{} {
+	flattened := make([]map[string]interface{}, len(ipv6AccessConfigs))
+	for i, ac := range ipv6AccessConfigs {
+		flattened[i] = map[string]interface{}{
+			"network_tier": ac.NetworkTier,
+		}
+		flattened[i]["public_ptr_domain_name"] = ac.PublicPtrDomainName
+	}
+	return flattened
+}
+
 func flattenNetworkInterfaces(d *schema.ResourceData, config *Config, networkInterfaces []*computeBeta.NetworkInterface) ([]map[string]interface{}, string, string, string, error) {
 	flattened := make([]map[string]interface{}, len(networkInterfaces))
 	var region, internalIP, externalIP string
@@ -179,13 +190,15 @@ func flattenNetworkInterfaces(d *schema.ResourceData, config *Config, networkInt
 		region = subnet.Region
 
 		flattened[i] = map[string]interface{}{
-			"network_ip":         iface.NetworkIP,
-			"network":            ConvertSelfLinkToV1(iface.Network),
-			"subnetwork":         ConvertSelfLinkToV1(iface.Subnetwork),
-			"subnetwork_project": subnet.Project,
-			"access_config":      ac,
-			"alias_ip_range":     flattenAliasIpRange(iface.AliasIpRanges),
-			"nic_type":           iface.NicType,
+			"network_ip":          iface.NetworkIP,
+			"network":             ConvertSelfLinkToV1(iface.Network),
+			"subnetwork":          ConvertSelfLinkToV1(iface.Subnetwork),
+			"subnetwork_project":  subnet.Project,
+			"access_config":       ac,
+			"alias_ip_range":      flattenAliasIpRange(iface.AliasIpRanges),
+			"nic_type":            iface.NicType,
+			"stack_type":          iface.StackType,
+			"ipv6_access_configs": flattenIpv6AccessConfigs(iface.Ipv6AccessConfigs),
 		}
 		// Instance template interfaces never have names, so they're absent
 		// in the instance template network_interface schema. We want to use the
@@ -219,6 +232,22 @@ func expandAccessConfigs(configs []interface{}) []*computeBeta.AccessConfig {
 	return acs
 }
 
+func expandIpv6AccessConfigs(configs []interface{}) []*computeBeta.AccessConfig {
+	iacs := make([]*computeBeta.AccessConfig, len(configs))
+	for i, raw := range configs {
+		iacs[i] = &computeBeta.AccessConfig{}
+		if raw != nil {
+			data := raw.(map[string]interface{})
+			iacs[i].NetworkTier = data["network_tier"].(string)
+			if ptr, ok := data["public_ptr_domain_name"]; ok && ptr != "" {
+				iacs[i].PublicPtrDomainName = ptr.(string)
+			}
+			iacs[i].Type = "DIRECT_IPV6" // Currently only type supported
+		}
+	}
+	return iacs
+}
+
 func expandNetworkInterfaces(d TerraformResourceData, config *Config) ([]*computeBeta.NetworkInterface, error) {
 	configs := d.Get("network_interface").([]interface{})
 	ifaces := make([]*computeBeta.NetworkInterface, len(configs))
@@ -243,12 +272,14 @@ func expandNetworkInterfaces(d TerraformResourceData, config *Config) ([]*comput
 		}
 
 		ifaces[i] = &computeBeta.NetworkInterface{
-			NetworkIP:     data["network_ip"].(string),
-			Network:       nf.RelativeLink(),
-			Subnetwork:    sf.RelativeLink(),
-			AccessConfigs: expandAccessConfigs(data["access_config"].([]interface{})),
-			AliasIpRanges: expandAliasIpRanges(data["alias_ip_range"].([]interface{})),
-			NicType:       data["nic_type"].(string),
+			NetworkIP:         data["network_ip"].(string),
+			Network:           nf.RelativeLink(),
+			Subnetwork:        sf.RelativeLink(),
+			AccessConfigs:     expandAccessConfigs(data["access_config"].([]interface{})),
+			AliasIpRanges:     expandAliasIpRanges(data["alias_ip_range"].([]interface{})),
+			NicType:           data["nic_type"].(string),
+			StackType:         data["stack_type"].(string),
+			Ipv6AccessConfigs: expandIpv6AccessConfigs(data["ipv6_access_configs"].([]interface{})),
 		}
 	}
 	return ifaces, nil

--- a/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
+++ b/mmv1/third_party/terraform/utils/compute_instance_helpers.go.erb
@@ -198,7 +198,7 @@ func flattenNetworkInterfaces(d *schema.ResourceData, config *Config, networkInt
 			"alias_ip_range":      flattenAliasIpRange(iface.AliasIpRanges),
 			"nic_type":            iface.NicType,
 			"stack_type":          iface.StackType,
-			"ipv6_access_configs": flattenIpv6AccessConfigs(iface.Ipv6AccessConfigs),
+			"ipv6_access_config": flattenIpv6AccessConfigs(iface.Ipv6AccessConfigs),
 		}
 		// Instance template interfaces never have names, so they're absent
 		// in the instance template network_interface schema. We want to use the
@@ -279,7 +279,7 @@ func expandNetworkInterfaces(d TerraformResourceData, config *Config) ([]*comput
 			AliasIpRanges:     expandAliasIpRanges(data["alias_ip_range"].([]interface{})),
 			NicType:           data["nic_type"].(string),
 			StackType:         data["stack_type"].(string),
-			Ipv6AccessConfigs: expandIpv6AccessConfigs(data["ipv6_access_configs"].([]interface{})),
+			Ipv6AccessConfigs: expandIpv6AccessConfigs(data["ipv6_access_config"].([]interface{})),
 		}
 	}
 	return ifaces, nil

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -294,7 +294,6 @@ The `network_interface` block supports:
 
 * `nic_type` - (Optional) The type of vNIC to be used on this interface. Possible values: GVNIC, VIRTIO_NET.
 
-
 * `stack_type` - (Optional) The stack type for this network interface to identify whether the IPv6 feature is enabled or not. Values are IPV4_IPV6 or IPV4_ONLY. If not specified, IPV4_ONLY will be used.
 
 * `ipv6_access_config` - (Optional) An array of IPv6 access configurations for this interface.

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance.html.markdown
@@ -294,6 +294,14 @@ The `network_interface` block supports:
 
 * `nic_type` - (Optional) The type of vNIC to be used on this interface. Possible values: GVNIC, VIRTIO_NET.
 
+
+* `stack_type` - (Optional) The stack type for this network interface to identify whether the IPv6 feature is enabled or not. Values are IPV4_IPV6 or IPV4_ONLY. If not specified, IPV4_ONLY will be used.
+
+* `ipv6_access_config` - (Optional) An array of IPv6 access configurations for this interface.
+Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig
+specified, then this instance will have no external IPv6 Internet access. Structure documented below.
+
+
 The `access_config` block supports:
 
 * `nat_ip` - (Optional) The IP address that will be 1:1 mapped to the instance's
@@ -307,6 +315,14 @@ The `access_config` block supports:
 * `network_tier` - (Optional) The [networking tier][network-tier] used for configuring this instance.
     This field can take the following values: PREMIUM or STANDARD. If this field is
     not specified, it is assumed to be PREMIUM.
+
+The `ipv6_access_config` block supports:
+
+* `public_ptr_domain_name` - (Optional) The domain name to be used when creating DNSv6
+    records for the external IPv6 ranges..
+
+* `network_tier` - (Optional) The service-level to be provided for IPv6 traffic when the
+    subnet has an external subnet. Only PREMIUM tier is valid for IPv6.
 
 The `alias_ip_range` block supports:
 
@@ -420,9 +436,18 @@ exported:
 
 * `cpu_platform` - The CPU platform used by this instance.
 
+* `ipv6_access_type` - One of EXTERNAL, INTERNAL to indicate whether the IP can be accessed from the Internet.
+This field is always inherited from its subnetwork.
+
 * `network_interface.0.network_ip` - The internal ip address of the instance, either manually or dynamically assigned.
 
 * `network_interface.0.access_config.0.nat_ip` - If the instance has an access config, either the given external ip (in the `nat_ip` field) or the ephemeral (generated) ip (if you didn't provide one).
+
+* `network_interface.0.ipv6_access_config.0.external_ipv6` - The first IPv6 address of the external IPv6 range
+associated with this instance, prefix length is stored in externalIpv6PrefixLength in ipv6AccessConfig.
+The field is output only, an IPv6 address from a subnetwork associated with the instance will be allocated dynamically.
+
+* `network_interface.0.ipv6_access_config.0.external_ipv6_prefix_length` - The prefix length of the external IPv6 range.
 
 * `attached_disk.0.disk_encryption_key_sha256` - The [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
     encoded SHA-256 hash of the [customer-supplied encryption key]

--- a/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
+++ b/mmv1/third_party/terraform/website/docs/r/compute_instance_template.html.markdown
@@ -377,6 +377,12 @@ The `network_interface` block supports:
 
 * `nic_type` - (Optional) The type of vNIC to be used on this interface. Possible values: GVNIC, VIRTIO_NET.
 
+* `stack_type` - (Optional) The stack type for this network interface to identify whether the IPv6 feature is enabled or not. Values are IPV4_IPV6 or IPV4_ONLY. If not specified, IPV4_ONLY will be used.
+
+* `ipv6_access_config` - (Optional) An array of IPv6 access configurations for this interface.
+Currently, only one IPv6 access config, DIRECT_IPV6, is supported. If there is no ipv6AccessConfig
+specified, then this instance will have no external IPv6 Internet access. Structure documented below.
+
 The `access_config` block supports:
 
 * `nat_ip` - (Optional) The IP address that will be 1:1 mapped to the instance's
@@ -385,6 +391,11 @@ The `access_config` block supports:
 * `network_tier` - (Optional) The [networking tier][network-tier] used for configuring
     this instance template. This field can take the following values: PREMIUM or
     STANDARD. If this field is not specified, it is assumed to be PREMIUM.
+
+The `ipv6_access_config` block supports:
+
+* `network_tier` - (Optional) The service-level to be provided for IPv6 traffic when the
+    subnet has an external subnet. Only PREMIUM tier is valid for IPv6.
 
 The `alias_ip_range` block supports:
 


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->

Fixes https://github.com/hashicorp/terraform-provider-google/issues/9860

I'm unsure if these fields are updateable. The documentation seems to suggest it is ([`This field can be both set at instance creation and update network interface operations.`](https://cloud.google.com/compute/docs/reference/rest/v1/instances)) however, the [documentation](https://cloud.google.com/compute/docs/reference/rest/v1/instances/updateNetworkInterface) for the `updateNetworkInterface` seems to suggest `This method can only update an interface's alias IP range and attached network`. I tried a few things, but only ran into errors, so left it off.

<!--
Replace each [ ] with [X] to check it. Switch to the preview view to make it easier to click on links.
These steps will speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.
-->
If this PR is for Terraform, I acknowledge that I have:

- [x] Searched through the [issue tracker](https://github.com/hashicorp/terraform-provider-google/issues) for an open issue that this either resolves or contributes to, commented on it to claim it, and written "fixes {url}" or "part of {url}" in this PR description. If there were no relevant open issues, I opened one and commented that I would like to work on it (not necessary for very small changes).
- [x] [Generated Terraform](https://github.com/GoogleCloudPlatform/magic-modules#generating-downstream-tools), and ran `make test` and `make lint` to ensure it passes unit and linter tests.
- [x] Ensured that all new fields I added that can be set by a user appear in at least one [example](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/templates/terraform/examples) (for generated resources) or [third_party test](https://github.com/GoogleCloudPlatform/magic-modules/tree/master/third_party/terraform/tests) (for handwritten resources or update tests).
- [x] [Ran](https://github.com/hashicorp/terraform-provider-google/blob/master/.github/CONTRIBUTING.md#tests) relevant acceptance tests (If the acceptance tests do not yet pass or you are unable to run them, please let your reviewer know).
- [x] Read the [Release Notes Guide](https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md) before writing my release note below.

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none
    
Unless you choose release-note:none, please add a release note.

See .ci/RELEASE_NOTES_GUIDE.md for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:enhancement
compute: added external IPv6 support on `google_compute_subnetwork` and `google_compute_instance.network_interfaces`
```
