### PR TITLE
Added internal HTTPS load balancer example with http-to-https redirect

### DIFF
--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2038,7 +2038,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           l7_ilb_test_vm: "l7-ilb-test-vm"
           l7_ilb_redirect: "l7-ilb-redirect"
           l7_ilb_target_http_proxy: "l7-ilb-target-http-proxy"
-          l7_ilb_redirect_url_map "l7-ilb-redirect-url-map"
+          l7_ilb_redirect_url_map: "l7-ilb-redirect-url-map"
         min_version: beta
         ignore_read_extra:
           - "target"

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2018,6 +2018,32 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   RegionUrlMap: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples
+        name: "int_https_lb_https_redirect"
+        primary_resource_id: "default"
+        vars:
+          l7_ilb_network: "l7-ilb-network”
+          l7_ilb_proxy_subnet: “proxy_subnet"
+          l7_ilb_subnet: "l7-ilb-subnet"
+          l7_ilb_ip: "l7-ilb-ip"
+          l7_ilb_forwarding_rule: "l7-ilb-forwarding-rule"
+          l7_ilb_regional_ssl_cert: "l7-ilb-regional-ssl-cert"
+          l7_ilb_target_https_proxy: "l7-ilb-target-https-proxy"
+          l7_ilb_regional_url_map: "l7-ilb-regional-url-map"
+          l7_ilb_backend_service: "l7-ilb-backend-service"
+          l7_ilb_mig_template: "l7-ilb-mig-template"
+          l7_ilb_hc: ""l7-ilb-hc"
+          l7_ilb_mig1: "l7-ilb-mig1"
+          l7_ilb_fw_allow_hc: "l7-ilb-fw-allow-hc"
+          l7_ilb_fw_allow_ilb_to_backends: "l7-ilb-fw-allow-ilb-to-backends"
+          l7_ilb_test_vm: "l7-ilb-test-vm"
+          l7_ilb_redirect: "l7-ilb-redirect"
+          l7_ilb_target_http_proxy: "l7-ilb-target-http-proxy"
+          l7_ilb_redirect_url_map "l7-ilb-redirect-url-map"
+        min_version: beta
+        ignore_read_extra:
+          - "target"
+          - "ip_address"
+      - !ruby/object:Provider::Terraform::Examples
         name: "region_url_map_basic"
         primary_resource_id: "regionurlmap"
         vars:

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -336,31 +336,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   RegionBackendService: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples
-        name: "int_https_lb_https_redirect"
-        primary_resource_id: "default"
-        vars:
-          l7_ilb_network: "l7-ilb-network"
-          l7_ilb_proxy_subnet: "l7-ilb-proxy-subnet"
-          l7_ilb_subnet: "l7-ilb-subnet"
-          l7_ilb_ip: "l7-ilb-ip"
-          l7_ilb_forwarding_rule: "l7-ilb-forwarding-rule"
-          l7_ilb_target_https_proxy: "l7-ilb-target-https-proxy"
-          l7_ilb_regional_url_map: "l7-ilb-regional-url-map"
-          l7_ilb_backend_service: "l7-ilb-backend-service"
-          l7_ilb_mig_template: "l7-ilb-mig-template"
-          l7_ilb_hc: "l7-ilb-hc"
-          l7_ilb_mig1: "l7-ilb-mig1"
-          l7_ilb_fw_allow_hc: "l7-ilb-fw-allow-hc"
-          l7_ilb_fw_allow_ilb_to_backends: "l7-ilb-fw-allow-ilb-to-backends"
-          l7_ilb_test_vm: "l7-ilb-test-vm"
-          l7_ilb_redirect: "l7-ilb-redirect"
-          l7_ilb_target_http_proxy: "l7-ilb-target-http-proxy"
-          l7_ilb_redirect_url_map: "l7-ilb-redirect-url-map"
-        min_version: beta
-        ignore_read_extra:
-          - "target"
-          - "ip_address"
-      - !ruby/object:Provider::Terraform::Examples
         name: "region_backend_service_basic"
         primary_resource_id: "default"
         vars:
@@ -406,6 +381,31 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           region_backend_service_name: "region-service"
           health_check_name: "rbs-health-check"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "int_https_lb_https_redirect"
+        primary_resource_id: "default"
+        vars:
+          l7_ilb_network: "l7-ilb-network"
+          l7_ilb_proxy_subnet: "l7-ilb-proxy-subnet"
+          l7_ilb_subnet: "l7-ilb-subnet"
+          l7_ilb_ip: "l7-ilb-ip"
+          l7_ilb_forwarding_rule: "l7-ilb-forwarding-rule"
+          l7_ilb_target_https_proxy: "l7-ilb-target-https-proxy"
+          l7_ilb_regional_url_map: "l7-ilb-regional-url-map"
+          l7_ilb_backend_service: "l7-ilb-backend-service"
+          l7_ilb_mig_template: "l7-ilb-mig-template"
+          l7_ilb_hc: "l7-ilb-hc"
+          l7_ilb_mig1: "l7-ilb-mig1"
+          l7_ilb_fw_allow_hc: "l7-ilb-fw-allow-hc"
+          l7_ilb_fw_allow_ilb_to_backends: "l7-ilb-fw-allow-ilb-to-backends"
+          l7_ilb_test_vm: "l7-ilb-test-vm"
+          l7_ilb_redirect: "l7-ilb-redirect"
+          l7_ilb_target_http_proxy: "l7-ilb-target-http-proxy"
+          l7_ilb_redirect_url_map: "l7-ilb-redirect-url-map"
+        min_version: beta
+        ignore_read_extra:
+          - "target"
+          - "ip_address"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/region_backend_service.go.erb
       encoder: templates/terraform/encoders/region_backend_service.go.erb

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -336,6 +336,32 @@ overrides: !ruby/object:Overrides::ResourceOverrides
   RegionBackendService: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
       - !ruby/object:Provider::Terraform::Examples
+        name: "int_https_lb_https_redirect"
+        primary_resource_id: "default"
+        vars:
+          l7_ilb_network: "l7-ilb-network"
+          l7_ilb_proxy_subnet: "proxy_subnet"
+          l7_ilb_subnet: "l7-ilb-subnet"
+          l7_ilb_ip: "l7-ilb-ip"
+          l7_ilb_forwarding_rule: "l7-ilb-forwarding-rule"
+          l7_ilb_regional_ssl_cert: "l7-ilb-regional-ssl-cert"
+          l7_ilb_target_https_proxy: "l7-ilb-target-https-proxy"
+          l7_ilb_regional_url_map: "l7-ilb-regional-url-map"
+          l7_ilb_backend_service: "l7-ilb-backend-service"
+          l7_ilb_mig_template: "l7-ilb-mig-template"
+          l7_ilb_hc: "l7-ilb-hc"
+          l7_ilb_mig1: "l7-ilb-mig1"
+          l7_ilb_fw_allow_hc: "l7-ilb-fw-allow-hc"
+          l7_ilb_fw_allow_ilb_to_backends: "l7-ilb-fw-allow-ilb-to-backends"
+          l7_ilb_test_vm: "l7-ilb-test-vm"
+          l7_ilb_redirect: "l7-ilb-redirect"
+          l7_ilb_target_http_proxy: "l7-ilb-target-http-proxy"
+          l7_ilb_redirect_url_map: "l7-ilb-redirect-url-map"
+        min_version: beta
+        ignore_read_extra:
+          - "target"
+          - "ip_address"
+      - !ruby/object:Provider::Terraform::Examples
         name: "region_backend_service_basic"
         primary_resource_id: "default"
         vars:
@@ -2017,32 +2043,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         diff_suppress_func: 'portDiffSuppress'
   RegionUrlMap: !ruby/object:Overrides::Terraform::ResourceOverride
     examples:
-      - !ruby/object:Provider::Terraform::Examples
-        name: "int_https_lb_https_redirect"
-        primary_resource_id: "default"
-        vars:
-          l7_ilb_network: "l7-ilb-network"
-          l7_ilb_proxy_subnet: "proxy_subnet"
-          l7_ilb_subnet: "l7-ilb-subnet"
-          l7_ilb_ip: "l7-ilb-ip"
-          l7_ilb_forwarding_rule: "l7-ilb-forwarding-rule"
-          l7_ilb_regional_ssl_cert: "l7-ilb-regional-ssl-cert"
-          l7_ilb_target_https_proxy: "l7-ilb-target-https-proxy"
-          l7_ilb_regional_url_map: "l7-ilb-regional-url-map"
-          l7_ilb_backend_service: "l7-ilb-backend-service"
-          l7_ilb_mig_template: "l7-ilb-mig-template"
-          l7_ilb_hc: "l7-ilb-hc"
-          l7_ilb_mig1: "l7-ilb-mig1"
-          l7_ilb_fw_allow_hc: "l7-ilb-fw-allow-hc"
-          l7_ilb_fw_allow_ilb_to_backends: "l7-ilb-fw-allow-ilb-to-backends"
-          l7_ilb_test_vm: "l7-ilb-test-vm"
-          l7_ilb_redirect: "l7-ilb-redirect"
-          l7_ilb_target_http_proxy: "l7-ilb-target-http-proxy"
-          l7_ilb_redirect_url_map: "l7-ilb-redirect-url-map"
-        min_version: beta
-        ignore_read_extra:
-          - "target"
-          - "ip_address"
       - !ruby/object:Provider::Terraform::Examples
         name: "region_url_map_basic"
         primary_resource_id: "regionurlmap"

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -381,31 +381,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         vars:
           region_backend_service_name: "region-service"
           health_check_name: "rbs-health-check"
-      - !ruby/object:Provider::Terraform::Examples
-        name: "int_https_lb_https_redirect"
-        primary_resource_id: "default"
-        vars:
-          l7_ilb_network: "l7-ilb-network"
-          l7_ilb_proxy_subnet: "l7-ilb-proxy-subnet"
-          l7_ilb_subnet: "l7-ilb-subnet"
-          l7_ilb_ip: "l7-ilb-ip"
-          l7_ilb_forwarding_rule: "l7-ilb-forwarding-rule"
-          l7_ilb_target_https_proxy: "l7-ilb-target-https-proxy"
-          l7_ilb_regional_url_map: "l7-ilb-regional-url-map"
-          l7_ilb_backend_service: "l7-ilb-backend-service"
-          l7_ilb_mig_template: "l7-ilb-mig-template"
-          l7_ilb_hc: "l7-ilb-hc"
-          l7_ilb_mig1: "l7-ilb-mig1"
-          l7_ilb_fw_allow_hc: "l7-ilb-fw-allow-hc"
-          l7_ilb_fw_allow_ilb_to_backends: "l7-ilb-fw-allow-ilb-to-backends"
-          l7_ilb_test_vm: "l7-ilb-test-vm"
-          l7_ilb_redirect: "l7-ilb-redirect"
-          l7_ilb_target_http_proxy: "l7-ilb-target-http-proxy"
-          l7_ilb_redirect_url_map: "l7-ilb-redirect-url-map"
-        min_version: beta
-        ignore_read_extra:
-          - "target"
-          - "ip_address"
     custom_code: !ruby/object:Provider::Terraform::CustomCode
       constants: templates/terraform/constants/region_backend_service.go.erb
       encoder: templates/terraform/encoders/region_backend_service.go.erb
@@ -2078,6 +2053,31 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           region_url_map_name: "regionurlmap"
           home_region_backend_service_name: "home"
           region_health_check_name: "health-check"
+      - !ruby/object:Provider::Terraform::Examples
+        name: "int_https_lb_https_redirect"
+        primary_resource_id: "default"
+        vars:
+          l7_ilb_network: "l7-ilb-network"
+          l7_ilb_proxy_subnet: "l7-ilb-proxy-subnet"
+          l7_ilb_subnet: "l7-ilb-subnet"
+          l7_ilb_ip: "l7-ilb-ip"
+          l7_ilb_forwarding_rule: "l7-ilb-forwarding-rule"
+          l7_ilb_target_https_proxy: "l7-ilb-target-https-proxy"
+          l7_ilb_regional_url_map: "l7-ilb-regional-url-map"
+          l7_ilb_backend_service: "l7-ilb-backend-service"
+          l7_ilb_mig_template: "l7-ilb-mig-template"
+          l7_ilb_hc: "l7-ilb-hc"
+          l7_ilb_mig1: "l7-ilb-mig1"
+          l7_ilb_fw_allow_hc: "l7-ilb-fw-allow-hc"
+          l7_ilb_fw_allow_ilb_to_backends: "l7-ilb-fw-allow-ilb-to-backends"
+          l7_ilb_test_vm: "l7-ilb-test-vm"
+          l7_ilb_redirect: "l7-ilb-redirect"
+          l7_ilb_target_http_proxy: "l7-ilb-target-http-proxy"
+          l7_ilb_redirect_url_map: "l7-ilb-redirect-url-map"
+        min_version: beta
+        ignore_read_extra:
+          - "target"
+          - "ip_address"
     properties:
       region: !ruby/object:Overrides::Terraform::PropertyOverride
         default_from_api: true

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2021,8 +2021,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         name: "int_https_lb_https_redirect"
         primary_resource_id: "default"
         vars:
-          l7_ilb_network: "l7-ilb-network”
-          l7_ilb_proxy_subnet: “proxy_subnet"
+          l7_ilb_network: "l7-ilb-network"
+          l7_ilb_proxy_subnet: "proxy_subnet"
           l7_ilb_subnet: "l7-ilb-subnet"
           l7_ilb_ip: "l7-ilb-ip"
           l7_ilb_forwarding_rule: "l7-ilb-forwarding-rule"
@@ -2031,7 +2031,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           l7_ilb_regional_url_map: "l7-ilb-regional-url-map"
           l7_ilb_backend_service: "l7-ilb-backend-service"
           l7_ilb_mig_template: "l7-ilb-mig-template"
-          l7_ilb_hc: ""l7-ilb-hc"
+          l7_ilb_hc: "l7-ilb-hc"
           l7_ilb_mig1: "l7-ilb-mig1"
           l7_ilb_fw_allow_hc: "l7-ilb-fw-allow-hc"
           l7_ilb_fw_allow_ilb_to_backends: "l7-ilb-fw-allow-ilb-to-backends"

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -340,7 +340,7 @@ overrides: !ruby/object:Overrides::ResourceOverrides
         primary_resource_id: "default"
         vars:
           l7_ilb_network: "l7-ilb-network"
-          l7_ilb_proxy_subnet: "proxy_subnet"
+          l7_ilb_proxy_subnet: "l7-ilb-proxy-subnet"
           l7_ilb_subnet: "l7-ilb-subnet"
           l7_ilb_ip: "l7-ilb-ip"
           l7_ilb_forwarding_rule: "l7-ilb-forwarding-rule"

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -2055,7 +2055,8 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           region_health_check_name: "health-check"
       - !ruby/object:Provider::Terraform::Examples
         name: "int_https_lb_https_redirect"
-        primary_resource_id: "default"
+        primary_resource_id: "redirect"
+        skip_test: true
         vars:
           l7_ilb_network: "l7-ilb-network"
           l7_ilb_proxy_subnet: "l7-ilb-proxy-subnet"

--- a/mmv1/products/compute/terraform.yaml
+++ b/mmv1/products/compute/terraform.yaml
@@ -344,7 +344,6 @@ overrides: !ruby/object:Overrides::ResourceOverrides
           l7_ilb_subnet: "l7-ilb-subnet"
           l7_ilb_ip: "l7-ilb-ip"
           l7_ilb_forwarding_rule: "l7-ilb-forwarding-rule"
-          l7_ilb_regional_ssl_cert: "l7-ilb-regional-ssl-cert"
           l7_ilb_target_https_proxy: "l7-ilb-target-https-proxy"
           l7_ilb_regional_url_map: "l7-ilb-regional-url-map"
           l7_ilb_backend_service: "l7-ilb-backend-service"

--- a/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
+++ b/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
@@ -1,18 +1,14 @@
 # Internal HTTPS load balancer with HTTP-to-HTTPS redirect
 
 # [START cloudloadbalancing_int_https_with_redirect]
-# Enable API
-resource "google_project_service" "default" {
-  service = "compute.googleapis.com"
-}
 
-# VPC
+# VPC network
 resource "google_compute_network" "default" {
   name                    = "<%= ctx[:vars]['l7_ilb_network'] %>"
   auto_create_subnetworks = false
 }
 
-# proxy-only subnet
+# Proxy-only subnet
 resource "google_compute_subnetwork" "proxy_subnet" {
   name          = "<%= ctx[:vars]['l7_ilb_proxy_subnet'] %>"
   ip_cidr_range = "10.0.0.0/24"
@@ -22,7 +18,7 @@ resource "google_compute_subnetwork" "proxy_subnet" {
   network       = google_compute_network.default.id
 }
 
-# backend subnet
+# Backend subnet
 resource "google_compute_subnetwork" "default" {
   name          = "<%= ctx[:vars]['l7_ilb_subnet'] %>"
   ip_cidr_range = "10.0.1.0/24"
@@ -30,6 +26,7 @@ resource "google_compute_subnetwork" "default" {
   network       = google_compute_network.default.id
 }
 
+# Reserved internal address
 resource "google_compute_address" "default" {
   name         = "<%= ctx[:vars]['l7_ilb_ip'] %>"
   provider     = google-beta
@@ -105,7 +102,7 @@ resource "google_compute_region_target_https_proxy" "default" {
   ssl_certificates = [google_compute_region_ssl_certificate.default.self_link]
 }
 
-# Regional url map
+# Regional URL map
 resource "google_compute_region_url_map" "default" {
   name            = "<%= ctx[:vars]['l7_ilb_regional_url_map'] %>"
   region          = "europe-west1"
@@ -128,7 +125,7 @@ resource "google_compute_region_backend_service" "<%= ctx[:primary_resource_id] 
   }
 }
 
-# instance template
+# Instance template
 resource "google_compute_instance_template" "default" {
   name         = "<%= ctx[:vars]['l7_ilb_mig_template'] %>"
   machine_type = "e2-small"
@@ -199,7 +196,7 @@ resource "google_compute_region_instance_group_manager" "default" {
   target_size        = 2
 }
 
-# allow all access to health check ranges
+# Allow all access to health check ranges
 resource "google_compute_firewall" "default" {
   name          = "<%= ctx[:vars]['l7_ilb_fw_allow_hc'] %>"
   direction     = "INGRESS"
@@ -210,7 +207,7 @@ resource "google_compute_firewall" "default" {
   }
 }
 
-# allow http from proxy subnet to backends
+# Allow http from proxy subnet to backends
 resource "google_compute_firewall" "backends" {
   name          = "<%= ctx[:vars]['l7_ilb_fw_allow_ilb_to_backends'] %>"
   direction     = "INGRESS"
@@ -223,7 +220,7 @@ resource "google_compute_firewall" "backends" {
   }
 }
 
-# test instance
+# Test instance
 resource "google_compute_instance" "default" {
   name         = "<%= ctx[:vars]['l7_ilb_test_vm'] %>"
   zone         = "europe-west1-b"
@@ -239,7 +236,7 @@ resource "google_compute_instance" "default" {
   }
 }
 
-### http-to-https redirect ###
+### HTTP-to-HTTPS redirect ###
 
 # Regional forwarding rule
 resource "google_compute_forwarding_rule" "redirect" {
@@ -255,14 +252,14 @@ resource "google_compute_forwarding_rule" "redirect" {
   network_tier          = "PREMIUM"
 }
 
-# Regional http proxy
+# Regional HTTP proxy
 resource "google_compute_region_target_http_proxy" "default" {
   name    = "<%= ctx[:vars]['l7_ilb_target_http_proxy'] %>"
   region  = "europe-west1"
   url_map = google_compute_region_url_map.redirect.id
 }
 
-# Regional url map
+# Regional URL map
 resource "google_compute_region_url_map" "redirect" {
   name            = "<%= ctx[:vars]['l7_ilb_redirect_url_map'] %>"
   region          = "europe-west1"

--- a/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
+++ b/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
@@ -256,7 +256,7 @@ resource "google_compute_forwarding_rule" "redirect" {
 resource "google_compute_region_target_http_proxy" "default" {
   name    = "<%= ctx[:vars]['l7_ilb_target_http_proxy'] %>"
   region  = "europe-west1"
-  url_map = google_compute_region_url_map.default.id
+  url_map = google_compute_region_url_map.redirect.id
 }
 
 # Regional URL map

--- a/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
+++ b/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
@@ -58,7 +58,7 @@ resource "google_compute_forwarding_rule" "default" {
 # Regional SSL certificate
 resource "google_compute_region_ssl_certificate" "default" {
   region      = "europe-west1"
-  name        = "<%= ctx[:vars]['l7_ilb_regional_ssl_cert'] %>"
+  name_prefix = "my-certificate-"
   private_key = file("path/to/private.key")
   certificate = file("path/to/certificate.crt")
 

--- a/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
+++ b/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
@@ -61,6 +61,10 @@ resource "google_compute_region_ssl_certificate" "default" {
   name        = "<%= ctx[:vars]['l7_ilb_regional_ssl_cert'] %>"
   private_key = file("path/to/private.key")
   certificate = file("path/to/certificate.crt")
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 # Regional target HTTPS proxy

--- a/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
+++ b/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
@@ -1,0 +1,255 @@
+# Internal HTTPS load balancer with HTTP-to-HTTPS redirect
+
+# [START cloudloadbalancing_int_https_with_redirect]
+# Enable API
+resource "google_project_service" "default" {
+  service = "compute.googleapis.com"
+}
+
+# VPC
+resource "google_compute_network" "default" {
+  name                    = "<%= ctx[:vars]['l7_ilb_network'] %>"
+  auto_create_subnetworks = false
+}
+
+# proxy-only subnet
+resource "google_compute_subnetwork" "proxy_subnet" {
+  name          = "<%= ctx[:vars]['l7_ilb_proxy_subnet'] %>"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "europe-west1"
+  purpose       = "INTERNAL_HTTPS_LOAD_BALANCER"
+  role          = "ACTIVE"
+  network       = google_compute_network.default.id
+}
+
+# backend subnet
+resource "google_compute_subnetwork" "default" {
+  name          = "<%= ctx[:vars]['l7_ilb_subnet'] %>"
+  ip_cidr_range = "10.0.1.0/24"
+  region        = "europe-west1"
+  network       = google_compute_network.default.id
+}
+
+resource "google_compute_address" "default" {
+  name         = "<%= ctx[:vars]['l7_ilb_ip'] %>"
+  provider     = google-beta
+  subnetwork   = google_compute_subnetwork.default.id
+  address_type = "INTERNAL"
+  address      = "10.0.1.5"
+  region       = "europe-west1"
+  purpose      = "SHARED_LOADBALANCER_VIP"
+}
+
+# Regional forwarding rule
+resource "google_compute_forwarding_rule" "default" {
+  name                  = "<%= ctx[:vars]['l7_ilb_forwarding_rule'] %>"
+  region                = "europe-west1"
+  depends_on            = [google_compute_subnetwork.proxy_subnet]
+  ip_protocol           = "TCP"
+  ip_address            = google_compute_address.default.id
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  port_range            = "443"
+  target                = google_compute_region_target_https_proxy.default.id
+  network               = google_compute_network.default.id
+  subnetwork            = google_compute_subnetwork.default.id
+  network_tier          = "PREMIUM"
+}
+
+# Regional SSL certificate
+resource "google_compute_region_ssl_certificate" "default" {
+  region      = "europe-west1"
+  name        = "<%= ctx[:vars]['l7_ilb_regional_ssl_cert'] %>"
+  private_key = file("path/to/private.key")
+  certificate = file("path/to/certificate.crt")
+}
+
+# Regional target HTTPS proxy
+resource "google_compute_region_target_https_proxy" "default" {
+  name             = "<%= ctx[:vars]['l7_ilb_target_https_proxy'] %>"
+  region           = "europe-west1"
+  url_map          = google_compute_region_url_map.default.id
+  ssl_certificates = google_compute_region_ssl_certificate.default.id
+}
+
+# Regional url map
+resource "google_compute_region_url_map" "default" {
+  name            = "<%= ctx[:vars]['l7_ilb_regional_url_map'] %>"
+  region          = "europe-west1"
+  default_service = google_compute_region_backend_service.default.id
+}
+
+# Regional backend service
+resource "google_compute_region_backend_service" "default" {
+  name                  = "<%= ctx[:vars]['l7_ilb_backend_service'] %>"
+  region                = "europe-west1"
+  protocol              = "HTTP"
+  port_name             = "http-server"
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  timeout_sec           = 10
+  health_checks         = [google_compute_region_health_check.default.id]
+  backend {
+    group           = google_compute_region_instance_group_manager.default.instance_group
+    balancing_mode  = "UTILIZATION"
+    capacity_scaler = 1.0
+  }
+}
+
+# instance template
+resource "google_compute_instance_template" "default" {
+  name         = "<%= ctx[:vars]['l7_ilb_mig_template'] %>"
+  machine_type = "e2-small"
+  tags         = ["http-server"]
+  network_interface {
+    network    = google_compute_network.default.id
+    subnetwork = google_compute_subnetwork.default.id
+    access_config {
+      # add external ip to fetch packages
+    }
+  }
+  disk {
+    source_image = "debian-cloud/debian-10"
+    auto_delete  = true
+    boot         = true
+  }
+
+  # install nginx and serve a simple web page
+  metadata = {
+    startup-script = <<-EOF1
+      #! /bin/bash
+      set -euo pipefail
+
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update
+      apt-get install -y nginx-light jq
+
+      NAME=$(curl -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/hostname")
+      IP=$(curl -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip")
+      METADATA=$(curl -f -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/?recursive=True" | jq 'del(.["startup-script"])')
+
+      cat <<EOF > /var/www/html/index.html
+      <pre>
+      Name: $NAME
+      IP: $IP
+      Metadata: $METADATA
+      </pre>
+      EOF
+    EOF1
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Regional health check
+resource "google_compute_region_health_check" "default" {
+  name   = "<%= ctx[:vars]['l7_ilb_hc'] %>"
+  region = "europe-west1"
+  http_health_check {
+    port_specification = "USE_SERVING_PORT"
+  }
+}
+
+# Regional MIG
+resource "google_compute_region_instance_group_manager" "default" {
+  name   = "<%= ctx[:vars]['l7_ilb_mig1'] %>"
+  region = "europe-west1"
+  version {
+    instance_template = google_compute_instance_template.default.id
+    name              = "primary"
+  }
+  named_port {
+    name = "http-server"
+    port = 80
+  }
+  base_instance_name = "vm"
+  target_size        = 2
+}
+
+# allow all access to health check ranges
+resource "google_compute_firewall" "default" {
+  name          = "<%= ctx[:vars]['l7_ilb_fw_allow_hc'] %>"
+  direction     = "INGRESS"
+  network       = google_compute_network.default.id
+  source_ranges = ["130.211.0.0/22", "35.191.0.0/16", "35.235.240.0/20"]
+  allow {
+    protocol = "tcp"
+  }
+}
+
+# allow http from proxy subnet to backends
+resource "google_compute_firewall" "backends" {
+  name          = "<%= ctx[:vars]['l7_ilb_fw_allow_ilb_to_backends'] %>"
+  direction     = "INGRESS"
+  network       = google_compute_network.default.id
+  source_ranges = ["10.0.0.0/24"]
+  target_tags   = ["http-server"]
+  allow {
+    protocol = "tcp"
+    ports    = ["80", "443", "8080"]
+  }
+}
+
+# test instance
+resource "google_compute_instance" "default" {
+  name         = "<%= ctx[:vars]['l7_ilb_test_vm'] %>"
+  zone         = "europe-west1-b"
+  machine_type = "e2-small"
+  network_interface {
+    network    = google_compute_network.default.id
+    subnetwork = google_compute_subnetwork.default.id
+  }
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-10"
+    }
+  }
+}
+
+### http-to-https redirect ###
+
+# Regional forwarding rule
+resource "google_compute_forwarding_rule" "redirect" {
+  name                  = "<%= ctx[:vars]['l7_ilb_redirect'] %>"
+  region                = "europe-west1"
+  ip_protocol           = "TCP"
+  ip_address            = google_compute_address.default.id # Same as HTTPS load balancer
+  load_balancing_scheme = "INTERNAL_MANAGED"
+  port_range            = "80"
+  target                = google_compute_region_target_http_proxy.default.id
+  network               = google_compute_network.default.id
+  subnetwork            = google_compute_subnetwork.default.id
+  network_tier          = "PREMIUM"
+}
+
+# Regional http proxy
+resource "google_compute_region_target_http_proxy" "default" {
+  name    = "<%= ctx[:vars]['l7_ilb_target_http_proxy'] %>"
+  region  = "europe-west1"
+  url_map = google_compute_region_url_map.redirect.id
+}
+
+# Regional url map
+resource "google_compute_region_url_map" "<%= ctx[:primary_resource_id] %>" {
+  name            = "<%= ctx[:vars]['l7_ilb_redirect_url_map'] %>"
+  region          = "europe-west1"
+  default_service = google_compute_region_backend_service.default.id
+  host_rule {
+    hosts        = ["*"]
+    path_matcher = "allpaths"
+  }
+
+  path_matcher {
+    name            = "allpaths"
+    default_service = google_compute_region_backend_service.default.id
+    path_rule {
+      paths = ["/"]
+      url_redirect {
+        https_redirect         = true
+        host_redirect          = "10.0.1.5:443"
+        redirect_response_code = "PERMANENT_REDIRECT"
+        strip_query            = true
+      }
+    }
+  }
+}
+# [END cloudloadbalancing_int_https_with_redirect]

--- a/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
+++ b/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
@@ -98,19 +98,19 @@ resource "google_compute_region_ssl_certificate" "default" {
 resource "google_compute_region_target_https_proxy" "default" {
   name             = "<%= ctx[:vars]['l7_ilb_target_https_proxy'] %>"
   region           = "europe-west1"
-  url_map          = google_compute_region_url_map.default.id
+  url_map          = google_compute_region_url_map.https_lb.id
   ssl_certificates = [google_compute_region_ssl_certificate.default.self_link]
 }
 
 # Regional URL map
-resource "google_compute_region_url_map" "default" {
+resource "google_compute_region_url_map" "https_lb" {
   name            = "<%= ctx[:vars]['l7_ilb_regional_url_map'] %>"
   region          = "europe-west1"
   default_service = google_compute_region_backend_service.default.id
 }
 
 # Regional backend service
-resource "google_compute_region_backend_service" "<%= ctx[:primary_resource_id] %>" {
+resource "google_compute_region_backend_service" "default" {
   name                  = "<%= ctx[:vars]['l7_ilb_backend_service'] %>"
   region                = "europe-west1"
   protocol              = "HTTP"
@@ -256,11 +256,11 @@ resource "google_compute_forwarding_rule" "redirect" {
 resource "google_compute_region_target_http_proxy" "default" {
   name    = "<%= ctx[:vars]['l7_ilb_target_http_proxy'] %>"
   region  = "europe-west1"
-  url_map = google_compute_region_url_map.redirect.id
+  url_map = google_compute_region_url_map.default.id
 }
 
 # Regional URL map
-resource "google_compute_region_url_map" "redirect" {
+resource "google_compute_region_url_map" "<%= ctx[:primary_resource_id] %>" {
   name            = "<%= ctx[:vars]['l7_ilb_redirect_url_map'] %>"
   region          = "europe-west1"
   default_service = google_compute_region_backend_service.default.id

--- a/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
+++ b/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
@@ -91,7 +91,7 @@ resource "google_compute_region_ssl_certificate" "default" {
   name_prefix = "my-certificate-"
   private_key = tls_private_key.default.private_key_pem
   certificate = tls_self_signed_cert.default.cert_pem
-
+  region      = "europe-west1" 
   lifecycle {
     create_before_destroy = true
   }

--- a/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
+++ b/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
@@ -79,7 +79,7 @@ resource "google_compute_region_url_map" "default" {
 }
 
 # Regional backend service
-resource "google_compute_region_backend_service" "default" {
+resource "google_compute_region_backend_service" "<%= ctx[:primary_resource_id] %>" {
   name                  = "<%= ctx[:vars]['l7_ilb_backend_service'] %>"
   region                = "europe-west1"
   protocol              = "HTTP"
@@ -229,7 +229,7 @@ resource "google_compute_region_target_http_proxy" "default" {
 }
 
 # Regional url map
-resource "google_compute_region_url_map" "<%= ctx[:primary_resource_id] %>" {
+resource "google_compute_region_url_map" "redirect" {
   name            = "<%= ctx[:vars]['l7_ilb_redirect_url_map'] %>"
   region          = "europe-west1"
   default_service = google_compute_region_backend_service.default.id

--- a/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
+++ b/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
@@ -56,16 +56,48 @@ resource "google_compute_forwarding_rule" "default" {
 }
 
 # Regional SSL certificate
+resource "tls_private_key" "example" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "tls_self_signed_cert" "example" {
+  key_algorithm   = tls_private_key.example.algorithm
+  private_key_pem = tls_private_key.example.private_key_pem
+
+  # Certificate expires after 12 hours.
+  validity_period_hours = 12
+
+  # Generate a new certificate if Terraform is run within three
+  # hours of the certificate's expiration time.
+  early_renewal_hours = 3
+
+  # Reasonable set of uses for a server SSL certificate.
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+  ]
+
+  dns_names = ["example.com"]
+
+  subject {
+    common_name  = "example.com"
+    organization = "ACME Examples, Inc"
+  }
+}
+
 resource "google_compute_region_ssl_certificate" "default" {
-  region      = "europe-west1"
   name_prefix = "my-certificate-"
-  private_key = file("path/to/private.key")
-  certificate = file("path/to/certificate.crt")
+  private_key = tls_private_key.example.private_key_pem
+  certificate = tls_self_signed_cert.example.cert_pem
 
   lifecycle {
     create_before_destroy = true
   }
+
 }
+
 
 # Regional target HTTPS proxy
 resource "google_compute_region_target_https_proxy" "default" {

--- a/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
+++ b/mmv1/templates/terraform/examples/int_https_lb_https_redirect.tf.erb
@@ -55,15 +55,15 @@ resource "google_compute_forwarding_rule" "default" {
   network_tier          = "PREMIUM"
 }
 
-# Regional SSL certificate
-resource "tls_private_key" "example" {
+# Self-signed regional SSL certificate for testing
+resource "tls_private_key" "default" {
   algorithm = "RSA"
   rsa_bits  = 2048
 }
 
-resource "tls_self_signed_cert" "example" {
-  key_algorithm   = tls_private_key.example.algorithm
-  private_key_pem = tls_private_key.example.private_key_pem
+resource "tls_self_signed_cert" "default" {
+  key_algorithm   = tls_private_key.default.algorithm
+  private_key_pem = tls_private_key.default.private_key_pem
 
   # Certificate expires after 12 hours.
   validity_period_hours = 12
@@ -89,22 +89,20 @@ resource "tls_self_signed_cert" "example" {
 
 resource "google_compute_region_ssl_certificate" "default" {
   name_prefix = "my-certificate-"
-  private_key = tls_private_key.example.private_key_pem
-  certificate = tls_self_signed_cert.example.cert_pem
+  private_key = tls_private_key.default.private_key_pem
+  certificate = tls_self_signed_cert.default.cert_pem
 
   lifecycle {
     create_before_destroy = true
   }
-
 }
-
 
 # Regional target HTTPS proxy
 resource "google_compute_region_target_https_proxy" "default" {
   name             = "<%= ctx[:vars]['l7_ilb_target_https_proxy'] %>"
   region           = "europe-west1"
   url_map          = google_compute_region_url_map.default.id
-  ssl_certificates = google_compute_region_ssl_certificate.default.id
+  ssl_certificates = [google_compute_region_ssl_certificate.default.self_link]
 }
 
 # Regional url map


### PR DESCRIPTION
Intending to add this example to this page:

https://cloud.google.com/load-balancing/docs/l7-internal/int-https-lb-tf-examples

```release-note:none
```